### PR TITLE
fix: Unset classes in container to reduce side-effects between tests

### DIFF
--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -337,6 +337,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		self::tearDownAfterClassCleanStrayHooks();
 		self::tearDownAfterClassCleanStrayLocks();
 
+		// Ensure we start with fresh instances of some classes to reduce side-effects between tests
+		unset(\OC::$server[\OC\Files\AppData\Factory::class]);
+		unset(\OC::$server[\OC\App\AppStore\Fetcher\AppFetcher::class]);
+		unset(\OC::$server[\OC\Installer::class]);
+		unset(\OC::$server[\OC\Updater::class]);
+
 		/** @var SetupManager $setupManager */
 		$setupManager = Server::get(SetupManager::class);
 		$setupManager->tearDown();


### PR DESCRIPTION
## Summary

When executing 32bit tests we observe some sideffects as we remove all files from the data directory at
https://github.com/nextcloud/server/blob/22791c5843ace05505a4fa8e01167d85e544df34/tests/lib/TestCase.php#L396-L414
which includes appdata directory. Since we only check once if the appdata folder exists, following runs might fail, when the classes are retained. Therefore we specifically unset some classes to ensure the tests run through.

Test-Run: https://github.com/nextcloud/server/actions/runs/18461056236/job/52592428489