### PR TITLE
fix: Fix crash in files_version about uninitialized property

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -53,6 +53,15 @@ class CacheWrapper extends Cache {
 		}
 	}
 
+	protected function shouldEncrypt(string $targetPath): bool {
+		$cache = $this->getCache();
+		if ($cache instanceof Cache) {
+			return $cache->shouldEncrypt($targetPath);
+		} else {
+			return false;
+		}
+	}
+
 	/**
 	 * Make it easy for wrappers to modify every returned cache entry
 	 *


### PR DESCRIPTION
* Resolves: #55531 

## Summary

Fix "Typed property OC\\Files\\Cache\\Cache::$storage must not be accessed before initialization".
CacheWrapper does not initialized the private property so it needs to shadow all methods of Cache which are using it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
