### PR TITLE
Implement manual prefix setting for configuration ldap

### DIFF
--- a/apps/user_ldap/lib/Command/CreateEmptyConfig.php
+++ b/apps/user_ldap/lib/Command/CreateEmptyConfig.php
@@ -51,8 +51,8 @@ class CreateEmptyConfig extends Command {
 				$output->writeln('The prefix may only contain alphanumeric characters, dashes and underscores');
 				return self::FAILURE;
 			}
-			$availableConfigs = $this->helper->getServerConfigurationPrefixes();
-			if (in_array($configPrefix, $availableConfigs)) {
+			$configPrefix = $this->helper->registerNewServerConfigurationPrefix($configPrefix);
+			if ($configPrefix === false) {
 				$output->writeln('The prefix is already in use');
 				return self::FAILURE;
 			}

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -105,15 +105,33 @@ class Helper {
 	public function getNextServerConfigurationPrefix(): string {
 		$prefixes = $this->getServerConfigurationPrefixes();
 
-		if (count($prefixes) === 0) {
+		$filteredPrefixes = array_filter($prefixes, fn($p) => preg_match('/^s\d{2}$/', $p));
+
+		if (count($filteredPrefixes) === 0) {
 			$prefix = 's01';
 		} else {
-			sort($prefixes);
-			$lastKey = array_pop($prefixes);
+			sort($filteredPrefixes);
+			$lastKey = array_pop($filteredPrefixes);
 			$lastNumber = (int)str_replace('s', '', $lastKey);
 			$prefix = 's' . str_pad((string)($lastNumber + 1), 2, '0', STR_PAD_LEFT);
 		}
 
+		$prefixes[] = $prefix;
+		$this->appConfig->setValueArray('user_ldap', 'configuration_prefixes', $prefixes);
+		return $prefix;
+	}
+
+	/**
+	 * registers the given prefix as used, if it is not already in use
+	 *
+	 * @param string $prefix the prefix to register
+	 * @return string|false the given prefix on success, false if it is already in use
+	 */
+	public function registerNewServerConfigurationPrefix(string $prefix): string|false {
+		$prefixes = $this->getServerConfigurationPrefixes();
+		if (in_array($prefix, $prefixes)) {
+			return false;
+		}
 		$prefixes[] = $prefix;
 		$this->appConfig->setValueArray('user_ldap', 'configuration_prefixes', $prefixes);
 		return $prefix;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Needed for: https://github.com/nextcloud/all-in-one/pull/6909

## Summary

This allows you to manually define an LDAP configuration prefix. This is useful for scripts.

The scripts know the prefix and can manage their configuration without interacting with other configurations. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
