### PR TITLE
fix(caldav): disable remote access when calendar federation is off

### DIFF
--- a/apps/dav/lib/Listener/SabrePluginAuthInitListener.php
+++ b/apps/dav/lib/Listener/SabrePluginAuthInitListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Listener;
 
+use OCA\DAV\CalDAV\Federation\CalendarFederationConfig;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarAuth;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCP\EventDispatcher\Event;
@@ -20,8 +21,17 @@ use Sabre\DAV\Auth\Plugin;
  * @template-implements IEventListener<Event|SabrePluginAuthInitEvent>
  */
 class SabrePluginAuthInitListener implements IEventListener {
+	public function __construct(
+		private readonly CalendarFederationConfig $calendarFederationConfig,
+	) {
+	}
+
 	public function handle(Event $event): void {
 		if (!($event instanceof SabrePluginAuthInitEvent)) {
+			return;
+		}
+
+		if (!$this->calendarFederationConfig->isFederationEnabled()) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

As discussed in a meeting. Currently, only the creation of new federated shares is disabled. However, disabling the feature should also prevent remote instances from accessing the local calendar data.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
