### PR TITLE
fix(dav): Restrict properties allowed object classes

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -600,7 +600,16 @@ class CustomPropertiesBackend implements BackendInterface {
 			$valueType = self::PROPERTY_TYPE_HREF;
 			$value = $value->getHref();
 		} else {
-			if (!is_object($value)) {
+			if (is_array($value)) {
+				// For array only allow scalar values
+				foreach ($value as $item) {
+					if (!is_scalar($item)) {
+						throw new DavException(
+							"Property \"$name\" has an invalid value of array containing " . gettype($value),
+						);
+					}
+				}
+			} elseif (!is_object($value)) {
 				throw new DavException(
 					"Property \"$name\" has an invalid value of type " . gettype($value),
 				);
@@ -631,6 +640,10 @@ class CustomPropertiesBackend implements BackendInterface {
 			case self::PROPERTY_TYPE_HREF:
 				return new Href($value);
 			case self::PROPERTY_TYPE_OBJECT:
+				if (preg_match('/^a:/', $value)) {
+					// Array, unserialize only scalar values
+					return unserialize(str_replace('\x00', chr(0), $value), ['allowed_classes' => false]);
+				}
 				if (!preg_match('/^O\:\d+\:\"(OCA\\\\DAV\\\\|Sabre\\\\(Cal|Card)?DAV\\\\Xml\\\\Property\\\\)/', $value)) {
 					throw new \LogicException('Found an object class serialized in DB that is not allowed');
 				}

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -566,6 +566,18 @@ class CustomPropertiesBackend implements BackendInterface {
 		return $path;
 	}
 
+	private static function checkIsArrayOfScalar(string $name, array $array): void {
+		foreach ($array as $item) {
+			if (is_array($item)) {
+				self::checkIsArrayOfScalar($name, $item);
+			} elseif ($item !== null && !is_scalar($item)) {
+				throw new DavException(
+					"Property \"$name\" has an invalid value of array containing " . gettype($item),
+				);
+			}
+		}
+	}
+
 	/**
 	 * @throws ParseException If parsing a \Sabre\DAV\Xml\Property\Complex value fails
 	 * @throws DavException If the property value is invalid
@@ -602,25 +614,20 @@ class CustomPropertiesBackend implements BackendInterface {
 		} else {
 			if (is_array($value)) {
 				// For array only allow scalar values
-				foreach ($value as $item) {
-					if (!is_scalar($item)) {
-						throw new DavException(
-							"Property \"$name\" has an invalid value of array containing " . gettype($value),
-						);
-					}
-				}
+				self::checkIsArrayOfScalar($name, $value);
 			} elseif (!is_object($value)) {
 				throw new DavException(
 					"Property \"$name\" has an invalid value of type " . gettype($value),
 				);
-			}
-			if (!str_starts_with($value::class, 'Sabre\\DAV\\Xml\\Property\\')
-				&& !str_starts_with($value::class, 'Sabre\\CalDAV\\Xml\\Property\\')
-				&& !str_starts_with($value::class, 'Sabre\\CardDAV\\Xml\\Property\\')
-				&& !str_starts_with($value::class, 'OCA\\DAV\\')) {
-				throw new DavException(
-					"Property \"$name\" has an invalid value of class " . $value::class,
-				);
+			} else {
+				if (!str_starts_with($value::class, 'Sabre\\DAV\\Xml\\Property\\')
+					&& !str_starts_with($value::class, 'Sabre\\CalDAV\\Xml\\Property\\')
+					&& !str_starts_with($value::class, 'Sabre\\CardDAV\\Xml\\Property\\')
+					&& !str_starts_with($value::class, 'OCA\\DAV\\')) {
+					throw new DavException(
+						"Property \"$name\" has an invalid value of class " . $value::class,
+					);
+				}
 			}
 			$valueType = self::PROPERTY_TYPE_OBJECT;
 			// serialize produces null character

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -600,6 +600,19 @@ class CustomPropertiesBackend implements BackendInterface {
 			$valueType = self::PROPERTY_TYPE_HREF;
 			$value = $value->getHref();
 		} else {
+			if (!is_object($value)) {
+				throw new DavException(
+					"Property \"$name\" has an invalid value of type " . gettype($value),
+				);
+			}
+			if (!str_starts_with($value::class, 'Sabre\\DAV\\Xml\\Property\\')
+				&& !str_starts_with($value::class, 'Sabre\\CalDAV\\Xml\\Property\\')
+				&& !str_starts_with($value::class, 'Sabre\\CardDAV\\Xml\\Property\\')
+				&& !str_starts_with($value::class, 'OCA\\DAV\\')) {
+				throw new DavException(
+					"Property \"$name\" has an invalid value of class " . $value::class,
+				);
+			}
 			$valueType = self::PROPERTY_TYPE_OBJECT;
 			// serialize produces null character
 			// these can not be properly stored in some databases and need to be replaced
@@ -612,13 +625,20 @@ class CustomPropertiesBackend implements BackendInterface {
 	 * @return mixed|Complex|string
 	 */
 	private function decodeValueFromDatabase(string $value, int $valueType): mixed {
-		return match ($valueType) {
-			self::PROPERTY_TYPE_XML => new Complex($value),
-			self::PROPERTY_TYPE_HREF => new Href($value),
-			// some databases can not handel null characters, these are custom encoded during serialization
-			// this custom encoding needs to be first reversed before unserializing
-			self::PROPERTY_TYPE_OBJECT => unserialize(str_replace('\x00', chr(0), $value)),
-			default => $value,
+		switch ($valueType) {
+			case self::PROPERTY_TYPE_XML:
+				return new Complex($value);
+			case self::PROPERTY_TYPE_HREF:
+				return new Href($value);
+			case self::PROPERTY_TYPE_OBJECT:
+				if (!preg_match('/^O\:\d+\:\"(OCA\\\\DAV\\\\|Sabre\\\\(Cal|Card)?DAV\\\\Xml\\\\Property\\\\)/', $value)) {
+					throw new \LogicException('Found an object class serialized in DB that is not allowed');
+				}
+				// some databases can not handel null characters, these are custom encoded during serialization
+				// this custom encoding needs to be first reversed before unserializing
+				return unserialize(str_replace('\x00', chr(0), $value));
+			default:
+				return $value;
 		};
 	}
 


### PR DESCRIPTION
## Summary

Restrict which classes can be serialized by the DAV properties backend.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
