### PR TITLE
fix: create room/resource calendar synchronously

### DIFF
--- a/lib/private/Calendar/ResourcesRoomsUpdater.php
+++ b/lib/private/Calendar/ResourcesRoomsUpdater.php
@@ -102,8 +102,15 @@ class ResourcesRoomsUpdater {
 
 				$id = $this->addToCache($dbTable, $backendId, $resource);
 				$this->addMetadataToCache($dbTableMetadata, $foreignKey, $id, $metadata);
-				// we don't create the calendar here, it is created lazily
-				// when an event is actually scheduled with this resource / room
+
+				$principalName = implode('-', [$backendId, $newId]);
+				$this->calDavBackend->createCalendar(
+					implode('/', [$principalPrefix, $principalName]),
+					CalDavBackend::RESOURCE_BOOKING_CALENDAR_URI,
+					[
+						'{DAV:}displayname' => CalDavBackend::RESOURCE_BOOKING_CALENDAR_NAME,
+					],
+				);
 			}
 
 			foreach ($deletedIds as $deletedId) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: Community request (see public Groupware conversation on c.nc.c)

## Summary

Create room/resource calendars instantly when creating the room/resource instead of waiting until the first event is created.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
