### PR TITLE
Update Nextcloud Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,33 +4,35 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # PHP
 RUN apt-get update -y && \
-    apt install -y apache2 vim software-properties-common sudo nano gnupg2
+    apt install -y apache2 vim software-properties-common sudo nano gnupg2 wget curl git \
+    lsb-release ca-certificates apt-transport-https && \
+    add-apt-repository ppa:ondrej/php -y && \
+    apt-get update -y
 
 RUN apt-get install --no-install-recommends -y \
-    php8.3 \
-    php8.3-common \
-    php8.3-gd \
-    php8.3-zip \
-    php8.3-curl \
-    php8.3-xml \
-    php8.3-xmlrpc \
-    php8.3-mbstring \
-    php8.3-sqlite \
-    php8.3-xdebug \
-    php8.3-pgsql \
-    php8.3-intl \
-    php8.3-imagick \
-    php8.3-gmp \
-    php8.3-apcu \
-    php8.3-bcmath \
-    php8.3-redis \
-    php8.3-soap \
-    php8.3-imap \
-    php8.3-opcache \
-    php8.3-cli \
-    php8.3-dev \
+    php8.4 \
+    php8.4-common \
+    php8.4-gd \
+    php8.4-zip \
+    php8.4-curl \
+    php8.4-xml \
+    php8.4-xmlrpc \
+    php8.4-mbstring \
+    php8.4-sqlite \
+    php8.4-xdebug \
+    php8.4-pgsql \
+    php8.4-intl \
+    php8.4-imagick \
+    php8.4-gmp \
+    php8.4-apcu \
+    php8.4-bcmath \
+    php8.4-redis \
+    php8.4-soap \
+    php8.4-imap \
+    php8.4-opcache \
+    php8.4-cli \
+    php8.4-dev \
     libmagickcore-6.q16-7-extra \
-    curl \
     lsof \
     make \
 	unzip
@@ -42,39 +44,39 @@ RUN curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php && \
     php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
     rm /tmp/composer-setup.php /tmp/composer-setup.sig
 
-RUN echo "xdebug.remote_enable = 1" >> /etc/php/8.3/cli/conf.d/20-xdebug.ini && \
-    echo "xdebug.remote_autostart = 1" >> /etc/php/8.3/cli/conf.d/20-xdebug.ini && \
-	echo "apc.enable_cli=1" >> /etc/php/8.3/cli/conf.d/20-apcu.ini
+RUN echo "xdebug.remote_enable = 1" >> /etc/php/8.4/cli/conf.d/20-xdebug.ini && \
+    echo "xdebug.remote_autostart = 1" >> /etc/php/8.4/cli/conf.d/20-xdebug.ini && \
+	echo "apc.enable_cli=1" >> /etc/php/8.4/cli/conf.d/20-apcu.ini
 
 # Autostart XDebug for apache
 RUN { \
 	echo "xdebug.mode=debug"; \
 	echo "xdebug.start_with_request=yes"; \
-} >> /etc/php/8.3/apache2/conf.d/20-xdebug.ini
+} >> /etc/php/8.4/apache2/conf.d/20-xdebug.ini
 
 # Increase PHP memory limit to 512mb
-RUN sed -i 's/memory_limit = .*/memory_limit = 512M/' /etc/php/8.3/apache2/php.ini
+RUN sed -i 's/memory_limit = .*/memory_limit = 512M/' /etc/php/8.4/apache2/php.ini
 
-# Docker
-RUN apt-get -y install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable" && \
+# Docker CLI only (for controlling host Docker via socket)
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update -y && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io && \
+    apt-get install -y docker-ce-cli && \
     ln -s /var/run/docker-host.sock /var/run/docker.sock
 
 # Dedicated DevContainer user runs Apache
 ENV APACHE_RUN_USER=devcontainer
 ENV APACHE_RUN_GROUP=devcontainer
-RUN useradd -ms /bin/bash ${APACHE_RUN_USER} && \
+# Delete any existing user/group with UID/GID 1000 first
+RUN (getent passwd 1000 && userdel -r $(getent passwd 1000 | cut -d: -f1)) || true && \
+    (getent group 1000 && groupdel $(getent group 1000 | cut -d: -f1)) || true && \
+    groupadd -g 1000 ${APACHE_RUN_GROUP} && \
+    useradd -u 1000 -g 1000 -ms /bin/bash ${APACHE_RUN_USER} && \
 	adduser ${APACHE_RUN_USER} sudo && \
 	echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
 	sed -ri "s/^export APACHE_RUN_USER=.*$/export APACHE_RUN_USER=${APACHE_RUN_USER}/" "/etc/apache2/envvars" && \
@@ -84,6 +86,6 @@ USER devcontainer
 
 # NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-RUN bash --login -i -c 'source /home/devcontainer/.bashrc && nvm install 16'
+RUN bash --login -i -c 'source /home/devcontainer/.bashrc && nvm install 22'
 
 WORKDIR /var/www/html

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
-version: '3'
 services:
   nextclouddev:
     build: .

--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -6,3 +6,8 @@
 # Set git safe.directory
 git config --global --add safe.directory /var/www/html
 git config --global --add safe.directory /var/www/html/3rdparty
+
+# Ensure devcontainer user has access to docker socket
+if [ -S /var/run/docker.sock ]; then
+    sudo chmod 666 /var/run/docker.sock
+fi


### PR DESCRIPTION
## Summary

### Removed deprecations
* docker-compose version
* apt-key add command in docker installation

### Updates
* Upgrade from PHP8.3 to PHP8.4 (currently recommended for NC) from ppa:ondrej/php
* Use nodejs 20 by default

### Optimization
* Just install docker-ce-cli, not the full docker suite (speeds up docker build)
* Make sure user "devcontainer" has UID 1000. This increases the containers filesystem compatibility to most (unix-based) host systems because the default user there always has 1000 as well
* Ensure devcontainer user has access to docker without sudo

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
