### PR TITLE
[stable32] fix(ContactsManager): Fix conflict with value type from database

### DIFF
--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -45,7 +45,7 @@ class ContactsManager {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function setupSystemContactsProvider(IManager $cm, ?string $userId, IURLGenerator $urlGenerator) {
-		$systemAddressBookExposed = $this->appConfig->getValueBool('dav', 'system_addressbook_exposed', true);
+		$systemAddressBookExposed = $this->appConfig->getValueString('dav', 'system_addressbook_exposed', 'yes') === 'yes';
 		if (!$systemAddressBookExposed) {
 			return;
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

### ⚠️ UNIFIED SEARCH STOPPED WORKING

1. Try a search (search never returns results)
2. Observe search console (and Nextcloud error log)

<img width="1904" height="119" alt="image" src="https://github.com/user-attachments/assets/cc0d1982-1bbd-4ec9-bebc-4376aa332297" />

Regression from https://github.com/nextcloud/server/pull/55657
Cc @artonge 

**Fixes:**

```
# occ config:app:get dav system_addressbook_exposed
no
```

```
"Exception": "OCP\\Exceptions\\AppConfigTypeConflictException",
    "Message": "conflict with value type from database",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/AppConfig.php",
        "line": 413,
        "function": "getTypedValue",
        "class": "OC\\AppConfig",
        "type": "->",
        "args": [
          "dav",
          "system_addressbook_exposed",
          "true",
          false,
          32
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/CardDAV/ContactsManager.php",
        "line": 48,
        "function": "getValueBool",
        "class": "OC\\AppConfig",
        "type": "->",
        "args": [
          "dav",
          "system_addressbook_exposed",
          true
        ]
      },
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
