### PR TITLE
refactor: Deprecated user config from IConfig correctly

### DIFF
--- a/apps/dav/lib/CalDAV/TimezoneService.php
+++ b/apps/dav/lib/CalDAV/TimezoneService.php
@@ -12,6 +12,7 @@ namespace OCA\DAV\CalDAV;
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Calendar\ICalendar;
 use OCP\Calendar\IManager;
+use OCP\Config\IUserConfig;
 use OCP\IConfig;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VTimeZone;
@@ -22,13 +23,14 @@ class TimezoneService {
 
 	public function __construct(
 		private IConfig $config,
+		private IUserConfig $userConfig,
 		private PropertyMapper $propertyMapper,
 		private IManager $calendarManager,
 	) {
 	}
 
 	public function getUserTimezone(string $userId): ?string {
-		$fromConfig = $this->config->getUserValue(
+		$fromConfig = $this->userConfig->getValueString(
 			$userId,
 			'core',
 			'timezone',
@@ -51,7 +53,7 @@ class TimezoneService {
 		}
 
 		$principal = 'principals/users/' . $userId;
-		$uri = $this->config->getUserValue($userId, 'dav', 'defaultCalendar', CalDavBackend::PERSONAL_CALENDAR_URI);
+		$uri = $this->userConfig->getValueString($userId, 'dav', 'defaultCalendar', CalDavBackend::PERSONAL_CALENDAR_URI);
 		$calendars = $this->calendarManager->getCalendarsForPrincipal($principal);
 
 		/** @var ?VTimeZone $personalCalendarTimezone */

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
@@ -13,7 +13,8 @@ use OC\URLGenerator;
 use OCA\DAV\CalDAV\EventReader;
 use OCA\DAV\CalDAV\Schedule\IMipService;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\IConfig;
+use OCP\Config\IUserConfig;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IUserManager;
@@ -26,7 +27,8 @@ use Test\TestCase;
 
 class IMipServiceTest extends TestCase {
 	private URLGenerator&MockObject $urlGenerator;
-	private IConfig&MockObject $config;
+	private IUserConfig&MockObject $userConfig;
+	private IAppConfig&MockObject $appConfig;
 	private IDBConnection&MockObject $db;
 	private ISecureRandom&MockObject $random;
 	private IFactory&MockObject $l10nFactory;
@@ -47,7 +49,8 @@ class IMipServiceTest extends TestCase {
 		parent::setUp();
 
 		$this->urlGenerator = $this->createMock(URLGenerator::class);
-		$this->config = $this->createMock(IConfig::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->db = $this->createMock(IDBConnection::class);
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->l10nFactory = $this->createMock(IFactory::class);
@@ -63,12 +66,13 @@ class IMipServiceTest extends TestCase {
 			->willReturn($this->l10n);
 		$this->service = new IMipService(
 			$this->urlGenerator,
-			$this->config,
 			$this->db,
 			$this->random,
 			$this->l10nFactory,
 			$this->timeFactory,
-			$this->userManager
+			$this->userManager,
+			$this->userConfig,
+			$this->appConfig,
 		);
 
 		// construct calendar with a 1 hour event and same start/end time zones

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -24,6 +24,7 @@ use OCA\Files_Versions\Storage;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Command\IBus;
+use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
@@ -38,6 +39,7 @@ use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\FilesMetadata\IFilesMetadataManager;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IRequest;
@@ -368,12 +370,14 @@ class Trashbin implements IEventListener {
 	}
 
 	private static function getConfiguredTrashbinSize(string $user): int|float {
-		$config = Server::get(IConfig::class);
-		$userTrashbinSize = $config->getUserValue($user, 'files_trashbin', 'trashbin_size', '-1');
+		$userConfig = Server::get(IUserConfig::class);
+		$userTrashbinSize = $userConfig->getValueString($user, 'files_trashbin', 'trashbin_size', '-1');
 		if (is_numeric($userTrashbinSize) && ($userTrashbinSize > -1)) {
 			return Util::numericToNumber($userTrashbinSize);
 		}
-		$systemTrashbinSize = $config->getAppValue('files_trashbin', 'trashbin_size', '-1');
+
+		$appConfig = Server::get(IAppConfig::class);
+		$systemTrashbinSize = $appConfig->getValueString('files_trashbin', 'trashbin_size', '-1');
 		if (is_numeric($systemTrashbinSize)) {
 			return Util::numericToNumber($systemTrashbinSize);
 		}

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -11,10 +11,10 @@ use OCA\Theming\Service\BackgroundService;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\Config\IUserConfig;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\ICacheFactory;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IURLGenerator;
@@ -40,17 +40,17 @@ class ThemingDefaults extends \OC_Defaults {
 	 * ThemingDefaults constructor.
 	 */
 	public function __construct(
-		private IConfig $config,
-		private IAppConfig $appConfig,
-		private IL10N $l,
-		private IUserSession $userSession,
-		private IURLGenerator $urlGenerator,
-		private ICacheFactory $cacheFactory,
-		private Util $util,
-		private ImageManager $imageManager,
-		private IAppManager $appManager,
-		private INavigationManager $navigationManager,
-		private BackgroundService $backgroundService,
+		private readonly IAppConfig $appConfig,
+		private readonly IUserConfig $userConfig,
+		private readonly IL10N $l,
+		private readonly IUserSession $userSession,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly ICacheFactory $cacheFactory,
+		private readonly Util $util,
+		private readonly ImageManager $imageManager,
+		private readonly IAppManager $appManager,
+		private readonly INavigationManager $navigationManager,
+		private readonly BackgroundService $backgroundService,
 	) {
 		parent::__construct();
 
@@ -183,7 +183,7 @@ class ThemingDefaults extends \OC_Defaults {
 
 		// user-defined primary color
 		if (!empty($user)) {
-			$userPrimaryColor = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'primary_color', '');
+			$userPrimaryColor = $this->userConfig->getValueString($user->getUID(), Application::APP_ID, 'primary_color');
 			if (preg_match('/^\#([0-9a-f]{3}|[0-9a-f]{6})$/i', $userPrimaryColor)) {
 				return $userPrimaryColor;
 			}
@@ -209,7 +209,7 @@ class ThemingDefaults extends \OC_Defaults {
 
 		// user-defined background color
 		if (!empty($user)) {
-			$userBackgroundColor = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'background_color', '');
+			$userBackgroundColor = $this->userConfig->getValueString($user->getUID(), Application::APP_ID, 'background_color');
 			if (preg_match('/^\#([0-9a-f]{3}|[0-9a-f]{6})$/i', $userBackgroundColor)) {
 				return $userBackgroundColor;
 			}

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -14,10 +14,10 @@ use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\Config\IUserConfig;
 use OCP\Files\NotFoundException;
 use OCP\ICache;
 use OCP\ICacheFactory;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IURLGenerator;
@@ -28,7 +28,7 @@ use Test\TestCase;
 
 class ThemingDefaultsTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
-	private IConfig&MockObject $config;
+	private IUserConfig&MockObject $userConfig;
 	private IL10N&MockObject $l10n;
 	private IUserSession&MockObject $userSession;
 	private IURLGenerator&MockObject $urlGenerator;
@@ -46,7 +46,7 @@ class ThemingDefaultsTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->appConfig = $this->createMock(IAppConfig::class);
-		$this->config = $this->createMock(IConfig::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
@@ -63,8 +63,8 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getBaseUrl')
 			->willReturn('');
 		$this->template = new ThemingDefaults(
-			$this->config,
 			$this->appConfig,
+			$this->userConfig,
 			$this->l10n,
 			$this->userSession,
 			$this->urlGenerator,
@@ -468,9 +468,9 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getAppValueString')
 			->with('primary_color', '')
 			->willReturn($primaryColor);
-		$this->config
+		$this->userConfig
 			->expects($this->any())
-			->method('getUserValue')
+			->method('getValueString')
 			->with('user', 'theming', 'primary_color', '')
 			->willReturn($userPrimaryColor);
 

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -18,7 +18,6 @@ use OCA\User_LDAP\User\OfflineUser;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
 use OCP\IAppConfig;
-use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\Server;
@@ -55,7 +54,6 @@ class Access extends LDAPUtility {
 		public Connection $connection,
 		public Manager $userManager,
 		private Helper $helper,
-		private IConfig $config,
 		private IUserManager $ncUserManager,
 		private LoggerInterface $logger,
 		private IAppConfig $appConfig,
@@ -1572,14 +1570,12 @@ class Access extends LDAPUtility {
 	 * a *
 	 */
 	private function prepareSearchTerm(string $term): string {
-		$config = Server::get(IConfig::class);
-
-		$allowEnum = $config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
+		$allowEnum = $this->appConfig->getValueBool('core', 'shareapi_allow_share_dialog_user_enumeration', true);
 
 		$result = $term;
 		if ($term === '') {
 			$result = '*';
-		} elseif ($allowEnum !== 'no') {
+		} elseif ($allowEnum) {
 			$result = $term . '*';
 		}
 		return $result;

--- a/apps/user_ldap/lib/AccessFactory.php
+++ b/apps/user_ldap/lib/AccessFactory.php
@@ -9,7 +9,6 @@ namespace OCA\User_LDAP;
 use OCA\User_LDAP\User\Manager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
-use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
@@ -19,7 +18,6 @@ class AccessFactory {
 	public function __construct(
 		private ILDAPWrapper $ldap,
 		private Helper $helper,
-		private IConfig $config,
 		private IAppConfig $appConfig,
 		private IUserManager $ncUserManager,
 		private LoggerInterface $logger,
@@ -34,7 +32,6 @@ class AccessFactory {
 			$connection,
 			Server::get(Manager::class),
 			$this->helper,
-			$this->config,
 			$this->ncUserManager,
 			$this->logger,
 			$this->appConfig,

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -37,7 +37,8 @@ use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\Image;
-use OCP\IServerContainer;
+use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\IManager as IShareManager;
@@ -56,27 +57,22 @@ class Application extends App implements IBootstrap {
 		/**
 		 * Controller
 		 */
-		$container->registerService('RenewPasswordController', function (IAppContainer $appContainer) {
-			/** @var IServerContainer $server */
-			$server = $appContainer->get(IServerContainer::class);
-
+		$container->registerService('RenewPasswordController', function (ContainerInterface $appContainer) {
 			return new RenewPasswordController(
 				$appContainer->get('AppName'),
-				$server->getRequest(),
-				$appContainer->get('UserManager'),
-				$server->getConfig(),
+				$appContainer->get(IRequest::class),
+				$appContainer->get(IUserManager::class),
+				$appContainer->get(IConfig::class),
+				$appContainer->get(IUserConfig::class),
 				$appContainer->get(IL10N::class),
 				$appContainer->get('Session'),
-				$server->getURLGenerator()
+				$appContainer->get(IURLGenerator::class),
 			);
 		});
 
-		$container->registerService(ILDAPWrapper::class, function (IAppContainer $appContainer) {
-			/** @var IServerContainer $server */
-			$server = $appContainer->get(IServerContainer::class);
-
+		$container->registerService(ILDAPWrapper::class, function (ContainerInterface $appContainer) {
 			return new LDAP(
-				$server->getConfig()->getSystemValueString('ldap_log_file')
+				$appContainer->get(IConfig::class)->getSystemValueString('ldap_log_file')
 			);
 		});
 	}

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -29,6 +29,8 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\IAppContainer;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAvatarManager;
 use OCP\IConfig;
@@ -87,6 +89,8 @@ class Application extends App implements IBootstrap {
 			function (ContainerInterface $c) {
 				return new Manager(
 					$c->get(IConfig::class),
+					$c->get(IUserConfig::class),
+					$c->get(IAppConfig::class),
 					$c->get(LoggerInterface::class),
 					$c->get(IAvatarManager::class),
 					$c->get(Image::class),

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -8,6 +8,7 @@
 namespace OCA\User_LDAP;
 
 use OC\ServerNotAvailableException;
+use OCP\Config\IUserConfig;
 use OCP\Group\Backend\IBatchMethodsBackend;
 use OCP\Group\Backend\IDeleteGroupBackend;
 use OCP\Group\Backend\IGetDisplayNameBackend;
@@ -15,7 +16,6 @@ use OCP\Group\Backend\IGroupDetailsBackend;
 use OCP\Group\Backend\IIsAdminBackend;
 use OCP\Group\Backend\INamedBackend;
 use OCP\GroupInterface;
-use OCP\IConfig;
 use OCP\IUserManager;
 
 /**
@@ -23,11 +23,11 @@ use OCP\IUserManager;
  */
 class Group_Proxy extends Proxy implements GroupInterface, IGroupLDAP, IGetDisplayNameBackend, INamedBackend, IDeleteGroupBackend, IBatchMethodsBackend, IIsAdminBackend {
 	public function __construct(
-		private Helper $helper,
+		Helper $helper,
 		ILDAPWrapper $ldap,
 		AccessFactory $accessFactory,
 		private GroupPluginManager $groupPluginManager,
-		private IConfig $config,
+		private IUserConfig $userConfig,
 		private IUserManager $ncUserManager,
 	) {
 		parent::__construct($helper, $ldap, $accessFactory);
@@ -35,7 +35,7 @@ class Group_Proxy extends Proxy implements GroupInterface, IGroupLDAP, IGetDispl
 
 
 	protected function newInstance(string $configPrefix): Group_LDAP {
-		return new Group_LDAP($this->getAccess($configPrefix), $this->groupPluginManager, $this->config, $this->ncUserManager);
+		return new Group_LDAP($this->getAccess($configPrefix), $this->groupPluginManager, $this->userConfig, $this->ncUserManager);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Jobs/UpdateGroups.php
+++ b/apps/user_ldap/lib/Jobs/UpdateGroups.php
@@ -10,21 +10,21 @@ declare(strict_types=1);
 namespace OCA\User_LDAP\Jobs;
 
 use OCA\User_LDAP\Service\UpdateGroupsService;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\DB\Exception;
-use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 class UpdateGroups extends TimedJob {
 	public function __construct(
 		private UpdateGroupsService $service,
 		private LoggerInterface $logger,
-		IConfig $config,
+		IAppConfig $appConfig,
 		ITimeFactory $timeFactory,
 	) {
 		parent::__construct($timeFactory);
-		$this->interval = (int)$config->getAppValue('user_ldap', 'bgjRefreshInterval', '3600');
+		$this->interval = $appConfig->getAppValueInt('bgjRefreshInterval', 3600);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Migration/UUIDFixInsert.php
+++ b/apps/user_ldap/lib/Migration/UUIDFixInsert.php
@@ -8,41 +8,27 @@ namespace OCA\User_LDAP\Migration;
 
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\BackgroundJob\IJobList;
-use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class UUIDFixInsert implements IRepairStep {
 
 	public function __construct(
-		protected IConfig $config,
+		protected IAppConfig $appConfig,
 		protected UserMapping $userMapper,
 		protected GroupMapping $groupMapper,
 		protected IJobList $jobList,
 	) {
 	}
 
-	/**
-	 * Returns the step's name
-	 *
-	 * @return string
-	 * @since 9.1.0
-	 */
-	public function getName() {
+	public function getName(): string {
 		return 'Insert UUIDFix background job for user and group in batches';
 	}
 
-	/**
-	 * Run repair step.
-	 * Must throw exception on error.
-	 *
-	 * @param IOutput $output
-	 * @throws \Exception in case of failure
-	 * @since 9.1.0
-	 */
-	public function run(IOutput $output) {
-		$installedVersion = $this->config->getAppValue('user_ldap', 'installed_version', '1.2.1');
+	public function run(IOutput $output): void {
+		$installedVersion = $this->appConfig->getAppValueString('installed_version', '1.2.1');
 		if (version_compare($installedVersion, '1.2.1') !== -1) {
 			return;
 		}

--- a/apps/user_ldap/lib/User/DeletedUsersIndex.php
+++ b/apps/user_ldap/lib/User/DeletedUsersIndex.php
@@ -7,7 +7,7 @@
 namespace OCA\User_LDAP\User;
 
 use OCA\User_LDAP\Mapping\UserMapping;
-use OCP\IConfig;
+use OCP\Config\IUserConfig;
 use OCP\PreConditionNotMetException;
 use OCP\Share\IManager;
 
@@ -19,22 +19,23 @@ class DeletedUsersIndex {
 	protected ?array $deletedUsers = null;
 
 	public function __construct(
-		protected IConfig $config,
+		protected IUserConfig $userConfig,
 		protected UserMapping $mapping,
 		private IManager $shareManager,
 	) {
 	}
 
 	/**
-	 * reads LDAP users marked as deleted from the database
+	 * Reads LDAP users marked as deleted from the database.
+	 *
 	 * @return OfflineUser[]
 	 */
 	private function fetchDeletedUsers(): array {
-		$deletedUsers = $this->config->getUsersForUserValue('user_ldap', 'isDeleted', '1');
+		$deletedUsers = $this->userConfig->searchUsersByValueBool('user_ldap', 'isDeleted', true);
 
 		$userObjects = [];
 		foreach ($deletedUsers as $user) {
-			$userObject = new OfflineUser($user, $this->config, $this->mapping, $this->shareManager);
+			$userObject = new OfflineUser($user, $this->userConfig, $this->mapping, $this->shareManager);
 			if ($userObject->getLastLogin() > $userObject->getDetectedOn()) {
 				$userObject->unmark();
 			} else {
@@ -47,7 +48,8 @@ class DeletedUsersIndex {
 	}
 
 	/**
-	 * returns all LDAP users that are marked as deleted
+	 * Returns all LDAP users that are marked as deleted.
+	 *
 	 * @return OfflineUser[]
 	 */
 	public function getUsers(): array {
@@ -58,7 +60,7 @@ class DeletedUsersIndex {
 	}
 
 	/**
-	 * whether at least one user was detected as deleted
+	 * Whether at least one user was detected as deleted.
 	 */
 	public function hasUsers(): bool {
 		if (!is_array($this->deletedUsers)) {
@@ -68,7 +70,7 @@ class DeletedUsersIndex {
 	}
 
 	/**
-	 * marks a user as deleted
+	 * Marks a user as deleted.
 	 *
 	 * @throws PreConditionNotMetException
 	 */
@@ -77,12 +79,12 @@ class DeletedUsersIndex {
 			// the user is already marked, do not write to DB again
 			return;
 		}
-		$this->config->setUserValue($ocName, 'user_ldap', 'isDeleted', '1');
-		$this->config->setUserValue($ocName, 'user_ldap', 'foundDeleted', (string)time());
+		$this->userConfig->setValueBool($ocName, 'user_ldap', 'isDeleted', true);
+		$this->userConfig->setValueInt($ocName, 'user_ldap', 'foundDeleted', time());
 		$this->deletedUsers = null;
 	}
 
 	public function isUserMarked(string $ocName): bool {
-		return ($this->config->getUserValue($ocName, 'user_ldap', 'isDeleted', '0') === '1');
+		return ($this->userConfig->getValueBool($ocName, 'user_ldap', 'isDeleted', false) === true);
 	}
 }

--- a/apps/user_ldap/lib/User/DeletedUsersIndex.php
+++ b/apps/user_ldap/lib/User/DeletedUsersIndex.php
@@ -85,6 +85,6 @@ class DeletedUsersIndex {
 	}
 
 	public function isUserMarked(string $ocName): bool {
-		return ($this->userConfig->getValueBool($ocName, 'user_ldap', 'isDeleted', false) === true);
+		return $this->userConfig->getValueBool($ocName, 'user_ldap', 'isDeleted');
 	}
 }

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -8,7 +8,9 @@
 namespace OCA\User_LDAP\User;
 
 use OCA\User_LDAP\Access;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\Cache\CappedMemoryCache;
+use OCP\Config\IUserConfig;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -34,6 +36,8 @@ class Manager {
 
 	public function __construct(
 		protected IConfig $ocConfig,
+		protected IUserConfig $userConfig,
+		protected IAppConfig $appConfig,
 		protected LoggerInterface $logger,
 		protected IAvatarManager $avatarManager,
 		protected Image $image,
@@ -63,7 +67,7 @@ class Manager {
 	 */
 	private function createAndCache($dn, $uid) {
 		$this->checkAccess();
-		$user = new User($uid, $dn, $this->access, $this->ocConfig,
+		$user = new User($uid, $dn, $this->access, $this->ocConfig, $this->userConfig, $this->appConfig,
 			clone $this->image, $this->logger,
 			$this->avatarManager, $this->userManager,
 			$this->notificationManager);

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -162,25 +162,21 @@ class Manager {
 	}
 
 	/**
-	 * Checks whether the specified user is marked as deleted
-	 * @param string $id the Nextcloud user name
-	 * @return bool
+	 * Checks whether the specified user is marked as deleted.
+	 * @param string $id the Nextcloud username
 	 */
-	public function isDeletedUser($id) {
-		$isDeleted = $this->ocConfig->getUserValue(
-			$id, 'user_ldap', 'isDeleted', 0);
-		return (int)$isDeleted === 1;
+	public function isDeletedUser(string $id): bool {
+		return $this->userConfig->getValueBool(
+			$id, 'user_ldap', 'isDeleted');
 	}
 
 	/**
-	 * creates and returns an instance of OfflineUser for the specified user
-	 * @param string $id
-	 * @return OfflineUser
+	 * Creates and returns an instance of OfflineUser for the specified user.
 	 */
-	public function getDeletedUser($id) {
+	public function getDeletedUser(string $id): OfflineUser {
 		return new OfflineUser(
 			$id,
-			$this->ocConfig,
+			$this->userConfig,
 			$this->access->getUserMapper(),
 			$this->shareManager
 		);

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -20,6 +20,7 @@ use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
+use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
 use OCP\IAppConfig;
@@ -102,6 +103,8 @@ class AccessTest extends TestCase {
 		$um = $this->getMockBuilder(Manager::class)
 			->setConstructorArgs([
 				$this->createMock(IConfig::class),
+				$this->createMock(IUserConfig::class),
+				$this->createMock(\OCP\AppFramework\Services\IAppConfig::class),
 				$this->createMock(LoggerInterface::class),
 				$this->createMock(IAvatarManager::class),
 				$this->createMock(Image::class),

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -50,7 +50,6 @@ class AccessTest extends TestCase {
 	private LDAP&MockObject $ldap;
 	private Manager&MockObject $userManager;
 	private Helper&MockObject $helper;
-	private IConfig&MockObject $config;
 	private IUserManager&MockObject $ncUserManager;
 	private LoggerInterface&MockObject $logger;
 	private IAppConfig&MockObject $appConfig;
@@ -64,7 +63,6 @@ class AccessTest extends TestCase {
 			->getMock();
 		$this->userManager = $this->createMock(Manager::class);
 		$this->helper = $this->createMock(Helper::class);
-		$this->config = $this->createMock(IConfig::class);
 		$this->userMapper = $this->createMock(UserMapping::class);
 		$this->groupMapper = $this->createMock(GroupMapping::class);
 		$this->ncUserManager = $this->createMock(IUserManager::class);
@@ -78,7 +76,6 @@ class AccessTest extends TestCase {
 			$this->connection,
 			$this->userManager,
 			$this->helper,
-			$this->config,
 			$this->ncUserManager,
 			$this->logger,
 			$this->appConfig,
@@ -225,9 +222,7 @@ class AccessTest extends TestCase {
 	#[\PHPUnit\Framework\Attributes\DataProvider('dnInputDataProvider')]
 	public function testStringResemblesDN(string $input, array|bool $interResult, bool $expectedResult): void {
 		[$lw, $con, $um, $helper] = $this->getConnectorAndLdapMock();
-		/** @var IConfig&MockObject $config */
-		$config = $this->createMock(IConfig::class);
-		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
+		$access = new Access($lw, $con, $um, $helper, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
 
 		$lw->expects($this->exactly(1))
 			->method('explodeDN')
@@ -244,10 +239,8 @@ class AccessTest extends TestCase {
 	#[\PHPUnit\Framework\Attributes\DataProvider('dnInputDataProvider')]
 	public function testStringResemblesDNLDAPmod(string $input, array|bool $interResult, bool $expectedResult): void {
 		[, $con, $um, $helper] = $this->getConnectorAndLdapMock();
-		/** @var IConfig&MockObject $config */
-		$config = $this->createMock(IConfig::class);
 		$lw = new LDAP();
-		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
+		$access = new Access($lw, $con, $um, $helper, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
 
 		if (!function_exists('ldap_explode_dn')) {
 			$this->markTestSkipped('LDAP Module not available');
@@ -416,9 +409,6 @@ class AccessTest extends TestCase {
 	#[\PHPUnit\Framework\Attributes\DataProvider('dNAttributeProvider')]
 	public function testSanitizeDN(string $attribute): void {
 		[$lw, $con, $um, $helper] = $this->getConnectorAndLdapMock();
-		/** @var IConfig&MockObject $config */
-		$config = $this->createMock(IConfig::class);
-
 		$dnFromServer = 'cn=Mixed Cases,ou=Are Sufficient To,ou=Test,dc=example,dc=org';
 
 		$lw->expects($this->any())
@@ -430,7 +420,7 @@ class AccessTest extends TestCase {
 				$attribute => ['count' => 1, $dnFromServer]
 			]);
 
-		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
+		$access = new Access($lw, $con, $um, $helper, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
 		$values = $access->readAttribute('uid=whoever,dc=example,dc=org', $attribute);
 		$this->assertSame($values[0], strtolower($dnFromServer));
 	}

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -18,8 +18,8 @@ use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
 use OCA\User_LDAP\User_Proxy;
+use OCP\Config\IUserConfig;
 use OCP\GroupInterface;
-use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
@@ -37,7 +37,7 @@ use Test\TestCase;
 class Group_LDAPTest extends TestCase {
 	private Access&MockObject $access;
 	private GroupPluginManager&MockObject $pluginManager;
-	private IConfig&MockObject $config;
+	private IUserConfig&MockObject $userConfig;
 	private IUserManager&MockObject $ncUserManager;
 	private GroupLDAP $groupBackend;
 
@@ -46,12 +46,12 @@ class Group_LDAPTest extends TestCase {
 
 		$this->access = $this->getAccessMock();
 		$this->pluginManager = $this->createMock(GroupPluginManager::class);
-		$this->config = $this->createMock(IConfig::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
 		$this->ncUserManager = $this->createMock(IUserManager::class);
 	}
 
 	public function initBackend(): void {
-		$this->groupBackend = new GroupLDAP($this->access, $this->pluginManager, $this->config, $this->ncUserManager);
+		$this->groupBackend = new GroupLDAP($this->access, $this->pluginManager, $this->userConfig, $this->ncUserManager);
 	}
 
 	public function testCountEmptySearchString(): void {
@@ -772,9 +772,9 @@ class Group_LDAPTest extends TestCase {
 			->method('isDNPartOfBase')
 			->willReturn(true);
 
-		$this->config->expects($this->once())
-			->method('setUserValue')
-			->with('userX', 'user_ldap', 'cached-group-memberships-', \json_encode($expectedGroups));
+		$this->userConfig->expects($this->once())
+			->method('setValueArray')
+			->with('userX', 'user_ldap', 'cached-group-memberships-', $expectedGroups);
 
 		$this->initBackend();
 		$groups = $this->groupBackend->getUserGroups('userX');
@@ -810,9 +810,9 @@ class Group_LDAPTest extends TestCase {
 			->willReturn([]);
 
 		// empty group result should not be oer
-		$this->config->expects($this->once())
-			->method('setUserValue')
-			->with('userX', 'user_ldap', 'cached-group-memberships-', '[]');
+		$this->userConfig->expects($this->once())
+			->method('setValueArray')
+			->with('userX', 'user_ldap', 'cached-group-memberships-', []);
 
 		$ldapUser = $this->createMock(User::class);
 
@@ -846,10 +846,10 @@ class Group_LDAPTest extends TestCase {
 
 		$offlineUser = $this->createMock(OfflineUser::class);
 
-		$this->config->expects($this->any())
-			->method('getUserValue')
+		$this->userConfig->expects($this->any())
+			->method('getValueArray')
 			->with('userX', 'user_ldap', 'cached-group-memberships-', $this->anything())
-			->willReturn(\json_encode(['groupB', 'groupF']));
+			->willReturn(['groupB', 'groupF']);
 
 		$this->access->userManager->expects($this->any())
 			->method('get')
@@ -872,11 +872,11 @@ class Group_LDAPTest extends TestCase {
 
 		$offlineUser = $this->createMock(OfflineUser::class);
 
-		$this->config->expects($this->any())
-			->method('getUserValue')
+		$this->userConfig->expects($this->any())
+			->method('getValueArray')
 			->with('userX', 'user_ldap', 'cached-group-memberships-', $this->anything())
 			// results in a json object: {"0":"groupB","2":"groupF"}
-			->willReturn(\json_encode([0 => 'groupB', 2 => 'groupF']));
+			->willReturn([0 => 'groupB', 2 => 'groupF']);
 
 		$this->access->userManager->expects($this->any())
 			->method('get')
@@ -907,10 +907,10 @@ class Group_LDAPTest extends TestCase {
 			->method('getBackend')
 			->willReturn($userBackend);
 
-		$this->config->expects($this->atLeastOnce())
-			->method('getUserValue')
+		$this->userConfig->expects($this->atLeastOnce())
+			->method('getValueArray')
 			->with('userX', 'user_ldap', 'cached-group-memberships-', $this->anything())
-			->willReturn(\json_encode(['groupB', 'groupF']));
+			->willReturn(['groupB', 'groupF']);
 
 		$this->access->expects($this->any())
 			->method('username2dn')

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -15,16 +15,16 @@ use OCA\User_LDAP\Jobs\Sync;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group('DB')]
@@ -34,6 +34,8 @@ class SyncTest extends TestCase {
 	protected Manager&MockObject $userManager;
 	protected UserMapping&MockObject $mapper;
 	protected IConfig&MockObject $config;
+	protected IAppConfig&MockObject $appConfig;
+	protected \OCP\IAppConfig&MockObject $globalAppConfig;
 	protected IAvatarManager&MockObject $avatarManager;
 	protected IDBConnection&MockObject $dbc;
 	protected IUserManager&MockObject $ncUserManager;
@@ -51,6 +53,8 @@ class SyncTest extends TestCase {
 		$this->userManager = $this->createMock(Manager::class);
 		$this->mapper = $this->createMock(UserMapping::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->globalAppConfig = $this->createMock(\OCP\IAppConfig::class);
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
 		$this->dbc = $this->createMock(IDBConnection::class);
 		$this->ncUserManager = $this->createMock(IUserManager::class);
@@ -64,13 +68,9 @@ class SyncTest extends TestCase {
 
 		$this->sync = new Sync(
 			Server::get(ITimeFactory::class),
-			Server::get(IEventDispatcher::class),
 			$this->config,
-			$this->dbc,
-			$this->avatarManager,
-			$this->ncUserManager,
-			Server::get(LoggerInterface::class),
-			$this->notificationManager,
+			$this->appConfig,
+			$this->globalAppConfig,
 			$this->mapper,
 			$this->helper,
 			$this->connectionFactory,
@@ -100,17 +100,17 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('intervalDataProvider')]
+	#[DataProvider('intervalDataProvider')]
 	public function testUpdateInterval(int $userCount, int $pagingSize1, int $pagingSize2): void {
-		$this->config->expects($this->once())
-			->method('setAppValue')
-			->with('user_ldap', 'background_sync_interval', $this->anything())
-			->willReturnCallback(function ($a, $k, $interval) {
+		$this->appConfig->expects($this->once())
+			->method('setAppValueInt')
+			->with('background_sync_interval', $this->anything())
+			->willReturnCallback(function ($key, $interval) {
 				$this->assertTrue($interval >= SYNC::MIN_INTERVAL);
 				$this->assertTrue($interval <= SYNC::MAX_INTERVAL);
 				return true;
 			});
-		$this->config->expects($this->atLeastOnce())
+		$this->appConfig->expects($this->atLeastOnce())
 			->method('getAppKeys')
 			->willReturn([
 				'blabla',
@@ -119,8 +119,8 @@ class SyncTest extends TestCase {
 				'installed',
 				's07ldap_paging_size'
 			]);
-		$this->config->expects($this->exactly(2))
-			->method('getAppValue')
+		$this->appConfig->expects($this->exactly(2))
+			->method('getAppValueInt')
 			->willReturnOnConsecutiveCalls($pagingSize1, $pagingSize2);
 
 		$this->mapper->expects($this->atLeastOnce())
@@ -141,7 +141,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('moreResultsProvider')]
+	#[DataProvider('moreResultsProvider')]
 	public function testMoreResults($pagingSize, $results, $expected): void {
 		$connection = $this->getMockBuilder(Connection::class)
 			->setConstructorArgs([
@@ -198,7 +198,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('cycleDataProvider')]
+	#[DataProvider('cycleDataProvider')]
 	public function testDetermineNextCycle(?array $cycleData, array $prefixes, ?array $expectedCycle): void {
 		$this->helper->expects($this->any())
 			->method('getServerConfigurationPrefixes')
@@ -206,19 +206,18 @@ class SyncTest extends TestCase {
 			->willReturn($prefixes);
 
 		if (is_array($expectedCycle)) {
-			$calls = [
-				['user_ldap', 'background_sync_prefix', $expectedCycle['prefix']],
-				['user_ldap', 'background_sync_offset', $expectedCycle['offset']],
-			];
-			$this->config->expects($this->exactly(2))
-				->method('setAppValue')
-				->willReturnCallback(function () use (&$calls): void {
-					$expected = array_shift($calls);
-					$this->assertEquals($expected, func_get_args());
-				});
+			$this->appConfig->expects($this->once())
+				->method('setAppValueInt')
+				->with('background_sync_offset', $expectedCycle['offset']);
+
+			$this->appConfig->expects($this->once())
+				->method('setAppValueString')
+				->with('background_sync_prefix', $expectedCycle['prefix']);
 		} else {
-			$this->config->expects($this->never())
-				->method('setAppValue');
+			$this->appConfig->expects($this->never())
+				->method('setAppValueString');
+			$this->appConfig->expects($this->never())
+				->method('setAppValueInt');
 		}
 
 		$this->sync->setArgument($this->arguments);
@@ -235,8 +234,8 @@ class SyncTest extends TestCase {
 	public function testQualifiesToRun(): void {
 		$cycleData = ['prefix' => 's01'];
 
-		$this->config->expects($this->exactly(2))
-			->method('getAppValue')
+		$this->appConfig->expects($this->exactly(2))
+			->method('getAppValueInt')
 			->willReturnOnConsecutiveCalls(time() - 60 * 40, time() - 60 * 20);
 
 		$this->sync->setArgument($this->arguments);
@@ -249,76 +248,94 @@ class SyncTest extends TestCase {
 			#0 - one LDAP server, reset
 			[[
 				'prefixes' => [''],
-				'scheduledCycle' => ['prefix' => '', 'offset' => '4500'],
+				'scheduledCycle' => ['prefix' => '', 'offset' => 4500],
 				'pagingSize' => 500,
 				'usersThisCycle' => 0,
-				'expectedNextCycle' => ['prefix' => '', 'offset' => '0'],
+				'expectedNextCycle' => ['prefix' => '', 'offset' => 0],
 				'mappedUsers' => 123,
 			]],
 			#1 - 2 LDAP servers, next prefix
 			[[
 				'prefixes' => ['', 's01'],
-				'scheduledCycle' => ['prefix' => '', 'offset' => '4500'],
+				'scheduledCycle' => ['prefix' => '', 'offset' => 4500],
 				'pagingSize' => 500,
 				'usersThisCycle' => 0,
-				'expectedNextCycle' => ['prefix' => 's01', 'offset' => '0'],
+				'expectedNextCycle' => ['prefix' => 's01', 'offset' => 0],
 				'mappedUsers' => 123,
 			]],
 			#2 - 2 LDAP servers, rotate prefix
 			[[
 				'prefixes' => ['', 's01'],
-				'scheduledCycle' => ['prefix' => 's01', 'offset' => '4500'],
+				'scheduledCycle' => ['prefix' => 's01', 'offset' => 4500],
 				'pagingSize' => 500,
 				'usersThisCycle' => 0,
-				'expectedNextCycle' => ['prefix' => '', 'offset' => '0'],
+				'expectedNextCycle' => ['prefix' => '', 'offset' => 0],
 				'mappedUsers' => 123,
 			]],
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
+	#[DataProvider('runDataProvider')]
 	public function testRun(array $runData): void {
-		$this->config->expects($this->any())
-			->method('getAppValue')
-			->willReturnCallback(function ($app, $key, $default) use ($runData) {
+		$this->globalAppConfig->expects($this->any())
+			->method('getValueString')
+			->willReturnCallback(function (string $app, string $key, $default) use ($runData) {
 				if ($app === 'core' && $key === 'backgroundjobs_mode') {
 					return 'cron';
 				}
-				if ($app = 'user_ldap') {
-					// for getCycle()
-					if ($key === 'background_sync_prefix') {
-						return $runData['scheduledCycle']['prefix'];
-					}
-					if ($key === 'background_sync_offset') {
-						return $runData['scheduledCycle']['offset'];
-					}
-					// for qualifiesToRun()
-					if ($key === $runData['scheduledCycle']['prefix'] . '_lastChange') {
-						return time() - 60 * 40;
-					}
-					// for getMinPagingSize
-					if ($key === $runData['scheduledCycle']['prefix'] . 'ldap_paging_size') {
-						return $runData['pagingSize'];
-					}
+				return $default;
+			});
+
+		$this->appConfig->expects($this->any())
+			->method('getAppValueInt')
+			->willReturnCallback(function (string $key, int $default) use ($runData): int {
+				if ($key === 'background_sync_offset') {
+					return $runData['scheduledCycle']['offset'];
+				}
+				// for getMinPagingSize
+				if ($key === $runData['scheduledCycle']['prefix'] . 'ldap_paging_size') {
+					return $runData['pagingSize'];
+				}
+				// for qualifiesToRun()
+				if ($key === $runData['scheduledCycle']['prefix'] . '_lastChange') {
+					return time() - 60 * 40;
 				}
 
 				return $default;
 			});
 
+		$this->appConfig->expects($this->any())
+			->method('getAppValueString')
+			->willReturnCallback(function (string $key, string $default) use ($runData): string {
+				// for getCycle()
+				if ($key === 'background_sync_prefix') {
+					return $runData['scheduledCycle']['prefix'];
+				}
+				return $default;
+			});
+
 		$calls = [
-			['user_ldap', 'background_sync_prefix', $runData['expectedNextCycle']['prefix']],
-			['user_ldap', 'background_sync_offset', $runData['expectedNextCycle']['offset']],
-			['user_ldap', 'background_sync_interval', '43200'],
+			['background_sync_prefix', $runData['expectedNextCycle']['prefix'], false, false],
+			['background_sync_offset', $runData['expectedNextCycle']['offset'], false, false],
+			['background_sync_interval', 43200, false, false],
 		];
-		$this->config->expects($this->exactly(3))
-			->method('setAppValue')
-			->willReturnCallback(function () use (&$calls): void {
+		$this->appConfig->expects($this->once())
+			->method('setAppValueString')
+			->willReturnCallback(function () use (&$calls): bool {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
+				return true;
 			});
-		$this->config->expects($this->any())
+		$this->appConfig->expects($this->exactly(2))
+			->method('setAppValueInt')
+			->willReturnCallback(function () use (&$calls): bool {
+				$expected = array_shift($calls);
+				$this->assertEquals($expected, func_get_args());
+				return true;
+			});
+
+		$this->appConfig->expects($this->any())
 			->method('getAppKeys')
-			->with('user_ldap')
 			->willReturn([$runData['scheduledCycle']['prefix'] . 'ldap_paging_size']);
 
 		$this->helper->expects($this->any())

--- a/apps/user_ldap/tests/Migration/UUIDFixInsertTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixInsertTest.php
@@ -10,14 +10,14 @@ namespace OCA\User_LDAP\Tests\Migration;
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Migration\UUIDFixInsert;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\BackgroundJob\IJobList;
-use OCP\IConfig;
 use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class UUIDFixInsertTest extends TestCase {
-	protected IConfig&MockObject $config;
+	protected IAppConfig&MockObject $appConfig;
 	protected UserMapping&MockObject $userMapper;
 	protected GroupMapping&MockObject $groupMapper;
 	protected IJobList&MockObject $jobList;
@@ -27,11 +27,11 @@ class UUIDFixInsertTest extends TestCase {
 		parent::setUp();
 
 		$this->jobList = $this->createMock(IJobList::class);
-		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->userMapper = $this->createMock(UserMapping::class);
 		$this->groupMapper = $this->createMock(GroupMapping::class);
 		$this->job = new UUIDFixInsert(
-			$this->config,
+			$this->appConfig,
 			$this->userMapper,
 			$this->groupMapper,
 			$this->jobList
@@ -88,9 +88,9 @@ class UUIDFixInsertTest extends TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('recordProvider')]
 	public function testRun(array $userBatches, array $groupBatches): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('user_ldap', 'installed_version', '1.2.1')
+		$this->appConfig->expects($this->once())
+			->method('getAppValueString')
+			->with('installed_version', '1.2.1')
 			->willReturn('1.2.0');
 
 		$this->userMapper->expects($this->exactly(3))
@@ -116,9 +116,9 @@ class UUIDFixInsertTest extends TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('recordProviderTooLongAndNone')]
 	public function testRunWithManyAndNone(array $userBatches, array $groupBatches): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('user_ldap', 'installed_version', '1.2.1')
+		$this->appConfig->expects($this->once())
+			->method('getAppValueString')
+			->with('installed_version', '1.2.1')
 			->willReturn('1.2.0');
 
 		$this->userMapper->expects($this->exactly(5))
@@ -152,9 +152,9 @@ class UUIDFixInsertTest extends TestCase {
 	}
 
 	public function testDonNotRun(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('user_ldap', 'installed_version', '1.2.1')
+		$this->appConfig->expects($this->once())
+			->method('getAppValueString')
+			->with('installed_version', '1.2.1')
 			->willReturn('1.2.1');
 		$this->userMapper->expects($this->never())
 			->method('getList');

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -9,7 +9,7 @@ namespace OCA\User_LDAP\Tests\User;
 
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
-use OCP\IConfig;
+use OCP\Config\IUserConfig;
 use OCP\IDBConnection;
 use OCP\Server;
 use OCP\Share\IManager;
@@ -24,7 +24,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class DeletedUsersIndexTest extends \Test\TestCase {
 	protected DeletedUsersIndex $dui;
-	protected IConfig $config;
+	protected IUserConfig $userConfig;
 	protected IDBConnection $db;
 	protected UserMapping&MockObject $mapping;
 	protected IManager&MockObject $shareManager;
@@ -33,20 +33,20 @@ class DeletedUsersIndexTest extends \Test\TestCase {
 		parent::setUp();
 
 		// no mocks for those as tests go against DB
-		$this->config = Server::get(IConfig::class);
+		$this->userConfig = Server::get(IUserConfig::class);
 		$this->db = Server::get(IDBConnection::class);
 
 		// ensure a clean database
-		$this->config->deleteAppFromAllUsers('user_ldap');
+		$this->userConfig->deleteApp('user_ldap');
 
 		$this->mapping = $this->createMock(UserMapping::class);
 		$this->shareManager = $this->createMock(IManager::class);
 
-		$this->dui = new DeletedUsersIndex($this->config, $this->mapping, $this->shareManager);
+		$this->dui = new DeletedUsersIndex($this->userConfig, $this->mapping, $this->shareManager);
 	}
 
 	protected function tearDown(): void {
-		$this->config->deleteAppFromAllUsers('user_ldap');
+		$this->userConfig->deleteApp('user_ldap');
 		parent::tearDown();
 	}
 

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -13,6 +13,8 @@ use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\ILDAPWrapper;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\User;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\Config\IUserConfig;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -33,6 +35,8 @@ use Psr\Log\LoggerInterface;
 class ManagerTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected IConfig&MockObject $config;
+	protected IUserConfig&MockObject $userConfig;
+	protected IAppConfig&MockObject $appConfig;
 	protected LoggerInterface&MockObject $logger;
 	protected IAvatarManager&MockObject $avatarManager;
 	protected Image&MockObject $image;
@@ -49,6 +53,8 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->access = $this->createMock(Access::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
 		$this->image = $this->createMock(Image::class);
@@ -66,6 +72,8 @@ class ManagerTest extends \Test\TestCase {
 		/** @noinspection PhpUnhandledExceptionInspection */
 		$this->manager = new Manager(
 			$this->config,
+			$this->userConfig,
+			$this->appConfig,
 			$this->logger,
 			$this->avatarManager,
 			$this->image,

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -10,7 +10,7 @@ namespace OCA\User_LDAP\Tests\User;
 
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\OfflineUser;
-use OCP\IConfig;
+use OCP\Config\IUserConfig;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -19,19 +19,19 @@ use Test\TestCase;
 class OfflineUserTest extends TestCase {
 	protected UserMapping&MockObject $mapping;
 	protected string $uid;
-	protected IConfig&MockObject $config;
+	protected IUserConfig&MockObject $userConfig;
 	protected IManager&MockObject $shareManager;
 	protected OfflineUser $offlineUser;
 
 	public function setUp(): void {
 		$this->uid = 'deborah';
-		$this->config = $this->createMock(IConfig::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
 		$this->mapping = $this->createMock(UserMapping::class);
 		$this->shareManager = $this->createMock(IManager::class);
 
 		$this->offlineUser = new OfflineUser(
 			$this->uid,
-			$this->config,
+			$this->userConfig,
 			$this->mapping,
 			$this->shareManager
 		);

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -12,6 +12,8 @@ use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\ILDAPWrapper;
 use OCA\User_LDAP\User\User;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\Config\IUserConfig;
 use OCP\IAvatar;
 use OCP\IAvatarManager;
 use OCP\IConfig;
@@ -35,6 +37,8 @@ class UserTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected Connection&MockObject $connection;
 	protected IConfig&MockObject $config;
+	protected IUserConfig&MockObject $userConfig;
+	protected IAppConfig&MockObject $appConfig;
 	protected INotificationManager&MockObject $notificationManager;
 	protected IUserManager&MockObject $userManager;
 	protected Image&MockObject $image;
@@ -58,6 +62,8 @@ class UserTest extends \Test\TestCase {
 			->willReturn($this->connection);
 
 		$this->config = $this->createMock(IConfig::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
 		$this->image = $this->createMock(Image::class);
@@ -69,6 +75,8 @@ class UserTest extends \Test\TestCase {
 			$this->dn,
 			$this->access,
 			$this->config,
+			$this->userConfig,
+			$this->appConfig,
 			$this->image,
 			$this->logger,
 			$this->avatarManager,
@@ -118,8 +126,8 @@ class UserTest extends \Test\TestCase {
 				$this->equalTo('email'))
 			->willReturn(false);
 
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 
 		$this->user->updateEmail();
 	}
@@ -133,8 +141,8 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->never())
 			->method('readAttribute');
 
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 
 		$this->user->updateEmail();
 	}
@@ -296,8 +304,8 @@ class UserTest extends \Test\TestCase {
 			->method('get')
 			->with($this->uid);
 
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 
 		$this->user->updateQuota();
 	}
@@ -320,8 +328,8 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->never())
 			->method('readAttribute');
 
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('setValueFloat');
 
 		$this->user->updateQuota();
 	}
@@ -487,12 +495,12 @@ class UserTest extends \Test\TestCase {
 			->method('data')
 			->willReturn('this is a photo');
 
-		$this->config->expects($this->once())
-			->method('getUserValue')
+		$this->userConfig->expects($this->once())
+			->method('getValueString')
 			->with($this->uid, 'user_ldap', 'lastAvatarChecksum', '')
 			->willReturn('');
-		$this->config->expects($this->once())
-			->method('setUserValue')
+		$this->userConfig->expects($this->once())
+			->method('setValueString')
 			->with($this->uid, 'user_ldap', 'lastAvatarChecksum', md5('this is a photo'));
 
 		$avatar = $this->createMock(IAvatar::class);
@@ -535,12 +543,12 @@ class UserTest extends \Test\TestCase {
 			->method('data')
 			->willReturn('this is a photo');
 
-		$this->config->expects($this->once())
-			->method('getUserValue')
+		$this->userConfig->expects($this->once())
+			->method('getValueString')
 			->with($this->uid, 'user_ldap', 'lastAvatarChecksum', '')
 			->willReturn(md5('this is a photo'));
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->expects($this->never())
@@ -598,12 +606,12 @@ class UserTest extends \Test\TestCase {
 			->method('data')
 			->willReturn('this is a photo');
 
-		$this->config->expects($this->once())
-			->method('getUserValue')
+		$this->userConfig->expects($this->once())
+			->method('getValueString')
 			->with($this->uid, 'user_ldap', 'lastAvatarChecksum', '')
 			->willReturn('');
-		$this->config->expects($this->once())
-			->method('setUserValue')
+		$this->userConfig->expects($this->once())
+			->method('setValueString')
 			->with($this->uid, 'user_ldap', 'lastAvatarChecksum', md5('this is a photo'));
 
 		$avatar = $this->createMock(IAvatar::class);
@@ -652,10 +660,10 @@ class UserTest extends \Test\TestCase {
 		$this->image->expects($this->never())
 			->method('data');
 
-		$this->config->expects($this->never())
-			->method('getUserValue');
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('getValueString');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->expects($this->never())
@@ -705,12 +713,12 @@ class UserTest extends \Test\TestCase {
 			->method('data')
 			->willReturn('this is a photo');
 
-		$this->config->expects($this->once())
-			->method('getUserValue')
+		$this->userConfig->expects($this->once())
+			->method('getValueString')
 			->with($this->uid, 'user_ldap', 'lastAvatarChecksum', '')
 			->willReturn('');
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->expects($this->once())
@@ -756,10 +764,10 @@ class UserTest extends \Test\TestCase {
 		$this->image->expects($this->never())
 			->method('data');
 
-		$this->config->expects($this->never())
-			->method('getUserValue');
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('getValueString');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 
 		$this->avatarManager->expects($this->never())
 			->method('getAvatar');
@@ -800,12 +808,12 @@ class UserTest extends \Test\TestCase {
 		}
 
 		if ($expected !== '') {
-			$this->config->expects($this->once())
-				->method('setUserValue')
+			$this->userConfig->expects($this->once())
+				->method('setValueString')
 				->with($this->uid, 'user_ldap', 'extStorageHome', $expected);
 		} else {
-			$this->config->expects($this->once())
-				->method('deleteUserValue')
+			$this->userConfig->expects($this->once())
+				->method('deleteUserConfig')
 				->with($this->uid, 'user_ldap', 'extStorageHome');
 		}
 
@@ -814,12 +822,12 @@ class UserTest extends \Test\TestCase {
 	}
 
 	public function testMarkLogin(): void {
-		$this->config->expects($this->once())
-			->method('setUserValue')
+		$this->userConfig->expects($this->once())
+			->method('setValueBool')
 			->with($this->equalTo($this->uid),
 				$this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_FIRSTLOGIN),
-				$this->equalTo(1))
+				$this->equalTo(true))
 			->willReturn(true);
 
 		$this->user->markLogin();
@@ -881,6 +889,8 @@ class UserTest extends \Test\TestCase {
 				$this->dn,
 				$this->access,
 				$this->config,
+				$this->userConfig,
+				$this->appConfig,
 				$this->image,
 				$this->logger,
 				$this->avatarManager,
@@ -944,8 +954,8 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->never())
 			->method('readAttribute');
 
-		$this->config->expects($this->never())
-			->method('getAppValue');
+		$this->appConfig->expects($this->never())
+			->method('getAppValueBool');
 
 		/** @noinspection PhpUnhandledExceptionInspection */
 		$this->assertFalse($this->user->getHomePath());
@@ -966,8 +976,8 @@ class UserTest extends \Test\TestCase {
 			->willReturn($this->dn);
 
 		// asks for "enforce_home_folder_naming_rule"
-		$this->config->expects($this->once())
-			->method('getAppValue')
+		$this->appConfig->expects($this->once())
+			->method('getAppValueBool')
 			->willReturn(false);
 
 		/** @noinspection PhpUnhandledExceptionInspection */
@@ -992,8 +1002,8 @@ class UserTest extends \Test\TestCase {
 			->willReturn($this->dn);
 
 		// asks for "enforce_home_folder_naming_rule"
-		$this->config->expects($this->once())
-			->method('getAppValue')
+		$this->appConfig->expects($this->once())
+			->method('getAppValueBool')
 			->willReturn(true);
 
 		$this->user->getHomePath();
@@ -1010,12 +1020,12 @@ class UserTest extends \Test\TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('displayNameProvider')]
 	public function testComposeAndStoreDisplayName(string $part1, string $part2, string $expected, bool $expectTriggerChange): void {
-		$this->config->expects($this->once())
-			->method('setUserValue');
-		$oldName = $expectTriggerChange ? 'xxGunslingerxx' : null;
-		$this->config->expects($this->once())
-			->method('getUserValue')
-			->with($this->user->getUsername(), 'user_ldap', 'displayName', null)
+		$this->userConfig->expects($this->once())
+			->method('setValueString');
+		$oldName = $expectTriggerChange ? 'xxGunslingerxx' : '';
+		$this->userConfig->expects($this->once())
+			->method('getValueString')
+			->with($this->user->getUsername(), 'user_ldap', 'displayName', '')
 			->willReturn($oldName);
 
 		$ncUserObj = $this->createMock(\OC\User\User::class);
@@ -1037,10 +1047,10 @@ class UserTest extends \Test\TestCase {
 
 	public function testComposeAndStoreDisplayNameNoOverwrite(): void {
 		$displayName = 'Randall Flagg';
-		$this->config->expects($this->never())
-			->method('setUserValue');
-		$this->config->expects($this->once())
-			->method('getUserValue')
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
+		$this->userConfig->expects($this->once())
+			->method('getValueString')
 			->willReturn($displayName);
 
 		$this->userManager->expects($this->never())

--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -285,8 +285,8 @@ class WeatherStatusService {
 		$address = $this->userConfig->getValueString($this->userId, Application::APP_ID, 'address');
 		$mode = $this->userConfig->getValueInt($this->userId, Application::APP_ID, 'mode', self::MODE_MANUAL_LOCATION);
 		return [
-			'lat' => $lat === 0.0 ? '' : (string)$lat,
-			'lon' => $lon === 0.0 ? '' : (string)$lon,
+			'lat' => abs($lat) < PHP_FLOAT_EPSILON ? '' : (string)$lat,
+			'lon' => abs($lon) < PHP_FLOAT_EPSILON ? '' : (string)$lon,
 			'address' => $address,
 			'mode' => $mode,
 		];

--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -73,8 +73,9 @@ class WeatherStatusService {
 	 * @return list<string>
 	 */
 	public function getFavorites(): array {
-		$favoritesJson = $this->userConfig->getValueString($this->userId, Application::APP_ID, 'favorites', '');
-		return json_decode($favoritesJson, true) ?: [];
+		/** @var list<string> $favorites */
+		$favorites = $this->userConfig->getValueArray($this->userId, Application::APP_ID, 'favorites', []);
+		return $favorites;
 	}
 
 	/**
@@ -83,7 +84,7 @@ class WeatherStatusService {
 	 * @return WeatherStatusSuccess success state
 	 */
 	public function setFavorites(array $favorites): array {
-		$this->userConfig->setValueString($this->userId, Application::APP_ID, 'favorites', json_encode($favorites));
+		$this->userConfig->setValueArray($this->userId, Application::APP_ID, 'favorites', $favorites);
 		return ['success' => true];
 	}
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -410,15 +410,6 @@
       <code><![CDATA[is_array($modified['old'])]]></code>
     </RedundantCondition>
   </file>
-  <file src="apps/dav/lib/CalDAV/Schedule/IMipService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
-    <UndefinedMethod>
-      <code><![CDATA[getNormalizedValue]]></code>
-      <code><![CDATA[getNormalizedValue]]></code>
-    </UndefinedMethod>
-  </file>
   <file src="apps/dav/lib/CalDAV/Schedule/Plugin.php">
     <DeprecatedMethod>
       <code><![CDATA[getPropertiesForPath]]></code>
@@ -2020,7 +2011,6 @@
       <code><![CDATA[Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
 				'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))])]]></code>
       <code><![CDATA[Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', ['filePath' => $targetPath, 'trashPath' => $sourcePath])]]></code>
-      <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getUserFolder]]></code>
       <code><![CDATA[getUserFolder]]></code>
       <code><![CDATA[getUserFolder]]></code>
@@ -2425,8 +2415,6 @@
       <code><![CDATA[getMailer]]></code>
       <code><![CDATA[getSecureRandom]]></code>
       <code><![CDATA[getURLGenerator]]></code>
-      <code><![CDATA[query]]></code>
-      <code><![CDATA[query]]></code>
       <code><![CDATA[query]]></code>
       <code><![CDATA[query]]></code>
       <code><![CDATA[query]]></code>
@@ -2854,7 +2842,6 @@
   <file src="apps/user_ldap/lib/Access.php">
     <DeprecatedMethod>
       <code><![CDATA[emit]]></code>
-      <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
     <InvalidReturnStatement>
       <code><![CDATA[$uuid]]></code>
@@ -2869,10 +2856,6 @@
   </file>
   <file src="apps/user_ldap/lib/AppInfo/Application.php">
     <DeprecatedInterface>
-      <code><![CDATA[$server]]></code>
-      <code><![CDATA[$server]]></code>
-      <code><![CDATA[IAppContainer]]></code>
-      <code><![CDATA[IAppContainer]]></code>
       <code><![CDATA[IAppContainer]]></code>
       <code><![CDATA[IAppContainer]]></code>
     </DeprecatedInterface>
@@ -2884,10 +2867,6 @@
 			'loginName2UserName'
 		)]]></code>
       <code><![CDATA[dispatch]]></code>
-      <code><![CDATA[getConfig]]></code>
-      <code><![CDATA[getConfig]]></code>
-      <code><![CDATA[getRequest]]></code>
-      <code><![CDATA[getURLGenerator]]></code>
       <code><![CDATA[registerService]]></code>
       <code><![CDATA[registerService]]></code>
     </DeprecatedMethod>
@@ -2908,18 +2887,7 @@
 						break;]]></code>
     </ParadoxicalCondition>
   </file>
-  <file src="apps/user_ldap/lib/Controller/RenewPasswordController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/user_ldap/lib/Group_LDAP.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-    </DeprecatedMethod>
     <InvalidScalarArgument>
       <code><![CDATA[$groupID]]></code>
     </InvalidScalarArgument>
@@ -2937,26 +2905,9 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/Jobs/Sync.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getAppKeys]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[setAppValue]]></code>
-      <code><![CDATA[setAppValue]]></code>
-      <code><![CDATA[setAppValue]]></code>
-    </DeprecatedMethod>
     <InvalidOperand>
       <code><![CDATA[$i]]></code>
     </InvalidOperand>
-  </file>
-  <file src="apps/user_ldap/lib/Jobs/UpdateGroups.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/LDAPProvider.php">
     <DeprecatedInterface>
@@ -2989,11 +2940,6 @@
       <code><![CDATA[deleteAppValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/user_ldap/lib/Migration/UUIDFixInsert.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/user_ldap/lib/Migration/Version1120Date20210917155206.php">
     <DeprecatedMethod>
       <code><![CDATA[emit]]></code>
@@ -3005,28 +2951,10 @@
       <code><![CDATA[getDatabasePlatform]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/user_ldap/lib/User/DeletedUsersIndex.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUsersForUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/user_ldap/lib/User/Manager.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getUserValue]]></code>
-    </DeprecatedMethod>
     <InvalidDocblock>
       <code><![CDATA[public function setLdapAccess(Access $access) {]]></code>
     </InvalidDocblock>
-  </file>
-  <file src="apps/user_ldap/lib/User/OfflineUser.php">
-    <DeprecatedMethod>
-      <code><![CDATA[deleteUserValue]]></code>
-      <code><![CDATA[deleteUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/User/User.php">
     <DeprecatedConstant>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3034,24 +3034,6 @@
     </DeprecatedConstant>
     <DeprecatedMethod>
       <code><![CDATA[Util::connectHook('OC_User', 'post_login', $this, 'handlePasswordExpiry')]]></code>
-      <code><![CDATA[deleteUserValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/User_LDAP.php">
@@ -3119,29 +3101,6 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/weather_status/lib/Service/WeatherStatusService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
-      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/workflowengine/lib/Entity/File.php">

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -63,6 +63,25 @@
       <code><![CDATA[CommentsEvent::EVENT_PRE_UPDATE]]></code>
     </DeprecatedConstant>
   </file>
+  <file src="apps/dashboard/lib/Controller/DashboardApiController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dashboard/lib/Controller/DashboardController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dashboard/lib/Service/DashboardService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/appinfo/v1/caldav.php">
     <DeprecatedMethod>
       <code><![CDATA[exec]]></code>
@@ -161,6 +180,7 @@
   <file src="apps/dav/lib/BackgroundJob/GenerateBirthdayCalendarBackgroundJob.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/BackgroundJob/PruneOutdatedSyncTokensJob.php">
@@ -174,9 +194,21 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/dav/lib/BackgroundJob/UserStatusAutomation.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/CalDAV/BirthdayCalendar/EnablePlugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/CalDAV/BirthdayService.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
     <UndefinedMethod>
       <code><![CDATA[setDateTime]]></code>
@@ -220,6 +252,11 @@
     <NullableReturnStatement>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Calendar.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/CalendarHome.php">
     <DeprecatedMethod>
@@ -385,6 +422,7 @@
   <file src="apps/dav/lib/CalDAV/Schedule/Plugin.php">
     <DeprecatedMethod>
       <code><![CDATA[getPropertiesForPath]]></code>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[[$aclPlugin, 'propFind']]]></code>
@@ -512,6 +550,9 @@
   <file src="apps/dav/lib/Command/SyncBirthdayCalendar.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/Command/SyncSystemAddressBook.php">
@@ -847,6 +888,17 @@
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/dav/lib/Listener/CalendarDeletionDefaultUpdaterListener.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Listener/OutOfOfficeListener.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/Migration/BuildCalendarSearchIndex.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
@@ -941,6 +993,11 @@
       <code><![CDATA[getL10N]]></code>
       <code><![CDATA[getUserFolder]]></code>
       <code><![CDATA[getUserFolder]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Settings/AvailabilitySettings.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/Settings/CalDAVSettings.php">
@@ -1158,8 +1215,10 @@
   <file src="apps/encryption/lib/Recovery.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[getDirectoryContent]]></code>
@@ -1188,7 +1247,9 @@
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[file_exists]]></code>
@@ -1340,6 +1401,14 @@
       <code><![CDATA[\OC_Util::tearDownFS()]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/files/lib/Command/Object/Multi/Users.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUsersForUserValue]]></code>
+      <code><![CDATA[getUsersForUserValue]]></code>
+      <code><![CDATA[getUsersForUserValue]]></code>
+      <code><![CDATA[getUsersForUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files/lib/Command/Scan.php">
     <DeprecatedMethod>
       <code><![CDATA[listen]]></code>
@@ -1363,6 +1432,14 @@
       <code><![CDATA[null]]></code>
     </NullArgument>
   </file>
+  <file src="apps/files/lib/Controller/ApiController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files/lib/Controller/DirectEditingController.php">
     <InvalidArgument>
       <code><![CDATA[$templateId]]></code>
@@ -1371,6 +1448,11 @@
       <code><![CDATA[getTemplates]]></code>
       <code><![CDATA[open]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/files/lib/Controller/ViewController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files/lib/Helper.php">
     <UndefinedInterfaceMethod>
@@ -1421,6 +1503,19 @@
     <UndefinedInterfaceMethod>
       <code><![CDATA[isReadyForUser]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/files/lib/Service/UserConfig.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files/lib/Service/ViewConfig.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files_external/lib/Command/Notify.php">
     <DeprecatedClass>
@@ -1554,6 +1649,13 @@
       <code><![CDATA[new View('/' . \OC_User::getUser() . '/files/')]]></code>
     </InternalMethod>
   </file>
+  <file src="apps/files_sharing/lib/Controller/SettingsController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files_sharing/lib/Controller/ShareAPIController.php">
     <DeprecatedClass>
       <code><![CDATA[new QueryException()]]></code>
@@ -1632,6 +1734,7 @@
       <code><![CDATA[Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren')]]></code>
       <code><![CDATA[Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook')]]></code>
       <code><![CDATA[Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser')]]></code>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[file_exists]]></code>
@@ -1649,6 +1752,16 @@
       <code><![CDATA[new View('/')]]></code>
       <code><![CDATA[unlink]]></code>
     </InternalMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Listener/UserAddedToGroupListener.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Listener/UserShareAcceptanceListener.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files_sharing/lib/Middleware/SharingCheckMiddleware.php">
     <DeprecatedInterface>
@@ -1691,6 +1804,11 @@
     <DeprecatedInterface>
       <code><![CDATA[Scanner]]></code>
     </DeprecatedInterface>
+  </file>
+  <file src="apps/files_sharing/lib/Settings/Personal.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files_sharing/lib/ShareBackend/File.php">
     <InternalClass>
@@ -1824,7 +1942,10 @@
     </DeprecatedInterface>
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValueForUsers]]></code>
       <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/files_trashbin/lib/Helper.php">
@@ -2192,6 +2313,19 @@
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
     </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/lookup_server_connector/lib/UpdateLookupServer.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/oauth2/lib/Controller/OauthApiController.php">
     <NoInterfaceProperties>
@@ -2209,8 +2343,19 @@
     </DeprecatedConstant>
     <DeprecatedMethod>
       <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[implementsActions]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/PreferencesController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/provisioning_api/lib/Controller/UsersController.php">
@@ -2223,16 +2368,22 @@
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
     </DeprecatedConstant>
     <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[search]]></code>
       <code><![CDATA[search]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
     <TypeDoesNotContainNull>
       <code><![CDATA[$groupid === null]]></code>
@@ -2299,6 +2450,7 @@
   </file>
   <file src="apps/settings/lib/Controller/MailSettingsController.php">
     <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
@@ -2341,6 +2493,11 @@
     <InvalidArrayOffset>
       <code><![CDATA[[$user->getEMailAddress() => $user->getDisplayName()]]]></code>
     </InvalidArrayOffset>
+  </file>
+  <file src="apps/settings/lib/Mailer/NewUserMailHelper.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/settings/lib/Settings/Admin/ArtificialIntelligence.php">
     <DeprecatedInterface>
@@ -2392,6 +2549,13 @@
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
     </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/settings/lib/Settings/Personal/Security/Authtokens.php">
     <DeprecatedClass>
@@ -2460,6 +2624,10 @@
       <code><![CDATA[MapperEvent::EVENT_UNASSIGN]]></code>
       <code><![CDATA[MapperEvent::EVENT_UNASSIGN]]></code>
     </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$event->getObjectId()]]></code>
       <code><![CDATA[$event->getObjectId()]]></code>
@@ -2476,6 +2644,11 @@
     <DeprecatedMethod>
       <code><![CDATA[query]]></code>
       <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/systemtags/lib/Controller/LastUsedController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/testing/lib/AlternativeHomeUserBackend.php">
@@ -2507,6 +2680,16 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/Listener/GetDeclarativeSettingsValueListener.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/Listener/SetDeclarativeSettingsValueListener.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/testing/lib/Provider/FakeText2ImageProvider.php">
@@ -2547,6 +2730,7 @@
   <file src="apps/theming/lib/Capabilities.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/theming/lib/Command/UpdateConfig.php">
@@ -2561,6 +2745,14 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Controller/UserThemeController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/theming/lib/ImageManager.php">
@@ -2578,6 +2770,39 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/theming/lib/Jobs/RestoreBackgroundImageColor.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Listener/BeforeTemplateRenderedListener.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Service/BackgroundService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Service/ThemesService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/theming/lib/Settings/Admin.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
@@ -2589,11 +2814,22 @@
   <file src="apps/theming/lib/Settings/Personal.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/theming/lib/Themes/CommonThemeTrait.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Themes/DefaultTheme.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/theming/lib/Util.php">
@@ -2601,6 +2837,7 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
     <InvalidReturnStatement>
       <code><![CDATA[array_values($color->getRgb())]]></code>
@@ -2671,7 +2908,18 @@
 						break;]]></code>
     </ParadoxicalCondition>
   </file>
+  <file src="apps/user_ldap/lib/Controller/RenewPasswordController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/user_ldap/lib/Group_LDAP.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
     <InvalidScalarArgument>
       <code><![CDATA[$groupID]]></code>
     </InvalidScalarArgument>
@@ -2757,10 +3005,28 @@
       <code><![CDATA[getDatabasePlatform]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/user_ldap/lib/User/DeletedUsersIndex.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUsersForUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/user_ldap/lib/User/Manager.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
     <InvalidDocblock>
       <code><![CDATA[public function setLdapAccess(Access $access) {]]></code>
     </InvalidDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/User/OfflineUser.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/User/User.php">
     <DeprecatedConstant>
@@ -2768,7 +3034,24 @@
     </DeprecatedConstant>
     <DeprecatedMethod>
       <code><![CDATA[Util::connectHook('OC_User', 'post_login', $this, 'handlePasswordExpiry')]]></code>
+      <code><![CDATA[deleteUserValue]]></code>
       <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/User_LDAP.php">
@@ -2838,6 +3121,29 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/weather_status/lib/Service/WeatherStatusService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/workflowengine/lib/Entity/File.php">
     <DeprecatedConstant>
       <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
@@ -2873,6 +3179,12 @@
       <code><![CDATA[\OC_Util::tearDownFS()]]></code>
       <code><![CDATA[deleteAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/BackgroundJobs/LookupServerSendCheckBackgroundJob.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="core/Command/App/ListApps.php">
@@ -3055,10 +3367,19 @@
       <code><![CDATA[search]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/Command/User/Report.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUsersForUserValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="core/Command/User/Setting.php">
     <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
+      <code><![CDATA[getAllUserValues]]></code>
+      <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[search]]></code>
       <code><![CDATA[setEMailAddress]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="core/Controller/AppPasswordController.php">
@@ -3095,6 +3416,7 @@
   </file>
   <file src="core/Controller/LoginController.php">
     <DeprecatedMethod>
+      <code><![CDATA[deleteUserValue]]></code>
       <code><![CDATA[getDelay]]></code>
     </DeprecatedMethod>
   </file>
@@ -3105,6 +3427,7 @@
 			'preLoginNameUsedAsUserName',
 			['uid' => &$user]
 		)]]></code>
+      <code><![CDATA[deleteUserValue]]></code>
     </DeprecatedMethod>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
@@ -3114,6 +3437,11 @@
     <DeprecatedInterface>
       <code><![CDATA[IInitialStateService]]></code>
     </DeprecatedInterface>
+  </file>
+  <file src="core/Controller/ProfileApiController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="core/Controller/RecommendedAppsController.php">
     <DeprecatedInterface>
@@ -3179,6 +3507,12 @@
 			'preLoginNameUsedAsUserName',
 			['uid' => &$uid]
 		)]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Controller/WhatsNewController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserValue]]></code>
+      <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
   <file src="core/Middleware/TwoFactorMiddleware.php">
@@ -4174,7 +4508,6 @@
     </InvalidArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[createUser]]></code>
-      <code><![CDATA[getUsersForUserValueCaseInsensitive]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/User/Session.php">

--- a/lib/base.php
+++ b/lib/base.php
@@ -447,14 +447,14 @@ class OC {
 	}
 
 	private static function getSessionLifeTime(): int {
-		return Server::get(\OC\AllConfig::class)->getSystemValueInt('session_lifetime', 60 * 60 * 24);
+		return Server::get(IConfig::class)->getSystemValueInt('session_lifetime', 60 * 60 * 24);
 	}
 
 	/**
 	 * @return bool true if the session expiry should only be done by gc instead of an explicit timeout
 	 */
 	public static function hasSessionRelaxedExpiry(): bool {
-		return Server::get(\OC\AllConfig::class)->getSystemValueBool('session_relaxed_expiry', false);
+		return Server::get(IConfig::class)->getSystemValueBool('session_relaxed_expiry', false);
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1034,12 +1034,12 @@ class Server extends ServerContainer implements IServerContainer {
 					$backgroundService,
 				);
 				return new ThemingDefaults(
-					$c->get(\OCP\IConfig::class),
 					new AppConfig(
 						$c->get(\OCP\IConfig::class),
 						$c->get(\OCP\IAppConfig::class),
 						'theming',
 					),
+					$c->get(IUserConfig::class),
 					$c->get(IFactory::class)->get('theming'),
 					$c->get(IUserSession::class),
 					$c->get(IURLGenerator::class),

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -68,7 +68,7 @@ class Manager extends PublicEmitter implements IUserManager {
 
 	private DisplayNameCache $displayNameCache;
 
-	// FIXME: This constructor can't autoload any class requiring a DB connection.
+	// This constructor can't autoload any class requiring a DB connection.
 	public function __construct(
 		private IConfig $config,
 		ICacheFactory $cacheFactory,

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -164,6 +164,7 @@ interface IConfig {
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 * @since 6.0.0 - parameter $precondition was added in 8.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig} directly
 	 */
 	public function setUserValue($userId, $appName, $key, $value, $preCondition = null);
 
@@ -176,6 +177,7 @@ interface IConfig {
 	 * @param mixed $default the default value to be returned if the value isn't set
 	 * @return string
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig::getValuesByUsers} directly
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '');
 
@@ -186,6 +188,7 @@ interface IConfig {
 	 * @param string $key the key to get the value for
 	 * @param array $userIds the user IDs to fetch the values for
 	 * @return array Mapped values: userId => value
+	 * @deprecated 31.0.0 - use {@see IUserConfig::getValuesByUsers} directly
 	 * @since 8.0.0
 	 */
 	public function getUserValueForUsers($appName, $key, $userIds);
@@ -197,6 +200,7 @@ interface IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @return string[]
 	 * @since 8.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig::getKeys} directly
 	 */
 	public function getUserKeys($userId, $appName);
 
@@ -210,6 +214,7 @@ interface IConfig {
 	 *                 [ $key => $value ]
 	 *                 ]
 	 * @since 24.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig::getAllValues} directly
 	 */
 	public function getAllUserValues(string $userId): array;
 
@@ -220,6 +225,7 @@ interface IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 * @since 8.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig::deleteUserConfig} directly
 	 */
 	public function deleteUserValue($userId, $appName, $key);
 
@@ -228,6 +234,7 @@ interface IConfig {
 	 *
 	 * @param string $userId the userId of the user that we want to remove all values from
 	 * @since 8.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig::deleteAllUserConfig} directly
 	 */
 	public function deleteAllUserValues($userId);
 
@@ -236,6 +243,7 @@ interface IConfig {
 	 *
 	 * @param string $appName the appName of the app that we want to remove all values from
 	 * @since 8.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig::deleteApp} directly
 	 */
 	public function deleteAppFromAllUsers($appName);
 
@@ -248,6 +256,7 @@ interface IConfig {
 	 * @return list<string> of user IDs
 	 * @since 31.0.0 return type of `list<string>`
 	 * @since 8.0.0
+	 * @deprecated 31.0.0 - use {@see IUserConfig::searchUsersByValueString} directly
 	 */
 	public function getUsersForUserValue($appName, $key, $value);
 }

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -177,7 +177,7 @@ interface IConfig {
 	 * @param mixed $default the default value to be returned if the value isn't set
 	 * @return string
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig::getValuesByUsers} directly
+	 * @deprecated 31.0.0 - use {@see IUserConfig} directly
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '');
 

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -164,7 +164,7 @@ interface IConfig {
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 * @since 6.0.0 - parameter $precondition was added in 8.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig} directly
 	 */
 	public function setUserValue($userId, $appName, $key, $value, $preCondition = null);
 
@@ -177,7 +177,7 @@ interface IConfig {
 	 * @param mixed $default the default value to be returned if the value isn't set
 	 * @return string
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig} directly
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '');
 
@@ -188,7 +188,7 @@ interface IConfig {
 	 * @param string $key the key to get the value for
 	 * @param array $userIds the user IDs to fetch the values for
 	 * @return array Mapped values: userId => value
-	 * @deprecated 31.0.0 - use {@see IUserConfig::getValuesByUsers} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig::getValuesByUsers} directly
 	 * @since 8.0.0
 	 */
 	public function getUserValueForUsers($appName, $key, $userIds);
@@ -200,7 +200,7 @@ interface IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @return string[]
 	 * @since 8.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig::getKeys} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig::getKeys} directly
 	 */
 	public function getUserKeys($userId, $appName);
 
@@ -214,7 +214,7 @@ interface IConfig {
 	 *                 [ $key => $value ]
 	 *                 ]
 	 * @since 24.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig::getAllValues} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig::getAllValues} directly
 	 */
 	public function getAllUserValues(string $userId): array;
 
@@ -225,7 +225,7 @@ interface IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 * @since 8.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig::deleteUserConfig} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig::deleteUserConfig} directly
 	 */
 	public function deleteUserValue($userId, $appName, $key);
 
@@ -234,7 +234,7 @@ interface IConfig {
 	 *
 	 * @param string $userId the userId of the user that we want to remove all values from
 	 * @since 8.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig::deleteAllUserConfig} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig::deleteAllUserConfig} directly
 	 */
 	public function deleteAllUserValues($userId);
 
@@ -243,7 +243,7 @@ interface IConfig {
 	 *
 	 * @param string $appName the appName of the app that we want to remove all values from
 	 * @since 8.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig::deleteApp} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig::deleteApp} directly
 	 */
 	public function deleteAppFromAllUsers($appName);
 
@@ -254,9 +254,9 @@ interface IConfig {
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
 	 * @return list<string> of user IDs
-	 * @since 31.0.0 return type of `list<string>`
+	 * @since 33.0.0 return type of `list<string>`
 	 * @since 8.0.0
-	 * @deprecated 31.0.0 - use {@see IUserConfig::searchUsersByValueString} directly
+	 * @deprecated 33.0.0 - use {@see IUserConfig::searchUsersByValueString} directly
 	 */
 	public function getUsersForUserValue($appName, $key, $value);
 }

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -9,7 +9,6 @@
 namespace Test;
 
 use OC\AllConfig;
-use OC\SystemConfig;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
 use OCP\Server;
@@ -515,19 +514,5 @@ class AllConfigTest extends \Test\TestCase {
 
 		// cleanup
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
-	}
-
-	public function testGetUsersForUserValueCaseInsensitive(): void {
-		// mock the check for the database to run the correct SQL statements for each database type
-		$systemConfig = $this->createMock(SystemConfig::class);
-		$config = $this->getConfig($systemConfig);
-
-		$config->setUserValue('user1', 'myApp', 'myKey', 'test123');
-		$config->setUserValue('user2', 'myApp', 'myKey', 'TEST123');
-		$config->setUserValue('user3', 'myApp', 'myKey', 'test12345');
-
-		$users = $config->getUsersForUserValueCaseInsensitive('myApp', 'myKey', 'test123');
-		$this->assertSame(2, count($users));
-		$this->assertSame(['user1', 'user2'], $users);
 	}
 }

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -13,6 +13,7 @@ use OC\USER\BACKEND;
 use OC\User\Database;
 use OC\User\Manager;
 use OC\User\User;
+use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -53,7 +54,7 @@ class ManagerTest extends TestCase {
 
 	public function testGetBackends(): void {
 		$userDummyBackend = $this->createMock(\Test\Util\User\Dummy::class);
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($userDummyBackend);
 		$this->assertEquals([$userDummyBackend], $manager->getBackends());
 		$dummyDatabaseBackend = $this->createMock(Database::class);
@@ -63,77 +64,64 @@ class ManagerTest extends TestCase {
 
 
 	public function testUserExistsSingleBackendExists(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertTrue($manager->userExists('foo'));
 	}
 
 	public function testUserExistsTooLong(): void {
-		/** @var \Test\Util\User\Dummy|MockObject $backend */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->never())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertFalse($manager->userExists('foo' . str_repeat('a', 62)));
 	}
 
 	public function testUserExistsSingleBackendNotExists(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(false);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertFalse($manager->userExists('foo'));
 	}
 
 	public function testUserExistsNoBackends(): void {
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 
 		$this->assertFalse($manager->userExists('foo'));
 	}
 
 	public function testUserExistsTwoBackendsSecondExists(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend1
-		 */
 		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(false);
 
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend2
-		 */
 		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -141,23 +129,17 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testUserExistsTwoBackendsFirstExists(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend1
-		 */
 		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend2
-		 */
 		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->never())
 			->method('userExists');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -165,9 +147,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCheckPassword(): void {
-		/**
-		 * @var \OC\User\Backend&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('checkPassword')
@@ -184,7 +163,7 @@ class ManagerTest extends TestCase {
 				}
 			});
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$user = $manager->checkPassword('foo', 'bar');
@@ -192,9 +171,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCheckPasswordNotSupported(): void {
-		/**
-		 * @var \OC\User\Backend&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->never())
 			->method('checkPassword');
@@ -203,16 +179,13 @@ class ManagerTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertFalse($manager->checkPassword('foo', 'bar'));
 	}
 
 	public function testGetOneBackendExists(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
@@ -221,46 +194,39 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertEquals('foo', $manager->get('foo')->getUID());
 	}
 
 	public function testGetOneBackendNotExists(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(false);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertEquals(null, $manager->get('foo'));
 	}
 
 	public function testGetTooLong(): void {
-		/** @var \Test\Util\User\Dummy|MockObject $backend */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->never())
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->willReturn(false);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertEquals(null, $manager->get('foo' . str_repeat('a', 62)));
 	}
 
 	public function testGetOneBackendDoNotTranslateLoginNames(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
@@ -269,16 +235,13 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertEquals('bLeNdEr', $manager->get('bLeNdEr')->getUID());
 	}
 
 	public function testSearchOneBackend(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('getUsers')
@@ -287,7 +250,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$result = $manager->search('fo');
@@ -299,9 +262,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testSearchTwoBackendLimitOffset(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend1
-		 */
 		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->once())
 			->method('getUsers')
@@ -310,9 +270,6 @@ class ManagerTest extends TestCase {
 		$backend1->expects($this->never())
 			->method('loginName2UserName');
 
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend2
-		 */
 		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->once())
 			->method('getUsers')
@@ -321,7 +278,7 @@ class ManagerTest extends TestCase {
 		$backend2->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -366,7 +323,6 @@ class ManagerTest extends TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateUserInvalid')]
 	public function testCreateUserInvalid($uid, $password, $exception): void {
-		/** @var \Test\Util\User\Dummy&MockObject $backend */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('implementsActions')
@@ -374,7 +330,7 @@ class ManagerTest extends TestCase {
 			->willReturn(true);
 
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->expectException(\InvalidArgumentException::class, $exception);
@@ -382,9 +338,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCreateUserSingleBackendNotExists(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -401,7 +354,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$user = $manager->createUser('foo', 'bar');
@@ -412,9 +365,6 @@ class ManagerTest extends TestCase {
 	public function testCreateUserSingleBackendExists(): void {
 		$this->expectException(\Exception::class);
 
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -428,16 +378,13 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$manager->createUser('foo', 'bar');
 	}
 
 	public function testCreateUserSingleBackendNotSupported(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -449,14 +396,14 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('userExists');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$this->assertFalse($manager->createUser('foo', 'bar'));
 	}
 
 	public function testCreateUserNoBackends(): void {
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 
 		$this->assertFalse($manager->createUser('foo', 'bar'));
 	}
@@ -482,9 +429,6 @@ class ManagerTest extends TestCase {
 	public function testCreateUserTwoBackendExists(): void {
 		$this->expectException(\Exception::class);
 
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend1
-		 */
 		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->any())
 			->method('implementsActions')
@@ -498,9 +442,6 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(false);
 
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend2
-		 */
 		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->any())
 			->method('implementsActions')
@@ -514,7 +455,7 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -522,7 +463,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCountUsersNoBackend(): void {
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 
 		$result = $manager->countUsers();
 		$this->assertTrue(is_array($result));
@@ -530,9 +471,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCountUsersOneBackend(): void {
-		/**
-		 * @var \Test\Util\User\Dummy&MockObject $backend
-		 */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('countUsers')
@@ -547,7 +485,7 @@ class ManagerTest extends TestCase {
 			->method('getBackendName')
 			->willReturn('Mock_Test_Util_User_Dummy');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);
 
 		$result = $manager->countUsers();
@@ -588,7 +526,7 @@ class ManagerTest extends TestCase {
 			->method('getBackendName')
 			->willReturn('Mock_Test_Util_User_Dummy');
 
-		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -760,7 +698,7 @@ class ManagerTest extends TestCase {
 			->method('getAppValue')
 			->willReturnArgument(2);
 
-		$manager = new \OC\User\Manager($config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager = new Manager($config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$backend = new \Test\Util\User\Dummy();
 
 		$manager->registerBackend($backend);
@@ -771,27 +709,31 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetByEmail(): void {
-		/** @var AllConfig&MockObject */
-		$config = $this->getMockBuilder(AllConfig::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$config
-			->expects($this->once())
-			->method('getUsersForUserValueCaseInsensitive')
+		$userConfig = $this->createMock(IUserConfig::class);
+		$userConfig->expects($this->once())
+			->method('searchUsersByValueString')
 			->with('settings', 'email', 'test@example.com')
-			->willReturn(['uid1', 'uid99', 'uid2']);
+			->willReturnCallback(function () {
+				yield 'uid1';
+				yield 'uid99';
+				yield 'uid2';
+			});
 
-		$backend = $this->createMock(\Test\Util\User\Dummy::class);
-		$backend->expects($this->exactly(3))
-			->method('userExists')
-			->willReturnMap([
-				['uid1', true],
-				['uid99', false],
-				['uid2', true]
-			]);
-
-		$manager = new \OC\User\Manager($config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
-		$manager->registerBackend($backend);
+		$manager = $this->getMockBuilder(Manager::class)
+			->setConstructorArgs([$this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger])
+			->onlyMethods(['getUserConfig', 'get'])
+			->getMock();
+		$manager->method('getUserConfig')->willReturn($userConfig);
+		$manager->expects($this->exactly(3))
+			->method('get')
+			->willReturnCallback(function (string $uid): ?IUser {
+				if ($uid === 'uid99') {
+					return null;
+				}
+				$user = $this->createMock(IUser::class);
+				$user->method('getUID')->willReturn($uid);
+				return $user;
+			});
 
 		$users = $manager->getByEmail('test@example.com');
 		$this->assertCount(2, $users);


### PR DESCRIPTION
Mark the methods in the interface deprecated instead of just the one in the implementation.

## Summary

Mark the methods in the interface deprecated instead of just the one in the implementation.

One of them was not on the public interface, so I directly removed it and ported the only usage.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
