### PR TITLE
fix(ooo): don't catch general DB exceptions

### DIFF
--- a/apps/dav/lib/BackgroundJob/OutOfOfficeEventDispatcherJob.php
+++ b/apps/dav/lib/BackgroundJob/OutOfOfficeEventDispatcherJob.php
@@ -41,7 +41,7 @@ class OutOfOfficeEventDispatcherJob extends QueuedJob {
 
 		try {
 			$absence = $this->absenceMapper->findById($id);
-		} catch (DoesNotExistException|\OCP\DB\Exception $e) {
+		} catch (DoesNotExistException $e) {
 			$this->logger->error('Failed to dispatch out-of-office event: ' . $e->getMessage(), [
 				'exception' => $e,
 				'argument' => $argument,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

When creating an absence, the job doesn't differentiate between generalised DB errors and DoesNotExistException, thus simply returning even if the run was not successful. The job entry should remain in the oc_jobs table when a general DB error happens.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
