### PR TITLE
fix(settings): Improve TaskProcessingPickupSpeed setup check

### DIFF
--- a/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
@@ -46,9 +46,9 @@ class TaskProcessingPickupSpeed implements ISetupCheck {
 		if ($taskCount === 0) {
 			return SetupResult::success(
 				$this->l10n->n(
-					'No scheduled tasks in the last %n hour.',
-					'No scheduled tasks in the last %n hours.',
-					24 * $lastNDays
+					'No scheduled tasks in the last day.',
+					'No scheduled tasks in the last %n days.',
+					$lastNDays
 				)
 			);
 		}
@@ -69,17 +69,17 @@ class TaskProcessingPickupSpeed implements ISetupCheck {
 		if ($slowCount / $taskCount < self::MAX_SLOW_PERCENTAGE) {
 			return SetupResult::success(
 				$this->l10n->n(
-					'The task pickup speed has been ok in the last %n hour.',
-					'The task pickup speed has been ok in the last %n hours.',
-					24 * $lastNDays
+					'The task pickup speed has been ok in the last day.',
+					'The task pickup speed has been ok in the last %n days.',
+					$lastNDays
 				)
 			);
 		} else {
 			return SetupResult::warning(
 				$this->l10n->n(
-					'The task pickup speed has been slow in the last %n hour. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.',
-					'The task pickup speed has been slow in the last %n hours. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.',
-					24 * $lastNDays
+					'The task pickup speed has been slow in the last day. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.',
+					'The task pickup speed has been slow in the last %n days. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.',
+					$lastNDays
 				),
 				'https://docs.nextcloud.com/server/latest/admin_manual/ai/overview.html#improve-ai-task-pickup-speed'
 			);

--- a/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
@@ -67,7 +67,7 @@ class TaskProcessingPickupSpeed implements ISetupCheck {
 			}
 		}
 
-		if ($slowCount / $taskCount < self::MAX_SLOW_PERCENTAGE) {
+		if (($slowCount / $taskCount) < self::MAX_SLOW_PERCENTAGE) {
 			return SetupResult::success(
 				$this->l10n->n(
 					'The task pickup speed has been ok in the last day.',

--- a/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
@@ -38,7 +38,7 @@ class TaskProcessingPickupSpeed implements ISetupCheck {
 	public function run(): SetupResult {
 		$taskCount = 0;
 		$lastNDays = 1;
-		while($taskCount === 0 && $lastNDays < self::MAX_DAYS) {
+		while ($taskCount === 0 && $lastNDays < self::MAX_DAYS) {
 			$lastNDays++;
 			$tasks = $this->taskProcessingManager->getTasks(userId: '', scheduleAfter: $this->timeFactory->now()->getTimestamp() - 60 * 60 * 24 * $lastNDays); // userId: '' means no filter, whereas null would mean guest
 			$taskCount = count($tasks);

--- a/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
@@ -17,7 +17,8 @@ use OCP\TaskProcessing\IManager;
 
 class TaskProcessingPickupSpeed implements ISetupCheck {
 	public const MAX_SLOW_PERCENTAGE = 0.2;
-	public const TIME_SPAN = 24;
+
+	public const MAX_DAYS = 14;
 
 	public function __construct(
 		private IL10N $l10n,
@@ -35,10 +36,21 @@ class TaskProcessingPickupSpeed implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		$tasks = $this->taskProcessingManager->getTasks(userId: '', scheduleAfter: $this->timeFactory->now()->getTimestamp() - 60 * 60 * self::TIME_SPAN); // userId: '' means no filter, whereas null would mean guest
-		$taskCount = count($tasks);
+		$taskCount = 0;
+		$lastNDays = 1;
+		while($taskCount === 0 && $lastNDays < self::MAX_DAYS) {
+			$lastNDays++;
+			$tasks = $this->taskProcessingManager->getTasks(userId: '', scheduleAfter: $this->timeFactory->now()->getTimestamp() - 60 * 60 * 24 * $lastNDays); // userId: '' means no filter, whereas null would mean guest
+			$taskCount = count($tasks);
+		}
 		if ($taskCount === 0) {
-			return SetupResult::success($this->l10n->n('No scheduled tasks in the last %n hour.', 'No scheduled tasks in the last %n hours.', self::TIME_SPAN));
+			return SetupResult::success(
+				$this->l10n->n(
+					'No scheduled tasks in the last %n hour.',
+					'No scheduled tasks in the last %n hours.',
+					24 * $lastNDays
+				)
+			);
 		}
 		$slowCount = 0;
 		foreach ($tasks as $task) {
@@ -55,9 +67,22 @@ class TaskProcessingPickupSpeed implements ISetupCheck {
 		}
 
 		if ($slowCount / $taskCount < self::MAX_SLOW_PERCENTAGE) {
-			return SetupResult::success($this->l10n->n('The task pickup speed has been ok in the last %n hour.', 'The task pickup speed has been ok in the last %n hours.', self::TIME_SPAN));
+			return SetupResult::success(
+				$this->l10n->n(
+					'The task pickup speed has been ok in the last %n hour.',
+					'The task pickup speed has been ok in the last %n hours.',
+					24 * $lastNDays
+				)
+			);
 		} else {
-			return SetupResult::warning($this->l10n->n('The task pickup speed has been slow in the last %n hour. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.', 'The task pickup speed has been slow in the last %n hours. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.', self::TIME_SPAN), 'https://docs.nextcloud.com/server/latest/admin_manual/ai/overview.html#improve-ai-task-pickup-speed');
+			return SetupResult::warning(
+				$this->l10n->n(
+					'The task pickup speed has been slow in the last %n hour. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.',
+					'The task pickup speed has been slow in the last %n hours. Many tasks took longer than 4 minutes to be picked up. Consider setting up a worker to process tasks in the background.',
+					24 * $lastNDays
+				),
+				'https://docs.nextcloud.com/server/latest/admin_manual/ai/overview.html#improve-ai-task-pickup-speed'
+			);
 		}
 	}
 }

--- a/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
@@ -40,7 +40,8 @@ class TaskProcessingPickupSpeed implements ISetupCheck {
 		$lastNDays = 1;
 		while ($taskCount === 0 && $lastNDays < self::MAX_DAYS) {
 			$lastNDays++;
-			$tasks = $this->taskProcessingManager->getTasks(userId: '', scheduleAfter: $this->timeFactory->now()->getTimestamp() - 60 * 60 * 24 * $lastNDays); // userId: '' means no filter, whereas null would mean guest
+			// userId: '' means no filter, whereas null would mean guest
+			$tasks = $this->taskProcessingManager->getTasks(userId: '', scheduleAfter: $this->timeFactory->now()->getTimestamp() - (60 * 60 * 24 * $lastNDays));
 			$taskCount = count($tasks);
 		}
 		if ($taskCount === 0) {


### PR DESCRIPTION
## Summary
The current implementation of the task processing pick up speed setup check is not ideal, as it will return success if no tasks have been submitted in the last day, which may however, be a result of the tasks taking a long time. Thus I've rewritten the setup check here to go back multiple days if it doesn't find any tasks.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
