### PR TITLE
perf(dav): push carddav report filtering to the db

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBook.php
+++ b/apps/dav/lib/CardDAV/AddressBook.php
@@ -13,6 +13,8 @@ use OCP\IL10N;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\CardDAV\Backend\BackendInterface;
+use Sabre\CardDAV\IAddressBookObjectContainer;
+use Sabre\CardDAV\Xml\Request\AddressBookQueryReport;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\IMoveTarget;
@@ -25,7 +27,7 @@ use Sabre\DAV\PropPatch;
  * @package OCA\DAV\CardDAV
  * @property CardDavBackend $carddavBackend
  */
-class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable, IMoveTarget {
+class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable, IMoveTarget, IAddressBookObjectContainer {
 	/**
 	 * AddressBook constructor.
 	 *
@@ -257,5 +259,12 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable, IMov
 			Server::get(LoggerInterface::class)->error('Could not move calendar object: ' . $e->getMessage(), ['exception' => $e]);
 			return false;
 		}
+	}
+
+	public function addressBookQuery(AddressBookQueryReport $report): array {
+		return $this->carddavBackend->addressBookReport(
+			$this->addressBookInfo['id'],
+			$report,
+		);
 	}
 }

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -30,9 +30,12 @@ use PDO;
 use Sabre\CardDAV\Backend\BackendInterface;
 use Sabre\CardDAV\Backend\SyncSupport;
 use Sabre\CardDAV\Plugin;
+use Sabre\CardDAV\Xml\Request\AddressBookQueryReport;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Reader;
+use function in_array;
+use function strtoupper;
 
 class CardDavBackend implements BackendInterface, SyncSupport {
 	use TTransactional;
@@ -1532,5 +1535,83 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		}
 		// should already be handled, but just in case
 		throw new BadRequest('vCard can not be empty');
+	}
+
+	public function addressBookReport(int $addressBookId, AddressBookQueryReport $report): array {
+		$selectQuery = $this->db->getQueryBuilder();
+		$selectQuery->select('c.uri')
+			->from($this->dbCardsPropertiesTable, 'cp')
+			->join('cp', $this->dbCardsTable, 'c', $selectQuery->expr()->eq('c.id', 'cp.cardid', IQueryBuilder::PARAM_INT))
+			->where($selectQuery->expr()->eq('c.addressbookid', $selectQuery->createNamedParameter($addressBookId, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT));
+
+		$needsPostFilter = false;
+		$dbFilters = [];
+		foreach ($report->filters as $filter) {
+			if (!in_array(strtoupper($filter['name']), self::$indexProperties, true)) {
+				// We can't push the filter down to the DB
+				$needsPostFilter = true;
+			}
+			if (!empty($filter['param-filter'])) {
+				// Parameters are not indexed
+				$needsPostFilter = true;
+			}
+			if ($filter['is-not-defined'] === true) {
+				// Can't easily look for this with a query
+				$needsPostFilter = true;
+			}
+
+			foreach ($filter['text-matches'] as $matchFilter) {
+				// TODO: handle negate-condition
+				$dbFilters[] = $selectQuery->expr()->andX(
+					$selectQuery->expr()->eq(
+						'cp.name',
+						$selectQuery->createNamedParameter($filter['name']),
+					),
+					match ($matchFilter['match-type']) {
+						'equals' => $selectQuery->expr()->eq(
+							'cp.value',
+							$selectQuery->createNamedParameter($matchFilter['value'], IQueryBuilder::PARAM_STR)
+						),
+						'contains' => $selectQuery->expr()->like(
+							'cp.value',
+							$selectQuery->createNamedParameter('%' . $matchFilter['value'] . '%', IQueryBuilder::PARAM_STR) // TODO: escaping
+						),
+						'starts-with' => $selectQuery->expr()->eq(
+							'cp.value',
+							$selectQuery->createNamedParameter($matchFilter['value'] . '%', IQueryBuilder::PARAM_STR) // TODO: escaping
+						),
+						'ends-with' => $selectQuery->expr()->eq(
+							'cp.value',
+							$selectQuery->createNamedParameter('%' . $matchFilter['value'], IQueryBuilder::PARAM_STR) // TODO: escaping
+						),
+						default => throw new \InvalidArgumentException('Invalid filter match'),
+					}
+				);
+			}
+		}
+
+		if ($dbFilters !== []) {
+			$selectQuery->andWhere(
+				match ($report->test) {
+					'allof' => $selectQuery->expr()->andX(...$dbFilters),
+					'anyof' => $selectQuery->expr()->orX(...$dbFilters),
+					default => throw new \InvalidArgumentException('Invalid filter test'),
+				}
+			);
+		}
+
+		$selectQuery->groupBy('c.uri'); // deduplicate
+		$result = $selectQuery->executeQuery();
+		$uris = [];
+		while (($uri = $result->fetchOne()) !== false) {
+			$uris[] = $uri;
+		}
+		$result->closeCursor();
+
+		if ($needsPostFilter) {
+			// TODO implement
+		}
+
+		return $uris;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Searching on CardDAV is very expensive as the full address book is loaded into memory. This pushes filtering down into the DB.

## TODO

- [ ] Needs https://github.com/sabre-io/dav/pull/1599

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
