### PR TITLE
refactor: Separate concerns in link sharing checks 

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -106,7 +106,7 @@ class Capabilities implements ICapability {
 			$res['api_enabled'] = true;
 
 			$public = [];
-			$public['enabled'] = $this->shareManager->shareApiAllowLinks();
+			$public['enabled'] = $this->shareManager->canUserCreateLinkShares();
 			if ($public['enabled']) {
 				$public['password'] = [];
 				$public['password']['enforced'] = $this->shareManager->shareApiLinkEnforcePassword();

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -559,7 +559,7 @@ class Manager implements IManager {
 	 */
 	protected function linkCreateChecks(IShare $share) {
 		// Are link shares allowed?
-		if (!$this->shareApiAllowLinks()) {
+		if (!$this->canUserCreateLinkShares()) {
 			throw new \Exception($this->l->t('Link sharing is not allowed'));
 		}
 
@@ -1413,7 +1413,7 @@ class Manager implements IManager {
 		}
 		$share = null;
 		try {
-			if ($this->shareApiAllowLinks(checkGroupExclusion: false)) {
+			if ($this->isLinkSharingEnabled()) {
 				$provider = $this->factory->getProviderForType(IShare::TYPE_LINK);
 				$share = $provider->getShareByToken($token);
 			}
@@ -1740,28 +1740,55 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * Check if public link sharing is enabled globally
+	 *
+	 * @return bool
+	 * @since 33.0.0
+	 */
+	public function isLinkSharingEnabled(): bool {
+		return $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
+	}
+
+	/**
+	 * Check if a specific user can create public link shares
+	 *
+	 * This considers both global settings and user-specific group restrictions
+	 *
+	 * @param string|null $userId The user ID to check, or null for current user
+	 * @return bool
+	 * @since 33.0.0
+	 */
+	public function canUserCreateLinkShares(?string $userId = null): bool {
+		if (!$this->isLinkSharingEnabled()) {
+			return false;
+		}
+
+		$user = $userId ? $this->userManager->get($userId) : $this->userSession->getUser();
+		if (!$user) {
+			return true;
+		}
+
+		$excludedGroups = json_decode($this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '[]'));
+		if ($excludedGroups) {
+			$userGroups = $this->groupManager->getUserGroupIds($user);
+			return !(bool)array_intersect($excludedGroups, $userGroups);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Is public link sharing enabled
 	 *
 	 * @param bool $checkGroupExclusion Whether to check the current user's group exclusions
 	 * @return bool
+	 * @deprecated 33.0.0 Use isLinkSharingEnabled() or canUserCreateLinkShares() instead
 	 */
 	public function shareApiAllowLinks(bool $checkGroupExclusion = true) {
-		if ($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
-			return false;
-		}
-
 		if ($checkGroupExclusion) {
-			$user = $this->userSession->getUser();
-			if ($user) {
-				$excludedGroups = json_decode($this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '[]'));
-				if ($excludedGroups) {
-					$userGroups = $this->groupManager->getUserGroupIds($user);
-					return !(bool)array_intersect($excludedGroups, $userGroups);
-				}
-			}
+			return $this->canUserCreateLinkShares();
 		}
-
-		return true;
+		return $this->isLinkSharingEnabled();
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1413,7 +1413,7 @@ class Manager implements IManager {
 		}
 		$share = null;
 		try {
-			if ($this->shareApiAllowLinks()) {
+			if ($this->shareApiAllowLinks(checkGroupExclusion: false)) {
 				$provider = $this->factory->getProviderForType(IShare::TYPE_LINK);
 				$share = $provider->getShareByToken($token);
 			}
@@ -1742,19 +1742,22 @@ class Manager implements IManager {
 	/**
 	 * Is public link sharing enabled
 	 *
+	 * @param bool $checkGroupExclusion Whether to check the current user's group exclusions
 	 * @return bool
 	 */
-	public function shareApiAllowLinks() {
+	public function shareApiAllowLinks(bool $checkGroupExclusion = true) {
 		if ($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
 			return false;
 		}
 
-		$user = $this->userSession->getUser();
-		if ($user) {
-			$excludedGroups = json_decode($this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '[]'));
-			if ($excludedGroups) {
-				$userGroups = $this->groupManager->getUserGroupIds($user);
-				return !(bool)array_intersect($excludedGroups, $userGroups);
+		if ($checkGroupExclusion) {
+			$user = $this->userSession->getUser();
+			if ($user) {
+				$excludedGroups = json_decode($this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '[]'));
+				if ($excludedGroups) {
+					$userGroups = $this->groupManager->getUserGroupIds($user);
+					return !(bool)array_intersect($excludedGroups, $userGroups);
+				}
 			}
 		}
 

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -296,10 +296,30 @@ interface IManager {
 	public function shareApiEnabled();
 
 	/**
+	 * Check if public link sharing is enabled globally
+	 *
+	 * @return bool
+	 * @since 33.0.0
+	 */
+	public function isLinkSharingEnabled(): bool;
+
+	/**
+	 * Check if a specific user can create public link shares
+	 *
+	 * This considers both global settings and user-specific group restrictions
+	 *
+	 * @param string|null $userId The user ID to check, or null for current user
+	 * @return bool
+	 * @since 33.0.0
+	 */
+	public function canUserCreateLinkShares(?string $userId = null): bool;
+
+	/**
 	 * Is public link sharing enabled
 	 *
 	 * @return bool
 	 * @since 9.0.0
+	 * @deprecated 33.0.0 Use isLinkSharingEnabled() or canUserCreateLinkShares() instead
 	 */
 	public function shareApiAllowLinks();
 


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/55811 split `shareApiAllowLinks()` into two dedicated methods to improve clarity
and separation of concerns:

- `isLinkSharingEnabled()`: Checks if link sharing is globally enabled
- `canUserCreateLinkShares()`: Checks if a user can create link shares
  (considers both global settings and group restrictions)

The original shareApiAllowLinks() is now deprecated and acts as a
wrapper to maintain backward compatibility.