### PR TITLE
fix(previewCleanup): Also cleanup the database

### DIFF
--- a/tests/Core/Command/Preview/CleanupTest.php
+++ b/tests/Core/Command/Preview/CleanupTest.php
@@ -11,6 +11,7 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,7 @@ use Test\TestCase;
 class CleanupTest extends TestCase {
 	private IRootFolder&MockObject $rootFolder;
 	private LoggerInterface&MockObject $logger;
+	private IDBConnection&MockObject $connection;
 	private InputInterface&MockObject $input;
 	private OutputInterface&MockObject $output;
 	private Cleanup $repair;
@@ -28,9 +30,11 @@ class CleanupTest extends TestCase {
 		parent::setUp();
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->connection = $this->createMock(IDBConnection::class);
 		$this->repair = new Cleanup(
 			$this->rootFolder,
 			$this->logger,
+			$this->connection,
 		);
 
 		$this->input = $this->createMock(InputInterface::class);
@@ -50,7 +54,7 @@ class CleanupTest extends TestCase {
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
 		$appDataFolder->expects($this->once())->method('newFolder')->with('preview');
 
-		$this->rootFolder->expects($this->once())
+		$this->rootFolder->expects($this->atLeastOnce())
 			->method('getAppDataDirectoryName')
 			->willReturn('appdata_some_id');
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Related to https://github.com/nextcloud/server/issues/55709

## Summary

Also delete database entries, not only the preview files

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
