### PR TITLE
fix(workflow): Fix icon colors in settings

### DIFF
--- a/apps/workflowengine/src/styles/operation.scss
+++ b/apps/workflowengine/src/styles/operation.scss
@@ -59,6 +59,9 @@ small {
 	h3, small {
 		color: var(--color-primary-element-text)
 	}
+	.icon:not(.icon-invert) {
+		filter: invert(100%);
+	}
 }
 
 .actions__item:not(.colored) {
@@ -82,6 +85,3 @@ small {
 	}
 }
 
-.colored .icon-invert {
-	filter: var(--background-invert-if-bright);
-}


### PR DESCRIPTION
Before | After
---|---
<img width="1137" height="355" alt="Bildschirmfoto vom 2025-09-23 14-47-31" src="https://github.com/user-attachments/assets/952935d7-cc49-49b9-803f-19e1999b6298" /> | <img width="1137" height="355" alt="Bildschirmfoto vom 2025-09-23 14-44-49" src="https://github.com/user-attachments/assets/1e8f565c-7af2-4664-ace2-c80059d1c642" />
<img width="1137" height="355" alt="Bildschirmfoto vom 2025-09-23 14-47-43" src="https://github.com/user-attachments/assets/400a31b6-1be0-4c95-bf59-06b9183f2969" /> | <img width="1137" height="355" alt="Bildschirmfoto vom 2025-09-23 14-45-18" src="https://github.com/user-attachments/assets/09d58270-a6fc-4777-8e2c-85a48f76e4f4" />

It's arguable whether the icon+text should be white in all cases, similar to the old screenshot on https://github.com/nextcloud/files_accesscontrol?tab=readme-ov-file#how-it-works
But at least both should be same. cc @jancborchardt 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
