### PR TITLE
fix(Memcache): ensure global prefix depends on enabled apps

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -116,13 +116,16 @@ class Factory implements ICacheFactory {
 			$versions = [];
 			if ($config->getValue('installed', false)) {
 				$appConfig = \OCP\Server::get(IAppConfig::class);
-				$versions = $appConfig->getAppInstalledVersions();
+				// only get the enabled apps to clear the cache in case an app is enabled or disabled (e.g. clear routes)
+				$versions = $appConfig->getAppInstalledVersions(true);
+				ksort($versions);
 			}
 			$versions['core'] = implode('.', $this->serverVersion->getVersion());
 
 			// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
 			$instanceid = $config->getValue('instanceid');
-			$this->globalPrefix = hash('xxh128', $instanceid . implode(',', $versions));
+			$installedApps = implode(',', array_keys($versions)) . implode(',', array_values($versions));
+			$this->globalPrefix = hash('xxh128', $instanceid . $installedApps);
 		}
 		return $this->globalPrefix;
 	}


### PR DESCRIPTION
## Summary

- ensure the prefix is changed when an app is (dis)enabled
- ensure the app ids are included in the hash instead of only the version numbers
- ensure hash is deterministic by always use the same order.

see also https://github.com/nextcloud/server/pull/54383#discussion_r2284519309


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
