### PR TITLE
feat(test-case): allow to use PHPUnit Group attributes to mark tests requiring database

### DIFF
--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -34,6 +34,7 @@ use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 if (version_compare(\PHPUnit\Runner\Version::id(), 10, '>=')) {
 	trait OnNotSuccessfulTestTrait {
@@ -545,11 +546,22 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 		$r = new \ReflectionClass($this);
 		$doc = $r->getDocComment();
+
+		if (class_exists(Group::class)) {
+			$attributes = array_map(function (\ReflectionAttribute $attribute) {
+				/** @var Group $group */
+				$group = $attribute->newInstance();
+				return $group->name();
+			}, $r->getAttributes(Group::class));
+			if (count($attributes) > 0) {
+				return $attributes;
+			}
+		}
 		preg_match_all('#@group\s+(.*?)\n#s', $doc, $annotations);
 		return $annotations[1] ?? [];
 	}
 
-	protected function IsDatabaseAccessAllowed() {
+	protected function IsDatabaseAccessAllowed(): bool {
 		$annotations = $this->getGroupAnnotations();
 		if (isset($annotations)) {
 			if (in_array('DB', $annotations) || in_array('SLOWDB', $annotations)) {


### PR DESCRIPTION
Before that, only the annotation `@group DB` is possible to mark test classes as requiring the database. Now the `\PHPUnit\Framework\Attributes\Group` attribute can be used as long as PHPUnit 10+ is used:

```php
use PHPUnit\Framework\Attributes\Group;

#[Group('DB')]
class MyTest extends TestCase {
```

This is important due to PHPUnit 12 depreciation of annotations.

> Metadata found in doc-comment for class XXX. Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
