### PR TITLE
chore: ignore ESLint v9 autofixes in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,3 +21,5 @@ b06f5ba4c47450f355a8903c1a93ac68e8c6cfc2
 5981b7eb512aa411f51cad541d01c5c6e93476f0
 # Migrate `and` `or` operators to logical `&&` `||` operators
 660f3f6fd1ae5539b8f74bfa48859d1b9f1e6abf
+# Migrate to ESLint v9 enforced code style
+91f3b6b4ee60e0f8bb6e21f92d5bc52e4cebe657


### PR DESCRIPTION
## Summary

make git blame useful again

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
