### PR TITLE
feat(ocm): handle /.well-known/ocm

### DIFF
--- a/core/AppInfo/Application.php
+++ b/core/AppInfo/Application.php
@@ -22,6 +22,7 @@ use OC\Core\Listener\AddMissingPrimaryKeyListener;
 use OC\Core\Listener\BeforeTemplateRenderedListener;
 use OC\Core\Listener\PasswordUpdatedListener;
 use OC\Core\Notification\CoreNotifier;
+use OC\OCM\OCMDiscoveryHandler;
 use OC\TagManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -85,6 +86,7 @@ class Application extends App implements IBootstrap {
 		// config lexicon
 		$context->registerConfigLexicon(ConfigLexicon::class);
 
+		$context->registerWellKnownHandler(OCMDiscoveryHandler::class);
 		$context->registerCapability(Capabilities::class);
 	}
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1871,6 +1871,7 @@ return array(
     'OC\\Notification\\Notification' => $baseDir . '/lib/private/Notification/Notification.php',
     'OC\\OCM\\Model\\OCMProvider' => $baseDir . '/lib/private/OCM/Model/OCMProvider.php',
     'OC\\OCM\\Model\\OCMResource' => $baseDir . '/lib/private/OCM/Model/OCMResource.php',
+    'OC\\OCM\\OCMDiscoveryHandler' => $baseDir . '/lib/private/OCM/OCMDiscoveryHandler.php',
     'OC\\OCM\\OCMDiscoveryService' => $baseDir . '/lib/private/OCM/OCMDiscoveryService.php',
     'OC\\OCM\\OCMSignatoryManager' => $baseDir . '/lib/private/OCM/OCMSignatoryManager.php',
     'OC\\OCS\\ApiHelper' => $baseDir . '/lib/private/OCS/ApiHelper.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1912,6 +1912,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Notification\\Notification' => __DIR__ . '/../../..' . '/lib/private/Notification/Notification.php',
         'OC\\OCM\\Model\\OCMProvider' => __DIR__ . '/../../..' . '/lib/private/OCM/Model/OCMProvider.php',
         'OC\\OCM\\Model\\OCMResource' => __DIR__ . '/../../..' . '/lib/private/OCM/Model/OCMResource.php',
+        'OC\\OCM\\OCMDiscoveryHandler' => __DIR__ . '/../../..' . '/lib/private/OCM/OCMDiscoveryHandler.php',
         'OC\\OCM\\OCMDiscoveryService' => __DIR__ . '/../../..' . '/lib/private/OCM/OCMDiscoveryService.php',
         'OC\\OCM\\OCMSignatoryManager' => __DIR__ . '/../../..' . '/lib/private/OCM/OCMSignatoryManager.php',
         'OC\\OCS\\ApiHelper' => __DIR__ . '/../../..' . '/lib/private/OCS/ApiHelper.php',

--- a/lib/private/OCM/OCMDiscoveryHandler.php
+++ b/lib/private/OCM/OCMDiscoveryHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\OCM;
+
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Http\WellKnown\GenericResponse;
+use OCP\Http\WellKnown\IHandler;
+use OCP\Http\WellKnown\IRequestContext;
+use OCP\Http\WellKnown\IResponse;
+
+class OCMDiscoveryHandler implements IHandler {
+	public function __construct(
+		private readonly OCMDiscoveryService $discoveryService,
+	) {
+	}
+
+	public function handle(string $service, IRequestContext $context, ?IResponse $previousResponse): ?IResponse {
+		if ($service !== 'ocm') {
+			return $previousResponse;
+		}
+
+		return new GenericResponse(new JsonResponse($this->discoveryService->getLocalOCMProvider()));
+	}
+}


### PR DESCRIPTION
ocm documentation require to move from `/ocm-provider/` to `/.well-known/ocm`.
this PR returns discovery public data on request on `/.well-known/ocm`