### PR TITLE
Cleanup around storage constructor

### DIFF
--- a/apps/files_sharing/lib/External/Cache.php
+++ b/apps/files_sharing/lib/External/Cache.php
@@ -10,20 +10,10 @@ namespace OCA\Files_Sharing\External;
 use OCP\Federation\ICloudId;
 
 class Cache extends \OC\Files\Cache\Cache {
-	private $remote;
-	private $remoteUser;
-
-	/**
-	 * @param Storage $storage
-	 * @param ICloudId $cloudId
-	 */
 	public function __construct(
-		private $storage,
+		private Storage $storage,
 		private ICloudId $cloudId,
 	) {
-		[, $remote] = explode('://', $this->cloudId->getRemote(), 2);
-		$this->remote = $remote;
-		$this->remoteUser = $this->cloudId->getUser();
 		parent::__construct($this->storage);
 	}
 


### PR DESCRIPTION
## Summary

- Take a \OCP\...\IStorage instead of a \OC\...\Storage
- Port away from insertIfNotExist

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
