### PR TITLE
fix(caldav): avoid selecting every custom properties from table if we have no calendars to filter

### DIFF
--- a/apps/dav/lib/Db/PropertyMapper.php
+++ b/apps/dav/lib/Db/PropertyMapper.php
@@ -45,6 +45,9 @@ class PropertyMapper extends QBMapper {
 	 * @throws \OCP\DB\Exception
 	 */
 	public function findPropertiesByPathsAndUsers(array $calendars): array {
+		if (empty($calendars)) {
+			return [];
+		}
 		$selectQb = $this->db->getQueryBuilder();
 		$selectQb->select('*')
 			->from(self::TABLE_NAME);


### PR DESCRIPTION
## Summary

If the `$calendars` array is empty, we just select the whole properties from the tables, which makes no sense and leads to performance issues.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
