### PR TITLE
fix(cache): Ensure unique global prefix per instanceid

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -119,7 +119,10 @@ class Factory implements ICacheFactory {
 				$versions = $appConfig->getAppInstalledVersions();
 			}
 			$versions['core'] = implode('.', $this->serverVersion->getVersion());
-			$this->globalPrefix = hash('xxh128', implode(',', $versions));
+
+			// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
+			$instanceid = $config->getValue('instanceid');
+			$this->globalPrefix = hash('xxh128', $instanceid . implode(',', $versions));
 		}
 		return $this->globalPrefix;
 	}
@@ -132,7 +135,10 @@ class Factory implements ICacheFactory {
 	 */
 	public function withServerVersionPrefix(\Closure $closure): void {
 		$backupPrefix = $this->globalPrefix;
-		$this->globalPrefix = hash('xxh128', implode('.', $this->serverVersion->getVersion()));
+
+		// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
+		$instanceid = \OCP\Server::get(SystemConfig::class)->getValue('instanceid');
+		$this->globalPrefix = hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
 		$closure($this);
 		$this->globalPrefix = $backupPrefix;
 	}


### PR DESCRIPTION
## Summary

* Have 2 Nextcloud instances using the same PHP-FPM pool
* Ensure that both instances have the same version / apps
* Try to query capabilities, that are unique to both instance (e.g. talk signaling key)

Before this PR:
It's possible that instance 1 returns the key from instance 2 or vice versa

After this PR:
Key is correctly returned

* Related https://github.com/nextcloud/server/pull/54383/

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
