### PR TITLE
fix(files): decrement quota by actual bytes written in stream_write

### DIFF
--- a/lib/private/Files/Stream/Quota.php
+++ b/lib/private/Files/Stream/Quota.php
@@ -78,7 +78,10 @@ class Quota extends Wrapper {
 			$data = substr($data, 0, $this->limit);
 			$size = $this->limit;
 		}
-		$this->limit -= $size;
-		return fwrite($this->source, $data);
+		$written = fwrite($this->source, $data);
+		// Decrement quota by the actual number of bytes written ($written),
+		// not the intended size
+		$this->limit -= $written;
+		return $written;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #tbd/na <!-- related github issue -->

## Summary

Discovered while investigating random failures in the `QuotaTest` unit test.

**The problem:**

- `$size` is set to the length of `$data` after truncation.
- The quota (`$this->limit`) is decremented by `$size` before the actual write.
- The function returns the result of `fwrite()`, which may be more or less than `$size`.

If `fwrite()` writes fewer bytes than `$size` (e.g., disk full), the quota will still be reduced by `$size`, not the actual number written.

Similarly, if it writes more (for example, if the underlying buffer had data in it), the returned value will be higher than expected.

**The fix:**

- The quota is now decremented by the actual number of bytes written (`$written`) rather than the intended size.
- This ensures quota tracking stays accurate even if `fwrite` writes fewer (or more, due to underlying buffering) bytes than requested.

## TODO

- [ ] It's possible there are other spots with similar behavior; should be checked and followed up on separately as needed
- [ ] Backport?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
