### PR TITLE
fix(DirectEditing): expose already used methods on the public interface

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1399,7 +1399,6 @@
     </InvalidArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getTemplates]]></code>
-      <code><![CDATA[open]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="apps/files/lib/Helper.php">

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1449,9 +1449,6 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/files/lib/Controller/DirectEditingController.php">
-    <InvalidArgument>
-      <code><![CDATA[$templateId]]></code>
-    </InvalidArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getTemplates]]></code>
     </UndefinedInterfaceMethod>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1454,7 +1454,6 @@
     </InvalidArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getTemplates]]></code>
-      <code><![CDATA[open]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="apps/files/lib/Controller/ViewController.php">

--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -125,6 +125,7 @@ class Manager implements IManager {
 		throw new \RuntimeException('No creator found');
 	}
 
+	#[\Override]
 	public function open(string $filePath, ?string $editorId = null, ?int $fileId = null): string {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
 		$file = $userFolder->get($filePath);

--- a/lib/private/DirectEditing/Token.php
+++ b/lib/private/DirectEditing/Token.php
@@ -35,6 +35,7 @@ class Token implements IToken {
 		return $this->manager->getFileForToken($this->data['user_id'], $this->data['file_id'], $this->data['file_path']);
 	}
 
+	#[\Override]
 	public function getToken(): string {
 		return $this->data['token'];
 	}

--- a/lib/public/DirectEditing/IManager.php
+++ b/lib/public/DirectEditing/IManager.php
@@ -36,7 +36,7 @@ interface IManager {
 	public function edit(string $token): Response;
 
 	/**
-	 * Create a new token based on the file path and editor details
+	 * Create a file and generate a token based on the file path and editor details
 	 *
 	 * @since 18.0.0
 	 * @param string $path
@@ -48,6 +48,19 @@ interface IManager {
 	 * @throws RuntimeException
 	 */
 	public function create(string $path, string $editorId, string $creatorId, $templateId = null): string;
+
+	/**
+	 * Create a token based on an existing file path and editor details
+	 *
+	 * @since 33.0.0
+	 * @param string $filePath
+	 * @param string|null $editorId
+	 * @param int|null $fileId
+	 * @return string
+	 * @throws NotPermittedException
+	 * @throws RuntimeException
+	 */
+	public function open(string $filePath, ?string $editorId = null, ?int $fileId = null): string;
 
 	/**
 	 * Get the token details for a given token

--- a/lib/public/DirectEditing/IManager.php
+++ b/lib/public/DirectEditing/IManager.php
@@ -37,7 +37,7 @@ interface IManager {
 	public function edit(string $token): Response;
 
 	/**
-	 * Create a new token based on the file path and editor details
+	 * Create a file and generate a token based on the file path and editor details
 	 *
 	 * @since 18.0.0
 	 * @param string $path
@@ -49,6 +49,19 @@ interface IManager {
 	 * @throws RuntimeException
 	 */
 	public function create(string $path, string $editorId, string $creatorId, $templateId = null): string;
+
+	/**
+	 * Create a token based on an existing file path and editor details
+	 *
+	 * @since 33.0.0
+	 * @param string $filePath
+	 * @param string|null $editorId
+	 * @param int|null $fileId
+	 * @return string
+	 * @throws NotPermittedException
+	 * @throws RuntimeException
+	 */
+	public function open(string $filePath, ?string $editorId = null, ?int $fileId = null): string;
 
 	/**
 	 * Get the token details for a given token

--- a/lib/public/DirectEditing/IManager.php
+++ b/lib/public/DirectEditing/IManager.php
@@ -23,7 +23,6 @@ interface IManager {
 	 * Register a new editor
 	 *
 	 * @since 18.0.0
-	 * @param IEditor $directEditor
 	 */
 	public function registerDirectEditor(IEditor $directEditor): void;
 
@@ -31,8 +30,6 @@ interface IManager {
 	 * Open the editing page for a provided token
 	 *
 	 * @since 18.0.0
-	 * @param string $token
-	 * @return Response
 	 */
 	public function edit(string $token): Response;
 
@@ -40,11 +37,6 @@ interface IManager {
 	 * Create a file and generate a token based on the file path and editor details
 	 *
 	 * @since 18.0.0
-	 * @param string $path
-	 * @param string $editorId
-	 * @param string $creatorId
-	 * @param null $templateId
-	 * @return string
 	 * @throws NotPermittedException
 	 * @throws RuntimeException
 	 */
@@ -53,11 +45,7 @@ interface IManager {
 	/**
 	 * Create a token based on an existing file path and editor details
 	 *
-	 * @since 33.0.0
-	 * @param string $filePath
-	 * @param string|null $editorId
-	 * @param int|null $fileId
-	 * @return string
+	 * @since 35.0.0
 	 * @throws NotPermittedException
 	 * @throws RuntimeException
 	 */
@@ -67,8 +55,6 @@ interface IManager {
 	 * Get the token details for a given token
 	 *
 	 * @since 18.0.0
-	 * @param string $token
-	 * @return IToken
 	 */
 	public function getToken(string $token): IToken;
 
@@ -84,7 +70,6 @@ interface IManager {
 	 * Check if direct editing is enabled
 	 *
 	 * @since 20.0.0
-	 * @return bool
 	 */
 	public function isEnabled(): bool;
 

--- a/lib/public/DirectEditing/IToken.php
+++ b/lib/public/DirectEditing/IToken.php
@@ -62,4 +62,10 @@ interface IToken {
 	 * @return string
 	 */
 	public function getUser(): string;
+
+	/**
+	 * @since 33.0.0
+	 * @return string
+	 */
+	public function getToken(): string;
 }

--- a/lib/public/DirectEditing/IToken.php
+++ b/lib/public/DirectEditing/IToken.php
@@ -32,7 +32,6 @@ interface IToken {
 	 * Check if the token has already been used
 	 *
 	 * @since 18.0.0
-	 * @return bool
 	 */
 	public function hasBeenAccessed(): bool;
 
@@ -47,26 +46,22 @@ interface IToken {
 	 * Get the file that is related to the token
 	 *
 	 * @since 18.0.0
-	 * @return File
 	 * @throws NotFoundException
 	 */
 	public function getFile(): File;
 
 	/**
 	 * @since 18.0.0
-	 * @return string
 	 */
 	public function getEditor(): string;
 
 	/**
 	 * @since 18.0.0
-	 * @return string
 	 */
 	public function getUser(): string;
 
 	/**
-	 * @since 33.0.0
-	 * @return string
+	 * @since 35.0.0
 	 */
 	public function getToken(): string;
 }

--- a/lib/public/DirectEditing/IToken.php
+++ b/lib/public/DirectEditing/IToken.php
@@ -63,4 +63,10 @@ interface IToken {
 	 * @return string
 	 */
 	public function getUser(): string;
+
+	/**
+	 * @since 33.0.0
+	 * @return string
+	 */
+	public function getToken(): string;
 }


### PR DESCRIPTION
These methods had been on the implementation and are used in text for a long time already. They should be exposed on the public interface so we can cleanup the psalm baseline:

- https://github.com/nextcloud/text/blob/bc94c6d020f315e539402c71c02da2aa299dc2bf/tests/psalm-baseline.xml#L5
- https://github.com/nextcloud/text/blob/bc94c6d020f315e539402c71c02da2aa299dc2bf/tests/psalm-baseline.xml#L15