### PR TITLE
fix(contacts): Do not expose SAB in /contactsmenu

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -206,6 +206,7 @@ return array(
     'OCA\\DAV\\Comments\\EntityCollection' => $baseDir . '/../lib/Comments/EntityCollection.php',
     'OCA\\DAV\\Comments\\EntityTypeCollection' => $baseDir . '/../lib/Comments/EntityTypeCollection.php',
     'OCA\\DAV\\Comments\\RootCollection' => $baseDir . '/../lib/Comments/RootCollection.php',
+    'OCA\\DAV\\ConfigLexicon' => $baseDir . '/../lib/ConfigLexicon.php',
     'OCA\\DAV\\Connector\\LegacyDAVACL' => $baseDir . '/../lib/Connector/LegacyDAVACL.php',
     'OCA\\DAV\\Connector\\LegacyPublicAuth' => $baseDir . '/../lib/Connector/LegacyPublicAuth.php',
     'OCA\\DAV\\Connector\\Sabre\\AnonymousOptionsPlugin' => $baseDir . '/../lib/Connector/Sabre/AnonymousOptionsPlugin.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -221,6 +221,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Comments\\EntityCollection' => __DIR__ . '/..' . '/../lib/Comments/EntityCollection.php',
         'OCA\\DAV\\Comments\\EntityTypeCollection' => __DIR__ . '/..' . '/../lib/Comments/EntityTypeCollection.php',
         'OCA\\DAV\\Comments\\RootCollection' => __DIR__ . '/..' . '/../lib/Comments/RootCollection.php',
+        'OCA\\DAV\\ConfigLexicon' => __DIR__ . '/..' . '/../lib/ConfigLexicon.php',
         'OCA\\DAV\\Connector\\LegacyDAVACL' => __DIR__ . '/..' . '/../lib/Connector/LegacyDAVACL.php',
         'OCA\\DAV\\Connector\\LegacyPublicAuth' => __DIR__ . '/..' . '/../lib/Connector/LegacyPublicAuth.php',
         'OCA\\DAV\\Connector\\Sabre\\AnonymousOptionsPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/AnonymousOptionsPlugin.php',

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@ use OCA\DAV\Capabilities;
 use OCA\DAV\CardDAV\ContactsManager;
 use OCA\DAV\CardDAV\Notification\Notifier as NotifierCardDAV;
 use OCA\DAV\CardDAV\SyncService;
+use OCA\DAV\ConfigLexicon;
 use OCA\DAV\Events\AddressBookCreatedEvent;
 use OCA\DAV\Events\AddressBookDeletedEvent;
 use OCA\DAV\Events\AddressBookShareUpdatedEvent;
@@ -228,6 +229,8 @@ class Application extends App implements IBootstrap {
 		$context->registerDeclarativeSettings(SystemAddressBookSettings::class);
 		$context->registerEventListener(DeclarativeSettingsGetValueEvent::class, DavAdminSettingsListener::class);
 		$context->registerEventListener(DeclarativeSettingsSetValueEvent::class, DavAdminSettingsListener::class);
+
+		$context->registerConfigLexicon(ConfigLexicon::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -7,6 +7,8 @@
  */
 namespace OCA\DAV\CardDAV;
 
+use OCA\DAV\AppInfo\Application;
+use OCA\DAV\ConfigLexicon;
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Contacts\IManager;
 use OCP\IAppConfig;
@@ -45,7 +47,7 @@ class ContactsManager {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function setupSystemContactsProvider(IManager $cm, ?string $userId, IURLGenerator $urlGenerator) {
-		$systemAddressBookExposed = $this->appConfig->getValueBool('dav', 'system_addressbook_exposed', true);
+		$systemAddressBookExposed = $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED);
 		if (!$systemAddressBookExposed) {
 			return;
 		}

--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\CardDAV;
 
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Contacts\IManager;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -23,6 +24,7 @@ class ContactsManager {
 		private CardDavBackend $backend,
 		private IL10N $l10n,
 		private PropertyMapper $propertyMapper,
+		private IAppConfig $appConfig,
 	) {
 	}
 
@@ -43,6 +45,11 @@ class ContactsManager {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function setupSystemContactsProvider(IManager $cm, ?string $userId, IURLGenerator $urlGenerator) {
+		$systemAddressBookExposed = $this->appConfig->getValueBool('dav', 'system_addressbook_exposed', true);
+		if (!$systemAddressBookExposed) {
+			return;
+		}
+
 		$addressBooks = $this->backend->getAddressBooksForUser('principals/system/system');
 		$this->register($cm, $addressBooks, $urlGenerator, $userId);
 	}

--- a/apps/dav/lib/ConfigLexicon.php
+++ b/apps/dav/lib/ConfigLexicon.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV;
+
+use OCP\Config\Lexicon\Entry;
+use OCP\Config\Lexicon\ILexicon;
+use OCP\Config\Lexicon\Strictness;
+use OCP\Config\ValueType;
+
+/**
+ * Config Lexicon for files_sharing.
+ *
+ * Please Add & Manage your Config Keys in that file and keep the Lexicon up to date!
+ *
+ * {@see ILexicon}
+ */
+class ConfigLexicon implements ILexicon {
+	public const SYSTEM_ADDRESSBOOK_EXPOSED = 'system_addressbook_exposed';
+
+	public function getStrictness(): Strictness {
+		return Strictness::NOTICE;
+	}
+
+	public function getAppConfigs(): array {
+		return [
+			new Entry(
+				self::SYSTEM_ADDRESSBOOK_EXPOSED,
+				ValueType::BOOL,
+				defaultRaw: true,
+				definition: 'Whether to not expose the system address book to users',
+				lazy: true,
+			),
+		];
+	}
+
+	public function getUserConfigs(): array {
+		return [];
+	}
+}

--- a/apps/dav/lib/Listener/DavAdminSettingsListener.php
+++ b/apps/dav/lib/Listener/DavAdminSettingsListener.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Listener;
 
 use OCA\DAV\AppInfo\Application;
+use OCA\DAV\ConfigLexicon;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IAppConfig;
@@ -46,20 +47,16 @@ class DavAdminSettingsListener implements IEventListener {
 	}
 
 	private function handleGetValue(DeclarativeSettingsGetValueEvent $event): void {
-
 		if ($event->getFieldId() === 'system_addressbook_enabled') {
-			$event->setValue((int)$this->config->getValueBool('dav', 'system_addressbook_exposed', true));
+			$event->setValue((int)$this->config->getValueBool(Application::APP_ID, ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED));
 		}
-
 	}
 
 	private function handleSetValue(DeclarativeSettingsSetValueEvent $event): void {
-
 		if ($event->getFieldId() === 'system_addressbook_enabled') {
-			$this->config->setValueBool('dav', 'system_addressbook_exposed', (bool)$event->getValue());
+			$this->config->setValueBool(Application::APP_ID, ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED, (bool)$event->getValue());
 			$event->stopPropagation();
 		}
-
 	}
 
 }

--- a/apps/dav/lib/Migration/DisableSystemAddressBook.php
+++ b/apps/dav/lib/Migration/DisableSystemAddressBook.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Migration;
 
 use OCA\DAV\AppInfo\Application;
+use OCA\DAV\ConfigLexicon;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IUserManager;
@@ -40,7 +41,7 @@ class DisableSystemAddressBook implements IRepairStep {
 	 */
 	public function run(IOutput $output) {
 		// If the system address book exposure was previously set skip the repair step
-		if ($this->appConfig->hasAppKey('system_addressbook_exposed') === true) {
+		if ($this->appConfig->hasAppKey(ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED) === true) {
 			$output->info('Skipping repair step system address book exposed was previously set');
 			return;
 		}
@@ -50,7 +51,7 @@ class DisableSystemAddressBook implements IRepairStep {
 			$output->info("Skipping repair step system address book has less then the threshold $limit of contacts no need to disable");
 			return;
 		}
-		$this->appConfig->setAppValueBool('system_addressbook_exposed', false);
+		$this->appConfig->setAppValueBool(ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED, false);
 		$output->warning("System address book disabled because it has more then the threshold of $limit contacts this can be re-enabled later");
 		// Notify all admin users about the system address book being disabled
 		foreach ($this->groupManager->get('admin')->getUsers() as $user) {

--- a/apps/dav/lib/SetupChecks/SystemAddressBookSize.php
+++ b/apps/dav/lib/SetupChecks/SystemAddressBookSize.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAV\SetupChecks;
 
 use OCA\DAV\AppInfo\Application;
+use OCA\DAV\ConfigLexicon;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IUserManager;
@@ -33,7 +34,7 @@ class SystemAddressBookSize implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		if (!$this->appConfig->getValueBool(Application::APP_ID, 'system_addressbook_exposed', true)) {
+		if (!$this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED)) {
 			return SetupResult::success($this->l10n->t('The system address book is disabled'));
 		}
 

--- a/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
+++ b/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
@@ -12,6 +12,7 @@ use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Contacts\IManager;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -21,7 +22,8 @@ class ContactsManagerTest extends TestCase {
 	public function test(): void {
 		/** @var IManager&MockObject $cm */
 		$cm = $this->createMock(IManager::class);
-		$cm->expects($this->exactly(2))->method('registerAddressBook');
+		$cm->expects($this->exactly(1))->method('registerAddressBook');
+		/** @var IURLGenerator&MockObject $urlGenerator */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		/** @var CardDavBackend&MockObject $backEnd */
 		$backEnd = $this->createMock(CardDavBackend::class);
@@ -29,9 +31,12 @@ class ContactsManagerTest extends TestCase {
 			['{DAV:}displayname' => 'Test address book', 'uri' => 'default'],
 		]);
 		$propertyMapper = $this->createMock(PropertyMapper::class);
+		/** @var IAppConfig&MockObject $appConfig */
+		$appConfig = $this->createMock(IAppConfig::class);
 
+		/** @var IL10N&MockObject $l */
 		$l = $this->createMock(IL10N::class);
-		$app = new ContactsManager($backEnd, $l, $propertyMapper);
+		$app = new ContactsManager($backEnd, $l, $propertyMapper, $appConfig);
 		$app->setupContactsProvider($cm, 'user01', $urlGenerator);
 	}
 }

--- a/apps/dav/tests/unit/SetupChecks/SystemAddressBookSizeTest.php
+++ b/apps/dav/tests/unit/SetupChecks/SystemAddressBookSizeTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\SetupChecks;
 
 use OCA\DAV\AppInfo\Application;
+use OCA\DAV\ConfigLexicon;
 use OCA\DAV\SetupChecks\SystemAddressBookSize;
 use OCP\IAppConfig;
 use OCP\IL10N;
@@ -30,7 +31,7 @@ class SystemAddressBookSizeTest extends TestCase {
 
 	public function testSystemAddressBookDisabled() {
 		$this->appConfig->method('getValueBool')
-			->with(Application::APP_ID, 'system_addressbook_exposed', true)
+			->with(Application::APP_ID, ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED)
 			->willReturn(false);
 
 		$check = new SystemAddressBookSize($this->appConfig, $this->userManager, $this->l10n);

--- a/build/integration/features/contacts-menu.feature
+++ b/build/integration/features/contacts-menu.feature
@@ -192,3 +192,19 @@ Feature: contacts-menu
     And searching for contacts matching with "test"
     # Disabled because it regularly fails on drone:
     # Then the list of searched contacts has "0" contacts
+
+  Scenario: users cannot list other users from the system address book
+    Given user "user0" exists
+    And user "user1" exists
+    And invoking occ with "config:app:set dav system_addressbook_exposed --value false"
+    And Logging in using web as "user1"
+    And searching for contacts matching with ""
+    Then the list of searched contacts has "1" contacts
+    And invoking occ with "config:app:delete dav system_addressbook_exposed"
+
+  Scenario: users can list other users from the system address book
+    Given user "user0" exists
+    And user "user1" exists
+    And Logging in using web as "user1"
+    And searching for contacts matching with ""
+    Then the list of searched contacts has "2" contacts

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -512,10 +512,6 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CardDAV/UserAddressBooks.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getL10N]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$this->principalUri]]></code>
       <code><![CDATA[$this->principalUri]]></code>


### PR DESCRIPTION
When hitting the `/contactsmenu/contacts` endpoint with the `dav.system_addressbook_exposed` config switch set to `"no"`, the system address book content is still listed in the response.