### PR TITLE
Remove stable30 from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -124,50 +124,9 @@ updates:
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
-- package-ecosystem: composer
-  target-branch: stable30
-  directories:
-    - "/"
-    - "/build/integration"
-    - "/vendor-bin/cs-fixer"
-    - "/vendor-bin/openapi-extractor"
-    - "/vendor-bin/phpunit"
-    - "/vendor-bin/psalm"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "04:00"
-    timezone: Europe/Paris
-  labels:
-    - "3. to review"
-    - "feature: dependencies"
-  ignore:
-    # only patch updates on stable branches
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
 # frontend dependencies
 - package-ecosystem: npm
   target-branch: stable31
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "04:00"
-    timezone: Europe/Paris
-  open-pull-requests-limit: 20
-  labels:
-    - "3. to review"
-    - "feature: dependencies"
-  # Disable automatic rebasing because without a build CI will likely fail anyway
-  rebase-strategy: "disabled"
-  ignore:
-    # no major updates on stable branches
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
-
-- package-ecosystem: npm
-  target-branch: stable30
   directory: "/"
   schedule:
     interval: weekly


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
