### PR TITLE
chore: Remove duplicate entry in Authors file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -252,6 +252,7 @@ Michael Monreal <michael.monreal@gmail.com>
 Michael Roitzsch <reactorcontrol@icloud.com>
 michag86 <micha_g@arcor.de>
 Michiel de Jong <michiel@unhosted.org> Michiel@unhosted <michiel@unhosted.org>
+Micke Nordin <kano@sunet.se> Mikael Nordin <mickenordin@users.noreply.github.com>
 Miguel Prokop <miguel.prokop@vtu.com>
 miicha <pfitzner@physik.hu-berlin.de>
 Miquel Rodríguez Telep / Michael Rodríguez-Torrent <miquel@designunbound.co.uk>

--- a/AUTHORS
+++ b/AUTHORS
@@ -338,7 +338,6 @@
  - Mickey Knox <mickey@netfreaks.org>
  - Miguel Prokop <miguel.prokop@vtu.com>
  - Mikael Hammarin <mikael@try2.se>
- - Mikael Nordin <mickenordin@users.noreply.github.com>
  - Mikael Saarinen <mikaels@iki.fi>
  - Mikhail Sazanov <m@sazanof.ru>
  - Mitar <mitar.git@tnode.com>


### PR DESCRIPTION
I noticed that I was mentioned twice in the AUTHORS file, so this patch removes the one that should not be there.

The correct one is `Micke Nordin <kano@sunet.se>` a few lines up.