### PR TITLE
fix(CalDAV): imip set language per user

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -167,7 +167,7 @@ class IMipPlugin extends SabreIMipPlugin {
 			$iTipMessage->scheduleStatus = '1.0;We got the message, but it\'s not significant enough to warrant an email';
 			return;
 		}
-		$this->imipService->setL10n($attendee);
+		$this->imipService->setL10nFromAttendee($attendee);
 
 		// Build the sender name.
 		// Due to a bug in sabre, the senderName property for an iTIP message can actually also be a VObject Property

--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\IUserManager;
 use OCP\L10N\IFactory as L10NFactory;
 use OCP\Mail\IEMailTemplate;
 use OCP\Security\ISecureRandom;
@@ -44,6 +45,7 @@ class IMipService {
 		private ISecureRandom $random,
 		private L10NFactory $l10nFactory,
 		private ITimeFactory $timeFactory,
+		private readonly IUserManager $userManager,
 	) {
 		$language = $this->l10nFactory->findGenericLanguage();
 		$locale = $this->l10nFactory->findLocale($language);
@@ -870,18 +872,35 @@ class IMipService {
 	}
 
 	/**
-	 * @param Property|null $attendee
+	 * @param Property $attendee
 	 */
-	public function setL10n(?Property $attendee = null) {
-		if ($attendee === null) {
-			return;
+	public function setL10nFromAttendee(Property $attendee) {
+		$language = null;
+		$locale = null;
+		// check if the attendee is a system user
+		$userAddress = $attendee->getValue();
+		if (str_starts_with($userAddress, 'mailto:')) {
+			$userAddress = substr($userAddress, 7);
 		}
-
-		$lang = $attendee->offsetGet('LANGUAGE');
-		if ($lang instanceof Parameter) {
-			$lang = $lang->getValue();
-			$this->l10n = $this->l10nFactory->get('dav', $lang);
+		$users = $this->userManager->getByEmail($userAddress);
+		if ($users !== []) {
+			$user = array_shift($users);
+			$language = $this->config->getUserValue($user->getUID(), 'core', 'lang', null);
+			$locale = $this->config->getUserValue($user->getUID(), 'core', 'locale', null);
 		}
+		// fallback to attendee LANGUAGE parameter if language not set
+		if ($language === null && isset($attendee['LANGUAGE']) && $attendee['LANGUAGE'] instanceof Parameter) {
+			$language = $attendee['LANGUAGE']->getValue();
+		}
+		// fallback to system language if language not set
+		if ($language === null) {
+			$language = $this->l10nFactory->findGenericLanguage();
+		}
+		// fallback to system locale if locale not set
+		if ($locale === null) {
+			$locale = $this->l10nFactory->findLocale($language);
+		}
+		$this->l10n = $this->l10nFactory->get('dav', $language, $locale);
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginCharsetTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginCharsetTest.php
@@ -20,6 +20,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
@@ -55,6 +56,7 @@ class IMipPluginCharsetTest extends TestCase {
 	private IUrlGenerator&MockObject $urlGenerator;
 	private IUserSession&MockObject $userSession;
 	private LoggerInterface $logger;
+	private IUserManager&MockObject $userManager;
 
 	// Services
 	private EventComparisonService $eventComparisonService;
@@ -86,6 +88,8 @@ class IMipPluginCharsetTest extends TestCase {
 			->willReturn('en_US');
 		$this->l10nFactory->method('get')
 			->willReturn($l10n);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userManager->method('getByEmail')->willReturn([]);
 		$this->imipService = new IMipService(
 			$this->urlGenerator,
 			$this->config,
@@ -93,6 +97,7 @@ class IMipPluginCharsetTest extends TestCase {
 			$this->random,
 			$this->l10nFactory,
 			$this->timeFactory,
+			$this->userManager
 		);
 
 		// EventComparisonService

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -32,6 +33,7 @@ class IMipServiceTest extends TestCase {
 	private IL10N&MockObject $l10n;
 	private ITimeFactory&MockObject $timeFactory;
 	private IMipService $service;
+	private IUserManager&MockObject $userManager;
 
 
 	private VCalendar $vCalendar1a;
@@ -51,6 +53,7 @@ class IMipServiceTest extends TestCase {
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->l10nFactory->expects(self::once())
 			->method('findGenericLanguage')
 			->willReturn('en');
@@ -64,7 +67,8 @@ class IMipServiceTest extends TestCase {
 			$this->db,
 			$this->random,
 			$this->l10nFactory,
-			$this->timeFactory
+			$this->timeFactory,
+			$this->userManager
 		);
 
 		// construct calendar with a 1 hour event and same start/end time zones


### PR DESCRIPTION
## Summary
- Added logic to set the imip email language on a per attendee basis

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
