### PR TITLE
chore: ensure no `.only` is commited in test files

### DIFF
--- a/cypress/e2e/files/files-copy-move.cy.ts
+++ b/cypress/e2e/files/files-copy-move.cy.ts
@@ -77,7 +77,7 @@ describe('Files: Move or copy files', { testIsolation: true }, () => {
 		getRowForFile('original folder').should('not.exist')
 	})
 
-	it.only('Can move a file to its parent folder', () => {
+	it('Can move a file to its parent folder', () => {
 		cy.mkdir(currentUser, '/new-folder')
 		cy.uploadContent(currentUser, new Blob(), 'text/plain', '/new-folder/original.txt')
 		cy.login(currentUser)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@
 import { includeIgnoreFile } from '@eslint/compat'
 import { recommendedVue2 } from '@nextcloud/eslint-config'
 import CypressEslint from 'eslint-plugin-cypress'
+import noOnlyTests from 'eslint-plugin-no-only-tests'
 import { defineConfig } from 'eslint/config'
 import * as globals from 'globals'
 import { fileURLToPath } from 'node:url'
@@ -22,9 +23,7 @@ export default defineConfig([
 
 	...recommendedVue2,
 
-	// respect .gitignore
-	includeIgnoreFile(gitignorePath, 'Imported .gitignore patterns'),
-
+	// add globals configuration for Webpack injected variables
 	{
 		name: 'server/custom-webpack-globals',
 		files: ['**/*.js', '**/*.ts', '**/*.vue'],
@@ -35,6 +34,7 @@ export default defineConfig([
 		},
 	},
 
+	// Ensure that cjs files are treated as Node scripts
 	{
 		name: 'server/scripts-are-cjs',
 		files: [
@@ -55,6 +55,7 @@ export default defineConfig([
 			'jsdoc/require-jsdoc': 'off',
 		},
 	},
+
 	// Cypress setup
 	{
 		...CypressEslint.configs.recommended,
@@ -72,7 +73,23 @@ export default defineConfig([
 			'@typescript-eslint/no-unused-expressions': 'off',
 		},
 	},
-	// customer server ignore files
+
+	// Forbid commiting .only in test files (skipping tests is very unexpected)
+	{
+		name: 'server/no-only-in-tests',
+		files: ['cypress/**', 'apps/**/*.spec.*', 'core/**/*.spec.*'],
+		plugins: {
+			'no-only-tests': noOnlyTests,
+		},
+		rules: {
+			'no-only-tests/no-only-tests': 'error',
+		},
+	},
+
+	// respect .gitignore
+	includeIgnoreFile(gitignorePath, 'Imported .gitignore patterns'),
+
+	// custom server ignore files
 	{
 		name: 'server/ignored-files',
 		ignores: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,7 @@
         "dockerode": "^4.0.9",
         "eslint": "^9.36.0",
         "eslint-plugin-cypress": "^5.1.1",
+        "eslint-plugin-no-only-tests": "^3.3.0",
         "exports-loader": "^5.0.0",
         "file-loader": "^6.2.0",
         "handlebars-loader": "^1.7.3",
@@ -11764,6 +11765,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-perfectionist": {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "dockerode": "^4.0.9",
     "eslint": "^9.36.0",
     "eslint-plugin-cypress": "^5.1.1",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "exports-loader": "^5.0.0",
     "file-loader": "^6.2.0",
     "handlebars-loader": "^1.7.3",


### PR DESCRIPTION
## Summary

`.only` is only to be used for development, but must not be committed. Instead failing tests which should be kept for later should be skipped (`.skip`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
