### PR TITLE
feat: allow setting custom name for occ generated app password

### DIFF
--- a/core/Command/User/AuthTokens/Add.php
+++ b/core/Command/User/AuthTokens/Add.php
@@ -48,6 +48,12 @@ class Add extends Command {
 				InputOption::VALUE_NONE,
 				'Read password from environment variable NC_PASS/OC_PASS. Alternatively it will be asked for interactively or an app password without the login password will be created.'
 			)
+			->addOption(
+				'name',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Name for the app password, defaults to "cli".'
+			)
 		;
 	}
 
@@ -81,13 +87,15 @@ class Add extends Command {
 			$output->writeln('<info>No password provided. The generated app password will therefore have limited capabilities. Any operation that requires the login password will fail.</info>');
 		}
 
+		$tokenName = $input->getOption('name') ?: 'cli';
+
 		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 		$generatedToken = $this->tokenProvider->generateToken(
 			$token,
 			$user->getUID(),
 			$user->getUID(),
 			$password,
-			'cli',
+			$tokenName,
 			IToken::PERMANENT_TOKEN,
 			IToken::DO_NOT_REMEMBER
 		);


### PR DESCRIPTION
instead of always naming it "cli"

Fixes https://github.com/nextcloud/server/issues/55567