### PR TITLE
fix(files): Stop overwriting scan_permissions

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -173,7 +173,7 @@ class Cache implements ICache {
 			$data['storage_mtime'] = $data['mtime'];
 		}
 		if (isset($data['f_permissions'])) {
-			$data['scan_permissions'] = $data['f_permissions'];
+			$data['scan_permissions'] ??= $data['f_permissions'];
 		}
 		$data['permissions'] = (int)$data['permissions'];
 		if (isset($data['creation_time'])) {

--- a/lib/private/Files/Cache/Wrapper/CachePermissionsMask.php
+++ b/lib/private/Files/Cache/Wrapper/CachePermissionsMask.php
@@ -24,7 +24,7 @@ class CachePermissionsMask extends CacheWrapper {
 
 	protected function formatCacheEntry($entry) {
 		if (isset($entry['permissions'])) {
-			$entry['scan_permissions'] = $entry['permissions'];
+			$entry['scan_permissions'] ??= $entry['permissions'];
 			$entry['permissions'] &= $this->mask;
 		}
 		return $entry;

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -114,7 +114,7 @@ class PermissionsMask extends Wrapper {
 		$data = parent::getMetaData($path);
 
 		if ($data && isset($data['permissions'])) {
-			$data['scan_permissions'] = $data['scan_permissions'] ?? $data['permissions'];
+			$data['scan_permissions'] ??= $data['permissions'];
 			$data['permissions'] &= $this->mask;
 		}
 		return $data;
@@ -129,7 +129,7 @@ class PermissionsMask extends Wrapper {
 
 	public function getDirectoryContent(string $directory): \Traversable {
 		foreach ($this->getWrapperStorage()->getDirectoryContent($directory) as $data) {
-			$data['scan_permissions'] = $data['scan_permissions'] ?? $data['permissions'];
+			$data['scan_permissions'] ??= $data['permissions'];
 			$data['permissions'] &= $this->mask;
 
 			yield $data;


### PR DESCRIPTION
Copying a file from a groupfolder with ACL will result in a filecache entry with the ACL permissions still applied.
https://github.com/nextcloud/groupfolders/blob/3dfba93b129d5d0f329378c08bdb8c7b7b98d6d5/lib/ACL/ACLCacheWrapper.php#L47-L48 sets `scan_permissions` first and then applies the ACL permissions to the `permissions`. After that the CachePermissionMasks overwrites the `scan_permissions` with the `permissions` that already include the ACL permissions. tl;dr: Never overwrite the `scan_permissions` if they are already set, as they must be the original permissions.