### PR TITLE
Port away from deprecated Doctrine APIs

### DIFF
--- a/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
@@ -45,7 +45,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(4, $rows);
@@ -55,7 +55,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(2, $rows);
@@ -65,7 +65,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(4, $rows);
@@ -75,7 +75,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(1, $rows);
@@ -85,7 +85,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(4, $rows);
@@ -95,7 +95,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(3, $rows);
@@ -192,7 +192,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(4, $rows);
@@ -203,7 +203,7 @@ class BackendTest extends TestCase {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(5, $rows);

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
@@ -462,7 +462,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 				'displayname' => $query->createNamedParameter('Beamer1'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 
 		$query->insert($this->mainDbTable)
 			->values([
@@ -472,7 +472,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 				'displayname' => $query->createNamedParameter('TV1'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 
 		$query->insert($this->mainDbTable)
 			->values([
@@ -482,7 +482,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 				'displayname' => $query->createNamedParameter('Beamer2'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 		$id3 = $query->getLastInsertId();
 
 		$query->insert($this->mainDbTable)
@@ -493,7 +493,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 				'displayname' => $query->createNamedParameter('TV2'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 		$id4 = $query->getLastInsertId();
 
 		$query->insert($this->mainDbTable)
@@ -504,7 +504,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 				'displayname' => $query->createNamedParameter('Beamer3'),
 				'group_restrictions' => $query->createNamedParameter('["foo", "bar"]'),
 			])
-			->execute();
+			->executeStatement();
 
 		$query->insert($this->mainDbTable)
 			->values([
@@ -514,7 +514,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 				'displayname' => $query->createNamedParameter('Pointer'),
 				'group_restrictions' => $query->createNamedParameter('["group1", "bar"]'),
 			])
-			->execute();
+			->executeStatement();
 		$id6 = $query->getLastInsertId();
 
 		$query->insert($this->metadataDbTable)
@@ -523,34 +523,34 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 				'key' => $query->createNamedParameter('{http://nextcloud.com/ns}foo'),
 				'value' => $query->createNamedParameter('value1')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert($this->metadataDbTable)
 			->values([
 				$this->foreignKey => $query->createNamedParameter($id3),
 				'key' => $query->createNamedParameter('{http://nextcloud.com/ns}meta2'),
 				'value' => $query->createNamedParameter('value2')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert($this->metadataDbTable)
 			->values([
 				$this->foreignKey => $query->createNamedParameter($id4),
 				'key' => $query->createNamedParameter('{http://nextcloud.com/ns}meta1'),
 				'value' => $query->createNamedParameter('value1')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert($this->metadataDbTable)
 			->values([
 				$this->foreignKey => $query->createNamedParameter($id4),
 				'key' => $query->createNamedParameter('{http://nextcloud.com/ns}meta3'),
 				'value' => $query->createNamedParameter('value3-old')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert($this->metadataDbTable)
 			->values([
 				$this->foreignKey => $query->createNamedParameter($id6),
 				'key' => $query->createNamedParameter('{http://nextcloud.com/ns}meta99'),
 				'value' => $query->createNamedParameter('value99')
 			])
-			->execute();
+			->executeStatement();
 	}
 }

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -549,7 +549,7 @@ class CardDavBackendTest extends TestCase {
 			->from('cards_properties')
 			->orderBy('name');
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 
@@ -574,7 +574,7 @@ class CardDavBackendTest extends TestCase {
 		$query->select('*')
 			->from('cards_properties');
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 
@@ -598,7 +598,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 
 		$query = $this->db->getQueryBuilder();
 		$query->insert('cards_properties')
@@ -611,7 +611,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 
 		$this->invokePrivate($this->backend, 'purgeProperties', [1, 1]);
 
@@ -619,7 +619,7 @@ class CardDavBackendTest extends TestCase {
 		$query->select('*')
 			->from('cards_properties');
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 
@@ -642,7 +642,7 @@ class CardDavBackendTest extends TestCase {
 					'size' => $query->createNamedParameter(120)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 		$id = $query->getLastInsertId();
 
 		$this->assertSame($id,
@@ -686,7 +686,7 @@ class CardDavBackendTest extends TestCase {
 						'size' => $query->createNamedParameter(120),
 					]
 				);
-			$query->execute();
+			$query->executeStatement();
 			$vCardIds[] = $query->getLastInsertId();
 		}
 
@@ -701,7 +701,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
@@ -713,7 +713,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
@@ -725,7 +725,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
@@ -737,7 +737,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
@@ -749,7 +749,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 
 		$result = $this->backend->search(0, $pattern, $properties, $options);
 
@@ -795,7 +795,7 @@ class CardDavBackendTest extends TestCase {
 					'size' => $query->createNamedParameter(120),
 				]
 			);
-		$query->execute();
+		$query->executeStatement();
 
 		$id = $query->getLastInsertId();
 
@@ -823,7 +823,7 @@ class CardDavBackendTest extends TestCase {
 						'size' => $query->createNamedParameter(120),
 					]
 				);
-			$query->execute();
+			$query->executeStatement();
 		}
 
 		$result = $this->backend->getContact(0, 'uri0');
@@ -856,7 +856,7 @@ class CardDavBackendTest extends TestCase {
 					'preferred' => $query->createNamedParameter(0)
 				]
 			)
-			->execute();
+			->executeStatement();
 
 		$result = $this->backend->collectCardProperties(666, 'FN');
 		$this->assertEquals(['John Doe'], $result);

--- a/apps/federatedfilesharing/lib/Migration/Version1011Date20201120125158.php
+++ b/apps/federatedfilesharing/lib/Migration/Version1011Date20201120125158.php
@@ -30,7 +30,7 @@ class Version1011Date20201120125158 extends SimpleMigrationStep {
 		if ($schema->hasTable('federated_reshares')) {
 			$table = $schema->getTable('federated_reshares');
 			$remoteIdColumn = $table->getColumn('remote_id');
-			if ($remoteIdColumn && $remoteIdColumn->getType()->getName() !== Types::STRING) {
+			if ($remoteIdColumn && Type::lookupName($remoteIdColumn->getType()) !== Types::STRING) {
 				$remoteIdColumn->setNotnull(false);
 				$remoteIdColumn->setType(Type::getType(Types::STRING));
 				$remoteIdColumn->setOptions(['length' => 255]);

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -63,7 +63,7 @@ class DbHandlerTest extends TestCase {
 
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
@@ -87,7 +87,7 @@ class DbHandlerTest extends TestCase {
 
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 		$this->assertCount(2, $result);
@@ -99,7 +99,7 @@ class DbHandlerTest extends TestCase {
 		$this->dbHandler->removeServer($id2);
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
@@ -175,7 +175,7 @@ class DbHandlerTest extends TestCase {
 		$this->dbHandler->addServer('server1');
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
@@ -183,7 +183,7 @@ class DbHandlerTest extends TestCase {
 		$this->dbHandler->addSharedSecret('http://server1', 'secret');
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
-		$qResult = $query->execute();
+		$qResult = $query->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);

--- a/apps/files_external/tests/Service/StoragesServiceTestCase.php
+++ b/apps/files_external/tests/Service/StoragesServiceTestCase.php
@@ -315,7 +315,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 			->from('storages')
 			->where($qb->expr()->eq('numeric_id', $qb->expr()->literal($numericId)));
 
-		$result = $storageCheckQuery->execute();
+		$result = $storageCheckQuery->executeQuery();
 		$storages = $result->fetchAll();
 		$result->closeCursor();
 		$this->assertCount(0, $storages, 'expected 0 storages, got ' . json_encode($storages));

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -703,7 +703,7 @@ class Manager {
 						)
 					)
 				);
-			$qb->execute();
+			$qb->executeStatement();
 		} catch (\Doctrine\DBAL\Exception $ex) {
 			$this->logger->emergency('Could not delete user shares', ['exception' => $ex]);
 			return false;
@@ -798,7 +798,7 @@ class Manager {
 			->orderBy('id', 'ASC');
 
 		try {
-			$result = $qb->execute();
+			$result = $qb->executeQuery();
 			$shares = $result->fetchAll();
 			$result->closeCursor();
 

--- a/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
+++ b/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
@@ -88,7 +88,7 @@ class Version11300Date20201120141438 extends SimpleMigrationStep {
 		} else {
 			$table = $schema->getTable('share_external');
 			$remoteIdColumn = $table->getColumn('remote_id');
-			if ($remoteIdColumn && $remoteIdColumn->getType()->getName() !== Types::STRING) {
+			if ($remoteIdColumn && Type::lookupName($remoteIdColumn->getType()) !== Types::STRING) {
 				$remoteIdColumn->setNotnull(false);
 				$remoteIdColumn->setType(Type::getType(Types::STRING));
 				$remoteIdColumn->setOptions(['length' => 255]);

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -43,7 +43,8 @@ class ExpireSharesJobTest extends \Test\TestCase {
 
 		$this->connection = Server::get(IDBConnection::class);
 		// clear occasional leftover shares from other tests
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('share')->executeStatement();
 
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
@@ -58,7 +59,8 @@ class ExpireSharesJobTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('share')->executeStatement();
 
 		$userManager = Server::get(IUserManager::class);
 		$user1 = $userManager->get($this->user1);
@@ -81,7 +83,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 
 		$result = $qb->select('*')
 			->from('share')
-			->execute();
+			->executeQuery();
 
 		while ($row = $result->fetch()) {
 			$shares[] = $row;
@@ -151,7 +153,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 				->where($qb->expr()->eq('id', $qb->createParameter('id')))
 				->setParameter('id', $share['id'])
 				->setParameter('expiration', $expire)
-				->execute();
+				->executeStatement();
 
 			$shares = $this->getShares();
 			$this->assertCount(1, $shares);

--- a/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
+++ b/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
@@ -50,7 +50,7 @@ class SetPasswordColumnTest extends TestCase {
 
 	private function cleanDB() {
 		$query = $this->connection->getQueryBuilder();
-		$query->delete($this->table)->execute();
+		$query->delete($this->table)->executeStatement();
 	}
 
 	public function testAddPasswordColumn(): void {
@@ -80,7 +80,7 @@ class SetPasswordColumnTest extends TestCase {
 						'stime' => $query->createNamedParameter(time()),
 					]);
 
-				$this->assertSame(1, $query->execute());
+				$this->assertSame(1, $query->executeStatement());
 			}
 		}
 
@@ -91,7 +91,7 @@ class SetPasswordColumnTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('share');
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$allShares = $result->fetchAll();
 		$result->closeCursor();
 

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -122,15 +122,15 @@ abstract class TestCase extends \Test\TestCase {
 	protected function tearDown(): void {
 		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->delete('share');
-		$qb->execute();
+		$qb->executeStatement();
 
 		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->delete('mounts');
-		$qb->execute();
+		$qb->executeStatement();
 
 		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->delete('filecache')->runAcrossAllShards();
-		$qb->execute();
+		$qb->executeStatement();
 
 		parent::tearDown();
 	}
@@ -213,7 +213,7 @@ abstract class TestCase extends \Test\TestCase {
 			->where(
 				$qb->expr()->eq('id', $qb->createNamedParameter($shareID))
 			);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$share = $result->fetch();
 		$result->closeCursor();
 

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -27,7 +27,7 @@ class ClientMapperTest extends TestCase {
 
 	protected function tearDown(): void {
 		$query = Server::get(IDBConnection::class)->getQueryBuilder();
-		$query->delete('oauth2_clients')->execute();
+		$query->delete('oauth2_clients')->executeStatement();
 
 		parent::tearDown();
 	}

--- a/apps/settings/lib/SetupChecks/MysqlRowFormat.php
+++ b/apps/settings/lib/SetupChecks/MysqlRowFormat.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
  */
 namespace OCA\Settings\SetupChecks;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use OC\DB\Connection;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\SetupCheck\ISetupCheck;
@@ -34,7 +34,8 @@ class MysqlRowFormat implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+		if (!$this->connection->getDatabaseProvider() === IDBConnection::PLATFORM_MYSQL
+			&& !$this->connection->getDatabaseProvider() === IDBConnection::PLATFORM_MARIADB) {
 			return SetupResult::success($this->l10n->t('You are not using MySQL'));
 		}
 

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -8,10 +8,6 @@ declare(strict_types=1);
  */
 namespace OCA\Settings\SetupChecks;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -43,9 +39,8 @@ class SupportedDatabase implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		$version = null;
-		$databasePlatform = $this->connection->getDatabasePlatform();
-		if ($databasePlatform instanceof MySQLPlatform) {
+		$databasePlatform = $this->connection->getDatabaseProvider();
+		if ($databasePlatform === IDBConnection::PLATFORM_MYSQL || $databasePlatform === IDBConnection::PLATFORM_MARIADB) {
 			$statement = $this->connection->prepare("SHOW VARIABLES LIKE 'version';");
 			$result = $statement->execute();
 			$row = $result->fetch();
@@ -91,7 +86,7 @@ class SupportedDatabase implements ISetupCheck {
 					);
 				}
 			}
-		} elseif ($databasePlatform instanceof PostgreSQLPlatform) {
+		} elseif ($databasePlatform === IDBConnection::PLATFORM_POSTGRES) {
 			$statement = $this->connection->prepare('SHOW server_version;');
 			$result = $statement->execute();
 			$row = $result->fetch();
@@ -111,9 +106,9 @@ class SupportedDatabase implements ISetupCheck {
 						])
 				);
 			}
-		} elseif ($databasePlatform instanceof OraclePlatform) {
+		} elseif ($databasePlatform === IDBConnection::PLATFORM_ORACLE) {
 			$version = 'Oracle';
-		} elseif ($databasePlatform instanceof SqlitePlatform) {
+		} elseif ($databasePlatform === IDBConnection::PLATFORM_SQLITE) {
 			return SetupResult::warning(
 				$this->l10n->t('SQLite is currently being used as the backend database. For larger installations we recommend that you switch to a different database backend. This is particularly recommended when using the desktop client for file synchronisation. To migrate to another database use the command line tool: "occ db:convert-type".'),
 				$this->urlGenerator->linkToDocs('admin-db-conversion')

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -746,7 +746,7 @@ class ShareByMailProviderTest extends TestCase {
 			->from('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 
-		$qResult = $qb->execute();
+		$qResult = $qb->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 
@@ -799,7 +799,7 @@ class ShareByMailProviderTest extends TestCase {
 			->from('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 
-		$qResult = $qb->execute();
+		$qResult = $qb->executeQuery();
 		$result = $qResult->fetchAll();
 		$qResult->closeCursor();
 
@@ -1031,7 +1031,7 @@ class ShareByMailProviderTest extends TestCase {
 		$query->select('*')->from('share')
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$before = $result->fetchAll();
 		$result->closeCursor();
 
@@ -1044,7 +1044,7 @@ class ShareByMailProviderTest extends TestCase {
 		$query->select('*')->from('share')
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$after = $result->fetchAll();
 		$result->closeCursor();
 
@@ -1067,7 +1067,7 @@ class ShareByMailProviderTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')->from('share');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$before = $result->fetchAll();
 		$result->closeCursor();
 
@@ -1082,7 +1082,7 @@ class ShareByMailProviderTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')->from('share');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$after = $result->fetchAll();
 		$result->closeCursor();
 
@@ -1156,7 +1156,7 @@ class ShareByMailProviderTest extends TestCase {
 		 */
 		$qb->setValue('file_target', $qb->createNamedParameter(''));
 
-		$qb->execute();
+		$qb->executeStatement();
 		$id = $qb->getLastInsertId();
 
 		return (int)$id;

--- a/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
@@ -27,7 +27,7 @@ class BackupCodeMapperTest extends TestCase {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->mapper->getTableName())
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($this->testUID)));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	protected function setUp(): void {

--- a/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
+++ b/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
@@ -22,7 +22,7 @@ class UserStatusMapperTest extends TestCase {
 
 		// make sure that DB is empty
 		$qb = self::$realDatabase->getQueryBuilder();
-		$qb->delete('user_status')->execute();
+		$qb->delete('user_status')->executeStatement();
 
 		$this->mapper = new UserStatusMapper(self::$realDatabase);
 	}

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -107,7 +107,7 @@ class ManagerTest extends TestCase {
 		$query = $this->db->getQueryBuilder();
 		foreach (['flow_checks', 'flow_operations', 'flow_operations_scope'] as $table) {
 			$query->delete($table)
-				->execute();
+				->executeStatement();
 		}
 	}
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1268,11 +1268,6 @@
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
   </file>
-  <file src="apps/federatedfilesharing/lib/Migration/Version1011Date20201120125158.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getName]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/federatedfilesharing/lib/Notifications.php">
     <DeprecatedMethod>
       <code><![CDATA[sendNotification]]></code>
@@ -1707,11 +1702,6 @@
   <file src="apps/files_sharing/lib/Migration/SetPasswordColumn.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/files_sharing/lib/Migration/Version11300Date20201120141438.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getName]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/files_sharing/lib/MountProvider.php">
@@ -3054,19 +3044,8 @@
       <code><![CDATA[$this->appConfig->getValues($app, false)]]></code>
     </FalsableReturnStatement>
   </file>
-  <file src="core/Command/Db/AddMissingPrimaryKeys.php">
-    <DeprecatedMethod>
-      <code><![CDATA[hasPrimaryKey]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="core/Command/Db/ConvertFilecacheBigInt.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getName]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="core/Command/Db/ConvertType.php">
     <DeprecatedMethod>
-      <code><![CDATA[getName]]></code>
       <code><![CDATA[getPrimaryKeyColumns]]></code>
     </DeprecatedMethod>
     <InvalidScalarArgument>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2445,11 +2445,6 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/settings/lib/SetupChecks/SupportedDatabase.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getDatabasePlatform]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/sharebymail/lib/Settings/SettingsManager.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1628,8 +1628,6 @@
     <DeprecatedMethod>
       <code><![CDATA[Files::buildNotExistingFileName($shareFolder, $share['name'])]]></code>
       <code><![CDATA[Files::buildNotExistingFileName('/', $name)]]></code>
-      <code><![CDATA[execute]]></code>
-      <code><![CDATA[execute]]></code>
       <code><![CDATA[insertIfNotExist]]></code>
       <code><![CDATA[sendNotification]]></code>
       <code><![CDATA[sendNotification]]></code>

--- a/core/Command/Db/AddMissingPrimaryKeys.php
+++ b/core/Command/Db/AddMissingPrimaryKeys.php
@@ -55,7 +55,7 @@ class AddMissingPrimaryKeys extends Command {
 			foreach ($missingKeys as $missingKey) {
 				if ($schema->hasTable($missingKey['tableName'])) {
 					$table = $schema->getTable($missingKey['tableName']);
-					if (!$table->hasPrimaryKey()) {
+					if ($table->getPrimaryKey() === null) {
 						$output->writeln('<info>Adding primary key to the ' . $missingKey['tableName'] . ' table, this can take some time...</info>');
 						$table->setPrimaryKey($missingKey['columns'], $missingKey['primaryKeyName']);
 

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -70,7 +70,7 @@ class ConvertFilecacheBigInt extends Command {
 				$column = $table->getColumn($columnName);
 				$isAutoIncrement = $column->getAutoincrement();
 				$isAutoIncrementOnSqlite = $isSqlite && $isAutoIncrement;
-				if ($column->getType()->getName() !== Types::BIGINT && !$isAutoIncrementOnSqlite) {
+				if (Type::lookupName($column->getType()) !== Types::BIGINT && !$isAutoIncrementOnSqlite) {
 					$column->setType(Type::getType(Types::BIGINT));
 					$column->setOptions(['length' => 20]);
 

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -10,6 +10,7 @@ namespace OC\Core\Command\Db;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
 use OC\DB\Connection;
 use OC\DB\ConnectionFactory;
 use OC\DB\MigrationService;
@@ -379,7 +380,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 			return $this->columnTypes[$tableName][$columnName];
 		}
 
-		$type = $table->getColumn($columnName)->getType()->getName();
+		$type = Type::lookupName($table->getColumn($columnName)->getType());
 
 		switch ($type) {
 			case Types::BLOB:

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
 use OC\App\InfoParser;
 use OC\Migration\SimpleOutput;
 use OCP\App\IAppManager;
@@ -579,7 +580,7 @@ class MigrationService {
 
 					if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
 						// Oracle doesn't support boolean column with non-null value
-						if ($thing->getNotnull() && $thing->getType()->getName() === Types::BOOLEAN) {
+						if ($thing->getNotnull() && Type::lookupName($thing->getType()) === Types::BOOLEAN) {
 							$thing->setNotnull(false);
 						}
 					}
@@ -591,8 +592,8 @@ class MigrationService {
 
 				// If the column was just created OR the length changed OR the type changed
 				// we will NOT detect invalid length if the column is not modified
-				if (($sourceColumn === null || $sourceColumn->getLength() !== $thing->getLength() || $sourceColumn->getType()->getName() !== Types::STRING)
-					&& $thing->getLength() > 4000 && $thing->getType()->getName() === Types::STRING) {
+				if (($sourceColumn === null || $sourceColumn->getLength() !== $thing->getLength() || Type::lookupName($sourceColumn->getType()) !== Types::STRING)
+					&& $thing->getLength() > 4000 && Type::lookupName($thing->getType()) === Types::STRING) {
 					throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is type String, but exceeding the 4.000 length limit.');
 				}
 			}

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -610,7 +610,7 @@ class MigrationService {
 			}
 
 			$primaryKey = $table->getPrimaryKey();
-			if ($primaryKey instanceof Index && (!$sourceTable instanceof Table || !$sourceTable->hasPrimaryKey())) {
+			if ($primaryKey instanceof Index && (!$sourceTable instanceof Table || $sourceTable->getPrimaryKey() === null)) {
 				$indexName = strtolower($primaryKey->getName());
 				$isUsingDefaultName = $indexName === 'primary';
 

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -7,7 +7,6 @@
  */
 namespace OC\DB;
 
-use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -578,7 +577,7 @@ class MigrationService {
 						throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is NotNull, but has empty string or null as default.');
 					}
 
-					if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+					if ($this->connection->getDatabaseProvider() === IDBConnection::PLATFORM_ORACLE) {
 						// Oracle doesn't support boolean column with non-null value
 						if ($thing->getNotnull() && Type::lookupName($thing->getType()) === Types::BOOLEAN) {
 							$thing->setNotnull(false);

--- a/lib/public/Migration/BigIntMigration.php
+++ b/lib/public/Migration/BigIntMigration.php
@@ -39,7 +39,7 @@ abstract class BigIntMigration extends SimpleMigrationStep {
 
 			foreach ($columns as $columnName) {
 				$column = $table->getColumn($columnName);
-				if ($column->getType()->getName() !== Types::BIGINT) {
+				if (Type::lookupName($column->getType()) !== Types::BIGINT) {
 					$column->setType(Type::getType(Types::BIGINT));
 					$column->setOptions(['length' => 20]);
 				}

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -8,7 +8,6 @@
 
 namespace Test\DB;
 
-use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
@@ -708,8 +707,8 @@ class MigrationsTest extends \Test\TestCase {
 	#[TestWith([true])]
 	#[TestWith([false])]
 	public function testEnsureOracleConstraintsBooleanNotNull(bool $isOracle): void {
-		$this->db->method('getDatabasePlatform')
-			->willReturn($isOracle ? $this->createMock(OraclePlatform::class) : null);
+		$this->db->method('getDatabaseProvider')
+			->willReturn($isOracle ? IDBConnection::PLATFORM_ORACLE : IDBConnection::PLATFORM_MARIADB);
 
 		$column = $this->createMock(Column::class);
 		$column->expects($this->any())


### PR DESCRIPTION
## Summary

Remove all calls to the following APIs:

- `IQueryBuilder::execute`
- `Table::hasPrimaryKey`
- `Type::getName`

And from the following pattern:

`getDatabasePlatform() instanceof`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
