### PR TITLE
feat: add occ command to scan and delete orphaned keys

### DIFF
--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -67,6 +67,7 @@
 		<command>OCA\Encryption\Command\FixEncryptedVersion</command>
 		<command>OCA\Encryption\Command\FixKeyLocation</command>
 		<command>OCA\Encryption\Command\DropLegacyFileKey</command>
+		<command>OCA\Encryption\Command\CleanOrphanedKeys</command>
 	</commands>
 
 	<settings>

--- a/apps/encryption/composer/composer/autoload_classmap.php
+++ b/apps/encryption/composer/composer/autoload_classmap.php
@@ -8,6 +8,7 @@ $baseDir = $vendorDir;
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
     'OCA\\Encryption\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\Encryption\\Command\\CleanOrphanedKeys' => $baseDir . '/../lib/Command/CleanOrphanedKeys.php',
     'OCA\\Encryption\\Command\\DisableMasterKey' => $baseDir . '/../lib/Command/DisableMasterKey.php',
     'OCA\\Encryption\\Command\\DropLegacyFileKey' => $baseDir . '/../lib/Command/DropLegacyFileKey.php',
     'OCA\\Encryption\\Command\\EnableMasterKey' => $baseDir . '/../lib/Command/EnableMasterKey.php',

--- a/apps/encryption/composer/composer/autoload_static.php
+++ b/apps/encryption/composer/composer/autoload_static.php
@@ -23,6 +23,7 @@ class ComposerStaticInitEncryption
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
         'OCA\\Encryption\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\Encryption\\Command\\CleanOrphanedKeys' => __DIR__ . '/..' . '/../lib/Command/CleanOrphanedKeys.php',
         'OCA\\Encryption\\Command\\DisableMasterKey' => __DIR__ . '/..' . '/../lib/Command/DisableMasterKey.php',
         'OCA\\Encryption\\Command\\DropLegacyFileKey' => __DIR__ . '/..' . '/../lib/Command/DropLegacyFileKey.php',
         'OCA\\Encryption\\Command\\EnableMasterKey' => __DIR__ . '/..' . '/../lib/Command/EnableMasterKey.php',

--- a/apps/encryption/lib/Command/CleanOrphanedKeys.php
+++ b/apps/encryption/lib/Command/CleanOrphanedKeys.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Encryption\Command;
+
+use OC\Encryption\Util;
+use OC\Files\SetupManager;
+use OCA\Encryption\Crypto\Encryption;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+class CleanOrphanedKeys extends Command {
+
+	public function __construct(
+		protected IConfig $config,
+		protected QuestionHelper $questionHelper,
+		private IUserManager $userManager,
+		private Util $encryptionUtil,
+		private SetupManager $setupManager,
+		private IRootFolder $rootFolder,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct();
+
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('encryption:clean-orphaned-keys')
+			->setDescription('Scan the keys storage for orphaned keys and remove them');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$orphanedKeys = [];
+		$headline = 'Scanning all keys for file parity';
+		$output->writeln($headline);
+		$output->writeln(str_pad('', strlen($headline), '='));
+		$output->writeln("\n");
+		$progress = new ProgressBar($output);
+		$progress->setFormat(" %message% \n [%bar%]");
+
+		foreach ($this->userManager->getSeenUsers() as $user) {
+			$uid = $user->getUID();
+			$progress->setMessage('Scanning all keys for: ' . $uid);
+			$progress->advance();
+			$this->setupUserFileSystem($user);
+			$root = $this->encryptionUtil->getKeyStorageRoot() . '/' . $uid . '/files_encryption/keys';
+			$userOrphanedKeys = $this->scanFolder($output, $root, $uid);
+			$orphanedKeys = array_merge($orphanedKeys, $userOrphanedKeys);
+		}
+		$progress->setMessage('Scanned orphaned keys for all users');
+		$progress->finish();
+		$output->writeln("\n");
+		foreach ($orphanedKeys as $keyPath) {
+			$output->writeln('Orphaned key found: ' . $keyPath);
+		}
+		if (count($orphanedKeys) == 0) {
+			return self::SUCCESS;
+		}
+		$question = new ConfirmationQuestion('Do you want to delete all orphaned keys? (y/n) ', false);
+		if ($this->questionHelper->ask($input, $output, $question)) {
+			$this->deleteAll($orphanedKeys, $output);
+		} else {
+
+			$question = new ConfirmationQuestion('Do you want to delete specific keys? (y/n) ', false);
+			if ($this->questionHelper->ask($input, $output, $question)) {
+				$this->deleteSpecific($input, $output, $orphanedKeys);
+			}
+		}
+
+		return self::SUCCESS;
+	}
+
+	private function scanFolder(OutputInterface $output, string $folderPath, string $user) : array {
+		$orphanedKeys = [];
+		try {
+			$folder = $this->rootFolder->get($folderPath);
+		} catch (NotFoundException $e) {
+			// Happens when user doesn't have encrypted files
+			$this->logger->error('Error when accessing folder ' . $folderPath . ' for user ' . $user, ['exception' => $e]);
+			return [];
+		}
+
+		if (!($folder instanceof Folder)) {
+			$this->logger->error('Invalid folder');
+			return [];
+		}
+
+		foreach ($folder->getDirectoryListing() as $item) {
+			$path = $folderPath . '/' . $item->getName();
+			$stopValue = $this->stopCondition($path);
+			if ($stopValue === null) {
+				$this->logger->error('Reached unexpected state when scanning user\'s filesystem for orphaned encryption keys' . $path);
+			} elseif ($stopValue) {
+				$filePath = str_replace('files_encryption/keys/', '', $path);
+				try {
+					$this->rootFolder->get($filePath);
+				} catch (NotFoundException $e) {
+					// We found an orphaned key
+					$orphanedKeys[] = $path;
+					continue;
+				}
+			} else {
+				$orphanedKeys = array_merge($orphanedKeys, $this->scanFolder($output, $path, $user));
+			}
+		}
+		return $orphanedKeys;
+	}
+	/**
+	 * Checks the stop considition for the recursion
+	 * following the logic that keys are stored in files_encryption/keys/<user>/<path>/<fileName>/OC_DEFAULT_MODULE/<key>.sharekey
+	 * @param string $path path of the current folder
+	 * @return bool|null true if we should stop and found a key, false if we should continue, null if we shouldn't end up here
+	 */
+	private function stopCondition(string $path) : ?bool {
+		$folder = $this->rootFolder->get($path);
+		if ($folder instanceof Folder) {
+			$content = $folder->getDirectoryListing();
+			$subfolder = $content[0];
+			if (count($content) === 1 && $subfolder->getName() === Encryption::ID) {
+				if ($subfolder instanceof Folder) {
+					$content = $subfolder->getDirectoryListing();
+					if (count($content) === 1 && $content[0] instanceof File) {
+						return strtolower($content[0]->getExtension()) === 'sharekey' ;
+					}
+				}
+			}
+			return false;
+		}
+		// We shouldn't end up here, because we return true when reaching the folder named after the file containing OC_DEFAULT_MODULE
+		return null;
+	}
+	private function deleteAll(array $keys, OutputInterface $output) {
+		foreach ($keys as $key) {
+			$file = $this->rootFolder->get($key);
+			try {
+				$file->delete();
+				$output->writeln('Key deleted: ' . $key);
+			} catch (\Exception $e) {
+				$output->writeln('Failed to delete  ' . $key);
+				$this->logger->error('Error when deleting orphaned key ' . $key . '. ' . $e->getMessage());
+			}
+		}
+	}
+
+	private function deleteSpecific(InputInterface $input, OutputInterface $output, array $orphanedKeys) {
+		$question = new Question('Please enter path for key to delete: ');
+		$path = $this->questionHelper->ask($input, $output, $question);
+		if (!in_array(trim($path), $orphanedKeys)) {
+			$output->writeln('Wrong key path');
+		} else {
+			try {
+				$this->rootFolder->get(trim($path))->delete();
+				$output->writeln('Key deleted: ' . $path);
+			} catch (\Exception $e) {
+				$output->writeln('Failed to delete  ' . $path);
+				$this->logger->error('Error when deleting orphaned key ' . $path . '. ' . $e->getMessage());
+			}
+			$orphanedKeys = array_filter($orphanedKeys, function ($k) use ($path) {
+				return $k !== trim($path);
+			});
+		}
+		if (count($orphanedKeys) == 0) {
+			return;
+		}
+		$output->writeln('Remaining orphaned keys: ');
+		foreach ($orphanedKeys as $keyPath) {
+			$output->writeln($keyPath);
+		}
+		$question = new ConfirmationQuestion('Do you want to delete more orphaned keys? (y/n) ', false);
+		if ($this->questionHelper->ask($input, $output, $question)) {
+			$this->deleteSpecific($input, $output, $orphanedKeys);
+		}
+
+	}
+
+	/**
+	 * setup user file system
+	 */
+	protected function setupUserFileSystem(IUser $user): void {
+		$this->setupManager->tearDown();
+		$this->setupManager->setupForUser($user);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
As an administrator I want to be able to delete encryption Keys that are orphaned ( the encrypted file was deleted without the corresponding key) 
`encryption:clean-orphaned-keys` scans all users' filesytems for default module encryption Keys and lists them with possibility to delete all of them or specific ones

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
