### PR TITLE
feat(preview): Expire previews

### DIFF
--- a/build/rector-strict.php
+++ b/build/rector-strict.php
@@ -10,7 +10,7 @@ $nextcloudDir = dirname(__DIR__);
 return (require __DIR__ . '/rector-shared.php')
 	->withPaths([
 		$nextcloudDir . '/build/rector-strict.php',
-		// TODO: Add more files. The entry above is just there to stop rector from complaining about the fact that it ran without checking any files.
+		$nextcloudDir . '/core/BackgroundJobs/ExpirePreviewsJob.php',
 	])
 	->withPreparedSets(
 		deadCode: true,

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2917,4 +2917,12 @@ $CONFIG = [
 		'fe80::/10',
 		'10.0.0.1',
 	],
+
+	/**
+	 * Delete previews older than a certain number of days to reduce storage usage.
+	 * Less than one day is not allowed, so set it to 0 to disable the deletion.
+	 *
+	 * Defaults to ``0``.
+	 */
+	'preview_expiration_days' => 0,
 ];

--- a/core/BackgroundJobs/ExpirePreviewsJob.php
+++ b/core/BackgroundJobs/ExpirePreviewsJob.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\BackgroundJobs;
+
+use OC\Preview\PreviewService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
+
+class ExpirePreviewsJob extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private readonly IConfig $config,
+		private readonly PreviewService $service,
+	) {
+		parent::__construct($time);
+
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setInterval(60 * 60 * 24);
+	}
+
+	protected function run(mixed $argument): void {
+		$days = $this->config->getSystemValueInt('preview_expiration_days');
+		if ($days <= 0) {
+			return;
+		}
+
+		$this->service->deleteExpiredPreviews($days);
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1309,6 +1309,7 @@ return array(
     'OC\\Core\\BackgroundJobs\\BackgroundCleanupUpdaterBackupsJob' => $baseDir . '/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php',
     'OC\\Core\\BackgroundJobs\\CheckForUserCertificates' => $baseDir . '/core/BackgroundJobs/CheckForUserCertificates.php',
     'OC\\Core\\BackgroundJobs\\CleanupLoginFlowV2' => $baseDir . '/core/BackgroundJobs/CleanupLoginFlowV2.php',
+    'OC\\Core\\BackgroundJobs\\ExpirePreviewsJob' => $baseDir . '/core/BackgroundJobs/ExpirePreviewsJob.php',
     'OC\\Core\\BackgroundJobs\\GenerateMetadataJob' => $baseDir . '/core/BackgroundJobs/GenerateMetadataJob.php',
     'OC\\Core\\BackgroundJobs\\LookupServerSendCheckBackgroundJob' => $baseDir . '/core/BackgroundJobs/LookupServerSendCheckBackgroundJob.php',
     'OC\\Core\\BackgroundJobs\\PreviewMigrationJob' => $baseDir . '/core/BackgroundJobs/PreviewMigrationJob.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1350,6 +1350,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\BackgroundJobs\\BackgroundCleanupUpdaterBackupsJob' => __DIR__ . '/../../..' . '/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php',
         'OC\\Core\\BackgroundJobs\\CheckForUserCertificates' => __DIR__ . '/../../..' . '/core/BackgroundJobs/CheckForUserCertificates.php',
         'OC\\Core\\BackgroundJobs\\CleanupLoginFlowV2' => __DIR__ . '/../../..' . '/core/BackgroundJobs/CleanupLoginFlowV2.php',
+        'OC\\Core\\BackgroundJobs\\ExpirePreviewsJob' => __DIR__ . '/../../..' . '/core/BackgroundJobs/ExpirePreviewsJob.php',
         'OC\\Core\\BackgroundJobs\\GenerateMetadataJob' => __DIR__ . '/../../..' . '/core/BackgroundJobs/GenerateMetadataJob.php',
         'OC\\Core\\BackgroundJobs\\LookupServerSendCheckBackgroundJob' => __DIR__ . '/../../..' . '/core/BackgroundJobs/LookupServerSendCheckBackgroundJob.php',
         'OC\\Core\\BackgroundJobs\\PreviewMigrationJob' => __DIR__ . '/../../..' . '/core/BackgroundJobs/PreviewMigrationJob.php',

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Authentication\Token\PublicKeyTokenProvider;
 use OC\Authentication\Token\TokenCleanupJob;
+use OC\Core\BackgroundJobs\ExpirePreviewsJob;
 use OC\Core\BackgroundJobs\GenerateMetadataJob;
 use OC\Core\BackgroundJobs\PreviewMigrationJob;
 use OC\Log\Rotate;
@@ -526,6 +527,7 @@ class Setup {
 		$jobList->add(CleanupDeletedUsers::class);
 		$jobList->add(GenerateMetadataJob::class);
 		$jobList->add(PreviewMigrationJob::class);
+		$jobList->add(ExpirePreviewsJob::class);
 	}
 
 	/**

--- a/psalm-strict.xml
+++ b/psalm-strict.xml
@@ -16,6 +16,7 @@
 	phpVersion="8.2"
 >
 	<projectFiles>
+		<file name="core/BackgroundJobs/ExpirePreviewsJob.php"/>
 		<ignoreFiles>
 			<directory name="apps/**/composer"/>
 			<directory name="apps/**/tests"/>


### PR DESCRIPTION
Closes https://github.com/nextcloud/server/issues/45962

This is disabled by default, to avoid potentially heavy load for servers which need to regenerate previews. Admins should only enable this is if storage usage is a concern and they know which expiration threshold is good for their use-case.