### PR TITLE
fix(LDAP): properly disable require TLS certificate verification (if configured)

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -84,9 +84,10 @@ jobs:
         ports:
           - 6379:6379/tcp
       openldap:
-        image: ghcr.io/nextcloud/continuous-integration-openldap:openldap-7 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/nextcloud/continuous-integration-openldap:openldap-8 # zizmor: ignore[unpinned-images]
         ports:
           - 389:389
+          - 636:636
         env:
           SLAPD_DOMAIN: nextcloud.ci
           SLAPD_ORGANIZATION: Nextcloud

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -684,6 +684,22 @@ class Connection extends LDAPUtility {
 			return false;
 		}
 
+		if ($this->configuration->turnOffCertCheck) {
+			if ($this->ldap->setOption(null, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_NEVER)) {
+				$this->logger->debug(
+					'Turned off SSL certificate validation successfully.',
+					['app' => 'user_ldap']
+				);
+			} else {
+				$this->logger->warning(
+					'Could not turn off SSL certificate validation.',
+					['app' => 'user_ldap']
+				);
+			}
+		} else {
+			$this->ldap->setOption(null, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_DEMAND);
+		}
+
 		$this->ldapConnectionRes = $this->ldap->connect($host, $port) ?: null;
 
 		if ($this->ldapConnectionRes === null) {
@@ -703,20 +719,6 @@ class Connection extends LDAPUtility {
 		}
 
 		if ($this->configuration->ldapTLS) {
-			if ($this->configuration->turnOffCertCheck) {
-				if ($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_NEVER)) {
-					$this->logger->debug(
-						'Turned off SSL certificate validation successfully.',
-						['app' => 'user_ldap']
-					);
-				} else {
-					$this->logger->warning(
-						'Could not turn off SSL certificate validation.',
-						['app' => 'user_ldap']
-					);
-				}
-			}
-
 			if (!$this->ldap->startTls($this->ldapConnectionRes)) {
 				throw new ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
 			}

--- a/apps/user_ldap/lib/ILDAPWrapper.php
+++ b/apps/user_ldap/lib/ILDAPWrapper.php
@@ -151,7 +151,7 @@ interface ILDAPWrapper {
 
 	/**
 	 * Sets the value of the specified option to be $value
-	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param ?\LDAP\Connection $link LDAP link resource
 	 * @param int $option a defined LDAP Server option
 	 * @param mixed $value the new value for the option
 	 * @return bool true on success, false otherwise

--- a/build/integration/ldap_features/ldap-openldap.feature
+++ b/build/integration/ldap_features/ldap-openldap.feature
@@ -34,6 +34,22 @@ Feature: LDAP
     And Sending a "GET" to "/remote.php/webdav/welcome.txt" with requesttoken
     Then the HTTP status code should be "200"
 
+  Scenario: Test valid configuration with LDAPS protocol and port by logging in
+    Given modify LDAP configuration
+      | ldapHost         | ldaps://openldap:636 |
+      | turnOffCertCheck |                    1 |
+    And cookies are reset
+    And Logging in using web as "alice"
+    And Sending a "GET" to "/remote.php/webdav/welcome.txt" with requesttoken
+    Then the HTTP status code should be "200"
+
+  Scenario: Test failing LDAPS connection through TLS verification
+    Given modify LDAP configuration
+      | ldapHost         | ldaps://openldap:636 |
+      | turnOffCertCheck |                    0 |
+    And cookies are reset
+    And Expect ServerException on failed web login as "alice"
+
   Scenario: Look for a known LDAP user
     Given As an "admin"
     And sending "GET" to "/cloud/users?search=alice"


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #55519 
## Summary

- the old approach lead connection issues, as ldap_set_option was called too late. Specifically it needs to be called before ldap_connect and set globally!
- The old approach also connected it to the ldapTLS configuration, which has a misleading naming. It indicates StartTLS usage only, not plain TLS connections.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
