### PR TITLE
fix(dav): dav:remove-invalid-shares removing federated calendar shares

### DIFF
--- a/apps/dav/lib/Command/RemoveInvalidShares.php
+++ b/apps/dav/lib/Command/RemoveInvalidShares.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Command;
 
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\RemoteUserPrincipalBackend;
 use OCP\IDBConnection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,6 +25,7 @@ class RemoveInvalidShares extends Command {
 	public function __construct(
 		private IDBConnection $connection,
 		private Principal $principalBackend,
+		private RemoteUserPrincipalBackend $remoteUserPrincipalBackend,
 	) {
 		parent::__construct();
 	}
@@ -42,7 +44,8 @@ class RemoveInvalidShares extends Command {
 
 		while ($row = $result->fetch()) {
 			$principaluri = $row['principaluri'];
-			$p = $this->principalBackend->getPrincipalByPath($principaluri);
+			$p = $this->principalBackend->getPrincipalByPath($principaluri)
+				?? $this->remoteUserPrincipalBackend->getPrincipalByPath($principaluri);
 			if ($p === null) {
 				$this->deleteSharesForPrincipal($principaluri);
 			}

--- a/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
@@ -10,8 +10,11 @@ namespace OCA\DAV\Tests\unit\Command;
 
 use OCA\DAV\Command\RemoveInvalidShares;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\RemoteUserPrincipalBackend;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -23,32 +26,118 @@ use Test\TestCase;
  * @group DB
  */
 class RemoveInvalidSharesTest extends TestCase {
+	private RemoveInvalidShares $command;
+
+	private IDBConnection $db;
+	private Principal&MockObject $principalBackend;
+	private RemoteUserPrincipalBackend&MockObject $remoteUserPrincipalBackend;
+
 	protected function setUp(): void {
 		parent::setUp();
-		$db = Server::get(IDBConnection::class);
 
-		$db->insertIfNotExist('*PREFIX*dav_shares', [
+		$this->db = Server::get(IDBConnection::class);
+		$this->principalBackend = $this->createMock(Principal::class);
+		$this->remoteUserPrincipalBackend = $this->createMock(RemoteUserPrincipalBackend::class);
+
+		$this->db->insertIfNotExist('*PREFIX*dav_shares', [
 			'principaluri' => 'principal:unknown',
 			'type' => 'calendar',
 			'access' => 2,
 			'resourceid' => 666,
 		]);
+		$this->db->insertIfNotExist('*PREFIX*dav_shares', [
+			'principaluri' => 'principals/remote-users/foobar',
+			'type' => 'calendar',
+			'access' => 2,
+			'resourceid' => 666,
+		]);
+
+		$this->command = new RemoveInvalidShares(
+			$this->db,
+			$this->principalBackend,
+			$this->remoteUserPrincipalBackend,
+		);
 	}
 
-	public function test(): void {
-		$db = Server::get(IDBConnection::class);
-		$principal = $this->createMock(Principal::class);
-
-		$repair = new RemoveInvalidShares($db, $principal);
-		$this->invokePrivate($repair, 'run', [$this->createMock(InputInterface::class), $this->createMock(OutputInterface::class)]);
-
-		$query = $db->getQueryBuilder();
+	private function selectShares(): array {
+		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from('dav_shares')
-			->where($query->expr()->eq('principaluri', $query->createNamedParameter('principal:unknown')));
+			->where($query->expr()->in(
+				'principaluri',
+				$query->createNamedParameter(
+					['principal:unknown', 'principals/remote-users/foobar'],
+					IQueryBuilder::PARAM_STR_ARRAY,
+				),
+			));
 		$result = $query->executeQuery();
 		$data = $result->fetchAll();
 		$result->closeCursor();
-		$this->assertEquals(0, count($data));
+
+		return $data;
+	}
+
+	public function testWithoutPrincipals(): void {
+		$this->principalBackend->method('getPrincipalByPath')
+			->willReturnMap([
+				['principal:unknown', null],
+				['principals/remote-users/foobar', null],
+			]);
+		$this->remoteUserPrincipalBackend->method('getPrincipalByPath')
+			->willReturnMap([
+				['principal:unknown', null],
+				['principals/remote-users/foobar', null],
+			]);
+
+		$this->command->run(
+			$this->createMock(InputInterface::class),
+			$this->createMock(OutputInterface::class),
+		);
+
+		$data = $this->selectShares();
+		$this->assertCount(0, $data);
+	}
+
+	public function testWithLocalPrincipal(): void {
+		$this->principalBackend->method('getPrincipalByPath')
+			->willReturnMap([
+				['principal:unknown', ['uri' => 'principal:unknown']],
+				['principals/remote-users/foobar', null],
+			]);
+		$this->remoteUserPrincipalBackend->method('getPrincipalByPath')
+			->willReturnMap([
+				['principals/remote-users/foobar', null],
+			]);
+
+		$this->command->run(
+			$this->createMock(InputInterface::class),
+			$this->createMock(OutputInterface::class),
+		);
+
+		$data = $this->selectShares();
+		$this->assertCount(1, $data);
+		$this->assertEquals('principal:unknown', $data[0]['principaluri']);
+	}
+
+	public function testWithRemotePrincipal() {
+		$this->principalBackend->method('getPrincipalByPath')
+			->willReturnMap([
+				['principal:unknown', null],
+				['principals/remote-users/foobar', null],
+			]);
+		$this->remoteUserPrincipalBackend->method('getPrincipalByPath')
+			->willReturnMap([
+				['principal:unknown', null],
+				['principals/remote-users/foobar', ['uri' => 'principals/remote-users/foobar']],
+			]);
+
+		$this->command->run(
+			$this->createMock(InputInterface::class),
+			$this->createMock(OutputInterface::class),
+		);
+
+		$data = $this->selectShares();
+		$this->assertCount(1, $data);
+		$this->assertEquals('principals/remote-users/foobar', $data[0]['principaluri']);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

The command removes valid federated calendar shares as it is not able to find remote user principals.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
