### PR TITLE
fix: disable mp3 preview provider

### DIFF
--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -250,29 +250,29 @@ class PreviewManager implements IPreview {
 	 * List of enabled default providers
 	 *
 	 * The following providers are enabled by default:
-	 *  - OC\Preview\PNG
-	 *  - OC\Preview\JPEG
-	 *  - OC\Preview\GIF
 	 *  - OC\Preview\BMP
-	 *  - OC\Preview\XBitmap
+	 *  - OC\Preview\GIF
+	 *  - OC\Preview\JPEG
 	 *  - OC\Preview\MarkDown
-	 *  - OC\Preview\MP3
+	 *  - OC\Preview\PNG
 	 *  - OC\Preview\TXT
+	 *  - OC\Preview\XBitmap
 	 *
 	 * The following providers are disabled by default due to performance or privacy concerns:
 	 *  - OC\Preview\Font
 	 *  - OC\Preview\HEIC
 	 *  - OC\Preview\Illustrator
-	 *  - OC\Preview\Movie
-	 *  - OC\Preview\MSOfficeDoc
+	 *  - OC\Preview\MP3
 	 *  - OC\Preview\MSOffice2003
 	 *  - OC\Preview\MSOffice2007
+	 *  - OC\Preview\MSOfficeDoc
+	 *  - OC\Preview\Movie
 	 *  - OC\Preview\OpenDocument
 	 *  - OC\Preview\PDF
 	 *  - OC\Preview\Photoshop
 	 *  - OC\Preview\Postscript
-	 *  - OC\Preview\StarOffice
 	 *  - OC\Preview\SVG
+	 *  - OC\Preview\StarOffice
 	 *  - OC\Preview\TIFF
 	 *
 	 * @return array
@@ -294,7 +294,6 @@ class PreviewManager implements IPreview {
 
 		$this->defaultProviders = $this->config->getSystemValue('enabledPreviewProviders', array_merge([
 			Preview\MarkDown::class,
-			Preview\MP3::class,
 			Preview\TXT::class,
 			Preview\OpenDocument::class,
 		], $imageProviders));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

While embedding cover images into MP3 files is certainly a nice feature, and it’s useful that we can use them as previews, it still feels somewhat niche. However, since parsing MP3 files is complex and we’re aware of a few rough edges, I’d suggest disabling the provider by default.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
