### PR TITLE
refactor: Remove OC_Helper::streamCopy

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -118,18 +118,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * copy the contents of one stream to another
-	 *
-	 * @param resource $source
-	 * @param resource $target
-	 * @return array the number of bytes copied and result
-	 * @deprecated 5.0.0 - Use \OCP\Files::streamCopy
-	 */
-	public static function streamCopy($source, $target) {
-		return \OCP\Files::streamCopy($source, $target, true);
-	}
-
-	/**
 	 * Adds a suffix to the name in case the file exists
 	 *
 	 * @param string $path

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -115,7 +115,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$instance = $this->getLimitedStorage(16);
 		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
 		$outputStream = $instance->fopen('files/foo', 'w+');
-		[$count, $result] = \OC_Helper::streamCopy($inputStream, $outputStream);
+		[$count, $result] = Files::streamCopy($inputStream, $outputStream, true);
 		$this->assertEquals(12, $count);
 		$this->assertTrue($result);
 		fclose($inputStream);
@@ -126,7 +126,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$instance = $this->getLimitedStorage(9);
 		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
 		$outputStream = $instance->fopen('files/foo', 'w+');
-		[$count, $result] = \OC_Helper::streamCopy($inputStream, $outputStream);
+		[$count, $result] = Files::streamCopy($inputStream, $outputStream, true);
 		$this->assertEquals(9, $count);
 		$this->assertFalse($result);
 		fclose($inputStream);

--- a/tests/lib/FilesTest.php
+++ b/tests/lib/FilesTest.php
@@ -39,4 +39,36 @@ class FilesTest extends TestCase {
 		Files::rmdirr($baseDir);
 		$this->assertFalse(file_exists($baseDir));
 	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('streamCopyDataProvider')]
+	public function testStreamCopy($expectedCount, $expectedResult, $source, $target): void {
+		if (is_string($source)) {
+			$source = fopen($source, 'r');
+		}
+		if (is_string($target)) {
+			$target = fopen($target, 'w');
+		}
+
+		[$count, $result] = Files::streamCopy($source, $target, true);
+
+		if (is_resource($source)) {
+			fclose($source);
+		}
+		if (is_resource($target)) {
+			fclose($target);
+		}
+
+		$this->assertSame($expectedCount, $count);
+		$this->assertSame($expectedResult, $result);
+	}
+
+
+	public static function streamCopyDataProvider(): array {
+		return [
+			[0, false, false, false],
+			[0, false, \OC::$SERVERROOT . '/tests/data/lorem.txt', false],
+			[filesize(\OC::$SERVERROOT . '/tests/data/lorem.txt'), true, \OC::$SERVERROOT . '/tests/data/lorem.txt', \OC::$SERVERROOT . '/tests/data/lorem-copy.txt'],
+			[3670, true, \OC::$SERVERROOT . '/tests/data/testimage.png', \OC::$SERVERROOT . '/tests/data/testimage-copy.png'],
+		];
+	}
 }

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -12,18 +12,6 @@ use OC\Files\View;
 use OC_Helper;
 
 class LegacyHelperTest extends \Test\TestCase {
-	/** @var string */
-	private $originalWebRoot;
-
-	protected function setUp(): void {
-		$this->originalWebRoot = \OC::$WEBROOT;
-	}
-
-	protected function tearDown(): void {
-		// Reset webRoot
-		\OC::$WEBROOT = $this->originalWebRoot;
-	}
-
 	public function testBuildNotExistingFileNameForView(): void {
 		$viewMock = $this->createMock(View::class);
 		$this->assertEquals('/filename', OC_Helper::buildNotExistingFileNameForView('/', 'filename', $viewMock));
@@ -114,37 +102,5 @@ class LegacyHelperTest extends \Test\TestCase {
 				['dir/filename(1) (2) (4).ext', false],
 			]);
 		$this->assertEquals('dir/filename(1) (2) (4).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename(1) (2) (3).ext', $viewMock));
-	}
-
-	#[\PHPUnit\Framework\Attributes\DataProvider('streamCopyDataProvider')]
-	public function testStreamCopy($expectedCount, $expectedResult, $source, $target): void {
-		if (is_string($source)) {
-			$source = fopen($source, 'r');
-		}
-		if (is_string($target)) {
-			$target = fopen($target, 'w');
-		}
-
-		[$count, $result] = \OC_Helper::streamCopy($source, $target);
-
-		if (is_resource($source)) {
-			fclose($source);
-		}
-		if (is_resource($target)) {
-			fclose($target);
-		}
-
-		$this->assertSame($expectedCount, $count);
-		$this->assertSame($expectedResult, $result);
-	}
-
-
-	public static function streamCopyDataProvider(): array {
-		return [
-			[0, false, false, false],
-			[0, false, \OC::$SERVERROOT . '/tests/data/lorem.txt', false],
-			[filesize(\OC::$SERVERROOT . '/tests/data/lorem.txt'), true, \OC::$SERVERROOT . '/tests/data/lorem.txt', \OC::$SERVERROOT . '/tests/data/lorem-copy.txt'],
-			[3670, true, \OC::$SERVERROOT . '/tests/data/testimage.png', \OC::$SERVERROOT . '/tests/data/testimage-copy.png'],
-		];
 	}
 }


### PR DESCRIPTION
## Summary

Replace by Files::streamCopy, also deprecated but since less long

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
