### PR TITLE
fix(lexicon): execute repair step

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -20,6 +20,7 @@ use OC\Repair\CleanUpAbandonedApps;
 use OC\Repair\ClearFrontendCaches;
 use OC\Repair\ClearGeneratedAvatarCache;
 use OC\Repair\Collation;
+use OC\Repair\ConfigKeyMigration;
 use OC\Repair\Events\RepairAdvanceEvent;
 use OC\Repair\Events\RepairErrorEvent;
 use OC\Repair\Events\RepairFinishEvent;
@@ -201,6 +202,7 @@ class Repair implements IOutput {
 			\OCP\Server::get(AddCleanupDeletedUsersBackgroundJob::class),
 			\OCP\Server::get(SanitizeAccountProperties::class),
 			\OCP\Server::get(AddMovePreviewJob::class),
+			\OCP\Server::get(ConfigKeyMigration::class),
 		];
 	}
 


### PR DESCRIPTION
The repair step `ConfigKeyMigration` is not initiated on upgrade.

This repair step updates metadata about app/user config values based on its details in the configuration lexicon.