### PR TITLE
fix: Fetching previews on Oracle

### DIFF
--- a/lib/private/DB/QueryBuilder/Sharded/ShardedQueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardedQueryBuilder.php
@@ -236,12 +236,16 @@ class ShardedQueryBuilder extends ExtendedQueryBuilder {
 	}
 
 	public function innerJoin($fromAlias, $join, $alias, $condition = null) {
-		$this->checkJoin($join);
+		if (is_string($join)) {
+			$this->checkJoin($join);
+		}
 		return parent::innerJoin($fromAlias, $join, $alias, $condition);
 	}
 
 	public function leftJoin($fromAlias, $join, $alias, $condition = null) {
-		$this->checkJoin($join);
+		if (is_string($join)) {
+			$this->checkJoin($join);
+		}
 		return parent::leftJoin($fromAlias, $join, $alias, $condition);
 	}
 

--- a/lib/private/Preview/PreviewService.php
+++ b/lib/private/Preview/PreviewService.php
@@ -52,7 +52,7 @@ class PreviewService {
 
 		// Previews next to each others in the database are likely in the same storage, so group them
 		while ($row = $result->fetch()) {
-			if ($lastStorageId !== $row['storage_id']) {
+			if ($lastStorageId !== (int)$row['storage_id']) {
 				if ($lastStorageId !== -1) {
 					yield ['storageId' => $lastStorageId, 'fileIds' => $fileIds];
 					$fileIds = [];

--- a/lib/private/Preview/PreviewService.php
+++ b/lib/private/Preview/PreviewService.php
@@ -34,36 +34,53 @@ class PreviewService {
 	 * @return \Generator<array{storageId: int, fileIds: int[]}>
 	 */
 	public function getAvailableFileIds(): \Generator {
-		$maxQb = $this->connection->getQueryBuilder();
-		$maxQb->select($maxQb->func()->max('id'))
-			->from($this->previewMapper->getTableName())
-			->groupBy('file_id');
+		$lastId = null;
+		while (true) {
+			$maxQb = $this->connection->getQueryBuilder();
+			$maxQb->selectAlias($maxQb->func()->max('id'), 'max_id')
+				->from($this->previewMapper->getTableName())
+				->groupBy('file_id')
+				->orderBy('max_id', 'ASC');
 
-		$qb = $this->connection->getQueryBuilder();
-		$qb->select('file_id', 'storage_id')
-			->from($this->previewMapper->getTableName())
-			->where($qb->expr()->in('id', $qb->createFunction($maxQb->getSQL())));
+			$qb = $this->connection->getQueryBuilder();
 
-		$result = $qb->executeQuery();
-
-		$lastStorageId = -1;
-		/** @var int[] $fileIds */
-		$fileIds = [];
-
-		// Previews next to each others in the database are likely in the same storage, so group them
-		while ($row = $result->fetch()) {
-			if ($lastStorageId !== (int)$row['storage_id']) {
-				if ($lastStorageId !== -1) {
-					yield ['storageId' => $lastStorageId, 'fileIds' => $fileIds];
-					$fileIds = [];
-				}
-				$lastStorageId = (int)$row['storage_id'];
+			if ($lastId !== null) {
+				$maxQb->andWhere($maxQb->expr()->gt('id', $qb->createNamedParameter($lastId)));
 			}
-			$fileIds[] = (int)$row['file_id'];
-		}
 
-		if (count($fileIds) > 0) {
-			yield ['storageId' => $lastStorageId, 'fileIds' => $fileIds];
+			$qb->select('id', 'file_id', 'storage_id')
+				->from($this->previewMapper->getTableName(), 'p1')
+				->innerJoin('p1', $qb->createFunction('(' . $maxQb->getSQL() . ')'), 'p2', $qb->expr()->eq('p1.id', 'p2.max_id'))
+				->setMaxResults(1000);
+
+			$result = $qb->executeQuery();
+
+			$lastStorageId = -1;
+			/** @var int[] $fileIds */
+			$fileIds = [];
+
+			$found = false;
+			// Previews next to each others in the database are likely in the same storage, so group them
+			while ($row = $result->fetch()) {
+				$found = true;
+				if ($lastStorageId !== (int)$row['storage_id']) {
+					if ($lastStorageId !== -1) {
+						yield ['storageId' => $lastStorageId, 'fileIds' => $fileIds];
+						$fileIds = [];
+					}
+					$lastStorageId = (int)$row['storage_id'];
+				}
+				$fileIds[] = (int)$row['file_id'];
+				$lastId = $row['id'];
+			}
+
+			if (count($fileIds) > 0) {
+				yield ['storageId' => $lastStorageId, 'fileIds' => $fileIds];
+			}
+
+			if (!$found) {
+				break;
+			}
 		}
 	}
 

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -524,7 +524,7 @@ interface IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $fromAlias The alias that points to a from clause.
-	 * @param string $join The table name to join.
+	 * @param string|IQueryFunction $join The table name to join.
 	 * @param string $alias The alias of the join table.
 	 * @param string|ICompositeExpression|null $condition The condition for the join.
 	 *
@@ -549,7 +549,7 @@ interface IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $fromAlias The alias that points to a from clause.
-	 * @param string $join The table name to join.
+	 * @param string|IQueryFunction $join The table name to join.
 	 * @param string $alias The alias of the join table.
 	 * @param string|ICompositeExpression|null $condition The condition for the join.
 	 *
@@ -600,7 +600,7 @@ interface IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $fromAlias The alias that points to a from clause.
-	 * @param string $join The table name to join.
+	 * @param string|IQueryFunction $join The table name to join.
 	 * @param string $alias The alias of the join table.
 	 * @param string|ICompositeExpression|null $condition The condition for the join.
 	 *


### PR DESCRIPTION
- resolves https://github.com/nextcloud/server/issues/53779

## Summary

We need an explicit cast on Oracle as Oracle returns number as string.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
