### PR TITLE
fix(ocm): probe standardized .well-known endpoint

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -238,6 +238,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		try {
 			return $this->testRemoteUrl($this->getRemote() . '/ocm-provider/index.php')
 				   || $this->testRemoteUrl($this->getRemote() . '/ocm-provider/')
+				   || $this->testRemoteUrl($this->getRemote() . '/.well-known/ocm')
 				   || $this->testRemoteUrl($this->getRemote() . '/status.php');
 		} catch (\Exception $e) {
 			return false;


### PR DESCRIPTION
- Add `.well-known/ocm` to remote endpoint discovery checks.
- Improves compatibility with newer OCM deployments when probing remote servers.
