### PR TITLE
fix(ocm): normalize protocol to support multi with webdav option

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -106,6 +106,18 @@ class RequestHandlerController extends Controller {
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'receiveFederatedShare')]
 	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
+		if ($protocol['name'] === 'multi') {
+			if (isset($protocol['webdav'])) {
+				$webdav = $protocol['webdav'];
+				$protocol = [
+					'name' => 'webdav',
+					'options' => [
+						'sharedSecret' => $webdav['sharedSecret'],
+						'permissions' => '{http://open-cloud-mesh.org/ns}share-permissions',
+					],
+				];
+			}
+		}
 		try {
 			// if request is signed and well signed, no exception are thrown
 			// if request is not signed and host is known for not supporting signed request, no exception are thrown

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -106,17 +106,15 @@ class RequestHandlerController extends Controller {
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'receiveFederatedShare')]
 	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
-		if ($protocol['name'] === 'multi') {
-			if (isset($protocol['webdav'])) {
-				$webdav = $protocol['webdav'];
-				$protocol = [
-					'name' => 'webdav',
-					'options' => [
-						'sharedSecret' => $webdav['sharedSecret'],
-						'permissions' => '{http://open-cloud-mesh.org/ns}share-permissions',
-					],
-				];
-			}
+		if (($protocol['name'] ?? '' === 'multi') && (is_array($protocol['webdav'] ?? ''))) {
+			$webdav = $protocol['webdav'];
+			$protocol = [
+				'name' => 'webdav',
+				'options' => [
+					'sharedSecret' => $webdav['sharedSecret'],
+					'permissions' => '{http://open-cloud-mesh.org/ns}share-permissions',
+				],
+			];
 		}
 		try {
 			// if request is signed and well signed, no exception are thrown


### PR DESCRIPTION
- Added functionality to handle both plain `webdav` and `multi` protocols containing a `webdav` entry with a `sharedSecret`.

- Fix a bug where owner could empty because it was set ownerDisplayName

With these fixes we can accept OCM shares from CERNBox

