### PR TITLE
feat(querybuilder): Remove deprecated IQueryBuilder::execute

### DIFF
--- a/lib/private/DB/QueryBuilder/ExtendedQueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExtendedQueryBuilder.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OC\DB\QueryBuilder;
 
-use OC\DB\Exceptions\DbalException;
 use OCP\DB\IResult;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -45,21 +44,6 @@ abstract class ExtendedQueryBuilder implements IQueryBuilder {
 
 	public function getState() {
 		return $this->builder->getState();
-	}
-
-	public function execute(?IDBConnection $connection = null) {
-		try {
-			if ($this->getType() === \Doctrine\DBAL\Query\QueryBuilder::SELECT) {
-				return $this->executeQuery($connection);
-			} else {
-				return $this->executeStatement($connection);
-			}
-		} catch (DBALException $e) {
-			// `IQueryBuilder->execute` never wrapped the exception, but `executeQuery` and `executeStatement` do
-			/** @var \Doctrine\DBAL\Exception $previous */
-			$previous = $e->getPrevious();
-			throw $previous;
-		}
 	}
 
 	public function getSQL() {

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -9,7 +9,6 @@ namespace OC\DB\QueryBuilder;
 
 use Doctrine\DBAL\Query\QueryException;
 use OC\DB\ConnectionAdapter;
-use OC\DB\Exceptions\DbalException;
 use OC\DB\QueryBuilder\ExpressionBuilder\MySqlExpressionBuilder;
 use OC\DB\QueryBuilder\ExpressionBuilder\OCIExpressionBuilder;
 use OC\DB\QueryBuilder\ExpressionBuilder\PgSqlExpressionBuilder;
@@ -251,30 +250,6 @@ class QueryBuilder implements IQueryBuilder {
 				'app' => 'core',
 				'exception' => $exception,
 			]);
-		}
-	}
-
-	/**
-	 * Executes this query using the bound parameters and their types.
-	 *
-	 * Uses {@see Connection::executeQuery} for select statements and {@see Connection::executeUpdate}
-	 * for insert, update and delete statements.
-	 *
-	 * @return IResult|int
-	 */
-	public function execute(?IDBConnection $connection = null) {
-		try {
-			if ($this->getType() === \Doctrine\DBAL\Query\QueryBuilder::SELECT) {
-				return $this->executeQuery($connection);
-			} else {
-				return $this->executeStatement($connection);
-			}
-		} catch (DBALException $e) {
-			// `IQueryBuilder->execute` never wrapped the exception, but `executeQuery` and `executeStatement` do
-			/** @var \Doctrine\DBAL\Exception $previous */
-			$previous = $e->getPrevious();
-
-			throw $previous;
 		}
 	}
 

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -191,24 +191,6 @@ interface IQueryBuilder {
 	public function getState();
 
 	/**
-	 * Executes this query using the bound parameters and their types.
-	 *
-	 * Uses {@see Connection::executeQuery} for select statements and {@see Connection::executeStatement}
-	 * for insert, update and delete statements.
-	 *
-	 * Warning: until Nextcloud 20, this method could return a \Doctrine\DBAL\Driver\Statement but since
-	 *          that interface changed in a breaking way the adapter \OCP\DB\QueryBuilder\IStatement is returned
-	 *          to bridge old code to the new API
-	 *
-	 * @param ?IDBConnection $connection (optional) the connection to run the query against. since 30.0
-	 * @return IResult|int
-	 * @throws Exception since 21.0.0
-	 * @since 8.2.0
-	 * @deprecated 22.0.0 Use executeQuery or executeStatement
-	 */
-	public function execute(?IDBConnection $connection = null);
-
-	/**
 	 * Execute for select statements
 	 *
 	 * @param ?IDBConnection $connection (optional) the connection to run the query against. since 30.0


### PR DESCRIPTION
This won't work when we update to doctrine DBAL 4 and all usages in server were ported away.

I submitted a bunch of PR to fix some of the apps but apps maintainer should update their app, it's been deprecated for a very long time...

- [x] https://github.com/nextcloud/previewgenerator/pull/569
- [x] https://github.com/nextcloud/cookbook/pull/2882
- [x] https://github.com/nextcloud/social/pull/1989
- [ ] https://github.com/nextcloud/fulltextsearch/pull/934
- [x] https://github.com/nextcloud/maps/pull/1474
- [x] https://github.com/nextcloud/previewgenerator/pull/569
- [x] https://github.com/nextcloud/files_lock/pull/847
- [x] https://github.com/nextcloud/twofactor_webauthn/pull/885
- [x] https://github.com/nextcloud/twofactor_admin/pull/416
- [ ] https://github.com/nextcloud/globalsiteselector/pull/180
- [x] https://github.com/nextcloud/metavox/pull/17
- [x] https://github.com/nextcloud/circles/pull/2167
- [x] https://github.com/nextcloud/mail/pull/11936
- [x] https://github.com/nextcloud/guests/pull/1431

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
