### PR TITLE
fix: Move system-level `activity` app settings to the sample config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1283,6 +1283,49 @@ $CONFIG = [
 		=> 'https://f-droid.org/packages/com.nextcloud.client/',
 
 	/**
+	 * Activity
+	 *
+	 * Options for the activity app.
+	 */
+
+	/**
+	 * Retention of activities.
+	 *
+	 * A daily cron job deletes all activities for all users which are older than
+	 * the number of days specified here.
+	 *
+	 * Defaults to ``365``
+	 */
+
+	'activity_expire_days' => 365,
+
+	/**
+	 * Activities in Team Folders and External Storages.
+	 *
+	 * By default, activities in team folders or external storages are only generated 
+	 * for the current user. This is due to a limitations in current implementations. 
+	 * This config flag makes activities in group folders and external storages work
+	 * like in normal shares (when set to ``true``). WARNING: Enabling this comes with 
+	 * some CRITICAL trade-offs:
+	 *
+	 * - If team folder "Advanced Permissions" (ACLs) are used, activities do not 
+	 *   respect the permissions and therefore all users see all activities, even 
+	 *   for files and directories they do not have access to.
+     * - Users who had access to a team folder, share, or external storage can see 
+	 *   activities in their stream and emails that happen after they are removed 
+	 *   until they log in again.
+     * - Users who are newly added to a team folder, share, or external storage 
+	 *   cannot see activities in their stream or emails that happen after they 
+	 *   are added until they log in again.
+	 * 
+	 * WARNING: Before enabling this, read the warning Activity app chapter.
+	 *
+	 * Defaults to ``false``
+	 **/
+	
+	'activity_use_cached_mountpoints' => false,
+
+	/**
 	 * Apps
 	 *
 	 * Options for the Apps folder, Apps store, and App code checker.

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1311,10 +1311,10 @@ $CONFIG = [
 	 * - If team folder "Advanced Permissions" (ACLs) are used, activities do not
 	 *   respect the permissions and therefore all users see all activities, even
 	 *   for files and directories they do not have access to.
-     * - Users who had access to a team folder, share, or external storage can see
+	 * - Users who had access to a team folder, share, or external storage can see
 	 *   activities in their stream and emails that happen after they are removed
 	 *   until they log in again.
-     * - Users who are newly added to a team folder, share, or external storage
+	 * - Users who are newly added to a team folder, share, or external storage
 	 *   cannot see activities in their stream or emails that happen after they
 	 *   are added until they log in again.
 	 *

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1302,27 +1302,27 @@ $CONFIG = [
 	/**
 	 * Activities in Team Folders and External Storages.
 	 *
-	 * By default, activities in team folders or external storages are only generated 
-	 * for the current user. This is due to a limitations in current implementations. 
+	 * By default, activities in team folders or external storages are only generated
+	 * for the current user. This is due to a limitations in current implementations.
 	 * This config flag makes activities in group folders and external storages work
-	 * like in normal shares (when set to ``true``). WARNING: Enabling this comes with 
+	 * like in normal shares (when set to ``true``). WARNING: Enabling this comes with
 	 * some CRITICAL trade-offs:
 	 *
-	 * - If team folder "Advanced Permissions" (ACLs) are used, activities do not 
-	 *   respect the permissions and therefore all users see all activities, even 
+	 * - If team folder "Advanced Permissions" (ACLs) are used, activities do not
+	 *   respect the permissions and therefore all users see all activities, even
 	 *   for files and directories they do not have access to.
-     * - Users who had access to a team folder, share, or external storage can see 
-	 *   activities in their stream and emails that happen after they are removed 
+     * - Users who had access to a team folder, share, or external storage can see
+	 *   activities in their stream and emails that happen after they are removed
 	 *   until they log in again.
-     * - Users who are newly added to a team folder, share, or external storage 
-	 *   cannot see activities in their stream or emails that happen after they 
+     * - Users who are newly added to a team folder, share, or external storage
+	 *   cannot see activities in their stream or emails that happen after they
 	 *   are added until they log in again.
-	 * 
+	 *
 	 * WARNING: Before enabling this, read the warning Activity app chapter.
 	 *
 	 * Defaults to ``false``
 	 **/
-	
+
 	'activity_use_cached_mountpoints' => false,
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

These entries are currently hard-coded in the manual itself (on the config parameter page that is generated from this config sample file) [here](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#activity-app). 

This PR simple moves them to the proper place, the config sample file itself. They'll then still appear in that page in the manual.

A separate PR (nextcloud/documentation#13789) in the docs repo will remove their hard-coded entries in the manual, but this is not dependent on that PR.

Some light edits were made to the content (drawn from [the separate Activity app chapter in the manual](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/activity_configuration.html#activities-in-groupfolders-or-external-storages)), but the focus of this PR isn't about improving the content itself so not overly concerned with making that perfect at this time (unless you see any obvious typo).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
