### PR TITLE
fix(ocm): ignore cache if not setup

### DIFF
--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -84,9 +84,11 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 					throw new OCMProviderException('Previous discovery failed.');
 				}
 
-				$provider->import(json_decode($cached ?? '', true, 8, JSON_THROW_ON_ERROR) ?? []);
-				$this->remoteProviders[$remote] = $provider;
-				return $provider;
+				if ($cached !== null) {
+					$provider->import(json_decode($cached, true, 8, JSON_THROW_ON_ERROR) ?? []);
+					$this->remoteProviders[$remote] = $provider;
+					return $provider;
+				}
 			} catch (JsonException|OCMProviderException $e) {
 				$this->logger->warning('cache issue on ocm discovery', ['exception' => $e]);
 			}


### PR DESCRIPTION
if cache is not enabled, the JsonException is triggered, generating useless warning in the logs