### PR TITLE
Improve connectivity check

### DIFF
--- a/apps/settings/lib/SetupChecks/InternetConnectivity.php
+++ b/apps/settings/lib/SetupChecks/InternetConnectivity.php
@@ -41,7 +41,7 @@ class InternetConnectivity implements ISetupCheck {
 		}
 
 		$siteArray = $this->config->getSystemValue('connectivity_check_domains', [
-			'https://www.nextcloud.com', 'https://www.startpage.com', 'https://www.eff.org', 'https://www.edri.org'
+			'https://connectivity.nextcloud.com', 'https://www.startpage.com', 'https://www.eff.org', 'https://www.edri.org'
 		]);
 
 		foreach ($siteArray as $site) {
@@ -67,7 +67,7 @@ class InternetConnectivity implements ISetupCheck {
 		}
 		try {
 			$client = $this->clientService->newClient();
-			$client->get($site);
+			$client->head($site);
 		} catch (\Exception $e) {
 			$this->logger->error('Cannot connect to: ' . $site, [
 				'app' => 'internet_connection_check',

--- a/apps/settings/lib/SetupChecks/InternetConnectivity.php
+++ b/apps/settings/lib/SetupChecks/InternetConnectivity.php
@@ -41,7 +41,7 @@ class InternetConnectivity implements ISetupCheck {
 		}
 
 		$siteArray = $this->config->getSystemValue('connectivity_check_domains', [
-			'https://connectivity.nextcloud.com', 'https://www.startpage.com', 'https://www.eff.org', 'https://www.edri.org'
+			'https://connectivity.nextcloud.com', 'https://www.eff.org', 'https://edri.org'
 		]);
 
 		foreach ($siteArray as $site) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Current version does a GET on our website, which is heavier than needed, both for our website and the Nextcloud instances.
Changed to a dedicated service and a HEAD request.
Also took the opportunity to remove startpage and correct edri url to avoid a redirection.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
