### PR TITLE
feat: use task processing to send emails

### DIFF
--- a/lib/public/Json/JsonDeserializable.php
+++ b/lib/public/Json/JsonDeserializable.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Json;
+
+/**
+ * Interface for objects that can be deserialized from JSON data.
+ *
+ * @since 33.0.0
+ */
+interface JsonDeserializable {
+
+	public static function jsonDeserialize(array|string $data): static;
+
+}

--- a/lib/public/Mail/Provider/Address.php
+++ b/lib/public/Mail/Provider/Address.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
  */
 namespace OCP\Mail\Provider;
 
+use JsonSerializable;
+use OCP\Json\JsonDeserializable;
+
 /**
  * Mail Address Object
  *
@@ -16,7 +19,7 @@ namespace OCP\Mail\Provider;
  * @since 30.0.0
  *
  */
-class Address implements \OCP\Mail\Provider\IAddress {
+class Address implements IAddress, JsonSerializable, JsonDeserializable {
 
 	/**
 	 * initialize the mail address object
@@ -30,6 +33,37 @@ class Address implements \OCP\Mail\Provider\IAddress {
 		protected ?string $address = null,
 		protected ?string $label = null,
 	) {
+	}
+
+	/**
+	 * export this objects data as an array
+	 *
+	 * @since 33.0.0
+	 *
+	 * @return array representation of this object as an array
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'address' => $this->address,
+			'label' => $this->label,
+		];
+	}
+
+	/**
+	 * import this objects data from an array
+	 *
+	 * @since 33.0.0
+	 *
+	 * @param array array representation of this object
+	 */
+	public static function jsonDeserialize(array|string $data): static {
+		if (is_string($data)) {
+			$data = json_decode($data, true);
+		}
+		$address = $data['address'] ?? null;
+		$label = $data['label'] ?? null;
+
+		return new static($address, $label);
 	}
 
 	/**

--- a/lib/public/Mail/Provider/Attachment.php
+++ b/lib/public/Mail/Provider/Attachment.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
  */
 namespace OCP\Mail\Provider;
 
+use JsonSerializable;
+use OCP\Json\JsonDeserializable;
+
 /**
  * Mail Attachment Object
  *
@@ -16,7 +19,7 @@ namespace OCP\Mail\Provider;
  * @since 30.0.0
  *
  */
-class Attachment implements \OCP\Mail\Provider\IAttachment {
+class Attachment implements IAttachment, JsonSerializable, JsonDeserializable {
 
 	/**
 	 * initialize the mail attachment object
@@ -34,6 +37,41 @@ class Attachment implements \OCP\Mail\Provider\IAttachment {
 		protected ?string $type,
 		protected bool $embedded = false,
 	) {
+	}
+
+	/**
+	 * export this objects data as an array
+	 *
+	 * @since 33.0.0
+	 *
+	 * @return array representation of this object as an array
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'contents' => base64_encode($this->contents ?? ''),
+			'name' => $this->name,
+			'type' => $this->type,
+			'embedded' => $this->embedded,
+		];
+	}
+
+	/**
+	 * import this objects data from an array
+	 *
+	 * @since 33.0.0
+	 *
+	 * @param array array representation of this object
+	 */
+	public static function jsonDeserialize(array|string $data): static {
+		if (is_string($data)) {
+			$data = json_decode($data, true);
+		}
+		$contents = base64_decode($data['contents'] ?? '');
+		$name = $data['name'] ?? null;
+		$type = $data['type'] ?? null;
+		$embedded = $data['embedded'] ?? false;
+
+		return new static($contents, $name, $type, $embedded);
 	}
 
 	/**

--- a/lib/public/TaskProcessing/EShapeType.php
+++ b/lib/public/TaskProcessing/EShapeType.php
@@ -24,6 +24,8 @@ enum EShapeType: int {
 	case Video = 4;
 	case File = 5;
 	case Enum = 6;
+	case Array = 7;
+	case Object = 8;
 	case ListOfNumbers = 10;
 	case ListOfTexts = 11;
 	case ListOfImages = 12;
@@ -72,6 +74,12 @@ enum EShapeType: int {
 		if ($this === EShapeType::ListOfNumbers && (!is_array($value) || count(array_filter($value, fn ($item) => !is_numeric($item))) > 0)) {
 			throw new ValidationException('Non-numeric list item provided for ListOfNumbers slot');
 		}
+		if ($this === EShapeType::Array && !is_array($value)) {
+			throw new ValidationException('Non-array item provided for Array slot');
+		}
+		if ($this === EShapeType::Object && !is_object($value)) {
+			throw new ValidationException('Non-object item provided for Object slot');
+		}
 	}
 
 	/**
@@ -108,6 +116,12 @@ enum EShapeType: int {
 		}
 		if ($this === EShapeType::ListOfFiles && (!is_array($value) || count(array_filter($value, fn ($item) => !is_numeric($item))) > 0)) {
 			throw new ValidationException('Non-audio list item provided for ListOfFiles slot');
+		}
+		if ($this === EShapeType::Array && !is_array($value)) {
+			throw new ValidationException('Non-array item provided for Array slot');
+		}
+		if ($this === EShapeType::Object && !is_object($value)) {
+			throw new ValidationException('Non-object item provided for Object slot');
 		}
 	}
 
@@ -174,6 +188,12 @@ enum EShapeType: int {
 		}
 		if ($this === EShapeType::ListOfFiles && (!is_array($value) || count(array_filter($value, fn ($item) => !is_numeric($item))) > 0)) {
 			throw new ValidationException('Non-audio list item provided for ListOfFiles slot');
+		}
+		if ($this === EShapeType::Array && !is_array($value)) {
+			throw new ValidationException('Non-array item provided for Array slot');
+		}
+		if ($this === EShapeType::Object && !is_object($value)) {
+			throw new ValidationException('Non-object item provided for Object slot');
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Required for https://github.com/nextcloud/mail/pull/11964
- Added interface for easy object creation from json
- Modified mail provider object to be serializable and de-serializable
- Modified task processing logic to accept objects and arrays


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
