### PR TITLE
refactor: Port away from more IQueryBuilder::execute

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2132,11 +2132,6 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/testing/lib/Locking/FakeDBLockingProvider.php">
-    <DeprecatedMethod>
-      <code><![CDATA[executeUpdate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/testing/lib/Provider/FakeText2ImageProvider.php">
     <DeprecatedInterface>
       <code><![CDATA[FakeText2ImageProvider]]></code>
@@ -2674,7 +2669,6 @@
   </file>
   <file src="core/Command/Db/ConvertType.php">
     <DeprecatedMethod>
-      <code><![CDATA[execute]]></code>
       <code><![CDATA[getName]]></code>
       <code><![CDATA[getPrimaryKeyColumns]]></code>
     </DeprecatedMethod>
@@ -3020,34 +3014,6 @@
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
-  </file>
-  <file src="core/Migrations/Version13000Date20170718121200.php">
-    <DeprecatedMethod>
-      <code><![CDATA[execute]]></code>
-      <code><![CDATA[execute]]></code>
-      <code><![CDATA[execute]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="core/Migrations/Version14000Date20180404140050.php">
-    <DeprecatedMethod>
-      <code><![CDATA[execute]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="core/Migrations/Version16000Date20190427105638.php">
-    <DeprecatedMethod>
-      <code><![CDATA[execute]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="core/Migrations/Version18000Date20190920085628.php">
-    <DeprecatedMethod>
-      <code><![CDATA[execute]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="core/Migrations/Version20000Date20201109081918.php">
-    <DeprecatedMethod>
-      <code><![CDATA[execute]]></code>
-      <code><![CDATA[execute]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="core/Service/LoginFlowV2Service.php">
     <DeprecatedClass>

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -358,7 +358,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 							$insertQuery->setParameter($key, $value);
 						}
 					}
-					$insertQuery->execute();
+					$insertQuery->executeStatement();
 				}
 				$result->closeCursor();
 

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -31,7 +31,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 		if ($table->hasColumn('fileid')) {
 			$qb = $this->connection->getQueryBuilder();
 			$qb->delete('properties');
-			$qb->execute();
+			$qb->executeStatement();
 		}
 	}
 
@@ -1008,6 +1008,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('dav_properties');
+		$result = $query->executeQuery();
 
 		$insert = $this->connection->getQueryBuilder();
 		$insert->insert('properties')
@@ -1016,14 +1017,13 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			->setValue('propertyvalue', $insert->createParameter('propertyvalue'))
 			->setValue('userid', $insert->createParameter('userid'));
 
-		$result = $query->execute();
 		while ($row = $result->fetch()) {
 			preg_match('/(calendar)\/([A-z0-9-@_]+)\//', $row['propertypath'], $match);
 			$insert->setParameter('propertypath', (string)$row['propertypath'])
 				->setParameter('propertyname', (string)$row['propertyname'])
 				->setParameter('propertyvalue', (string)$row['propertyvalue'])
 				->setParameter('userid', ($match[2] ?? ''));
-			$insert->execute();
+			$insert->executeStatement();
 		}
 	}
 }

--- a/core/Migrations/Version14000Date20180404140050.php
+++ b/core/Migrations/Version14000Date20180404140050.php
@@ -62,6 +62,6 @@ class Version14000Date20180404140050 extends SimpleMigrationStep {
 
 		$qb->update('users')
 			->set('uid_lower', $qb->func()->lower('uid'));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 }

--- a/core/Migrations/Version16000Date20190427105638.php
+++ b/core/Migrations/Version16000Date20190427105638.php
@@ -29,7 +29,7 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 		$this->connection
 			->getQueryBuilder()
 			->delete('collres_accesscache')
-			->execute();
+			->executeStatement();
 	}
 
 	/**

--- a/core/Migrations/Version18000Date20190920085628.php
+++ b/core/Migrations/Version18000Date20190920085628.php
@@ -55,6 +55,6 @@ class Version18000Date20190920085628 extends SimpleMigrationStep {
 		$query = $this->connection->getQueryBuilder();
 		$query->update('groups')
 			->set('displayname', 'gid');
-		$query->execute();
+		$query->executeStatement();
 	}
 }

--- a/core/Migrations/Version20000Date20201109081918.php
+++ b/core/Migrations/Version20000Date20201109081918.php
@@ -77,12 +77,12 @@ class Version20000Date20201109081918 extends SimpleMigrationStep {
 			->setValue('identifier', $insert->createParameter('identifier'))
 			->setValue('credentials', $insert->createParameter('credentials'));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$insert->setParameter('user', (string)$row['user'])
 				->setParameter('identifier', (string)$row['identifier'])
 				->setParameter('credentials', (string)$row['credentials']);
-			$insert->execute();
+			$insert->executeStatement();
 		}
 		$result->closeCursor();
 	}


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
