### PR TITLE
refactor(Sabre/Node): Remove dead code

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -32,13 +32,6 @@ abstract class Node implements \Sabre\DAV\INode {
 	 */
 	protected $path;
 
-	/**
-	 * node properties cache
-	 *
-	 * @var array
-	 */
-	protected $property_cache = null;
-
 	protected FileInfo $info;
 
 	/**
@@ -138,10 +131,6 @@ abstract class Node implements \Sabre\DAV\INode {
 		$this->path = $newPath;
 
 		$this->refreshInfo();
-	}
-
-	public function setPropertyCache($property_cache) {
-		$this->property_cache = $property_cache;
 	}
 
 	/**


### PR DESCRIPTION
property_cache is no longer used.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
