### PR TITLE
fix: Stop infinite loop in ExpireTrash

### DIFF
--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -78,6 +78,7 @@ class ExpireTrash extends TimedJob {
 			// If the last batch was not full it means that we reached the end of the user list.
 			if ($count < self::USER_BATCH_SIZE) {
 				$this->resetOffset();
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

* Regression from https://github.com/nextcloud/server/pull/52825

After updating to NC32, I noticed that cronjobs would not end anymore. Checking the DB revealed:

```
+----+----------------------------------------------+----------+------------+--------------+-------------+--------------------+------------------------------------------------------------------+----------------+
| id | class                                        | argument | last_run   | last_checked | reserved_at | execution_duration | argument_hash                                                    | time_sensitive |
+----+----------------------------------------------+----------+------------+--------------+-------------+--------------------+------------------------------------------------------------------+----------------+
|  5 | OCA\Files_Trashbin\BackgroundJob\ExpireTrash | null     | 1758741001 |   1758741001 |  1758741001 |               1800 | 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b |              1 |
+----+----------------------------------------------+----------+------------+--------------+-------------+--------------------+------------------------------------------------------------------+----------------+
```

There seems to be no exit condition, so we loop over all users for 30 minutes. From the mysql log:

```
# grep background_job_expire_trash_offset /tmp/mysql.log 
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '20', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '30', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '40', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '50', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '0', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '10', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '20', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '30', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '40', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '50', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '0', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '10', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '20', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
		531567 Query	UPDATE `oc_appconfig` SET `configvalue` = '30', `lazy` = 0, `type` = 8 WHERE (`appid` = 'files_trashbin') AND (`configkey` = 'background_job_expire_trash_offset')
```

_**The original PR is about parallel runs, we might need a different check in that case, not totally sure.**_

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
