### PR TITLE
fix(reference): Respect IReferenceProvider::getCacheTTL() in ReferenceManager

### DIFF
--- a/lib/private/Collaboration/Reference/ReferenceManager.php
+++ b/lib/private/Collaboration/Reference/ReferenceManager.php
@@ -108,11 +108,14 @@ class ReferenceManager implements IReferenceManager {
 		}
 		if ($reference) {
 			$cachePrefix = $matchedProvider->getCachePrefix($referenceId);
+			// Respect provider's custom cache TTL, fallback to default if not specified
+			$cacheTtl = method_exists($matchedProvider, 'getCacheTTL') ? $matchedProvider->getCacheTTL() : self::CACHE_TTL;
+			$cacheTtl = $cacheTtl ?? self::CACHE_TTL;
 			if ($cachePrefix !== '') {
 				// If a prefix is used we set an additional key to know when we need to delete by prefix during invalidateCache()
-				$this->cache->set('hasPrefix-' . md5($cachePrefix), true, self::CACHE_TTL);
+				$this->cache->set('hasPrefix-' . md5($cachePrefix), true, $cacheTtl);
 			}
-			$this->cache->set($cacheKey, Reference::toCache($reference), self::CACHE_TTL);
+			$this->cache->set($cacheKey, Reference::toCache($reference), $cacheTtl);
 			return $reference;
 		}
 


### PR DESCRIPTION
## What does this PR fix?

Fixes #56012

## Changes
The ReferenceManager was ignoring the `getCacheTTL()` method defined in the IReferenceProvider interface and always using the hardcoded 3600 second TTL.

This change respects the provider's custom cache TTL with a fallback to the default CACHE_TTL constant, allowing providers to specify shorter TTLs for frequently-changing data such as external API integrations.

## Implementation
- Call `getCacheTTL()` on the matched provider
- Use the returned TTL if specified, otherwise fallback to `self::CACHE_TTL`
- Apply the TTL to both the prefix marker cache and the reference cache

## Backward Compatibility
✅ Fully backward compatible:
- Existing providers that don't override `getCacheTTL()` will get the default 3600s TTL
- The change is purely additive and doesn't modify any API signatures