### PR TITLE
fix: avoid outer "uncaught exception" for ServerMaintenanceMode

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -58,6 +58,7 @@ use OCA\DAV\DAV\ViewOnlyPlugin;
 use OCA\DAV\Db\PropertyMapper;
 use OCA\DAV\Events\SabrePluginAddEvent;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
+use OCA\DAV\Exception\ServerMaintenanceMode;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\FileSearchBackend;
 use OCA\DAV\Files\LazySearchBackend;
@@ -422,12 +423,18 @@ class Server {
 		/** @var IEventLogger $eventLogger */
 		$eventLogger = \OCP\Server::get(IEventLogger::class);
 		$eventLogger->start('dav_server_exec', '');
-		$this->server->start();
-		$eventLogger->end('dav_server_exec');
-		if ($this->profiler->isEnabled()) {
-			$eventLogger->end('runtime');
-			$profile = $this->profiler->collect(\OCP\Server::get(IRequest::class), new Response());
-			$this->profiler->saveProfile($profile);
+		try {
+			$this->server->start();
+		} catch (ServerMaintenanceMode $e) {
+			// Sabre already sent a 503; avoid the global "Uncaught exception" log.
+			// do not rethrow
+		} finally {
+			$eventLogger->end('dav_server_exec');
+			if ($this->profiler->isEnabled()) {
+				$eventLogger->end('runtime');
+				$profile = $this->profiler->collect(\OCP\Server::get(IRequest::class), new Response());
+				$this->profiler->saveProfile($profile);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #55894 <!-- related github issue -->

## Summary

We already exclude ServerMaintenanceMode in the inner logger, but there are some spots where it can can bubble up still via DAV.


## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
