### PR TITLE
fix(FilesDropPlugin): Ensure all request for file request have a nickname

### DIFF
--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -24,7 +24,7 @@ class Capabilities implements ICapability {
 		$capabilities = [
 			'dav' => [
 				'chunking' => '1.0',
-				'public_shares_chunking' => false,
+				'public_shares_chunking' => true,
 			]
 		];
 		if ($this->config->getSystemValueBool('bulkupload.enabled', true)) {

--- a/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
+++ b/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
@@ -87,6 +87,23 @@ class FilesDropPlugin extends ServerPlugin {
 			throw new MethodNotAllowed('Only PUT, MKCOL and MOVE are allowed on files drop');
 		}
 
+		// Extract the attributes for the file request
+		$isFileRequest = false;
+		$attributes = $this->share->getAttributes();
+		if ($attributes !== null) {
+			$isFileRequest = $attributes->getAttribute('fileRequest', 'enabled') === true;
+		}
+
+		// Retrieve the nickname from the request
+		$nickname = $request->hasHeader('X-NC-Nickname')
+			? trim(urldecode($request->getHeader('X-NC-Nickname')))
+			: null;
+
+		// We need a valid nickname for file requests
+		if ($isFileRequest && !$nickname) {
+			throw new BadRequest('A nickname header is required for file requests');
+		}
+
 		// If this is a folder creation request
 		// let's stop there and let the onMkcol handle it
 		if ($request->getMethod() === 'MKCOL') {
@@ -113,23 +130,6 @@ class FilesDropPlugin extends ServerPlugin {
 		$rootPath = substr($path, 0, strpos($path, $token) + strlen($token));
 		// e.g /Folder/image.jpg
 		$relativePath = substr($path, strlen($rootPath));
-
-		// Extract the attributes for the file request
-		$isFileRequest = false;
-		$attributes = $this->share->getAttributes();
-		if ($attributes !== null) {
-			$isFileRequest = $attributes->getAttribute('fileRequest', 'enabled') === true;
-		}
-
-		// Retrieve the nickname from the request
-		$nickname = $request->hasHeader('X-NC-Nickname')
-			? trim(urldecode($request->getHeader('X-NC-Nickname')))
-			: null;
-
-		// We need a valid nickname for file requests
-		if ($isFileRequest && !$nickname) {
-			throw new BadRequest('A nickname header is required for file requests');
-		}
 
 		if ($nickname) {
 			try {

--- a/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
+++ b/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
@@ -113,7 +113,6 @@ class FilesDropPlugin extends ServerPlugin {
 		$rootPath = substr($path, 0, strpos($path, $token) + strlen($token));
 		// e.g /Folder/image.jpg
 		$relativePath = substr($path, strlen($rootPath));
-		$isRootUpload = substr_count($relativePath, '/') === 1;
 
 		// Extract the attributes for the file request
 		$isFileRequest = false;
@@ -130,14 +129,6 @@ class FilesDropPlugin extends ServerPlugin {
 		// We need a valid nickname for file requests
 		if ($isFileRequest && !$nickname) {
 			throw new BadRequest('A nickname header is required for file requests');
-		}
-
-		// We're only allowing the upload of
-		// long path with subfolders if a nickname is set.
-		// This prevents confusion when uploading files and help
-		// classify them by uploaders.
-		if (!$nickname && !$isRootUpload) {
-			throw new BadRequest('A nickname header is required when uploading subfolders');
 		}
 
 		if ($nickname) {

--- a/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
+++ b/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
@@ -69,8 +69,8 @@ class FilesDropPlugin extends ServerPlugin {
 	public function beforeMethod(RequestInterface $request, ResponseInterface $response) {
 		$isChunkedUpload = $this->isChunkedUpload($request);
 
-		// For the final MOVE request of a chunked upload it is necessary to modify the Destination header.
-		if ($isChunkedUpload && $request->getMethod() !== 'MOVE') {
+		// For the PUT and MOVE requests of a chunked upload it is necessary to modify the Destination header.
+		if ($isChunkedUpload && $request->getMethod() !== 'MOVE' && $request->getMethod() !== 'PUT') {
 			return;
 		}
 

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -30,7 +30,7 @@ class CapabilitiesTest extends TestCase {
 		$expected = [
 			'dav' => [
 				'chunking' => '1.0',
-				'public_shares_chunking' => false,
+				'public_shares_chunking' => true,
 			],
 		];
 		$this->assertSame($expected, $capabilities->getCapabilities());
@@ -50,7 +50,7 @@ class CapabilitiesTest extends TestCase {
 		$expected = [
 			'dav' => [
 				'chunking' => '1.0',
-				'public_shares_chunking' => false,
+				'public_shares_chunking' => true,
 				'bulkupload' => '1.0',
 			],
 		];
@@ -71,7 +71,7 @@ class CapabilitiesTest extends TestCase {
 		$expected = [
 			'dav' => [
 				'chunking' => '1.0',
-				'public_shares_chunking' => false,
+				'public_shares_chunking' => true,
 				'absence-supported' => true,
 				'absence-replacement' => true,
 			],

--- a/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
+++ b/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
@@ -13,6 +13,7 @@ use OCP\Files\NotFoundException;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Server;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
@@ -23,6 +24,7 @@ class FilesDropPluginTest extends TestCase {
 	private FilesDropPlugin $plugin;
 
 	private Folder&MockObject $node;
+	private IAttributes&MockObject $attributes;
 	private IShare&MockObject $share;
 	private Server&MockObject $server;
 	private RequestInterface&MockObject $request;
@@ -45,10 +47,10 @@ class FilesDropPluginTest extends TestCase {
 		$this->request = $this->createMock(RequestInterface::class);
 		$this->response = $this->createMock(ResponseInterface::class);
 
-		$attributes = $this->createMock(IAttributes::class);
+		$this->attributes = $this->createMock(IAttributes::class);
 		$this->share->expects($this->any())
 			->method('getAttributes')
-			->willReturn($attributes);
+			->willReturn($this->attributes);
 
 		$this->share
 			->method('getToken')
@@ -104,7 +106,7 @@ class FilesDropPluginTest extends TestCase {
 		$this->plugin->beforeMethod($this->request, $this->response);
 	}
 
-	public function testMKCOL(): void {
+	public function testFileDropMKCOLWithoutNickname(): void {
 		$this->plugin->enable();
 		$this->plugin->setShare($this->share);
 
@@ -112,6 +114,45 @@ class FilesDropPluginTest extends TestCase {
 			->willReturn('MKCOL');
 
 		$this->expectNotToPerformAssertions();
+
+		$this->plugin->beforeMethod($this->request, $this->response);
+	}
+
+	public function testFileRequestNoMKCOLWithoutNickname(): void {
+		$this->plugin->enable();
+		$this->plugin->setShare($this->share);
+
+		$this->request->method('getMethod')
+			->willReturn('MKCOL');
+
+		$this->attributes
+			->method('getAttribute')
+			->with('fileRequest', 'enabled')
+			->willReturn(true);
+
+		$this->expectException(BadRequest::class);
+
+		$this->plugin->beforeMethod($this->request, $this->response);
+	}
+
+	public function testFileRequestMKCOLWithNickname(): void {
+		$this->plugin->enable();
+		$this->plugin->setShare($this->share);
+
+		$this->request->method('getMethod')
+			->willReturn('MKCOL');
+
+		$this->attributes
+			->method('getAttribute')
+			->with('fileRequest', 'enabled')
+			->willReturn(true);
+
+		$this->request->method('hasHeader')
+			->with('X-NC-Nickname')
+			->willReturn(true);
+		$this->request->method('getHeader')
+			->with('X-NC-Nickname')
+			->willReturn('nickname');
 
 		$this->plugin->beforeMethod($this->request, $this->response);
 	}

--- a/build/integration/features/bootstrap/FilesDropContext.php
+++ b/build/integration/features/bootstrap/FilesDropContext.php
@@ -57,7 +57,7 @@ class FilesDropContext implements Context, SnippetAcceptingContext {
 	/**
 	 * @When Creating folder :folder in drop
 	 */
-	public function creatingFolderInDrop($folder) {
+	public function creatingFolderInDrop($folder, $nickname = null) {
 		$client = new Client();
 		$options = [];
 		if (count($this->lastShareData->data->element) > 0) {
@@ -73,10 +73,22 @@ class FilesDropContext implements Context, SnippetAcceptingContext {
 			'X-REQUESTED-WITH' => 'XMLHttpRequest',
 		];
 
+		if ($nickname) {
+			$options['headers']['X-NC-NICKNAME'] = $nickname;
+		}
+
 		try {
 			$this->response = $client->request('MKCOL', $fullUrl, $options);
 		} catch (\GuzzleHttp\Exception\ClientException $e) {
 			$this->response = $e->getResponse();
 		}
+	}
+
+
+	/**
+	 * @When Creating folder :folder in drop as :nickName
+	 */
+	public function creatingFolderInDropWithNickname($folder, $nickname) {
+		return $this->creatingFolderInDrop($folder, $nickname);
 	}
 }

--- a/build/integration/filesdrop_features/filesdrop.feature
+++ b/build/integration/filesdrop_features/filesdrop.feature
@@ -33,7 +33,7 @@ Feature: FilesDrop
     And Downloading file "/drop/a (2).txt"
     Then Downloaded content should be "def"
 
-  Scenario: Files drop forbid directory without a nickname
+  Scenario: Files request forbid directory without a nickname
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
@@ -41,12 +41,26 @@ Feature: FilesDrop
       | path | drop |
       | shareType | 3 |
       | publicUpload | true |
+	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
     And Updating last share with
       | permissions | 4 |
     When Dropping file "/folder/a.txt" with "abc"
     Then the HTTP status code should be "400"
 
-  Scenario: Files drop allows MKCOL
+Scenario: Files drop allow MKCOL without a nickname
+	Given user "user0" exists
+	And As an "user0"
+	And user "user0" created a folder "/drop"
+	And as "user0" creating a share with
+		| path | drop |
+		| shareType | 3 |
+		| publicUpload | true |
+	And Updating last share with
+		| permissions | 4 |
+	When Creating folder "folder" in drop
+	Then the HTTP status code should be "201"
+
+	Scenario: Files request forbid MKCOL without a nickname
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
@@ -54,12 +68,13 @@ Feature: FilesDrop
       | path | drop |
       | shareType | 3 |
       | publicUpload | true |
+	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
     And Updating last share with
       | permissions | 4 |
     When Creating folder "folder" in drop
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "400"
 
-  Scenario: Files drop forbid subfolder creation without a nickname
+  Scenario: Files request allows MKCOL with a nickname
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
@@ -67,6 +82,21 @@ Feature: FilesDrop
       | path | drop |
       | shareType | 3 |
       | publicUpload | true |
+	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+    And Updating last share with
+      | permissions | 4 |
+    When Creating folder "folder" in drop as "nickname"
+    Then the HTTP status code should be "201"
+
+  Scenario: Files request forbid subfolder creation without a nickname
+    Given user "user0" exists
+    And As an "user0"
+    And user "user0" created a folder "/drop"
+    And as "user0" creating a share with
+      | path | drop |
+      | shareType | 3 |
+      | publicUpload | true |
+	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
     And Updating last share with
       | permissions | 4 |
     When dropping file "/folder/a.txt" with "abc"


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/55800

I just noticed there is also another bug with file drop: You can't upload folders, because it will tell you that a nickname is required. So MKCOL is fine without a nickname, as long as it's not for a file request. This is also reproducible on master before the other PR was merged.
I removed the check and simply ensured that all requests on a file request need to have the nickname set. Before this logic was intertwined with the MKCOL logic which lead to these issues.