### PR TITLE
docs: avoid indention error in converted config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -51,7 +51,7 @@ $CONFIG = [
 	 * all your passwords. This example is for documentation only, and you should
 	 * never use it.
 	 *
-	 * @deprecated This salt is deprecated and only used for legacy-compatibility,
+	 * @deprecated 9.0.0 This salt is deprecated and only used for legacy-compatibility,
 	 * developers should *NOT* use this value for anything nowadays.
 	 */
 	'passwordsalt' => '',
@@ -1580,7 +1580,8 @@ $CONFIG = [
 	 * Sort groups in the user settings by name instead of the user count
 	 *
 	 * By enabling this, the user count beside the group name is disabled as well.
-	 * @deprecated since Nextcloud 29 - Use the frontend instead or set the app config value ``group.sortBy`` for ``core`` to ``2``
+	 *
+	 * @deprecated 29.0.0 Use the frontend instead or set the app config value ``group.sortBy`` for ``core`` to ``2``
 	 */
 	'sort_groups_by_name' => false,
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2370,7 +2370,8 @@ $CONFIG = [
 	/**
 	 * Allow creation of external storages of type "Local" via the web interface and
 	 * APIs. When disabled, local storages can still be created using the occ command::
-	 *   occ files_external:create /mountpoint local null::null -c datadir=/path/to/data
+	 *
+	 *      occ files_external:create /mountpoint local null::null -c datadir=/path/to/data
 	 *
 	 * Defaults to ``true``
 	 */
@@ -2530,7 +2531,8 @@ $CONFIG = [
 	/**
 	 * Set the data fingerprint for the current data served. Used by clients to
 	 * detect if a backup has been restored. Update this by running::
-	 *   occ maintenance:data-fingerprint
+	 *
+	 *      occ maintenance:data-fingerprint
 	 *
 	 * Changing or deleting this value may cause connected clients to stall until
 	 * conflicts are resolved.


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Error when building the docs:

```
reading sources... [100%] configuration_server/config_sample_php_parameters
/home/daniel/Code/nextcloud-docs/admin_manual/configuration_server/config_sample_php_parameters.rst:3644: ERROR: Unexpected indentation. [docutils]
/home/daniel/Code/nextcloud-docs/admin_manual/configuration_server/config_sample_php_parameters.rst:3890: ERROR: Unexpected indentation. [docutils]
```

Caused by:

```
Allow creation of external storages of type "Local" via the web interface and
APIs. When disabled, local storages can still be created using the occ command::
  occ files_external:create /mountpoint local null::null -c datadir=/path/to/data
```

(c.f. https://github.com/nextcloud/documentation/blob/978e27d3a47239fff6d35157770461986f046fdf/admin_manual/configuration_server/config_sample_php_parameters.rst?plain=1#L3642-L3644)

I'd also think the command is nicer as a block and easier to copy, however is it's currently causing an issue and there are also of couple of other occ references in that file using the other syntax.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
