### PR TITLE
fix(trashbin): make sure the trashed files are deleted if we don't have any available space left

### DIFF
--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -11,7 +11,6 @@ use OC\Files\SetupManager;
 use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Expiration;
-use OCA\Files_Trashbin\Helper;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -66,8 +65,7 @@ class ExpireTrash extends TimedJob {
 
 				try {
 					if ($this->setupFS($user)) {
-						$dirContent = Helper::getTrashFiles('/', $uid, 'mtime');
-						Trashbin::deleteExpiredFiles($dirContent, $uid);
+						Trashbin::expire($uid);
 					}
 				} catch (\Throwable $e) {
 					$this->logger->error('Error while expiring trashbin for user ' . $uid, ['exception' => $e]);

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -844,7 +844,7 @@ class Trashbin implements IEventListener {
 		$dirContent = Helper::getTrashFiles('/', $user, 'mtime');
 
 		// delete all files older then $retention_obligation
-		[$delSize, $count] = self::deleteExpiredFiles($dirContent, $user);
+		[$delSize, $count] = self::deleteExpiredFiles($dirContent, $user, $availableSpace <= 0);
 
 		$availableSpace += $delSize;
 
@@ -906,9 +906,10 @@ class Trashbin implements IEventListener {
 	 *
 	 * @param array $files list of files sorted by mtime
 	 * @param string $user
+	 * @param bool $quotaExceeded
 	 * @return array{int|float, int} size of deleted files and number of deleted files
 	 */
-	public static function deleteExpiredFiles($files, $user) {
+	public static function deleteExpiredFiles($files, $user, bool $quotaExceeded = false) {
 		/** @var Expiration $expiration */
 		$expiration = Server::get(Expiration::class);
 		$size = 0;
@@ -916,7 +917,7 @@ class Trashbin implements IEventListener {
 		foreach ($files as $file) {
 			$timestamp = $file['mtime'];
 			$filename = $file['name'];
-			if ($expiration->isExpired($timestamp)) {
+			if ($expiration->isExpired($timestamp, $quotaExceeded)) {
 				try {
 					$size += self::delete($filename, $user, $timestamp);
 					$count++;


### PR DESCRIPTION
## Summary

Logic taken from the `files_versions` expiration.

It seems the second argument from the `isExpired` method wasn't even used anywhere, so I think the `auto` policy depending on free available storage doesn't work at all.

Note that on cases without any user quota set, files will only be deleted when the actual available space is 0 or less.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
