### PR TITLE
refactor: apply rector rules for PHPUnit 10

### DIFF
--- a/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
+++ b/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
@@ -24,10 +24,9 @@ use Test\TestCase;
 /**
  * Class ApplicationTest
  *
- * @group DB
- *
  * @package OCA\Comments\Tests\Unit\AppInfo
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ApplicationTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
+++ b/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
@@ -17,9 +17,7 @@ use Sabre\VObject\Component\VCard;
 use Sabre\VObject\UUIDUtil;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RecentContactMapperTest extends TestCase {
 	private RecentContactMapper $recentContactMapper;
 	private ITimeFactory $time;

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -211,7 +211,7 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 		}
 
 		if ($info->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
-			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info, $this->tree, $this->shareManager);
+			$node = new Directory($this->fileView, $info, $this->tree, $this->shareManager);
 		} else {
 			// In case reading a directory was allowed but it turns out the node was a not a directory, reject it now.
 			if (!$this->info->isReadable()) {

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -92,6 +92,7 @@ use OCP\ISession;
 use OCP\ITagManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
 use OCP\Profiler\IProfiler;
 use OCP\SabrePluginEvent;
@@ -351,7 +352,7 @@ class Server {
 						\OCP\Server::get(IMipService::class),
 						\OCP\Server::get(EventComparisonService::class),
 						\OCP\Server::get(\OCP\Mail\Provider\IManager::class),
-						\OCP\Server::get(\OCP\Mail\IEmailValidator::class),
+						\OCP\Server::get(IEmailValidator::class),
 					));
 				}
 				$this->server->addPlugin(new \OCA\DAV\CalDAV\Search\SearchPlugin());

--- a/apps/dav/tests/integration/DAV/Sharing/CalDavSharingBackendTest.php
+++ b/apps/dav/tests/integration/DAV/Sharing/CalDavSharingBackendTest.php
@@ -28,9 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CalDavSharingBackendTest extends TestCase {
 
 	private IDBConnection $db;

--- a/apps/dav/tests/integration/DAV/Sharing/SharingMapperTest.php
+++ b/apps/dav/tests/integration/DAV/Sharing/SharingMapperTest.php
@@ -14,9 +14,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SharingMapperTest extends TestCase {
 
 	private SharingMapper $mapper;

--- a/apps/dav/tests/integration/Db/PropertyMapperTest.php
+++ b/apps/dav/tests/integration/Db/PropertyMapperTest.php
@@ -13,9 +13,7 @@ use OCA\DAV\Db\PropertyMapper;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PropertyMapperTest extends TestCase {
 
 	/** @var PropertyMapper */

--- a/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
@@ -22,9 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 use function scandir;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CalendarMigratorTest extends TestCase {
 
 	private IUserManager $userManager;

--- a/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
@@ -22,9 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 use function scandir;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ContactsMigratorTest extends TestCase {
 
 	private IUserManager $userManager;

--- a/apps/dav/tests/unit/AppInfo/ApplicationTest.php
+++ b/apps/dav/tests/unit/AppInfo/ApplicationTest.php
@@ -16,10 +16,10 @@ use Test\TestCase;
 /**
  * Class ApplicationTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\Unit\AppInfo
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ApplicationTest extends TestCase {
 	public function test(): void {
 		$app = new Application();

--- a/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
@@ -25,9 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserStatusAutomationTest extends TestCase {
 	protected ITimeFactory&MockObject $time;
 	protected IJobList&MockObject $jobList;

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -39,10 +39,10 @@ use Test\TestCase;
 /**
  * Class CalDavBackendTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\CalDAV
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 abstract class AbstractCalDavBackend extends TestCase {
 
 

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
@@ -13,9 +13,7 @@ use OCP\Activity\IFilter;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class GenericTest extends TestCase {
 	public static function dataFilters(): array {
 		return [

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -28,9 +28,8 @@ use function time;
 
 /**
  * Class CalDavBackendTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CalDavBackendTest extends AbstractCalDavBackend {
 	public function testCalendarOperations(): void {
 		$calendarId = $this->createTestCalendar();

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -29,10 +29,10 @@ use Test\TestCase;
 /**
  * Class PublicCalendarRootTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\CalDAV
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PublicCalendarRootTest extends TestCase {
 	public const UNIT_TEST_USER = '';
 	private CalDavBackend $backend;

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
@@ -17,9 +17,7 @@ use OCA\DAV\Capabilities;
 use OCP\AppFramework\QueryException;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class NotificationProviderManagerTest extends TestCase {
 	private NotificationProviderManager $providerManager;
 

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -43,10 +43,10 @@ use function time;
 /**
  * Class CardDavBackendTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\CardDAV
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CardDavBackendTest extends TestCase {
 	private Principal&MockObject $principal;
 	private IUserManager&MockObject $userManager;

--- a/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
@@ -23,8 +23,8 @@ use Test\TestCase;
  * Class RemoveInvalidSharesTest
  *
  * @package OCA\DAV\Tests\Unit\Repair
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RemoveInvalidSharesTest extends TestCase {
 	private RemoveInvalidShares $command;
 

--- a/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
@@ -20,10 +20,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class LegacyPublicAuthTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LegacyPublicAuthTest extends \Test\TestCase {
 	private ISession&MockObject $session;
 	private IRequest&MockObject $request;

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -27,8 +27,8 @@ use Test\TestCase;
  * Class AuthTest
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AuthTest extends TestCase {
 	private ISession&MockObject $session;
 	private Session&MockObject $userSession;

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -19,9 +19,7 @@ use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class BearerAuthTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private ISession&MockObject $session;

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -22,10 +22,10 @@ use Sabre\DAV\Tree;
 /**
  * Class CustomPropertiesBackend
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CustomPropertiesBackendTest extends \Test\TestCase {
 	private \Sabre\DAV\Server $server;
 	private \Sabre\DAV\Tree&MockObject $tree;

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -55,9 +55,7 @@ class TestViewDirectory extends View {
 }
 
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DirectoryTest extends \Test\TestCase {
 	use UserTrait;
 

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -46,10 +46,10 @@ use Test\Traits\UserTrait;
 /**
  * Class File
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FileTest extends TestCase {
 	use MountProviderTrait;
 	use UserTrait;

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -35,9 +35,7 @@ use Sabre\HTTP\ResponseInterface;
 use Sabre\Xml\Service;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FilesPluginTest extends TestCase {
 
 	private Tree&MockObject $tree;

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -29,9 +29,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class NodeTest
  *
- * @group DB
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class NodeTest extends \Test\TestCase {
 	public static function davPermissionsProvider(): array {
 		return [

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -23,10 +23,10 @@ use OCP\Files\Mount\IMountManager;
 /**
  * Class ObjectTreeTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ObjectTreeTest extends \Test\TestCase {
 	public static function copyDataProvider(): array {
 		return [

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -22,10 +22,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class PublicAuthTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PublicAuthTest extends \Test\TestCase {
 
 	private ISession&MockObject $session;

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
@@ -14,10 +14,10 @@ use OCP\Files\FileInfo;
 /**
  * Class DeleteTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DeleteTest extends RequestTestCase {
 	public function testBasicUpload(): void {
 		$user = self::getUniqueID();

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
@@ -14,10 +14,10 @@ use OCP\Lock\ILockingProvider;
 /**
  * Class DownloadTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DownloadTest extends RequestTestCase {
 	public function testDownload(): void {
 		$user = self::getUniqueID();

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
@@ -17,10 +17,10 @@ use Test\Traits\EncryptionTrait;
 /**
  * Class EncryptionMasterKeyUploadTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class EncryptionMasterKeyUploadTest extends UploadTest {
 	use EncryptionTrait;
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
@@ -17,10 +17,10 @@ use Test\Traits\EncryptionTrait;
 /**
  * Class EncryptionUploadTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class EncryptionUploadTest extends UploadTest {
 	use EncryptionTrait;
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
@@ -14,10 +14,10 @@ use OCP\Server;
 /**
  * Class PartFileInRootUploadTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PartFileInRootUploadTest extends UploadTest {
 	protected function setUp(): void {
 		$config = Server::get(IConfig::class);

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
@@ -16,10 +16,10 @@ use OCP\Lock\ILockingProvider;
 /**
  * Class UploadTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UploadTest extends RequestTestCase {
 	public function testBasicUpload(): void {
 		$user = self::getUniqueID();

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -25,9 +25,7 @@ use Sabre\DAVACL\IACL;
 use Sabre\DAVACL\IPrincipal;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CustomPropertiesBackendTest extends TestCase {
 	private const BASE_URI = '/remote.php/dav/';
 

--- a/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
+++ b/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
@@ -21,8 +21,8 @@ use Test\TestCase;
  * Class CalDAVRemoveEmptyValueTest
  *
  * @package OCA\DAV\Tests\Unit\DAV\Migration
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CalDAVRemoveEmptyValueTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 	private CalDavBackend&MockObject $backend;

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -14,10 +14,10 @@ use OCP\IRequest;
 /**
  * Class ServerTest
  *
- * @group DB
  *
  * @package OCA\DAV\Tests\Unit
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ServerTest extends \Test\TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('providesUris')]

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -31,9 +31,9 @@ use Test\Traits\UserTrait;
 /**
  * Class FixEncryptedVersionTest
  *
- * @group DB
  * @package OCA\Encryption\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FixEncryptedVersionTest extends TestCase {
 	use MountProviderTrait;
 	use EncryptionTrait;

--- a/apps/encryption/tests/Command/TestEnableMasterKey.php
+++ b/apps/encryption/tests/Command/TestEnableMasterKey.php
@@ -19,6 +19,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class TestEnableMasterKey extends TestCase {
+	public function __construct() {
+		parent::__construct(static::class);
+	}
 	protected EnableMasterKey $enableMasterKey;
 	protected Util&MockObject $util;
 	protected IAppConfig&MockObject $config;

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -306,9 +306,8 @@ class CryptTest extends TestCase {
 
 	/**
 	 * test decrypt()
-	 *
-	 * @depends testEncrypt
 	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testEncrypt')]
 	public function testDecrypt($data): void {
 		$result = self::invokePrivate(
 			$this->crypt,

--- a/apps/encryption/tests/EncryptedStorageTest.php
+++ b/apps/encryption/tests/EncryptedStorageTest.php
@@ -23,9 +23,7 @@ class TemporaryNoEncrypted extends Temporary implements IDisableEncryptionStorag
 
 }
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class EncryptedStorageTest extends TestCase {
 	use MountProviderTrait;
 	use EncryptionTrait;

--- a/apps/encryption/tests/Listeners/UserEventsListenersTest.php
+++ b/apps/encryption/tests/Listeners/UserEventsListenersTest.php
@@ -30,9 +30,7 @@ use OCP\User\Events\UserLoggedOutEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserEventsListenersTest extends TestCase {
 
 	protected Util&MockObject $util;

--- a/apps/encryption/tests/PassphraseServiceTest.php
+++ b/apps/encryption/tests/PassphraseServiceTest.php
@@ -21,9 +21,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PassphraseServiceTest extends TestCase {
 
 	protected Util&MockObject $util;

--- a/apps/encryption/tests/SessionTest.php
+++ b/apps/encryption/tests/SessionTest.php
@@ -28,17 +28,13 @@ class SessionTest extends TestCase {
 		$this->instance->getPrivateKey();
 	}
 
-	/**
-	 * @depends testThatGetPrivateKeyThrowsExceptionWhenNotSet
-	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testThatGetPrivateKeyThrowsExceptionWhenNotSet')]
 	public function testSetAndGetPrivateKey(): void {
 		$this->instance->setPrivateKey('dummyPrivateKey');
 		$this->assertEquals('dummyPrivateKey', $this->instance->getPrivateKey());
 	}
 
-	/**
-	 * @depends testSetAndGetPrivateKey
-	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testSetAndGetPrivateKey')]
 	public function testIsPrivateKeySet(): void {
 		$this->instance->setPrivateKey('dummyPrivateKey');
 		$this->assertTrue($this->instance->isPrivateKeySet());

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -31,8 +31,8 @@ use Psr\Log\LoggerInterface;
  * Class RequestHandlerTest
  *
  * @package OCA\FederatedFileSharing\Tests
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RequestHandlerControllerTest extends \Test\TestCase {
 	private string $owner = 'owner';
 	private string $user1 = 'user1';

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -36,8 +36,8 @@ use Psr\Log\LoggerInterface;
  * Class FederatedShareProviderTest
  *
  * @package OCA\FederatedFileSharing\Tests
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FederatedShareProviderTest extends \Test\TestCase {
 	protected IDBConnection $connection;
 	protected AddressHandler&MockObject $addressHandler;

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -17,12 +17,9 @@ use OCP\IUserSession;
 use OCP\Server;
 
 /**
- * Class Test_Files_Sharing_Base
- *
- * @group DB
- *
  * Base class for sharing tests.
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 abstract class TestCase extends \Test\TestCase {
 	public const TEST_FILES_SHARING_API_USER1 = 'test-share-user1';
 	public const TEST_FILES_SHARING_API_USER2 = 'test-share-user2';

--- a/apps/federation/lib/DbHandler.php
+++ b/apps/federation/lib/DbHandler.php
@@ -20,8 +20,6 @@ use OCP\IL10N;
  * Handles all database calls for the federation app
  *
  * @todo Port to QBMapper
- *
- * @group DB
  * @package OCA\Federation
  */
 class DbHandler {

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -27,10 +27,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class GetSharedSecretTest
  *
- * @group DB
  *
  * @package OCA\Federation\Tests\BackgroundJob
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class GetSharedSecretTest extends TestCase {
 
 	private MockObject&IClient $httpClient;

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -16,9 +16,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DbHandlerTest extends TestCase {
 	private DbHandler $dbHandler;
 	private IL10N&MockObject $il10n;

--- a/apps/files/tests/Activity/Filter/GenericTest.php
+++ b/apps/files/tests/Activity/Filter/GenericTest.php
@@ -17,8 +17,8 @@ use Test\TestCase;
  * Class GenericTest
  *
  * @package OCA\Files\Tests\Activity\Filter
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class GenericTest extends TestCase {
 	public static function dataFilters(): array {
 		return [

--- a/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
+++ b/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
@@ -18,10 +18,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class DeleteOrphanedItemsJobTest
  *
- * @group DB
  *
  * @package Test\BackgroundJob
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 	protected IDBConnection $connection;
 	protected LoggerInterface $logger;

--- a/apps/files/tests/BackgroundJob/ScanFilesTest.php
+++ b/apps/files/tests/BackgroundJob/ScanFilesTest.php
@@ -27,8 +27,8 @@ use Test\Traits\UserTrait;
  * Class ScanFilesTest
  *
  * @package OCA\Files\Tests\BackgroundJob
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ScanFilesTest extends TestCase {
 	use UserTrait;
 	use MountProviderTrait;

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -22,10 +22,10 @@ use Test\TestCase;
 /**
  * Class DeleteOrphanedFilesTest
  *
- * @group DB
  *
  * @package OCA\Files\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DeleteOrphanedFilesTest extends TestCase {
 
 	private DeleteOrphanedFiles $command;

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -41,10 +41,10 @@ use Test\TestCase;
 /**
  * Class ViewControllerTest
  *
- * @group RoutingWeirdness
  *
  * @package OCA\Files\Tests\Controller
  */
+#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 class ViewControllerTest extends TestCase {
 	private ContainerInterface&MockObject $container;
 	private IAppManager&MockObject $appManager;

--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -24,10 +24,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class TagServiceTest
  *
- * @group DB
  *
  * @package OCA\Files
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class TagServiceTest extends \Test\TestCase {
 	private string $user;
 	private IUserSession&MockObject $userSession;

--- a/apps/files_external/tests/Listener/StorePasswordListenerTest.php
+++ b/apps/files_external/tests/Listener/StorePasswordListenerTest.php
@@ -18,9 +18,7 @@ use OCP\User\Events\UserLoggedInEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class StorePasswordListenerTest extends TestCase {
 	protected IUser&MockObject $mockedUser;
 

--- a/apps/files_external/tests/OwnCloudFunctionsTest.php
+++ b/apps/files_external/tests/OwnCloudFunctionsTest.php
@@ -13,10 +13,10 @@ use OCA\Files_External\Lib\Storage\OwnCloud;
 /**
  * Class OwnCloudFunctions
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class OwnCloudFunctionsTest extends \Test\TestCase {
 	public static function configUrlProvider(): array {
 		return [

--- a/apps/files_external/tests/Service/DBConfigServiceTest.php
+++ b/apps/files_external/tests/Service/DBConfigServiceTest.php
@@ -14,9 +14,7 @@ use OCP\Security\ICrypto;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DBConfigServiceTest extends TestCase {
 	private IDBConnection $connection;
 	private DBConfigService $dbConfig;

--- a/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
@@ -13,9 +13,7 @@ use OCA\Files_External\MountConfig;
 
 use OCA\Files_External\Service\GlobalStoragesService;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/files_external/tests/Service/StoragesServiceTestCase.php
+++ b/apps/files_external/tests/Service/StoragesServiceTestCase.php
@@ -53,9 +53,7 @@ class CleaningDBConfig extends DBConfigService {
 	}
 }
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 abstract class StoragesServiceTestCase extends \Test\TestCase {
 	protected StoragesService $service;
 	protected BackendService&MockObject $backendService;

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -20,9 +20,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 	use UserTrait;
 

--- a/apps/files_external/tests/Service/UserStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserStoragesServiceTest.php
@@ -22,9 +22,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserStoragesServiceTest extends StoragesServiceTestCase {
 	use UserTrait;
 

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -12,11 +12,11 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
 /**
  * Class Amazons3Test
  *
- * @group DB
- * @group S3
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group('S3')]
 class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/** @var AmazonS3 */

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -13,11 +13,11 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
 /**
  * Class Amazons3Test
  *
- * @group DB
- * @group S3
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group('S3')]
 class Amazons3Test extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/** @var AmazonS3 */

--- a/apps/files_external/tests/Storage/FtpTest.php
+++ b/apps/files_external/tests/Storage/FtpTest.php
@@ -13,10 +13,10 @@ use OCA\Files_External\Lib\Storage\FTP;
 /**
  * Class FtpTest
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FtpTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/OwncloudTest.php
+++ b/apps/files_external/tests/Storage/OwncloudTest.php
@@ -13,10 +13,10 @@ use OCA\Files_External\Lib\Storage\OwnCloud;
 /**
  * Class OwnCloudTest
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class OwncloudTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/SFTP_KeyTest.php
+++ b/apps/files_external/tests/Storage/SFTP_KeyTest.php
@@ -13,10 +13,10 @@ use OCA\Files_External\Lib\Storage\SFTP_Key;
 /**
  * Class SFTP_KeyTest
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SFTP_KeyTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -13,10 +13,10 @@ use OCA\Files_External\Lib\Storage\SFTP;
 /**
  * Class SftpTest
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SftpTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/**

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -17,10 +17,10 @@ use PHPUnit\Framework\ExpectationFailedException;
 /**
  * Class SmbTest
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SmbTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/**

--- a/apps/files_external/tests/Storage/SwiftTest.php
+++ b/apps/files_external/tests/Storage/SwiftTest.php
@@ -14,10 +14,10 @@ use OCA\Files_External\Lib\Storage\Swift;
 /**
  * Class SwiftTest
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SwiftTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
+++ b/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
@@ -8,10 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Files_External\Tests\Storage;
 
-/**
- * @group DB
- * @group S3
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group('S3')]
 class VersionedAmazonS3Test extends Amazons3Test {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/files_external/tests/Storage/WebdavTest.php
+++ b/apps/files_external/tests/Storage/WebdavTest.php
@@ -16,10 +16,10 @@ use OCP\Server;
 /**
  * Class WebdavTest
  *
- * @group DB
  *
  * @package OCA\Files_External\Tests\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class WebdavTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -47,6 +47,7 @@ use Test\Traits\EmailValidatorTrait;
 /**
  * Class ApiTest
  */
+#[\PHPUnit\Framework\Attributes\Medium]
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class ApiTest extends TestCase {
 	use EmailValidatorTrait;
@@ -182,7 +183,6 @@ class ApiTest extends TestCase {
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 	}
-
 
 	public function testCreateShareGroupFile(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
@@ -323,9 +323,6 @@ class ApiTest extends TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testSharePermissions(): void {
 		// sharing file to a user should work if shareapi_exclude_groups is set
 		// to no
@@ -373,10 +370,6 @@ class ApiTest extends TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-
-	/**
-	 * @medium
-	 */
 	public function testGetAllShares(): void {
 		$node = $this->userFolder->get($this->filename);
 
@@ -434,9 +427,6 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share2);
 	}
 
-	/**
-	 * @medium
-	 */
 	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 	public function testPublicLinkUrl(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
@@ -482,9 +472,6 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	/**
-	 * @medium
-	 */
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
 	public function testGetShareFromSource(): void {
@@ -515,9 +502,6 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share2);
 	}
 
-	/**
-	 * @medium
-	 */
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
 	public function testGetShareFromSourceWithReshares(): void {
@@ -557,9 +541,6 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share2);
 	}
 
-	/**
-	 * @medium
-	 */
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
 	public function testGetShareFromId(): void {
 		$node = $this->userFolder->get($this->filename);
@@ -582,9 +563,6 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share1);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testGetShareFromFolder(): void {
 		$node1 = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
@@ -602,7 +580,6 @@ class ApiTest extends TestCase {
 			->setShareType(IShare::TYPE_LINK)
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share2);
-
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares('false', 'false', 'true', $this->folder);
@@ -639,7 +616,6 @@ class ApiTest extends TestCase {
 
 	/**
 	 * share a folder, than reshare a file within the shared folder and check if we construct the correct path
-	 * @medium
 	 */
 	public function testGetShareFromFolderReshares(): void {
 		$node1 = $this->userFolder->get($this->folder);
@@ -699,7 +675,6 @@ class ApiTest extends TestCase {
 
 	/**
 	 * reshare a sub folder and check if we get the correct path
-	 * @medium
 	 */
 	public function testGetShareFromSubFolderReShares(): void {
 		$node1 = $this->userFolder->get($this->folder . $this->subfolder);
@@ -741,7 +716,6 @@ class ApiTest extends TestCase {
 
 	/**
 	 * test re-re-share of folder if the path gets constructed correctly
-	 * @medium
 	 */
 	public function XtestGetShareFromFolderReReShares() {
 		$node1 = $this->userFolder->get($this->folder . $this->subfolder);
@@ -818,7 +792,6 @@ class ApiTest extends TestCase {
 
 	/**
 	 * test multiple shared folder if the path gets constructed correctly
-	 * @medium
 	 */
 	public function testGetShareMultipleSharedFolder(): void {
 		$this->setUp();
@@ -883,7 +856,6 @@ class ApiTest extends TestCase {
 
 	/**
 	 * test re-re-share of folder if the path gets constructed correctly
-	 * @medium
 	 */
 	public function testGetShareFromFileReReShares(): void {
 		$node1 = $this->userFolder->get($this->folder . $this->subfolder);
@@ -937,9 +909,6 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share3);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testGetShareFromUnknownId(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER3);
 		try {
@@ -951,9 +920,6 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	/**
-	 * @medium
-	 */
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
 	public function testUpdateShare(): void {
@@ -1013,9 +979,6 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share2);
 	}
 
-	/**
-	 * @medium
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataAllowFederationOnPublicShares')]
 	public function testUpdateShareUpload(array $appConfig, int $permissions): void {
 		$this->appConfig->method('getValueBool')->willReturnMap([
@@ -1056,9 +1019,6 @@ class ApiTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testUpdateShareExpireDate(): void {
 		$node1 = $this->userFolder->get($this->folder);
 		$share1 = $this->shareManager->newShare();
@@ -1119,7 +1079,6 @@ class ApiTest extends TestCase {
 
 		$share1 = $this->shareManager->getShareById($share1->getFullId());
 
-
 		// date shouldn't be changed
 		$this->assertEquals($dateWithinRange, $share1->getExpirationDate());
 		// cleanup
@@ -1128,9 +1087,6 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share1);
 	}
 
-	/**
-	 * @medium
-	 */
 	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
 	public function testDeleteShare(): void {
 		$node1 = $this->userFolder->get($this->filename);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -43,12 +43,11 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\Traits\EmailValidatorTrait;
 
+// TODO: convert to real integration tests
 /**
  * Class ApiTest
- *
- * @group DB
- * TODO: convert to real integration tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ApiTest extends TestCase {
 	use EmailValidatorTrait;
 
@@ -217,9 +216,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	/**
-	 * @group RoutingWeirdness
-	 */
+	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 	public function testCreateShareLink(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
@@ -242,10 +239,8 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	/**
-	 * @group RoutingWeirdness
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataAllowFederationOnPublicShares')]
+	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 	public function testCreateShareLinkPublicUpload(array $appConfig, int $permissions): void {
 		$this->appConfig->method('getValueBool')
 			->willReturnMap([$appConfig]);
@@ -441,8 +436,8 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @medium
-	 * @group RoutingWeirdness
 	 */
+	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 	public function testPublicLinkUrl(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
@@ -489,9 +484,9 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShareUserFile
-	 * @depends testCreateShareLink
 	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
 	public function testGetShareFromSource(): void {
 		$node = $this->userFolder->get($this->filename);
 		$share = $this->shareManager->newShare();
@@ -522,9 +517,9 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShareUserFile
-	 * @depends testCreateShareLink
 	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
 	public function testGetShareFromSourceWithReshares(): void {
 		$node = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
@@ -564,8 +559,8 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShareUserFile
 	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
 	public function testGetShareFromId(): void {
 		$node = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
@@ -958,9 +953,9 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShareUserFile
-	 * @depends testCreateShareLink
 	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
 	public function testUpdateShare(): void {
 		$password = md5(time());
 
@@ -1135,8 +1130,8 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShareUserFile
 	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
 	public function testDeleteShare(): void {
 		$node1 = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
@@ -1323,10 +1318,9 @@ class ApiTest extends TestCase {
 
 	/**
 	 * Make sure only ISO 8601 dates are accepted
-	 *
-	 * @group RoutingWeirdness
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('datesProvider')]
+	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 	public function testPublicLinkExpireDate($date, $valid): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 
@@ -1356,9 +1350,7 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share);
 	}
 
-	/**
-	 * @group RoutingWeirdness
-	 */
+	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 	public function testCreatePublicLinkExpireDateValid(): void {
 		$config = Server::get(IConfig::class);
 

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -22,9 +22,8 @@ use OCP\Share\IShare;
 
 /**
  * Class CacheTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CacheTest extends TestCase {
 
 	/**

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -31,9 +31,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Class CapabilitiesTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CapabilitiesTest extends \Test\TestCase {
 
 	/**

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -20,10 +20,10 @@ use Test\TestCase;
 /**
  * Class CleanupRemoteStoragesTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CleanupRemoteStoragesTest extends TestCase {
 
 	protected IDBConnection $connection;

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -63,8 +63,8 @@ use Test\Traits\EmailValidatorTrait;
  * Class ShareAPIControllerTest
  *
  * @package OCA\Files_Sharing\Tests\Controller
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ShareAPIControllerTest extends TestCase {
 	use EmailValidatorTrait;
 

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -50,10 +50,9 @@ use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * @group DB
- *
  * @package OCA\Files_Sharing\Controllers
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ShareControllerTest extends \Test\TestCase {
 
 	private string $user;

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -23,10 +23,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class ShareesTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests\API
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ShareesAPIControllerTest extends TestCase {
 	/** @var ShareesAPIController */
 	protected $sharees;

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -20,10 +20,10 @@ use OCP\Share\IShare;
 /**
  * Class DeleteOrphanedSharesJobTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 	/**
 	 * @var bool

--- a/apps/files_sharing/tests/EncryptedSizePropagationTest.php
+++ b/apps/files_sharing/tests/EncryptedSizePropagationTest.php
@@ -12,9 +12,7 @@ use OCP\ITempManager;
 use OCP\Server;
 use Test\Traits\EncryptionTrait;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class EncryptedSizePropagationTest extends SizePropagationTest {
 	use EncryptionTrait;
 

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -17,10 +17,10 @@ use OCP\Share\IShare;
 /**
  * Class EtagPropagationTest
  *
- * @group SLOWDB
  *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('SLOWDB')]
 class EtagPropagationTest extends PropagationTestCase {
 
 	/**

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -20,10 +20,10 @@ use OCP\Share\IShare;
 /**
  * Class ExpireSharesJobTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ExpireSharesJobTest extends \Test\TestCase {
 
 	/** @var ExpireSharesJob */

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -22,10 +22,10 @@ use OCP\IUserManager;
 /**
  * Class Cache
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests\External
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CacheTest extends TestCase {
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -41,10 +41,10 @@ use Test\Traits\UserTrait;
 /**
  * Class ManagerTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests\External
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends TestCase {
 	use UserTrait;
 

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -12,9 +12,7 @@ use OCA\Files_Sharing\External\Scanner;
 use OCA\Files_Sharing\External\Storage;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ScannerTest extends TestCase {
 	protected Scanner $scanner;
 	/** @var Storage|\PHPUnit\Framework\MockObject\MockObject */

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -16,9 +16,8 @@ use OCP\Http\Client\IResponse;
 
 /**
  * Tests for the external Storage class for remote shares.
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ExternalStorageTest extends \Test\TestCase {
 	public static function optionsProvider() {
 		return [

--- a/apps/files_sharing/tests/GroupEtagPropagationTest.php
+++ b/apps/files_sharing/tests/GroupEtagPropagationTest.php
@@ -13,10 +13,9 @@ use OCP\Constants;
 use OCP\Share\IShare;
 
 /**
- * @group SLOWDB
- *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('SLOWDB')]
 class GroupEtagPropagationTest extends PropagationTestCase {
 	/**
 	 * "user1" creates /test, /test/sub and shares with group1

--- a/apps/files_sharing/tests/HelperTest.php
+++ b/apps/files_sharing/tests/HelperTest.php
@@ -14,9 +14,8 @@ use OCP\Server;
 
 /**
  * Class HelperTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HelperTest extends TestCase {
 
 	/**

--- a/apps/files_sharing/tests/LockingTest.php
+++ b/apps/files_sharing/tests/LockingTest.php
@@ -19,10 +19,10 @@ use OCP\Share\IShare;
 /**
  * Class LockingTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LockingTest extends TestCase {
 	/**
 	 * @var \Test\Util\User\Dummy

--- a/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
+++ b/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
@@ -17,9 +17,8 @@ use OCP\Share\IShare;
 
 /**
  * Class SetPasswordColumnTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SetPasswordColumnTest extends TestCase {
 
 	/** @var IDBConnection */

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -25,9 +25,7 @@ use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MountProviderTest extends \Test\TestCase {
 
 	protected MountProvider $provider;

--- a/apps/files_sharing/tests/ShareTest.php
+++ b/apps/files_sharing/tests/ShareTest.php
@@ -19,9 +19,8 @@ use OCP\Share\IShare;
 
 /**
  * Class ShareTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ShareTest extends TestCase {
 	public const TEST_FOLDER_NAME = '/folder_share_api_test';
 

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -22,9 +22,8 @@ use OCP\Share\IShare;
 
 /**
  * Class SharedMountTest
- *
- * @group SLOWDB
  */
+#[\PHPUnit\Framework\Attributes\Group('SLOWDB')]
 class SharedMountTest extends TestCase {
 
 	/** @var IGroupManager */

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -100,9 +100,6 @@ class SharedMountTest extends TestCase {
 		$this->view->unlink($this->folder);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testDeleteParentOfMountPoint(): void {
 		// share to user
 		$share = $this->share(

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -62,8 +62,6 @@ class SharedStorageTest extends TestCase {
 
 	/**
 	 * if the parent of the mount point is gone then the mount point should move up
-	 *
-	 * @medium
 	 */
 	public function testParentOfMountPointIsGone(): void {
 
@@ -107,9 +105,6 @@ class SharedStorageTest extends TestCase {
 		$this->view->unlink($this->folder);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testRenamePartFile(): void {
 
 		// share to user

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -25,9 +25,8 @@ use OCP\Share\IShare;
 
 /**
  * Class SharedStorageTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SharedStorageTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -29,10 +29,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class SharesReminderJobTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SharesReminderJobTest extends \Test\TestCase {
 	private SharesReminderJob $job;
 	private IDBConnection $db;

--- a/apps/files_sharing/tests/SizePropagationTest.php
+++ b/apps/files_sharing/tests/SizePropagationTest.php
@@ -17,10 +17,10 @@ use Test\Traits\UserTrait;
 /**
  * Class SizePropagationTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SizePropagationTest extends TestCase {
 	use UserTrait;
 

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -27,12 +27,9 @@ use OCP\Share\IShare;
 use Test\Traits\MountProviderTrait;
 
 /**
- * Class TestCase
- *
- * @group DB
- *
  * Base class for sharing tests.
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 abstract class TestCase extends \Test\TestCase {
 	use MountProviderTrait;
 

--- a/apps/files_sharing/tests/UnshareChildrenTest.php
+++ b/apps/files_sharing/tests/UnshareChildrenTest.php
@@ -55,9 +55,6 @@ class UnshareChildrenTest extends TestCase {
 		parent::tearDown();
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testUnshareChildren(): void {
 		$fileInfo2 = Filesystem::getFileInfo($this->folder);
 

--- a/apps/files_sharing/tests/UnshareChildrenTest.php
+++ b/apps/files_sharing/tests/UnshareChildrenTest.php
@@ -15,10 +15,10 @@ use OCP\Util;
 /**
  * Class UnshareChildrenTest
  *
- * @group DB
  *
  * @package OCA\Files_Sharing\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UnshareChildrenTest extends TestCase {
 	protected $subsubfolder;
 

--- a/apps/files_sharing/tests/UpdaterTest.php
+++ b/apps/files_sharing/tests/UpdaterTest.php
@@ -21,9 +21,8 @@ use OCP\Share\IShare;
 
 /**
  * Class UpdaterTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UpdaterTest extends TestCase {
 	public const TEST_FOLDER_NAME = '/folder_share_updater_test';
 

--- a/apps/files_sharing/tests/WatcherTest.php
+++ b/apps/files_sharing/tests/WatcherTest.php
@@ -15,9 +15,8 @@ use OCP\Share\IShare;
 
 /**
  * Class WatcherTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class WatcherTest extends TestCase {
 
 	/** @var Storage */

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -24,10 +24,10 @@ use Test\TestCase;
 /**
  * Class CleanUpTest
  *
- * @group DB
  *
  * @package OCA\Files_Trashbin\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CleanUpTest extends TestCase {
 	protected IUserManager&MockObject $userManager;
 	protected IRootFolder&MockObject $rootFolder;

--- a/apps/files_trashbin/tests/Command/ExpireTest.php
+++ b/apps/files_trashbin/tests/Command/ExpireTest.php
@@ -14,10 +14,10 @@ use Test\TestCase;
 /**
  * Class ExpireTest
  *
- * @group DB
  *
  * @package OCA\Files_Trashbin\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ExpireTest extends TestCase {
 	public function testExpireNonExistingUser(): void {
 		$command = new Expire('test');

--- a/apps/files_trashbin/tests/Command/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/Command/ExpireTrashTest.php
@@ -24,10 +24,10 @@ use Test\TestCase;
 /**
  * Class ExpireTrashTest
  *
- * @group DB
  *
  * @package OCA\Files_Trashbin\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ExpireTrashTest extends TestCase {
 	private Expiration $expiration;
 	private Node $userFolder;

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -46,10 +46,10 @@ class TemporaryNoCross extends Temporary {
 /**
  * Class Storage
  *
- * @group DB
  *
  * @package OCA\Files_Trashbin\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class StorageTest extends \Test\TestCase {
 	use MountProviderTrait;
 

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -33,9 +33,8 @@ use OCP\Share\IShare;
 
 /**
  * Class Test_Encryption
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class TrashbinTest extends \Test\TestCase {
 	public const TEST_TRASHBIN_USER1 = 'test-trashbin-user1';
 	public const TEST_TRASHBIN_USER2 = 'test-trashbin-user2';

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -22,10 +22,10 @@ use Test\TestCase;
 /**
  * Class CleanupTest
  *
- * @group DB
  *
  * @package OCA\Files_Versions\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CleanupTest extends TestCase {
 	protected Manager&MockObject $userManager;
 	protected IRootFolder&MockObject $rootFolder;

--- a/apps/files_versions/tests/Command/ExpireTest.php
+++ b/apps/files_versions/tests/Command/ExpireTest.php
@@ -14,10 +14,10 @@ use Test\TestCase;
 /**
  * Class ExpireTest
  *
- * @group DB
  *
  * @package OCA\Files_Versions\Tests\Command
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ExpireTest extends TestCase {
 	public function testExpireNonExistingUser(): void {
 		$command = new Expire($this->getUniqueID('test'), '');

--- a/apps/files_versions/tests/StorageTest.php
+++ b/apps/files_versions/tests/StorageTest.php
@@ -16,9 +16,7 @@ use OCP\Server;
 use Test\TestCase;
 use Test\Traits\UserTrait;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class StorageTest extends TestCase {
 	use UserTrait;
 

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -34,9 +34,8 @@ use OCP\Util;
 /**
  * Class Test_Files_versions
  * this class provide basic files versions test
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class VersioningTest extends \Test\TestCase {
 	public const TEST_VERSIONS_USER = 'test-versions-user';
 	public const TEST_VERSIONS_USER2 = 'test-versions-user2';

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -137,7 +137,6 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @medium
 	 * test expire logic
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('versionsProvider')]

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -23,9 +23,7 @@ use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LoginRedirectorControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private IURLGenerator&MockObject $urlGenerator;

--- a/apps/oauth2/tests/Controller/SettingsControllerTest.php
+++ b/apps/oauth2/tests/Controller/SettingsControllerTest.php
@@ -22,9 +22,7 @@ use OCP\Security\ISecureRandom;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SettingsControllerTest extends TestCase {
 	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	private $request;

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -14,9 +14,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AccessTokenMapperTest extends TestCase {
 	/** @var AccessTokenMapper */
 	private $accessTokenMapper;

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -13,9 +13,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ClientMapperTest extends TestCase {
 	/** @var ClientMapper */
 	private $clientMapper;

--- a/apps/provisioning_api/tests/CapabilitiesTest.php
+++ b/apps/provisioning_api/tests/CapabilitiesTest.php
@@ -19,8 +19,8 @@ use Test\TestCase;
  * Note: group DB needed because of usage of overwriteService()
  *
  * @package OCA\Provisioning_API\Tests
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CapabilitiesTest extends TestCase {
 
 	protected IAppManager&MockObject $appManager;

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -22,10 +22,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class AppsTest
  *
- * @group DB
  *
  * @package OCA\Provisioning_API\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppsControllerTest extends TestCase {
 	private IAppManager $appManager;
 	private IAppConfig&MockObject $appConfig;

--- a/apps/settings/tests/AppInfo/ApplicationTest.php
+++ b/apps/settings/tests/AppInfo/ApplicationTest.php
@@ -25,8 +25,8 @@ use Test\TestCase;
  * Class ApplicationTest
  *
  * @package Tests\Settings
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ApplicationTest extends TestCase {
 	protected Application $app;
 	protected IAppContainer $container;

--- a/apps/settings/tests/Controller/AdminSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AdminSettingsControllerTest.php
@@ -26,10 +26,10 @@ use Test\TestCase;
 /**
  * Class AdminSettingsControllerTest
  *
- * @group DB
  *
  * @package Tests\Settings\Controller
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AdminSettingsControllerTest extends TestCase {
 
 	private IRequest&MockObject $request;

--- a/apps/settings/tests/Controller/AppSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AppSettingsControllerTest.php
@@ -34,9 +34,8 @@ use Test\TestCase;
  * Class AppSettingsControllerTest
  *
  * @package Tests\Settings\Controller
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppSettingsControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private IL10N&MockObject $l10n;

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -25,9 +25,9 @@ use Test\TestCase;
 /**
  * Class CheckSetupControllerTest
  *
- * @backupStaticAttributes
  * @package Tests\Settings\Controller
  */
+#[\PHPUnit\Framework\Attributes\BackupStaticProperties(true)]
 class CheckSetupControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private IConfig&MockObject $config;

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -37,10 +37,9 @@ use OCP\Mail\IMailer;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * @group DB
- *
  * @package Tests\Settings\Controller
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UsersControllerTest extends \Test\TestCase {
 	private IGroupManager&MockObject $groupManager;
 	private UserManager&MockObject $userManager;

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -21,9 +21,7 @@ use OCP\IUrlGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ServerTest extends TestCase {
 	private IDBConnection $connection;
 	private Server&MockObject $admin;

--- a/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
+++ b/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
@@ -16,9 +16,7 @@ use OCP\Server;
 use OCP\SetupCheck\SetupResult;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SupportedDatabaseTest extends TestCase {
 	private IL10N $l10n;
 	private IUrlGenerator $urlGenerator;

--- a/apps/settings/tests/UserMigration/AccountMigratorTest.php
+++ b/apps/settings/tests/UserMigration/AccountMigratorTest.php
@@ -23,9 +23,7 @@ use Sabre\VObject\UUIDUtil;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AccountMigratorTest extends TestCase {
 	private IUserManager $userManager;
 	private IAvatarManager $avatarManager;

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -47,8 +47,8 @@ use Test\Traits\EmailValidatorTrait;
  * Class ShareByMailProviderTest
  *
  * @package OCA\ShareByMail\Tests
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ShareByMailProviderTest extends TestCase {
 	use EmailValidatorTrait;
 

--- a/apps/theming/tests/Migration/Version2006Date20240905111627Test.php
+++ b/apps/theming/tests/Migration/Version2006Date20240905111627Test.php
@@ -20,9 +20,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class Version2006Date20240905111627Test extends TestCase {
 
 	private IAppConfig&MockObject $appConfig;
@@ -75,9 +73,7 @@ class Version2006Date20240905111627Test extends TestCase {
 		], $setValueCalls);
 	}
 
-	/**
-	 * @group DB
-	 */
+	#[\PHPUnit\Framework\Attributes\Group('DB')]
 	public function testRestoreUserColors(): void {
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
@@ -126,8 +122,8 @@ class Version2006Date20240905111627Test extends TestCase {
 
 	/**
 	 * Ensure only users with background color but no primary color are migrated
-	 * @group DB
 	 */
+	#[\PHPUnit\Framework\Attributes\Group('DB')]
 	public function testRestoreUserColorsWithConflicts(): void {
 		$this->appConfig->expects(self::once())
 			->method('getValueString')

--- a/apps/theming/tests/ServicesTest.php
+++ b/apps/theming/tests/ServicesTest.php
@@ -24,9 +24,9 @@ use Test\TestCase;
 /**
  * Class ServicesTest
  *
- * @group DB
  * @package OCA\Theming\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ServicesTest extends TestCase {
 	protected App $app;
 

--- a/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
@@ -15,9 +15,7 @@ use OCP\IUser;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class BackupCodeMapperTest extends TestCase {
 	private IDBConnection $db;
 	private BackupCodeMapper $mapper;

--- a/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
@@ -16,9 +16,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class BackupCodeStorageTest extends TestCase {
 	private IManager&MockObject $notificationManager;
 	private string $testUID = 'test123456789';

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -37,10 +37,10 @@ use Test\TestCase;
 /**
  * Class AccessTest
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AccessTest extends TestCase {
 	protected UserMapping&MockObject $userMapper;
 	protected IManager&MockObject $shareManager;

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -16,10 +16,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class Test_Connection
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ConnectionTest extends \Test\TestCase {
 	protected ILDAPWrapper&MockObject $ldap;
 	protected Connection $connection;

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -30,10 +30,10 @@ use Test\TestCase;
 /**
  * Class GroupLDAPTest
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class Group_LDAPTest extends TestCase {
 	private Access&MockObject $access;
 	private GroupPluginManager&MockObject $pluginManager;

--- a/apps/user_ldap/tests/HelperTest.php
+++ b/apps/user_ldap/tests/HelperTest.php
@@ -13,9 +13,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HelperTest extends \Test\TestCase {
 	private IAppConfig&MockObject $appConfig;
 

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -27,9 +27,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SyncTest extends TestCase {
 	protected Helper&MockObject $helper;
 	protected LDAP&MockObject $ldapWrapper;

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -28,10 +28,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class LDAPProviderTest
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LDAPProviderTest extends \Test\TestCase {
 	private function getServerMock(IUserLDAP $userBackend, IGroupLDAP $groupBackend) {
 		$server = $this->getMockBuilder('OC\Server')

--- a/apps/user_ldap/tests/Mapping/GroupMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/GroupMappingTest.php
@@ -16,10 +16,10 @@ use OCP\IDBConnection;
 /**
  * Class GroupMappingTest
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests\Mapping
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class GroupMappingTest extends AbstractMappingTestCase {
 	public function getMapper(IDBConnection $dbMock, ICacheFactory $cacheFactory, IAppConfig $appConfig): GroupMapping {
 		return new GroupMapping($dbMock, $cacheFactory, $appConfig, true);

--- a/apps/user_ldap/tests/Mapping/UserMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/UserMappingTest.php
@@ -17,10 +17,10 @@ use OCP\Support\Subscription\IAssertion;
 /**
  * Class UserMappingTest
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests\Mapping
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserMappingTest extends AbstractMappingTestCase {
 	public function getMapper(IDBConnection $dbMock, ICacheFactory $cacheFactory, IAppConfig $appConfig): UserMapping {
 		return new UserMapping($dbMock, $cacheFactory, $appConfig, true, $this->createMock(IAssertion::class));

--- a/apps/user_ldap/tests/Migration/UUIDFixGroupTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixGroupTest.php
@@ -15,8 +15,8 @@ use OCA\User_LDAP\Migration\UUIDFixGroup;
  * Class UUIDFixGroupTest
  *
  * @package OCA\Group_LDAP\Tests\Migration
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UUIDFixGroupTest extends AbstractUUIDFixTestCase {
 	protected function setUp(): void {
 		$this->isUser = false;

--- a/apps/user_ldap/tests/Migration/UUIDFixUserTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixUserTest.php
@@ -15,8 +15,8 @@ use OCA\User_LDAP\User_Proxy;
  * Class UUIDFixUserTest
  *
  * @package OCA\User_LDAP\Tests\Migration
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UUIDFixUserTest extends AbstractUUIDFixTestCase {
 	protected function setUp(): void {
 		$this->isUser = true;

--- a/apps/user_ldap/tests/Settings/AdminTest.php
+++ b/apps/user_ldap/tests/Settings/AdminTest.php
@@ -18,9 +18,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
- * @group DB
  * @package OCA\User_LDAP\Tests\Settings
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AdminTest extends TestCase {
 	private IL10N&MockObject $l10n;
 	private ITemplateManager $templateManager;

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -18,10 +18,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class DeletedUsersIndexTest
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests\User
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DeletedUsersIndexTest extends \Test\TestCase {
 	protected DeletedUsersIndex $dui;
 	protected IConfig $config;

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -26,10 +26,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class Test_User_Manager
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests\User
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected IConfig&MockObject $config;

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -27,10 +27,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class UserTest
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests\User
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected Connection&MockObject $connection;

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -19,7 +19,6 @@ use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
 use OCA\User_LDAP\User_LDAP;
-use OCA\User_LDAP\User_LDAP as UserLDAP;
 use OCA\User_LDAP\UserPluginManager;
 use OCP\HintException;
 use OCP\IConfig;
@@ -48,7 +47,7 @@ class User_LDAPTest extends TestCase {
 	protected Manager&MockObject $userManager;
 	protected LoggerInterface&MockObject $logger;
 	protected DeletedUsersIndex&MockObject $deletedUsersIndex;
-	protected UserLDAP $backend;
+	protected User_LDAP $backend;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -72,7 +71,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->deletedUsersIndex = $this->createMock(DeletedUsersIndex::class);
 
-		$this->backend = new UserLDAP(
+		$this->backend = new User_LDAP(
 			$this->access,
 			$this->notificationManager,
 			$this->pluginManager,
@@ -178,7 +177,7 @@ class User_LDAPTest extends TestCase {
 			->method('get')
 			->willReturn($user);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		Server::get(IUserManager::class)->registerBackend($backend);
 
@@ -188,7 +187,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testCheckPasswordWrongPassword(): void {
 		$this->prepareAccessForCheckPassword();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'wrong');
@@ -197,7 +196,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testCheckPasswordWrongUser(): void {
 		$this->prepareAccessForCheckPassword();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $backend->checkPassword('mallory', 'evil');
@@ -212,7 +211,7 @@ class User_LDAPTest extends TestCase {
 			->method('get')
 			->willReturn(null);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'dt19');
@@ -230,7 +229,7 @@ class User_LDAPTest extends TestCase {
 			->method('get')
 			->willReturn($user);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user = Server::get(IUserManager::class)->checkPassword('roland', 'dt19');
@@ -243,7 +242,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testCheckPasswordPublicAPIWrongPassword(): void {
 		$this->prepareAccessForCheckPassword();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user = Server::get(IUserManager::class)->checkPassword('roland', 'wrong');
@@ -256,7 +255,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testCheckPasswordPublicAPIWrongUser(): void {
 		$this->prepareAccessForCheckPassword();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user = Server::get(IUserManager::class)->checkPassword('mallory', 'evil');
@@ -268,7 +267,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testDeleteUserCancel(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$result = $backend->deleteUser('notme');
 		$this->assertFalse($result);
 	}
@@ -305,7 +304,7 @@ class User_LDAPTest extends TestCase {
 			->with($uid)
 			->willReturn(true);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->deleteUser($uid);
 		$this->assertTrue($result);
@@ -394,7 +393,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersNoParam(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->getUsers();
 		$this->assertCount(3, $result);
@@ -402,7 +401,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersLimitOffset(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->getUsers('', 1, 2);
 		$this->assertCount(1, $result);
@@ -410,7 +409,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersLimitOffset2(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->getUsers('', 2, 1);
 		$this->assertCount(2, $result);
@@ -418,7 +417,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersSearchWithResult(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->getUsers('yo');
 		$this->assertCount(2, $result);
@@ -426,7 +425,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersSearchEmptyResult(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->getUsers('nix');
 		$this->assertCount(0, $result);
@@ -442,7 +441,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersViaAPINoParam(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers();
@@ -451,7 +450,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersViaAPILimitOffset(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('', 1, 2);
@@ -460,7 +459,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersViaAPILimitOffset2(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('', 2, 1);
@@ -469,7 +468,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersViaAPISearchWithResult(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('yo');
@@ -478,7 +477,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetUsersViaAPISearchEmptyResult(): void {
 		$this->prepareAccessForGetUsers();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('nix');
@@ -486,7 +485,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testUserExists(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$this->userManager->expects($this->never())
@@ -506,7 +505,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testUserExistsForDeleted(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$mapper = $this->createMock(UserMapping::class);
@@ -531,7 +530,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testUserExistsForNeverExisting(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$this->access->expects($this->any())
@@ -550,7 +549,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testUserExistsPublicAPI(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 		Server::get(IUserManager::class)->registerBackend($backend);
 
@@ -583,7 +582,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testDeleteUserExisting(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		//we do not support deleting existing users at all
 		$result = $backend->deleteUser('gunslinger');
@@ -591,7 +590,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetHomeAbsolutePath(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$this->connection->expects($this->any())
@@ -645,7 +644,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetHomeRelative(): void {
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$dataDir = Server::get(IConfig::class)->getSystemValue(
@@ -703,7 +702,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetHomeNoPath(): void {
 		$this->expectException(\Exception::class);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$this->connection->expects($this->any())
@@ -748,7 +747,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetHomeDeletedUser(): void {
 		$uid = 'newyorker';
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$this->connection->expects($this->any())
@@ -841,7 +840,7 @@ class User_LDAPTest extends TestCase {
 
 	public function testGetDisplayName(): void {
 		$this->prepareAccessForGetDisplayName();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$this->connection->expects($this->any())
@@ -932,7 +931,7 @@ class User_LDAPTest extends TestCase {
 				}
 			});
 		$this->prepareAccessForGetDisplayName();
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
 		$this->connection->expects($this->any())
@@ -1024,7 +1023,7 @@ class User_LDAPTest extends TestCase {
 			->method('countUsers')
 			->willReturn(5);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->countUsers();
 		$this->assertEquals(5, $result);
@@ -1035,7 +1034,7 @@ class User_LDAPTest extends TestCase {
 			->method('countUsers')
 			->willReturn(false);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
 		$result = $backend->countUsers();
 		$this->assertFalse($result);
@@ -1079,7 +1078,7 @@ class User_LDAPTest extends TestCase {
 			->method('writeToCache')
 			->with($this->equalTo('loginName2UserName-' . $loginName), $this->equalTo($username));
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$user = $this->createMock(User::class);
 		$user->expects($this->any())
 			->method('getUsername')
@@ -1126,7 +1125,7 @@ class User_LDAPTest extends TestCase {
 			->method('getAttributes')
 			->willReturn(['dn', 'uid', 'mail', 'displayname']);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$name = $backend->loginName2UserName($loginName);
 		$this->assertSame(false, $name);
 
@@ -1163,7 +1162,7 @@ class User_LDAPTest extends TestCase {
 			->method('getAttributes')
 			->willReturn(['dn', 'uid', 'mail', 'displayname']);
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$name = $backend->loginName2UserName($loginName);
 		$this->assertSame(false, $name);
 
@@ -1238,7 +1237,7 @@ class User_LDAPTest extends TestCase {
 		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($this->createMock(User::class));
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$this->assertTrue(\OC_User::setPassword('roland', 'dt'));
@@ -1251,7 +1250,7 @@ class User_LDAPTest extends TestCase {
 			->method('get')
 			->willReturn($this->createMock(User::class));
 
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturn($this->createMock(User::class));
@@ -1267,7 +1266,7 @@ class User_LDAPTest extends TestCase {
 			->willReturn($this->createMock(User::class));
 
 		$this->prepareAccessForSetPassword(false);
-		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
+		$backend = new User_LDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$this->assertFalse(\OC_User::setPassword('roland', 'dt12234$'));

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -35,10 +35,10 @@ use Test\TestCase;
 /**
  * Class Test_User_Ldap_Direct
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class User_LDAPTest extends TestCase {
 	protected Access&MockObject $access;
 	protected OfflineUser&MockObject $offlineUser;
@@ -48,7 +48,7 @@ class User_LDAPTest extends TestCase {
 	protected Manager&MockObject $userManager;
 	protected LoggerInterface&MockObject $logger;
 	protected DeletedUsersIndex&MockObject $deletedUsersIndex;
-	protected User_LDAP $backend;
+	protected UserLDAP $backend;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -72,7 +72,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->deletedUsersIndex = $this->createMock(DeletedUsersIndex::class);
 
-		$this->backend = new User_LDAP(
+		$this->backend = new UserLDAP(
 			$this->access,
 			$this->notificationManager,
 			$this->pluginManager,

--- a/apps/user_ldap/tests/WizardTest.php
+++ b/apps/user_ldap/tests/WizardTest.php
@@ -18,10 +18,10 @@ use Test\TestCase;
 /**
  * Class Test_Wizard
  *
- * @group DB
  *
  * @package OCA\User_LDAP\Tests
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class WizardTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/user_status/tests/Integration/Service/StatusServiceIntegrationTest.php
+++ b/apps/user_status/tests/Integration/Service/StatusServiceIntegrationTest.php
@@ -18,9 +18,7 @@ use Test\TestCase;
 use function sleep;
 use function time;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class StatusServiceIntegrationTest extends TestCase {
 
 	private StatusService $service;

--- a/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
+++ b/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
@@ -18,9 +18,7 @@ use OCP\Server;
 use OCP\User\Events\UserCreatedEvent;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class WebhookListenerMapperTest extends TestCase {
 	private IDBConnection $connection;
 	private WebhookListenerMapper $mapper;

--- a/apps/workflowengine/tests/Check/FileMimeTypeTest.php
+++ b/apps/workflowengine/tests/Check/FileMimeTypeTest.php
@@ -25,9 +25,7 @@ class TemporaryNoLocal extends Temporary {
 	}
 }
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FileMimeTypeTest extends TestCase {
 	/** @var IL10N */
 	private $l10n;

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -40,8 +40,8 @@ use Test\TestCase;
  * Class ManagerTest
  *
  * @package OCA\WorkflowEngine\Tests
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends TestCase {
 	protected Manager $manager;
 	protected IDBConnection $db;

--- a/build/rector.php
+++ b/build/rector.php
@@ -12,9 +12,7 @@ use PhpParser\Node;
 use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector;
-use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\ValueObject\Application\File;
 
@@ -86,17 +84,13 @@ $config = RectorConfig::configure()
 	// ->withPhpSets()
 	->withImportNames(importShortClasses:false)
 	->withTypeCoverageLevel(0)
-	->withRules([
-		UseSpecificWillMethodRector::class,
-		StaticDataProviderClassMethodRector::class,
-		DataProviderAnnotationToAttributeRector::class,
-	])
 	->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
 		'inline_public' => true,
 		'rename_property' => true,
 	])
 	->withSets([
 		NextcloudSets::NEXTCLOUD_27,
+		PHPUnitSetList::PHPUNIT_100,
 	]);
 
 $config->registerService(NextcloudNamespaceSkipVoter::class, tag:ClassNameImportSkipVoterInterface::class);

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.2"
 		},
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true
@@ -24,7 +24,7 @@
 		}
 	},
 	"require": {
-		"php": "^8.1",
+		"php": "^8.2",
 		"ext-ctype": "*",
 		"ext-curl": "*",
 		"ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7eec232d4a6c2dea5a37ba784aa1b2ad",
+    "content-hash": "d065a83a3541ae968e174ccc250e446c",
     "packages": [],
     "packages-dev": [
         {
@@ -67,11 +67,11 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -91,9 +91,9 @@
         "ext-zip": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/core/Controller/WhatsNewController.php
+++ b/core/Controller/WhatsNewController.php
@@ -12,6 +12,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -19,7 +20,7 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\PreConditionNotMetException;
 
-class WhatsNewController extends \OCP\AppFramework\OCSController {
+class WhatsNewController extends OCSController {
 	public function __construct(
 		string $appName,
 		IRequest $request,

--- a/cron.php
+++ b/cron.php
@@ -41,7 +41,7 @@ Options:
 		$jobClasses = empty($jobClasses) ? null : $jobClasses;
 
 		if ($verbose) {
-			$cronService->registerVerboseCallback(function (string $message) {
+			$cronService->registerVerboseCallback(function (string $message): void {
 				echo $message . PHP_EOL;
 			});
 		}

--- a/tests/Core/Command/Apps/AppsDisableTest.php
+++ b/tests/Core/Command/Apps/AppsDisableTest.php
@@ -16,9 +16,8 @@ use Test\TestCase;
 
 /**
  * Class AppsDisableTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppsDisableTest extends TestCase {
 	/** @var CommandTester */
 	private $commandTester;

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -18,9 +18,8 @@ use Test\TestCase;
 
 /**
  * Class AppsEnableTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppsEnableTest extends TestCase {
 	/** @var CommandTester */
 	private $commandTester;

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -39,9 +39,9 @@ use Test\TestCase;
 /**
  * Class AccountManagerTest
  *
- * @group DB
  * @package Test\Accounts
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AccountManagerTest extends TestCase {
 
 	/** accounts table name */

--- a/tests/lib/Accounts/HooksTest.php
+++ b/tests/lib/Accounts/HooksTest.php
@@ -23,8 +23,8 @@ use Test\TestCase;
  * Class HooksTest
  *
  * @package Test\Accounts
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HooksTest extends TestCase {
 
 	private LoggerInterface&MockObject $logger;

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -8,19 +8,18 @@
 
 namespace Test;
 
-/**
- * Class AllConfigTest
- *
- * @group DB
- *
- * @package Test
- */
 use OC\AllConfig;
 use OC\SystemConfig;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
 use OCP\Server;
 
+/**
+ * Class AllConfigTest
+ *
+ * @package Test
+ */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AllConfigTest extends \Test\TestCase {
 	/** @var IDBConnection */
 	protected $connection;

--- a/tests/lib/AppConfigIntegrationTest.php
+++ b/tests/lib/AppConfigIntegrationTest.php
@@ -23,10 +23,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 /**
- * @group DB
- *
  * @package Test
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppConfigIntegrationTest extends TestCase {
 	protected IAppConfig $appConfig;
 	protected IDBConnection $connection;

--- a/tests/lib/AppFramework/Db/QBMapperDBTest.php
+++ b/tests/lib/AppFramework/Db/QBMapperDBTest.php
@@ -61,8 +61,8 @@ class QBDBTestMapper extends QBMapper {
 
 /**
  * Test real database handling (serialization)
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class QBMapperDBTest extends TestCase {
 	protected IDBConnection $connection;
 	protected bool $schemaSetup = false;

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -22,9 +22,7 @@ use OCP\IConfig;
 use OCP\IRequestId;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DIContainerTest extends \Test\TestCase {
 	private DIContainer&MockObject $container;
 

--- a/tests/lib/AppFramework/DependencyInjection/DIIntergrationTests.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIIntergrationTests.php
@@ -34,6 +34,9 @@ class ClassB {
 }
 
 class DIIntergrationTests extends TestCase {
+	public function __construct() {
+		parent::__construct(static::class);
+	}
 	private DIContainer $container;
 	private ServerContainer $server;
 

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -76,8 +76,8 @@ class TestController extends Controller {
  * Class DispatcherTest
  *
  * @package Test\AppFramework\Http
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DispatcherTest extends \Test\TestCase {
 	/** @var MiddlewareDispatcher */
 	private $middlewareDispatcher;

--- a/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
@@ -25,9 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\AppFramework\Middleware\Security\Mock\RateLimitingMiddlewareController;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RateLimitingMiddlewareTest extends TestCase {
 	private IRequest|MockObject $request;
 	private IUserSession|MockObject $userSession;

--- a/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
@@ -134,9 +134,6 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	public function arguments3($a, float $b, int $c, $d) {
 	}
 
-	/**
-	 * @requires PHP 7
-	 */
 	public function testReadTypeIntAnnotationsScalarTypes(): void {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(

--- a/tests/lib/AppScriptSortTest.php
+++ b/tests/lib/AppScriptSortTest.php
@@ -16,8 +16,8 @@ use Psr\Log\LoggerInterface;
  * Class AppScriptSortTest
  *
  * @package Test
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppScriptSortTest extends \Test\TestCase {
 	private $logger;
 

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -27,9 +27,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Class AppTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppTest extends \Test\TestCase {
 	public const TEST_USER1 = 'user1';
 	public const TEST_USER2 = 'user2';

--- a/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
@@ -18,9 +18,7 @@ use OCP\IUser;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PublicKeyTokenMapperTest extends TestCase {
 	/** @var PublicKeyTokenMapper */
 	private $mapper;

--- a/tests/lib/Authentication/Token/RemoteWipeTest.php
+++ b/tests/lib/Authentication/Token/RemoteWipeTest.php
@@ -12,7 +12,6 @@ namespace Test\Authentication\Token;
 use OC\Authentication\Events\RemoteWipeFinished;
 use OC\Authentication\Events\RemoteWipeStarted;
 use OC\Authentication\Exceptions\WipeTokenException;
-use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IProvider as ITokenProvider;
 use OC\Authentication\Token\IToken;
 use OC\Authentication\Token\IWipeableToken;
@@ -39,7 +38,7 @@ class RemoteWipeTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->tokenProvider = $this->createMock(ITokenProvider::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 

--- a/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
@@ -14,9 +14,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ProviderUserAssignmentDaoTest extends TestCase {
 	/** @var IDBConnection */
 	private $dbConn;

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -23,9 +23,9 @@ use Test\TestCase;
 /**
  * Class JobList
  *
- * @group DB
  * @package Test\BackgroundJob
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class JobListTest extends TestCase {
 	/** @var \OC\BackgroundJob\JobList */
 	protected $instance;

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -24,10 +24,10 @@ use Test\Traits\UserTrait;
 /**
  * Class FileCacheTest
  *
- * @group DB
  *
  * @package Test\Cache
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FileCacheTest extends TestCache {
 	use UserTrait;
 

--- a/tests/lib/Command/BackgroundModeTest.php
+++ b/tests/lib/Command/BackgroundModeTest.php
@@ -16,9 +16,7 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class BackgroundModeTest extends TestCase {
 	private IAppConfig $appConfig;
 

--- a/tests/lib/Command/CronBusTest.php
+++ b/tests/lib/Command/CronBusTest.php
@@ -11,9 +11,7 @@ use OC\Command\CronBus;
 use OCP\BackgroundJob\IJobList;
 use Test\BackgroundJob\DummyJobList;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CronBusTest extends AsyncBusTestCase {
 	/**
 	 * @var IJobList

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -31,9 +31,8 @@ use Test\TestCase;
 
 /**
  * Class ManagerTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends TestCase {
 	/** @var IDBConnection */
 	private $connection;

--- a/tests/lib/Config/LexiconTest.php
+++ b/tests/lib/Config/LexiconTest.php
@@ -25,10 +25,10 @@ use Test\TestCase;
 /**
  * Class UserPreferencesTest
  *
- * @group DB
  *
  * @package Test
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LexiconTest extends TestCase {
 	/** @var AppConfig */
 	private IAppConfig $appConfig;

--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -25,10 +25,10 @@ use Test\TestCase;
 /**
  * Class UserPreferencesTest
  *
- * @group DB
  *
  * @package Test
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserConfigTest extends TestCase {
 	protected IDBConnection $connection;
 	private IConfig $config;

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -17,9 +17,7 @@ use OC\DB\Adapter;
 use OC\DB\Connection;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ConnectionTest extends TestCase {
 
 	public function testSingleNodeConnectsToPrimaryOnly(): void {

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -24,10 +24,10 @@ use OCP\Server;
 /**
  * Class MigratorTest
  *
- * @group DB
  *
  * @package Test\DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MigratorTest extends \Test\TestCase {
 	/**
 	 * @var \Doctrine\DBAL\Connection $connection

--- a/tests/lib/DB/OCPostgreSqlPlatformTest.php
+++ b/tests/lib/DB/OCPostgreSqlPlatformTest.php
@@ -19,10 +19,10 @@ use Doctrine\DBAL\Types\Types;
  * custom OCPostgreSqlPlatform behavior has been upstreamed, test is left to
  * ensure behavior stays correct.
  *
- * @group DB
  *
  * @package Test\DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class OCPostgreSqlPlatformTest extends \Test\TestCase {
 	public function testAlterBigint(): void {
 		$platform = new PostgreSQLPlatform();

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -16,9 +16,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ExpressionBuilderDBTest extends TestCase {
 	/** @var \Doctrine\DBAL\Connection|IDBConnection */
 	protected $connection;

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -19,10 +19,10 @@ use Test\TestCase;
 /**
  * Class ExpressionBuilderTest
  *
- * @group DB
  *
  * @package Test\DB\QueryBuilder
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ExpressionBuilderTest extends TestCase {
 	/** @var ExpressionBuilder */
 	protected $expressionBuilder;

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -16,10 +16,10 @@ use Test\TestCase;
 /**
  * Class FunctionBuilderTest
  *
- * @group DB
  *
  * @package Test\DB\QueryBuilder
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FunctionBuilderTest extends TestCase {
 	/** @var \Doctrine\DBAL\Connection|IDBConnection */
 	protected $connection;

--- a/tests/lib/DB/QueryBuilder/Partitioned/PartitionedQueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/Partitioned/PartitionedQueryBuilderTest.php
@@ -18,9 +18,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PartitionedQueryBuilderTest extends TestCase {
 	private IDBConnection $connection;
 	private ShardConnectionManager $shardConnectionManager;

--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -27,10 +27,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class QueryBuilderTest
  *
- * @group DB
  *
  * @package Test\DB\QueryBuilder
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class QueryBuilderTest extends \Test\TestCase {
 	private SystemConfig&MockObject $config;
 	private LoggerInterface&MockObject $logger;

--- a/tests/lib/DB/QueryBuilder/Sharded/SharedQueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/Sharded/SharedQueryBuilderTest.php
@@ -19,9 +19,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SharedQueryBuilderTest extends TestCase {
 	private IDBConnection $connection;
 	private AutoIncrementHandler $autoIncrementHandler;

--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -83,8 +83,8 @@ class Editor implements IEditor {
  * Class ManagerTest
  *
  * @package Test\DirectEditing
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends TestCase {
 	private $manager;
 	/**

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -28,10 +28,10 @@ use Test\TestCase;
 /**
  * Class DecryptAllTest
  *
- * @group DB
  *
  * @package Test\Encryption
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DecryptAllTest extends TestCase {
 	private IUserManager&MockObject $userManager;
 	private Manager&MockObject $encryptionManager;

--- a/tests/lib/Encryption/ManagerTest.php
+++ b/tests/lib/Encryption/ManagerTest.php
@@ -87,9 +87,7 @@ class ManagerTest extends TestCase {
 		return $this->manager;
 	}
 
-	/**
-	 * @depends testModuleRegistration
-	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testModuleRegistration')]
 	public function testModuleReRegistration($manager): void {
 		$this->expectException(ModuleAlreadyExistsException::class);
 		$this->expectExceptionMessage('Id "ID0" already used by encryption module "TestDummyModule0"');

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -19,9 +19,7 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CloudIdManagerTest extends TestCase {
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;

--- a/tests/lib/Federation/CloudIdTest.php
+++ b/tests/lib/Federation/CloudIdTest.php
@@ -15,9 +15,7 @@ use OCP\Federation\ICloudIdManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CloudIdTest extends TestCase {
 	protected CloudIdManager&MockObject $cloudIdManager;
 

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -33,10 +33,10 @@ class LongId extends Temporary {
 /**
  * Class CacheTest
  *
- * @group DB
  *
  * @package Test\Files\Cache
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CacheTest extends \Test\TestCase {
 	/**
 	 * @var Temporary $storage ;

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -19,9 +19,7 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FileAccessTest extends TestCase {
 	private IDBConnection $dbConnection;
 	private FileAccess $fileAccess;

--- a/tests/lib/Files/Cache/HomeCacheTest.php
+++ b/tests/lib/Files/Cache/HomeCacheTest.php
@@ -42,10 +42,10 @@ class DummyUser extends User {
 /**
  * Class HomeCacheTest
  *
- * @group DB
  *
  * @package Test\Files\Cache
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HomeCacheTest extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Home $storage

--- a/tests/lib/Files/Cache/LocalRootScannerTest.php
+++ b/tests/lib/Files/Cache/LocalRootScannerTest.php
@@ -13,9 +13,7 @@ use OCP\ITempManager;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LocalRootScannerTest extends TestCase {
 	/** @var LocalRootStorage */
 	private $storage;

--- a/tests/lib/Files/Cache/MoveFromCacheTraitTest.php
+++ b/tests/lib/Files/Cache/MoveFromCacheTraitTest.php
@@ -19,9 +19,8 @@ class FallBackCrossCacheMoveCache extends Cache {
 
 /**
  * Class MoveFromCacheTraitTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MoveFromCacheTraitTest extends CacheTest {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Files/Cache/PropagatorTest.php
+++ b/tests/lib/Files/Cache/PropagatorTest.php
@@ -13,9 +13,7 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Storage\IStorage;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PropagatorTest extends TestCase {
 	/** @var IStorage */
 	private $storage;

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -22,10 +22,10 @@ use Test\TestCase;
 /**
  * Class ScannerTest
  *
- * @group DB
  *
  * @package Test\Files\Cache
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ScannerTest extends TestCase {
 	private Storage $storage;
 	private Scanner $scanner;

--- a/tests/lib/Files/Cache/SearchBuilderTest.php
+++ b/tests/lib/Files/Cache/SearchBuilderTest.php
@@ -21,9 +21,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SearchBuilderTest extends TestCase {
 	/** @var IQueryBuilder */
 	private $builder;

--- a/tests/lib/Files/Cache/UpdaterLegacyTest.php
+++ b/tests/lib/Files/Cache/UpdaterLegacyTest.php
@@ -21,10 +21,10 @@ use OCP\Server;
 /**
  * Class UpdaterLegacyTest
  *
- * @group DB
  *
  * @package Test\Files\Cache
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UpdaterLegacyTest extends \Test\TestCase {
 	/**
 	 * @var Storage $storage

--- a/tests/lib/Files/Cache/UpdaterTest.php
+++ b/tests/lib/Files/Cache/UpdaterTest.php
@@ -20,10 +20,10 @@ use OCP\Files\Storage\IStorage;
 /**
  * Class UpdaterTest
  *
- * @group DB
  *
  * @package Test\Files\Cache
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UpdaterTest extends \Test\TestCase {
 	/**
 	 * @var Storage

--- a/tests/lib/Files/Cache/WatcherTest.php
+++ b/tests/lib/Files/Cache/WatcherTest.php
@@ -18,6 +18,7 @@ use OC\Files\Storage\Temporary;
  *
  * @package Test\Files\Cache
  */
+#[\PHPUnit\Framework\Attributes\Medium]
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class WatcherTest extends \Test\TestCase {
 	/**
@@ -42,9 +43,6 @@ class WatcherTest extends \Test\TestCase {
 		parent::tearDown();
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testWatcher(): void {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
@@ -83,9 +81,7 @@ class WatcherTest extends \Test\TestCase {
 		$this->assertFalse($cache->inCache('folder/bar2.txt'));
 	}
 
-	/**
-	 * @medium
-	 */
+
 	public function testFileToFolder(): void {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();

--- a/tests/lib/Files/Cache/WatcherTest.php
+++ b/tests/lib/Files/Cache/WatcherTest.php
@@ -15,10 +15,10 @@ use OC\Files\Storage\Temporary;
 /**
  * Class WatcherTest
  *
- * @group DB
  *
  * @package Test\Files\Cache
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class WatcherTest extends \Test\TestCase {
 	/**
 	 * @var Storage[] $storages

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -23,10 +23,10 @@ use Test\Files\Cache\CacheTest;
 /**
  * Class CacheJail
  *
- * @group DB
  *
  * @package Test\Files\Cache\Wrapper
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CacheJailTest extends CacheTest {
 	/**
 	 * @var Cache $sourceCache

--- a/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
@@ -16,10 +16,10 @@ use Test\Files\Cache\CacheTest;
 /**
  * Class CachePermissionsMask
  *
- * @group DB
  *
  * @package Test\Files\Cache\Wrapper
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CachePermissionsMaskTest extends CacheTest {
 	/**
 	 * @var Cache $sourceCache

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -32,9 +32,7 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 use Test\Util\User\Dummy;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserMountCacheTest extends TestCase {
 	private IDBConnection $connection;
 	private IUserManager $userManager;

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -23,10 +23,10 @@ use Psr\Log\LoggerInterface;
 /**
  * Class EtagTest
  *
- * @group DB
  *
  * @package Test\Files
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class EtagTest extends \Test\TestCase {
 	private $datadir;
 

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -49,10 +49,10 @@ class DummyMountProvider implements IMountProvider {
 /**
  * Class FilesystemTest
  *
- * @group DB
  *
  * @package Test\Files
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FilesystemTest extends \Test\TestCase {
 	public const TEST_FILESYSTEM_USER1 = 'test-filesystem-user1';
 	public const TEST_FILESYSTEM_USER2 = 'test-filesystem-user1';

--- a/tests/lib/Files/Mount/RootMountProviderTest.php
+++ b/tests/lib/Files/Mount/RootMountProviderTest.php
@@ -18,9 +18,7 @@ use OCP\App\IAppManager;
 use OCP\IConfig;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RootMountProviderTest extends TestCase {
 	private StorageFactory $loader;
 

--- a/tests/lib/Files/Node/FileTest.php
+++ b/tests/lib/Files/Node/FileTest.php
@@ -16,10 +16,10 @@ use OCP\Files\NotPermittedException;
 /**
  * Class FileTest
  *
- * @group DB
  *
  * @package Test\Files\Node
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FileTest extends NodeTestCase {
 	protected function createTestNode($root, $view, $path, array $data = [], $internalPath = '', $storage = null) {
 		if ($data || $internalPath || $storage) {

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -42,10 +42,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class FolderTest
  *
- * @group DB
  *
  * @package Test\Files\Node
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FolderTest extends NodeTestCase {
 	protected function createTestNode($root, $view, $path, array $data = [], $internalPath = '', $storage = null) {
 		$view->expects($this->any())

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -45,10 +45,10 @@ use Test\Traits\UserTrait;
 /**
  * Class HookConnectorTest
  *
- * @group DB
  *
  * @package Test\Files\Node
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HookConnectorTest extends TestCase {
 	use UserTrait;
 	use MountProviderTrait;

--- a/tests/lib/Files/Node/IntegrationTest.php
+++ b/tests/lib/Files/Node/IntegrationTest.php
@@ -26,10 +26,10 @@ use Test\Traits\UserTrait;
 /**
  * Class IntegrationTest
  *
- * @group DB
  *
  * @package Test\Files\Node
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class IntegrationTest extends \Test\TestCase {
 	use UserTrait;
 

--- a/tests/lib/Files/ObjectStore/AzureTest.php
+++ b/tests/lib/Files/ObjectStore/AzureTest.php
@@ -11,9 +11,7 @@ use OC\Files\ObjectStore\Azure;
 use OCP\IConfig;
 use OCP\Server;
 
-/**
- * @group PRIMARY-azure
- */
+#[\PHPUnit\Framework\Attributes\Group('PRIMARY-azure')]
 class AzureTest extends ObjectStoreTestCase {
 	protected function getInstance() {
 		$config = Server::get(IConfig::class)->getSystemValue('objectstore');

--- a/tests/lib/Files/ObjectStore/ObjectStoreScannerTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreScannerTest.php
@@ -14,9 +14,7 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\Storage\IStorage;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ObjectStoreScannerTest extends TestCase {
 	private IStorage $storage;
 	private ICache $cache;

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -15,9 +15,7 @@ use OCP\Constants;
 use OCP\Files\ObjectStore\IObjectStore;
 use Test\Files\Storage\Storage;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ObjectStoreStorageTest extends Storage {
 	/** @var ObjectStoreStorageOverwrite */
 	protected $instance;

--- a/tests/lib/Files/ObjectStore/ObjectStoreStoragesDifferentBucketTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStoragesDifferentBucketTest.php
@@ -13,9 +13,7 @@ use OC\Files\Storage\Temporary;
 use OCP\Files\ObjectStore\IObjectStore;
 use Test\Files\Storage\StoragesTestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ObjectStoreStoragesDifferentBucketTest extends StoragesTestCase {
 	/**
 	 * @var IObjectStore

--- a/tests/lib/Files/ObjectStore/ObjectStoreStoragesSameBucketTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStoragesSameBucketTest.php
@@ -13,9 +13,7 @@ use OC\Files\Storage\Temporary;
 use OCP\Files\ObjectStore\IObjectStore;
 use Test\Files\Storage\StoragesTestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ObjectStoreStoragesSameBucketTest extends StoragesTestCase {
 	/**
 	 * @var IObjectStore

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -44,9 +44,7 @@ class NonSeekableStream extends Wrapper {
 	}
 }
 
-/**
- * @group PRIMARY-s3
- */
+#[\PHPUnit\Framework\Attributes\Group('PRIMARY-s3')]
 class S3Test extends ObjectStoreTestCase {
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Files/ObjectStore/SwiftTest.php
+++ b/tests/lib/Files/ObjectStore/SwiftTest.php
@@ -13,9 +13,7 @@ use OCP\Files\ObjectStore\IObjectStore;
 use OCP\IConfig;
 use OCP\Server;
 
-/**
- * @group PRIMARY-swift
- */
+#[\PHPUnit\Framework\Attributes\Group('PRIMARY-swift')]
 class SwiftTest extends ObjectStoreTestCase {
 	/**
 	 * @return IObjectStore

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -17,10 +17,10 @@ use OCP\Server;
 /**
  * Class PathVerificationTest
  *
- * @group DB
  *
  * @package Test\Files
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PathVerificationTest extends \Test\TestCase {
 	/**
 	 * @var View

--- a/tests/lib/Files/Search/QueryOptimizer/CombinedTests.php
+++ b/tests/lib/Files/Search/QueryOptimizer/CombinedTests.php
@@ -14,6 +14,9 @@ use OCP\Files\Search\ISearchComparison;
 use Test\TestCase;
 
 class CombinedTests extends TestCase {
+	public function __construct() {
+		parent::__construct(static::class);
+	}
 	private QueryOptimizer $optimizer;
 
 	protected function setUp(): void {

--- a/tests/lib/Files/Search/SearchIntegrationTest.php
+++ b/tests/lib/Files/Search/SearchIntegrationTest.php
@@ -14,9 +14,7 @@ use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SearchIntegrationTest extends TestCase {
 	private $cache;
 	private $storage;

--- a/tests/lib/Files/SimpleFS/SimpleFolderTest.php
+++ b/tests/lib/Files/SimpleFS/SimpleFolderTest.php
@@ -16,9 +16,7 @@ use OCP\Files\SimpleFS\ISimpleFolder;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SimpleFolderTest extends \Test\TestCase {
 	use MountProviderTrait;
 	use UserTrait;

--- a/tests/lib/Files/Storage/CommonTest.php
+++ b/tests/lib/Files/Storage/CommonTest.php
@@ -21,10 +21,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class CommonTest
  *
- * @group DB
  *
  * @package Test\Files\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CommonTest extends Storage {
 
 	private string $tmpDir;

--- a/tests/lib/Files/Storage/CopyDirectoryTest.php
+++ b/tests/lib/Files/Storage/CopyDirectoryTest.php
@@ -27,10 +27,10 @@ class CopyDirectoryStorage extends StorageNoRecursiveCopy {
 /**
  * Class CopyDirectoryTest
  *
- * @group DB
  *
  * @package Test\Files\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CopyDirectoryTest extends Storage {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Files/Storage/HomeTest.php
+++ b/tests/lib/Files/Storage/HomeTest.php
@@ -37,10 +37,10 @@ class DummyUser extends User {
 /**
  * Class Home
  *
- * @group DB
  *
  * @package Test\Files\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HomeTest extends Storage {
 	/**
 	 * @var string tmpDir

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -19,10 +19,10 @@ use OCP\Server;
 /**
  * Class LocalTest
  *
- * @group DB
  *
  * @package Test\Files\Storage
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LocalTest extends Storage {
 	/**
 	 * @var string tmpDir

--- a/tests/lib/Files/Storage/Wrapper/KnownMtimeTest.php
+++ b/tests/lib/Files/Storage/Wrapper/KnownMtimeTest.php
@@ -13,9 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Clock\ClockInterface;
 use Test\Files\Storage\Storage;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class KnownMtimeTest extends Storage {
 	/** @var Temporary */
 	private $sourceStorage;

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -14,9 +14,7 @@ use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\Constants;
 use OCP\Files\Cache\IScanner;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 	/**
 	 * @var Temporary

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -19,10 +19,10 @@ use OCP\Server;
 /**
  * Class QuotaTest
  *
- * @group DB
  *
  * @package Test\Files\Storage\Wrapper
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class QuotaTest extends \Test\Files\Storage\Storage {
 	/**
 	 * @var string tmpDir

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -43,10 +43,10 @@ class TestScanner extends Scanner {
 /**
  * Class ScannerTest
  *
- * @group DB
  *
  * @package Test\Files\Utils
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ScannerTest extends \Test\TestCase {
 	/**
 	 * @var \Test\Util\User\Dummy

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -93,6 +93,7 @@ class TestEventHandler {
  *
  * @package Test\Files
  */
+#[\PHPUnit\Framework\Attributes\Medium]
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class ViewTest extends \Test\TestCase {
 	use UserTrait;
@@ -172,9 +173,6 @@ class ViewTest extends \Test\TestCase {
 		parent::tearDown();
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testCacheAPI(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -255,9 +253,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals([], $rootView->getDirectoryContent('/non/existing'));
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testGetPath(): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
@@ -307,9 +302,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertNull($folderView->getPath($id1));
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testMountPointOverwrite(): void {
 		$storage1 = $this->getTestStorage(false);
 		$storage2 = $this->getTestStorage();
@@ -391,9 +383,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals($textSize, $folderData[0]['size']);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testSearch(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -441,9 +430,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertCount(3, $folderView->searchByMime('text'));
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testWatcher(): void {
 		$storage1 = $this->getTestStorage();
 		Filesystem::mount($storage1, [], '/');
@@ -462,27 +448,18 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals(3, $cachedData['size']);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testCopyBetweenStorageNoCross(): void {
 		$storage1 = $this->getTestStorage(true, TemporaryNoCross::class);
 		$storage2 = $this->getTestStorage(true, TemporaryNoCross::class);
 		$this->copyBetweenStorages($storage1, $storage2);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testCopyBetweenStorageCross(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
 		$this->copyBetweenStorages($storage1, $storage2);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testCopyBetweenStorageCrossNonLocal(): void {
 		$storage1 = $this->getTestStorage(true, TemporaryNoLocal::class);
 		$storage2 = $this->getTestStorage(true, TemporaryNoLocal::class);
@@ -508,27 +485,18 @@ class ViewTest extends \Test\TestCase {
 		$this->assertTrue($rootView->file_exists('/substorage/folder/bar.txt'));
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testMoveBetweenStorageNoCross(): void {
 		$storage1 = $this->getTestStorage(true, TemporaryNoCross::class);
 		$storage2 = $this->getTestStorage(true, TemporaryNoCross::class);
 		$this->moveBetweenStorages($storage1, $storage2);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testMoveBetweenStorageCross(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
 		$this->moveBetweenStorages($storage1, $storage2);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testMoveBetweenStorageCrossNonLocal(): void {
 		$storage1 = $this->getTestStorage(true, TemporaryNoLocal::class);
 		$storage2 = $this->getTestStorage(true, TemporaryNoLocal::class);
@@ -549,9 +517,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertTrue($rootView->file_exists('anotherfolder/bar.txt'));
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testUnlink(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -593,9 +558,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertFalse($rootView->file_exists('sub'));
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testUnlinkRootMustFail(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -612,9 +574,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertFalse($rootView->unlink('/substorage'));
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testTouch(): void {
 		$storage = $this->getTestStorage(true, TemporaryNoTouch::class);
 
@@ -636,9 +595,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals($cachedData['storage_mtime'], $cachedData['mtime']);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testTouchFloat(): void {
 		$storage = $this->getTestStorage(true, TemporaryNoTouch::class);
 
@@ -653,9 +609,6 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals(500, $cachedData['mtime']);
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testViewHooks(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -719,9 +672,6 @@ class ViewTest extends \Test\TestCase {
 		return $storage;
 	}
 
-	/**
-	 * @medium
-	 */
 	public function testViewHooksIfRootStartsTheSame(): void {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -90,10 +90,10 @@ class TestEventHandler {
 /**
  * Class ViewTest
  *
- * @group DB
  *
  * @package Test\Files
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ViewTest extends \Test\TestCase {
 	use UserTrait;
 

--- a/tests/lib/FilesMetadata/FilesMetadataManagerTest.php
+++ b/tests/lib/FilesMetadata/FilesMetadataManagerTest.php
@@ -26,9 +26,7 @@ use Test\TestCase;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FilesMetadataManagerTest extends TestCase {
 	use UserTrait;
 	use MountProviderTrait;
@@ -49,7 +47,7 @@ class FilesMetadataManagerTest extends TestCase {
 
 		$this->jobList = $this->createMock(JobList::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
-		$this->eventDispatcher->method('dispatchTyped')->willReturnCallback(function (Event $event) {
+		$this->eventDispatcher->method('dispatchTyped')->willReturnCallback(function (Event $event): void {
 			if ($event instanceof AMetadataEvent) {
 				$name = $event->getNode()->getName();
 				if (isset($this->metadata[$name])) {

--- a/tests/lib/Group/Backend.php
+++ b/tests/lib/Group/Backend.php
@@ -10,9 +10,8 @@ namespace Test\Group;
 
 /**
  * Class Backend
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 abstract class Backend extends \Test\TestCase {
 	/**
 	 * @var \OC\Group\Backend $backend

--- a/tests/lib/Group/DatabaseTest.php
+++ b/tests/lib/Group/DatabaseTest.php
@@ -12,9 +12,8 @@ use OC\Group\Database;
 
 /**
  * Class Database
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DatabaseTest extends Backend {
 	private $groups = [];
 

--- a/tests/lib/Group/Dummy.php
+++ b/tests/lib/Group/Dummy.php
@@ -10,10 +10,12 @@ namespace Test\Group;
 
 /**
  * Class Dummy
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class Dummy extends Backend {
+	public function __construct() {
+		parent::__construct(static::class);
+	}
 	protected function setUp(): void {
 		parent::setUp();
 		$this->backend = new \Test\Util\Group\Dummy();

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -19,9 +19,8 @@ use Test\Traits\UserTrait;
 
 /**
  * Test the storage functions of OC_Helper
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HelperStorageTest extends \Test\TestCase {
 	use UserTrait;
 

--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -172,9 +172,7 @@ class ImageTest extends \Test\TestCase {
 		$this->assertNull($img->data());
 	}
 
-	/**
-	 * @depends testData
-	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testData')]
 	public function testToString(): void {
 		$img = new Image();
 		$img->loadFromFile(OC::$SERVERROOT . '/tests/data/testimage.png');

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -14,9 +14,9 @@ use OCP\Server;
 /**
  * Class InfoXmlTest
  *
- * @group DB
  * @package Test
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class InfoXmlTest extends TestCase {
 	private IAppManager $appManager;
 

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -25,8 +25,8 @@ use Psr\Log\LoggerInterface;
  * Class InstallerTest
  *
  * @package Test
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class InstallerTest extends TestCase {
 	private static $appid = 'testapp';
 	private $appstore;

--- a/tests/lib/Lock/DBLockingProviderTest.php
+++ b/tests/lib/Lock/DBLockingProviderTest.php
@@ -17,10 +17,10 @@ use OCP\Server;
 /**
  * Class DBLockingProvider
  *
- * @group DB
  *
  * @package Test\Lock
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DBLockingProviderTest extends LockingProvider {
 	/**
 	 * @var \OC\Lock\DBLockingProvider

--- a/tests/lib/Lock/NonCachingDBLockingProviderTest.php
+++ b/tests/lib/Lock/NonCachingDBLockingProviderTest.php
@@ -13,10 +13,9 @@ use OCP\Lock\ILockingProvider;
 use OCP\Server;
 
 /**
- * @group DB
- *
  * @package Test\Lock
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class NonCachingDBLockingProviderTest extends DBLockingProviderTest {
 	/**
 	 * @return ILockingProvider

--- a/tests/lib/Lockdown/Filesystem/NoFSTest.php
+++ b/tests/lib/Lockdown/Filesystem/NoFSTest.php
@@ -14,9 +14,7 @@ use OCP\Authentication\Token\IToken;
 use OCP\Server;
 use Test\Traits\UserTrait;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class NoFSTest extends \Test\TestCase {
 	use UserTrait;
 

--- a/tests/lib/Memcache/APCuTest.php
+++ b/tests/lib/Memcache/APCuTest.php
@@ -10,10 +10,8 @@ namespace Test\Memcache;
 
 use OC\Memcache\APCu;
 
-/**
- * @group Memcache
- * @group APCu
- */
+#[\PHPUnit\Framework\Attributes\Group('Memcache')]
+#[\PHPUnit\Framework\Attributes\Group('APCu')]
 class APCuTest extends Cache {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Memcache/ArrayCacheTest.php
+++ b/tests/lib/Memcache/ArrayCacheTest.php
@@ -10,9 +10,7 @@ namespace Test\Memcache;
 
 use OC\Memcache\ArrayCache;
 
-/**
- * @group Memcache
- */
+#[\PHPUnit\Framework\Attributes\Group('Memcache')]
 class ArrayCacheTest extends Cache {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Memcache/CasTraitTest.php
+++ b/tests/lib/Memcache/CasTraitTest.php
@@ -11,9 +11,7 @@ namespace Test\Memcache;
 use OC\Memcache\ArrayCache;
 use Test\TestCase;
 
-/**
- * @group Memcache
- */
+#[\PHPUnit\Framework\Attributes\Group('Memcache')]
 class CasTraitTest extends TestCase {
 	/**
 	 * @return \OC\Memcache\CasTrait

--- a/tests/lib/Memcache/FactoryTest.php
+++ b/tests/lib/Memcache/FactoryTest.php
@@ -51,9 +51,7 @@ class Test_Factory_Unavailable_Cache2 extends NullCache {
 	}
 }
 
-/**
- * @group Memcache
- */
+#[\PHPUnit\Framework\Attributes\Group('Memcache')]
 class FactoryTest extends \Test\TestCase {
 	public const AVAILABLE1 = '\\Test\\Memcache\\Test_Factory_Available_Cache1';
 	public const AVAILABLE2 = '\\Test\\Memcache\\Test_Factory_Available_Cache2';

--- a/tests/lib/Memcache/MemcachedTest.php
+++ b/tests/lib/Memcache/MemcachedTest.php
@@ -10,10 +10,8 @@ namespace Test\Memcache;
 
 use OC\Memcache\Memcached;
 
-/**
- * @group Memcache
- * @group Memcached
- */
+#[\PHPUnit\Framework\Attributes\Group('Memcache')]
+#[\PHPUnit\Framework\Attributes\Group('Memcached')]
 class MemcachedTest extends Cache {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();

--- a/tests/lib/Memcache/RedisTest.php
+++ b/tests/lib/Memcache/RedisTest.php
@@ -12,10 +12,8 @@ use OC\Memcache\Redis;
 use OCP\IConfig;
 use OCP\Server;
 
-/**
- * @group Memcache
- * @group Redis
- */
+#[\PHPUnit\Framework\Attributes\Group('Memcache')]
+#[\PHPUnit\Framework\Attributes\Group('Redis')]
 class RedisTest extends Cache {
 	/**
 	 * @var Redis cache;

--- a/tests/lib/Preview/BackgroundCleanupJobTest.php
+++ b/tests/lib/Preview/BackgroundCleanupJobTest.php
@@ -25,10 +25,10 @@ use Test\Traits\UserTrait;
 /**
  * Class BackgroundCleanupJobTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class BackgroundCleanupJobTest extends \Test\TestCase {
 	use MountProviderTrait;
 	use UserTrait;

--- a/tests/lib/Preview/BitmapTest.php
+++ b/tests/lib/Preview/BitmapTest.php
@@ -13,10 +13,10 @@ use OC\Preview\Postscript;
 /**
  * Class BitmapTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class BitmapTest extends Provider {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Preview/HEICTest.php
+++ b/tests/lib/Preview/HEICTest.php
@@ -12,10 +12,10 @@ use OC\Preview\HEIC;
 /**
  * Class BitmapTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HEICTest extends Provider {
 	protected function setUp(): void {
 		if (!in_array('HEIC', \Imagick::queryFormats('HEI*'))) {

--- a/tests/lib/Preview/ImageTest.php
+++ b/tests/lib/Preview/ImageTest.php
@@ -13,10 +13,10 @@ use OC\Preview\JPEG;
 /**
  * Class ImageTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ImageTest extends Provider {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Preview/MP3Test.php
+++ b/tests/lib/Preview/MP3Test.php
@@ -13,10 +13,10 @@ use OC\Preview\MP3;
 /**
  * Class MP3Test
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MP3Test extends Provider {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Preview/MovePreviewJobTest.php
+++ b/tests/lib/Preview/MovePreviewJobTest.php
@@ -29,9 +29,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MovePreviewJobTest extends TestCase {
 	private IAppData $previewAppData;
 	private PreviewMapper $previewMapper;

--- a/tests/lib/Preview/MovieBrokenStuckFfmpegTest.php
+++ b/tests/lib/Preview/MovieBrokenStuckFfmpegTest.php
@@ -11,10 +11,10 @@ namespace Test\Preview;
 /**
  * Class MovieTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MovieBrokenStuckFfmpegTest extends MovieTest {
 	protected string $fileName = 'broken-video.webm';
 }

--- a/tests/lib/Preview/MovieTest.php
+++ b/tests/lib/Preview/MovieTest.php
@@ -15,10 +15,10 @@ use OCP\Server;
 /**
  * Class MovieTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MovieTest extends Provider {
 	protected string $fileName = 'testimage.mp4';
 	protected int $width = 560;

--- a/tests/lib/Preview/MovieTestRemoteFile.php
+++ b/tests/lib/Preview/MovieTestRemoteFile.php
@@ -18,11 +18,14 @@ use OCP\Server;
 /**
  * Class MovieTestRemoteFile
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class MovieTestRemoteFile extends Provider {
+	public function __construct() {
+		parent::__construct(static::class);
+	}
 	// 1080p (1920x1080) 30 FPS HEVC/H264, 10 secs, avg. bitrate: ~10 Mbps
 	protected string $fileName = 'testvideo-remote-file.mp4';
 	protected int $width = 1920;

--- a/tests/lib/Preview/OfficeTest.php
+++ b/tests/lib/Preview/OfficeTest.php
@@ -15,10 +15,10 @@ use OCP\Server;
 /**
  * Class OfficeTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class OfficeTest extends Provider {
 	protected function setUp(): void {
 		$binaryFinder = Server::get(IBinaryFinder::class);

--- a/tests/lib/Preview/PreviewMapperTest.php
+++ b/tests/lib/Preview/PreviewMapperTest.php
@@ -16,9 +16,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PreviewMapperTest extends TestCase {
 	private PreviewMapper $previewMapper;
 	private IDBConnection $connection;

--- a/tests/lib/Preview/PreviewServiceTest.php
+++ b/tests/lib/Preview/PreviewServiceTest.php
@@ -17,10 +17,8 @@ use OCP\Server;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group DB
- */
 #[CoversClass(PreviewService::class)]
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PreviewServiceTest extends TestCase {
 	private PreviewService $previewService;
 	private PreviewMapper $previewMapper;

--- a/tests/lib/Preview/Provider.php
+++ b/tests/lib/Preview/Provider.php
@@ -72,12 +72,12 @@ abstract class Provider extends \Test\TestCase {
 	/**
 	 * Launches all the tests we have
 	 *
-	 * @requires extension imagick
 	 *
 	 * @param int $widthAdjustment
 	 * @param int $heightAdjustment
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dimensionsDataProvider')]
+	#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('imagick')]
 	public function testGetThumbnail($widthAdjustment, $heightAdjustment): void {
 		$ratio = round($this->width / $this->height, 2);
 		$this->maxWidth = $this->width - $widthAdjustment;

--- a/tests/lib/Preview/SVGTest.php
+++ b/tests/lib/Preview/SVGTest.php
@@ -14,10 +14,10 @@ use OCP\Files\File;
 /**
  * Class SVGTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SVGTest extends Provider {
 	protected function setUp(): void {
 		$checkImagick = new \Imagick();
@@ -45,10 +45,8 @@ class SVGTest extends Provider {
 		];
 	}
 
-	/**
-	 * @requires extension imagick
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetThumbnailSVGHref')]
+	#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('imagick')]
 	public function testGetThumbnailSVGHref(string $content): void {
 		$handle = fopen('php://temp', 'w+');
 		fwrite($handle, '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">

--- a/tests/lib/Preview/TXTTest.php
+++ b/tests/lib/Preview/TXTTest.php
@@ -13,10 +13,10 @@ use OC\Preview\TXT;
 /**
  * Class TXTTest
  *
- * @group DB
  *
  * @package Test\Preview
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class TXTTest extends Provider {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Repair/CleanTagsTest.php
+++ b/tests/lib/Repair/CleanTagsTest.php
@@ -19,10 +19,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Tests for the cleaning the tags tables
  *
- * @group DB
  *
  * @see \OC\Repair\CleanTags
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CleanTagsTest extends \Test\TestCase {
 
 	private ?int $createdFile = null;

--- a/tests/lib/Repair/OldGroupMembershipSharesTest.php
+++ b/tests/lib/Repair/OldGroupMembershipSharesTest.php
@@ -19,10 +19,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class OldGroupMembershipSharesTest
  *
- * @group DB
  *
  * @package Test\Repair
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class OldGroupMembershipSharesTest extends \Test\TestCase {
 
 	private IDBConnection $connection;

--- a/tests/lib/Repair/Owncloud/UpdateLanguageCodesTest.php
+++ b/tests/lib/Repair/Owncloud/UpdateLanguageCodesTest.php
@@ -19,10 +19,10 @@ use Test\TestCase;
 /**
  * Class UpdateLanguageCodesTest
  *
- * @group DB
  *
  * @package Test\Repair
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UpdateLanguageCodesTest extends TestCase {
 
 	protected IDBConnection $connection;

--- a/tests/lib/Repair/RepairCollationTest.php
+++ b/tests/lib/Repair/RepairCollationTest.php
@@ -31,10 +31,10 @@ class TestCollationRepair extends Collation {
 /**
  * Tests for the converting of MySQL tables to InnoDB engine
  *
- * @group DB
  *
  * @see \OC\Repair\RepairMimeTypes
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RepairCollationTest extends TestCase {
 
 	private TestCollationRepair $repair;

--- a/tests/lib/Repair/RepairInvalidSharesTest.php
+++ b/tests/lib/Repair/RepairInvalidSharesTest.php
@@ -20,10 +20,10 @@ use Test\TestCase;
 /**
  * Tests for repairing invalid shares
  *
- * @group DB
  *
  * @see \OC\Repair\RepairInvalidShares
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RepairInvalidSharesTest extends TestCase {
 
 	private RepairInvalidShares $repair;

--- a/tests/lib/Repair/RepairMimeTypesTest.php
+++ b/tests/lib/Repair/RepairMimeTypesTest.php
@@ -20,10 +20,10 @@ use OCP\Server;
 /**
  * Tests for the converting of legacy storages to home storages.
  *
- * @group DB
  *
  * @see \OC\Repair\RepairMimeTypes
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RepairMimeTypesTest extends \Test\TestCase {
 
 	private RepairMimeTypes $repair;

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -21,10 +21,10 @@ use Test\TestCase;
 /**
  * Class RouterTest
  *
- * @group RoutingWeirdness
  *
  * @package Test\Route
  */
+#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 class RouterTest extends TestCase {
 	private Router $router;
 	private IAppManager&MockObject $appManager;

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -25,9 +25,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Class CertificateManagerTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CertificateManagerTest extends \Test\TestCase {
 	use \Test\Traits\UserTrait;
 	use \Test\Traits\MountProviderTrait;

--- a/tests/lib/Security/CredentialsManagerTest.php
+++ b/tests/lib/Security/CredentialsManagerTest.php
@@ -13,9 +13,7 @@ namespace Test\Security;
 use OCP\Security\ICredentialsManager;
 use OCP\Server;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CredentialsManagerTest extends \Test\TestCase {
 	#[\PHPUnit\Framework\Attributes\DataProvider('credentialsProvider')]
 	public function testWithDB($userId, $identifier): void {

--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -16,10 +16,10 @@ use OCP\Comments\ICommentsManager;
 /**
  * Class Server
  *
- * @group DB
  *
  * @package Test
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ServerTest extends \Test\TestCase {
 	/** @var Server */
 	protected $server;

--- a/tests/lib/Share/HelperTest.php
+++ b/tests/lib/Share/HelperTest.php
@@ -10,10 +10,7 @@ namespace Test\Share;
 
 use OC\Share\Helper;
 
-/**
- * @group DB
- * Class Helper
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HelperTest extends \Test\TestCase {
 	public static function expireDateProvider(): array {
 		return [

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -21,9 +21,8 @@ use OCP\Server;
 
 /**
  * Class Test_Share
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ShareTest extends \Test\TestCase {
 	protected $itemType;
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -41,8 +41,8 @@ use Psr\Log\LoggerInterface;
  * Class DefaultShareProviderTest
  *
  * @package Test\Share20
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DefaultShareProviderTest extends \Test\TestCase {
 	/** @var IDBConnection */
 	protected $dbConn;

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -74,8 +74,8 @@ class DummyShareManagerListener {
  * Class ManagerTest
  *
  * @package Test\Share20
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends \Test\TestCase {
 	/** @var Manager */
 	protected $manager;

--- a/tests/lib/Share20/ShareByMailProviderTest.php
+++ b/tests/lib/Share20/ShareByMailProviderTest.php
@@ -35,8 +35,8 @@ use Test\Traits\EmailValidatorTrait;
  * Class ShareByMailProviderTest
  *
  * @package Test\Share20
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ShareByMailProviderTest extends TestCase {
 	use EmailValidatorTrait;
 

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -19,9 +19,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SubAdminTest extends \Test\TestCase {
 	/** @var IUserManager */
 	private $userManager;

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -26,9 +26,9 @@ use Test\TestCase;
 /**
  * Class TestSystemTagManager
  *
- * @group DB
  * @package Test\SystemTag
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SystemTagManagerTest extends TestCase {
 	private ISystemTagManager $tagManager;
 	private IDBConnection $connection;

--- a/tests/lib/SystemTag/SystemTagObjectMapperTest.php
+++ b/tests/lib/SystemTag/SystemTagObjectMapperTest.php
@@ -26,9 +26,9 @@ use Test\TestCase;
 /**
  * Class TestSystemTagObjectMapper
  *
- * @group DB
  * @package Test\SystemTag
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SystemTagObjectMapperTest extends TestCase {
 	/**
 	 * @var ISystemTagManager

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -24,9 +24,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Class TagsTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class TagsTest extends \Test\TestCase {
 	protected $objectType;
 	/** @var IUser */
@@ -269,9 +268,7 @@ class TagsTest extends \Test\TestCase {
 		$this->assertEquals(9, count($tagger->getIdsForTag('Family')));
 	}
 
-	/**
-	 * @depends testTagAs
-	 */
+	#[\PHPUnit\Framework\Attributes\Depends('testTagAs')]
 	public function testUnTag(): void {
 		$objIds = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 

--- a/tests/lib/TaskProcessing/TaskProcessingTest.php
+++ b/tests/lib/TaskProcessing/TaskProcessingTest.php
@@ -570,9 +570,7 @@ class ConflictingExternalTaskType implements ITaskType {
 	}
 }
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class TaskProcessingTest extends \Test\TestCase {
 	private IManager $manager;
 	private Coordinator $coordinator;

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -10,7 +10,9 @@ namespace Test;
 
 use DOMDocument;
 use DOMNode;
+use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\Command\QueueBus;
+use OC\Files\AppData\Factory;
 use OC\Files\Cache\Storage;
 use OC\Files\Config\MountProviderCollection;
 use OC\Files\Filesystem;
@@ -20,7 +22,9 @@ use OC\Files\Mount\RootMountProvider;
 use OC\Files\ObjectStore\PrimaryObjectStoreConfig;
 use OC\Files\SetupManager;
 use OC\Files\View;
+use OC\Installer;
 use OC\Template\Base;
+use OC\Updater;
 use OCP\AppFramework\QueryException;
 use OCP\Command\IBus;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -338,10 +342,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		self::tearDownAfterClassCleanStrayLocks();
 
 		// Ensure we start with fresh instances of some classes to reduce side-effects between tests
-		unset(\OC::$server[\OC\Files\AppData\Factory::class]);
-		unset(\OC::$server[\OC\App\AppStore\Fetcher\AppFetcher::class]);
-		unset(\OC::$server[\OC\Installer::class]);
-		unset(\OC::$server[\OC\Updater::class]);
+		unset(\OC::$server[Factory::class]);
+		unset(\OC::$server[AppFetcher::class]);
+		unset(\OC::$server[Installer::class]);
+		unset(\OC::$server[Updater::class]);
 
 		/** @var SetupManager $setupManager */
 		$setupManager = Server::get(SetupManager::class);

--- a/tests/lib/TextProcessing/TextProcessingTest.php
+++ b/tests/lib/TextProcessing/TextProcessingTest.php
@@ -88,9 +88,7 @@ class FreePromptProvider implements IProvider {
 	}
 }
 
-/**
- * @group DB
- */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class TextProcessingTest extends \Test\TestCase {
 	private IManager $manager;
 	private Coordinator $coordinator;

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -69,7 +69,6 @@ class UrlGeneratorTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @small
 	 * test linkTo URL construction
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('provideDocRootAppUrlParts')]
@@ -80,7 +79,6 @@ class UrlGeneratorTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @small
 	 * test linkTo URL construction in sub directory
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('provideSubDirAppUrlParts')]
@@ -131,7 +129,6 @@ class UrlGeneratorTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @small
 	 * test absolute URL construction
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('provideDocRootURLs')]
@@ -143,7 +140,6 @@ class UrlGeneratorTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @small
 	 * test absolute URL construction
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('provideSubDirURLs')]

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -18,9 +18,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class DatabaseTest
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DatabaseTest extends Backend {
 	/** @var array */
 	private $users;

--- a/tests/lib/User/Dummy.php
+++ b/tests/lib/User/Dummy.php
@@ -9,6 +9,9 @@
 namespace Test\User;
 
 class Dummy extends Backend {
+	public function __construct() {
+		parent::__construct(static::class);
+	}
 	protected function setUp(): void {
 		parent::setUp();
 		$this->backend = new \Test\Util\User\Dummy();

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -26,10 +26,10 @@ use Test\TestCase;
 /**
  * Class ManagerTest
  *
- * @group DB
  *
  * @package Test\User
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends TestCase {
 	/** @var IConfig */
 	private $config;
@@ -694,10 +694,8 @@ class ManagerTest extends TestCase {
 		$user4->delete();
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
+	#[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+	#[\PHPUnit\Framework\Attributes\PreserveGlobalState(enabled: false)]
 	public function testRecentlyActive(): void {
 		$config = Server::get(IConfig::class);
 		$manager = Server::get(IUserManager::class);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -42,9 +42,9 @@ use function array_diff;
 use function get_class_methods;
 
 /**
- * @group DB
  * @package Test\User
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SessionTest extends \Test\TestCase {
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -30,10 +30,10 @@ use Test\TestCase;
 /**
  * Class UserTest
  *
- * @group DB
  *
  * @package Test\User
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UserTest extends TestCase {
 	/** @var IEventDispatcher|MockObject */
 	protected $dispatcher;

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -16,9 +16,8 @@ use OCP\Util;
 
 /**
  * Tests for server check functions
- *
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UtilCheckServerTest extends \Test\TestCase {
 	private $datadir;
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -20,8 +20,8 @@ use OCP\Util;
  * Class UtilTest
  *
  * @package Test
- * @group DB
  */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UtilTest extends \Test\TestCase {
 	public function testGetVersion(): void {
 		$version = Util::getVersion();

--- a/vendor-bin/cs-fixer/composer.json
+++ b/vendor-bin/cs-fixer/composer.json
@@ -2,7 +2,7 @@
 	"config": {
 		"sort-packages": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.2"
 		}
 	},
 	"require": {

--- a/vendor-bin/cs-fixer/composer.lock
+++ b/vendor-bin/cs-fixer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "427da07c086c9f916d995f88b29aba1b",
+    "content-hash": "8cbbdb84c616b60e794c2dbc79430b55",
     "packages": [
         {
             "name": "kubawerlos/php-cs-fixer-custom-fixers",
@@ -159,13 +159,13 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/vendor-bin/openapi-extractor/composer.json
+++ b/vendor-bin/openapi-extractor/composer.json
@@ -2,7 +2,7 @@
 	"config": {
 		"sort-packages": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.2"
 		}
 	},
 	"require": {

--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23c96ff7007b72dfd2bbe9cbf35a2843",
+    "content-hash": "3ff765a37b9cd42a699a884d4ca86687",
     "packages": [
         {
             "name": "adhocore/cli",
@@ -241,7 +241,7 @@
     "platform": {},
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -1,11 +1,11 @@
 {
-    "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "8.1"
-        }
-    },
-    "require": {
-        "phpunit/phpunit": "^10.5.35"
-    }
+	"config": {
+		"sort-packages": true,
+		"platform": {
+			"php": "8.2"
+		}
+	},
+	"require": {
+		"phpunit/phpunit": "^10.5.35"
+	}
 }

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc73ab48735180a776db9ff4490049a1",
+    "content-hash": "fe499dcaa1d3271e1c594fa83044161b",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -1634,13 +1634,13 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,13 +1,13 @@
 {
-    "require": {
-        "vimeo/psalm": "^5.9"
-    },
-    "config": {
-        "platform": {
-            "php": "8.1"
-        },
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true
-        }
-    }
+	"require": {
+		"vimeo/psalm": "^5.9"
+	},
+	"config": {
+		"platform": {
+			"php": "8.2"
+		},
+		"allow-plugins": {
+			"composer/package-versions-deprecated": true
+		}
+	}
 }

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "686c83ce8e622abe36a4790642b55ebe",
+    "content-hash": "3c3342f1efd61cbab152269740efd448",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2091,13 +2091,13 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -1,6 +1,11 @@
 {
-    "require-dev": {
-        "rector/rector": "^2.0",
-        "nextcloud/rector": "^0.4.1"
-    }
+	"require-dev": {
+		"rector/rector": "^2.0",
+		"nextcloud/rector": "^0.4.1"
+	},
+	"config": {
+		"platform": {
+			"php": "8.2"
+		}
+	}
 }

--- a/vendor-bin/rector/composer.lock
+++ b/vendor-bin/rector/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "347262bc75027c88fa21b011f732aa31",
+    "content-hash": "95ec45e01b8b0c2e38a68797676d1673",
     "packages": [],
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "v31.0.4",
+            "version": "v32.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "1fb984268039921920ade298ef5a58e8fe3de7da"
+                "reference": "f25b267f759f10e5aad18ed15f14b9881df5652d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1fb984268039921920ade298ef5a58e8fe3de7da",
-                "reference": "1fb984268039921920ade298ef5a58e8fe3de7da",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f25b267f759f10e5aad18ed15f14b9881df5652d",
+                "reference": "f25b267f759f10e5aad18ed15f14b9881df5652d",
                 "shasum": ""
             },
             "require": {
@@ -31,7 +31,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable31": "31.0.0-dev"
+                    "dev-stable32": "32.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -51,9 +51,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/v31.0.4"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/v32.0.0"
             },
-            "time": "2025-04-15T00:50:16+00:00"
+            "time": "2025-09-16T00:45:44+00:00"
         },
         {
             "name": "nextcloud/rector",
@@ -436,28 +436,28 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
+                "reference": "541057574806f942c94662b817a50f63f7345360"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/541057574806f942c94662b817a50f63f7345360",
+                "reference": "541057574806f942c94662b817a50f63f7345360",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
                 "php": "^7.2 || ^8.0"
             },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
             },
             "type": "library",
             "extra": {
@@ -488,9 +488,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.0"
             },
-            "time": "2022-06-03T18:03:27+00:00"
+            "time": "2025-10-20T12:43:39+00:00"
         }
     ],
     "aliases": [],
@@ -500,5 +500,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
* preparation for [PHPUnit 11](https://github.com/nextcloud/server/pull/55870)

## Summary

Apply rector rules for PHPUnit 10, meaning resolving deprecation in v10 so the transit to v11 will be smoother.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
