### PR TITLE
feat(cloud-federation-api): accept folder shares

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -106,6 +106,9 @@ class RequestHandlerController extends Controller {
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'receiveFederatedShare')]
 	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
+		if ($resourceType === 'folder') {
+			$resourceType = 'file';
+		}
 		try {
 			// if request is signed and well signed, no exception are thrown
 			// if request is not signed and host is known for not supporting signed request, no exception are thrown

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -106,9 +106,6 @@ class RequestHandlerController extends Controller {
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'receiveFederatedShare')]
 	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
-		if ($resourceType === 'folder') {
-			$resourceType = 'file';
-		}
 		try {
 			// if request is signed and well signed, no exception are thrown
 			// if request is not signed and host is known for not supporting signed request, no exception are thrown

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -35,10 +35,13 @@ class Application extends App implements IBootstrap {
 
 	private function registerCloudFederationProvider(ICloudFederationProviderManager $manager,
 		IAppContainer $appContainer): void {
-		$manager->addCloudFederationProvider('file',
-			'Federated Files Sharing',
-			function () use ($appContainer): CloudFederationProviderFiles {
-				return $appContainer->get(CloudFederationProviderFiles::class);
-			});
+		$fileResourceTypes = ['file', 'folder'];
+		foreach ($fileResourceTypes as $type) {
+			$manager->addCloudFederationProvider($type,
+				'Federated Files Sharing',
+				function () use ($appContainer): CloudFederationProviderFiles {
+					return $appContainer->get(CloudFederationProviderFiles::class);
+				});
+		}
 	}
 }


### PR DESCRIPTION
Normalize resourceType from folder to file in
RequestHandlerController::addShare() to allow accepting OCM folder shares from oCIS/OpenCloud/CERNBox.
