### PR TITLE
Fix type and other psalm issues in lib/private/Template

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4037,27 +4037,6 @@
       <code><![CDATA[$tag]]></code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="lib/private/Template/CSSResourceLocator.php">
-    <ParamNameMismatch>
-      <code><![CDATA[$style]]></code>
-      <code><![CDATA[$style]]></code>
-    </ParamNameMismatch>
-  </file>
-  <file src="lib/private/Template/JSConfigHelper.php">
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
-  </file>
-  <file src="lib/private/Template/JSResourceLocator.php">
-    <InvalidArgument>
-      <code><![CDATA[false]]></code>
-    </InvalidArgument>
-    <ParamNameMismatch>
-      <code><![CDATA[$script]]></code>
-      <code><![CDATA[$script]]></code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/private/URLGenerator.php">
     <InvalidReturnStatement>
       <code><![CDATA[$path]]></code>

--- a/build/rector.php
+++ b/build/rector.php
@@ -67,6 +67,7 @@ $config = RectorConfig::configure()
 		$nextcloudDir . '/status.php',
 		$nextcloudDir . '/version.php',
 		$nextcloudDir . '/lib/private/Share20/ProviderFactory.php',
+		$nextcloudDir . '/lib/private/Template',
 		$nextcloudDir . '/tests',
 		// $nextcloudDir . '/config',
 		// $nextcloudDir . '/lib',

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -117,7 +117,7 @@ class L10N implements IL10N {
 	/**
 	 * Localization
 	 * @param string $type Type of localization
-	 * @param \DateTime|int|string $data parameters for this localization
+	 * @param \DateTime|int|string|null $data parameters for this localization
 	 * @param array $options
 	 * @return string|int|false
 	 *

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1048,7 +1048,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getAppDataDir('js'),
 				$c->get(IURLGenerator::class),
 				$this->get(ICacheFactory::class),
-				$c->get(SystemConfig::class),
+				$c->get(\OCP\IConfig::class),
 				$c->get(LoggerInterface::class)
 			);
 		});

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -1,39 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Template;
 
 use OCP\Defaults;
+use OCP\IL10N;
 
 class Base {
-	private $template; // The template
 	private array $vars = [];
 
-	/** @var \OCP\IL10N */
-	private $l10n;
-
-	/** @var Defaults */
-	private $theme;
-
-	/**
-	 * @param string $template
-	 * @param string $requestToken
-	 * @param \OCP\IL10N $l10n
-	 * @param string $cspNonce
-	 * @param Defaults $theme
-	 */
-	public function __construct($template, $requestToken, $l10n, $theme, $cspNonce) {
+	public function __construct(
+		private string $template,
+		string $requestToken,
+		private IL10N $l10n,
+		private Defaults $theme,
+		string $cspNonce,
+	) {
 		$this->vars = [
 			'cspNonce' => $cspNonce,
 			'requesttoken' => $requestToken,
 		];
-		$this->l10n = $l10n;
-		$this->template = $template;
-		$this->theme = $theme;
 	}
 
 	/**

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -1,37 +1,48 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Template;
 
+use OCP\App\AppPathNotFoundException;
+use OCP\App\IAppManager;
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 class CSSResourceLocator extends ResourceLocator {
-	public function __construct(LoggerInterface $logger) {
-		parent::__construct($logger);
+	public function __construct(
+		LoggerInterface $logger,
+		IConfig $config,
+		protected IAppManager $appManager,
+	) {
+		parent::__construct($logger, $config);
 	}
 
-	/**
-	 * @param string $style
-	 */
-	public function doFind($style) {
-		$app = substr($style, 0, strpos($style, '/'));
-		if ($this->appendIfExist($this->serverroot, $style . '.css')
-			|| $this->appendIfExist($this->serverroot, 'core/' . $style . '.css')
+	public function doFind(string $resource): void {
+		$parts = explode('/', $resource, 2);
+		if (count($parts) < 2) {
+			return;
+		}
+		[$app,$subpath] = $parts;
+		if ($this->appendIfExist($this->serverroot, $resource . '.css')
+			|| $this->appendIfExist($this->serverroot, 'core/' . $resource . '.css')
 		) {
 			return;
 		}
-		$style = substr($style, strpos($style, '/') + 1);
-		$app_path = \OC_App::getAppPath($app);
-		$app_url = \OC_App::getAppWebPath($app);
-
-		if ($app_path === false && $app_url === false) {
+		try {
+			$app_path = $this->appManager->getAppPath($app);
+			$app_url = $this->appManager->getAppWebPath($app);
+		} catch (AppPathNotFoundException $e) {
 			$this->logger->error('Could not find resource {resource} to load', [
-				'resource' => $app . '/' . $style . '.css',
+				'resource' => $app . '/' . $subpath . '.css',
 				'app' => 'cssresourceloader',
+				'exception' => $e,
 			]);
 			return;
 		}
@@ -41,24 +52,21 @@ class CSSResourceLocator extends ResourceLocator {
 		// turned into cwd.
 		$app_path = realpath($app_path);
 
-		$this->append($app_path, $style . '.css', $app_url);
+		$this->append($app_path, $subpath . '.css', $app_url);
 	}
 
-	/**
-	 * @param string $style
-	 */
-	public function doFindTheme($style) {
+	public function doFindTheme(string $resource): void {
 		$theme_dir = 'themes/' . $this->theme . '/';
-		$this->appendIfExist($this->serverroot, $theme_dir . 'apps/' . $style . '.css')
-			|| $this->appendIfExist($this->serverroot, $theme_dir . $style . '.css')
-			|| $this->appendIfExist($this->serverroot, $theme_dir . 'core/' . $style . '.css');
+		$this->appendIfExist($this->serverroot, $theme_dir . 'apps/' . $resource . '.css')
+			|| $this->appendIfExist($this->serverroot, $theme_dir . $resource . '.css')
+			|| $this->appendIfExist($this->serverroot, $theme_dir . 'core/' . $resource . '.css');
 	}
 
-	public function append($root, $file, $webRoot = null, $throw = true, $scss = false) {
+	public function append(string $root, string $file, ?string $webRoot = null, bool $throw = true, bool $scss = false): void {
 		if (!$scss) {
 			parent::append($root, $file, $webRoot, $throw);
 		} else {
-			if (!$webRoot) {
+			if ($webRoot === null || $webRoot === '') {
 				$webRoot = $this->findWebRoot($root);
 
 				if ($webRoot === null) {

--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\Template;
 
 use OC\SystemConfig;
@@ -17,43 +20,19 @@ use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
 class JSCombiner {
-	/** @var IAppData */
-	protected $appData;
+	protected ICache $depsCache;
 
-	/** @var IURLGenerator */
-	protected $urlGenerator;
-
-	/** @var ICache */
-	protected $depsCache;
-
-	/** @var SystemConfig */
-	protected $config;
-
-	protected LoggerInterface $logger;
-
-	/** @var ICacheFactory */
-	private $cacheFactory;
-
-	public function __construct(IAppData $appData,
-		IURLGenerator $urlGenerator,
-		ICacheFactory $cacheFactory,
-		SystemConfig $config,
-		LoggerInterface $logger) {
-		$this->appData = $appData;
-		$this->urlGenerator = $urlGenerator;
-		$this->cacheFactory = $cacheFactory;
+	public function __construct(
+		protected IAppData $appData,
+		protected IURLGenerator $urlGenerator,
+		protected ICacheFactory $cacheFactory,
+		protected SystemConfig $config,
+		protected LoggerInterface $logger,
+	) {
 		$this->depsCache = $this->cacheFactory->createDistributed('JS-' . md5($this->urlGenerator->getBaseUrl()));
-		$this->config = $config;
-		$this->logger = $logger;
 	}
 
-	/**
-	 * @param string $root
-	 * @param string $file
-	 * @param string $app
-	 * @return bool
-	 */
-	public function process($root, $file, $app) {
+	public function process(string $root, string $file, string $app): bool {
 		if ($this->config->getValue('debug') || !$this->config->getValue('installed')) {
 			return false;
 		}
@@ -76,12 +55,7 @@ class JSCombiner {
 		return $this->cache($path, $fileName, $folder);
 	}
 
-	/**
-	 * @param string $fileName
-	 * @param ISimpleFolder $folder
-	 * @return bool
-	 */
-	protected function isCached($fileName, ISimpleFolder $folder) {
+	protected function isCached(string $fileName, ISimpleFolder $folder): bool {
 		$fileName = str_replace('.json', '.js', $fileName);
 
 		if (!$folder->fileExists($fileName)) {
@@ -126,13 +100,7 @@ class JSCombiner {
 		}
 	}
 
-	/**
-	 * @param string $path
-	 * @param string $fileName
-	 * @param ISimpleFolder $folder
-	 * @return bool
-	 */
-	protected function cache($path, $fileName, ISimpleFolder $folder) {
+	protected function cache(string $path, string $fileName, ISimpleFolder $folder): bool {
 		$deps = [];
 		$fullPath = $path . '/' . $fileName;
 		$data = json_decode(file_get_contents($fullPath));
@@ -183,12 +151,7 @@ class JSCombiner {
 		}
 	}
 
-	/**
-	 * @param string $appName
-	 * @param string $fileName
-	 * @return string
-	 */
-	public function getCachedJS($appName, $fileName) {
+	public function getCachedJS(string $appName, string $fileName): string {
 		$tmpfileLoc = explode('/', $fileName);
 		$fileName = array_pop($tmpfileLoc);
 		$fileName = str_replace('.json', '.js', $fileName);
@@ -197,12 +160,9 @@ class JSCombiner {
 	}
 
 	/**
-	 * @param string $root
-	 * @param string $file
 	 * @return string[]
 	 */
-	public function getContent($root, $file) {
-		/** @var array $data */
+	public function getContent(string $root, string $file): array {
 		$data = json_decode(file_get_contents($root . '/' . $file));
 		if (!is_array($data)) {
 			return [];
@@ -226,7 +186,7 @@ class JSCombiner {
 	 *
 	 * @throws NotFoundException
 	 */
-	public function resetCache() {
+	public function resetCache(): void {
 		$this->cacheFactory->createDistributed('JS-')->clear();
 		$appDirectory = $this->appData->getDirectoryListing();
 		foreach ($appDirectory as $folder) {

--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 
 namespace OC\Template;
 
-use OC\SystemConfig;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
@@ -26,14 +26,14 @@ class JSCombiner {
 		protected IAppData $appData,
 		protected IURLGenerator $urlGenerator,
 		protected ICacheFactory $cacheFactory,
-		protected SystemConfig $config,
+		protected IConfig $config,
 		protected LoggerInterface $logger,
 	) {
 		$this->depsCache = $this->cacheFactory->createDistributed('JS-' . md5($this->urlGenerator->getBaseUrl()));
 	}
 
 	public function process(string $root, string $file, string $app): bool {
-		if ($this->config->getValue('debug') || !$this->config->getValue('installed')) {
+		if ($this->config->getSystemValueBool('debug') || !$this->config->getSystemValueBool('installed')) {
 			return false;
 		}
 

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -141,8 +141,12 @@ class JSConfigHelper {
 
 		$capabilities = $this->capabilitiesManager->getCapabilities(false, true);
 
-		$userFirstDay = $this->config->getUserValue($uid, 'core', AUserDataOCSController::USER_FIELD_FIRST_DAY_OF_WEEK, null);
-		$firstDay = (int)($userFirstDay ?? $this->l->l('firstday', null));
+		$firstDay = $this->config->getUserValue($uid, 'core', AUserDataOCSController::USER_FIELD_FIRST_DAY_OF_WEEK, '');
+		if ($firstDay === '') {
+			$firstDay = (int)$this->l->l('firstday', null);
+		} else {
+			$firstDay = (int)$firstDay;
+		}
 
 		$config = [
 			/** @deprecated 30.0.0 - use files capabilities instead */

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -1,51 +1,53 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Template;
 
 use Psr\Log\LoggerInterface;
 
 abstract class ResourceLocator {
-	protected $theme;
+	protected string $theme;
 
-	protected $mapping;
-	protected $serverroot;
-	protected $webroot;
+	protected array $mapping;
+	protected string $serverroot;
+	protected string $webroot;
 
-	protected $resources = [];
+	protected array $resources = [];
 
-	protected LoggerInterface $logger;
-
-	public function __construct(LoggerInterface $logger) {
-		$this->logger = $logger;
+	public function __construct(
+		protected LoggerInterface $logger,
+		\OCP\IConfig $config,
+	) {
 		$this->mapping = [
 			\OC::$SERVERROOT => \OC::$WEBROOT
 		];
 		$this->serverroot = \OC::$SERVERROOT;
 		$this->webroot = \OC::$WEBROOT;
-		$this->theme = \OC_Util::getTheme();
+
+		$this->theme = $config->getSystemValueString('theme', '');
+
+		if ($this->theme === '') {
+			if (is_dir(\OC::$SERVERROOT . '/themes/default')) {
+				$this->theme = 'default';
+			}
+		}
 	}
 
-	/**
-	 * @param string $resource
-	 */
-	abstract public function doFind($resource);
+	abstract public function doFind(string $resource): void;
 
-	/**
-	 * @param string $resource
-	 */
-	abstract public function doFindTheme($resource);
+	abstract public function doFindTheme(string $resource): void;
 
 	/**
 	 * Finds the resources and adds them to the list
-	 *
-	 * @param array $resources
 	 */
-	public function find($resources) {
+	public function find(array $resources): void {
 		foreach ($resources as $resource) {
 			try {
 				$this->doFind($resource);
@@ -74,8 +76,8 @@ abstract class ResourceLocator {
 	 * @param string|null $webRoot base for path, default map $root to $webRoot
 	 * @return bool True if the resource was found, false otherwise
 	 */
-	protected function appendIfExist($root, $file, $webRoot = null) {
-		if ($root !== false && is_file($root . '/' . $file)) {
+	protected function appendIfExist(string $root, string $file, ?string $webRoot = null): bool {
+		if (is_file($root . '/' . $file)) {
 			$this->append($root, $file, $webRoot, false);
 			return true;
 		}
@@ -95,10 +97,9 @@ abstract class ResourceLocator {
 	 * then /srv/www/apps, /srv/www/apps, /srv/www, ... until we find a
 	 * valid web root
 	 *
-	 * @param string $root
 	 * @return string|null The web root or null on failure
 	 */
-	protected function findWebRoot($root) {
+	protected function findWebRoot(string $root): ?string {
 		$webRoot = null;
 		$tmpRoot = $root;
 
@@ -135,15 +136,8 @@ abstract class ResourceLocator {
 	 * @param bool $throw Throw an exception, when the route does not exist
 	 * @throws ResourceNotFoundException Only thrown when $throw is true and the resource is missing
 	 */
-	protected function append($root, $file, $webRoot = null, $throw = true) {
-		if (!is_string($root)) {
-			if ($throw) {
-				throw new ResourceNotFoundException($file, $webRoot);
-			}
-			return;
-		}
-
-		if (!$webRoot) {
+	protected function append(string $root, string $file, ?string $webRoot = null, bool $throw = true): void {
+		if ($webRoot === null || $webRoot === '') {
 			$webRoot = $this->findWebRoot($root);
 
 			if ($webRoot === null) {
@@ -166,9 +160,8 @@ abstract class ResourceLocator {
 
 	/**
 	 * Returns the list of all resources that should be loaded
-	 * @return array
 	 */
-	public function getResources() {
+	public function getResources(): array {
 		return $this->resources;
 	}
 }

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace OC\Template;
 
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 abstract class ResourceLocator {
@@ -23,7 +24,7 @@ abstract class ResourceLocator {
 
 	public function __construct(
 		protected LoggerInterface $logger,
-		\OCP\IConfig $config,
+		IConfig $config,
 	) {
 		$this->mapping = [
 			\OC::$SERVERROOT => \OC::$WEBROOT

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -18,7 +18,6 @@ abstract class ResourceLocator {
 
 	protected array $mapping;
 	protected string $serverroot;
-	protected string $webroot;
 
 	protected array $resources = [];
 
@@ -30,7 +29,6 @@ abstract class ResourceLocator {
 			\OC::$SERVERROOT => \OC::$WEBROOT
 		];
 		$this->serverroot = \OC::$SERVERROOT;
-		$this->webroot = \OC::$WEBROOT;
 
 		$this->theme = $config->getSystemValueString('theme', '');
 
@@ -53,7 +51,7 @@ abstract class ResourceLocator {
 			try {
 				$this->doFind($resource);
 			} catch (ResourceNotFoundException $e) {
-				$resourceApp = substr($resource, 0, strpos($resource, '/'));
+				[$resourceApp] = explode('/', $resource, 2);
 				$this->logger->debug('Could not find resource file "' . $e->getResourcePath() . '"', ['app' => $resourceApp]);
 			}
 		}
@@ -62,7 +60,7 @@ abstract class ResourceLocator {
 				try {
 					$this->doFindTheme($resource);
 				} catch (ResourceNotFoundException $e) {
-					$resourceApp = substr($resource, 0, strpos($resource, '/'));
+					[$resourceApp] = explode('/', $resource, 2);
 					$this->logger->debug('Could not find resource file in theme "' . $e->getResourcePath() . '"', ['app' => $resourceApp]);
 				}
 			}

--- a/lib/private/Template/ResourceNotFoundException.php
+++ b/lib/private/Template/ResourceNotFoundException.php
@@ -1,30 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Template;
 
 class ResourceNotFoundException extends \LogicException {
-	protected $resource;
-	protected $webPath;
-
-	/**
-	 * @param string $resource
-	 * @param string $webPath
-	 */
-	public function __construct($resource, $webPath) {
+	public function __construct(
+		protected string $resource,
+		protected string $webPath,
+	) {
 		parent::__construct('Resource not found');
-		$this->resource = $resource;
-		$this->webPath = $webPath;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getResourcePath() {
+	public function getResourcePath(): string {
 		return $this->webPath . '/' . $this->resource;
 	}
 }

--- a/lib/private/Template/TemplateManager.php
+++ b/lib/private/Template/TemplateManager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\Template;
 
+use OC\SystemConfig;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -79,7 +80,7 @@ class TemplateManager implements ITemplateManager {
 			$this->eventDispatcher->dispatchTyped($event);
 			print($response->render());
 		} catch (\Throwable $e1) {
-			$logger = \OCP\Server::get(LoggerInterface::class);
+			$logger = Server::get(LoggerInterface::class);
 			$logger->error('Rendering themed error page failed. Falling back to un-themed error page.', [
 				'app' => 'core',
 				'exception' => $e1,
@@ -112,8 +113,8 @@ class TemplateManager implements ITemplateManager {
 		$debug = false;
 		http_response_code($statusCode);
 		try {
-			$debug = (bool)Server::get(\OC\SystemConfig::class)->getValue('debug', false);
-			$serverLogsDocumentation = Server::get(\OC\SystemConfig::class)->getValue('documentation_url.server_logs', '');
+			$debug = (bool)Server::get(SystemConfig::class)->getValue('debug', false);
+			$serverLogsDocumentation = Server::get(SystemConfig::class)->getValue('documentation_url.server_logs', '');
 			$request = Server::get(IRequest::class);
 			$content = $this->getTemplate('', 'exception', 'error', false);
 			$content->assign('errorClass', get_class($exception));

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
@@ -42,8 +43,8 @@ class TemplateLayout {
 	/** @var string[] */
 	private static array $cacheBusterCache = [];
 
-	public static ?CSSResourceLocator $cssLocator = null;
-	public static ?JSResourceLocator $jsLocator = null;
+	public ?CSSResourceLocator $cssLocator = null;
+	public ?JSResourceLocator $jsLocator = null;
 
 	public function __construct(
 		private IConfig $config,
@@ -214,7 +215,7 @@ class TemplateLayout {
 		}
 
 		// Add the js files
-		$jsFiles = self::findJavascriptFiles(Util::getScripts());
+		$jsFiles = $this->findJavascriptFiles(Util::getScripts());
 		$page->assign('jsfiles', []);
 		if ($this->config->getSystemValueBool('installed', false) && $renderAs != TemplateResponse::RENDER_AS_ERROR) {
 			// this is on purpose outside of the if statement below so that the initial state is prefilled (done in the getConfig() call)
@@ -265,12 +266,12 @@ class TemplateLayout {
 			&& !preg_match('/^\/login/', $pathInfo)
 			&& $renderAs !== TemplateResponse::RENDER_AS_ERROR
 		) {
-			$cssFiles = self::findStylesheetFiles(\OC_Util::$styles);
+			$cssFiles = $this->findStylesheetFiles(\OC_Util::$styles);
 		} else {
 			// If we ignore the scss compiler,
 			// we need to load the guest css fallback
 			Util::addStyle('guest');
-			$cssFiles = self::findStylesheetFiles(\OC_Util::$styles);
+			$cssFiles = $this->findStylesheetFiles(\OC_Util::$styles);
 		}
 
 		$page->assign('cssfiles', []);
@@ -365,12 +366,12 @@ class TemplateLayout {
 		return self::$cacheBusterCache[$path];
 	}
 
-	public static function findStylesheetFiles(array $styles): array {
-		if (!self::$cssLocator) {
-			self::$cssLocator = \OCP\Server::get(CSSResourceLocator::class);
+	private function findStylesheetFiles(array $styles): array {
+		if ($this->cssLocator === null) {
+			$this->cssLocator = \OCP\Server::get(CSSResourceLocator::class);
 		}
-		self::$cssLocator->find($styles);
-		return self::$cssLocator->getResources();
+		$this->cssLocator->find($styles);
+		return $this->cssLocator->getResources();
 	}
 
 	public function getAppNamefromPath(string $path): string|false {
@@ -387,12 +388,12 @@ class TemplateLayout {
 		return false;
 	}
 
-	public static function findJavascriptFiles(array $scripts): array {
-		if (!self::$jsLocator) {
-			self::$jsLocator = \OCP\Server::get(JSResourceLocator::class);
+	private function findJavascriptFiles(array $scripts): array {
+		if ($this->jsLocator === null) {
+			$this->jsLocator = \OCP\Server::get(JSResourceLocator::class);
 		}
-		self::$jsLocator->find($scripts);
-		return self::$jsLocator->getResources();
+		$this->jsLocator->find($scripts);
+		return $this->jsLocator->getResources();
 	}
 
 	/**

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -12,7 +12,6 @@ use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Installer;
 use OC\Repair;
 use OC\Repair\Events\RepairErrorEvent;
-use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -246,41 +245,6 @@ class OC_App {
 	 */
 	public static function findAppInDirectories(string $appId, bool $ignoreCache = false) {
 		return Server::get(AppManager::class)->findAppInDirectories($appId, $ignoreCache);
-	}
-
-	/**
-	 * Get the directory for the given app.
-	 * If the app is defined in multiple directories, the first one is taken. (false if not found)
-	 *
-	 * @psalm-taint-specialize
-	 *
-	 * @param string $appId
-	 * @param bool $refreshAppPath should be set to true only during install/upgrade
-	 * @return string|false
-	 * @deprecated 11.0.0 use Server::get(IAppManager)->getAppPath()
-	 */
-	public static function getAppPath(string $appId, bool $refreshAppPath = false) {
-		try {
-			return Server::get(IAppManager::class)->getAppPath($appId, $refreshAppPath);
-		} catch (AppPathNotFoundException) {
-			return false;
-		}
-	}
-
-	/**
-	 * Get the path for the given app on the access
-	 * If the app is defined in multiple directories, the first one is taken. (false if not found)
-	 *
-	 * @param string $appId
-	 * @return string|false
-	 * @deprecated 18.0.0 use Server::get(IAppManager)->getAppWebPath()
-	 */
-	public static function getAppWebPath(string $appId) {
-		try {
-			return Server::get(IAppManager::class)->getAppWebPath($appId);
-		} catch (AppPathNotFoundException) {
-			return false;
-		}
 	}
 
 	/**

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -12,6 +12,7 @@ use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Installer;
 use OC\Repair;
 use OC\Repair\Events\RepairErrorEvent;
+use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -426,7 +427,11 @@ class OC_App {
 					$info['level'] = self::supportedApp;
 				}
 
-				$appPath = self::getAppPath($app);
+				try {
+					$appPath = $appManager->getAppPath($app);
+				} catch (AppPathNotFoundException) {
+					$appPath = false;
+				}
 				if ($appPath !== false) {
 					$appIcon = $appPath . '/img/' . $app . '.svg';
 					if (file_exists($appIcon)) {

--- a/lib/public/IL10N.php
+++ b/lib/public/IL10N.php
@@ -50,7 +50,7 @@ interface IL10N {
 	/**
 	 * Localization
 	 * @param string $type Type of localization
-	 * @param \DateTime|int|string $data parameters for this localization
+	 * @param \DateTime|int|string|null $data parameters for this localization
 	 * @param array $options currently supports following options:
 	 *                       - 'width': handed into \Punic\Calendar::formatDate as second parameter
 	 * @return string|int|false

--- a/tests/lib/Template/CSSResourceLocatorTest.php
+++ b/tests/lib/Template/CSSResourceLocatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -12,30 +14,25 @@ use OC\Files\AppData\AppData;
 use OC\Files\AppData\Factory;
 use OC\Template\CSSResourceLocator;
 use OCA\Theming\ThemingDefaults;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class CSSResourceLocatorTest extends \Test\TestCase {
-	/** @var IAppData|\PHPUnit\Framework\MockObject\MockObject */
-	protected $appData;
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	protected $urlGenerator;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $config;
-	/** @var ThemingDefaults|\PHPUnit\Framework\MockObject\MockObject */
-	protected $themingDefaults;
-	/** @var ICacheFactory|\PHPUnit\Framework\MockObject\MockObject */
-	protected $cacheFactory;
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	protected $logger;
-	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $timeFactory;
-	/** @var AppConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $appConfig;
+	private IAppData&MockObject $appData;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IConfig&MockObject $config;
+	private ThemingDefaults&MockObject $themingDefaults;
+	private ICacheFactory&MockObject $cacheFactory;
+	private LoggerInterface&MockObject $logger;
+	private ITimeFactory&MockObject $timeFactory;
+	private AppConfig&MockObject $appConfig;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -56,6 +53,8 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 		$factory->method('get')->with('css')->willReturn($this->appData);
 		return new CSSResourceLocator(
 			$this->logger,
+			$this->createMock(IConfig::class),
+			Server::get(IAppManager::class),
 			'theme',
 			['core' => 'map'],
 			['3rd' => 'party'],
@@ -74,8 +73,8 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 		return rmdir($directory);
 	}
 
-	private function randomString() {
-		return sha1(uniqid(mt_rand(), true));
+	private function randomString(): string {
+		return sha1(random_bytes(10));
 	}
 
 	public function testFindWithAppPathSymlink(): void {

--- a/tests/lib/Template/JSCombinerTest.php
+++ b/tests/lib/Template/JSCombinerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -7,7 +9,6 @@
 
 namespace Test\Template;
 
-use OC\SystemConfig;
 use OC\Template\JSCombiner;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
@@ -16,33 +17,29 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class JSCombinerTest extends \Test\TestCase {
-	/** @var IAppData|\PHPUnit\Framework\MockObject\MockObject */
-	protected $appData;
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	protected $urlGenerator;
-	/** @var SystemConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $config;
-	/** @var ICache|\PHPUnit\Framework\MockObject\MockObject */
-	protected $depsCache;
-	/** @var JSCombiner */
-	protected $jsCombiner;
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	protected $logger;
-	/** @var ICacheFactory|\PHPUnit\Framework\MockObject\MockObject */
-	protected $cacheFactory;
+	private IAppData&MockObject $appData;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IConfig&MockObject $config;
+	private ICache&MockObject $depsCache;
+	private LoggerInterface&MockObject $logger;
+	private ICacheFactory&MockObject $cacheFactory;
+
+	private JSCombiner $jsCombiner;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->appData = $this->createMock(IAppData::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->config = $this->createMock(SystemConfig::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->depsCache = $this->createMock(ICache::class);
 		$this->cacheFactory->expects($this->atLeastOnce())
@@ -61,7 +58,7 @@ class JSCombinerTest extends \Test\TestCase {
 	public function testProcessDebugMode(): void {
 		$this->config
 			->expects($this->once())
-			->method('getValue')
+			->method('getSystemValueBool')
 			->with('debug')
 			->willReturn(true);
 
@@ -72,7 +69,7 @@ class JSCombinerTest extends \Test\TestCase {
 	public function testProcessNotInstalled(): void {
 		$this->config
 			->expects($this->exactly(2))
-			->method('getValue')
+			->method('getSystemValueBool')
 			->willReturnMap([
 				['debug', false],
 				['installed', false]
@@ -85,10 +82,10 @@ class JSCombinerTest extends \Test\TestCase {
 	public function testProcessUncachedFileNoAppDataFolder(): void {
 		$this->config
 			->expects($this->exactly(2))
-			->method('getValue')
+			->method('getSystemValueBool')
 			->willReturnMap([
-				['debug', '', false],
-				['installed', '', true],
+				['debug', false],
+				['installed', true],
 			]);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('awesomeapp')->willThrowException(new NotFoundException());
@@ -121,10 +118,10 @@ class JSCombinerTest extends \Test\TestCase {
 	public function testProcessUncachedFile(): void {
 		$this->config
 			->expects($this->exactly(2))
-			->method('getValue')
+			->method('getSystemValueBool')
 			->willReturnMap([
-				['debug', '', false],
-				['installed', '', true],
+				['debug', false],
+				['installed', true],
 			]);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('awesomeapp')->willReturn($folder);
@@ -155,10 +152,10 @@ class JSCombinerTest extends \Test\TestCase {
 	public function testProcessCachedFile(): void {
 		$this->config
 			->expects($this->exactly(2))
-			->method('getValue')
+			->method('getSystemValueBool')
 			->willReturnMap([
-				['debug', '', false],
-				['installed', '', true],
+				['debug', false],
+				['installed', true],
 			]);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('awesomeapp')->willReturn($folder);
@@ -192,10 +189,10 @@ class JSCombinerTest extends \Test\TestCase {
 	public function testProcessCachedFileMemcache(): void {
 		$this->config
 			->expects($this->exactly(2))
-			->method('getValue')
+			->method('getSystemValueBool')
 			->willReturnMap([
-				['debug', '', false],
-				['installed', '', true],
+				['debug', false],
+				['installed', true],
 			]);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -7,42 +9,37 @@
 
 namespace Test\Template;
 
-use OC\SystemConfig;
 use OC\Template\JSCombiner;
 use OC\Template\JSResourceLocator;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\Files\IAppData;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class JSResourceLocatorTest extends \Test\TestCase {
-	/** @var IAppData|\PHPUnit\Framework\MockObject\MockObject */
-	protected $appData;
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	protected $urlGenerator;
-	/** @var SystemConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $config;
-	/** @var ICacheFactory|\PHPUnit\Framework\MockObject\MockObject */
-	protected $cacheFactory;
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	protected $logger;
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $appManager;
+	private IAppData&MockObject $appData;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IConfig&MockObject $config;
+	private ICacheFactory&MockObject $cacheFactory;
+	private LoggerInterface&MockObject $logger;
+	private IAppManager&MockObject $appManager;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->appData = $this->createMock(IAppData::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->config = $this->createMock(SystemConfig::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 	}
 
-	private function jsResourceLocator() {
+	private function jsResourceLocator(): JSResourceLocator {
 		$jsCombiner = new JSCombiner(
 			$this->appData,
 			$this->urlGenerator,
@@ -52,6 +49,7 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		);
 		return new JSResourceLocator(
 			$this->logger,
+			$this->config,
 			$jsCombiner,
 			$this->appManager,
 		);
@@ -69,8 +67,8 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		return rmdir($directory);
 	}
 
-	private function randomString() {
-		return sha1(uniqid(mt_rand(), true));
+	private function randomString(): string {
+		return sha1(random_bytes(10));
 	}
 
 	public function testFindWithAppPathSymlink(): void {

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -9,6 +9,7 @@
 namespace Test\Template;
 
 use OC\SystemConfig;
+use OC\Template\ResourceLocator;
 use OC\Template\ResourceNotFoundException;
 use Psr\Log\LoggerInterface;
 
@@ -46,7 +47,7 @@ class ResourceLocatorTest extends \Test\TestCase {
 		$locator->expects($this->once())
 			->method('doFindTheme')
 			->with('foo');
-		/** @var \OC\Template\ResourceLocator $locator */
+		/** @var ResourceLocator $locator */
 		$locator->find(['foo']);
 	}
 
@@ -69,13 +70,13 @@ class ResourceLocatorTest extends \Test\TestCase {
 		$this->logger->expects($this->exactly(2))
 			->method('debug')
 			->with($this->stringContains('map/foo'));
-		/** @var \OC\Template\ResourceLocator $locator */
+		/** @var ResourceLocator $locator */
 		$locator->find(['foo']);
 	}
 
 	public function testAppendIfExist(): void {
 		$locator = $this->getResourceLocator('theme');
-		/** @var \OC\Template\ResourceLocator $locator */
+		/** @var ResourceLocator $locator */
 		$method = new \ReflectionMethod($locator, 'appendIfExist');
 		$method->setAccessible(true);
 

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -8,34 +10,30 @@
 
 namespace Test\Template;
 
-use OC\SystemConfig;
 use OC\Template\ResourceLocator;
 use OC\Template\ResourceNotFoundException;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class ResourceLocatorTest extends \Test\TestCase {
-	/** @var \PHPUnit\Framework\MockObject\MockObject */
-	protected $logger;
+	private LoggerInterface&MockObject $logger;
+	private IConfig&MockObject $config;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->config = $this->createMock(IConfig::class);
 	}
 
-	/**
-	 * @param string $theme
-	 * @return \PHPUnit\Framework\MockObject\MockObject
-	 */
-	public function getResourceLocator($theme) {
-		$systemConfig = $this->createMock(SystemConfig::class);
-		$systemConfig
+	public function getResourceLocator(string $theme): ResourceLocator&MockObject {
+		$this->config
 			->expects($this->any())
-			->method('getValue')
+			->method('getSystemValueString')
 			->with('theme', '')
 			->willReturn($theme);
-		$this->overwriteService(SystemConfig::class, $systemConfig);
-		return $this->getMockForAbstractClass('OC\Template\ResourceLocator',
-			[$this->logger],
+		return $this->getMockForAbstractClass(ResourceLocator::class,
+			[$this->logger, $this->config],
 			'', true, true, true, []);
 	}
 
@@ -47,16 +45,10 @@ class ResourceLocatorTest extends \Test\TestCase {
 		$locator->expects($this->once())
 			->method('doFindTheme')
 			->with('foo');
-		/** @var ResourceLocator $locator */
 		$locator->find(['foo']);
 	}
 
 	public function testFindNotFound(): void {
-		$systemConfig = $this->createMock(SystemConfig::class);
-		$systemConfig->method('getValue')
-			->with('theme', '')
-			->willReturn('theme');
-		$this->overwriteService(SystemConfig::class, $systemConfig);
 		$locator = $this->getResourceLocator('theme',
 			['core' => 'map'], ['3rd' => 'party'], ['foo' => 'bar']);
 		$locator->expects($this->once())
@@ -70,13 +62,11 @@ class ResourceLocatorTest extends \Test\TestCase {
 		$this->logger->expects($this->exactly(2))
 			->method('debug')
 			->with($this->stringContains('map/foo'));
-		/** @var ResourceLocator $locator */
 		$locator->find(['foo']);
 	}
 
 	public function testAppendIfExist(): void {
 		$locator = $this->getResourceLocator('theme');
-		/** @var ResourceLocator $locator */
 		$method = new \ReflectionMethod($locator, 'appendIfExist');
 		$method->setAccessible(true);
 

--- a/tests/lib/TemplateLayoutTest.php
+++ b/tests/lib/TemplateLayoutTest.php
@@ -44,7 +44,13 @@ class TemplateLayoutTest extends \Test\TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataVersionHash')]
-	public function testVersionHash($path, $file, $installed, $debug, $expected): void {
+	public function testVersionHash(
+		string|false $path,
+		string|false $file,
+		bool $installed,
+		bool $debug,
+		string $expected,
+	): void {
 		$this->appManager->expects(self::any())
 			->method('getAppVersion')
 			->willReturnCallback(fn ($appId) => match ($appId) {
@@ -59,8 +65,8 @@ class TemplateLayoutTest extends \Test\TestCase {
 		$this->config->expects(self::atLeastOnce())
 			->method('getSystemValueBool')
 			->willReturnMap([
-				['installed', false, $installed],
-				['debug', false, $debug],
+				['installed', $installed],
+				['debug', $debug],
 			]);
 		$this->config->expects(self::any())
 			->method('getAppValue')


### PR DESCRIPTION
## Summary

Cleanup typing, run rector, fix psalm issues, and move away from deprecated methods in lib/private/Template folder.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
