### PR TITLE
fix(AppFramework): Check for responder existence

### DIFF
--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -222,8 +222,7 @@ class Dispatcher {
 		// format response
 		if ($response instanceof DataResponse || !($response instanceof Response)) {
 			$format = $this->request->getFormat();
-
-			if ($format !== null) {
+			if ($format !== null && $controller->isResponderRegistered($format)) {
 				$response = $controller->buildResponse($response, $format);
 			} else {
 				$response = $controller->buildResponse($response);

--- a/lib/private/AppFramework/Middleware/OCSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/OCSMiddleware.php
@@ -110,7 +110,10 @@ class OCSMiddleware extends Middleware {
 	 * @return V1Response|V2Response
 	 */
 	private function buildNewResponse(Controller $controller, $code, $message) {
-		$format = $this->request->getFormat() ?? 'xml';
+		$format = $this->request->getFormat();
+		if ($format === null || !$controller->isResponderRegistered($format)) {
+			$format = 'xml';
+		}
 
 		$data = new DataResponse();
 		$data->setStatus($code);

--- a/lib/public/AppFramework/Controller.php
+++ b/lib/public/AppFramework/Controller.php
@@ -7,6 +7,7 @@
  */
 namespace OCP\AppFramework;
 
+use Closure;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -32,7 +33,7 @@ abstract class Controller {
 	protected $request;
 
 	/**
-	 * @var array
+	 * @var array<string, Closure>
 	 * @since 7.0.0
 	 */
 	private $responders;
@@ -113,10 +114,10 @@ abstract class Controller {
 	/**
 	 * Registers a formatter for a type
 	 * @param string $format
-	 * @param \Closure $responder
+	 * @param Closure $responder
 	 * @since 7.0.0
 	 */
-	protected function registerResponder($format, \Closure $responder) {
+	protected function registerResponder($format, Closure $responder) {
 		$this->responders[$format] = $responder;
 	}
 
@@ -138,5 +139,9 @@ abstract class Controller {
 		}
 		throw new \DomainException('No responder registered for format '
 			. $format . '!');
+	}
+
+	public function isResponderRegistered(string $responder): bool {
+		return isset($this->responders[$responder]);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/55619

Make sure to check that the responder actually exists, before trying to use it instead of falling back to the default.