### PR TITLE
fix(l10n): do not consider user language when getting the generic one

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -228,27 +228,7 @@ class Factory implements IFactory {
 			return $defaultLanguage;
 		}
 
-		// Step 3.1: Check if Nextcloud is already installed before we try to access user info
-		if (!$this->config->getSystemValueBool('installed', false)) {
-			return 'en';
-		}
-		// Step 3.2: Check the current user (if any) for their preferred language
-		$user = $this->userSession->getUser();
-		if ($user !== null) {
-			$userLang = $this->config->getUserValue($user->getUID(), 'core', 'lang', null);
-			if ($userLang !== null) {
-				return $userLang;
-			}
-		}
-
-		// Step 4: Check the request headers
-		try {
-			return $this->getLanguageFromRequest($appId);
-		} catch (LanguageNotFoundException $e) {
-			// Ignore and continue
-		}
-
-		// Step 5: fall back to English
+		// Step 3: fall back to English
 		return 'en';
 	}
 

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -551,8 +551,24 @@ class FactoryTest extends TestCase {
 		self::assertSame($expected, $lang);
 	}
 
+	public function testFindGenericLanguageByRequestParam(): void {
+		$factory = $this->getFactory();
+		$this->request->expects(self::once())
+			->method('getParam')
+			->with('forceLanguage')
+			->willReturn('cz');
+
+		$lang = $factory->findGenericLanguage();
+
+		self::assertSame('cz', $lang);
+	}
+
 	public function testFindGenericLanguageByEnforcedLanguage(): void {
 		$factory = $this->getFactory();
+		$this->request->expects(self::once())
+			->method('getParam')
+			->with('forceLanguage')
+			->willReturn(null);
 		$this->config->expects(self::once())
 			->method('getSystemValue')
 			->with('force_language', false)
@@ -565,6 +581,10 @@ class FactoryTest extends TestCase {
 
 	public function testFindGenericLanguageByDefaultLanguage(): void {
 		$factory = $this->getFactory(['languageExists']);
+		$this->request->expects(self::once())
+			->method('getParam')
+			->with('forceLanguage')
+			->willReturn(null);
 		$this->config->expects(self::exactly(2))
 			->method('getSystemValue')
 			->willReturnMap([
@@ -581,83 +601,40 @@ class FactoryTest extends TestCase {
 		self::assertSame('cz', $lang);
 	}
 
-	public function testFindGenericLanguageByUserLanguage(): void {
+	public function testFindGenericLanguageByDefaultLanguageNotExists(): void {
+		$factory = $this->getFactory(['languageExists']);
+		$this->request->expects(self::once())
+			->method('getParam')
+			->with('forceLanguage')
+			->willReturn(null);
+		$this->config->expects(self::exactly(2))
+			->method('getSystemValue')
+			->willReturnMap([
+				['force_language', false, false,],
+				['default_language', false, 'cz',],
+			]);
+		$factory->expects(self::once())
+			->method('languageExists')
+			->with(null, 'cz')
+			->willReturn(false);
+
+		$lang = $factory->findGenericLanguage();
+
+		self::assertSame('en', $lang);
+	}
+
+	public function testFindGenericLanguageFallback(): void {
 		$factory = $this->getFactory();
+		$this->request->expects(self::once())
+			->method('getParam')
+			->with('forceLanguage')
+			->willReturn(null);
 		$this->config->expects(self::exactly(2))
 			->method('getSystemValue')
 			->willReturnMap([
 				['force_language', false, false,],
 				['default_language', false, false,],
 			]);
-		$user = $this->createMock(IUser::class);
-		$this->userSession->expects(self::once())
-			->method('getUser')
-			->willReturn($user);
-		$user->method('getUID')->willReturn('user123');
-		$this->config->expects(self::once())
-			->method('getUserValue')
-			->with('user123', 'core', 'lang', null)
-			->willReturn('cz');
-
-		$lang = $factory->findGenericLanguage();
-
-		self::assertSame('cz', $lang);
-	}
-
-	public function testFindGenericLanguageByRequestLanguage(): void {
-		$factory = $this->getFactory(['findAvailableLanguages', 'languageExists']);
-		$this->config->method('getSystemValue')
-			->willReturnMap([
-				['force_language', false, false,],
-				['default_language', false, false,],
-			]);
-		$user = $this->createMock(IUser::class);
-		$this->userSession->expects(self::once())
-			->method('getUser')
-			->willReturn($user);
-		$user->method('getUID')->willReturn('user123');
-		$this->config->expects(self::once())
-			->method('getUserValue')
-			->with('user123', 'core', 'lang', null)
-			->willReturn(null);
-		$this->request->expects(self::once())
-			->method('getHeader')
-			->with('ACCEPT_LANGUAGE')
-			->willReturn('cz');
-		$factory->expects(self::once())
-			->method('findAvailableLanguages')
-			->with(null)
-			->willReturn(['cz']);
-
-		$lang = $factory->findGenericLanguage();
-
-		self::assertSame('cz', $lang);
-	}
-
-	public function testFindGenericLanguageFallback(): void {
-		$factory = $this->getFactory(['findAvailableLanguages', 'languageExists']);
-		$this->config->method('getSystemValue')
-			->willReturnMap([
-				['force_language', false, false,],
-				['default_language', false, false,],
-			]);
-		$user = $this->createMock(IUser::class);
-		$this->userSession->expects(self::once())
-			->method('getUser')
-			->willReturn($user);
-		$user->method('getUID')->willReturn('user123');
-		$this->config->expects(self::once())
-			->method('getUserValue')
-			->with('user123', 'core', 'lang', null)
-			->willReturn(null);
-		$this->request->expects(self::once())
-			->method('getHeader')
-			->with('ACCEPT_LANGUAGE')
-			->willReturn('');
-		$factory->expects(self::never())
-			->method('findAvailableLanguages');
-		$factory->expects(self::never())
-			->method('languageExists');
 
 		$lang = $factory->findGenericLanguage();
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

The documentation of the method says it does not consider the user's language but it does. I adjusted the implementation because we already have the `getLanguage()` method which considers the user's language.

### TODO

- [x] Fix tests 
- [x] Fix CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
