### PR TITLE
fix(ldap): Fix copying and creating LDAP configuration

### DIFF
--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -109,7 +109,7 @@ class Helper {
 			$prefix = 's01';
 		} else {
 			sort($prefixes);
-			$lastKey = array_pop($prefixes);
+			$lastKey = end($prefixes);
 			$lastNumber = (int)str_replace('s', '', $lastKey);
 			$prefix = 's' . str_pad((string)($lastNumber + 1), 2, '0', STR_PAD_LEFT);
 		}


### PR DESCRIPTION
* Follow-up of https://github.com/nextcloud/server/pull/52916
* Follow-up of https://github.com/nextcloud/server/pull/55475

## Summary

`array_pop` was used instead of `end`, as a result the new prefix list did not contain the previous one, and new configuration prefixes were replacing instead of being added to the list of prefixes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
