### PR TITLE
fix(OCM): align parameter naming with spec and extend OCMProvider

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -236,7 +236,7 @@ class RequestHandlerController extends Controller {
 	 *
 	 * @param string $recipientProvider The address of the recipent's provider
 	 * @param string $token The token used for the invitation
-	 * @param string $userId The userId of the recipient at the recipient's provider
+	 * @param string $userID The userID of the recipient at the recipient's provider
 	 * @param string $email The email address of the recipient
 	 * @param string $name The display name of the recipient
 	 *
@@ -251,8 +251,8 @@ class RequestHandlerController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'inviteAccepted')]
-	public function inviteAccepted(string $recipientProvider, string $token, string $userId, string $email, string $name): JSONResponse {
-		$this->logger->debug('Processing share invitation for ' . $userId . ' with token ' . $token . ' and email ' . $email . ' and name ' . $name);
+	public function inviteAccepted(string $recipientProvider, string $token, string $userID, string $email, string $name): JSONResponse {
+		$this->logger->debug('Processing share invitation for ' . $userID . ' with token ' . $token . ' and email ' . $email . ' and name ' . $name);
 
 		$updated = $this->timeFactory->getTime();
 
@@ -309,7 +309,7 @@ class RequestHandlerController extends Controller {
 		$invitation->setRecipientEmail($email);
 		$invitation->setRecipientName($name);
 		$invitation->setRecipientProvider($recipientProvider);
-		$invitation->setRecipientUserId($userId);
+		$invitation->setRecipientUserId($userID);
 		$invitation->setAcceptedAt($updated);
 		$invitation = $this->federatedInviteMapper->update($invitation);
 

--- a/apps/cloud_federation_api/openapi.json
+++ b/apps/cloud_federation_api/openapi.json
@@ -354,7 +354,7 @@
                                 "required": [
                                     "recipientProvider",
                                     "token",
-                                    "userId",
+                                    "userID",
                                     "email",
                                     "name"
                                 ],
@@ -367,9 +367,9 @@
                                         "type": "string",
                                         "description": "The token used for the invitation"
                                     },
-                                    "userId": {
+                                    "userID": {
                                         "type": "string",
-                                        "description": "The userId of the recipient at the recipient's provider"
+                                        "description": "The userID of the recipient at the recipient's provider"
                                     },
                                     "email": {
                                         "type": "string",

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -269,6 +269,7 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 			'version' => $this->getApiVersion(), // informative but real version
 			'endPoint' => $this->getEndPoint(),
 			'publicKey' => $this->getSignatory()?->jsonSerialize(),
+			'provider' => $this->getProvider(),
 			'resourceTypes' => $resourceTypes
 		];
 

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -227,6 +227,7 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 		}
 		$this->setResourceTypes($resources);
 		$this->setInviteAcceptDialog($data['inviteAcceptDialog'] ?? '');
+		$this->setCapabilities($data['capabilities'] ?? []);
 
 		if (isset($data['publicKey'])) {
 			// import details about the remote request signing public key, if available

--- a/openapi.json
+++ b/openapi.json
@@ -15985,7 +15985,7 @@
                                 "required": [
                                     "recipientProvider",
                                     "token",
-                                    "userId",
+                                    "userID",
                                     "email",
                                     "name"
                                 ],
@@ -15998,9 +15998,9 @@
                                         "type": "string",
                                         "description": "The token used for the invitation"
                                     },
-                                    "userId": {
+                                    "userID": {
                                         "type": "string",
-                                        "description": "The userId of the recipient at the recipient's provider"
+                                        "description": "The userID of the recipient at the recipient's provider"
                                     },
                                     "email": {
                                         "type": "string",


### PR DESCRIPTION
This PR updates the **cloud_federation_api** and OCM provider model:

- Rename `userId` → `userID` in `inviteAccepted` (controller, logs, mapper, OpenAPI).
- Extend `OCMProvider`:
  - Import `capabilities` from discovery data.
  - Include `provider` in `jsonSerialize()` output.

**Fixes**
- Spec compliant clients send `userID` (not `userId`).
- Discovery consumers now receive `provider` and `capabilities`.