### PR TITLE
fix(appstore): Also catch ClientException and ServerException

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -6,7 +6,9 @@
  */
 namespace OC\App\AppStore\Fetcher;
 
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ServerException;
 use OC\Files\AppData\Factory;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -88,7 +90,7 @@ abstract class Fetcher {
 		$client = $this->clientService->newClient();
 		try {
 			$response = $client->get($this->getEndpoint(), $options);
-		} catch (ConnectException $e) {
+		} catch (ConnectException|ClientException|ServerException $e) {
 			$this->config->setAppValue('settings', 'appstore-fetcher-lastFailure', (string)time());
 			$this->logger->error('Failed to connect to the app store', ['exception' => $e]);
 			return [];


### PR DESCRIPTION
## Summary

We currently only catch connection errors, so in case of a client or server error (e.g. 429 for client error), it is not recognized as an error and we retry nearly instantly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
