### PR TITLE
fix(ocm-sharing): The owner needs to be set for sharing to work

### DIFF
--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -108,7 +108,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 
 		$token = $share->getShareSecret();
 		$name = $share->getResourceName();
-		$owner = $share->getOwnerDisplayName();
+		$owner = $share->getOwnerDisplayName() ?: $share->getOwner();
 		$sharedBy = $share->getSharedByDisplayName();
 		$shareWith = $share->getShareWith();
 		$remoteId = $share->getProviderId();


### PR DESCRIPTION
The specification says that the display name is optional and can thus be empty, and in fact it is from oCIS and CERNBox shares.

The correct thing to set is the required opaque id from the remote provider, the `owner` which will always be there.

Moved here from #55752 


