### PR TITLE
fix(files_sharing): Hide 'Open locally' action

### DIFF
--- a/apps/files/src/actions/openLocallyAction.ts
+++ b/apps/files/src/actions/openLocallyAction.ts
@@ -10,12 +10,13 @@ import IconWeb from '@mdi/svg/svg/web.svg?raw'
 import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
 import { DialogBuilder, showError } from '@nextcloud/dialogs'
-import { FileAction, Permission } from '@nextcloud/files'
+import { FileAction } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
 import { encodePath } from '@nextcloud/paths'
 import { generateOcsUrl } from '@nextcloud/router'
 import { isPublicShare } from '@nextcloud/sharing/public'
 import logger from '../logger.ts'
+import { isSyncable } from '../utils/permissions.ts'
 
 export const action = new FileAction({
 	id: 'edit-locally',
@@ -34,7 +35,7 @@ export const action = new FileAction({
 			return false
 		}
 
-		return (nodes[0].permissions & Permission.UPDATE) !== 0
+		return isSyncable(nodes[0])
 	},
 
 	async exec(node: Node) {

--- a/apps/files/src/utils/permissions.ts
+++ b/apps/files/src/utils/permissions.ts
@@ -36,3 +36,34 @@ export function isDownloadable(node: Node): boolean {
 
 	return true
 }
+
+
+/**
+ * Check permissions on the node if it can be synced/open locally
+ *
+ * @param node The node to check
+ * @return True if syncable, false otherwise
+ */
+export function isSyncable(node: Node): boolean {
+	if ((node.permissions & Permission.UPDATE) === 0) {
+		return false
+	}
+
+	// check hide-download property of shares
+	if (node.attributes['hide-download'] === true
+		|| node.attributes['hide-download'] === 'true'
+	) {
+		return false
+	}
+
+	// If the mount type is a share, ensure it got download permissions.
+	if (node.attributes['share-attributes']) {
+		const shareAttributes = JSON.parse(node.attributes['share-attributes'] || '[]') as Array<ShareAttribute>
+		const downloadAttribute = shareAttributes.find(({ scope, key }: ShareAttribute) => scope === 'permissions' && key === 'download')
+		if (downloadAttribute !== undefined) {
+			return downloadAttribute.value === true
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
This patch ensures that the "Open locally" context menu item is not displayed for files in a share where the "download and sync" permission has not been granted.

This prevents user confusion, as the action would fail anyway. The fix adds a permission check before rendering the menu item, and adds a corresponding unit test to verify this behavior.

Resolves: #54970

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
