### PR TITLE
Add unit tests for AdminDelegation command and AuthorizedGroupService

### DIFF
--- a/apps/settings/lib/Command/AdminDelegation/Add.php
+++ b/apps/settings/lib/Command/AdminDelegation/Add.php
@@ -36,7 +36,7 @@ class Add extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output): int {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
 		$settingClass = $input->getArgument('settingClass');
 		if (!in_array(IDelegatedSettings::class, (array)class_implements($settingClass), true)) {

--- a/apps/settings/tests/Command/AdminDelegation/AddTest.php
+++ b/apps/settings/tests/Command/AdminDelegation/AddTest.php
@@ -44,13 +44,6 @@ class AddTest extends TestCase {
 		$this->output = $this->createMock(OutputInterface::class);
 	}
 
-	/**
-	 * Helper method to execute the command using reflection since execute() is protected
-	 */
-	private function executeCommand(): int {
-		return self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
-	}
-
 	public function testExecuteSuccessfulDelegation(): void {
 		$settingClass = \OCA\Settings\Settings\Admin\Server::class;
 		$groupId = 'testgroup';
@@ -79,7 +72,7 @@ class AddTest extends TestCase {
 			->with($groupId, $settingClass)
 			->willReturn($authorizedGroup);
 
-		$result = $this->executeCommand();
+		$result = $this->command->execute($this->input, $this->output);
 
 		$this->assertEquals(0, $result);
 	}
@@ -93,7 +86,7 @@ class AddTest extends TestCase {
 			->with('settingClass')
 			->willReturn($settingClass);
 
-		$result = $this->executeCommand();
+		$result = $this->command->execute($this->input, $this->output);
 
 		// Should return exit code 2 for invalid setting class
 		$this->assertEquals(2, $result);
@@ -116,7 +109,7 @@ class AddTest extends TestCase {
 			->with($groupId)
 			->willReturn(false);
 
-		$result = $this->executeCommand();
+		$result = $this->command->execute($this->input, $this->output);
 
 		// Should return exit code 3 for non-existent group
 		$this->assertEquals(3, $result);

--- a/apps/settings/tests/Command/AdminDelegation/AddTest.php
+++ b/apps/settings/tests/Command/AdminDelegation/AddTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\Tests\Command\AdminDelegation;
+
+use OC\Settings\AuthorizedGroup;
+use OCA\Settings\Command\AdminDelegation\Add;
+use OCA\Settings\Service\AuthorizedGroupService;
+use OCP\IGroupManager;
+use OCP\Settings\IManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Test\TestCase;
+
+class AddTest extends TestCase {
+
+	private IManager&MockObject $settingManager;
+	private AuthorizedGroupService&MockObject $authorizedGroupService;
+	private IGroupManager&MockObject $groupManager;
+	private Add $command;
+	private InputInterface&MockObject $input;
+	private OutputInterface&MockObject $output;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->settingManager = $this->createMock(IManager::class);
+		$this->authorizedGroupService = $this->createMock(AuthorizedGroupService::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->command = new Add(
+			$this->settingManager,
+			$this->authorizedGroupService,
+			$this->groupManager
+		);
+
+		$this->input = $this->createMock(InputInterface::class);
+		$this->output = $this->createMock(OutputInterface::class);
+	}
+
+	/**
+	 * Helper method to execute the command using reflection since execute() is protected
+	 */
+	private function executeCommand(): int {
+		return self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
+	}
+
+	public function testExecuteSuccessfulDelegation(): void {
+		$settingClass = \OCA\Settings\Settings\Admin\Server::class;
+		$groupId = 'testgroup';
+
+		// Mock valid delegated settings class
+		$this->input->expects($this->exactly(2))
+			->method('getArgument')
+			->willReturnMap([
+				['settingClass', $settingClass],
+				['groupId', $groupId]
+			]);
+
+		// Mock group exists
+		$this->groupManager->expects($this->once())
+			->method('groupExists')
+			->with($groupId)
+			->willReturn(true);
+
+		// Mock successful creation
+		$authorizedGroup = new AuthorizedGroup();
+		$authorizedGroup->setGroupId($groupId);
+		$authorizedGroup->setClass($settingClass);
+
+		$this->authorizedGroupService->expects($this->once())
+			->method('create')
+			->with($groupId, $settingClass)
+			->willReturn($authorizedGroup);
+
+		$result = $this->executeCommand();
+
+		$this->assertEquals(0, $result);
+	}
+
+	public function testExecuteInvalidSettingClass(): void {
+		// Use a real class that exists but doesn't implement IDelegatedSettings
+		$settingClass = 'stdClass';
+
+		$this->input->expects($this->once())
+			->method('getArgument')
+			->with('settingClass')
+			->willReturn($settingClass);
+
+		$result = $this->executeCommand();
+
+		// Should return exit code 2 for invalid setting class
+		$this->assertEquals(2, $result);
+	}
+
+	public function testExecuteNonExistentGroup(): void {
+		$settingClass = \OCA\Settings\Settings\Admin\Server::class;
+		$groupId = 'nonexistentgroup';
+
+		$this->input->expects($this->exactly(2))
+			->method('getArgument')
+			->willReturnMap([
+				['settingClass', $settingClass],
+				['groupId', $groupId]
+			]);
+
+		// Mock group does not exist
+		$this->groupManager->expects($this->once())
+			->method('groupExists')
+			->with($groupId)
+			->willReturn(false);
+
+		$result = $this->executeCommand();
+
+		// Should return exit code 3 for non-existent group
+		$this->assertEquals(3, $result);
+	}
+}

--- a/apps/settings/tests/Service/AuthorizedGroupServiceTest.php
+++ b/apps/settings/tests/Service/AuthorizedGroupServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\Tests\Service;
+
+use OC\Settings\AuthorizedGroup;
+use OC\Settings\AuthorizedGroupMapper;
+use OCA\Settings\Service\AuthorizedGroupService;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class AuthorizedGroupServiceTest extends TestCase {
+
+	private AuthorizedGroupMapper&MockObject $mapper;
+	private AuthorizedGroupService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->mapper = $this->createMock(AuthorizedGroupMapper::class);
+		$this->service = new AuthorizedGroupService($this->mapper);
+	}
+
+	public function testCreateAllowsDifferentGroupsSameClass(): void {
+		$groupId1 = 'testgroup1';
+		$groupId2 = 'testgroup2';
+		$class = 'TestClass';
+
+		$expectedGroup1 = new AuthorizedGroup();
+		$expectedGroup1->setGroupId($groupId1);
+		$expectedGroup1->setClass($class);
+		$expectedGroup1->setId(123);
+
+		$expectedGroup2 = new AuthorizedGroup();
+		$expectedGroup2->setGroupId($groupId2);
+		$expectedGroup2->setClass($class);
+		$expectedGroup2->setId(124);
+
+		$this->mapper->expects($this->exactly(2))
+			->method('insert')
+			->willReturnOnConsecutiveCalls($expectedGroup1, $expectedGroup2);
+
+		// Both creations should succeed
+		$result1 = $this->service->create($groupId1, $class);
+		$this->assertEquals($groupId1, $result1->getGroupId());
+		$this->assertEquals($class, $result1->getClass());
+
+		$result2 = $this->service->create($groupId2, $class);
+		$this->assertEquals($groupId2, $result2->getGroupId());
+		$this->assertEquals($class, $result2->getClass());
+	}
+
+	public function testCreateAllowsSameGroupDifferentClasses(): void {
+		$groupId = 'testgroup';
+		$class1 = 'TestClass1';
+		$class2 = 'TestClass2';
+
+		$expectedGroup1 = new AuthorizedGroup();
+		$expectedGroup1->setGroupId($groupId);
+		$expectedGroup1->setClass($class1);
+		$expectedGroup1->setId(123);
+
+		$expectedGroup2 = new AuthorizedGroup();
+		$expectedGroup2->setGroupId($groupId);
+		$expectedGroup2->setClass($class2);
+		$expectedGroup2->setId(124);
+
+		$this->mapper->expects($this->exactly(2))
+			->method('insert')
+			->willReturnOnConsecutiveCalls($expectedGroup1, $expectedGroup2);
+
+		// Both creations should succeed
+		$result1 = $this->service->create($groupId, $class1);
+		$result2 = $this->service->create($groupId, $class2);
+
+		$this->assertEquals($groupId, $result1->getGroupId());
+		$this->assertEquals($groupId, $result2->getGroupId());
+		$this->assertEquals($class1, $result1->getClass());
+		$this->assertEquals($class2, $result2->getClass());
+	}
+}


### PR DESCRIPTION
## Summary
* php unitests are testing occ `admin-delegation:add` in order to extend admin-delegation functionality later
```shell
occ admin-delegation:add OCA\\DAV\\Settings\\CalDAVSettings group1 
```                                                                                  


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
