### PR TITLE
fix(dav): allow multiple link shares token in session

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -55,8 +55,11 @@ class Auth extends AbstractBasic {
 	 * @see https://github.com/owncloud/core/issues/13245
 	 */
 	public function isDavAuthenticated(string $username): bool {
-		return !is_null($this->session->get(self::DAV_AUTHENTICATED))
-		&& $this->session->get(self::DAV_AUTHENTICATED) === $username;
+		if (is_null($this->session->get(self::DAV_AUTHENTICATED))) {
+			return false;
+		}
+
+		return $this->session->get(self::DAV_AUTHENTICATED) === $username;
 	}
 
 	/**

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -316,7 +316,7 @@ class PublicAuthTest extends \Test\TestCase {
 			)->willReturn(false);
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
-		$this->session->method('get')->with('public_link_authenticated')->willReturn('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['42']);
 
 		$result = self::invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
 

--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -90,9 +90,15 @@ class MountPublicLinkController extends Controller {
 		}
 
 		// make sure that user is authenticated in case of a password protected link
-		$storedPassword = $share->getPassword();
-		$authenticated = $this->session->get(PublicAuth::DAV_AUTHENTICATED) === $share->getId()
+		$allowedShareIds = $this->session->get(PublicAuth::DAV_AUTHENTICATED);
+		if (!is_array($allowedShareIds)) {
+			$allowedShareIds = [];
+		}
+
+		$authenticated = in_array($share->getId(), $allowedShareIds)
 			|| $this->shareManager->checkPassword($share, $password);
+
+		$storedPassword = $share->getPassword();
 		if (!empty($storedPassword) && !$authenticated) {
 			$response = new JSONResponse(
 				['message' => 'No permission to access the share'],

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -197,7 +197,12 @@ class ShareController extends AuthPublicShareController {
 		}
 
 		// For share this was always set so it is still used in other apps
-		$this->session->set(PublicAuth::DAV_AUTHENTICATED, $this->share->getId());
+		$allowedShareIds = $this->session->get(PublicAuth::DAV_AUTHENTICATED);
+		if (!is_array($allowedShareIds)) {
+			$allowedShareIds = [];
+		}
+
+		$this->session->set(PublicAuth::DAV_AUTHENTICATED, array_merge($allowedShareIds, [$this->share->getId()]));
 	}
 
 	protected function authFailed() {

--- a/lib/public/AppFramework/AuthPublicShareController.php
+++ b/lib/public/AppFramework/AuthPublicShareController.php
@@ -158,8 +158,7 @@ abstract class AuthPublicShareController extends PublicShareController {
 		$this->session->regenerateId(true, true);
 		$response = $this->getRedirect();
 
-		$this->session->set('public_link_authenticated_token', $this->getToken());
-		$this->session->set('public_link_authenticated_password_hash', $this->getPasswordHash());
+		$this->storeTokenSession($this->getToken(), $this->getPasswordHash());
 
 		$this->authSucceeded();
 

--- a/tests/lib/AppFramework/Controller/AuthPublicShareControllerTest.php
+++ b/tests/lib/AppFramework/Controller/AuthPublicShareControllerTest.php
@@ -112,17 +112,15 @@ class AuthPublicShareControllerTest extends \Test\TestCase {
 				['public_link_authenticate_redirect', json_encode(['foo' => 'bar'])],
 			]);
 
-		$tokenSet = false;
-		$hashSet = false;
+		$tokenStored = false;
 		$this->session
 			->method('set')
-			->willReturnCallback(function ($key, $value) use (&$tokenSet, &$hashSet) {
-				if ($key === 'public_link_authenticated_token' && $value === 'token') {
-					$tokenSet = true;
-					return true;
-				}
-				if ($key === 'public_link_authenticated_password_hash' && $value === 'hash') {
-					$hashSet = true;
+			->willReturnCallback(function ($key, $value) use (&$tokenStored) {
+				if ($key === AuthPublicShareController::DAV_AUTHENTICATED_FRONTEND) {
+					$decoded = json_decode($value, true);
+					if (isset($decoded['token']) && $decoded['token'] === 'hash') {
+						$tokenStored = true;
+					}
 					return true;
 				}
 				return false;
@@ -134,7 +132,6 @@ class AuthPublicShareControllerTest extends \Test\TestCase {
 		$result = $this->controller->authenticate('password');
 		$this->assertInstanceOf(RedirectResponse::class, $result);
 		$this->assertSame('myLink!', $result->getRedirectURL());
-		$this->assertTrue($tokenSet);
-		$this->assertTrue($hashSet);
+		$this->assertTrue($tokenStored);
 	}
 }

--- a/tests/lib/AppFramework/Controller/PublicShareControllerTest.php
+++ b/tests/lib/AppFramework/Controller/PublicShareControllerTest.php
@@ -74,10 +74,8 @@ class PublicShareControllerTest extends \Test\TestCase {
 		$controller = new TestController('app', $this->request, $this->session, $hash2, $protected);
 
 		$this->session->method('get')
-			->willReturnMap([
-				['public_link_authenticated_token', $token1],
-				['public_link_authenticated_password_hash', $hash1],
-			]);
+			->with(PublicShareController::DAV_AUTHENTICATED_FRONTEND)
+			->willReturn("{\"$token1\":\"$hash1\"}");
 
 		$controller->setToken($token2);
 


### PR DESCRIPTION
## Summary
Previously: we set the session based on the password/share combo. Accessing a new one will override the previous one.
Now: we store the allowed tokens in an array.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
