### PR TITLE
docs(previews): mp3 preview provider is no longer enabled by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1386,16 +1386,14 @@ $CONFIG = [
 	/**
 	 * Previews
 	 *
-	 * Nextcloud supports previews of image files, the covers of MP3 files, and text
-	 * files. These options control enabling and disabling previews, and thumbnail
-	 * size.
+	 * Nextcloud supports generating previews for various file types, such as images, audio files, and text files.
+	 * These options control enabling and disabling previews, and thumbnail size.
 	 */
 
 	/**
 	 * By default, Nextcloud can generate previews for the following filetypes:
 	 *
 	 * - Image files
-	 * - Covers of MP3 files
 	 * - Text documents
 	 *
 	 * Valid values are ``true``, to enable previews, or
@@ -1510,21 +1508,21 @@ $CONFIG = [
 	 * The following providers are disabled by default due to performance or privacy
 	 * concerns:
 	 *
+	 *  - ``OC\Preview\EMF``
 	 *  - ``OC\Preview\Font``
 	 *  - ``OC\Preview\HEIC``
 	 *  - ``OC\Preview\Illustrator``
-	 *  - ``OC\Preview\Movie``
+	 *  - ``OC\Preview\MP3``
 	 *  - ``OC\Preview\MSOffice2003``
 	 *  - ``OC\Preview\MSOffice2007``
 	 *  - ``OC\Preview\MSOfficeDoc``
+	 *  - ``OC\Preview\Movie``
 	 *  - ``OC\Preview\PDF``
 	 *  - ``OC\Preview\Photoshop``
 	 *  - ``OC\Preview\Postscript``
-	 *  - ``OC\Preview\StarOffice``
 	 *  - ``OC\Preview\SVG``
+	 *  - ``OC\Preview\StarOffice``
 	 *  - ``OC\Preview\TIFF``
-	 *  - ``OC\Preview\EMF``
-	 *
 	 *
 	 * Defaults to the following providers:
 	 *
@@ -1533,11 +1531,11 @@ $CONFIG = [
 	 *  - ``OC\Preview\JPEG``
 	 *  - ``OC\Preview\Krita``
 	 *  - ``OC\Preview\MarkDown``
-	 *  - ``OC\Preview\MP3``
 	 *  - ``OC\Preview\OpenDocument``
 	 *  - ``OC\Preview\PNG``
 	 *  - ``OC\Preview\TXT``
 	 *  - ``OC\Preview\XBitmap``
+	 *
 	 */
 	'enabledPreviewProviders' => [
 		'OC\Preview\BMP',
@@ -1545,7 +1543,6 @@ $CONFIG = [
 		'OC\Preview\JPEG',
 		'OC\Preview\Krita',
 		'OC\Preview\MarkDown',
-		'OC\Preview\MP3',
 		'OC\Preview\OpenDocument',
 		'OC\Preview\PNG',
 		'OC\Preview\TXT',


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Follow-up for https://github.com/nextcloud/server/pull/55658 

No backport required; I will cherry-pick the commit to the 55658 backports right away.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
