### PR TITLE
fix(TaskProcessing): Make sure list command int filter parameters are parsed as ints

### DIFF
--- a/core/Command/TaskProcessing/ListCommand.php
+++ b/core/Command/TaskProcessing/ListCommand.php
@@ -54,7 +54,7 @@ class ListCommand extends Base {
 				'status',
 				's',
 				InputOption::VALUE_OPTIONAL,
-				'only get the tasks that have a specific status (STATUS_UNKNOWN=0, STATUS_SCHEDULED=1, STATUS_RUNNING=2, STATUS_SUCCESSFUL=3, STATUS_FAILED=4, STATUS_CANCELLED=5)'
+				'only get the tasks that have a specific status (STATUS_UNKNOWN=0, STATUS_SCHEDULED=1, STATUS_RUNNING=2, STATUS_SUCCESSFUL=3, STATUS_FAILED=4, STATUS_CANCELLED=5)',
 			)
 			->addOption(
 				'scheduledAfter',
@@ -81,9 +81,9 @@ class ListCommand extends Base {
 		$type = $input->getOption('type');
 		$appId = $input->getOption('appId');
 		$customId = $input->getOption('customId');
-		$status = $input->getOption('status');
-		$scheduledAfter = $input->getOption('scheduledAfter');
-		$endedBefore = $input->getOption('endedBefore');
+		$status = $input->getOption('status') !== null ? (int)$input->getOption('status') : null;
+		$scheduledAfter = $input->getOption('scheduledAfter') != null ? (int)$input->getOption('scheduledAfter') : null;
+		$endedBefore = $input->getOption('endedBefore') !== null ? (int)$input->getOption('endedBefore') : null;
 
 		$tasks = $this->taskProcessingManager->getTasks($userIdFilter, $type, $appId, $customId, $status, $scheduledAfter, $endedBefore);
 		$arrayTasks = array_map(static function (Task $task) {


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
