### PR TITLE
fix(l10n): Don't fallback from 3-letter languages to 2-letter

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -496,7 +496,7 @@ class Factory implements IFactory {
 
 				// Fallback from de_De to de
 				foreach ($available as $available_language) {
-					if (substr($preferred_language, 0, 2) === $available_language) {
+					if ($preferred_language_parts[0] === $available_language) {
 						return $available_language;
 					}
 				}

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -351,6 +351,12 @@ class FactoryTest extends TestCase {
 			[null, 'de,en', ['ru', 'en'], 'en'],
 			[null, 'de-DE,en-US;q=0.8,en;q=0.6', ['ru', 'en'], 'en'],
 
+			// Don't fall back from kab (Kabyle) to ka (Georgian) - Unless specifically requested
+			[null, 'kab;q=0.8,en;q=0.6', ['ka', 'en'], 'en'],
+			[null, 'kab;q=0.8,de;q=0.6', ['ka', 'en', 'de'], 'de'],
+			[null, 'kab;q=0.8,de;q=0.7,ka;q=0.6', ['ka', 'en', 'de'], 'de'],
+			[null, 'kab;q=0.8,ka;q=0.7,de;q=0.6', ['ka', 'en', 'de'], 'ka'],
+
 			// Language for app
 			['files_pdfviewer', 'de', ['de'], 'de'],
 			['files_pdfviewer', 'de,en', ['de'], 'de'],


### PR DESCRIPTION
Fix #55274


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
