### PR TITLE
refactor(IPropagator): Cleanup implementation

### DIFF
--- a/lib/private/Files/Cache/HomePropagator.php
+++ b/lib/private/Files/Cache/HomePropagator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -7,31 +9,11 @@
  */
 namespace OC\Files\Cache;
 
+use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
 
 class HomePropagator extends Propagator {
-	private $ignoredBaseFolders;
-
-	/**
-	 * @param \OC\Files\Storage\Storage $storage
-	 */
-	public function __construct(\OC\Files\Storage\Storage $storage, IDBConnection $connection) {
-		parent::__construct($storage, $connection);
-		$this->ignoredBaseFolders = ['files_encryption'];
-	}
-
-
-	/**
-	 * @param string $internalPath
-	 * @param int $time
-	 * @param int $sizeDifference number of bytes the file has grown
-	 */
-	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
-		[$baseFolder] = explode('/', $internalPath, 2);
-		if (in_array($baseFolder, $this->ignoredBaseFolders)) {
-			return [];
-		} else {
-			parent::propagateChange($internalPath, $time, $sizeDifference);
-		}
+	public function __construct(IStorage $storage, IDBConnection $connection) {
+		parent::__construct($storage, $connection, ignore: ['files_encryption']);
 	}
 }

--- a/lib/private/Files/Cache/Wrapper/JailPropagator.php
+++ b/lib/private/Files/Cache/Wrapper/JailPropagator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -8,21 +10,14 @@ namespace OC\Files\Cache\Wrapper;
 
 use OC\Files\Cache\Propagator;
 use OC\Files\Storage\Wrapper\Jail;
+use Override;
 
 class JailPropagator extends Propagator {
-	/**
-	 * @var Jail
-	 */
-	protected $storage;
-
-	/**
-	 * @param string $internalPath
-	 * @param int $time
-	 * @param int $sizeDifference
-	 */
-	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
-		/** @var \OC\Files\Storage\Storage $storage */
-		[$storage, $sourceInternalPath] = $this->storage->resolvePath($internalPath);
+	#[Override]
+	public function propagateChange(string $internalPath, int $time, int $sizeDifference = 0): void {
+		/** @var Jail $jail */
+		$jail = $this->storage;
+		[$storage, $sourceInternalPath] = $jail->resolvePath($internalPath);
 		$storage->getPropagator()->propagateChange($sourceInternalPath, $time, $sizeDifference);
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -215,7 +215,9 @@ class Jail extends Wrapper {
 	}
 
 	/**
-	 * Resolve the path for the source of the share
+	 * Resolve the path for the source of the share.
+	 *
+	 * @return array{0: IStorage, 1: string}
 	 */
 	public function resolvePath(string $path): array {
 		return [$this->getWrapperStorage(), $this->getUnjailedPath($path)];

--- a/lib/public/Files/Cache/IPropagator.php
+++ b/lib/public/Files/Cache/IPropagator.php
@@ -1,20 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCP\Files\Cache;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
- * Propagate etags and mtimes within the storage
+ * Propagate ETags and mtimes within the storage.
  *
  * @since 9.0.0
  */
+#[Consumable(since: '9.0.0')]
 interface IPropagator {
 	/**
-	 * Mark the beginning of a propagation batch
+	 * Mark the beginning of a propagation batch.
 	 *
 	 * Note that not all cache setups support propagation in which case this will be a noop
 	 *
@@ -23,20 +29,20 @@ interface IPropagator {
 	 *
 	 * @since 9.1.0
 	 */
-	public function beginBatch();
+	public function beginBatch(): void;
 
 	/**
-	 * Commit the active propagation batch
+	 * Commit the active propagation batch.
 	 *
 	 * @since 9.1.0
 	 */
-	public function commitBatch();
+	public function commitBatch(): void;
 
 	/**
 	 * @param string $internalPath
 	 * @param int $time
-	 * @param int $sizeDifference
+	 * @param int $sizeDifference The number of bytes the file has grown.
 	 * @since 9.0.0
 	 */
-	public function propagateChange($internalPath, $time, $sizeDifference = 0);
+	public function propagateChange(string $internalPath, int $time, int $sizeDifference = 0): void;
 }


### PR DESCRIPTION
## Summary

- Add missing type hinting
- Use only public methods from IStorage instead of relying on internal \OC\Storage methods
- Refactor HomePropagator to use ignore argument from Propagator instead of reimplementing the same logic.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
