### PR TITLE
chore: update webhook_listeners description

### DIFF
--- a/apps/webhook_listeners/appinfo/info.xml
+++ b/apps/webhook_listeners/appinfo/info.xml
@@ -3,36 +3,57 @@
   - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
-	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
-	<id>webhook_listeners</id>
-	<name>Nextcloud webhook support</name>
-	<summary>Nextcloud webhook support</summary>
-	<description>Nextcloud webhook support</description>
-	<version>1.4.0</version>
-	<licence>agpl</licence>
-	<author>Côme Chilliet</author>
-	<namespace>WebhookListeners</namespace>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
+    <id>webhook_listeners</id>
+    <name>Nextcloud Webhook Support</name>
 
-	<types>
-		<filesystem/>
-	</types>
+    <summary>Send notifications to external services whenever something important happens, like when files are changed or updated.</summary>
+    <description>
+        <![CDATA[
+        Set up webhooks that automatically notify external services whenever certain events - like file changes - occur 
+        within Nextcloud. By configuring these webhooks, administrators can specify which actions in their Nextcloud instance 
+        should trigger notifications and where those notifications should be sent, enabling seamless integration with other platforms 
+        and automating workflows.
 
-	<category>customization</category>
-	<website>https://github.com/nextcloud/server</website>
-	<bugs>https://github.com/nextcloud/server/issues</bugs>
-	<repository>https://github.com/nextcloud/server.git</repository>
+        The app works by monitoring Nextcloud’s event system and dispatching HTTP requests (webhooks) containing relevant event 
+        data to the specified endpoints whenever a configured event takes place. This approach makes it easy to connect Nextcloud 
+        with external tools, allowing for real-time interactions without needing to manually check for updates or changes.
 
-	<dependencies>
-		<nextcloud min-version="33" max-version="33"/>
-	</dependencies>
+        Administrators can configure webhook listeners via the app's OCS API. The app also provides a command-line tool to list 
+        currently configured webhooks. There are no Web UI settings.
+        ]]>
+    </description>
 
-	<commands>
-		<command>OCA\WebhookListeners\Command\ListWebhooks</command>
-	</commands>
+    <version>1.4.1</version>
+    <licence>agpl</licence>
+    <author>Côme Chilliet</author>
+    <namespace>WebhookListeners</namespace>
+    <types>
+        <filesystem/>
+    </types>
 
-	<settings>
-		<admin-delegation>OCA\WebhookListeners\Settings\Admin</admin-delegation>
-		<admin-delegation-section>OCA\WebhookListeners\Settings\AdminSection</admin-delegation-section>
-	</settings>
+    <documentation>
+        <admin>https://docs.nextcloud.com/server/latest/admin_manual/webhook_listeners/index.html</admin>
+        <developer>https://docs.nextcloud.com/server/latest/developer_manual/_static/openapi.html#/operations/webhook_listeners-webhooks-index</developer>
+    </documentation>
+
+    <category>customization</category>
+
+    <website>https://github.com/nextcloud/server</website>
+    <bugs>https://github.com/nextcloud/server/issues</bugs>
+    <repository>https://github.com/nextcloud/server.git</repository>
+
+    <dependencies>
+        <nextcloud min-version="33" max-version="33"/>
+    </dependencies>
+
+    <commands>
+        <command>OCA\WebhookListeners\Command\ListWebhooks</command>
+    </commands>
+
+    <settings>
+        <admin-delegation>OCA\WebhookListeners\Settings\Admin</admin-delegation>
+        <admin-delegation-section>OCA\WebhookListeners\Settings\AdminSection</admin-delegation-section>
+    </settings>
 </info>

--- a/apps/webhook_listeners/openapi.json
+++ b/apps/webhook_listeners/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "webhook_listeners",
         "version": "0.0.1",
-        "description": "Nextcloud webhook support",
+        "description": "Send notifications to external services whenever something important happens, like when files are changed or updated.",
         "license": {
             "name": "agpl"
         }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves/supercededes: #51214 (from @pReya)

## Summary

- Revised the summary
- Expanded the description 
- Added developer doc link
- Updated OpenAPI spec
- Fixed conflicts to prepare for merger

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
