### PR TITLE
fix: don't suggest files:scan with object store in info:file

### DIFF
--- a/core/Command/Info/File.php
+++ b/core/Command/Info/File.php
@@ -100,7 +100,9 @@ class File extends Command {
 			}, $children));
 			if ($childSize != $node->getSize()) {
 				$output->writeln('    <error>warning: folder has a size of ' . Util::humanFileSize($node->getSize()) . " but it's children sum up to " . Util::humanFileSize($childSize) . '</error>.');
-				$output->writeln('    Run <info>occ files:scan --path ' . $node->getPath() . '</info> to attempt to resolve this.');
+				if (!$node->getStorage()->instanceOfStorage(ObjectStoreStorage::class)) {
+					$output->writeln('    Run <info>occ files:scan --path ' . $node->getPath() . '</info> to attempt to resolve this.');
+				}
 			}
 			if ($showChildren) {
 				$output->writeln('  children: ' . count($children) . ':');


### PR DESCRIPTION
Let's not confuse users with commands that won't for them.