### PR TITLE
fix(live-photo): Allow files-live-photo meta data with edit permissions

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -693,7 +693,7 @@ class FilesPlugin extends ServerPlugin {
 	private function initFilesMetadataManager(): IFilesMetadataManager {
 		/** @var IFilesMetadataManager $manager */
 		$manager = \OCP\Server::get(IFilesMetadataManager::class);
-		$manager->initMetadata('files-live-photo', IMetadataValueWrapper::TYPE_STRING, false, IMetadataValueWrapper::EDIT_REQ_OWNERSHIP);
+		$manager->initMetadata('files-live-photo', IMetadataValueWrapper::TYPE_STRING, false, IMetadataValueWrapper::EDIT_REQ_WRITE_PERMISSION);
 
 		return $manager;
 	}


### PR DESCRIPTION
### Steps
- Have a folder received as share
- Enable iOS auto upload to that folder
- Disable iOS auto upload
- Enable iOS auto upload again

### Before
- `FilesMetadataException(you do not have enough rights to update 'files-live-photo' on this node)` is thrown and never catched.
- WebDAV responds with 500
- Auto upload is paused for 20 minutes to not DOS the server in case of a temporary error
- result: Uploading 24k items with autoupload takes 8000 hours = 333 days

<details>

```json
{
  "reqId": "OpeHNcIfPRVMBJm5AiuZ",
  "level": 3,
  "time": "2024-12-18T19:15:48+01:00",
  "remoteAddr": "9…",
  "user": "…",
  "app": "webdav",
  "method": "PROPPATCH",
  "url": "/remote.php/dav/files/…/IMG_5573.mov",
  "message": "you do not have enough rights to update 'files-live-photo' on this node",
  "userAgent": "Mozilla/5.0 (iOS) Nextcloud-iOS/6.1.9",
  "version": "30.0.4.1",
  "exception": {
    "Exception": "OCP\\FilesMetadata\\Exceptions\\FilesMetadataException",
    "Message": "you do not have enough rights to update 'files-live-photo' on this node",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/PropPatch.php",
        "line": 254,
        "function": "OCA\\DAV\\Connector\\Sabre\\{closure}",
        "class": "OCA\\DAV\\Connector\\Sabre\\FilesPlugin",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/PropPatch.php",
        "line": 225,
        "function": "doCallBackSingleProp",
        "class": "Sabre\\DAV\\PropPatch",
        "type": "->"
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 1264,
        "function": "commit",
        "class": "Sabre\\DAV\\PropPatch",
        "type": "->"
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 373,
        "function": "updateProperties",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "httpPropPatch",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->"
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 472,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->"
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Server.php",
        "line": 43,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->"
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Server.php",
        "line": 371,
        "function": "start",
        "class": "OCA\\DAV\\Connector\\Sabre\\Server",
        "type": "->"
      },
      {
        "file": "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php",
        "line": 19,
        "function": "exec",
        "class": "OCA\\DAV\\Server",
        "type": "->"
      },
      {
        "file": "/var/www/nextcloud/remote.php",
        "line": 146,
        "args": [
          "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/FilesPlugin.php",
    "Line": 589,
    "message": "you do not have enough rights to update 'files-live-photo' on this node",
    "exception": {},
    "CustomMessage": "you do not have enough rights to update 'files-live-photo' on this node"
  }
}

```

</details>

### After
Write permissions is enough => upload works 207

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
