### PR TITLE
fix(auth): remove legacy session credential fallbacks and improve code clarity

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3460,11 +3460,6 @@
       <code><![CDATA[$this->tar->extractInString($path)]]></code>
     </UndefinedDocblockClass>
   </file>
-  <file src="lib/private/Authentication/LoginCredentials/Store.php">
-    <RedundantCondition>
-      <code><![CDATA[$trySession]]></code>
-    </RedundantCondition>
-  </file>
   <file src="lib/private/Authentication/Token/PublicKeyToken.php">
     <UndefinedMagicMethod>
       <code><![CDATA[getExpires]]></code>

--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -66,9 +66,11 @@ class Store implements IStore {
 	}
 
 	/**
-	 * @since 12
+	 * Returns login credentials for the current user.
 	 *
-	 * @return ICredentials the login credentials of the current user
+	 * Attempts to retrieve credentials using the token provider first.
+	 * If the token is invalid or passwordless, falls back to session credentials.
+	 *
 	 * @throws CredentialsUnavailableException
 	 */
 	public function getLoginCredentials(): ICredentials {
@@ -76,7 +78,6 @@ class Store implements IStore {
 			throw new CredentialsUnavailableException();
 		}
 
-		$trySession = false;
 		try {
 			$sessionId = $this->session->getId();
 			$token = $this->tokenProvider->getToken($sessionId);
@@ -87,33 +88,54 @@ class Store implements IStore {
 
 			return new Credentials($uid, $user, $password);
 		} catch (SessionNotAvailableException $ex) {
-			$this->logger->debug('could not get login credentials because session is unavailable', ['app' => 'core', 'exception' => $ex]);
+			// Session backend is required for token retrieval; give up early if unavailable.
+			$this->logger->debug('Session unavailable', ['app' => 'core', 'exception' => $ex]);
+			throw new CredentialsUnavailableException('Session unavailable');
 		} catch (InvalidTokenException $ex) {
-			$this->logger->debug('could not get login credentials because the token is invalid: ' . $ex->getMessage(), ['app' => 'core']);
-			$trySession = true;
+			// e.g., expired; fallback to session credentials
+			// TODO: Figure out why exception had to be dropped in #32685
+			$this->logger->debug('Invalid token: ' . $ex->getMessage(), ['app' => 'core']);
+			return $this->getSessionCredentials();
 		} catch (PasswordlessTokenException $ex) {
-			$this->logger->debug('could not get login credentials because the token has no password', ['app' => 'core', 'exception' => $ex]);
-			$trySession = true;
+			// e.g., SSO/OAuth; fallback to session credentials
+			$this->logger->debug('Token has no password', ['app' => 'core', 'exception' => $ex]);
+			return $this->getSessionCredentials();
+		}
+	}
+
+	/**
+	 * Returns login credentials from session.
+	 *
+	 * Only called as a fallback if token credentials are invalid or passwordless.
+	 * Requires 'uid' and 'loginName' to be present in the session credentials.
+	 * Password may be null for passwordless flows.
+	 *
+	 * @throws CredentialsUnavailableException
+	 */
+	private function getSessionCredentials(): ICredentials {
+		if (!$this->session->exists('login_credentials')) {
+			throw new CredentialsUnavailableException('No valid login credentials in session');
+		}
+		$credsRaw = $this->session->get('login_credentials');
+		/** @var array $creds */
+		$creds = json_decode($credsRaw, true);
+
+		// Explicitly check for decode failure or non-array result
+		if (!is_array($creds)) {
+			throw new CredentialsUnavailableException('Session credentials could not be decoded');
 		}
 
-		if ($trySession && $this->session->exists('login_credentials')) {
-			/** @var array $creds */
-			$creds = json_decode($this->session->get('login_credentials'), true);
-			if ($creds['password'] !== null) {
-				try {
-					$creds['password'] = $this->crypto->decrypt($creds['password']);
-				} catch (Exception $e) {
-					//decryption failed, continue with old password as it is
-				}
+		if (!isset($creds['uid'], $creds['loginName'])) {
+			throw new CredentialsUnavailableException('Session credentials missing required fields');
+		}
+		if (isset($creds['password']) && $creds['password'] !== null) {
+			try {
+				$creds['password'] = $this->crypto->decrypt($creds['password']);
+			} catch (Exception $e) {
+				// Decryption failed; continue with password as stored (may be null).
 			}
-			return new Credentials(
-				$creds['uid'],
-				$creds['loginName'] ?? $this->session->get('loginname') ?? $creds['uid'], // Pre 20 didn't have a loginName property, hence fall back to the session value and then to the UID
-				$creds['password']
-			);
 		}
-
-		// If we reach this line, an exception was thrown.
-		throw new CredentialsUnavailableException();
+		// Password may be null for passwordless authentication flows
+		return new Credentials($creds['uid'], $creds['loginName'], $creds['password'] ?? null);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #na <!-- related github issue -->

## Summary

- Removes no longer needed legacy fallback (used only for v19->v20; was added in #22641).
- Explicitly handles JSON decode failures.
- Includes minor readability improvements, such as splitting out session fallback (non-legacy) into a dedicated function.
- Updates docblocks.
- Adds clearer exception messages

Outside of dropping the no longer applicable v19 legacy fallback behavior, there should be no breaking changes here. Other changes are purely code readability (e.g. re-ordering, separation of concerns, adjusting logic to not need temporary flag variable, minimize nesting, short/focused docblocks).

## TODO

- [x] Have to finish adjusting the unit tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
