### PR TITLE
fix(appstore): Make appstore timeout configurable

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -67,7 +67,7 @@ abstract class Fetcher {
 		}
 
 		$options = [
-			'timeout' => 60,
+			'timeout' => (int)$this->config->getAppValue('settings', 'appstore-timeout', '120')
 		];
 
 		if ($ETag !== '') {

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -2133,7 +2133,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 			->expects($this->once())
 			->method('get')
 			->with('https://apps.nextcloud.com/api/v1/apps.json', [
-				'timeout' => 60,
+				'timeout' => 120,
 				'headers' => [
 					'X-NC-Subscription-Key' => 'subscription-key',
 				],
@@ -2191,6 +2191,12 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 			->method('getSystemValueBool')
 			->willReturnArgument(1);
 
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['settings', 'appstore-fetcher-lastFailure', '0', '0'],
+				['settings', 'appstore-timeout', '120', '120'],
+			]);
+
 		$file = $this->createMock(ISimpleFile::class);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$folder
@@ -2218,7 +2224,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 			->expects($this->once())
 			->method('get')
 			->with('https://custom.appsstore.endpoint/api/v1/apps.json', [
-				'timeout' => 60,
+				'timeout' => 120,
 			])
 			->willReturn($response);
 		$response

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -443,6 +443,12 @@ abstract class FetcherBase extends TestCase {
 		$this->config->method('getSystemValueBool')
 			->willReturnArgument(1);
 
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['settings', 'appstore-fetcher-lastFailure', '0', '0'],
+				['settings', 'appstore-timeout', '120', '120'],
+			]);
+
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
 		$this->appData
@@ -488,7 +494,7 @@ abstract class FetcherBase extends TestCase {
 			->with(
 				$this->equalTo($this->endpoint),
 				$this->equalTo([
-					'timeout' => 60,
+					'timeout' => 120,
 					'headers' => [
 						'If-None-Match' => '"myETag"'
 					]
@@ -521,6 +527,12 @@ abstract class FetcherBase extends TestCase {
 			});
 		$this->config->method('getSystemValueBool')
 			->willReturnArgument(1);
+
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['settings', 'appstore-fetcher-lastFailure', '0', '0'],
+				['settings', 'appstore-timeout', '120', '120'],
+			]);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -565,7 +577,7 @@ abstract class FetcherBase extends TestCase {
 			->with(
 				$this->equalTo($this->endpoint),
 				$this->equalTo([
-					'timeout' => 60,
+					'timeout' => 120,
 					'headers' => [
 						'If-None-Match' => '"myETag"',
 					]
@@ -607,6 +619,12 @@ abstract class FetcherBase extends TestCase {
 		$this->config->method('getSystemValueBool')
 			->willReturnArgument(1);
 
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['settings', 'appstore-fetcher-lastFailure', '0', '0'],
+				['settings', 'appstore-timeout', '120', '120'],
+			]);
+
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
 		$this->appData
@@ -643,7 +661,7 @@ abstract class FetcherBase extends TestCase {
 			->with(
 				$this->equalTo($this->endpoint),
 				$this->equalTo([
-					'timeout' => 60,
+					'timeout' => 120,
 				])
 			)
 			->willReturn($response);


### PR DESCRIPTION
* Resolves: #40082

## Summary

Make the appstore timeout configurable and increase default to 120s.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
