### PR TITLE
test: mock appstore response in Cypress tests

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -178,7 +178,7 @@ SPDX-FileCopyrightText = "2020 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
-path = ["cypress/tsconfig.json", "dist/icons.css"]
+path = ["cypress/tsconfig.json", "cypress/fixtures/appstore/apps.json", "dist/icons.css"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"

--- a/cypress/e2e/core/setup.ts
+++ b/cypress/e2e/core/setup.ts
@@ -113,6 +113,9 @@ describe('Can install Nextcloud', { testIsolation: true, retries: 0 }, () => {
 function sharedSetup() {
 	const randAdmin = 'admin-' + Math.random().toString(36).substring(2, 15)
 
+	// mock appstore
+	cy.intercept('**/settings/apps/list', { fixture: 'appstore/apps.json' })
+
 	// Fill in the form
 	cy.get('[data-cy-setup-form-field="adminlogin"]').type(randAdmin)
 	cy.get('[data-cy-setup-form-field="adminpass"]').type(randAdmin)

--- a/cypress/fixtures/appstore/apps.json
+++ b/cypress/fixtures/appstore/apps.json
@@ -1,0 +1,46 @@
+{
+	"apps": [
+		{
+			"id": "calendar",
+			"name": "Calendar",
+			"isCompatible": true,
+			"canInstall": true
+		},
+		{
+			"id": "contacts",
+			"name": "Contacts",
+			"isCompatible": true,
+			"canInstall": true
+		},
+		{
+			"id": "mail",
+			"name": "Mail",
+			"isCompatible": true,
+			"canInstall": true
+		},
+		{
+			"id": "spreed",
+			"name": "Talk",
+			"isCompatible": true,
+			"canInstall": true
+		},
+		{
+			"id": "richdocuments",
+			"name": "Richdocuments",
+			"isCompatible": true,
+			"canInstall": true
+		},
+		{
+			"id": "notes",
+			"name": "Notes",
+			"isCompatible": true,
+			"canInstall": true
+		},
+		{
+			"id": "richdocumentscode",
+			"name": "Richdocuments Code",
+			"isCompatible": true,
+			"canInstall": true
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Mock the appstore response, so we do not need to contact the real app store.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
