### PR TITLE
test: adjust cypress tests for changes filter behavior

### DIFF
--- a/cypress/e2e/files/files-filtering.cy.ts
+++ b/cypress/e2e/files/files-filtering.cy.ts
@@ -149,26 +149,6 @@ describe('files: Filter in files list', { testIsolation: true }, () => {
 		getRowForFile('folder').should('be.visible')
 	})
 
-	it('keeps name filter when changing the directory', () => {
-		// All are visible by default
-		getRowForFile('folder').should('be.visible')
-		getRowForFile('file.txt').should('be.visible')
-
-		// Set up a search query
-		appNavigation.searchInput()
-			.type('folder')
-
-		// See that only the folder is visible
-		getRowForFile('folder').should('be.visible')
-		getRowForFile('file.txt').should('not.exist')
-
-		// go to that folder
-		navigateToFolder('folder')
-
-		// see that the folder is also filtered
-		getRowForFile('text.txt').should('not.exist')
-	})
-
 	it('keeps type filter when changing the directory', () => {
 		// All are visible by default
 		getRowForFile('folder').should('be.visible')
@@ -249,6 +229,31 @@ describe('files: Filter in files list', { testIsolation: true }, () => {
 		cy.findByRole('menuitemcheckbox', { name: 'Folders' })
 			.should('be.visible')
 			.and('have.attr', 'aria-checked', 'true')
+	})
+
+	/** Regression test of https://github.com/nextcloud/server/issues/53038 */
+	it('resets name filter when changing the directory', () => {
+		// All are visible by default
+		getRowForFile('folder').should('be.visible')
+		getRowForFile('file.txt').should('be.visible')
+
+		// Set up a search query
+		appNavigation.searchInput()
+			.type('folder')
+
+		// See that only the folder is visible
+		getRowForFile('folder').should('be.visible')
+		getRowForFile('file.txt').should('not.exist')
+
+		// go to that folder
+		navigateToFolder('folder')
+
+		// see the search is cleared
+		appNavigation.searchInput()
+			.should('have.value', '')
+
+		// see that the folder content is showed
+		getRowForFile('text.txt').should('be.visible')
 	})
 
 	it('resets filter when changing the view', () => {


### PR DESCRIPTION
In https://github.com/nextcloud/server/issues/53038 we changed the behavior: The filename filter is reset when changing the directory. So we need to also adjust the Cypress tests.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
