### PR TITLE
fix(user_ldap): Fix configuration creation and copy

### DIFF
--- a/apps/user_ldap/ajax/getNewServerConfigPrefix.php
+++ b/apps/user_ldap/ajax/getNewServerConfigPrefix.php
@@ -15,11 +15,7 @@ use OCP\Server;
 \OC_JSON::callCheck();
 
 $helper = Server::get(Helper::class);
-$serverConnections = $helper->getServerConfigurationPrefixes();
-sort($serverConnections);
-$lk = array_pop($serverConnections);
-$ln = (int)str_replace('s', '', $lk);
-$nk = 's' . str_pad((string)($ln + 1), 2, '0', STR_PAD_LEFT);
+$nk = $helper->getNextServerConfigurationPrefix();
 
 $resultData = ['configPrefix' => $nk];
 


### PR DESCRIPTION
Follow-up of #52916

## Summary

The endpoint was not correctly registering the new prefix.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
