### PR TITLE
feat(route): globalsiteselector as root url generator

### DIFF
--- a/lib/private/AppFramework/Routing/RouteParser.php
+++ b/lib/private/AppFramework/Routing/RouteParser.php
@@ -20,6 +20,7 @@ class RouteParser {
 		'core',
 		'files_sharing',
 		'files',
+		'globalsiteselector',
 		'profile',
 		'settings',
 		'spreed',


### PR DESCRIPTION
to allow `globalsiteselector` to manage internal link in globalscale