### PR TITLE
fix: Use proper userId in taskprocessing trigger tests

### DIFF
--- a/tests/lib/TaskProcessing/TaskProcessingTest.php
+++ b/tests/lib/TaskProcessing/TaskProcessingTest.php
@@ -1289,7 +1289,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		$this->manager = $this->createManagerInstance();
 
 		// Act
-		$task = new Task($externalProvider->getTaskTypeId(), ['input' => ''], 'tests', 'foobar');
+		$task = new Task($externalProvider->getTaskTypeId(), ['input' => ''], 'tests', null);
 		$this->manager->scheduleTask($task);
 	}
 
@@ -1305,12 +1305,12 @@ class TaskProcessingTest extends \Test\TestCase {
 		$this->configureEventDispatcherMock(providersToAdd: [$externalProvider]);
 		$this->manager = $this->createManagerInstance();
 
-		$task = new Task($externalProvider->getTaskTypeId(), ['input' => ''], 'tests', 'foobar');
+		$task = new Task($externalProvider->getTaskTypeId(), ['input' => ''], 'tests', null);
 		$this->manager->scheduleTask($task);
 		$this->manager->lockTask($task);
 
 		// Act
-		$task = new Task($externalProvider->getTaskTypeId(), ['input' => ''], 'tests', 'foobar');
+		$task = new Task($externalProvider->getTaskTypeId(), ['input' => ''], 'tests', null);
 		$this->manager->scheduleTask($task);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
Tries to restore green CI on 32bit tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
