### PR TITLE
refactor: use IEmailValidator.isValid instead of IMailer.validateEmailAddress

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -16,6 +16,7 @@ use OCP\IUser;
 use OCP\L10N\IFactory as L10NFactory;
 use OCP\Mail\Headers\AutoSubmitted;
 use OCP\Mail\IEMailTemplate;
+use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -39,6 +40,7 @@ class EmailProvider extends AbstractProvider {
 		LoggerInterface $logger,
 		L10NFactory $l10nFactory,
 		IURLGenerator $urlGenerator,
+		private IEmailValidator $emailValidator,
 	) {
 		parent::__construct($logger, $l10nFactory, $urlGenerator, $config);
 	}
@@ -96,7 +98,7 @@ class EmailProvider extends AbstractProvider {
 			$template->addFooter();
 
 			foreach ($emailAddresses as $emailAddress) {
-				if (!$this->mailer->validateMailAddress($emailAddress)) {
+				if (!$this->emailValidator->isValid($emailAddress)) {
 					$this->logger->error('Email address {address} for reminder notification is incorrect', ['app' => 'dav', 'address' => $emailAddress]);
 					continue;
 				}
@@ -180,7 +182,7 @@ class EmailProvider extends AbstractProvider {
 
 		$organizerEMail = substr($organizer->getValue(), 7);
 
-		if (!$this->mailer->validateMailAddress($organizerEMail)) {
+		if (!$this->emailValidator->isValid($organizerEMail)) {
 			return null;
 		}
 
@@ -251,7 +253,7 @@ class EmailProvider extends AbstractProvider {
 					foreach ($emailAddressesOfDelegates as $addressesOfDelegate) {
 						if (strcasecmp($addressesOfDelegate, 'mailto:') === 0) {
 							$delegateEmail = substr($addressesOfDelegate, 7);
-							if ($this->mailer->validateMailAddress($delegateEmail)) {
+							if ($this->emailValidator->isValid($delegateEmail)) {
 								$emailAddresses[$delegateEmail] = [];
 							}
 						}
@@ -311,7 +313,7 @@ class EmailProvider extends AbstractProvider {
 			return null;
 		}
 		$attendeeEMail = substr($attendee->getValue(), 7);
-		if (!$this->mailer->validateMailAddress($attendeeEMail)) {
+		if (!$this->emailValidator->isValid($attendeeEMail)) {
 			return null;
 		}
 

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IAppConfig;
 use OCP\IUserSession;
+use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
 use OCP\Mail\Provider\Address;
 use OCP\Mail\Provider\Attachment;
@@ -63,6 +64,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		private IMipService $imipService,
 		private EventComparisonService $eventComparisonService,
 		private IMailManager $mailManager,
+		private IEmailValidator $emailValidator,
 	) {
 		parent::__construct('');
 	}
@@ -119,7 +121,7 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		// Strip off mailto:
 		$recipient = substr($iTipMessage->recipient, 7);
-		if (!$this->mailer->validateMailAddress($recipient)) {
+		if (!$this->emailValidator->isValid($recipient)) {
 			// Nothing to send if the recipient doesn't have a valid email address
 			$iTipMessage->scheduleStatus = '5.0; EMail delivery failed';
 			return;

--- a/apps/dav/lib/Listener/CalendarContactInteractionListener.php
+++ b/apps/dav/lib/Listener/CalendarContactInteractionListener.php
@@ -18,7 +18,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IUser;
 use OCP\IUserSession;
-use OCP\Mail\IMailer;
+use OCP\Mail\IEmailValidator;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\Component\VEvent;
 use Sabre\VObject\Parameter;
@@ -36,7 +36,7 @@ class CalendarContactInteractionListener implements IEventListener {
 		private IEventDispatcher $dispatcher,
 		private IUserSession $userSession,
 		private Principal $principalConnector,
-		private IMailer $mailer,
+		private IEmailValidator $emailValidator,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -129,7 +129,7 @@ class CalendarContactInteractionListener implements IEventListener {
 				continue;
 			}
 			$email = substr($mailTo, strlen('mailto:'));
-			if (!$this->mailer->validateMailAddress($email)) {
+			if (!$this->emailValidator->isValid($email)) {
 				// This really isn't a valid email
 				continue;
 			}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -350,7 +350,8 @@ class Server {
 						$userSession,
 						\OCP\Server::get(IMipService::class),
 						\OCP\Server::get(EventComparisonService::class),
-						\OCP\Server::get(\OCP\Mail\Provider\IManager::class)
+						\OCP\Server::get(\OCP\Mail\Provider\IManager::class),
+						\OCP\Server::get(\OCP\Mail\IEmailValidator::class),
 					));
 				}
 				$this->server->addPlugin(new \OCA\DAV\CalDAV\Search\SearchPlugin());

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/EmailProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/EmailProviderTest.php
@@ -17,8 +17,10 @@ use OCP\Mail\IMessage;
 use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\VObject\Component\VCalendar;
+use Test\Traits\EmailValidatorTrait;
 
 class EmailProviderTest extends AbstractNotificationProviderTestCase {
+	use EmailValidatorTrait;
 	public const USER_EMAIL = 'frodo@hobb.it';
 	private IMailer&MockObject $mailer;
 
@@ -32,7 +34,8 @@ class EmailProviderTest extends AbstractNotificationProviderTestCase {
 			$this->mailer,
 			$this->logger,
 			$this->l10nFactory,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 		);
 	}
 
@@ -92,15 +95,6 @@ class EmailProviderTest extends AbstractNotificationProviderTestCase {
 				$template1,
 				$template2
 			);
-
-		$this->mailer->expects($this->exactly(4))
-			->method('validateMailAddress')
-			->willReturnMap([
-				['uid1@example.com', true],
-				['uid2@example.com', true],
-				['uid3@example.com', true],
-				['invalid', false],
-			]);
 
 		$this->mailer->expects($this->exactly(3))
 			->method('createMessage')
@@ -189,17 +183,6 @@ class EmailProviderTest extends AbstractNotificationProviderTestCase {
 				$template1,
 				$template2,
 			);
-		$this->mailer->expects($this->atLeastOnce())
-			->method('validateMailAddress')
-			->willReturnMap([
-				['foo1@example.org', true],
-				['foo3@example.org', true],
-				['foo4@example.org', true],
-				['uid1@example.com', true],
-				['uid2@example.com', true],
-				['uid3@example.com', true],
-				['invalid', false],
-			]);
 		$this->mailer->expects($this->exactly(6))
 			->method('createMessage')
 			->with()
@@ -277,17 +260,6 @@ class EmailProviderTest extends AbstractNotificationProviderTestCase {
 			->willReturnOnConsecutiveCalls(
 				$template1,
 			);
-		$this->mailer->expects($this->atLeastOnce())
-			->method('validateMailAddress')
-			->willReturnMap([
-				['foo1@example.org', true],
-				['foo3@example.org', true],
-				['foo4@example.org', true],
-				['uid1@example.com', true],
-				['uid2@example.com', true],
-				['uid3@example.com', true],
-				['invalid', false],
-			]);
 		$this->mailer->expects($this->exactly(2))
 			->method('createMessage')
 			->with()

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginCharsetTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginCharsetTest.php
@@ -38,8 +38,10 @@ use Sabre\VObject\ITip\Message;
 use Sabre\VObject\Property\ICalendar\CalAddress;
 use Symfony\Component\Mime\Email;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 
 class IMipPluginCharsetTest extends TestCase {
+	use EmailValidatorTrait;
 	// Dependencies
 	private Defaults&MockObject $defaults;
 	private IAppConfig&MockObject $appConfig;
@@ -102,8 +104,6 @@ class IMipPluginCharsetTest extends TestCase {
 		$this->mailer = $this->createMock(IMailer::class);
 		$this->mailer->method('createMessage')
 			->willReturn($message);
-		$this->mailer->method('validateMailAddress')
-			->willReturn(true);
 		$this->logger = new NullLogger();
 		$this->defaults = $this->createMock(Defaults::class);
 		$this->defaults->method('getName')
@@ -125,6 +125,7 @@ class IMipPluginCharsetTest extends TestCase {
 			$this->imipService,
 			$this->eventComparisonService,
 			$this->mailManager,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 		);
 
 		// ITipMessage

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -30,6 +30,7 @@ use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VEvent;
 use Sabre\VObject\ITip\Message;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 use function array_merge;
 
 interface IMailServiceMock extends IMailService, IMailMessageSend {
@@ -38,6 +39,8 @@ interface IMailServiceMock extends IMailService, IMailMessageSend {
 }
 
 class IMipPluginTest extends TestCase {
+	use EmailValidatorTrait;
+
 	private IMessage&MockObject $mailMessage;
 	private IMailer&MockObject $mailer;
 	private IEMailTemplate&MockObject $emailTemplate;
@@ -107,6 +110,7 @@ class IMipPluginTest extends TestCase {
 			$this->service,
 			$this->eventComparisonService,
 			$this->mailManager,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 		);
 	}
 
@@ -173,10 +177,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->willReturn(['new' => [$newVevent], 'old' => [$oldVEvent]]);
@@ -280,10 +280,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('the-shire@hobb.it')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->willReturn(['new' => [$newVevent], 'old' => [$oldVEvent]]);
@@ -358,10 +354,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('circle+82utEV1Fle8wvxndZLK5TVAPtxj8IIe@middle.earth')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->willReturn(['new' => [$newVevent], 'old' => null]);
@@ -463,10 +455,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->willReturn(['old' => [] ,'new' => [$newVevent]]);
@@ -541,15 +529,11 @@ class IMipPluginTest extends TestCase {
 		$message->message->VEVENT->add('ATTENDEE', 'mailto:' . 'frodo@hobb.it', ['RSVP' => 'TRUE']);
 		$message->sender = 'mailto:gandalf@wiz.ard';
 		$message->senderName = 'Mr. Wizard';
-		$message->recipient = 'mailto:' . 'frodo@hobb.it';
+		$message->recipient = 'mailto:' . 'frodo@@hobb.it';
 
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(false);
 
 		$this->plugin->schedule($message);
 		$this->assertEquals('5.0', $message->getScheduleStatus());
@@ -598,10 +582,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->willReturn(['old' => [] ,'new' => [$newVevent]]);
@@ -755,11 +735,6 @@ class IMipPluginTest extends TestCase {
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->willReturn(['old' => [] ,'new' => [$event]]);
-		// construct mail mock returns
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(true);
 		// construct mail provider mock returns
 		$this->mailService
 			->method('initiateMessage')
@@ -819,10 +794,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->willReturn(['new' => [$newVevent], 'old' => [$oldVEvent]]);
@@ -917,10 +888,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->with($newVCalendar, null)
@@ -1014,10 +981,6 @@ class IMipPluginTest extends TestCase {
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
 			->willReturn(1496912700);
-		$this->mailer->expects(self::once())
-			->method('validateMailAddress')
-			->with('frodo@hobb.it')
-			->willReturn(true);
 		$this->eventComparisonService->expects(self::once())
 			->method('findModified')
 			->with($newVCalendar, null)

--- a/apps/dav/tests/unit/Listener/CalendarContactInteractionListenerTest.php
+++ b/apps/dav/tests/unit/Listener/CalendarContactInteractionListenerTest.php
@@ -17,17 +17,18 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use OCP\IUserSession;
-use OCP\Mail\IMailer;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 
 class CalendarContactInteractionListenerTest extends TestCase {
+	use EmailValidatorTrait;
+
 	private IEventDispatcher&MockObject $eventDispatcher;
 	private IUserSession&MockObject $userSession;
 	private Principal&MockObject $principalConnector;
 	private LoggerInterface&MockObject $logger;
-	private IMailer&MockObject $mailer;
 	private CalendarContactInteractionListener $listener;
 
 	protected function setUp(): void {
@@ -36,14 +37,13 @@ class CalendarContactInteractionListenerTest extends TestCase {
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->principalConnector = $this->createMock(Principal::class);
-		$this->mailer = $this->createMock(IMailer::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->listener = new CalendarContactInteractionListener(
 			$this->eventDispatcher,
 			$this->userSession,
 			$this->principalConnector,
-			$this->mailer,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 			$this->logger
 		);
 	}
@@ -162,7 +162,6 @@ END:VCALENDAR
 EVENT]);
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects(self::once())->method('getUser')->willReturn($user);
-		$this->mailer->expects(self::once())->method('validateMailAddress')->willReturn(true);
 		$this->eventDispatcher->expects(self::once())
 			->method('dispatchTyped')
 			->with(self::equalTo((new ContactInteractedWithEvent($user))->setEmail('user@domain.tld')));

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -55,6 +55,7 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
 use OCP\Server;
 use OCP\Share\Exceptions\GenericShareException;
@@ -102,6 +103,7 @@ class ShareAPIController extends OCSController {
 		private IProviderFactory $factory,
 		private IMailer $mailer,
 		private ITagManager $tagManager,
+		private IEmailValidator $emailValidator,
 		private ?TrustedServers $trustedServers,
 		private ?string $userId = null,
 	) {
@@ -746,7 +748,7 @@ class ShareAPIController extends OCSController {
 			// Only share by mail have a recipient
 			if (is_string($shareWith) && $shareType === IShare::TYPE_EMAIL) {
 				// If sending a mail have been requested, validate the mail address
-				if ($share->getMailSend() && !$this->mailer->validateMailAddress($shareWith)) {
+				if ($share->getMailSend() && !$this->emailValidator->isValid($shareWith)) {
 					throw new OCSNotFoundException($this->l->t('Please specify a valid email address'));
 				}
 				$share->setSharedWith($shareWith);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -41,6 +41,7 @@ use OCP\UserStatus\IManager as IUserStatusManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Test\Traits\EmailValidatorTrait;
 
 /**
  * Class ApiTest
@@ -49,6 +50,8 @@ use Psr\Log\LoggerInterface;
  * TODO: convert to real integration tests
  */
 class ApiTest extends TestCase {
+	use EmailValidatorTrait;
+
 	public const TEST_FOLDER_NAME = '/folder_share_api_test';
 	public const APP_NAME = 'files_sharing';
 
@@ -141,6 +144,7 @@ class ApiTest extends TestCase {
 			$providerFactory,
 			$mailer,
 			$tagManager,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 			$trustedServers,
 			$userId,
 		);

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -54,6 +54,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 
 /**
  * Class ShareAPIControllerTest
@@ -62,6 +63,7 @@ use Test\TestCase;
  * @group DB
  */
 class ShareAPIControllerTest extends TestCase {
+	use EmailValidatorTrait;
 
 	private string $appName = 'files_sharing';
 	private string $currentUser;
@@ -146,8 +148,9 @@ class ShareAPIControllerTest extends TestCase {
 			$this->factory,
 			$this->mailer,
 			$this->tagManager,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 			$this->trustedServers,
-			$this->currentUser
+			$this->currentUser,
 		);
 
 	}
@@ -177,6 +180,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])->onlyMethods(['formatShare'])
@@ -889,6 +893,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])
@@ -1603,6 +1608,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])
@@ -1976,6 +1982,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])->onlyMethods(['formatShare'])
@@ -2076,6 +2083,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])->onlyMethods(['formatShare'])
@@ -2504,6 +2512,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])->onlyMethods(['formatShare'])
@@ -2577,6 +2586,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])->onlyMethods(['formatShare'])
@@ -2817,6 +2827,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->factory,
 				$this->mailer,
 				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
 				$this->trustedServers,
 				$this->currentUser,
 			])->onlyMethods(['formatShare'])

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -25,6 +25,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
 use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\IHasher;
@@ -70,6 +71,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		private IHasher $hasher,
 		private IEventDispatcher $eventDispatcher,
 		private IShareManager $shareManager,
+		private IEmailValidator $emailValidator,
 	) {
 	}
 
@@ -246,7 +248,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 		$emails = $this->getSharedWithEmails($share);
 		$validEmails = array_filter($emails, function (string $email) {
-			return $this->mailer->validateMailAddress($email);
+			return $this->emailValidator->isValid($email);
 		});
 
 		if (count($validEmails) === 0) {
@@ -722,7 +724,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 								|| ($originalShare->getSendPasswordByTalk() && !$share->getSendPasswordByTalk()))) {
 			$emails = $this->getSharedWithEmails($share);
 			$validEmails = array_filter($emails, function ($email) {
-				return $this->mailer->validateMailAddress($email);
+				return $this->emailValidator->isValid($email);
 			});
 			$this->sendPassword($share, $plainTextPassword, $validEmails);
 		}

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -41,6 +41,7 @@ use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 
 /**
  * Class ShareByMailProviderTest
@@ -49,6 +50,7 @@ use Test\TestCase;
  * @group DB
  */
 class ShareByMailProviderTest extends TestCase {
+	use EmailValidatorTrait;
 
 	private IDBConnection $connection;
 
@@ -122,6 +124,7 @@ class ShareByMailProviderTest extends TestCase {
 					$this->hasher,
 					$this->eventDispatcher,
 					$this->shareManager,
+					$this->getEmailValidatorWithStrictEmailCheck(),
 				])
 				->onlyMethods($mockedMethods)
 				->getMock();
@@ -143,6 +146,7 @@ class ShareByMailProviderTest extends TestCase {
 			$this->hasher,
 			$this->eventDispatcher,
 			$this->shareManager,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 		);
 	}
 
@@ -199,9 +203,6 @@ class ShareByMailProviderTest extends TestCase {
 		$share->expects($this->any())->method('getNote')->willReturn('');
 		$share->expects($this->any())->method('getToken')->willReturn('token');
 
-		// Assume the mail address is valid.
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
-
 		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject', 'createShareActivity', 'autoGeneratePassword', 'createPasswordSendActivity', 'sendEmail', 'sendPassword', 'sendPasswordToOwner']);
 		$instance->expects($this->once())->method('getSharedWith')->willReturn([]);
 		$instance->expects($this->once())->method('createMailShare')->with($share)->willReturn(42);
@@ -240,9 +241,6 @@ class ShareByMailProviderTest extends TestCase {
 		$share->expects($this->any())->method('getId')->willReturn(42);
 		$share->expects($this->any())->method('getNote')->willReturn('');
 		$share->expects($this->any())->method('getToken')->willReturn('token');
-
-		// Assume the mail address is valid.
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject', 'createShareActivity', 'autoGeneratePassword', 'createPasswordSendActivity', 'sendEmail', 'sendPassword', 'sendPasswordToOwner']);
 
@@ -286,9 +284,6 @@ class ShareByMailProviderTest extends TestCase {
 		$share->expects($this->any())->method('getId')->willReturn(42);
 		$share->expects($this->any())->method('getNote')->willReturn('');
 		$share->expects($this->any())->method('getToken')->willReturn('token');
-
-		// Assume the mail address is valid.
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$instance = $this->getInstance([
 			'getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject',
@@ -351,9 +346,6 @@ class ShareByMailProviderTest extends TestCase {
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
 			->with(new GenerateSecurePasswordEvent(PasswordContext::SHARING));
-
-		// Assume the mail address is valid.
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject', 'createShareActivity', 'createPasswordSendActivity', 'sendPasswordToOwner']);
 
@@ -434,9 +426,6 @@ class ShareByMailProviderTest extends TestCase {
 		$this->urlGenerator->expects($this->once())->method('linkToRouteAbsolute')
 			->with('files_sharing.sharecontroller.showShare', ['token' => 'token'])
 			->willReturn('https://example.com/file.txt');
-
-		// Assume the mail address is valid.
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject', 'createShareActivity', 'autoGeneratePassword', 'createPasswordSendActivity', 'sendPasswordToOwner']);
 
@@ -525,9 +514,6 @@ class ShareByMailProviderTest extends TestCase {
 		$this->urlGenerator->expects($this->once())->method('linkToRouteAbsolute')
 			->with('files_sharing.sharecontroller.showShare', ['token' => 'token'])
 			->willReturn('https://example.com/file.txt');
-
-		// Assume the mail address is valid.
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject', 'createShareActivity', 'autoGeneratePassword', 'createPasswordSendActivity']);
 
@@ -623,9 +609,6 @@ class ShareByMailProviderTest extends TestCase {
 			'receiver2@example.com',
 			'receiver3@example.com',
 		]);
-
-		// Assume the mail address is valid.
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject', 'createShareActivity', 'autoGeneratePassword', 'createPasswordSendActivity', 'sendEmail', 'sendPassword', 'sendPasswordToOwner']);
 
@@ -1188,7 +1171,6 @@ class ShareByMailProviderTest extends TestCase {
 			->willReturn(new Share($rootFolder, $userManager));
 
 		$provider = $this->getInstance(['sendMailNotification', 'createShareActivity']);
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$u1 = $userManager->createUser('testFed', md5((string)time()));
 		$u2 = $userManager->createUser('testFed2', md5((string)time()));
@@ -1235,7 +1217,6 @@ class ShareByMailProviderTest extends TestCase {
 			->willReturn(new Share($rootFolder, $userManager));
 
 		$provider = $this->getInstance(['sendMailNotification', 'createShareActivity']);
-		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
 
 		$u1 = $userManager->createUser('testFed', md5((string)time()));
 		$u2 = $userManager->createUser('testFed2', md5((string)time()));
@@ -1370,9 +1351,6 @@ class ShareByMailProviderTest extends TestCase {
 			->method('useTemplate')
 			->with($template);
 
-		$this->mailer->expects($this->once())
-			->method('validateMailAddress')
-			->willReturn(true);
 		$this->mailer
 			->expects($this->once())
 			->method('send')
@@ -1492,9 +1470,6 @@ class ShareByMailProviderTest extends TestCase {
 			->method('useTemplate')
 			->with($template);
 
-		$this->mailer->expects($this->once())
-			->method('validateMailAddress')
-			->willReturn(true);
 		$this->mailer
 			->expects($this->once())
 			->method('send')
@@ -1619,9 +1594,6 @@ class ShareByMailProviderTest extends TestCase {
 			->method('useTemplate')
 			->with($template);
 
-		$this->mailer->expects($this->once())
-			->method('validateMailAddress')
-			->willReturn(true);
 		$this->mailer
 			->expects($this->once())
 			->method('send')
@@ -1717,9 +1689,6 @@ class ShareByMailProviderTest extends TestCase {
 			->method('useTemplate')
 			->with($template);
 
-		$this->mailer->expects($this->once())
-			->method('validateMailAddress')
-			->willReturn(true);
 		$this->mailer
 			->expects($this->once())
 			->method('send')
@@ -1818,9 +1787,6 @@ class ShareByMailProviderTest extends TestCase {
 			->method('useTemplate')
 			->with($template);
 
-		$this->mailer->expects($this->once())
-			->method('validateMailAddress')
-			->willReturn(true);
 		$this->mailer
 			->expects($this->once())
 			->method('send')
@@ -1915,9 +1881,6 @@ class ShareByMailProviderTest extends TestCase {
 			->method('useTemplate')
 			->with($template);
 
-		$this->mailer->expects($this->once())
-			->method('validateMailAddress')
-			->willReturn(true);
 		$this->mailer
 			->expects($this->once())
 			->method('send')

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -356,12 +356,6 @@
     </UndefinedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php">
-    <DeprecatedMethod>
-      <code><![CDATA[validateMailAddress]]></code>
-      <code><![CDATA[validateMailAddress]]></code>
-      <code><![CDATA[validateMailAddress]]></code>
-      <code><![CDATA[validateMailAddress]]></code>
-    </DeprecatedMethod>
     <LessSpecificReturnStatement>
       <code><![CDATA[$emailAddresses]]></code>
     </LessSpecificReturnStatement>
@@ -431,9 +425,6 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipPlugin.php">
-    <DeprecatedMethod>
-      <code><![CDATA[validateMailAddress]]></code>
-    </DeprecatedMethod>
     <RedundantCast>
       <code><![CDATA[(string)$iTipMessage->recipientName]]></code>
     </RedundantCast>
@@ -839,11 +830,6 @@
   <file src="apps/dav/lib/Files/RootCollection.php">
     <DeprecatedMethod>
       <code><![CDATA[getUserFolder]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/dav/lib/Listener/CalendarContactInteractionListener.php">
-    <DeprecatedMethod>
-      <code><![CDATA[validateMailAddress]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/Migration/BuildCalendarSearchIndex.php">
@@ -1458,7 +1444,6 @@
     </DeprecatedClass>
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[validateMailAddress]]></code>
     </DeprecatedMethod>
     <RedundantCast>
       <code><![CDATA[(int)$code]]></code>
@@ -2061,10 +2046,6 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/sharebymail/lib/ShareByMailProvider.php">
-    <DeprecatedMethod>
-      <code><![CDATA[validateMailAddress]]></code>
-      <code><![CDATA[validateMailAddress]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[(int)$data['id']]]></code>
@@ -2820,11 +2801,6 @@
       <code><![CDATA[listen]]></code>
       <code><![CDATA[listen]]></code>
       <code><![CDATA[listen]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="core/Command/User/Add.php">
-    <DeprecatedMethod>
-      <code><![CDATA[validateMailAddress]]></code>
     </DeprecatedMethod>
   </file>
   <file src="core/Command/User/AuthTokens/Add.php">
@@ -3754,7 +3730,6 @@
       <code><![CDATA[$groups]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
-      <code><![CDATA[\OC\Group\Group[]]]></code>
       <code><![CDATA[\OC\Group\Group[]]]></code>
     </MoreSpecificReturnType>
     <UndefinedInterfaceMethod>

--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -15,7 +15,7 @@ use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
-use OCP\Mail\IMailer;
+use OCP\Mail\IEmailValidator;
 use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\ISecureRandom;
 use Symfony\Component\Console\Command\Command;
@@ -30,7 +30,7 @@ class Add extends Command {
 	public function __construct(
 		protected IUserManager $userManager,
 		protected IGroupManager $groupManager,
-		protected IMailer $mailer,
+		private IEmailValidator $emailValidator,
 		private IAppConfig $appConfig,
 		private NewUserMailHelper $mailHelper,
 		private IEventDispatcher $eventDispatcher,
@@ -169,7 +169,7 @@ class Add extends Command {
 
 		$email = $input->getOption('email');
 		if (!empty($email)) {
-			if (!$this->mailer->validateMailAddress($email)) {
+			if (!$this->emailValidator->isValid($email)) {
 				$output->writeln(\sprintf(
 					'<error>The given email address "%s" is invalid. Email not set for the user.</error>',
 					$email,

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -17,7 +17,7 @@ use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
-use OCP\Mail\IMailer;
+use OCP\Mail\IEmailValidator;
 use OCP\Share\IShare;
 
 class MailPlugin implements ISearchPlugin {
@@ -40,7 +40,7 @@ class MailPlugin implements ISearchPlugin {
 		private IGroupManager $groupManager,
 		private KnownUserService $knownUserService,
 		private IUserSession $userSession,
-		private IMailer $mailer,
+		private IEmailValidator $emailValidator,
 		private mixed $shareWithGroupOnlyExcludeGroupsList = [],
 	) {
 		$this->shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
@@ -236,7 +236,7 @@ class MailPlugin implements ISearchPlugin {
 			$userResults['wide'] = array_slice($userResults['wide'], $offset, $limit);
 		}
 
-		if (!$searchResult->hasExactIdMatch($emailType) && $this->mailer->validateMailAddress($search)) {
+		if (!$searchResult->hasExactIdMatch($emailType) && $this->emailValidator->isValid($search)) {
 			$result['exact'][] = [
 				'label' => $search,
 				'uuid' => $search,

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -15,7 +15,7 @@ use OC\AppScriptDependency;
 use OC\AppScriptSort;
 use OC\Security\CSRF\CsrfTokenManager;
 use OCP\L10N\IFactory;
-use OCP\Mail\IMailer;
+use OCP\Mail\IEmailValidator;
 use OCP\Share\IManager;
 use Psr\Container\ContainerExceptionInterface;
 
@@ -305,8 +305,8 @@ class Util {
 		$host_name = $config->getSystemValueString('mail_domain', $host_name);
 		$defaultEmailAddress = $user_part . '@' . $host_name;
 
-		$mailer = \OCP\Server::get(IMailer::class);
-		if ($mailer->validateMailAddress($defaultEmailAddress)) {
+		$emailValidator = \OCP\Server::get(IEmailValidator::class);
+		if ($emailValidator->isValid($defaultEmailAddress)) {
 			return $defaultEmailAddress;
 		}
 

--- a/tests/Core/Command/User/AddTest.php
+++ b/tests/Core/Command/User/AddTest.php
@@ -22,8 +22,11 @@ use OCP\Security\ISecureRandom;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 
 class AddTest extends TestCase {
+	use EmailValidatorTrait;
+
 	/** @var IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $userManager;
 
@@ -62,7 +65,6 @@ class AddTest extends TestCase {
 
 		$this->userManager = static::createMock(IUserManager::class);
 		$this->groupManager = static::createStub(IGroupManager::class);
-		$this->mailer = static::createMock(IMailer::class);
 		$this->appConfig = static::createMock(IAppConfig::class);
 		$this->mailHelper = static::createMock(NewUserMailHelper::class);
 		$this->eventDispatcher = static::createStub(IEventDispatcher::class);
@@ -76,7 +78,7 @@ class AddTest extends TestCase {
 		$this->addCommand = new Add(
 			$this->userManager,
 			$this->groupManager,
-			$this->mailer,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 			$this->appConfig,
 			$this->mailHelper,
 			$this->eventDispatcher,
@@ -99,9 +101,6 @@ class AddTest extends TestCase {
 
 		$this->appConfig->method('getValueString')
 			->willReturn($shouldSendEmail ? 'yes' : 'no');
-
-		$this->mailer->method('validateMailAddress')
-			->willReturn($isEmailValid);
 
 		$this->mailHelper->method('generateTemplate')
 			->willReturn(static::createMock(IEMailTemplate::class));

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -22,11 +22,13 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\Mail\IMailer;
 use OCP\Share\IShare;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 
 class MailPluginTest extends TestCase {
+	use EmailValidatorTrait;
+
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
@@ -51,9 +53,6 @@ class MailPluginTest extends TestCase {
 	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
 
-	/** @var IMailer|\PHPUnit\Framework\MockObject\MockObject */
-	protected $mailer;
-
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -62,7 +61,6 @@ class MailPluginTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->knownUserService = $this->createMock(KnownUserService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
-		$this->mailer = $this->createMock(IMailer::class);
 		$this->cloudIdManager = new CloudIdManager(
 			$this->createMock(ICacheFactory::class),
 			$this->createMock(IEventDispatcher::class),
@@ -82,7 +80,7 @@ class MailPluginTest extends TestCase {
 			$this->groupManager,
 			$this->knownUserService,
 			$this->userSession,
-			$this->mailer
+			$this->getEmailValidatorWithStrictEmailCheck(),
 		);
 	}
 
@@ -114,9 +112,6 @@ class MailPluginTest extends TestCase {
 			->willReturn('current');
 		$this->userSession->method('getUser')
 			->willReturn($currentUser);
-
-		$this->mailer->method('validateMailAddress')
-			->willReturn($validEmail);
 
 		$this->contactsManager->expects($this->any())
 			->method('search')
@@ -600,9 +595,6 @@ class MailPluginTest extends TestCase {
 		$currentUser->expects($this->any())
 			->method('getUID')
 			->willReturn('currentUser');
-
-		$this->mailer->method('validateMailAddress')
-			->willReturn($validEmail);
 
 		$this->contactsManager->expects($this->any())
 			->method('search')

--- a/tests/lib/Share20/ShareByMailProviderTest.php
+++ b/tests/lib/Share20/ShareByMailProviderTest.php
@@ -29,6 +29,7 @@ use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
+use Test\Traits\EmailValidatorTrait;
 
 /**
  * Class ShareByMailProviderTest
@@ -37,6 +38,8 @@ use Test\TestCase;
  * @group DB
  */
 class ShareByMailProviderTest extends TestCase {
+	use EmailValidatorTrait;
+
 	/** @var IDBConnection */
 	protected $dbConn;
 
@@ -121,6 +124,7 @@ class ShareByMailProviderTest extends TestCase {
 			$this->hasher,
 			$this->eventDispatcher,
 			$this->shareManager,
+			$this->getEmailValidatorWithStrictEmailCheck(),
 		);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Follow up for https://github.com/nextcloud/server/pull/53834 to use the new IEmailValidator.isValid method.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
