### PR TITLE
refactor: use logical `&&` `||` instead of weak `and` `or` operators

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -19,3 +19,5 @@ af6de04e9e141466dc229e444ff3f146f4a34765
 b06f5ba4c47450f355a8903c1a93ac68e8c6cfc2
 # Update to coding-standard 1.4.0
 5981b7eb512aa411f51cad541d01c5c6e93476f0
+# Migrate `and` `or` operators to logical `&&` `||` operators
+660f3f6fd1ae5539b8f74bfa48859d1b9f1e6abf

--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -240,7 +240,7 @@ class AssemblyStream implements \Icewind\Streams\File {
 		} else {
 			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
 		}
-		if (isset($context['nodes']) and is_array($context['nodes'])) {
+		if (isset($context['nodes']) && is_array($context['nodes'])) {
 			$this->nodes = $context['nodes'];
 		} else {
 			throw new \BadMethodCallException('Invalid context, nodes not set');

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -84,7 +84,7 @@ abstract class TestCase extends \Test\TestCase {
 			$userObject = $userManager->createUser($user, $password);
 			$group = $groupManager->createGroup('group');
 
-			if ($group and $userObject) {
+			if ($group && $userObject) {
 				$group->addUser($userObject);
 			}
 		}

--- a/apps/files/lib/Command/Put.php
+++ b/apps/files/lib/Command/Put.php
@@ -42,7 +42,7 @@ class Put extends Command {
 			$output->writeln("<error>$fileOutput is a folder</error>");
 			return self::FAILURE;
 		}
-		if (!$node and is_numeric($fileOutput)) {
+		if (!$node && is_numeric($fileOutput)) {
 			$output->writeln("<error>$fileOutput not found</error>");
 			return self::FAILURE;
 		}

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -26,9 +26,9 @@ class Helper {
 	public static function compareFileNames(FileInfo $a, FileInfo $b) {
 		$aType = $a->getType();
 		$bType = $b->getType();
-		if ($aType === 'dir' and $bType !== 'dir') {
+		if ($aType === 'dir' && $bType !== 'dir') {
 			return -1;
-		} elseif ($aType !== 'dir' and $bType === 'dir') {
+		} elseif ($aType !== 'dir' && $bType === 'dir') {
 			return 1;
 		} else {
 			return Util::naturalSortCompare($a->getName(), $b->getName());

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -265,7 +265,7 @@ class FTP extends Common {
 			case 'c':
 			case 'c+':
 				//emulate these
-				if ($useExisting and $this->file_exists($path)) {
+				if ($useExisting && $this->file_exists($path)) {
 					if (!$this->isUpdatable($path)) {
 						return false;
 					}

--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -53,7 +53,7 @@ class SFTPReadStream implements File {
 		} else {
 			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
 		}
-		if (isset($context['session']) and $context['session'] instanceof \phpseclib\Net\SFTP) {
+		if (isset($context['session']) && $context['session'] instanceof \phpseclib\Net\SFTP) {
 			$this->sftp = $context['session'];
 		} else {
 			throw new \BadMethodCallException('Invalid context, session not set');

--- a/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
@@ -51,7 +51,7 @@ class SFTPWriteStream implements File {
 		} else {
 			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
 		}
-		if (isset($context['session']) and $context['session'] instanceof \phpseclib\Net\SFTP) {
+		if (isset($context['session']) && $context['session'] instanceof \phpseclib\Net\SFTP) {
 			$this->sftp = $context['session'];
 		} else {
 			throw new \BadMethodCallException('Invalid context, session not set');

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -407,7 +407,7 @@ class SMB extends Common implements INotifyStorage {
 	 * check if a file or folder has been updated since $time
 	 */
 	public function hasUpdated(string $path, int $time): bool {
-		if (!$path and $this->root === '/') {
+		if (!$path && $this->root === '/') {
 			// mtime doesn't work for shares, but giving the nature of the backend,
 			// doing a full update is still just fast enough
 			return true;

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -126,9 +126,9 @@ class Swift extends Common {
 	}
 
 	public function __construct(array $parameters) {
-		if ((empty($parameters['key']) and empty($parameters['password']))
-			or (empty($parameters['user']) && empty($parameters['userid'])) or empty($parameters['bucket'])
-			or empty($parameters['region'])
+		if ((empty($parameters['key']) && empty($parameters['password']))
+			|| (empty($parameters['user']) && empty($parameters['userid'])) || empty($parameters['bucket'])
+			|| empty($parameters['region'])
 		) {
 			throw new StorageBadConfigException('API Key or password, Login, Bucket and Region have to be configured.');
 		}

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -55,7 +55,7 @@ foreach ($_['authMechanisms'] as $authMechanism) {
 	<h2 class="inlineblock" data-anchor-name="external-storage"><?php p($l->t('External storage')); ?></h2>
 	<a target="_blank" rel="noreferrer" class="icon-info" title="<?php p($l->t('Open documentation'));?>" href="<?php p(link_to_docs('admin-external-storage')); ?>"></a>
 	<p class="settings-hint"><?php p($l->t('External storage enables you to mount external storage services and devices as secondary Nextcloud storage devices. You may also allow people to mount their own external storage services.')); ?></p>
-	<?php if (isset($_['dependencies']) and ($_['dependencies'] !== '') and $canCreateMounts) {
+	<?php if (isset($_['dependencies']) && ($_['dependencies'] !== '') && $canCreateMounts) {
 		print_unescaped('' . $_['dependencies'] . '');
 	} ?>
 	<table id="externalStorage" class="grid" data-admin='<?php print_unescaped(json_encode($_['visibilityType'] === BackendService::VISIBILITY_ADMIN)); ?>'>

--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -49,7 +49,7 @@ class CleanUp extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$users = $input->getArgument('user_id');
 		$verbose = $input->getOption('verbose');
-		if ((!empty($users)) and ($input->getOption('all-users'))) {
+		if (!empty($users) && $input->getOption('all-users')) {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
 		} elseif (!empty($users)) {
 			foreach ($users as $user) {

--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -396,7 +396,7 @@ class FileEventsListener implements IEventListener {
 		$manager = Filesystem::getMountManager();
 		$mount = $manager->find($absOldPath);
 		$internalPath = $mount->getInternalPath($absOldPath);
-		if ($internalPath === '' and $mount instanceof MoveableMount) {
+		if ($internalPath === '' && $mount instanceof MoveableMount) {
 			return;
 		}
 

--- a/apps/user_ldap/lib/Command/ShowConfig.php
+++ b/apps/user_ldap/lib/Command/ShowConfig.php
@@ -75,7 +75,7 @@ class ShowConfig extends Base {
 		InputInterface $input,
 		OutputInterface $output,
 	): void {
-		$renderTable = $input->getOption('output') === 'table' or $input->getOption('output') === null;
+		$renderTable = $input->getOption('output') === 'table' || $input->getOption('output') === null;
 		$showPassword = $input->getOption('show-password');
 
 		$configs = [];

--- a/apps/user_ldap/lib/LDAPProvider.php
+++ b/apps/user_ldap/lib/LDAPProvider.php
@@ -53,7 +53,7 @@ class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
 			}
 		}
 
-		if (!$userBackendFound or !$groupBackendFound) {
+		if (!$userBackendFound || !$groupBackendFound) {
 			throw new \Exception('To use the LDAPProvider, user_ldap app must be enabled');
 		}
 	}

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -49,7 +49,7 @@ class SetupController {
 			return;
 		}
 
-		if (isset($post['install']) and $post['install'] == 'true') {
+		if (isset($post['install']) && $post['install'] == 'true') {
 			// We have to launch the installation process :
 			$e = $this->setupHelper->install($post);
 			$errors = ['errors' => $e];
@@ -136,7 +136,7 @@ class SetupController {
 		$directoryIsSet = isset($post['directory']);
 		$adminAccountIsSet = isset($post['adminlogin']);
 
-		if ($dbIsSet and $directoryIsSet and $adminAccountIsSet) {
+		if ($dbIsSet && $directoryIsSet && $adminAccountIsSet) {
 			$post['install'] = 'true';
 		}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -83,7 +83,7 @@ class OC {
 	public static function initPaths(): void {
 		if (defined('PHPUNIT_CONFIG_DIR')) {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
-		} elseif (defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
+		} elseif (defined('PHPUNIT_RUN') && PHPUNIT_RUN && is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';
 		} elseif ($dir = getenv('NEXTCLOUD_CONFIG_DIR')) {
 			self::$configDir = rtrim($dir, '/') . '/';

--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -89,7 +89,7 @@ class TAR extends Archive {
 		if ($this->fileExists($path)) {
 			$this->remove($path);
 		}
-		if ($source and $source[0] == '/' and file_exists($source)) {
+		if ($source && $source[0] === '/' && file_exists($source)) {
 			$source = file_get_contents($source);
 		}
 		$result = $this->tar->addString($path, $source);
@@ -122,9 +122,9 @@ class TAR extends Archive {
 		}
 		foreach ($this->cachedHeaders as $header) {
 			if ($file == $header['filename']
-				or $file . '/' == $header['filename']
-				or '/' . $file . '/' == $header['filename']
-				or '/' . $file == $header['filename']
+				|| $file . '/' == $header['filename']
+				|| '/' . $file . '/' == $header['filename']
+				|| '/' . $file == $header['filename']
 			) {
 				return $header;
 			}
@@ -161,7 +161,7 @@ class TAR extends Archive {
 			if ($file[0] == '/') {
 				$file = substr($file, 1);
 			}
-			if (substr($file, 0, $pathLength) == $path and $file != $path) {
+			if (substr($file, 0, $pathLength) == $path && $file != $path) {
 				$result = substr($file, $pathLength);
 				if ($pos = strpos($result, '/')) {
 					$result = substr($result, 0, $pos + 1);
@@ -244,13 +244,13 @@ class TAR extends Archive {
 	 */
 	public function fileExists(string $path): bool {
 		$files = $this->getFiles();
-		if ((in_array($path, $files)) or (in_array($path . '/', $files))) {
+		if ((in_array($path, $files)) || (in_array($path . '/', $files))) {
 			return true;
 		} else {
 			$folderPath = rtrim($path, '/') . '/';
 			$pathLength = strlen($folderPath);
 			foreach ($files as $file) {
-				if (strlen($file) > $pathLength and substr($file, 0, $pathLength) == $folderPath) {
+				if (strlen($file) > $pathLength && substr($file, 0, $pathLength) == $folderPath) {
 					return true;
 				}
 			}
@@ -296,10 +296,10 @@ class TAR extends Archive {
 		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 		if ($this->fileExists($path)) {
 			$this->extractFile($path, $tmpFile);
-		} elseif ($mode == 'r' or $mode == 'rb') {
+		} elseif ($mode == 'r' || $mode == 'rb') {
 			return false;
 		}
-		if ($mode == 'r' or $mode == 'rb') {
+		if ($mode == 'r' || $mode == 'rb') {
 			return fopen($tmpFile, $mode);
 		} else {
 			$handle = fopen($tmpFile, $mode);

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -44,7 +44,7 @@ class ZIP extends Archive {
 	 * @param string $source either a local file or string data
 	 */
 	public function addFile(string $path, string $source = ''): bool {
-		if ($source and $source[0] == '/' and file_exists($source)) {
+		if ($source && $source[0] === '/' && file_exists($source)) {
 			$result = $this->zip->addFile($source, $path);
 		} else {
 			$result = $this->zip->addFromString($path, $source);
@@ -92,7 +92,7 @@ class ZIP extends Archive {
 		$folderContent = [];
 		$pathLength = strlen($path);
 		foreach ($files as $file) {
-			if (substr($file, 0, $pathLength) == $path and $file != $path) {
+			if (substr($file, 0, $pathLength) == $path && $file != $path) {
 				if (strrpos(substr($file, 0, -1), '/') <= $pathLength) {
 					$folderContent[] = substr($file, $pathLength);
 				}
@@ -169,7 +169,7 @@ class ZIP extends Archive {
 	 * check if a file or folder exists in the archive
 	 */
 	public function fileExists(string $path): bool {
-		return ($this->zip->locateName($path) !== false) or ($this->zip->locateName($path . '/') !== false);
+		return ($this->zip->locateName($path) !== false) || ($this->zip->locateName($path . '/') !== false);
 	}
 
 	/**
@@ -188,7 +188,7 @@ class ZIP extends Archive {
 	 * @return bool|resource
 	 */
 	public function getStream(string $path, string $mode) {
-		if ($mode == 'r' or $mode == 'rb') {
+		if ($mode === 'r' || $mode === 'rb') {
 			return $this->zip->getStream($path);
 		} else {
 			//since we can't directly get a writable stream,

--- a/lib/private/Command/CronBus.php
+++ b/lib/private/Command/CronBus.php
@@ -44,7 +44,7 @@ class CronBus extends AsyncBus {
 	private function serializeCommand($command): string {
 		if ($command instanceof \Closure) {
 			return serialize(new SerializableClosure($command));
-		} elseif (is_callable($command) or $command instanceof ICommand) {
+		} elseif (is_callable($command) || $command instanceof ICommand) {
 			return serialize($command);
 		} else {
 			throw new \InvalidArgumentException('Invalid command');

--- a/lib/private/EventSource.php
+++ b/lib/private/EventSource.php
@@ -31,7 +31,7 @@ class EventSource implements IEventSource {
 		\OC_Util::obEnd();
 		header('Cache-Control: no-cache');
 		header('X-Accel-Buffering: no');
-		$this->fallback = isset($_GET['fallback']) and $_GET['fallback'] == 'true';
+		$this->fallback = isset($_GET['fallback']) && $_GET['fallback'] == 'true';
 		if ($this->fallback) {
 			$this->fallBackId = (int)$_GET['fallback_id'];
 			/**
@@ -73,7 +73,7 @@ class EventSource implements IEventSource {
 	 * @suppress PhanDeprecatedFunction
 	 */
 	public function send($type, $data = null) {
-		if ($data and !preg_match('/^[A-Za-z0-9_]+$/', $type)) {
+		if ($data && !preg_match('/^[A-Za-z0-9_]+$/', $type)) {
 			throw new \BadMethodCallException('Type needs to be alphanumeric (' . $type . ')');
 		}
 		$this->init();

--- a/lib/private/Files/Cache/HomeCache.php
+++ b/lib/private/Files/Cache/HomeCache.php
@@ -18,9 +18,9 @@ class HomeCache extends Cache {
 	 * @return int|float
 	 */
 	public function calculateFolderSize($path, $entry = null) {
-		if ($path !== '/' and $path !== '' and $path !== 'files' and $path !== 'files_trashbin' and $path !== 'files_versions') {
+		if ($path !== '/' && $path !== '' && $path !== 'files' && $path !== 'files_trashbin' && $path !== 'files_versions') {
 			return parent::calculateFolderSize($path, $entry);
-		} elseif ($path === '' or $path === '/') {
+		} elseif ($path === '' || $path === '/') {
 			// since the size of / isn't used (the size of /files is used instead) there is no use in calculating it
 			return 0;
 		} else {
@@ -34,7 +34,7 @@ class HomeCache extends Cache {
 	 */
 	public function get($file) {
 		$data = parent::get($file);
-		if ($file === '' or $file === '/') {
+		if ($file === '' || $file === '/') {
 			// only the size of the "files" dir counts
 			$filesData = parent::get('files');
 

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -102,7 +102,7 @@ class Updater implements IUpdater {
 	 * @param int $time
 	 */
 	public function update($path, $time = null, ?int $sizeDifference = null) {
-		if (!$this->enabled or Scanner::isPartialFile($path)) {
+		if (!$this->enabled || Scanner::isPartialFile($path)) {
 			return;
 		}
 		if (is_null($time)) {
@@ -134,7 +134,7 @@ class Updater implements IUpdater {
 	 * @param string $path
 	 */
 	public function remove($path) {
-		if (!$this->enabled or Scanner::isPartialFile($path)) {
+		if (!$this->enabled || Scanner::isPartialFile($path)) {
 			return;
 		}
 
@@ -204,7 +204,7 @@ class Updater implements IUpdater {
 	 * Utility to copy or rename a file or folder in the cache and update the size, etag and mtime of the parent folders
 	 */
 	private function copyOrRenameFromStorage(IStorage $sourceStorage, string $source, string $target, callable $operation): void {
-		if (!$this->enabled or Scanner::isPartialFile($source) or Scanner::isPartialFile($target)) {
+		if (!$this->enabled || Scanner::isPartialFile($source) || Scanner::isPartialFile($target)) {
 			return;
 		}
 

--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -116,7 +116,7 @@ class Watcher implements IWatcher {
 	 * @return bool
 	 */
 	public function needsUpdate($path, $cachedData) {
-		if ($this->watchPolicy === self::CHECK_ALWAYS or ($this->watchPolicy === self::CHECK_ONCE and !in_array($path, $this->checkedPaths))) {
+		if ($this->watchPolicy === self::CHECK_ALWAYS || ($this->watchPolicy === self::CHECK_ONCE && !in_array($path, $this->checkedPaths))) {
 			$this->checkedPaths[] = $path;
 			return $cachedData['storage_mtime'] === null || $this->storage->hasUpdated($path, $cachedData['storage_mtime']);
 		}

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -104,7 +104,7 @@ class CacheJail extends CacheWrapper {
 	 * @return ICacheEntry|false
 	 */
 	public function get($file) {
-		if (is_string($file) or $file == '') {
+		if (is_string($file) || $file == '') {
 			$file = $this->getSourcePath($file);
 		}
 		return parent::get($file);

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -209,7 +209,7 @@ class MountPoint implements IMountPoint {
 	 */
 	public function getInternalPath($path) {
 		$path = Filesystem::normalizePath($path, true, false, true);
-		if ($this->mountPoint === $path or $this->mountPoint . '/' === $path) {
+		if ($this->mountPoint === $path || $this->mountPoint . '/' === $path) {
 			$internalPath = '';
 		} else {
 			$internalPath = substr($path, strlen($this->mountPoint));

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -404,7 +404,7 @@ class Node implements INode {
 	public function copy($targetPath) {
 		$targetPath = $this->normalizePath($targetPath);
 		$parent = $this->root->get(dirname($targetPath));
-		if ($parent instanceof Folder and $this->isValidPath($targetPath) and $parent->isCreatable()) {
+		if ($parent instanceof Folder && $this->isValidPath($targetPath) && $parent->isCreatable()) {
 			$nonExisting = $this->createNonExistingNode($targetPath);
 			$this->sendHooks(['preCopy'], [$this, $nonExisting]);
 			$this->sendHooks(['preWrite'], [$nonExisting]);

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -185,7 +185,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		$this->remove($target);
 
 		$this->removeCachedFile($source);
-		return $this->copy($source, $target) and $this->remove($source);
+		return $this->copy($source, $target) && $this->remove($source);
 	}
 
 	public function copy(string $source, string $target): bool {

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -40,19 +40,19 @@ class PermissionsMask extends Wrapper {
 	}
 
 	public function isUpdatable(string $path): bool {
-		return $this->checkMask(Constants::PERMISSION_UPDATE) and parent::isUpdatable($path);
+		return $this->checkMask(Constants::PERMISSION_UPDATE) && parent::isUpdatable($path);
 	}
 
 	public function isCreatable(string $path): bool {
-		return $this->checkMask(Constants::PERMISSION_CREATE) and parent::isCreatable($path);
+		return $this->checkMask(Constants::PERMISSION_CREATE) && parent::isCreatable($path);
 	}
 
 	public function isDeletable(string $path): bool {
-		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::isDeletable($path);
+		return $this->checkMask(Constants::PERMISSION_DELETE) && parent::isDeletable($path);
 	}
 
 	public function isSharable(string $path): bool {
-		return $this->checkMask(Constants::PERMISSION_SHARE) and parent::isSharable($path);
+		return $this->checkMask(Constants::PERMISSION_SHARE) && parent::isSharable($path);
 	}
 
 	public function getPermissions(string $path): int {
@@ -62,30 +62,30 @@ class PermissionsMask extends Wrapper {
 	public function rename(string $source, string $target): bool {
 		//This is a rename of the transfer file to the original file
 		if (dirname($source) === dirname($target) && strpos($source, '.ocTransferId') > 0) {
-			return $this->checkMask(Constants::PERMISSION_CREATE) and parent::rename($source, $target);
+			return $this->checkMask(Constants::PERMISSION_CREATE) && parent::rename($source, $target);
 		}
-		return $this->checkMask(Constants::PERMISSION_UPDATE) and parent::rename($source, $target);
+		return $this->checkMask(Constants::PERMISSION_UPDATE) && parent::rename($source, $target);
 	}
 
 	public function copy(string $source, string $target): bool {
-		return $this->checkMask(Constants::PERMISSION_CREATE) and parent::copy($source, $target);
+		return $this->checkMask(Constants::PERMISSION_CREATE) && parent::copy($source, $target);
 	}
 
 	public function touch(string $path, ?int $mtime = null): bool {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkMask($permissions) and parent::touch($path, $mtime);
+		return $this->checkMask($permissions) && parent::touch($path, $mtime);
 	}
 
 	public function mkdir(string $path): bool {
-		return $this->checkMask(Constants::PERMISSION_CREATE) and parent::mkdir($path);
+		return $this->checkMask(Constants::PERMISSION_CREATE) && parent::mkdir($path);
 	}
 
 	public function rmdir(string $path): bool {
-		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::rmdir($path);
+		return $this->checkMask(Constants::PERMISSION_DELETE) && parent::rmdir($path);
 	}
 
 	public function unlink(string $path): bool {
-		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::unlink($path);
+		return $this->checkMask(Constants::PERMISSION_DELETE) && parent::unlink($path);
 	}
 
 	public function file_put_contents(string $path, mixed $data): int|float|false {
@@ -94,7 +94,7 @@ class PermissionsMask extends Wrapper {
 	}
 
 	public function fopen(string $path, string $mode) {
-		if ($mode === 'r' or $mode === 'rb') {
+		if ($mode === 'r' || $mode === 'rb') {
 			return parent::fopen($path, $mode);
 		} else {
 			$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -227,7 +227,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 			// FIXME Temporary fix to keep existing checks working
 			$class = '\OCA\Files_Sharing\SharedStorage';
 		}
-		return is_a($this, $class) or $this->getWrapperStorage()->instanceOfStorage($class);
+		return is_a($this, $class) || $this->getWrapperStorage()->instanceOfStorage($class);
 	}
 
 	/**

--- a/lib/private/Files/Utils/PathHelper.php
+++ b/lib/private/Files/Utils/PathHelper.php
@@ -16,7 +16,7 @@ class PathHelper {
 	 * @return ?string
 	 */
 	public static function getRelativePath(string $root, string $path) {
-		if ($root === '' or $root === '/') {
+		if ($root === '' || $root === '/') {
 			return self::normalizePath($path);
 		}
 		if ($path === $root) {
@@ -34,7 +34,7 @@ class PathHelper {
 	 * @return string
 	 */
 	public static function normalizePath(string $path): string {
-		if ($path === '' or $path === '/') {
+		if ($path === '' || $path === '/') {
 			return '/';
 		}
 		// No null bytes

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -181,7 +181,7 @@ class Group implements IGroup {
 			$this->emitter->emit('\OC\Group', 'preRemoveUser', [$this, $user]);
 		}
 		foreach ($this->backends as $backend) {
-			if ($backend->implementsActions(\OC\Group\Backend::REMOVE_FROM_GOUP) and $backend->inGroup($user->getUID(), $this->gid)) {
+			if ($backend->implementsActions(\OC\Group\Backend::REMOVE_FROM_GOUP) && $backend->inGroup($user->getUID(), $this->gid)) {
 				$backend->removeFromGroup($user->getUID(), $this->gid);
 				$result = true;
 			}
@@ -220,7 +220,7 @@ class Group implements IGroup {
 					}
 				}
 			}
-			if (!is_null($limit) and $limit <= 0) {
+			if (!is_null($limit) && $limit <= 0) {
 				return $users;
 			}
 		}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -278,7 +278,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 			foreach ($newGroups as $groupId => $group) {
 				$groups[$groupId] = $group;
 			}
-			if (!is_null($limit) and $limit <= 0) {
+			if (!is_null($limit) && $limit <= 0) {
 				return array_values($groups);
 			}
 		}

--- a/lib/private/Hooks/EmitterTrait.php
+++ b/lib/private/Hooks/EmitterTrait.php
@@ -41,7 +41,7 @@ trait EmitterTrait {
 	public function removeListener($scope = null, $method = null, ?callable $callback = null) {
 		$names = [];
 		$allNames = array_keys($this->listeners);
-		if ($scope and $method) {
+		if ($scope && $method) {
 			$name = $scope . '::' . $method;
 			if (isset($this->listeners[$name])) {
 				$names[] = $name;

--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -898,7 +898,7 @@ class Image implements IImage {
 		}
 
 		// preserve transparency
-		if ($this->imageType == IMAGETYPE_GIF or $this->imageType == IMAGETYPE_PNG) {
+		if ($this->imageType === IMAGETYPE_GIF || $this->imageType === IMAGETYPE_PNG) {
 			$alpha = imagecolorallocatealpha($process, 0, 0, 0, 127);
 			if ($alpha === false) {
 				$alpha = null;
@@ -930,7 +930,7 @@ class Image implements IImage {
 		}
 		$widthOrig = imagesx($this->resource);
 		$heightOrig = imagesy($this->resource);
-		if ($widthOrig === $heightOrig and $size == 0) {
+		if ($widthOrig === $heightOrig && $size == 0) {
 			return true;
 		}
 		$ratioOrig = $widthOrig / $heightOrig;
@@ -957,7 +957,7 @@ class Image implements IImage {
 		}
 
 		// preserve transparency
-		if ($this->imageType == IMAGETYPE_GIF or $this->imageType == IMAGETYPE_PNG) {
+		if ($this->imageType === IMAGETYPE_GIF || $this->imageType === IMAGETYPE_PNG) {
 			$alpha = imagecolorallocatealpha($process, 0, 0, 0, 127);
 			if ($alpha === false) {
 				$alpha = null;
@@ -1018,7 +1018,7 @@ class Image implements IImage {
 		}
 
 		// preserve transparency
-		if ($this->imageType == IMAGETYPE_GIF or $this->imageType == IMAGETYPE_PNG) {
+		if ($this->imageType === IMAGETYPE_GIF || $this->imageType === IMAGETYPE_PNG) {
 			$alpha = imagecolorallocatealpha($process, 0, 0, 0, 127);
 			if ($alpha === false) {
 				$alpha = null;

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -498,7 +498,7 @@ class Installer {
 		foreach (\OC::$APPSROOTS as $app_dir) {
 			if ($dir = opendir($app_dir['path'])) {
 				while (false !== ($filename = readdir($dir))) {
-					if ($filename[0] !== '.' and is_dir($app_dir['path'] . "/$filename")) {
+					if ($filename[0] !== '.' && is_dir($app_dir['path'] . "/$filename")) {
 						if (file_exists($app_dir['path'] . "/$filename/appinfo/info.xml")) {
 							if ($this->config->getAppValue($filename, 'installed_version') === '') {
 								$enabled = $this->appManager->isDefaultEnabled($filename);

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -385,7 +385,7 @@ class Checker {
 	 */
 	public function getResults(): ?array {
 		$cachedResults = $this->cache->get(self::CACHE_KEY);
-		if (!\is_null($cachedResults) and $cachedResults !== false) {
+		if (!\is_null($cachedResults) && $cachedResults !== false) {
 			return json_decode($cachedResults, true);
 		}
 

--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -53,7 +53,7 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 	/** @inheritDoc */
 	protected function markRelease(string $path, int $type): void {
 		if ($type === self::LOCK_SHARED) {
-			if (isset($this->acquiredLocks['shared'][$path]) and $this->acquiredLocks['shared'][$path] > 0) {
+			if (isset($this->acquiredLocks['shared'][$path]) && $this->acquiredLocks['shared'][$path] > 0) {
 				$this->acquiredLocks['shared'][$path]--;
 				if ($this->acquiredLocks['shared'][$path] === 0) {
 					unset($this->acquiredLocks['shared'][$path]);

--- a/lib/private/Memcache/APCu.php
+++ b/lib/private/Memcache/APCu.php
@@ -101,7 +101,7 @@ class APCu extends Cache implements IMemcache {
 	 */
 	public function cas($key, $old, $new) {
 		// apc only does cas for ints
-		if (is_int($old) and is_int($new)) {
+		if (is_int($old) && is_int($new)) {
 			return apcu_cas($this->getPrefix() . $key, $old, $new);
 		} else {
 			return $this->casEmulated($key, $old, $new);

--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -82,7 +82,7 @@ class Memcached extends Cache implements IMemcache {
 
 	public function get($key) {
 		$result = self::$cache->get($this->getNameSpace() . $key);
-		if ($result === false and self::$cache->getResultCode() == \Memcached::RES_NOTFOUND) {
+		if ($result === false && self::$cache->getResultCode() === \Memcached::RES_NOTFOUND) {
 			return null;
 		} else {
 			return $result;

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -226,7 +226,7 @@ class PreviewManager implements IPreview {
 		}
 
 		$mount = $file->getMountPoint();
-		if ($mount and !$mount->getOption('previews', true)) {
+		if ($mount && !$mount->getOption('previews', true)) {
 			return false;
 		}
 

--- a/lib/private/Security/Certificate.php
+++ b/lib/private/Security/Certificate.php
@@ -85,7 +85,7 @@ class Certificate implements ICertificate {
 
 	public function isExpired(): bool {
 		$now = new \DateTime();
-		return $this->issueDate > $now or $now > $this->expireDate;
+		return $this->issueDate > $now || $now > $this->expireDate;
 	}
 
 	public function getIssuerName(): ?string {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -926,7 +926,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$ini = $c->get(IniGetWrapper::class);
 			$config = $c->get(\OCP\IConfig::class);
 			$ttl = $config->getSystemValueInt('filelocking.ttl', max(3600, $ini->getNumeric('max_execution_time')));
-			if ($config->getSystemValueBool('filelocking.enabled', true) or (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
+			if ($config->getSystemValueBool('filelocking.enabled', true) || (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				/** @var \OC\Memcache\Factory $memcacheFactory */
 				$memcacheFactory = $c->get(ICacheFactory::class);
 				$memcache = $memcacheFactory->createLocking('lock');

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -215,9 +215,9 @@ class URLGenerator implements IURLGenerator {
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$appName/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$appName/img/$basename.png")) {
 			$path = \OC::$WEBROOT . "/themes/$theme/apps/$appName/img/$basename.png";
-		} elseif (!empty($appName) and file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$file")) {
+		} elseif (!empty($appName) && file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$file")) {
 			$path = \OC::$WEBROOT . "/themes/$theme/$appName/img/$file";
-		} elseif (!empty($appName) and (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$basename.svg")
+		} elseif (!empty($appName) && (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$basename.png"))) {
 			$path = \OC::$WEBROOT . "/themes/$theme/$appName/img/$basename.png";
 		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$file")) {
@@ -232,9 +232,9 @@ class URLGenerator implements IURLGenerator {
 		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")
 			&& file_exists($appPath . "/img/$basename.png")) {
 			$path = $this->getAppManager()->getAppWebPath($appName) . "/img/$basename.png";
-		} elseif (!empty($appName) and file_exists(\OC::$SERVERROOT . "/$appName/img/$file")) {
+		} elseif (!empty($appName) && file_exists(\OC::$SERVERROOT . "/$appName/img/$file")) {
 			$path = \OC::$WEBROOT . "/$appName/img/$file";
-		} elseif (!empty($appName) and (!file_exists(\OC::$SERVERROOT . "/$appName/img/$basename.svg")
+		} elseif (!empty($appName) && (!file_exists(\OC::$SERVERROOT . "/$appName/img/$basename.svg")
 				&& file_exists(\OC::$SERVERROOT . "/$appName/img/$basename.png"))) {
 			$path = \OC::$WEBROOT . "/$appName/img/$basename.png";
 		} elseif (file_exists(\OC::$SERVERROOT . "/core/img/$file")) {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -585,7 +585,7 @@ class User implements IUser {
 	 */
 	public function setQuota($quota) {
 		$oldQuota = $this->config->getUserValue($this->uid, 'files', 'quota', '');
-		if ($quota !== 'none' and $quota !== 'default') {
+		if ($quota !== 'none' && $quota !== 'default') {
 			$bytesQuota = \OCP\Util::computerFileSize($quota);
 			if ($bytesQuota === false) {
 				throw new InvalidArgumentException('Failed to set quota to invalid value ' . $quota);

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -101,7 +101,7 @@ class OC_Helper {
 		$obd = OC::$server->get(IniGetWrapper::class)->getString('open_basedir');
 		if ($obd != 'none') {
 			$obd_values = explode(PATH_SEPARATOR, $obd);
-			if (count($obd_values) > 0 and $obd_values[0]) {
+			if (count($obd_values) > 0 && $obd_values[0]) {
 				// open_basedir is in effect !
 				// We need to check if the program is in one of these dirs :
 				$dirs = $obd_values;

--- a/lib/private/legacy/OC_Hook.php
+++ b/lib/private/legacy/OC_Hook.php
@@ -40,7 +40,7 @@ class OC_Hook {
 
 		// don't connect hooks twice
 		foreach (self::$registered[$signalClass][$signalName] as $hook) {
-			if ($hook['class'] === $slotClass and $hook['name'] === $slotName) {
+			if ($hook['class'] === $slotClass && $hook['name'] === $slotName) {
 				return false;
 			}
 		}

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -59,7 +59,7 @@ class OC_User {
 			Server::get(IUserManager::class)->registerBackend($backend);
 		} else {
 			// You'll never know what happens
-			if ($backend === null or !is_string($backend)) {
+			if ($backend === null || !is_string($backend)) {
 				$backend = 'database';
 			}
 

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -332,7 +332,7 @@ class OC_Util {
 
 		// Check if config folder is writable.
 		if (!(bool)$config->getValue('config_is_read_only', false)) {
-			if (!is_writable(OC::$configDir) or !is_readable(OC::$configDir)) {
+			if (!is_writable(OC::$configDir) || !is_readable(OC::$configDir)) {
 				$errors[] = [
 					'error' => $l->t('Cannot write into "config" directory.'),
 					'hint' => $l->t('This can usually be fixed by giving the web server write access to the config directory. See %s',
@@ -356,7 +356,7 @@ class OC_Util {
 							[$urlGenerator->linkToDocs('admin-dir_permissions')])
 					];
 				}
-			} elseif (!is_writable($CONFIG_DATADIRECTORY) or !is_readable($CONFIG_DATADIRECTORY)) {
+			} elseif (!is_writable($CONFIG_DATADIRECTORY) || !is_readable($CONFIG_DATADIRECTORY)) {
 				// is_writable doesn't work for NFS mounts, so try to write a file and check if it exists.
 				$testFile = sprintf('%s/%s.tmp', $CONFIG_DATADIRECTORY, uniqid('data_dir_writability_test_'));
 				$handle = fopen($testFile, 'w');

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -98,7 +98,7 @@ class Files {
 	 * @deprecated 14.0.0
 	 */
 	public static function streamCopy($source, $target, ?bool $includeResult = null) {
-		if (!$source or !$target) {
+		if (!$source || !$target) {
 			return $includeResult ? [0, false] : 0;
 		}
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -514,7 +514,7 @@ class Util {
 		$it = new \RecursiveIteratorIterator($aIt);
 
 		while ($it->valid()) {
-			if (((isset($index) and ($it->key() == $index)) or !isset($index)) and ($it->current() == $needle)) {
+			if (((isset($index) && ($it->key() == $index)) || !isset($index)) && ($it->current() == $needle)) {
 				return $aIt->key();
 			}
 

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -46,7 +46,9 @@ class AppManagerTest extends TestCase {
 		$config->expects($this->any())
 			->method('getValue')
 			->willReturnCallback(function ($app, $key, $default) use (&$appConfig) {
-				return (isset($appConfig[$app]) and isset($appConfig[$app][$key])) ? $appConfig[$app][$key] : $default;
+				return (isset($appConfig[$app]) && isset($appConfig[$app][$key]))
+					? $appConfig[$app][$key]
+					: $default;
 			});
 		$config->expects($this->any())
 			->method('setValue')

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -68,7 +68,7 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('/');
 		$content = [];
 		while (($file = readdir($dh)) !== false) {
-			if ($file != '.' and $file != '..') {
+			if ($file !== '.' && $file !== '..') {
 				$content[] = $file;
 			}
 		}
@@ -101,7 +101,7 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('/');
 		$content = [];
 		while (($file = readdir($dh)) !== false) {
-			if ($file != '.' and $file != '..') {
+			if ($file != '.' && $file != '..') {
 				$content[] = $file;
 			}
 		}
@@ -429,7 +429,7 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('#foo');
 		$content = [];
 		while ($file = readdir($dh)) {
-			if ($file != '.' and $file != '..') {
+			if ($file != '.' && $file != '..') {
 				$content[] = $file;
 			}
 		}

--- a/tests/lib/Files/Storage/Wrapper/EncodingTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncodingTest.php
@@ -197,7 +197,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		$dh = $this->instance->opendir('/test');
 		$content = [];
 		while (($file = readdir($dh)) !== false) {
-			if ($file != '.' and $file != '..') {
+			if ($file !== '.' && $file !== '..') {
 				$content[] = $file;
 			}
 		}

--- a/tests/lib/Hooks/BasicEmitterTest.php
+++ b/tests/lib/Hooks/BasicEmitterTest.php
@@ -133,7 +133,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->expectException(\Test\Hooks\EmittedException::class);
 
 		$this->emitter->listen('Test', 'test', function ($foo, $bar): void {
-			if ($foo == 'foo' and $bar == 'bar') {
+			if ($foo === 'foo' && $bar === 'bar') {
 				throw new EmittedException;
 			}
 		});
@@ -145,7 +145,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->expectException(\Test\Hooks\EmittedException::class);
 
 		$this->emitter->listen('Test', 'test', function ($foo, $bar): void {
-			if ($foo == 'foo' and $bar == 'bar') {
+			if ($foo === 'foo' && $bar === 'bar') {
 				throw new EmittedException;
 			}
 		});


### PR DESCRIPTION
## Summary

Weak operators like `and` and `or` are misleading as they work different as most people expect them to work.
So migrate to consistent usage of logical operators like `&&` and `||`.

See also https://www.php.net/manual/en/language.operators.precedence.php

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
