### PR TITLE
Validate filename when creating file from template

### DIFF
--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -15,6 +15,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\GenericFileException;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
@@ -65,6 +66,7 @@ class TemplateManager implements ITemplateManager {
 		IConfig $config,
 		IFactory $l10nFactory,
 		LoggerInterface $logger,
+		private IFilenameValidator $filenameValidator,
 	) {
 		$this->serverContainer = $serverContainer;
 		$this->eventDispatcher = $eventDispatcher;
@@ -171,7 +173,9 @@ class TemplateManager implements ITemplateManager {
 				}
 			}
 
-			$targetFile = $folder->newFile(basename($filePath), ($template instanceof File ? $template->fopen('rb') : null));
+			$filename = basename($filePath);
+			$this->filenameValidator->validateFilename($filename);
+			$targetFile = $folder->newFile($filename, ($template instanceof File ? $template->fopen('rb') : null));
 
 			$this->eventDispatcher->dispatchTyped(new FileCreatedFromTemplateEvent($template, $targetFile, $templateFields));
 			return $this->formatFile($userFolder->get($filePath));

--- a/tests/lib/Files/Template/TemplateManagerTest.php
+++ b/tests/lib/Files/Template/TemplateManagerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace lib\Files\Template;
+
+use OC\AppFramework\Bootstrap\Coordinator;
+use OC\AppFramework\Bootstrap\RegistrationContext;
+use OC\Files\FilenameValidator;
+use OC\Files\Template\TemplateManager;
+use OCP\Files\Folder;
+use OCP\Files\GenericFileException;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\IPreview;
+use OCP\L10N\IFactory;
+use Psr\Log\NullLogger;
+use Test\TestCase;
+
+class TemplateManagerTest extends TestCase {
+
+	private IRootFolder $rootFolder;
+	private Coordinator $bootstrapCoordinator;
+
+	private TemplateManager $templateManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')
+			->willReturnCallback(fn ($string, $params) => sprintf($string, ...$params));
+		$l10nFactory = $this->createMock(IFactory::class);
+		$l10nFactory->method('get')
+			->willReturn($l10n);
+		$database = $this->createMock(IDBConnection::class);
+		$database->method('supports4ByteText')->willReturn(true);
+		$config = $this->createMock(IConfig::class);
+		$logger = new NullLogger();
+
+		$filenameValidator = new FilenameValidator(
+			$l10nFactory,
+			$database,
+			$config,
+			$logger,
+		);
+
+		$serverContainer = $this->createMock(\OCP\IServerContainer::class);
+		$eventDispatcher = $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class);
+		$this->bootstrapCoordinator = $this->createMock(Coordinator::class);
+		$this->bootstrapCoordinator->method('getRegistrationContext')
+			->willReturn(new RegistrationContext($logger));
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(\OCP\IUserSession::class);
+		$userManager = $this->createMock(\OCP\IUserManager::class);
+		$previewManager = $this->createMock(IPreview::class);
+
+		$this->templateManager = new TemplateManager(
+			$serverContainer,
+			$eventDispatcher,
+			$this->bootstrapCoordinator,
+			$this->rootFolder,
+			$userSession,
+			$userManager,
+			$previewManager,
+			$config,
+			$l10nFactory,
+			$logger,
+			$filenameValidator
+		);
+	}
+
+	public function testCreateFromTemplateShoudValidateFilename(): void {
+		$this->expectException(GenericFileException::class);
+
+		$fileDirectory = '/';
+		$filePath = $fileDirectory . str_repeat('a', 251);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')
+			->willReturnCallback(function ($path) use ($filePath, $fileDirectory) {
+				if ($path === $filePath) {
+					throw new NotFoundException();
+				}
+				return $this->createMock(Folder::class);
+			});
+		$userFolder->method('nodeExists')
+			->willReturnCallback(function ($path) use ($filePath, $fileDirectory) {
+				return $path === $fileDirectory;
+			});
+		$this->rootFolder->method('getUserFolder')
+			->willReturn($userFolder);
+
+		$this->templateManager->createFromTemplate($filePath);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Validate the filename when creating a file from template. 

**Steps to reproduce**

* Log in as alice
* Open Files
* Click "New" and "New text file"
* Use the filename: `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.md`

**Outcome** 

On most installations this leads to a `NotPermittedException` exception because the filename is too long for oc_filecache.name. However, on MySQL/MariaDB without strict mode, such a filename is not rejected but truncated.  

Jonas and Ferdinand discussed `OCP\Files\Folder.newFile` not validating the filename in https://github.com/nextcloud/server/issues/47563. Would it make sense to add a similar check in `assertPathLength` to ensure it fits both `oc_filecache.path` and `oc_filecache.name`, given the technical limitation of 250 characters?


## TODO

- [ ] CI
- [ ] Review


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
