### PR TITLE
fix(encryption): Increment `lastChunkNr` when size is off

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -464,6 +464,7 @@ class Encryption extends Wrapper {
 			if (strlen($lastChunkContentEncrypted) > $blockSize) {
 				$newUnencryptedSize += $unencryptedBlockSize;
 				$lastChunkContentEncrypted = substr($lastChunkContentEncrypted, $blockSize);
+				$lastChunkNr++;
 			}
 		}
 


### PR DESCRIPTION
When computing the unencrypted file size, we need the size of the last encrypted chunk as its size is usually not the regular 8192 bits.

To avoid reading the whole file, we seek directly to that last chunk based on the expected file size. When the expected file size is smaller than the actual one, we have a logic in place to continue reading until we reach the end of the file.

In that logic, we forgot to increment the `$lastChunkNr` which is important when we later check the signature of the chunk.

This commit adds that missing increment.
