### PR TITLE
feat(previews): Use SnowflakeId generator for previews

### DIFF
--- a/core/BackgroundJobs/MovePreviewJob.php
+++ b/core/BackgroundJobs/MovePreviewJob.php
@@ -26,6 +26,7 @@ use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\Snowflake\IGenerator;
 use Override;
 use Psr\Log\LoggerInterface;
 
@@ -44,6 +45,7 @@ class MovePreviewJob extends TimedJob {
 		private readonly IMimeTypeDetector $mimeTypeDetector,
 		private readonly IMimeTypeLoader $mimeTypeLoader,
 		private readonly LoggerInterface $logger,
+		private readonly IGenerator $generator,
 		IAppDataFactory $appDataFactory,
 	) {
 		parent::__construct($time);
@@ -136,6 +138,7 @@ class MovePreviewJob extends TimedJob {
 			$path = $fileId . '/' . $previewFile->getName();
 			/** @var SimpleFile $previewFile */
 			$preview = Preview::fromPath($path, $this->mimeTypeDetector);
+			$preview->setId($this->generator->nextId());
 			if (!$preview) {
 				$this->logger->error('Unable to import old preview at path.');
 				continue;

--- a/core/Migrations/Version33000Date20251023110529.php
+++ b/core/Migrations/Version33000Date20251023110529.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\ModifyColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migrate away from auto-increment
+ */
+#[ModifyColumn(table: 'preview_locations', name: 'id', description: 'Remove auto-increment')]
+#[ModifyColumn(table: 'previews', name: 'id', description: 'Remove auto-increment')]
+#[ModifyColumn(table: 'preview_versions', name: 'id', description: 'Remove auto-increment')]
+class Version33000Date20251023110529 extends SimpleMigrationStep {
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('preview_locations')) {
+			$schema->dropAutoincrementColumn('preview_locations', 'id');
+		}
+
+		if ($schema->hasTable('preview_versions')) {
+			$schema->dropAutoincrementColumn('preview_versions', 'id');
+		}
+
+		if ($schema->hasTable('previews')) {
+			$schema->dropAutoincrementColumn('previews', 'id');
+		}
+
+		return $schema;
+	}
+}

--- a/core/Migrations/Version33000Date20251023120529.php
+++ b/core/Migrations/Version33000Date20251023120529.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Use unique index for preview_locations
+ */
+#[AddIndex(table: 'preview_locations', type: IndexType::UNIQUE)]
+class Version33000Date20251023120529 extends SimpleMigrationStep {
+	public function __construct(
+		private readonly IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('preview_locations')) {
+			$table = $schema->getTable('preview_locations');
+			$table->addUniqueIndex(['bucket_name', 'object_store_name'], 'unique_bucket_store');
+		}
+
+		return $schema;
+	}
+
+	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		// This shouldn't run on a production instance, only daily
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('preview_locations');
+		$result = $qb->executeQuery();
+
+		$set = [];
+
+		while ($row = $result->fetch()) {
+			// Iterate over all the rows with duplicated rows
+			$id = $row['id'];
+
+			if (isset($set[$row['bucket_name'] . '_' . $row['object_store_name']])) {
+				// duplicate
+				$authoritativeId = $set[$row['bucket_name'] . '_' . $row['object_store_name']];
+				$qb = $this->connection->getQueryBuilder();
+				$qb->select('id')
+					->from('preview_locations')
+					->where($qb->expr()->eq('bucket_name', $qb->createNamedParameter($row['bucket_name'])))
+					->andWhere($qb->expr()->eq('object_store_name', $qb->createNamedParameter($row['object_store_name'])))
+					->andWhere($qb->expr()->neq('id', $qb->createNamedParameter($authoritativeId)));
+
+				$result = $qb->executeQuery();
+				while ($row = $result->fetch()) {
+					// Update previews entries to the now de-duplicated id
+					$qb = $this->connection->getQueryBuilder();
+					$qb->update('previews')
+						->set('location_id', $qb->createNamedParameter($id))
+						->where($qb->expr()->eq('id', $qb->createNamedParameter($row['id'])));
+					$qb->executeStatement();
+
+					$qb = $this->connection->getQueryBuilder();
+					$qb->delete('preview_locations')
+						->where($qb->expr()->eq('id', $qb->createNamedParameter($row['id'])));
+					$qb->executeStatement();
+				}
+				break;
+			}
+			$set[$row['bucket_name'] . '_' . $row['object_store_name']] = $row['id'];
+		}
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1530,6 +1530,8 @@ return array(
     'OC\\Core\\Migrations\\Version32000Date20250731062008' => $baseDir . '/core/Migrations/Version32000Date20250731062008.php',
     'OC\\Core\\Migrations\\Version32000Date20250806110519' => $baseDir . '/core/Migrations/Version32000Date20250806110519.php',
     'OC\\Core\\Migrations\\Version33000Date20250819110529' => $baseDir . '/core/Migrations/Version33000Date20250819110529.php',
+    'OC\\Core\\Migrations\\Version33000Date20251023110529' => $baseDir . '/core/Migrations/Version33000Date20251023110529.php',
+    'OC\\Core\\Migrations\\Version33000Date20251023120529' => $baseDir . '/core/Migrations/Version33000Date20251023120529.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\ResponseDefinitions' => $baseDir . '/core/ResponseDefinitions.php',
     'OC\\Core\\Service\\CronService' => $baseDir . '/core/Service/CronService.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1571,6 +1571,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version32000Date20250731062008' => __DIR__ . '/../../..' . '/core/Migrations/Version32000Date20250731062008.php',
         'OC\\Core\\Migrations\\Version32000Date20250806110519' => __DIR__ . '/../../..' . '/core/Migrations/Version32000Date20250806110519.php',
         'OC\\Core\\Migrations\\Version33000Date20250819110529' => __DIR__ . '/../../..' . '/core/Migrations/Version33000Date20250819110529.php',
+        'OC\\Core\\Migrations\\Version33000Date20251023110529' => __DIR__ . '/../../..' . '/core/Migrations/Version33000Date20251023110529.php',
+        'OC\\Core\\Migrations\\Version33000Date20251023120529' => __DIR__ . '/../../..' . '/core/Migrations/Version33000Date20251023120529.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\ResponseDefinitions' => __DIR__ . '/../../..' . '/core/ResponseDefinitions.php',
         'OC\\Core\\Service\\CronService' => __DIR__ . '/../../..' . '/core/Service/CronService.php',

--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -204,7 +204,7 @@ class Dispatcher {
 		try {
 			$response = \call_user_func_array([$controller, $methodName], $arguments);
 		} catch (\TypeError $e) {
-			// Only intercept TypeErrors occuring on the first line, meaning that the invocation of the controller method failed.
+			// Only intercept TypeErrors occurring on the first line, meaning that the invocation of the controller method failed.
 			// Any other TypeError happens inside the controller method logic and should be logged as normal.
 			if ($e->getFile() === $this->reflector->getFile() && $e->getLine() === $this->reflector->getStartLine()) {
 				$this->logger->debug('Failed to call controller method: ' . $e->getMessage(), ['exception' => $e]);

--- a/lib/private/Preview/Db/Preview.php
+++ b/lib/private/Preview/Db/Preview.php
@@ -17,14 +17,16 @@ use OCP\Files\IMimeTypeDetector;
 /**
  * Preview entity mapped to the oc_previews and oc_preview_locations table.
  *
+ * @method string getId()
+ * @method void setId(string $id)
  * @method int getFileId() Get the file id of the original file.
  * @method void setFileId(int $fileId)
  * @method int getStorageId() Get the storage id of the original file.
  * @method void setStorageId(int $fileId)
  * @method int getOldFileId() Get the old location in the file-cache table, for legacy compatibility.
  * @method void setOldFileId(int $oldFileId)
- * @method int getLocationId() Get the location id in the preview_locations table. Only set when using an object store as primary storage.
- * @method void setLocationId(int $locationId)
+ * @method string getLocationId() Get the location id in the preview_locations table. Only set when using an object store as primary storage.
+ * @method void setLocationId(string $locationId)
  * @method string|null getBucketName() Get the bucket name where the preview is stored. This is stored in the preview_locations table.
  * @method string|null getObjectStoreName() Get the object store name where the preview is stored. This is stored in the preview_locations table.
  * @method int getWidth() Get the width of the preview.
@@ -46,7 +48,7 @@ use OCP\Files\IMimeTypeDetector;
  * @method string getEtag() Get the etag of the preview.
  * @method void setEtag(string $etag)
  * @method string|null getVersion() Get the version for files_versions_s3
- * @method void setVersionId(int $versionId)
+ * @method void setVersionId(string $versionId)
  * @method bool|null getIs() Get the version for files_versions_s3
  * @method bool isEncrypted() Get whether the preview is encrypted. At the moment every preview is unencrypted.
  * @method void setEncrypted(bool $encrypted)
@@ -57,7 +59,7 @@ class Preview extends Entity {
 	protected ?int $fileId = null;
 	protected ?int $oldFileId = null;
 	protected ?int $storageId = null;
-	protected ?int $locationId = null;
+	protected ?string $locationId = null;
 	protected ?string $bucketName = null;
 	protected ?string $objectStoreName = null;
 	protected ?int $width = null;
@@ -72,14 +74,15 @@ class Preview extends Entity {
 	protected ?bool $cropped = null;
 	protected ?string $etag = null;
 	protected ?string $version = null;
-	protected ?int $versionId = null;
+	protected ?string $versionId = null;
 	protected ?bool $encrypted = null;
 
 	public function __construct() {
+		$this->addType('id', Types::STRING);
 		$this->addType('fileId', Types::BIGINT);
 		$this->addType('storageId', Types::BIGINT);
 		$this->addType('oldFileId', Types::BIGINT);
-		$this->addType('locationId', Types::BIGINT);
+		$this->addType('locationId', Types::STRING);
 		$this->addType('width', Types::INTEGER);
 		$this->addType('height', Types::INTEGER);
 		$this->addType('mimetypeId', Types::INTEGER);

--- a/lib/private/Preview/Storage/LocalPreviewStorage.php
+++ b/lib/private/Preview/Storage/LocalPreviewStorage.php
@@ -22,6 +22,7 @@ use OCP\Files\NotPermittedException;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\Snowflake\IGenerator;
 use Override;
 use Psr\Log\LoggerInterface;
 use RecursiveDirectoryIterator;
@@ -38,6 +39,7 @@ class LocalPreviewStorage implements IPreviewStorage {
 		private readonly IDBConnection $connection,
 		private readonly IMimeTypeDetector $mimeTypeDetector,
 		private readonly LoggerInterface $logger,
+		private readonly IGenerator $generator,
 	) {
 		$this->instanceId = $this->config->getSystemValueString('instanceid');
 		$this->rootFolder = $this->config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data');
@@ -118,6 +120,7 @@ class LocalPreviewStorage implements IPreviewStorage {
 					$this->logger->error('Unable to parse preview information for ' . $file->getRealPath());
 					continue;
 				}
+				$preview->setId($this->generator->nextId());
 				try {
 					$preview->setSize($file->getSize());
 					$preview->setMtime($file->getMtime());

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -23,6 +23,7 @@ use OCP\IBinaryFinder;
 use OCP\IConfig;
 use OCP\IPreview;
 use OCP\Preview\IProviderV2;
+use OCP\Snowflake\IGenerator;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
@@ -141,6 +142,7 @@ class PreviewManager implements IPreview {
 				$this->container->get(LoggerInterface::class),
 				$this->container->get(PreviewMapper::class),
 				$this->container->get(StorageFactory::class),
+				$this->container->get(IGenerator::class),
 			);
 		}
 		return $this->generator;

--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -19,10 +19,8 @@ use function substr;
  * @psalm-consistent-constructor
  */
 abstract class Entity {
-	/**
-	 * @var int
-	 */
-	public $id;
+	/** @var int $id */
+	public $id = null;
 
 	private array $_updatedFields = [];
 	/** @var array<string, \OCP\DB\Types::*> */

--- a/lib/public/DB/ISchemaWrapper.php
+++ b/lib/public/DB/ISchemaWrapper.php
@@ -90,4 +90,11 @@ interface ISchemaWrapper {
 	 * @since 23.0.0
 	 */
 	public function getDatabasePlatform();
+
+	/**
+	 * Drop autoincrement from an existing table of the database.
+	 *
+	 * @since 33.0.0
+	 */
+	public function dropAutoincrementColumn(string $table, string $column): void;
 }

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -22,6 +22,7 @@ use OCP\IPreview;
 use OCP\Preview\BeforePreviewFetchedEvent;
 use OCP\Preview\IProviderV2;
 use OCP\Preview\IVersionedPreviewFile;
+use OCP\Snowflake\IGenerator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -41,6 +42,7 @@ class GeneratorTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 	private StorageFactory&MockObject $storageFactory;
 	private PreviewMapper&MockObject $previewMapper;
+	private IGenerator&MockObject $snowflakeGenerator;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -52,6 +54,7 @@ class GeneratorTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->previewMapper = $this->createMock(PreviewMapper::class);
 		$this->storageFactory = $this->createMock(StorageFactory::class);
+		$this->snowflakeGenerator = $this->createMock(IGenerator::class);
 
 		$this->generator = new Generator(
 			$this->config,
@@ -61,6 +64,7 @@ class GeneratorTest extends TestCase {
 			$this->logger,
 			$this->previewMapper,
 			$this->storageFactory,
+			$this->snowflakeGenerator,
 		);
 	}
 

--- a/tests/lib/Preview/MovePreviewJobTest.php
+++ b/tests/lib/Preview/MovePreviewJobTest.php
@@ -24,6 +24,7 @@ use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Server;
+use OCP\Snowflake\IGenerator;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -123,6 +124,7 @@ class MovePreviewJobTest extends TestCase {
 			$this->mimeTypeDetector,
 			$this->mimeTypeLoader,
 			$this->logger,
+			Server::get(IGenerator::class),
 			Server::get(IAppDataFactory::class),
 		);
 		$this->invokePrivate($job, 'run', [[]]);
@@ -155,6 +157,7 @@ class MovePreviewJobTest extends TestCase {
 			$this->mimeTypeDetector,
 			$this->mimeTypeLoader,
 			$this->logger,
+			Server::get(IGenerator::class),
 			Server::get(IAppDataFactory::class)
 		);
 		$this->invokePrivate($job, 'run', [[]]);
@@ -195,6 +198,7 @@ class MovePreviewJobTest extends TestCase {
 			$this->mimeTypeDetector,
 			$this->mimeTypeLoader,
 			$this->logger,
+			Server::get(IGenerator::class),
 			Server::get(IAppDataFactory::class)
 		);
 		$this->invokePrivate($job, 'run', [[]]);

--- a/tests/lib/Preview/PreviewServiceTest.php
+++ b/tests/lib/Preview/PreviewServiceTest.php
@@ -14,7 +14,7 @@ use OC\Preview\Db\Preview;
 use OC\Preview\Db\PreviewMapper;
 use OC\Preview\PreviewService;
 use OCP\Server;
-use PHPUnit\Framework\Attributes\CoversClass;
+use OCP\Snowflake\IGenerator;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(PreviewService::class)]
@@ -22,10 +22,12 @@ use PHPUnit\Framework\TestCase;
 class PreviewServiceTest extends TestCase {
 	private PreviewService $previewService;
 	private PreviewMapper $previewMapper;
+	private IGenerator $snowflakeGenerator;
 
 	protected function setUp(): void {
 		$this->previewService = Server::get(PreviewService::class);
 		$this->previewMapper = Server::get(PreviewMapper::class);
+		$this->snowflakeGenerator = Server::get(IGenerator::class);
 		$this->previewService->deleteAll();
 	}
 
@@ -36,6 +38,7 @@ class PreviewServiceTest extends TestCase {
 	public function testGetAvailableFileIds(): void {
 		foreach (range(1, 20) as $i) {
 			$preview = new Preview();
+			$preview->setId($this->snowflakeGenerator->nextId());
 			$preview->setFileId($i % 10);
 			$preview->setStorageId(1);
 			$preview->setWidth($i);

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [33, 0, 0, 2];
+$OC_Version = [33, 0, 0, 3];
 
 // The human-readable string
 $OC_VersionString = '33.0.0 dev';


### PR DESCRIPTION
## Summary

Allow to get an id for the storing the preview on disk before inserting  the preview on the DB.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
