### PR TITLE
fix(PHP): Drop PHP 8.1 for Nextcloud 33

### DIFF
--- a/.github/workflows/autocheckers.yml
+++ b/.github/workflows/autocheckers.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
 
     name: PHP checkers
 
@@ -75,7 +75,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
 
     name: Translation and Files checkers
 

--- a/.github/workflows/files-external-ftp.yml
+++ b/.github/workflows/files-external-ftp.yml
@@ -45,10 +45,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.4']
+        php-versions: ['8.2', '8.4']
         ftpd: ['proftpd', 'vsftpd', 'pure-ftpd']
         include:
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.ftpd }}

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.4']
+        php-versions: ['8.2', '8.4']
         include:
           - php-versions: '8.3'
             coverage: ${{ github.event_name != 'pull_request' }}
@@ -134,7 +134,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.4']
+        php-versions: ['8.2', '8.4']
         include:
           - php-versions: '8.3'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/files-external-sftp.yml
+++ b/.github/workflows/files-external-sftp.yml
@@ -45,10 +45,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.4']
+        php-versions: ['8.2', '8.4']
         sftpd: ['openssh']
         include:
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.sftpd }}

--- a/.github/workflows/files-external-smb-kerberos.yml
+++ b/.github/workflows/files-external-smb-kerberos.yml
@@ -67,10 +67,10 @@ jobs:
       - name: Pull images
         run: |
           docker pull ghcr.io/icewind1991/samba-krb-test-dc
-          docker pull ghcr.io/icewind1991/samba-krb-test-apache
+          docker pull ghcr.io/icewind1991/samba-krb-test-apache-gssapi:8.4
           docker pull ghcr.io/icewind1991/samba-krb-test-client
           docker tag ghcr.io/icewind1991/samba-krb-test-dc icewind1991/samba-krb-test-dc
-          docker tag ghcr.io/icewind1991/samba-krb-test-apache icewind1991/samba-krb-test-apache
+          docker tag ghcr.io/icewind1991/samba-krb-test-apache-gssapi:8.4 icewind1991/samba-krb-test-apache-gssapi
           docker tag ghcr.io/icewind1991/samba-krb-test-client icewind1991/samba-krb-test-client
 
       - name: Setup AD-DC

--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -45,9 +45,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
         include:
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-smb

--- a/.github/workflows/files-external-webdav.yml
+++ b/.github/workflows/files-external-webdav.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/integration-dav.yml
+++ b/.github/workflows/integration-dav.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         endpoint: ['old', 'new']
         service: ['CalDAV', 'CardDAV']
 

--- a/.github/workflows/integration-litmus.yml
+++ b/.github/workflows/integration-litmus.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         endpoint: ['webdav', 'dav']
 
     name: Litmus WebDAV ${{ matrix.endpoint }}

--- a/.github/workflows/integration-s3-primary.yml
+++ b/.github/workflows/integration-s3-primary.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         key: ['objectstore', 'objectstore_multibucket']
 
     name: php${{ matrix.php-versions }}-${{ matrix.key }}-minio

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -73,7 +73,7 @@ jobs:
           - 'theming_features'
           - 'videoverification_features'
 
-        php-versions: ['8.1']
+        php-versions: ['8.4']
         spreed-versions: ['main']
         activity-versions: ['master']
 

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.2', '8.3', '8.4' ]
 
     name: php-lint
 

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -49,9 +49,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.2', '8.3']
         include:
-          - php-versions: '8.3'
+          - php-versions: '8.4'
             coverage: true
 
     name: php${{ matrix.php-versions }}-azure

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.2']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.2']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2.35.4
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: ctype, curl, dom, fileinfo, gd, json, libxml, mbstring, openssl, pcntl, pdo, posix, session, simplexml, xml, xmlreader, xmlwriter, zip, zlib
           coverage: none
           ini-file: development

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
 
     name: performance-${{ matrix.php-versions }}
 

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1','8.3']
+        php-versions: ['8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout server

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         mariadb-versions: ['10.3', '10.6', '10.11', '11.4', '11.8']
         include:
           - php-versions: '8.3'

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.3', '8.4']
+        php-versions: ['8.3', '8.4']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         mysql-versions: ['8.4']
 
     name: Sharding - MySQL ${{ matrix.mysql-versions }} (PHP ${{ matrix.php-versions }}) - database tests

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         mysql-versions: ['8.0', '8.4']
         include:
           - mysql-versions: '8.0'

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.3', '8.4']
+        php-versions: ['8.3', '8.4']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/phpunit-object-store-primary.yml
+++ b/.github/workflows/phpunit-object-store-primary.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         key: ['s3', 's3-multibucket']
 
     name: php${{ matrix.php-versions }}-${{ matrix.key }}-minio

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -61,9 +61,9 @@ jobs:
       matrix:
         include:
           - oracle-versions: '11'
-            php-versions: '8.1'
+            php-versions: '8.2'
           - oracle-versions: '18'
-            php-versions: '8.1'
+            php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}
           - oracle-versions: '21'
             php-versions: '8.2'

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         # To keep the matrix smaller we ignore PostgreSQL versions in between as we already test the minimum and the maximum
         postgres-versions: ['13', '17']
         include:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -59,9 +59,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4']
         include:
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: SQLite (PHP ${{ matrix.php-versions }})

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 #v2.35.4
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
@@ -67,7 +67,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 #v2.35.4
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
 
@@ -102,7 +102,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 #v2.35.4
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
@@ -133,7 +133,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 #v2.35.4
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:

--- a/apps/files_external/tests/sso-setup/start-apache.sh
+++ b/apps/files_external/tests/sso-setup/start-apache.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="${0%/*}"
 
 docker rm -f apache 2>/dev/null > /dev/null
 
-docker run -d --name apache -v $2:/var/www/html -v /var/www/html/data -v /var/www/html/config -v /var/www/html/extra-apps -v /tmp/shared:/shared --dns $1 --hostname httpd.domain.test icewind1991/samba-krb-test-apache 1>&2
+docker run -d --name apache -v $2:/var/www/html -v /var/www/html/data -v /var/www/html/config -v /var/www/html/extra-apps -v /tmp/shared:/shared --dns $1 --hostname httpd.domain.test icewind1991/samba-krb-test-apache-gssapi 1>&2
 APACHE_IP=$(docker inspect apache --format '{{.NetworkSettings.IPAddress}}')
 docker exec apache chown 33 /var/www/html/config /var/www/html/data /var/www/html/extra-apps
 docker cp "$SCRIPT_DIR/apps.config.php" apache:/var/www/html/config/apps.config.php

--- a/apps/settings/lib/SetupChecks/PhpOutdated.php
+++ b/apps/settings/lib/SetupChecks/PhpOutdated.php
@@ -14,10 +14,10 @@ use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
 class PhpOutdated implements ISetupCheck {
-	public const DEPRECATED_PHP_VERSION = '8.1';
-	public const DEPRECATED_SINCE = '30';
-	public const FUTURE_REQUIRED_PHP_VERSION = '8.2';
-	public const FUTURE_REQUIRED_STARTING = '32';
+	public const DEPRECATED_PHP_VERSION = '8.2';
+	public const DEPRECATED_SINCE = '33';
+	public const FUTURE_REQUIRED_PHP_VERSION = '8.3';
+	public const FUTURE_REQUIRED_STARTING = '34';
 
 	public function __construct(
 		private IL10N $l10n,
@@ -33,7 +33,7 @@ class PhpOutdated implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		if (PHP_VERSION_ID < 80200) {
+		if (PHP_VERSION_ID < 80300) {
 			return SetupResult::warning($this->l10n->t('You are currently running PHP %1$s. PHP %2$s is deprecated since Nextcloud %3$s. Nextcloud %4$s may require at least PHP %5$s. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [
 				PHP_VERSION,
 				self::DEPRECATED_PHP_VERSION,

--- a/lib/versioncheck.php
+++ b/lib/versioncheck.php
@@ -6,9 +6,9 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Show warning if a PHP version below 8.1 is used,
-if (PHP_VERSION_ID < 80100) {
+if (PHP_VERSION_ID < 80200) {
 	http_response_code(500);
-	echo 'This version of Nextcloud requires at least PHP 8.1<br/>';
+	echo 'This version of Nextcloud requires at least PHP 8.2<br/>';
 	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
 	exit(1);
 }


### PR DESCRIPTION
Preparation for PHP 8.5 next month

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
