### PR TITLE
enh(search): Proper incremental pagination

### DIFF
--- a/core/AppInfo/ConfigLexicon.php
+++ b/core/AppInfo/ConfigLexicon.php
@@ -34,6 +34,7 @@ class ConfigLexicon implements ILexicon {
 	public const USER_TIMEZONE = 'timezone';
 
 	public const UNIFIED_SEARCH_MIN_SEARCH_LENGTH = 'unified_search_min_search_length';
+	public const UNIFIED_SEARCH_MAX_RESULTS_PER_REQUEST = 'unified_search_max_results_per_request';
 
 	public const LASTCRON_TIMESTAMP = 'lastcron';
 
@@ -93,6 +94,7 @@ class ConfigLexicon implements ILexicon {
 			new Entry(self::OCM_DISCOVERY_ENABLED, ValueType::BOOL, true, 'enable/disable OCM', lazy: true),
 			new Entry(self::OCM_INVITE_ACCEPT_DIALOG, ValueType::STRING, '', 'route to local invite accept dialog', lazy: true, note: 'set as empty string to disable feature'),
 			new Entry(self::UNIFIED_SEARCH_MIN_SEARCH_LENGTH, ValueType::INT, 1, 'Minimum search length to trigger the request', lazy: false, rename: 'unified-search.min-search-length'),
+			new Entry(self::UNIFIED_SEARCH_MAX_RESULTS_PER_REQUEST, ValueType::INT, 25, 'Maximum results returned per search request', lazy: false, rename: 'unified-search.max-results-per-request'),
 		];
 	}
 

--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -78,6 +78,7 @@ class UnifiedSearchController extends OCSController {
 	 * @param int|null $sortOrder Order of entries
 	 * @param int|null $limit Maximum amount of entries (capped by configurable unified-search.max-results-per-request, default: 25)
 	 * @param int|string|null $cursor Offset for searching
+	 * @param int|null $offset Skip this many results
 	 * @param string $from The current user URL
 	 *
 	 * @return DataResponse<Http::STATUS_OK, CoreUnifiedSearchResult, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, string, array{}>
@@ -95,6 +96,7 @@ class UnifiedSearchController extends OCSController {
 		?int $sortOrder = null,
 		?int $limit = null,
 		$cursor = null,
+		?int $offset = null,
 		string $from = '',
 	): DataResponse {
 		[$route, $routeParameters] = $this->getRouteInformation($from);
@@ -123,7 +125,8 @@ class UnifiedSearchController extends OCSController {
 					$limit,
 					$cursor,
 					$route,
-					$routeParameters
+					$routeParameters,
+					$offset
 				)
 			)->jsonSerialize()
 		);

--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -72,7 +72,7 @@ class UnifiedSearchController extends OCSController {
 	 * @param string $providerId ID of the provider
 	 * @param string $term Term to search
 	 * @param int|null $sortOrder Order of entries
-	 * @param int|null $limit Maximum amount of entries, limited to 25
+	 * @param int|null $limit Maximum amount of entries
 	 * @param int|string|null $cursor Offset for searching
 	 * @param string $from The current user URL
 	 *
@@ -96,7 +96,7 @@ class UnifiedSearchController extends OCSController {
 		[$route, $routeParameters] = $this->getRouteInformation($from);
 
 		$limit ??= SearchQuery::LIMIT_DEFAULT;
-		$limit = max(1, min($limit, 25));
+		$limit = max(1, $limit);
 
 		try {
 			$filters = $this->composer->buildFilterList($providerId, $this->request->getParams());

--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace OC\Core\Controller;
 
 use InvalidArgumentException;
+use OC\Core\AppInfo\Application;
+use OC\Core\AppInfo\ConfigLexicon;
 use OC\Core\ResponseDefinitions;
 use OC\Search\SearchComposer;
 use OC\Search\SearchQuery;
@@ -19,6 +21,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -39,6 +42,7 @@ class UnifiedSearchController extends OCSController {
 		private IRouter $router,
 		private IURLGenerator $urlGenerator,
 		private IL10N $l10n,
+		private IAppConfig $appConfig,
 	) {
 		parent::__construct('core', $request);
 	}
@@ -72,7 +76,7 @@ class UnifiedSearchController extends OCSController {
 	 * @param string $providerId ID of the provider
 	 * @param string $term Term to search
 	 * @param int|null $sortOrder Order of entries
-	 * @param int|null $limit Maximum amount of entries
+	 * @param int|null $limit Maximum amount of entries (capped by configurable unified-search.max-results-per-request, default: 25)
 	 * @param int|string|null $cursor Offset for searching
 	 * @param string $from The current user URL
 	 *
@@ -96,7 +100,8 @@ class UnifiedSearchController extends OCSController {
 		[$route, $routeParameters] = $this->getRouteInformation($from);
 
 		$limit ??= SearchQuery::LIMIT_DEFAULT;
-		$limit = max(1, $limit);
+		$maxLimit = $this->appConfig->getValueInt(Application::APP_ID, ConfigLexicon::UNIFIED_SEARCH_MAX_RESULTS_PER_REQUEST);
+		$limit = max(1, min($limit, $maxLimit));
 
 		try {
 			$filters = $this->composer->buildFilterList($providerId, $this->request->getParams());

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -8511,7 +8511,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries, limited to 25",
+                        "description": "Maximum amount of entries",
                         "schema": {
                             "type": "integer",
                             "format": "int64",

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -8511,7 +8511,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries",
+                        "description": "Maximum amount of entries (capped by configurable unified-search.max-results-per-request, default: 25)",
                         "schema": {
                             "type": "integer",
                             "format": "int64",

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -8511,7 +8511,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries, limited to 25",
+                        "description": "Maximum amount of entries",
                         "schema": {
                             "type": "integer",
                             "format": "int64",

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -8511,7 +8511,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries",
+                        "description": "Maximum amount of entries (capped by configurable unified-search.max-results-per-request, default: 25)",
                         "schema": {
                             "type": "integer",
                             "format": "int64",

--- a/core/src/services/UnifiedSearchService.js
+++ b/core/src/services/UnifiedSearchService.js
@@ -49,9 +49,10 @@ export async function getProviders() {
  * @param {string} options.limit the search
  * @param {string} options.person the search
  * @param {object} options.extraQueries additional queries to filter search results
+ * @param options.offset
  * @return {object} {request: Promise, cancel: Promise}
  */
-export function search({ type, query, cursor, since, until, limit, person, extraQueries = {} }) {
+export function search({ type, query, cursor, since, until, limit, person, offset, extraQueries = {} }) {
 	/**
 	 * Generate an axios cancel token
 	 */
@@ -66,6 +67,7 @@ export function search({ type, query, cursor, since, until, limit, person, extra
 			until,
 			limit,
 			person,
+			offset,
 			// Sending which location we're currently at
 			from: window.location.pathname.replace('/index.php', '') + window.location.search,
 			...extraQueries,

--- a/lib/private/Search/SearchQuery.php
+++ b/lib/private/Search/SearchQuery.php
@@ -26,6 +26,7 @@ class SearchQuery implements ISearchQuery {
 		private int|string|null $cursor = null,
 		private string $route = '',
 		private array $routeParameters = [],
+		private ?int $offset = null,
 	) {
 	}
 
@@ -53,6 +54,21 @@ class SearchQuery implements ISearchQuery {
 
 	public function getCursor(): int|string|null {
 		return $this->cursor;
+	}
+
+	public function getOffset(): ?int {
+		return $this->offset;
+	}
+
+	public function getEffectiveOffset(): int {
+		// Prefer explicit offset, fall back to cursor if numeric, otherwise 0
+		if ($this->offset !== null) {
+			return $this->offset;
+		}
+		if (is_numeric($this->cursor)) {
+			return (int)$this->cursor;
+		}
+		return 0;
 	}
 
 	public function getRoute(): string {

--- a/lib/public/Search/ISearchQuery.php
+++ b/lib/public/Search/ISearchQuery.php
@@ -73,6 +73,23 @@ interface ISearchQuery {
 	public function getCursor();
 
 	/**
+	 * Get the offset for pagination (number of results to skip)
+	 *
+	 * @return int|null
+	 * @since 33.0.0
+	 */
+	public function getOffset(): ?int;
+
+	/**
+	 * Get the effective offset for pagination (offset or cursor as fallback)
+	 * This method helps with backward compatibility for providers that use cursor as offset
+	 *
+	 * @return int
+	 * @since 33.0.0
+	 */
+	public function getEffectiveOffset(): int;
+
+	/**
 	 * @return string
 	 * @since 20.0.0
 	 */

--- a/openapi.json
+++ b/openapi.json
@@ -12020,7 +12020,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries, limited to 25",
+                        "description": "Maximum amount of entries",
                         "schema": {
                             "type": "integer",
                             "format": "int64",

--- a/openapi.json
+++ b/openapi.json
@@ -12020,7 +12020,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries",
+                        "description": "Maximum amount of entries (capped by configurable unified-search.max-results-per-request, default: 25)",
                         "schema": {
                             "type": "integer",
                             "format": "int64",


### PR DESCRIPTION
We implemented a max entries per result config that ultimately hides possible search results after 25 (default)  or configured maximum.

This fix implements getting new entries starting from an offset with the allowed

Related: https://github.com/nextcloud/server/pull/55434
