### PR TITLE
Display delegated section in common settings for delegated non-admin

### DIFF
--- a/apps/settings/lib/Controller/CommonSettingsTrait.php
+++ b/apps/settings/lib/Controller/CommonSettingsTrait.php
@@ -142,13 +142,17 @@ trait CommonSettingsTrait {
 		$user = $this->userSession->getUser();
 		assert($user !== null, 'No user logged in for settings');
 
-		$this->declarativeSettingsManager->loadSchemas();
-		$declarativeSettings = $this->declarativeSettingsManager->getFormsWithValues($user, $type, $section);
+		$declarativeSettings = [];
 
-		foreach ($declarativeSettings as &$form) {
-			foreach ($form['fields'] as &$field) {
-				if (isset($field['sensitive']) && $field['sensitive'] === true && !empty($field['value'])) {
-					$field['value'] = 'dummySecret';
+		if ($type === 'admin' && $this->groupManager->isAdmin($user->getUID())) {
+			$this->declarativeSettingsManager->loadSchemas();
+			$declarativeSettings = $this->declarativeSettingsManager->getFormsWithValues($user, $type, $section);
+
+			foreach ($declarativeSettings as &$form) {
+				foreach ($form['fields'] as &$field) {
+					if (isset($field['sensitive']) && $field['sensitive'] === true && !empty($field['value'])) {
+						$field['value'] = 'dummySecret';
+					}
 				}
 			}
 		}

--- a/apps/settings/lib/Controller/CommonSettingsTrait.php
+++ b/apps/settings/lib/Controller/CommonSettingsTrait.php
@@ -136,13 +136,17 @@ trait CommonSettingsTrait {
 		$user = $this->userSession->getUser();
 		assert($user !== null, 'No user logged in for settings');
 
-		$this->declarativeSettingsManager->loadSchemas();
-		$declarativeSettings = $this->declarativeSettingsManager->getFormsWithValues($user, $type, $section);
+		$declarativeSettings = [];
 
-		foreach ($declarativeSettings as &$form) {
-			foreach ($form['fields'] as &$field) {
-				if (isset($field['sensitive']) && $field['sensitive'] === true && !empty($field['value'])) {
-					$field['value'] = 'dummySecret';
+		if ($type !== 'admin' || $this->groupManager->isAdmin($user->getUID())) {
+			$this->declarativeSettingsManager->loadSchemas();
+			$declarativeSettings = $this->declarativeSettingsManager->getFormsWithValues($user, $type, $section);
+
+			foreach ($declarativeSettings as &$form) {
+				foreach ($form['fields'] as &$field) {
+					if (isset($field['sensitive']) && $field['sensitive'] === true && !empty($field['value'])) {
+						$field['value'] = 'dummySecret';
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

IDeclarativeSettingsForm can't be delegated and can be shown only to admin. Lets not load IDeclarativeSettings for non admins. Otherwise we get "Access forbidden" while displaying /settings/admin and prevent to show delegated sections to non admin like:

Background jobs   OCA\Settings\Settings\Admin\Server
Email server      OCA\Settings\Settings\Admin\Mail


## Before state

```shell
# create group1
occ group:add group1

# create user  
OC_PASS=g1user1 ./occ user:add --password-from-env --display-name g1user1 --group group1  -- g1user1


# delegate Mail setting so group1 
./occ admin-delegation:add OCA\\Settings\\Settings\\Admin\\Mail group1
```

* login and check Administration * Basic Settings
e.g. open http://localhost:8080/index.php/settings/admin

* Observe: Access forbidden
<img width="1238" height="884" alt="Selection_20251002-004" src="https://github.com/user-attachments/assets/40524e1c-1f5c-4115-887a-56b91d896c3d" />

## After state

<img width="1238" height="884" alt="Selection_20251002-003" src="https://github.com/user-attachments/assets/ea6a0587-bd36-47ff-9a96-b27db6bee72e" />



## Todo

- [ ] validate delegated configurations can be used by group users with delegation


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
