### PR TITLE
 chore(static analysis): enforce stricter Psalm checks for new code

### DIFF
--- a/LICENSES/PHP-3.01.txt
+++ b/LICENSES/PHP-3.01.txt
@@ -1,0 +1,27 @@
+The PHP License, version 3.01
+
+Copyright (c) 1999 - 2012 The PHP Group. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, is permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. The name "PHP" must not be used to endorse or promote products derived from this software without prior written permission. For written permission, please contact group@php.net.
+
+4. Products derived from this software may not be called "PHP", nor may "PHP" appear in their name, without prior written permission from group@php.net. You may indicate that your software works in conjunction with PHP by saying "Foo for PHP" instead of calling it "PHP Foo" or "phpfoo"
+
+5. The PHP Group may publish revised and/or new versions of the license from time to time. Each version will be given a distinguishing version number. Once covered code has been published under a particular version of the license, you may always continue to use it under the terms of that version. You may also choose to use such covered code under the terms of any subsequent version of the license published by the PHP Group. No one other than the PHP Group has the right to modify the terms applicable to covered code created under this License.
+
+6. Redistributions of any form whatsoever must retain the following acknowledgment: "This product includes PHP software, freely available from <http://www.php.net/software/>".
+
+THIS SOFTWARE IS PROVIDED BY THE PHP DEVELOPMENT TEAM ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE PHP DEVELOPMENT TEAM OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This software consists of voluntary contributions made by many individuals on behalf of the PHP Group.
+
+The PHP Group can be contacted via Email at group@php.net.
+
+For more information on the PHP Group and the PHP project, please see <http://www.php.net>.
+
+PHP includes the Zend Engine, freely available at <http://www.zend.com>.

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -38,11 +38,32 @@
 			['uid' => &$uid]
 		)]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($entry, '@')]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$description]]></code>
+      <code><![CDATA[$invitation->getUserId()]]></code>
+      <code><![CDATA[$sharedByDisplayName]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/comments/lib/Activity/Listener.php">
     <DeprecatedConstant>
       <code><![CDATA[CommentsEvent::EVENT_ADD]]></code>
     </DeprecatedConstant>
+  </file>
+  <file src="apps/comments/lib/Activity/Provider.php">
+    <PossiblyNullReference>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/comments/lib/Listener/CommentsEntityEventListener.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/comments/lib/Listener/CommentsEventListener.php">
     <DeprecatedConstant>
@@ -63,7 +84,29 @@
       <code><![CDATA[CommentsEvent::EVENT_PRE_UPDATE]]></code>
     </DeprecatedConstant>
   </file>
+  <file src="apps/comments/lib/Notification/Notifier.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$mentionTypeCount[$mention['type']]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/dashboard/lib/Controller/DashboardApiController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dashboard/lib/Controller/DashboardController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/dav/appinfo/v1/caldav.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[Server::get(IUserSession::class)]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[exec]]></code>
       <code><![CDATA[getAppValue]]></code>
@@ -74,6 +117,9 @@
     </UndefinedGlobalVariable>
   </file>
   <file src="apps/dav/appinfo/v1/carddav.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[Server::get(IUserSession::class)]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[exec]]></code>
       <code><![CDATA[getL10N]]></code>
@@ -102,6 +148,9 @@
     </UndefinedGlobalVariable>
   </file>
   <file src="apps/dav/appinfo/v1/webdav.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[Server::get(IUserSession::class)]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code><![CDATA[\OC_Util::obEnd()]]></code>
     </DeprecatedClass>
@@ -152,6 +201,15 @@
       <code><![CDATA[registerEventListener]]></code>
     </InvalidArgument>
   </file>
+  <file src="apps/dav/lib/Avatars/AvatarNode.php">
+    <PossiblyFalseReference>
+      <code><![CDATA[resource]]></code>
+    </PossiblyFalseReference>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$res]]></code>
+      <code><![CDATA[$res]]></code>
+    </PossiblyInvalidArgument>
+  </file>
   <file src="apps/dav/lib/BackgroundJob/EventReminderJob.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
@@ -174,10 +232,48 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/dav/lib/BulkUpload/BulkUploadPlugin.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getETag]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/BulkUpload/MultipartRequestParser.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$hash]]></code>
+      <code><![CDATA[$value]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Backend.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
   <file src="apps/dav/lib/CalDAV/BirthdayService.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$book['principaluri']]]></code>
+      <code><![CDATA[$book['uri']]]></code>
+      <code><![CDATA[$calendar['id']]]></code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$existingBirthday->VEVENT->DTSTART]]></code>
+      <code><![CDATA[$existingBirthday->VEVENT->SUMMARY]]></code>
+      <code><![CDATA[$newCalendarData->VEVENT->DTSTART]]></code>
+      <code><![CDATA[$newCalendarData->VEVENT->SUMMARY]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
+      <code><![CDATA[$vEvent->DTEND]]></code>
+      <code><![CDATA[$vEvent->DTSTART]]></code>
+      <code><![CDATA[getValue]]></code>
+      <code><![CDATA[getValue]]></code>
+      <code><![CDATA[getValue]]></code>
+      <code><![CDATA[getValue]]></code>
+      <code><![CDATA[setDateTime]]></code>
+      <code><![CDATA[setDateTime]]></code>
+    </PossiblyNullReference>
     <UndefinedMethod>
       <code><![CDATA[setDateTime]]></code>
       <code><![CDATA[setDateTime]]></code>
@@ -197,6 +293,12 @@
       <code><![CDATA[$calendarData]]></code>
       <code><![CDATA[$calendarData]]></code>
     </ParamNameMismatch>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$this->objectData['calendardata']]]></code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$this->caldavBackend->getCalendarObject($this->calendarInfo['id'], $this->objectData['uri'], CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION)]]></code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="apps/dav/lib/CalDAV/CalDavBackend.php">
     <DeprecatedMethod>
@@ -220,6 +322,33 @@
     <NullableReturnStatement>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$restoreUri]]></code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$restoreUri]]></code>
+    </PossiblyInvalidCast>
+    <PossiblyNullArgument>
+      <code><![CDATA[$calendarData]]></code>
+      <code><![CDATA[$calendarData]]></code>
+      <code><![CDATA[$calendarData]]></code>
+      <code><![CDATA[$calendarData]]></code>
+      <code><![CDATA[$calendarRow]]></code>
+      <code><![CDATA[$calendarRow]]></code>
+      <code><![CDATA[$calendarRow]]></code>
+      <code><![CDATA[$sourceCalendarRow]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Calendar.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$acl]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$sourceNode->getOwner()]]></code>
+      <code><![CDATA[$this->getOwner()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/CalDAV/CalendarHome.php">
     <DeprecatedMethod>
@@ -238,20 +367,81 @@
       <code><![CDATA[calendarSearch]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/CalDAV/CalendarImpl.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$recipient]]></code>
+    </PossiblyUndefinedVariable>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$vObject]]></code>
+    </PropertyTypeCoercion>
+  </file>
   <file src="apps/dav/lib/CalDAV/CalendarManager.php">
     <DeprecatedMethod>
       <code><![CDATA[registerCalendar]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/CalDAV/CalendarObject.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$vObject]]></code>
+      <code><![CDATA[$vObject]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="apps/dav/lib/CalDAV/CalendarRoot.php">
     <ParamNameMismatch>
       <code><![CDATA[$principal]]></code>
     </ParamNameMismatch>
   </file>
+  <file src="apps/dav/lib/CalDAV/EventReader.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[isFloating]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[getDateInterval]]></code>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[isFloating]]></code>
+      <code><![CDATA[isFloating]]></code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Export/ExportService.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$consecutive]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Federation/FederationSharingService.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$shareable->getOwner()]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/dav/lib/CalDAV/ICSExportPlugin/ICSExportPlugin.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Import/ImportService.php">
+    <PossiblyInvalidClone>
+      <code><![CDATA[clone $importer->PRODID]]></code>
+      <code><![CDATA[clone $importer->VERSION]]></code>
+      <code><![CDATA[clone $vObject->VTIMEZONE]]></code>
+      <code><![CDATA[clone $vObject->VTIMEZONE]]></code>
+    </PossiblyInvalidClone>
+    <PossiblyNullIterator>
+      <code><![CDATA[$importer->VTIMEZONE]]></code>
+    </PossiblyNullIterator>
+    <PossiblyNullReference>
+      <code><![CDATA[getValue]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Import/TextImporter.php">
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$this->structure]]></code>
+      <code><![CDATA[$this->structure]]></code>
+    </PossiblyNullArrayOffset>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$components]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php">
     <DeprecatedMethod>
@@ -289,6 +479,19 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$vevent->DTEND]]></code>
     </LessSpecificReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[DateTimeParser::parse($vevent->DURATION->getValue())]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidClone>
+      <code><![CDATA[clone $vevent->DTSTART]]></code>
+      <code><![CDATA[clone $vevent->DTSTART]]></code>
+      <code><![CDATA[clone $vevent->DTSTART]]></code>
+    </PossiblyInvalidClone>
+    <PossiblyNullReference>
+      <code><![CDATA[hasTime]]></code>
+      <code><![CDATA[isFloating]]></code>
+      <code><![CDATA[isFloating]]></code>
+    </PossiblyNullReference>
     <UndefinedMethod>
       <code><![CDATA[hasTime]]></code>
       <code><![CDATA[isFloating]]></code>
@@ -302,6 +505,15 @@
     <MoreSpecificReturnType>
       <code><![CDATA[array<string, array{LANG?: string}>]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$cuType->getValue()]]></code>
+      <code><![CDATA[$partstat->getValue()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[isFloating]]></code>
+    </PossiblyNullReference>
     <UndefinedMethod>
       <code><![CDATA[getDateTime]]></code>
       <code><![CDATA[getDateTime]]></code>
@@ -324,6 +536,11 @@
     </TypeDoesNotContainType>
   </file>
   <file src="apps/dav/lib/CalDAV/Reminder/ReminderService.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$valarm->parent]]></code>
+      <code><![CDATA[$valarm->parent]]></code>
+      <code><![CDATA[$vevent->parent]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
@@ -336,6 +553,16 @@
       <code><![CDATA[VObject\Component\VCalendar|null]]></code>
       <code><![CDATA[VObject\Component\VEvent[]]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullIterator>
+      <code><![CDATA[$event->VALARM]]></code>
+      <code><![CDATA[$event->VALARM]]></code>
+    </PossiblyNullIterator>
+    <PossiblyNullReference>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[serialize]]></code>
+      <code><![CDATA[serialize]]></code>
+      <code><![CDATA[serialize]]></code>
+    </PossiblyNullReference>
     <UndefinedMethod>
       <code><![CDATA[getDateTime]]></code>
       <code><![CDATA[getDateTime]]></code>
@@ -358,6 +585,14 @@
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$resourceId]]></code>
+      <code><![CDATA[$resourceId]]></code>
+    </PossiblyUndefinedArrayOffset>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$stmt]]></code>
+      <code><![CDATA[$stmt]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="apps/dav/lib/CalDAV/RetentionService.php">
     <DeprecatedMethod>
@@ -365,6 +600,14 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipPlugin.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$iTipMessage->senderName->getValue()]]></code>
+      <code><![CDATA[$iTipMessage->senderName->getValue()]]></code>
+      <code><![CDATA[$modified['new']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getDisplayName]]></code>
+    </PossiblyNullReference>
     <RedundantCast>
       <code><![CDATA[(string)$iTipMessage->recipientName]]></code>
     </RedundantCast>
@@ -377,6 +620,54 @@
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$startTime]]></code>
+      <code><![CDATA[$startTime]]></code>
+      <code><![CDATA[$startTime]]></code>
+      <code><![CDATA[$startTime]]></code>
+      <code><![CDATA[$startTime]]></code>
+      <code><![CDATA[$startTime]]></code>
+      <code><![CDATA[$this->l10n->l('time', $er->endDateTime(), ['width' => 'short'])]]></code>
+      <code><![CDATA[$this->l10n->l('time', $er->endDateTime(), ['width' => 'short'])]]></code>
+      <code><![CDATA[$this->l10n->l('time', $er->endDateTime(), ['width' => 'short'])]]></code>
+      <code><![CDATA[$this->l10n->l('time', $er->endDateTime(), ['width' => 'short'])]]></code>
+      <code><![CDATA[$this->l10n->l('time', $er->endDateTime(), ['width' => 'short'])]]></code>
+      <code><![CDATA[$this->l10n->l('time', $er->endDateTime(), ['width' => 'short'])]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[DateTimeParser::parse($component->DURATION->getValue())]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$attendeeName]]></code>
+      <code><![CDATA[$er->recurrenceDate()]]></code>
+      <code><![CDATA[$er->recurrenceDate()]]></code>
+      <code><![CDATA[$eventReaderPrevious]]></code>
+      <code><![CDATA[$organizerName]]></code>
+      <code><![CDATA[$partstat->getValue()]]></code>
+      <code><![CDATA[$partstat->getValue()]]></code>
+      <code><![CDATA[$role->getValue()]]></code>
+      <code><![CDATA[$role->getValue()]]></code>
+      <code><![CDATA[$rsvp->getValue()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+      <code><![CDATA[$endTime]]></code>
+    </PossiblyUndefinedVariable>
     <UndefinedMethod>
       <code><![CDATA[getNormalizedValue]]></code>
       <code><![CDATA[getNormalizedValue]]></code>
@@ -393,6 +684,36 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$vevent->DTEND]]></code>
     </LessSpecificReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[DateTimeParser::parse($vevent->DURATION->getValue())]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidClone>
+      <code><![CDATA[clone $vevent->DTSTART]]></code>
+      <code><![CDATA[clone $vevent->DTSTART]]></code>
+      <code><![CDATA[clone $vevent->DTSTART]]></code>
+    </PossiblyInvalidClone>
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$sequence]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullArgument>
+      <code><![CDATA[$calendarNode->getOwner()]]></code>
+      <code><![CDATA[$calendarNode->getOwner()]]></code>
+      <code><![CDATA[$calendarUserType]]></code>
+      <code><![CDATA[$calendarUserType]]></code>
+      <code><![CDATA[$fbTypeParameter->getValue()]]></code>
+      <code><![CDATA[$principalUri]]></code>
+      <code><![CDATA[$rsvp->getValue()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[getValue]]></code>
+      <code><![CDATA[hasTime]]></code>
+      <code><![CDATA[isFloating]]></code>
+      <code><![CDATA[isFloating]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$vObject]]></code>
+    </PropertyTypeCoercion>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getChildren]]></code>
     </UndefinedInterfaceMethod>
@@ -433,10 +754,33 @@
       <code><![CDATA[!isset($newProps['filters']['props']) || !is_array($newProps['filters']['props'])]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="apps/dav/lib/CalDAV/SyncService.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$response['token']]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dav/lib/CalDAV/WebcalCaching/Connection.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$body]]></code>
+      <code><![CDATA[$body]]></code>
+      <code><![CDATA[$body]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php">
     <InvalidArgument>
       <code><![CDATA[$webcalData]]></code>
     </InvalidArgument>
+  </file>
+  <file src="apps/dav/lib/CardDAV/Activity/Backend.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/dav/lib/CardDAV/AddressBook.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$acl]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="apps/dav/lib/CardDAV/AddressBookImpl.php">
     <InvalidArgument>
@@ -449,6 +793,12 @@
     <MoreSpecificReturnType>
       <code><![CDATA[VCard]]></code>
     </MoreSpecificReturnType>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$user]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$user]]></code>
+    </PossiblyInvalidOperand>
   </file>
   <file src="apps/dav/lib/CardDAV/AddressBookRoot.php">
     <ParamNameMismatch>
@@ -465,6 +815,18 @@
     <MoreSpecificReturnType>
       <code><![CDATA[VCard]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$addressBookData]]></code>
+      <code><![CDATA[$addressBookData]]></code>
+      <code><![CDATA[$addressBookData]]></code>
+      <code><![CDATA[$addressBookData]]></code>
+      <code><![CDATA[$addressBookRow]]></code>
+      <code><![CDATA[$addressBookRow]]></code>
+      <code><![CDATA[$sourceAddressBookRow]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$addressBooks[$row['id']][$readOnlyPropertyName]]]></code>
+    </PossiblyUndefinedArrayOffset>
     <TypeDoesNotContainType>
       <code><![CDATA[$addressBooks[$row['id']][$readOnlyPropertyName] === 0]]></code>
     </TypeDoesNotContainType>
@@ -478,11 +840,35 @@
     <InvalidNullableReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidNullableReturnType>
+    <PossiblyInvalidMethodCall>
+      <code><![CDATA[getResponses]]></code>
+    </PossiblyInvalidMethodCall>
+  </file>
+  <file src="apps/dav/lib/CardDAV/PhotoCache.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$photo]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$parsed['path']]]></code>
+      <code><![CDATA[$parsed['path']]]></code>
+      <code><![CDATA[$photo->data()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/CardDAV/Plugin.php">
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[string|null]]></code>
     </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="apps/dav/lib/CardDAV/SyncService.php">
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$book['id']]]></code>
+      <code><![CDATA[$systemAddressBook['id']]]></code>
+      <code><![CDATA[$systemAddressBook['id']]]></code>
+      <code><![CDATA[$systemAddressBook['id']]]></code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference>
+      <code><![CDATA[getValue]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/dav/lib/CardDAV/SystemAddressbook.php">
     <DeprecatedMethod>
@@ -496,6 +882,9 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$servers]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/CardDAV/UserAddressBooks.php">
     <InvalidArgument>
@@ -507,6 +896,23 @@
     <DeprecatedMethod>
       <code><![CDATA[getL10NFactory]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Command/ImportCalendar.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tempPath]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$tempFile]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/dav/lib/Command/MoveCalendar.php">
+    <PossiblyNullReference>
+      <code><![CDATA[writeln]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$prefix]]></code>
+      <code><![CDATA[$userOrGroup]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/dav/lib/Command/SendEventReminders.php">
     <DeprecatedMethod>
@@ -528,9 +934,19 @@
     <DeprecatedMethod>
       <code><![CDATA[getPropertiesForPath]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$args['limit']]]></code>
+      <code><![CDATA[$args['offset']]]></code>
+      <code><![CDATA[$request->getHeader('Content-Type')]]></code>
+    </PossiblyNullArgument>
     <UndefinedFunction>
       <code><![CDATA[\Sabre\HTTP\toDate($value)]]></code>
     </UndefinedFunction>
+  </file>
+  <file src="apps/dav/lib/Comments/EntityCollection.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/Comments/RootCollection.php">
     <DeprecatedConstant>
@@ -544,6 +960,9 @@
     <InvalidNullableReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidNullableReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$request->getHeader('Authorization')]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/Auth.php">
     <LessSpecificReturnStatement>
@@ -552,15 +971,57 @@
     <MoreSpecificReturnType>
       <code><![CDATA[array{bool, string}]]></code>
     </MoreSpecificReturnType>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($data[1], '/')]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/BearerAuth.php">
     <DeprecatedClass>
       <code><![CDATA[\OC_Util::setupFS($userId)]]></code>
       <code><![CDATA[\OC_Util::setupFS()]]></code>
     </DeprecatedClass>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[tryTokenLogin]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/ChecksumUpdatePlugin.php">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->server->tree]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
+      <code><![CDATA[getNodeForPath]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getBaseUri]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/CopyEtagHeaderPlugin.php">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->server->httpResponse]]></code>
+      <code><![CDATA[$this->server->tree]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
+      <code><![CDATA[getNodeForPath]]></code>
+      <code><![CDATA[setHeader]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/DavAclPlugin.php">
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[getOwner]]></code>
+    </PossiblyUndefinedMethod>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/Directory.php">
     <InternalMethod>
@@ -611,6 +1072,12 @@
     <ParamNameMismatch>
       <code><![CDATA[$fullSourcePath]]></code>
     </ParamNameMismatch>
+    <PossiblyNullArgument>
+      <code><![CDATA[$data]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getInternalPath]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/File.php">
     <DeprecatedClass>
@@ -646,11 +1113,44 @@
     <MoreSpecificReturnType>
       <code><![CDATA[\OCP\Files\File]]></code>
     </MoreSpecificReturnType>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$wrappedData]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getRelativePath]]></code>
+      <code><![CDATA[getRelativePath]]></code>
+      <code><![CDATA[isCreatable]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$partFilePath]]></code>
+      <code><![CDATA[$res]]></code>
+      <code><![CDATA[$res]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/FilesPlugin.php">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->server->httpRequest]]></code>
+      <code><![CDATA[$this->server->httpResponse]]></code>
+      <code><![CDATA[$this->server->tree]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
+      <code><![CDATA[getNodeForPath]]></code>
+      <code><![CDATA[setHeader]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/FilesReportPlugin.php">
     <InvalidNullableReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidNullableReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
     <UndefinedClass>
       <code><![CDATA[Circles]]></code>
     </UndefinedClass>
@@ -662,6 +1162,9 @@
     <DeprecatedMethod>
       <code><![CDATA[getL10N]]></code>
     </DeprecatedMethod>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$server]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/Node.php">
     <InternalMethod>
@@ -687,6 +1190,13 @@
       <code><![CDATA[$this->info->getId()]]></code>
       <code><![CDATA[$this->info->getId()]]></code>
     </NullableReturnStatement>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->fileView->getAbsolutePath($this->path)]]></code>
+      <code><![CDATA[$this->fileView->getAbsolutePath($this->path)]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$this->fileView->getRelativePath($info->getPath())]]></code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ObjectTree.php">
     <InternalMethod>
@@ -699,6 +1209,12 @@
       <code><![CDATA[verifyPath]]></code>
       <code><![CDATA[verifyPath]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$data]]></code>
+    </PossiblyNullArgument>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$rootNode]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/Principal.php">
     <DeprecatedMethod>
@@ -729,10 +1245,18 @@
       <code><![CDATA[Circles]]></code>
     </UndefinedClass>
   </file>
+  <file src="apps/dav/lib/Connector/Sabre/PropfindCompressionPlugin.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$server]]></code>
+    </PropertyTypeCoercion>
+  </file>
   <file src="apps/dav/lib/Connector/Sabre/QuotaPlugin.php">
     <InternalMethod>
       <code><![CDATA[free_space]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$request->getHeader('Destination')]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ServerFactory.php">
     <DeprecatedMethod>
@@ -743,24 +1267,58 @@
       <code><![CDATA[getFileInfo]]></code>
       <code><![CDATA[getRoot]]></code>
     </InternalMethod>
+    <PossiblyFalseReference>
+      <code><![CDATA[getType]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$userFolder]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[addChild]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ShareTypeList.php">
     <InvalidArgument>
       <code><![CDATA[$shareType]]></code>
     </InvalidArgument>
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$tree]]></code>
+    </PossiblyInvalidIterator>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ShareeList.php">
     <InvalidArgument>
       <code><![CDATA[$share->getShareType()]]></code>
     </InvalidArgument>
   </file>
+  <file src="apps/dav/lib/Connector/Sabre/SharesPlugin.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/TagList.php">
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$tree]]></code>
+    </PossiblyInvalidIterator>
+  </file>
   <file src="apps/dav/lib/Connector/Sabre/TagsPlugin.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$fileIds]]></code>
+    </ArgumentTypeCoercion>
     <NullableReturnStatement>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getId]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$files]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="apps/dav/lib/Controller/BirthdayCalendarController.php">
     <DeprecatedMethod>
@@ -768,10 +1326,29 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/dav/lib/Controller/DirectController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$userFolder->getRelativePath($file->getPath())]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/dav/lib/Controller/InvitationResponseController.php">
+    <PossiblyNullPropertyAssignment>
+      <code><![CDATA[$vEvent]]></code>
+    </PossiblyNullPropertyAssignment>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$vObject]]></code>
+    </PropertyTypeCoercion>
     <UndefinedPropertyAssignment>
       <code><![CDATA[$vEvent->DTSTAMP]]></code>
     </UndefinedPropertyAssignment>
+  </file>
+  <file src="apps/dav/lib/DAV/CustomPropertiesBackend.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$value]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$calendar->getOwner()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/DAV/GroupPrincipalBackend.php">
     <InvalidNullableReturnType>
@@ -796,6 +1373,13 @@
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+    <PossiblyNullArgument>
+      <code><![CDATA[$elements[2]]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$elements[1]]]></code>
+      <code><![CDATA[$elements[2]]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/dav/lib/DAV/RemoteUserPrincipalBackend.php">
     <InvalidNullableReturnType>
@@ -806,10 +1390,25 @@
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/dav/lib/DAV/Sharing/Backend.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$shareable->getOwner()]]></code>
+      <code><![CDATA[$shareable->getOwner()]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/dav/lib/DAV/Sharing/Plugin.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidPropertyFetch>
+      <code><![CDATA[$message->remove]]></code>
+      <code><![CDATA[$message->set]]></code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
+  <file src="apps/dav/lib/DAV/Sharing/Xml/ShareRequest.php">
+    <PossiblyNullIterator>
+      <code><![CDATA[$elements]]></code>
+    </PossiblyNullIterator>
   </file>
   <file src="apps/dav/lib/DAV/SystemPrincipalBackend.php">
     <InvalidNullableReturnType>
@@ -819,7 +1418,29 @@
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/dav/lib/DAV/ViewOnlyPlugin.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$node->getId()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getById]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/Db/Absence.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$timezone]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="apps/dav/lib/Files/BrowserErrorPagePlugin.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$body]]></code>
+    </PossiblyInvalidArgument>
+  </file>
   <file src="apps/dav/lib/Files/FileSearchBackend.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$arguments]]></code>
+    </ArgumentTypeCoercion>
     <InternalMethod>
       <code><![CDATA[getRelativePath]]></code>
     </InternalMethod>
@@ -832,6 +1453,13 @@
     <ParamNameMismatch>
       <code><![CDATA[$search]]></code>
     </ParamNameMismatch>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$argument]]></code>
+      <code><![CDATA[$operator->arguments]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$query->where]]></code>
+    </PossiblyNullArgument>
     <RedundantCondition>
       <code><![CDATA[$date->getTimestamp() !== false]]></code>
     </RedundantCondition>
@@ -840,6 +1468,11 @@
       <code><![CDATA[$operator->arguments[0]->name]]></code>
     </UndefinedPropertyFetch>
   </file>
+  <file src="apps/dav/lib/Files/FilesHome.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$view]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/dav/lib/Files/LazySearchBackend.php">
     <InvalidReturnStatement>
       <code><![CDATA[$this->backend->getArbiterPath()]]></code>
@@ -847,11 +1480,41 @@
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="apps/dav/lib/Files/RootCollection.php">
     <DeprecatedMethod>
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Files/Sharing/FilesDropPlugin.php">
+    <PossiblyFalseOperand>
+      <code><![CDATA[strpos($destination, $baseUrl)]]></code>
+      <code><![CDATA[strpos($path, $token)]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$destination]]></code>
+      <code><![CDATA[$destination]]></code>
+      <code><![CDATA[$request->getHeader('X-NC-Nickname')]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dav/lib/Listener/CalendarFederationNotificationListener.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$calendarInfo['uri']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/dav/lib/Listener/CalendarObjectReminderUpdaterListener.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$fullObject]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dav/lib/Listener/OutOfOfficeListener.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$tzId]]></code>
+      <code><![CDATA[$tzId]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="apps/dav/lib/Migration/BuildCalendarSearchIndex.php">
     <DeprecatedMethod>
@@ -859,11 +1522,31 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/dav/lib/Migration/CalDAVRemoveEmptyValue.php">
+    <PossiblyFalseOperand>
+      <code><![CDATA[$count]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$calObject['calendardata']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$calObject['calendardata']]]></code>
+    </PossiblyNullArrayAccess>
+  </file>
   <file src="apps/dav/lib/Migration/ChunkCleanup.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/DisableSystemAddressBook.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUsers]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/dav/lib/Migration/RegenerateBirthdayCalendars.php">
     <DeprecatedMethod>
@@ -890,6 +1573,21 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/dav/lib/Paginate/PaginatePlugin.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$request->getHeader(self::PAGINATE_TOKEN_HEADER)]]></code>
+      <code><![CDATA[$request->getHeader(self::PAGINATE_TOKEN_HEADER)]]></code>
+      <code><![CDATA[$token]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dav/lib/Provisioning/Apple/AppleProvisioningPlugin.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$parsedUrl['host']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parsedUrl['host']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
   <file src="apps/dav/lib/RootCollection.php">
     <DeprecatedMethod>
       <code><![CDATA[getL10N]]></code>
@@ -900,6 +1598,10 @@
     <InvalidOperand>
       <code><![CDATA[$query->getCursor()]]></code>
     </InvalidOperand>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$principalId]]></code>
+      <code><![CDATA[$principalType]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/dav/lib/Search/EventsSearchProvider.php">
     <FalsableReturnStatement>
@@ -920,6 +1622,20 @@
     <InvalidReturnType>
       <code><![CDATA[string]]></code>
     </InvalidReturnType>
+    <PossiblyInvalidClone>
+      <code><![CDATA[clone $eventComponent->DTSTART]]></code>
+      <code><![CDATA[clone $eventComponent->DTSTART]]></code>
+      <code><![CDATA[clone $eventComponent->DTSTART]]></code>
+    </PossiblyInvalidClone>
+    <PossiblyNullReference>
+      <code><![CDATA[getDateTime]]></code>
+      <code><![CDATA[hasTime]]></code>
+      <code><![CDATA[isFloating]]></code>
+      <code><![CDATA[isFloating]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$principalId]]></code>
+    </PossiblyUndefinedArrayOffset>
     <UndefinedMethod>
       <code><![CDATA[getDateTime]]></code>
       <code><![CDATA[getDateTime]]></code>
@@ -939,6 +1655,11 @@
     </UndefinedMethod>
   </file>
   <file src="apps/dav/lib/Server.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->server->tree]]></code>
+      <code><![CDATA[\OCP\Server::get(IRequest::class)]]></code>
+      <code><![CDATA[\OCP\Server::get(IUserSession::class)]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[dispatch]]></code>
       <code><![CDATA[dispatch]]></code>
@@ -949,6 +1670,15 @@
       <code><![CDATA[getUserFolder]]></code>
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$userFolder]]></code>
+      <code><![CDATA[\OCP\Server::get(IUserSession::class)->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dav/lib/Settings/AvailabilitySettings.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/Settings/CalDAVSettings.php">
     <DeprecatedMethod>
@@ -960,6 +1690,31 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagPlugin.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$taggedObjects]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$color]]></code>
+      <code><![CDATA[$request->getHeader('Content-Type')]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagsByIdCollection.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagsObjectList.php">
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$tree]]></code>
+    </PossiblyInvalidIterator>
+  </file>
   <file src="apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php">
     <ParamNameMismatch>
       <code><![CDATA[$tagId]]></code>
@@ -970,6 +1725,9 @@
     <ParamNameMismatch>
       <code><![CDATA[$objectName]]></code>
     </ParamNameMismatch>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php">
     <DeprecatedConstant>
@@ -997,9 +1755,18 @@
     <InvalidReturnType>
       <code><![CDATA[array]]></code>
     </InvalidReturnType>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
     <RedundantFunctionCall>
       <code><![CDATA[array_values]]></code>
     </RedundantFunctionCall>
+  </file>
+  <file src="apps/dav/lib/Upload/ChunkingPlugin.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->server->tree->getNodeForPath($sourcePath)]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="apps/dav/lib/Upload/ChunkingV2Plugin.php">
     <InternalClass>
@@ -1010,6 +1777,22 @@
       <code><![CDATA[new View()]]></code>
       <code><![CDATA[putFileInfo]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->server->httpRequest->getHeader('X-OC-CTime')]]></code>
+      <code><![CDATA[$this->server->httpRequest->getHeader('X-OC-MTime')]]></code>
+      <code><![CDATA[$this->server->httpRequest->getHeader(self::DESTINATION_HEADER)]]></code>
+      <code><![CDATA[$this->uploadId]]></code>
+      <code><![CDATA[$this->uploadPath]]></code>
+      <code><![CDATA[$this->uploadPath]]></code>
+      <code><![CDATA[$this->uploadPath]]></code>
+      <code><![CDATA[$this->uploadPath]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getRelativePath]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->server->tree->getNodeForPath($path)]]></code>
+    </PropertyTypeCoercion>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getId]]></code>
       <code><![CDATA[getId]]></code>
@@ -1019,7 +1802,29 @@
       <code><![CDATA[getSize]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/Upload/FutureFile.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$nodes]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="apps/dav/lib/Upload/UploadAutoMkcolPlugin.php">
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[childExists]]></code>
+      <code><![CDATA[createDirectory]]></code>
+      <code><![CDATA[getChild]]></code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="apps/dav/lib/Upload/UploadFolder.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$this->node->getChild($name)]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="apps/dav/lib/Upload/UploadHome.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$this->impl()->getChild($name)]]></code>
+    </ArgumentTypeCoercion>
     <InternalClass>
       <code><![CDATA[new View($folder->getPath())]]></code>
     </InternalClass>
@@ -1028,6 +1833,9 @@
     </InternalMethod>
   </file>
   <file src="apps/dav/lib/UserMigration/ContactsMigrator.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$vCards]]></code>
+    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement>
       <code><![CDATA[[
 			'name' => $addressBookNode->getName(),
@@ -1057,8 +1865,15 @@
       <code><![CDATA[unlink]]></code>
       <code><![CDATA[unlink]]></code>
     </InternalMethod>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$copyResource]]></code>
+      <code><![CDATA[$sourceResource]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="apps/encryption/lib/Command/FixEncryptedVersion.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['OCA\Files_Sharing\ISharedStorage']]></code>
+    </ArgumentTypeCoercion>
     <InternalMethod>
       <code><![CDATA[file_exists]]></code>
       <code><![CDATA[fopen]]></code>
@@ -1093,6 +1908,14 @@
       <code><![CDATA[rmdir]]></code>
       <code><![CDATA[rmdir]]></code>
     </InternalMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$fh]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="apps/encryption/lib/Command/RecoverUser.php">
+    <PossiblyNullReference>
+      <code><![CDATA[setPassword]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/encryption/lib/Command/ScanLegacyFormat.php">
     <InternalClass>
@@ -1105,10 +1928,34 @@
       <code><![CDATA[stat]]></code>
     </InternalMethod>
   </file>
+  <file src="apps/encryption/lib/Controller/SettingsController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="apps/encryption/lib/Crypto/Crypt.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$privateKey]]></code>
+      <code><![CDATA[$private_key]]></code>
+      <code><![CDATA[$tmp_key]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[opensslSeal]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$catFile]]></code>
+      <code><![CDATA[$catFile]]></code>
+      <code><![CDATA[$catFile]]></code>
+      <code><![CDATA[$catFile]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$endAt]]></code>
+      <code><![CDATA[strpos($privateKey,
+					self::HEADER_END)]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
     <TypeDoesNotContainType>
       <code><![CDATA[get_class($res) === 'OpenSSLAsymmetricKey']]></code>
     </TypeDoesNotContainType>
@@ -1124,8 +1971,15 @@
       <code><![CDATA[unlink]]></code>
       <code><![CDATA[unlink]]></code>
     </InternalMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$fp]]></code>
+      <code><![CDATA[$fp]]></code>
+    </PossiblyFalseArgument>
   </file>
   <file src="apps/encryption/lib/Crypto/Encryption.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['\OCP\Files\IHomeStorage']]></code>
+    </ArgumentTypeCoercion>
     <ImplementedParamTypeMismatch>
       <code><![CDATA[$position]]></code>
     </ImplementedParamTypeMismatch>
@@ -1137,6 +1991,13 @@
       <code><![CDATA[new View()]]></code>
       <code><![CDATA[new View()]]></code>
     </InternalMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$length]]></code>
+      <code><![CDATA[$pos]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$this->crypt->symmetricEncryptFileContent($chunk, $this->fileKey, $this->version + 1, (string)$position)]]></code>
+    </PossiblyFalseOperand>
   </file>
   <file src="apps/encryption/lib/KeyManager.php">
     <DeprecatedMethod>
@@ -1154,6 +2015,19 @@
     <InvalidThrow>
       <code><![CDATA[throw $exception;]]></code>
     </InvalidThrow>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$encryptedKey]]></code>
+      <code><![CDATA[$encryptedKey]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$keyPair['privateKey']]]></code>
+      <code><![CDATA[$keyPair['privateKey']]]></code>
+      <code><![CDATA[$keyPair['publicKey']]]></code>
+      <code><![CDATA[$keyPair['publicKey']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$fileInfo->getId()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/encryption/lib/Migration/SetMasterKeyStatus.php">
     <DeprecatedMethod>
@@ -1174,6 +2048,11 @@
       <code><![CDATA[getDirectoryContent]]></code>
       <code><![CDATA[is_dir]]></code>
     </InternalMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/encryption/lib/Settings/Admin.php">
     <DeprecatedMethod>
@@ -1190,6 +2069,9 @@
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/encryption/lib/Util.php">
     <DeprecatedMethod>
@@ -1201,6 +2083,12 @@
       <code><![CDATA[file_exists]]></code>
       <code><![CDATA[getMount]]></code>
     </InternalMethod>
+    <PossiblyFalseReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$userSession->isLoggedIn() ? $userSession->getUser() : false]]></code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="apps/federatedfilesharing/lib/AddressHandler.php">
     <DeprecatedMethod>
@@ -1221,6 +2109,14 @@
       <code><![CDATA[IAppContainer]]></code>
     </DeprecatedInterface>
   </file>
+  <file src="apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$body]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="apps/federatedfilesharing/lib/Controller/RequestHandlerController.php">
     <InvalidArgument>
       <code><![CDATA[$id]]></code>
@@ -1231,6 +2127,19 @@
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$remoteId]]></code>
     </InvalidArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strpos($remote, '://')]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$owner]]></code>
+      <code><![CDATA[$owner]]></code>
+      <code><![CDATA[$remote]]></code>
+      <code><![CDATA[$shareWith]]></code>
+      <code><![CDATA[$sharedBy]]></code>
+      <code><![CDATA[$sharedByFederatedId]]></code>
+      <code><![CDATA[$token]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/federatedfilesharing/lib/FederatedShareProvider.php">
     <DeprecatedMethod>
@@ -1249,8 +2158,27 @@
       <code><![CDATA[$shareId]]></code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$remoteId]]></code>
+      <code><![CDATA[$token]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$expirationDate]]></code>
+      <code><![CDATA[$share->getExpirationDate()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$remoteId]]></code>
+      <code><![CDATA[$send]]></code>
+      <code><![CDATA[$token]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="apps/federatedfilesharing/lib/Notifications.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['OCA\FederatedFileSharing\BackgroundJob\RetryJob']]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[sendNotification]]></code>
       <code><![CDATA[sendNotification]]></code>
@@ -1291,6 +2219,38 @@
     <InvalidReturnType>
       <code><![CDATA[string]]></code>
     </InvalidReturnType>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strpos($remote, '://')]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$file]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUsers]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/federatedfilesharing/lib/Settings/Personal.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getCloudId]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/federation/lib/BackgroundJob/GetSharedSecret.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$body]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$body]]></code>
+    </PossiblyInvalidOperand>
+  </file>
+  <file src="apps/federation/lib/Controller/OCSAuthAPIController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['OCA\Federation\BackgroundJob\GetSharedSecret']]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="apps/federation/lib/Controller/SettingsController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$servers]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/federation/lib/DbHandler.php">
     <LessSpecificReturnStatement>
@@ -1299,6 +2259,25 @@
     <MoreSpecificReturnType>
       <code><![CDATA[list<array{id: int, url: string, url_hash: string, shared_secret: ?string, status: int, sync_token: ?string}>]]></code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="apps/federation/lib/Listener/TrustedServerRemovedListener.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$class]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$event->getUrl()]]></code>
+      <code><![CDATA[$event->getUrl()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/federation/lib/SyncFederationAddressBooks.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$ocsDiscoveryService]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="apps/federation/lib/TrustedServers.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$body]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/files/lib/Activity/Provider.php">
     <FalsableReturnStatement>
@@ -1339,6 +2318,11 @@
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/files/lib/BackgroundJob/SanitizeFilenames.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$errors]]></code>
+    </PossiblyInvalidArgument>
+  </file>
   <file src="apps/files/lib/BackgroundJob/ScanFiles.php">
     <DeprecatedClass>
       <code><![CDATA[\OC_Util::tearDownFS()]]></code>
@@ -1346,6 +2330,29 @@
     <DeprecatedMethod>
       <code><![CDATA[\OC_Util::tearDownFS()]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/files/lib/BackgroundJob/TransferOwnership.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$path]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files/lib/Collaboration/Resources/Listener.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[[self::class, 'shareModification']]]></code>
+      <code><![CDATA[[self::class, 'shareModification']]]></code>
+      <code><![CDATA[[self::class, 'shareModification']]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="apps/files/lib/Command/Copy.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getInternalPath]]></code>
+      <code><![CDATA[isDeletable]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files/lib/Command/Delete.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$user]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/files/lib/Command/Scan.php">
     <DeprecatedMethod>
@@ -1355,6 +2362,12 @@
       <code><![CDATA[listen]]></code>
       <code><![CDATA[search]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getId]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$user]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/files/lib/Command/ScanAppData.php">
     <DeprecatedMethod>
@@ -1369,6 +2382,48 @@
     <NullArgument>
       <code><![CDATA[null]]></code>
     </NullArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$headers]]></code>
+      <code><![CDATA[$headers]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/files/lib/Controller/ApiController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[function (Node $node) use ($shareTypesForNodes) {
+			$shareTypes = $shareTypesForNodes[$node->getId()] ?? [];
+			$file = Helper::formatFileInfo($node->getFileInfo());
+			$file['hasPreview'] = $this->previewManager->isAvailable($node);
+			$parts = explode('/', dirname($node->getPath()), 4);
+			if (isset($parts[3])) {
+				$file['path'] = '/' . $parts[3];
+			} else {
+				$file['path'] = '/';
+			}
+			if (!empty($shareTypes)) {
+				$file['shareTypes'] = $shareTypes;
+			}
+			return $file;
+		}]]></code>
+      <code><![CDATA[function (Node $node) {
+			return $node->getId();
+		}]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$tags]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getRecent]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files/lib/Controller/ConversionApiController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/files/lib/Controller/DirectEditingController.php">
     <InvalidArgument>
@@ -1379,6 +2434,24 @@
       <code><![CDATA[open]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/files/lib/Controller/OpenLocalEditorController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files/lib/Controller/TransferOwnershipController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files/lib/Controller/ViewController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="apps/files/lib/Helper.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[$i]]></code>
@@ -1387,11 +2460,30 @@
       <code><![CDATA[$i]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/files/lib/Listener/SyncLivePhotosListener.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$peerFile]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullReference>
+      <code><![CDATA[getFirstNodeById]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="apps/files/lib/Migration/Version2003Date20241021095629.php">
     <DeprecatedMethod>
       <code><![CDATA[deleteAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/files/lib/Search/FilesSearchProvider.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$comparisons]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$query->getCursor()]]></code>
+    </PossiblyInvalidOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$path]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/files/lib/Service/OwnershipTransferService.php">
     <DeprecatedClass>
@@ -1425,27 +2517,83 @@
       <code><![CDATA[unlink]]></code>
       <code><![CDATA[verifyPath]]></code>
     </InternalMethod>
+    <PossiblyFalseReference>
+      <code><![CDATA[getInternalPath]]></code>
+      <code><![CDATA[getSize]]></code>
+      <code><![CDATA[getSize]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullArgument>
+      <code><![CDATA[$nodePath]]></code>
+      <code><![CDATA[$path]]></code>
+    </PossiblyNullArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[isReadyForUser]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/files/lib/Service/TagService.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$currentTags]]></code>
+      <code><![CDATA[$currentTags]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="apps/files_external/lib/Command/Create.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$value]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/files_external/lib/Command/Import.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$authBackend]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/files_external/lib/Command/Notify.php">
     <DeprecatedClass>
       <code><![CDATA[\OC_Util::normalizeUnicode($parent)]]></code>
       <code><![CDATA[\OC_Util::normalizeUnicode($path)]]></code>
     </DeprecatedClass>
+    <PossiblyNullReference>
+      <code><![CDATA[getBackend]]></code>
+      <code><![CDATA[getId]]></code>
+      <code><![CDATA[getId]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_external/lib/Command/Scan.php">
     <DeprecatedMethod>
       <code><![CDATA[listen]]></code>
       <code><![CDATA[listen]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$e->getReadablePath()]]></code>
+      <code><![CDATA[$e->getReadablePath()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files_external/lib/Command/Verify.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$value]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/files_external/lib/Config/UserContext.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_external/lib/Controller/StoragesController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
       <code><![CDATA[(int)$status]]></code>
     </RedundantCast>
+  </file>
+  <file src="apps/files_external/lib/Controller/UserGlobalStoragesController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_external/lib/Lib/Backend/Backend.php">
     <LessSpecificReturnStatement>
@@ -1454,6 +2602,58 @@
     <MoreSpecificReturnType>
       <code><![CDATA[class-string<IStorage>]]></code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="apps/files_external/lib/Lib/Backend/SMB.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$pass]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files_external/lib/Lib/LegacyDependencyCheckPolyfill.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$message]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files_external/lib/Lib/PersonalMount.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$targetParts[2]]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$targetParts[2]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/AmazonS3.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[strrpos($path, '.')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$this->params['bucket']]]></code>
+      <code><![CDATA[$this->params['hostname']]]></code>
+      <code><![CDATA[$this->params['key']]]></code>
+    </PossiblyNullArrayAccess>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/FTP.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$stream]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/FtpConnection.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$files]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$response[0]]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$response[0]]]></code>
+    </PossiblyNullArrayAccess>
   </file>
   <file src="apps/files_external/lib/Lib/Storage/SFTP.php">
     <InternalClass>
@@ -1464,8 +2664,28 @@
       <code><![CDATA[new View('/' . $userId . '/files_external')]]></code>
       <code><![CDATA[put]]></code>
     </InternalMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$keyPath]]></code>
+      <code><![CDATA[$keyPath]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parsed['host']]]></code>
+      <code><![CDATA[$parsed['host']]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/files_external/lib/Lib/Storage/SMB.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[strrpos($path, '.')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$parameters['share']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parameters['share']]]></code>
+    </PossiblyUndefinedArrayOffset>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
       <code><![CDATA[(int)$e->getCode()]]></code>
@@ -1476,6 +2696,28 @@
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
   </file>
+  <file src="apps/files_external/lib/Lib/Storage/StreamWrapper.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$fh]]></code>
+      <code><![CDATA[$fh]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->constructUrl($path)]]></code>
+      <code><![CDATA[$this->constructUrl($path)]]></code>
+      <code><![CDATA[$this->constructUrl($path)]]></code>
+      <code><![CDATA[$this->constructUrl($path)]]></code>
+      <code><![CDATA[$this->constructUrl($path)]]></code>
+      <code><![CDATA[$this->constructUrl($path)]]></code>
+      <code><![CDATA[$this->constructUrl($path)]]></code>
+      <code><![CDATA[$this->constructUrl($source)]]></code>
+      <code><![CDATA[$this->constructUrl($target)]]></code>
+      <code><![CDATA[$this->constructUrl($target)]]></code>
+      <code><![CDATA[$url]]></code>
+      <code><![CDATA[$url]]></code>
+      <code><![CDATA[$url]]></code>
+      <code><![CDATA[$url]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/files_external/lib/Lib/Storage/Swift.php">
     <InvalidArgument>
       <code><![CDATA[$object->lastModified]]></code>
@@ -1484,6 +2726,29 @@
       <code><![CDATA[filetype]]></code>
       <code><![CDATA[fopen]]></code>
     </InvalidNullableReturnType>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$dh]]></code>
+      <code><![CDATA[$dh]]></code>
+      <code><![CDATA[$dh]]></code>
+      <code><![CDATA[$source]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[strrpos($path, '.')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseReference>
+      <code><![CDATA[copy]]></code>
+      <code><![CDATA[copy]]></code>
+      <code><![CDATA[mergeMetadata]]></code>
+    </PossiblyFalseReference>
+  </file>
+  <file src="apps/files_external/lib/Lib/StorageConfig.php">
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$id ?? -1]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$message]]></code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="apps/files_external/lib/Migration/DummyUserSession.php">
     <InvalidReturnType>
@@ -1512,6 +2777,10 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/files_external/lib/Service/StoragesService.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$applicableGroups]]></code>
+      <code><![CDATA[$applicableUsers]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[Util::emitHook(
 				Filesystem::CLASSNAME,
@@ -1523,6 +2792,37 @@
 				]
 			)]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/files_external/lib/Service/UserGlobalStoragesService.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->getUser()]]></code>
+      <code><![CDATA[$this->getUser()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files_external/lib/Service/UserStoragesService.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files_external/lib/Settings/Personal.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files_external/templates/settings.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$_['visibilityType']]]></code>
+      <code><![CDATA[$_['visibilityType']]]></code>
+      <code><![CDATA[$_['visibilityType']]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/files_reminders/lib/Model/RichReminder.php">
     <ConstructorSignatureMismatch>
@@ -1536,6 +2836,14 @@
       <code><![CDATA[query]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/files_sharing/lib/Cache.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[[
+				$storageFilter,
+				new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'path', $this->getGetUnjailedRoot()),
+			]]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="apps/files_sharing/lib/Capabilities.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
@@ -1545,12 +2853,38 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/files_sharing/lib/Command/ExiprationNotification.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getTimestamp]]></code>
+      <code><![CDATA[getTimestamp]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="apps/files_sharing/lib/Controller/DeletedShareAPIController.php">
     <DeprecatedClass>
       <code><![CDATA[new QueryException()]]></code>
       <code><![CDATA[new QueryException()]]></code>
       <code><![CDATA[new QueryException()]]></code>
     </DeprecatedClass>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getDisplayName]]></code>
+      <code><![CDATA[getDisplayName]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/PublicPreviewController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$file]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidMethodCall>
+      <code><![CDATA[getMimeType]]></code>
+    </PossiblyInvalidMethodCall>
   </file>
   <file src="apps/files_sharing/lib/Controller/RemoteController.php">
     <InternalClass>
@@ -1560,6 +2894,10 @@
       <code><![CDATA[getFileInfo]]></code>
       <code><![CDATA[new View('/' . \OC_User::getUser() . '/files/')]]></code>
     </InternalMethod>
+    <PossiblyFalseOperand>
+      <code><![CDATA[\OC_User::getUser()]]></code>
+      <code><![CDATA[\OC_User::getUser()]]></code>
+    </PossiblyFalseOperand>
   </file>
   <file src="apps/files_sharing/lib/Controller/ShareAPIController.php">
     <DeprecatedClass>
@@ -1570,6 +2908,69 @@
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$displayNameLength]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($share->getSharedWith(), '[')]]></code>
+      <code><![CDATA[strrpos($share->getSharedWith(), '[')]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$file]]></code>
+      <code><![CDATA[$file]]></code>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$node]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$userId]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[format]]></code>
+      <code><![CDATA[format]]></code>
+      <code><![CDATA[getParent]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$share['share_with']]]></code>
+    </PossiblyUndefinedArrayOffset>
     <RedundantCast>
       <code><![CDATA[(int)$code]]></code>
       <code><![CDATA[(int)$code]]></code>
@@ -1599,8 +3000,42 @@
       <code><![CDATA[emitAccessShareHook]]></code>
       <code><![CDATA[emitAccessShareHook]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->share]]></code>
+      <code><![CDATA[$this->share]]></code>
+      <code><![CDATA[$this->share]]></code>
+      <code><![CDATA[$this->share]]></code>
+      <code><![CDATA[$this->share]]></code>
+      <code><![CDATA[$this->share]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getPassword]]></code>
+      <code><![CDATA[getPassword]]></code>
+      <code><![CDATA[getShareType]]></code>
+      <code><![CDATA[getSharedWith]]></code>
+      <code><![CDATA[getSharedWith]]></code>
+      <code><![CDATA[setPassword]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/ShareesAPIController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files_sharing/lib/ExpireSharesJob.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$id]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/files_sharing/lib/External/Cache.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$remote]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/files_sharing/lib/External/Manager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->storageLoader]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code><![CDATA[Files::buildNotExistingFileName($shareFolder, $share['name'])]]></code>
       <code><![CDATA[Files::buildNotExistingFileName('/', $name)]]></code>
@@ -1620,19 +3055,52 @@
     <MoreSpecificReturnType>
       <code><![CDATA[Mount]]></code>
     </MoreSpecificReturnType>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$groupShare['user']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->uid]]></code>
+      <code><![CDATA[$this->uid]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getCache]]></code>
+      <code><![CDATA[inGroup]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files_sharing/lib/External/MountProvider.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storageFactory]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="apps/files_sharing/lib/External/Scanner.php">
     <DeprecatedInterface>
       <code><![CDATA[Scanner]]></code>
     </DeprecatedInterface>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$storage]]></code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="apps/files_sharing/lib/External/Storage.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedInterface>
       <code><![CDATA[Storage]]></code>
     </DeprecatedInterface>
     <DeprecatedMethod>
       <code><![CDATA[Util::isSharingDisabledForUser()]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$response->getBody()]]></code>
+      <code><![CDATA[$result]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="apps/files_sharing/lib/Helper.php">
     <DeprecatedMethod>
@@ -1646,6 +3114,9 @@
       <code><![CDATA[is_dir]]></code>
       <code><![CDATA[mkdir]]></code>
     </InternalMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[file_exists]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_sharing/lib/Hooks.php">
     <InternalClass>
@@ -1656,6 +3127,13 @@
       <code><![CDATA[new View('/')]]></code>
       <code><![CDATA[unlink]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$path]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getAbsolutePath]]></code>
+      <code><![CDATA[instanceOfStorage]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_sharing/lib/Middleware/SharingCheckMiddleware.php">
     <DeprecatedInterface>
@@ -1693,14 +3171,28 @@
       <code><![CDATA[new View('/' . $parentShare->getShareOwner() . '/files')]]></code>
       <code><![CDATA[new View('/' . $user->getUID() . '/files')]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$share->getNodeCacheEntry()]]></code>
+    </PossiblyNullArgument>
     <RedundantFunctionCall>
       <code><![CDATA[array_values]]></code>
     </RedundantFunctionCall>
   </file>
+  <file src="apps/files_sharing/lib/Notification/Listener.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUsers]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="apps/files_sharing/lib/Scanner.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['\OCA\Files_Sharing\SharedStorage']]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedInterface>
       <code><![CDATA[Scanner]]></code>
     </DeprecatedInterface>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$storage]]></code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="apps/files_sharing/lib/ShareBackend/File.php">
     <InternalClass>
@@ -1719,6 +3211,11 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$shareWith]]></code>
     </MoreSpecificImplementedParamType>
+    <PossiblyNullReference>
+      <code><![CDATA[getCache]]></code>
+      <code><![CDATA[isOutgoingServer2serverGroupShareEnabled]]></code>
+      <code><![CDATA[isOutgoingServer2serverShareEnabled]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_sharing/lib/SharedMount.php">
     <InternalMethod>
@@ -1730,8 +3227,21 @@
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$storage]]></code>
+    </NonInvariantDocblockPropertyType>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getStorageId]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_sharing/lib/SharedStorage.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedInterface>
       <code><![CDATA[SharedStorage]]></code>
     </DeprecatedInterface>
@@ -1754,6 +3264,20 @@
     <NullableReturnStatement>
       <code><![CDATA[$this->sourceRootInfo]]></code>
     </NullableReturnStatement>
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[$this->nonMaskedStorage->getCache()->get($this->rootPath)]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+    <PossiblyNullArgument>
+      <code><![CDATA[$sourcePath]]></code>
+      <code><![CDATA[$sourcePath]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$this->superShare->getNodeCacheEntry()]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getRelativePath]]></code>
+      <code><![CDATA[getRelativePath]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_sharing/lib/SharesReminderJob.php">
     <DeprecatedConstant>
@@ -1767,6 +3291,15 @@
     <DeprecatedMethod>
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseOperand>
+      <code><![CDATA[\OC_User::getUser()]]></code>
+      <code><![CDATA[\OC_User::getUser()]]></code>
+      <code><![CDATA[\OC_User::getUser()]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[instanceOfStorage]]></code>
+    </PossiblyNullReference>
     <UndefinedMethod>
       <code><![CDATA[moveMount]]></code>
     </UndefinedMethod>
@@ -1815,6 +3348,14 @@
       <code><![CDATA[is_dir]]></code>
       <code><![CDATA[new View('/' . $user)]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$userObject]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getMinAgeAsTimestamp]]></code>
+      <code><![CDATA[getSeenUsers]]></code>
+      <code><![CDATA[userExists]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_trashbin/lib/Command/RestoreAllFiles.php">
     <DeprecatedClass>
@@ -1831,7 +3372,18 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/files_trashbin/lib/Controller/PreviewController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$file]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/files_trashbin/lib/Helper.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storage]]></code>
+    </ArgumentTypeCoercion>
     <InternalClass>
       <code><![CDATA[new View('/' . $user . '/files_trashbin/files')]]></code>
     </InternalClass>
@@ -1842,6 +3394,12 @@
       <code><![CDATA[is_dir]]></code>
       <code><![CDATA[new View('/' . $user . '/files_trashbin/files')]]></code>
     </InternalMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getCache]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$pathparts['extension']]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="apps/files_trashbin/lib/Sabre/AbstractTrash.php">
     <InvalidNullableReturnType>
@@ -1889,11 +3447,25 @@
     <DeprecatedMethod>
       <code><![CDATA[dispatch]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[dispatchTyped]]></code>
+      <code><![CDATA[getById]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[moveToTrash]]></code>
+      <code><![CDATA[userExists]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_trashbin/lib/Trash/LegacyTrashBackend.php">
     <InternalMethod>
       <code><![CDATA[getRelativePath]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$item->isRootItem() ? $item->getDeletedTime() : null]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getOriginalLocation]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[$file]]></code>
     </UndefinedInterfaceMethod>
@@ -2011,6 +3583,44 @@
     <InvalidArgument>
       <code><![CDATA[$timestamp]]></code>
     </InvalidArgument>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$location]]></code>
+      <code><![CDATA[$location]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$location]]></code>
+      <code><![CDATA[$location]]></code>
+      <code><![CDATA[$location]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyFalseReference>
+      <code><![CDATA[$fileInfo]]></code>
+      <code><![CDATA[$info]]></code>
+    </PossiblyFalseReference>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$info['fileid']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$path]]></code>
+      <code><![CDATA[$path]]></code>
+      <code><![CDATA[$root]]></code>
+      <code><![CDATA[$timestamp]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getParent]]></code>
+      <code><![CDATA[getParent]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="apps/files_versions/lib/AppInfo/Application.php">
     <DeprecatedClass>
@@ -2061,8 +3671,19 @@
       <code><![CDATA[is_dir]]></code>
       <code><![CDATA[new View('/' . $user)]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$userObject]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files_versions/lib/Controller/PreviewController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_versions/lib/Listener/FileEventsListener.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$previousNode]]></code>
+    </ArgumentTypeCoercion>
     <InternalClass>
       <code><![CDATA[new View($user . '/files')]]></code>
     </InternalClass>
@@ -2070,6 +3691,18 @@
       <code><![CDATA[file_exists]]></code>
       <code><![CDATA[new View($user . '/files')]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$newPath]]></code>
+      <code><![CDATA[$newPath]]></code>
+      <code><![CDATA[$oldPath]]></code>
+      <code><![CDATA[$oldPath]]></code>
+      <code><![CDATA[$path]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/files_versions/lib/Listener/VersionAuthorListener.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$node]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="apps/files_versions/lib/Sabre/RestoreFolder.php">
     <InvalidNullableReturnType>
@@ -2080,6 +3713,9 @@
     </NullableReturnStatement>
   </file>
   <file src="apps/files_versions/lib/Sabre/VersionFile.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->version->getSourceFile()]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[getLabel]]></code>
       <code><![CDATA[setVersionLabel]]></code>
@@ -2156,6 +3792,32 @@
       <code><![CDATA[unlockFile]]></code>
       <code><![CDATA[unlockFile]]></code>
     </InternalMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$uid]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$availableSpace]]></code>
+      <code><![CDATA[$quota]]></code>
+      <code><![CDATA[$uid]]></code>
+      <code><![CDATA[$versionsBegin]]></code>
+      <code><![CDATA[$versionsBegin]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyFalseReference>
+      <code><![CDATA[$fileInfo]]></code>
+      <code><![CDATA[$info]]></code>
+      <code><![CDATA[getData]]></code>
+      <code><![CDATA[getEncryptedVersion]]></code>
+      <code><![CDATA[isUpdateable]]></code>
+    </PossiblyFalseReference>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$info['fileid']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$fileInfo->getId()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getOwner]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/files_versions/lib/Versions/LegacyVersionsBackend.php">
     <InternalClass>
@@ -2170,6 +3832,30 @@
       <code><![CDATA[new View('/' . $user->getUID())]]></code>
       <code><![CDATA[new View('/' . $user->getUID())]]></code>
     </InternalMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$version->getRevisionId()]]></code>
+      <code><![CDATA[$version->getRevisionId()]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$file->getId()]]></code>
+      <code><![CDATA[$relativePath]]></code>
+      <code><![CDATA[$relativePath]]></code>
+      <code><![CDATA[$sourceFile->getId()]]></code>
+      <code><![CDATA[$this->mimeTypeLoader->getMimetypeById($versions['db']->getMimetype())]]></code>
+      <code><![CDATA[$userFolder->getRelativePath($file->getPath())]]></code>
+      <code><![CDATA[$version->getSourceFile()->getId()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getTimestamp]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/files_versions/lib/Versions/VersionManager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$node]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$file->getOwner()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php">
     <DeprecatedConstant>
@@ -2183,6 +3869,10 @@
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
+    <PossiblyNullArgument>
+      <code><![CDATA[$client_secret]]></code>
+      <code><![CDATA[$code]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/provisioning_api/lib/Controller/AUserDataOCSController.php">
     <DeprecatedClass>
@@ -2198,8 +3888,45 @@
       <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[implementsActions]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseReference>
+      <code><![CDATA[getSize]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullArgument>
+      <code><![CDATA[$currentLoggedInUser]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/GroupsController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$groupManager]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$currentUser]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[delete]]></code>
+      <code><![CDATA[getUsers]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/PreferencesController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/provisioning_api/lib/Controller/UsersController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$groupManager]]></code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedConstant>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
@@ -2220,10 +3947,46 @@
       <code><![CDATA[search]]></code>
       <code><![CDATA[search]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$group]]></code>
+      <code><![CDATA[$group]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$currentLoggedInUser]]></code>
+      <code><![CDATA[$limit]]></code>
+      <code><![CDATA[$limit]]></code>
+      <code><![CDATA[$this->groupManager->get($group)]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[addUser]]></code>
+      <code><![CDATA[getGID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+    </PossiblyNullReference>
     <TypeDoesNotContainNull>
       <code><![CDATA[$groupid === null]]></code>
       <code><![CDATA[$groupid === null]]></code>
     </TypeDoesNotContainNull>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/VerificationController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/provisioning_api/lib/FederatedShareProviderFactory.php">
     <DeprecatedInterface>
@@ -2246,6 +4009,36 @@
     </InvalidReturnType>
   </file>
   <file src="apps/settings/lib/AppInfo/Application.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[function (IAppContainer $appContainer) {
+			/** @var IServerContainer $serverContainer */
+			$serverContainer = $appContainer->query(IServerContainer::class);
+			return $serverContainer->getSettingsManager();
+		}]]></code>
+      <code><![CDATA[function (IAppContainer $appContainer) {
+			/** @var IServerContainer $serverContainer */
+			$serverContainer = $appContainer->query(IServerContainer::class);
+			return $serverContainer->query(IProvider::class);
+		}]]></code>
+      <code><![CDATA[function (IAppContainer $appContainer) {
+			/** @var Server $server */
+			$server = $appContainer->query(IServerContainer::class);
+			/** @var Defaults $defaults */
+			$defaults = $server->query(Defaults::class);
+
+			return new NewUserMailHelper(
+				$defaults,
+				$server->getURLGenerator(),
+				$server->getL10NFactory(),
+				$server->getMailer(),
+				$server->getSecureRandom(),
+				new TimeFactory(),
+				$server->getConfig(),
+				$server->getCrypto(),
+				Util::getDefaultEmailAddress('no-reply')
+			);
+		}]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedInterface>
       <code><![CDATA[$serverContainer]]></code>
       <code><![CDATA[$serverContainer]]></code>
@@ -2278,12 +4071,44 @@
     <DeprecatedConstant>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
     </DeprecatedConstant>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$publishedCode]]></code>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="apps/settings/lib/Controller/AppSettingsController.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getSupportedApps]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$appScreenshot]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/settings/lib/Controller/AuthSettingsController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$token]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/settings/lib/Controller/ChangePasswordController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$loginName]]></code>
+      <code><![CDATA[$recoveryPassword]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$userSession]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="apps/settings/lib/Controller/CommonSettingsTrait.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/settings/lib/Controller/MailSettingsController.php">
     <DeprecatedMethod>
@@ -2294,8 +4119,15 @@
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getDisplayName]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/settings/lib/Controller/UsersController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$data['scope']]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedConstant>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
@@ -2315,11 +4147,19 @@
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[validateMailAddress]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getGID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/settings/lib/Controller/WebAuthnController.php">
     <DeprecatedMethod>
       <code><![CDATA[PublicKeyCredentialCreationOptions::createFromArray($this->session->get(self::WEBAUTHN_REGISTRATION))]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/settings/lib/Hooks.php">
     <DeprecatedMethod>
@@ -2329,6 +4169,11 @@
     <InvalidArrayOffset>
       <code><![CDATA[[$user->getEMailAddress() => $user->getDisplayName()]]]></code>
     </InvalidArrayOffset>
+  </file>
+  <file src="apps/settings/lib/Listener/AppPasswordCreatedActivityListener.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/settings/lib/Settings/Admin/ArtificialIntelligence.php">
     <DeprecatedInterface>
@@ -2346,6 +4191,9 @@
 				continue;
 			}]]></code>
     </DeprecatedInterface>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$defaultValue]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="apps/settings/lib/Settings/Admin/Security.php">
     <UndefinedInterfaceMethod>
@@ -2356,6 +4204,9 @@
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->isProfileEnabledByDefault($this->config)]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/settings/lib/Settings/Admin/Sharing.php">
     <DeprecatedMethod>
@@ -2380,14 +4231,43 @@
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
     </DeprecatedConstant>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$uid]]></code>
+      <code><![CDATA[$uid]]></code>
+      <code><![CDATA[$uid]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/settings/lib/Settings/Personal/Security/Authtokens.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[function (IToken $token) use ($sessionToken) {
+			$data = $token->jsonSerialize();
+			$data['canDelete'] = true;
+			$data['canRename'] = $token instanceof INamedToken && $data['type'] !== IToken::WIPE_TOKEN;
+			if ($sessionToken->getId() === $token->getId()) {
+				$data['canDelete'] = false;
+				$data['canRename'] = false;
+				$data['current'] = true;
+			}
+			return $data;
+		}]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code><![CDATA[IToken::WIPE_TOKEN]]></code>
     </DeprecatedClass>
     <DeprecatedInterface>
       <code><![CDATA[IToken]]></code>
     </DeprecatedInterface>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/Security/Password.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/settings/lib/Settings/Personal/Security/WebAuthn.php">
     <DeprecatedInterface>
@@ -2401,6 +4281,9 @@
     <DeprecatedMethod>
       <code><![CDATA[dispatch]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/settings/lib/SetupChecks/CheckUserCertificates.php">
     <DeprecatedMethod>
@@ -2411,6 +4294,11 @@
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DataDirectoryProtected.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$body]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/settings/lib/SetupChecks/EmailTestSuccessful.php">
     <DeprecatedMethod>
@@ -2423,6 +4311,34 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$tasks]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/TaskProcessingSuccessRate.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$tasks]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/settings/lib/UserMigration/AccountMigrator.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$avatarFile->read()]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="apps/settings/templates/settings/admin/additional-mail.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$_['mail_sendmailmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+      <code><![CDATA[$_['mail_smtpmode']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
   <file src="apps/sharebymail/lib/Settings/SettingsManager.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
@@ -2434,6 +4350,13 @@
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$share->getPassword()]]></code>
+      <code><![CDATA[$share->getPassword()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/systemtags/lib/Activity/Listener.php">
     <DeprecatedConstant>
@@ -2466,6 +4389,19 @@
       <code><![CDATA[query]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/systemtags/lib/Controller/LastUsedController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/systemtags/lib/Search/TagSearchProvider.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$query->getCursor()]]></code>
+    </PossiblyInvalidOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$path]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/testing/lib/AlternativeHomeUserBackend.php">
     <DeprecatedInterface>
       <code><![CDATA[AlternativeHomeUserBackend]]></code>
@@ -2485,6 +4421,15 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/testing/lib/Controller/LockingController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA[(int)$this->config->getAppValue('testing', $lock)]]></code>
+      <code><![CDATA[(int)$this->config->getAppValue('testing', $lock)]]></code>
+      <code><![CDATA[(int)$this->config->getAppValue('testing', $lock)]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[deleteAppValue]]></code>
       <code><![CDATA[getAppKeys]]></code>
@@ -2496,6 +4441,13 @@
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/Conversion/ConversionProvider.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+    </PossiblyFalseArgument>
   </file>
   <file src="apps/testing/lib/Provider/FakeText2ImageProvider.php">
     <DeprecatedInterface>
@@ -2532,6 +4484,12 @@
       <code><![CDATA[FakeTranslationProvider]]></code>
     </DeprecatedInterface>
   </file>
+  <file src="apps/testing/lib/TaskProcessing/FakeTranslateProvider.php">
+    <PossiblyInvalidArrayOffset>
+      <code><![CDATA[$coreLanguages[$input['origin_language']]]]></code>
+      <code><![CDATA[$coreLanguages[$input['target_language']]]]></code>
+    </PossiblyInvalidArrayOffset>
+  </file>
   <file src="apps/theming/lib/Capabilities.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
@@ -2544,12 +4502,26 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/theming/lib/Controller/IconController.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->fileAccessHelper->file_get_contents($fallbackLogo)]]></code>
+      <code><![CDATA[$this->fileAccessHelper->file_get_contents($fallbackLogo)]]></code>
+    </PossiblyFalseArgument>
+  </file>
   <file src="apps/theming/lib/Controller/ThemingController.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$info['name']]]></code>
+    </PossiblyNullArrayAccess>
+  </file>
+  <file src="apps/theming/lib/Controller/UserThemeController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/theming/lib/ImageManager.php">
     <DeprecatedMethod>
@@ -2565,6 +4537,31 @@
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$newTmpFile]]></code>
+      <code><![CDATA[$newTmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$outputImage]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="apps/theming/lib/Listener/BeforeTemplateRenderedListener.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/theming/lib/Service/ThemeInjectionService.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/theming/lib/Service/ThemesService.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/theming/lib/Settings/Admin.php">
     <DeprecatedMethod>
@@ -2617,6 +4614,9 @@
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$file->read()]]></code>
+    </PossiblyFalseArgument>
   </file>
   <file src="apps/theming/lib/Util.php">
     <DeprecatedMethod>
@@ -2631,6 +4631,11 @@
       <code><![CDATA[array{0: int, 1: int, 2: int}]]></code>
     </InvalidReturnType>
   </file>
+  <file src="apps/twofactor_backupcodes/lib/Controller/SettingsController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="apps/twofactor_backupcodes/lib/Migration/Version1002Date20170919123342.php">
     <DeprecatedMethod>
       <code><![CDATA[getName]]></code>
@@ -2644,6 +4649,12 @@
       <code><![CDATA[\OC_JSON::error(['message' => $e->getMessage()])]]></code>
       <code><![CDATA[\OC_JSON::success()]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$_POST['ldap_clear_mapping']]]></code>
+    </PossiblyInvalidCast>
+    <PossiblyUndefinedGlobalVariable>
+      <code><![CDATA[$result]]></code>
+    </PossiblyUndefinedGlobalVariable>
   </file>
   <file src="apps/user_ldap/ajax/deleteConfiguration.php">
     <DeprecatedMethod>
@@ -2653,6 +4664,9 @@
       <code><![CDATA[\OC_JSON::error(['message' => $l->t('Failed to delete the server configuration')])]]></code>
       <code><![CDATA[\OC_JSON::success()]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$_POST['ldap_serverconfig_chooser']]]></code>
+    </PossiblyInvalidCast>
   </file>
   <file src="apps/user_ldap/ajax/getConfiguration.php">
     <DeprecatedMethod>
@@ -2661,6 +4675,9 @@
       <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
       <code><![CDATA[\OC_JSON::success(['configuration' => $configuration])]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$_POST['ldap_serverconfig_chooser']]]></code>
+    </PossiblyInvalidCast>
   </file>
   <file src="apps/user_ldap/ajax/getNewServerConfigPrefix.php">
     <DeprecatedMethod>
@@ -2669,6 +4686,9 @@
       <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
       <code><![CDATA[\OC_JSON::success($resultData)]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$_POST['copyConfig']]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="apps/user_ldap/ajax/setConfiguration.php">
     <DeprecatedMethod>
@@ -2677,6 +4697,9 @@
       <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
       <code><![CDATA[\OC_JSON::success()]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$_POST['ldap_serverconfig_chooser']]]></code>
+    </PossiblyInvalidCast>
   </file>
   <file src="apps/user_ldap/ajax/testConfiguration.php">
     <DeprecatedMethod>
@@ -2692,6 +4715,9 @@
       <code><![CDATA[\OC_JSON::success(['message'
 			=> $l->t('Valid configuration, connection established!')])]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$_POST['ldap_serverconfig_chooser']]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="apps/user_ldap/ajax/wizard.php">
     <DeprecatedMethod>
@@ -2712,6 +4738,16 @@
       <code><![CDATA[\OC_JSON::success($result->getResultArray())]]></code>
       <code><![CDATA[\OC_JSON::success()]]></code>
     </DeprecatedMethod>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$_POST['action']]]></code>
+      <code><![CDATA[$_POST['ldap_serverconfig_chooser']]]></code>
+    </PossiblyInvalidCast>
+    <PossiblyNullArgument>
+      <code><![CDATA[$setParameters]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$setParameters[0]]]></code>
+    </PossiblyNullArrayAccess>
   </file>
   <file src="apps/user_ldap/appinfo/routes.php">
     <InvalidScope>
@@ -2730,6 +4766,29 @@
     <InvalidReturnType>
       <code><![CDATA[string[]]]></code>
     </InvalidReturnType>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strpos($queryData[1], '-')]]></code>
+      <code><![CDATA[strrpos($lastName, '_')]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$sr]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$bases]]></code>
+      <code><![CDATA[$bases]]></code>
+      <code><![CDATA[$this->connection->ldapBase]]></code>
+      <code><![CDATA[$this->connection->ldapBaseGroups]]></code>
+      <code><![CDATA[$this->connection->ldapBaseGroups]]></code>
+      <code><![CDATA[$this->connection->ldapBaseUsers]]></code>
+      <code><![CDATA[$this->connection->ldapBaseUsers]]></code>
+    </PossiblyInvalidIterator>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[composeAndStoreDisplayName]]></code>
+      <code><![CDATA[processAttributes]]></code>
+    </PossiblyUndefinedMethod>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$usernameAttribute]]></code>
+    </PossiblyUndefinedVariable>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
@@ -2759,6 +4818,21 @@
       <code><![CDATA[registerService]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/user_ldap/lib/Command/CheckUser.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getDN]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/user_ldap/lib/Command/CreateEmptyConfig.php">
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[false]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+  </file>
+  <file src="apps/user_ldap/lib/Command/ShowConfig.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$configIDs]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
   <file src="apps/user_ldap/lib/Configuration.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
@@ -2774,16 +4848,43 @@
 						$subj = $key;
 						break;]]></code>
     </ParadoxicalCondition>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$ttl]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$setParameters]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$this->bindResult['result']]]></code>
+      <code><![CDATA[$this->bindResult['result']]]></code>
+      <code><![CDATA[$this->bindResult['sum']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="apps/user_ldap/lib/Controller/ConfigAPIController.php">
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[false]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
   </file>
   <file src="apps/user_ldap/lib/Group_LDAP.php">
     <InvalidScalarArgument>
       <code><![CDATA[$groupID]]></code>
     </InvalidScalarArgument>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->access->groupname2dn($gid)]]></code>
+    </PossiblyFalseArgument>
   </file>
   <file src="apps/user_ldap/lib/Group_Proxy.php">
     <ParamNameMismatch>
       <code><![CDATA[$gid]]></code>
     </ParamNameMismatch>
+    <PossiblyNullReference>
+      <code><![CDATA[implementsActions]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="apps/user_ldap/lib/Helper.php">
+    <RiskyCast>
+      <code><![CDATA[str_replace('s', '', $lastKey)]]></code>
+    </RiskyCast>
   </file>
   <file src="apps/user_ldap/lib/Jobs/CleanUp.php">
     <DeprecatedMethod>
@@ -2808,11 +4909,23 @@
     <InvalidOperand>
       <code><![CDATA[$i]]></code>
     </InvalidOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$cycleData['prefix']]]></code>
+      <code><![CDATA[$minPagingSize]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/user_ldap/lib/Jobs/UpdateGroups.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/LDAP.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[!empty($extended_error) ? $extended_error : $errorMsg]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$errorMsg]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/user_ldap/lib/LDAPProvider.php">
     <DeprecatedInterface>
@@ -2836,6 +4949,9 @@
       <code><![CDATA[getDatabasePlatform]]></code>
       <code><![CDATA[insertIfNotExist]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[get]]></code>
+    </PossiblyNullReference>
     <RedundantCondition>
       <code><![CDATA[isset($qb)]]></code>
     </RedundantCondition>
@@ -2864,10 +4980,24 @@
       <code><![CDATA[getDatabasePlatform]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="apps/user_ldap/lib/Settings/Admin.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$parameters]]></code>
+      <code><![CDATA[$parameters]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
   <file src="apps/user_ldap/lib/User/Manager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->access->getUserMapper()]]></code>
+    </ArgumentTypeCoercion>
     <InvalidDocblock>
       <code><![CDATA[public function setLdapAccess(Access $access) {]]></code>
     </InvalidDocblock>
+    <PossiblyNullReference>
+      <code><![CDATA[getConnection]]></code>
+      <code><![CDATA[getUserMapper]]></code>
+      <code><![CDATA[username2dn]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/user_ldap/lib/User/User.php">
     <DeprecatedConstant>
@@ -2877,6 +5007,9 @@
       <code><![CDATA[Util::connectHook('OC_User', 'post_login', $this, 'handlePasswordExpiry')]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->image->data()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/user_ldap/lib/User_LDAP.php">
     <DeprecatedInterface>
@@ -2892,6 +5025,14 @@
     <NullableReturnStatement>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->access->username2dn($uid)]]></code>
+      <code><![CDATA[$this->access->username2dn($uid)]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$limit]]></code>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
     <RedundantCondition>
       <code><![CDATA[$displayName && (count($displayName) > 0)]]></code>
       <code><![CDATA[is_string($dn)]]></code>
@@ -2904,11 +5045,48 @@
     <ParamNameMismatch>
       <code><![CDATA[$uid]]></code>
     </ParamNameMismatch>
+    <PossiblyNullArgument>
+      <code><![CDATA[$limit]]></code>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getBackendName]]></code>
+      <code><![CDATA[hasUserListings]]></code>
+      <code><![CDATA[implementsActions]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/user_ldap/lib/Wizard.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$entry]]></code>
+      <code><![CDATA[$entry]]></code>
+    </ArgumentTypeCoercion>
     <InvalidArrayOffset>
       <code><![CDATA[$possibleAttrs[$i]]]></code>
     </InvalidArrayOffset>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$attrs[$possibleAttrs[$i]]]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyInvalidArrayOffset>
+      <code><![CDATA[$this->configuration->ldapBaseGroups[0]]]></code>
+      <code><![CDATA[$this->configuration->ldapBase[0]]]></code>
+      <code><![CDATA[$this->configuration->ldapBase[0]]]></code>
+      <code><![CDATA[$this->configuration->ldapBase[0]]]></code>
+    </PossiblyInvalidArrayOffset>
+    <PossiblyNullArgument>
+      <code><![CDATA[$maxEntryObjC]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[n]]></code>
+      <code><![CDATA[n]]></code>
+      <code><![CDATA[n]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="apps/user_status/lib/AppInfo/Application.php">
     <DeprecatedMethod>
@@ -2920,6 +5098,22 @@
     <UndefinedInterfaceMethod>
       <code><![CDATA[registerProvider]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/user_status/lib/Connector/UserStatus.php">
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[DateTimeImmutable::createFromFormat('U', (string)$this->internalStatus->getClearAt())]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+  </file>
+  <file src="apps/user_status/lib/Controller/UserStatusController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php">
     <DeprecatedInterface>
@@ -2944,6 +5138,71 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$status->getMessageId()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/weather_status/lib/Service/WeatherStatusService.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$body]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$formattedAddress]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userManager->get($this->userId)]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="apps/webhook_listeners/lib/BackgroundJobs/WebhookCall.php">
+    <PossiblyInvalidMethodCall>
+      <code><![CDATA[getBody]]></code>
+      <code><![CDATA[getBody]]></code>
+      <code><![CDATA[getStatusCode]]></code>
+    </PossiblyInvalidMethodCall>
+  </file>
+  <file src="apps/workflowengine/lib/Check/AbstractStringCheck.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$pattern]]></code>
+      <code><![CDATA[$value]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="apps/workflowengine/lib/Check/FileMimeType.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$path]]></code>
+      <code><![CDATA[$this->request->getPathInfo() ?? '']]></code>
+      <code><![CDATA[$this->request->getPathInfo() ?? '']]></code>
+      <code><![CDATA[$this->request->getPathInfo() ?? '']]></code>
+      <code><![CDATA[$this->request->getPathInfo() ?? '']]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="apps/workflowengine/lib/Check/FileSize.php">
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[false]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+  </file>
+  <file src="apps/workflowengine/lib/Check/RequestTime.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$timezone1]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="apps/workflowengine/lib/Check/RequestURL.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->request->getPathInfo() ?? '']]></code>
+      <code><![CDATA[$this->request->getPathInfo() ?? '']]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$this->request->getPathInfo()]]></code>
+    </PossiblyFalseOperand>
   </file>
   <file src="apps/workflowengine/lib/Entity/File.php">
     <DeprecatedConstant>
@@ -2955,8 +5214,39 @@
       <code><![CDATA[getSubject]]></code>
       <code><![CDATA[getSubject]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getCache]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[getSubject]]></code>
+      <code><![CDATA[getSubject]]></code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="apps/workflowengine/lib/Manager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$entity]]></code>
+      <code><![CDATA[$scope->getScope()]]></code>
+      <code><![CDATA[(int)$row['scope_type']]]></code>
+      <code><![CDATA[(int)$row['type']]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="apps/workflowengine/lib/Service/RuleMatcher.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$class]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[executeCheck]]></code>
+    </PossiblyUndefinedMethod>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$scopes]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="apps/workflowengine/lib/Settings/ASettings.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->getScope()]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code><![CDATA[dispatch]]></code>
     </DeprecatedMethod>
@@ -2982,10 +5272,33 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/BackgroundJobs/MovePreviewJob.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$previewFile->getSize()]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->mimeTypeLoader->getMimetypeById((int)$result[0]['mimetype'])]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="core/Command/App/ListApps.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
+  </file>
+  <file src="core/Command/Background/Job.php">
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$row['execution_duration']]]></code>
+      <code><![CDATA[$row['last_checked']]]></code>
+      <code><![CDATA[$row['last_run']]]></code>
+      <code><![CDATA[$row['last_run']]]></code>
+      <code><![CDATA[$row['reserved_at']]]></code>
+      <code><![CDATA[$row['reserved_at']]]></code>
+    </PossiblyNullArrayAccess>
+  </file>
+  <file src="core/Command/Base.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->valueToString($item, false)]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="core/Command/Broadcast/Test.php">
     <DeprecatedMethod>
@@ -2996,6 +5309,11 @@
     <DeprecatedClass>
       <code><![CDATA[\OC_Util::checkServer($this->config)]]></code>
     </DeprecatedClass>
+  </file>
+  <file src="core/Command/Config/App/SetConfig.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$keyDetails['note']]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="core/Command/Config/Import.php">
     <DeprecatedMethod>
@@ -3017,6 +5335,18 @@
       <code><![CDATA[$this->appConfig->getValues($app, false)]]></code>
     </FalsableReturnStatement>
   </file>
+  <file src="core/Command/Config/Preset.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$list]]></code>
+      <code><![CDATA[$list]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="core/Command/Config/System/CastHelper.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="core/Command/Db/ConvertType.php">
     <DeprecatedMethod>
       <code><![CDATA[getPrimaryKeyColumns]]></code>
@@ -3025,6 +5355,16 @@
       <code><![CDATA[0]]></code>
       <code><![CDATA[1]]></code>
     </InvalidScalarArgument>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$count]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$count]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$currentMigration]]></code>
+      <code><![CDATA[$currentMigration]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="core/Command/Db/ExportSchema.php">
     <DeprecatedMethod>
@@ -3092,6 +5432,24 @@
       <code><![CDATA[\OC_Util::tearDownFS()]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/Command/Group/Delete.php">
+    <PossiblyNullReference>
+      <code><![CDATA[delete]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="core/Command/Info/File.php">
+    <PossiblyNullIterator>
+      <code><![CDATA[$configs]]></code>
+    </PossiblyNullIterator>
+  </file>
+  <file src="core/Command/Info/FileUtils.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$cacheEntry]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getCache]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="core/Command/Log/File.php">
     <InvalidReturnStatement>
       <code><![CDATA[[0]]]></code>
@@ -3101,6 +5459,9 @@
     </InvalidReturnType>
   </file>
   <file src="core/Command/Log/Manage.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$timezone]]></code>
+    </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[$levelNum]]></code>
     </InvalidArgument>
@@ -3109,6 +5470,18 @@
     <InvalidScalarArgument>
       <code><![CDATA[$this->timeFactory->getTime()]]></code>
     </InvalidScalarArgument>
+  </file>
+  <file src="core/Command/Preview/Generate.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[function (array $sizes) use ($crop, $mode) {
+			return [
+				'width' => $sizes[0],
+				'height' => $sizes[1],
+				'crop' => $crop,
+				'mode' => $mode,
+			];
+		}]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="core/Command/Security/BruteforceAttempts.php">
     <DeprecatedMethod>
@@ -3148,6 +5521,24 @@
     </DeprecatedClass>
   </file>
   <file src="core/Command/User/AuthTokens/ListCommand.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[function (IToken $token) use ($input): mixed {
+			$sensitive = [
+				'password',
+				'password_hash',
+				'token',
+				'public_key',
+				'private_key',
+			];
+			$data = array_diff_key($token->jsonSerialize(), array_flip($sensitive));
+
+			if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
+				$data = $this->formatTokenForPlainOutput($data);
+			}
+
+			return $data;
+		}]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
       <code><![CDATA[IToken::TEMPORARY_TOKEN]]></code>
@@ -3162,19 +5553,36 @@
       <code><![CDATA[search]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/Command/User/Report.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$rows]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
   <file src="core/Command/User/Setting.php">
     <DeprecatedMethod>
       <code><![CDATA[search]]></code>
       <code><![CDATA[setEMailAddress]]></code>
     </DeprecatedMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getDisplayName]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="core/Controller/AppPasswordController.php">
     <DeprecatedClass>
       <code><![CDATA[IToken::DO_NOT_REMEMBER]]></code>
       <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
     </DeprecatedClass>
+    <PossiblyNullArgument>
+      <code><![CDATA[$loginName]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="core/Controller/AutoCompleteController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[[
+				'itemType' => $itemType,
+				'itemId' => $itemId,
+			]]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code><![CDATA[new AutoCompleteEvent([
 			'search' => $search,
@@ -3190,7 +5598,31 @@
       <code><![CDATA[dispatch]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/Controller/AvatarController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$image->data()]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="core/Controller/ClientFlowLoginController.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[strpos($this->request->getRequestUri(), '/index.php')]]></code>
+      <code><![CDATA[strpos($this->request->getRequestUri(), '/login/flow')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="core/Controller/ClientFlowLoginV2Controller.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[strpos($this->request->getRequestUri(), '/index.php')]]></code>
+      <code><![CDATA[strpos($this->request->getRequestUri(), '/login/v2')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
     <TypeDoesNotContainType>
       <code><![CDATA[!is_string($stateToken)]]></code>
     </TypeDoesNotContainType>
@@ -3200,10 +5632,33 @@
       <code><![CDATA[searchCollections]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="core/Controller/ContactsMenuController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="core/Controller/HoverCardController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="core/Controller/LoginController.php">
     <DeprecatedMethod>
       <code><![CDATA[getDelay]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$appName]]></code>
+      <code><![CDATA[$loginName]]></code>
+      <code><![CDATA[$redirect_url]]></code>
+      <code><![CDATA[$redirect_url]]></code>
+      <code><![CDATA[$redirect_url]]></code>
+      <code><![CDATA[$result->getErrorMessage()]]></code>
+      <code><![CDATA[$result->getRedirectUrl()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="core/Controller/LostController.php">
     <DeprecatedMethod>
@@ -3213,6 +5668,10 @@
 			['uid' => &$user]
 		)]]></code>
     </DeprecatedMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user ? $user->getEMailAddress() : '']]></code>
+    </PossiblyNullArgument>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
@@ -3222,6 +5681,24 @@
       <code><![CDATA[IInitialStateService]]></code>
     </DeprecatedInterface>
   </file>
+  <file src="core/Controller/PreviewController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$mode]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$url]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="core/Controller/ProfileApiController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$timezoneStringTarget]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="core/Controller/RecommendedAppsController.php">
     <DeprecatedInterface>
       <code><![CDATA[private]]></code>
@@ -3229,6 +5706,16 @@
     <DeprecatedMethod>
       <code><![CDATA[provideInitialState]]></code>
     </DeprecatedMethod>
+  </file>
+  <file src="core/Controller/ReferenceApiController.php">
+    <PossiblyNullReference>
+      <code><![CDATA[jsonSerialize]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="core/Controller/ReferenceController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$contentType]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="core/Controller/SetupController.php">
     <DeprecatedInterface>
@@ -3244,8 +5731,23 @@
     <DeprecatedClass>
       <code><![CDATA[\OC_Util::setupFS($task->getUserId())]]></code>
     </DeprecatedClass>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$node->fopen('rb')]]></code>
+      <code><![CDATA[$node->fopen('rb')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$provider]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="core/Controller/TeamsApiController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[array_map(fn (Team $team): string => $team->getId(), $teams)]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="core/Controller/TextProcessingApiController.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$type]]></code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code><![CDATA[Task]]></code>
       <code><![CDATA[new Task($type, $input, $appId, $this->userId, $identifier)]]></code>
@@ -3255,6 +5757,9 @@
       <code><![CDATA[Task]]></code>
       <code><![CDATA[private]]></code>
     </DeprecatedInterface>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="core/Controller/TextToImageApiController.php">
     <DeprecatedClass>
@@ -3270,10 +5775,26 @@
       <code><![CDATA[private]]></code>
     </DeprecatedInterface>
   </file>
+  <file src="core/Controller/TwoFactorChallengeController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="core/Controller/UnifiedSearchController.php">
     <DeprecatedInterface>
       <code><![CDATA[private]]></code>
     </DeprecatedInterface>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$urlPath]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$urlParts['path']]]></code>
+    </PossiblyUndefinedArrayOffset>
     <UndefinedInterfaceMethod>
       <code><![CDATA[findMatchingRoute]]></code>
     </UndefinedInterfaceMethod>
@@ -3288,6 +5809,14 @@
 		)]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/Listener/BeforeMessageLoggedEventListener.php">
+    <PossiblyNullIterator>
+      <code><![CDATA[$argv]]></code>
+    </PossiblyNullIterator>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$_SERVER['argv']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
   <file src="core/Middleware/TwoFactorMiddleware.php">
     <DeprecatedInterface>
       <code><![CDATA[private]]></code>
@@ -3299,6 +5828,12 @@
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="core/Service/LoginFlowV2Service.php">
     <DeprecatedClass>
@@ -3324,10 +5859,77 @@
       <code><![CDATA[listen]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/templates/layout.base.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$_]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="core/templates/layout.guest.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$_]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="core/templates/layout.public.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$_]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="core/templates/loginflow/authpicker.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[\OCP\Util::sanitizeHTML($_['client'])]]></code>
+    </PossiblyInvalidOperand>
+  </file>
+  <file src="core/templates/loginflow/grant.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[\OCP\Util::sanitizeHTML($_['client'])]]></code>
+    </PossiblyInvalidOperand>
+  </file>
+  <file src="core/templates/loginflowv2/authpicker.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[\OCP\Util::sanitizeHTML($_['client'])]]></code>
+    </PossiblyInvalidOperand>
+  </file>
+  <file src="core/templates/loginflowv2/grant.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[\OCP\Util::sanitizeHTML($_['client'])]]></code>
+    </PossiblyInvalidOperand>
+  </file>
   <file src="lib/base.php">
     <InvalidArgument>
       <code><![CDATA[$restrictions]]></code>
     </InvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$_SERVER['argv']]]></code>
+      <code><![CDATA[$cookieParams['path']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$_SERVER['argv']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Accounts/AccountManager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[AccountProperty::mapScopeToV2($property->getScope())]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$data]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Accounts/AccountProperty.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$scope]]></code>
+    </ArgumentTypeCoercion>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$newScope]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Activity/Event.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->getRichMessageParameters()]]></code>
+      <code><![CDATA[$this->getRichSubjectParameters()]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="lib/private/Activity/Manager.php">
     <InvalidPropertyAssignmentValue>
@@ -3341,11 +5943,116 @@
     <MoreSpecificReturnType>
       <code><![CDATA[ActivitySettings[]]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$currentUserId]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/AllConfig.php">
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$list]]></code>
+    </PossiblyInvalidIterator>
+  </file>
+  <file src="lib/private/App/AppManager.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->shippedApps]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$entry['app']]]></code>
+      <code><![CDATA[$entry['app']]]></code>
+    </PossiblyNullArrayAccess>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$versionToLoad['version']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/App/AppStore/Fetcher/Fetcher.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/App/CompareVersion.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$comparator]]></code>
+      <code><![CDATA[$comparator]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/App/InfoParser.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$fileCacheKey]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/private/AppConfig.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$sensitiveKeyExp]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/AppFramework/App.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$container->get(IRequest::class)]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$httpHeaders]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$app]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/AppFramework/Bootstrap/EventListenerRegistration.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$service]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="lib/private/AppFramework/Bootstrap/FunctionInjector.php">
     <UndefinedMethod>
       <code><![CDATA[getName]]></code>
     </UndefinedMethod>
+  </file>
+  <file src="lib/private/AppFramework/Bootstrap/MiddlewareRegistration.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$service]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/AppFramework/Bootstrap/PreviewProviderRegistration.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$service]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/AppFramework/Bootstrap/RegistrationContext.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$backend]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$taskProcessingProviderClass]]></code>
+      <code><![CDATA[$taskProcessingTaskTypeClass]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$appId]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/private/AppFramework/Bootstrap/ServiceRegistration.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$service]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/private/AppFramework/DependencyInjection/DIContainer.php">
     <InvalidReturnStatement>
@@ -3354,6 +6061,11 @@
     <InvalidReturnType>
       <code><![CDATA[\OCP\IServerContainer]]></code>
     </InvalidReturnType>
+  </file>
+  <file src="lib/private/AppFramework/Http/Dispatcher.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$throwable->getCode()]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/AppFramework/Http/Output.php">
     <InvalidReturnStatement>
@@ -3372,6 +6084,14 @@
       <code><![CDATA[isset($this->env[$key]) ? $this->env[$key] : null]]></code>
       <code><![CDATA[isset($this->files[$key]) ? $this->files[$key] : null]]></code>
     </NullableReturnStatement>
+    <PossiblyFalseArgument>
+      <code><![CDATA[strpos($IP, ':')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$this->items['get']]]></code>
+      <code><![CDATA[$this->items['post']]]></code>
+      <code><![CDATA[$this->items['urlParams']]]></code>
+    </PossiblyInvalidArgument>
     <RedundantCondition>
       <code><![CDATA[\is_array($params)]]></code>
     </RedundantCondition>
@@ -3380,9 +6100,25 @@
     </UndefinedFunction>
   </file>
   <file src="lib/private/AppFramework/Middleware/OCSMiddleware.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+    </ArgumentTypeCoercion>
     <InternalMethod>
       <code><![CDATA[setOCSVersion]]></code>
     </InternalMethod>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$response->getData()['message']]]></code>
+      <code><![CDATA[$response->getData()['message']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$message]]></code>
+      <code><![CDATA[$message]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$response->getData()['message']]]></code>
+      <code><![CDATA[$response->getData()['message']]]></code>
+    </PossiblyNullArrayAccess>
   </file>
   <file src="lib/private/AppFramework/Middleware/Security/CORSMiddleware.php">
     <NoInterfaceProperties>
@@ -3390,13 +6126,46 @@
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
+  <file src="lib/private/AppFramework/Middleware/Security/CSPMiddleware.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$policy]]></code>
+      <code><![CDATA[$policy]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$password]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$exception->getCode()]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
   <file src="lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$exception->getCode()]]></code>
+    </ArgumentTypeCoercion>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
     <UndefinedClass>
       <code><![CDATA[\OCA\Talk\Controller\PageController]]></code>
     </UndefinedClass>
+  </file>
+  <file src="lib/private/AppFramework/OCS/BaseResponse.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$v]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$dataResponse->getData()]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
   </file>
   <file src="lib/private/AppFramework/Services/AppConfig.php">
     <MoreSpecificImplementedParamType>
@@ -3404,19 +6173,159 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="lib/private/AppFramework/Utility/SimpleContainer.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$name]]></code>
+    </ArgumentTypeCoercion>
     <MissingTemplateParam>
       <code><![CDATA[ArrayAccess]]></code>
     </MissingTemplateParam>
+    <PossiblyNullArgument>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
   </file>
+  <file src="lib/private/AppFramework/Utility/TimeFactory.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$timezone]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="lib/private/Archive/TAR.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmpBase]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[strrpos($file, '.')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$folder]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmp]]></code>
+      <code><![CDATA[$tmpBase]]></code>
+      <code><![CDATA[$tmpBase]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$this->cachedHeaders]]></code>
+    </PossiblyInvalidIterator>
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->tar->listContent()]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
     <UndefinedDocblockClass>
       <code><![CDATA[$this->tar->extractInString($path)]]></code>
     </UndefinedDocblockClass>
   </file>
+  <file src="lib/private/Archive/ZIP.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php">
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[getWrapperStorage]]></code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="lib/private/Authentication/Login/ClearLostPasswordTokensCommand.php">
+    <PossiblyFalseReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Authentication/Login/CompleteLoginCommand.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$loginData->getUser()]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$loginData->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Authentication/Login/CreateSessionTokenCommand.php">
+    <PossiblyFalseReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullArgument>
+      <code><![CDATA[$loginData->getPassword()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Authentication/Login/FinishRememberedLoginCommand.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$loginData->getUser()]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$loginData->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Authentication/Login/LoginData.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$password]]></code>
+      <code><![CDATA[$redirectUrl]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/private/Authentication/Login/SetUserTimezoneCommand.php">
+    <PossiblyFalseReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Authentication/Login/TwoFactorCommand.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+      <code><![CDATA[$loginData->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Authentication/Login/UidLoginCommand.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$loginData->getPassword()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Authentication/Login/UpdateLastPasswordConfirmCommand.php">
+    <PossiblyFalseReference>
+      <code><![CDATA[getLastLogin]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullReference>
+      <code><![CDATA[getLastLogin]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="lib/private/Authentication/LoginCredentials/Store.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$creds['password']]]></code>
+    </PossiblyNullArgument>
     <RedundantCondition>
       <code><![CDATA[$trySession]]></code>
     </RedundantCondition>
@@ -3441,6 +6350,27 @@
       <code><![CDATA[setType]]></code>
     </UndefinedMagicMethod>
   </file>
+  <file src="lib/private/Authentication/Token/PublicKeyTokenProvider.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$newToken]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$savedToken->getPassword()]]></code>
+      <code><![CDATA[$token->getPassword()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Authentication/Token/RemoteWipe.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$dbToken]]></code>
+      <code><![CDATA[$dbToken]]></code>
+      <code><![CDATA[function (IToken $token) {
+			return $token instanceof IWipeableToken;
+		}]]></code>
+      <code><![CDATA[function (IToken $token) {
+			return $token instanceof IWipeableToken;
+		}]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="lib/private/Authentication/TwoFactorAuth/ProviderSet.php">
     <InvalidArgument>
       <code><![CDATA[$this->providers]]></code>
@@ -3459,11 +6389,46 @@
       <code><![CDATA[$this->providers]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/Avatar/Avatar.php">
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$box[2]]]></code>
+      <code><![CDATA[$box[4]]]></code>
+      <code><![CDATA[$box[5]]]></code>
+      <code><![CDATA[$box[7]]]></code>
+    </PossiblyInvalidArrayAccess>
+  </file>
+  <file src="lib/private/Avatar/UserAvatar.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$avatar->mimeType()]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$index]]></code>
+    </PossiblyFalseArgument>
+  </file>
   <file src="lib/private/Cache/File.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[bool|mixed]]></code>
       <code><![CDATA[bool|mixed]]></code>
     </LessSpecificImplementedReturnType>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Calendar/CalendarEventBuilder.php">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->status->value]]></code>
+    </PossiblyNullPropertyFetch>
   </file>
   <file src="lib/private/Calendar/Manager.php">
     <LessSpecificReturnStatement>
@@ -3501,6 +6466,74 @@
 				return $provider->getCalendars($principalUri, $calendarUris);
 			}, $context->getCalendarProviders())]]></code>
     </NamedArgumentNotAllowed>
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$parsedResponse]]></code>
+    </PossiblyInvalidIterator>
+    <PossiblyNullArgument>
+      <code><![CDATA[$propertyValue]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[add]]></code>
+      <code><![CDATA[getPropertyvalue]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[handleIMipMessage]]></code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="lib/private/Calendar/Resource/Manager.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->backends]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Calendar/ResourcesRoomsUpdater.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Calendar/Room/Manager.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->backends]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Collaboration/Collaborators/LookupPlugin.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getCloudId]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Collaboration/Collaborators/MailPlugin.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Collaboration/Collaborators/Search.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$limit]]></code>
+      <code><![CDATA[$limit]]></code>
+      <code><![CDATA[$offset]]></code>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Collaboration/Collaborators/UserPlugin.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[preg_replace('/ \(.*\)$/', '', $userDisplayName)]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[format]]></code>
+      <code><![CDATA[format]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Collaboration/Resources/Manager.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$access]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="lib/private/Command/CallableJob.php">
     <ParamNameMismatch>
@@ -3522,20 +6555,102 @@
       <code><![CDATA[$this->delete($key)]]></code>
       <code><![CDATA[$this->set($key, $value)]]></code>
     </InvalidOperand>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$needsUpdate]]></code>
+      <code><![CDATA[$needsUpdate]]></code>
+    </PossiblyFalseOperand>
     <UndefinedVariable>
       <code><![CDATA[$CONFIG]]></code>
       <code><![CDATA[$CONFIG]]></code>
     </UndefinedVariable>
+  </file>
+  <file src="lib/private/Config/ConfigManager.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$entry->getRename()]]></code>
+      <code><![CDATA[$entry->getRename()]]></code>
+      <code><![CDATA[$entry->getRename()]]></code>
+      <code><![CDATA[$entry->getRename()]]></code>
+      <code><![CDATA[$entry->getRename()]]></code>
+      <code><![CDATA[$entry->getRename()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[clearCache]]></code>
+      <code><![CDATA[clearCacheAll]]></code>
+      <code><![CDATA[getConfigDetailsFromLexicon]]></code>
+      <code><![CDATA[getConfigDetailsFromLexicon]]></code>
+      <code><![CDATA[getConfigDetailsFromLexicon]]></code>
+      <code><![CDATA[getConfigDetailsFromLexicon]]></code>
+      <code><![CDATA[getValueMixed]]></code>
+      <code><![CDATA[getValueMixed]]></code>
+      <code><![CDATA[ignoreLexiconAliases]]></code>
+      <code><![CDATA[ignoreLexiconAliases]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[Server::get(IAppConfig::class)]]></code>
+      <code><![CDATA[Server::get(IUserConfig::class)]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Config/PresetManager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[Server::get(IAppConfig::class)]]></code>
+      <code><![CDATA[Server::get(IUserConfig::class)]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullReference>
+      <code><![CDATA[disableApp]]></code>
+      <code><![CDATA[enableApp]]></code>
+      <code><![CDATA[isDownloaded]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[Server::get(IAppManager::class)]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Config/UserConfig.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$lazy]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$aliases]]></code>
+    </PossiblyNullArrayOffset>
   </file>
   <file src="lib/private/Console/Application.php">
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
+  <file src="lib/private/Contacts/ContactsMenu/Manager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$entries]]></code>
+      <code><![CDATA[usort($entries, function (Entry $entryA, Entry $entryB) {
+			$aStatusTimestamp = $entryA->getProperty(Entry::PROPERTY_STATUS_MESSAGE_TIMESTAMP);
+			$bStatusTimestamp = $entryB->getProperty(Entry::PROPERTY_STATUS_MESSAGE_TIMESTAMP);
+			if (!$aStatusTimestamp && !$bStatusTimestamp) {
+				return strcasecmp($entryA->getFullName(), $entryB->getFullName());
+			}
+			if ($aStatusTimestamp === null) {
+				return 1;
+			}
+			if ($bStatusTimestamp === null) {
+				return -1;
+			}
+			return $bStatusTimestamp - $aStatusTimestamp;
+		})]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$timezoneStringCurrent]]></code>
+      <code><![CDATA[$timezoneStringTarget]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="lib/private/ContactsManager.php">
     <InvalidArgument>
       <code><![CDATA[$searchOptions]]></code>
     </InvalidArgument>
+  </file>
+  <file src="lib/private/ContextChat/ContentManager.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$op]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="lib/private/DB/AdapterMySQL.php">
     <InternalMethod>
@@ -3552,6 +6667,39 @@
     <InvalidArgument>
       <code><![CDATA[$params]]></code>
     </InvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[query]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$this->getParams()['charset']]]></code>
+      <code><![CDATA[$traces[1]['file']]]></code>
+      <code><![CDATA[$traces[1]['line']]]></code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyTypeCoercion>
+      <code><![CDATA[array_map(function (ShardDefinition $shard) {
+			return array_merge([$shard->table], $shard->companionTables);
+		}, $this->shards)]]></code>
+      <code><![CDATA[new $params['adapter']($this)]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/DB/ConnectionFactory.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$connectionParams]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/DB/DbDataCollector.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->debugStack->queries]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->debugStack->queries]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$query['params']]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/private/DB/Exceptions/DbalException.php">
     <RedundantCondition>
@@ -3568,6 +6716,20 @@
     <MoreSpecificReturnType>
       <code><![CDATA[IMigrationStep]]></code>
     </MoreSpecificReturnType>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$table]]></code>
+      <code><![CDATA[$table]]></code>
+      <code><![CDATA[$thing]]></code>
+      <code><![CDATA[$thing]]></code>
+      <code><![CDATA[$thing]]></code>
+      <code><![CDATA[$thing]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/private/DB/PgSqlTools.php">
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$sequenceInfo['column_name']]]></code>
+      <code><![CDATA[$sequenceInfo['table_name']]]></code>
+    </PossiblyInvalidArrayAccess>
   </file>
   <file src="lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php">
     <ImplicitToStringCast>
@@ -3577,6 +6739,9 @@
       <code><![CDATA[$y]]></code>
       <code><![CDATA[$y]]></code>
     </InvalidArgument>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$queryBuilder->func()]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php">
     <InternalMethod>
@@ -3585,6 +6750,48 @@
     <InvalidArrayOffset>
       <code><![CDATA[$params['collation']]]></code>
     </InvalidArrayOffset>
+  </file>
+  <file src="lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$x]]></code>
+      <code><![CDATA[$x]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php">
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[getServerVersion]]></code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="lib/private/DB/QueryBuilder/Partitioned/JoinCondition.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[1]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/DB/QueryBuilder/Partitioned/PartitionedQueryBuilder.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$condition]]></code>
+      <code><![CDATA[$condition]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$checkColumn]]></code>
+      <code><![CDATA[$checkColumn]]></code>
+      <code><![CDATA[$joinCondition->fromAlias ?? $joinCondition->fromColumn]]></code>
+      <code><![CDATA[$joinCondition->fromAlias ?? $joinCondition->fromColumn]]></code>
+      <code><![CDATA[$joinCondition->toAlias ?? $joinCondition->toColumn]]></code>
+      <code><![CDATA[$joinCondition->toAlias ?? $joinCondition->toColumn]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/DB/QueryBuilder/QueryBuilder.php">
     <InvalidNullableReturnType>
@@ -3596,6 +6803,21 @@
     <ParamNameMismatch>
       <code><![CDATA[$selects]]></code>
     </ParamNameMismatch>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$condition]]></code>
+      <code><![CDATA[$condition]]></code>
+      <code><![CDATA[$condition]]></code>
+      <code><![CDATA[$condition]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$alias]]></code>
+      <code><![CDATA[$delete]]></code>
+      <code><![CDATA[$insert]]></code>
+      <code><![CDATA[$update]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$insert]]></code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/private/DB/QueryBuilder/QuoteHelper.php">
     <InvalidNullableReturnType>
@@ -3604,6 +6826,17 @@
     <NullableReturnStatement>
       <code><![CDATA[$string]]></code>
     </NullableReturnStatement>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$columnName]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/DB/QueryBuilder/Sharded/ShardedQueryBuilder.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->insertTable]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getShardForKey]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/private/DateTimeFormatter.php">
     <FalsableReturnStatement>
@@ -3620,6 +6853,15 @@
       <code><![CDATA[string]]></code>
     </InvalidReturnType>
   </file>
+  <file src="lib/private/DateTimeZone.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$timeZone]]></code>
+      <code><![CDATA[$timeZone]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$timestamp]]></code>
+    </PossiblyInvalidArgument>
+  </file>
   <file src="lib/private/Diagnostics/Query.php">
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[float]]></code>
@@ -3629,11 +6871,23 @@
     <InvalidArgument>
       <code><![CDATA[microtime(true)]]></code>
     </InvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$params]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="lib/private/DirectEditing/Manager.php">
     <InvalidReturnType>
       <code><![CDATA[TemplateResponse]]></code>
     </InvalidReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$filePath]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
     <UndefinedMethod>
       <code><![CDATA[$template]]></code>
       <code><![CDATA[$template]]></code>
@@ -3649,6 +6903,27 @@
       <code><![CDATA[getShareForToken]]></code>
     </UndefinedMethod>
   </file>
+  <file src="lib/private/EmojiHelper.php">
+    <PossiblyNullReference>
+      <code><![CDATA[setText]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Encryption/DecryptAll.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['OCA\Files_Sharing\SharedStorage']]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseReference>
+      <code><![CDATA[getMTime]]></code>
+    </PossiblyFalseReference>
+  </file>
+  <file src="lib/private/Encryption/EncryptionEventListener.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$event->getSource()]]></code>
+      <code><![CDATA[$event->getTarget()]]></code>
+      <code><![CDATA[$event->getTarget()]]></code>
+      <code><![CDATA[\OC::$server->get(IFile::class)]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="lib/private/Encryption/Keys/Storage.php">
     <InvalidNullableReturnType>
       <code><![CDATA[deleteUserKey]]></code>
@@ -3658,16 +6933,41 @@
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
     </NullArgument>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$clearData]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="lib/private/Encryption/Manager.php">
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[bool]]></code>
     </ImplementedReturnTypeMismatch>
   </file>
+  <file src="lib/private/EventSource.php">
+    <RiskyCast>
+      <code><![CDATA[$_GET['fallback_id']]]></code>
+    </RiskyCast>
+  </file>
   <file src="lib/private/Federation/CloudFederationProviderManager.php">
     <ParamNameMismatch>
       <code><![CDATA[$providerId]]></code>
     </ParamNameMismatch>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$e->getCode()]]></code>
+      <code><![CDATA[$e->getCode()]]></code>
+      <code><![CDATA[$response->getBody()]]></code>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Federation/CloudIdManager.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$remote]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="lib/private/Files/AppData/AppData.php">
     <LessSpecificReturnStatement>
@@ -3676,8 +6976,18 @@
     <MoreSpecificReturnType>
       <code><![CDATA[Folder]]></code>
     </MoreSpecificReturnType>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$appDataRootFolder->get($this->appId)]]></code>
+      <code><![CDATA[$this->rootFolder->get($name . '/' . $this->appId)]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/private/Files/Cache/Cache.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$sizes]]></code>
+      <code><![CDATA[$this->storage]]></code>
+      <code><![CDATA[$unencryptedOnlySizes]]></code>
+      <code><![CDATA[$unencryptedSizes]]></code>
+    </ArgumentTypeCoercion>
     <InvalidNullableReturnType>
       <code><![CDATA[array]]></code>
     </InvalidNullableReturnType>
@@ -3685,6 +6995,26 @@
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+    <PossiblyFalseArgument>
+      <code><![CDATA[strpos($value, '/')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$sourceStorageId]]></code>
+      <code><![CDATA[$targetStorageId]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyFalseReference>
+      <code><![CDATA[$entry]]></code>
+    </PossiblyFalseReference>
+  </file>
+  <file src="lib/private/Files/Cache/CacheEntry.php">
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$this->data]]></code>
+    </PossiblyNullArrayOffset>
+  </file>
+  <file src="lib/private/Files/Cache/CacheQueryBuilder.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->alias]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="lib/private/Files/Cache/FailedCache.php">
     <InvalidReturnStatement>
@@ -3704,11 +7034,49 @@
       <code><![CDATA[$file]]></code>
       <code><![CDATA[$file]]></code>
     </MoreSpecificImplementedParamType>
+    <PossiblyFalseReference>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$filesData]]></code>
+    </PossiblyFalseReference>
+    <PossiblyInvalidArrayAssignment>
+      <code><![CDATA[$data['size']]]></code>
+    </PossiblyInvalidArrayAssignment>
+  </file>
+  <file src="lib/private/Files/Cache/QuerySearchHelper.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storageFilters]]></code>
+      <code><![CDATA[[$searchQuery->getSearchOperation(), $storageFilter]]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="lib/private/Files/Cache/Scanner.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$existingData]]></code>
+    </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[self::SCAN_RECURSIVE_INCOMPLETE]]></code>
     </InvalidArgument>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$storage->getCache()]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Files/Cache/SearchBuilder.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$type]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </PossiblyInvalidCast>
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$operator->getValue()]]></code>
+      <code><![CDATA[$value]]></code>
+    </PossiblyInvalidIterator>
+    <PossiblyNullArgument>
+      <code><![CDATA[$metadataQuery]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[joinIndex]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/private/Files/Cache/Storage.php">
     <InvalidNullableReturnType>
@@ -3719,9 +7087,42 @@
     </NullableReturnStatement>
   </file>
   <file src="lib/private/Files/Cache/Updater.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$time]]></code>
+    </PossiblyNullArgument>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$storage->getCache()]]></code>
+      <code><![CDATA[$storage->getPropagator()]]></code>
+      <code><![CDATA[$storage->getScanner()]]></code>
+    </PropertyTypeCoercion>
     <RedundantCondition>
       <code><![CDATA[$this->cache instanceof Cache]]></code>
     </RedundantCondition>
+  </file>
+  <file src="lib/private/Files/Cache/Watcher.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$cachedEntry]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseReference>
+      <code><![CDATA[getStorageMTime]]></code>
+    </PossiblyFalseReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$storage->getCache()]]></code>
+      <code><![CDATA[$storage->getScanner()]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Files/Cache/Wrapper/CacheJail.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[[
+					$filter,
+					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR,
+						[
+							new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'path', $this->getGetUnjailedRoot()),
+							new SearchComparison(ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE, 'path', SearchComparison::escapeLikeParameter($this->getGetUnjailedRoot()) . '/%'),
+						],
+					)
+				]]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="lib/private/Files/Cache/Wrapper/CacheWrapper.php">
     <LessSpecificImplementedReturnType>
@@ -3729,7 +7130,21 @@
       <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
   </file>
+  <file src="lib/private/Files/Config/CachedMountInfo.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getParent]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Files/Config/LazyStorageMountInfo.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$this->mount->getNumericStorageId()]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
   <file src="lib/private/Files/Config/MountProviderCollection.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$mounts]]></code>
+      <code><![CDATA[$providers]]></code>
+    </ArgumentTypeCoercion>
     <InvalidOperand>
       <code><![CDATA[$user]]></code>
     </InvalidOperand>
@@ -3755,6 +7170,24 @@
       <code><![CDATA[array{int, string, int}]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="lib/private/Files/Conversion/ConversionManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getFileConversionProviders]]></code>
+      <code><![CDATA[getFileConversionProviders]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->preferredProviders]]></code>
+      <code><![CDATA[$this->providers]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Files/FileInfo.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$rootEntry]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$path]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
+  </file>
   <file src="lib/private/Files/Filesystem.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$mount->getStorage()]]></code>
@@ -3766,8 +7199,80 @@
       <code><![CDATA[Mount\MountPoint[]]]></code>
       <code><![CDATA[\OC\Files\Storage\Storage|null]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[addMount]]></code>
+      <code><![CDATA[copy]]></code>
+      <code><![CDATA[file_exists]]></code>
+      <code><![CDATA[file_get_contents]]></code>
+      <code><![CDATA[file_put_contents]]></code>
+      <code><![CDATA[filemtime]]></code>
+      <code><![CDATA[filesize]]></code>
+      <code><![CDATA[filetype]]></code>
+      <code><![CDATA[find]]></code>
+      <code><![CDATA[findIn]]></code>
+      <code><![CDATA[fopen]]></code>
+      <code><![CDATA[free_space]]></code>
+      <code><![CDATA[fromTmpFile]]></code>
+      <code><![CDATA[getDirectoryContent]]></code>
+      <code><![CDATA[getETag]]></code>
+      <code><![CDATA[getFileInfo]]></code>
+      <code><![CDATA[getMimeType]]></code>
+      <code><![CDATA[getOwner]]></code>
+      <code><![CDATA[getPath]]></code>
+      <code><![CDATA[hasUpdated]]></code>
+      <code><![CDATA[hash]]></code>
+      <code><![CDATA[isCreatable]]></code>
+      <code><![CDATA[isDeletable]]></code>
+      <code><![CDATA[isReadable]]></code>
+      <code><![CDATA[isSharable]]></code>
+      <code><![CDATA[isUpdatable]]></code>
+      <code><![CDATA[is_dir]]></code>
+      <code><![CDATA[is_file]]></code>
+      <code><![CDATA[mkdir]]></code>
+      <code><![CDATA[putFileInfo]]></code>
+      <code><![CDATA[readfile]]></code>
+      <code><![CDATA[rename]]></code>
+      <code><![CDATA[rmdir]]></code>
+      <code><![CDATA[search]]></code>
+      <code><![CDATA[searchByMime]]></code>
+      <code><![CDATA[searchByTag]]></code>
+      <code><![CDATA[stat]]></code>
+      <code><![CDATA[toTmpFile]]></code>
+      <code><![CDATA[touch]]></code>
+      <code><![CDATA[unlink]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[\OC::$server->get(IMountManager::class)]]></code>
+      <code><![CDATA[\OC::$server->get(IStorageFactory::class)]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Files/Lock/LockManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getLocks]]></code>
+      <code><![CDATA[lock]]></code>
+      <code><![CDATA[unlock]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Files/Mount/Manager.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->mounts]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/private/Files/Mount/MountPoint.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->storage]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$exception->getCode()]]></code>
+    </PossiblyInvalidArgument>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$loader]]></code>
+      <code><![CDATA[$this->loader->wrap($this, $this->storage)]]></code>
+      <code><![CDATA[new $class($this->arguments)]]></code>
+    </PropertyTypeCoercion>
     <UndefinedInterfaceMethod>
       <code><![CDATA[wrap]]></code>
     </UndefinedInterfaceMethod>
@@ -3781,6 +7286,10 @@
     </InvalidReturnType>
   </file>
   <file src="lib/private/Files/Node/Folder.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement>
       <code><![CDATA[array_map(function (FileInfo $file) {
 			return $this->createNode($file->getPath(), $file);
@@ -3792,8 +7301,23 @@
     <MoreSpecificReturnType>
       <code><![CDATA[\OC\Files\Node\Node[]]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$this->getRelativePath($uniqueName)]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getOwner]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$caches]]></code>
+      <code><![CDATA[$mountByMountPoint]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/private/Files/Node/HookConnector.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getAbsolutePath]]></code>
+      <code><![CDATA[getFileInfo]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[emit]]></code>
       <code><![CDATA[emit]]></code>
@@ -3824,6 +7348,12 @@
     </MoreSpecificReturnType>
   </file>
   <file src="lib/private/Files/Node/Node.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$oldFileInfo->getStorage()]]></code>
+      <code><![CDATA[function () use ($newPath) {
+				return $this->root->get($newPath);
+			}]]></code>
+    </ArgumentTypeCoercion>
     <InvalidNullableReturnType>
       <code><![CDATA[FileInfo]]></code>
     </InvalidNullableReturnType>
@@ -3842,12 +7372,25 @@
     <ParamNameMismatch>
       <code><![CDATA[$type]]></code>
     </ParamNameMismatch>
+    <PossiblyNullReference>
+      <code><![CDATA[getMetadata]]></code>
+      <code><![CDATA[getParentId]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[$this->fileInfo]]></code>
       <code><![CDATA[$this->fileInfo]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/Files/Node/Root.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$mountPoint->getStorage()]]></code>
+      <code><![CDATA[function (Node $node) use ($path) {
+			return PathHelper::getRelativePath($path, $node->getPath()) !== null;
+		}]]></code>
+      <code><![CDATA[function (Node $node) use ($path) {
+			return PathHelper::getRelativePath($path, $node->getPath()) !== null;
+		}]]></code>
+    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement>
       <code><![CDATA[$folders]]></code>
       <code><![CDATA[$this->mountManager->findByNumericId($numericId)]]></code>
@@ -3864,11 +7407,60 @@
     <NullableReturnStatement>
       <code><![CDATA[$this->user]]></code>
     </NullableReturnStatement>
+    <PossiblyNullArgument>
+      <code><![CDATA[$mountPoint->getStorage()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getCache]]></code>
+    </PossiblyNullReference>
     <UndefinedMethod>
       <code><![CDATA[remove]]></code>
     </UndefinedMethod>
   </file>
+  <file src="lib/private/Files/ObjectStore/Azure.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[strpos($this->endpoint, ':')]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/ObjectStore/ObjectStoreStorage.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storage]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$countStream]]></code>
+      <code><![CDATA[$countStream]]></code>
+      <code><![CDATA[$source]]></code>
+      <code><![CDATA[$sourceCacheEntry]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[strrpos($path, '.')]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$used]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyFalseReference>
+      <code><![CDATA[getId]]></code>
+      <code><![CDATA[getId]]></code>
+      <code><![CDATA[getId]]></code>
+      <code><![CDATA[getId]]></code>
+      <code><![CDATA[getMimeType]]></code>
+    </PossiblyFalseReference>
+    <PossiblyNullArgument>
+      <code><![CDATA[$result->get('ETag')]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$parts]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
   <file src="lib/private/Files/ObjectStore/S3ConnectionTrait.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->timeout]]></code>
+    </ArgumentTypeCoercion>
     <InternalClass>
       <code><![CDATA[ClientResolver::_default_signature_provider()]]></code>
       <code><![CDATA[ClientResolver::_default_signature_provider()]]></code>
@@ -3884,23 +7476,165 @@
     <InternalMethod>
       <code><![CDATA[upload]]></code>
     </InternalMethod>
+    <PossiblyNullReference>
+      <code><![CDATA[getState]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$uploader]]></code>
+    </PossiblyUndefinedVariable>
     <UndefinedFunction>
       <code><![CDATA[\Aws\serialize($command)]]></code>
     </UndefinedFunction>
   </file>
+  <file src="lib/private/Files/ObjectStore/S3Signature.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$expires]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Files/ObjectStore/Swift.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/ObjectStore/SwiftFactory.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$this->params['tenant']]]></code>
+      <code><![CDATA[$this->params['username']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Files/Search/QueryOptimizer/MergeDistributiveOperations.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$arguments]]></code>
+      <code><![CDATA[$outerOperations]]></code>
+      <code><![CDATA[$rightHandArguments]]></code>
+      <code><![CDATA[[$extractedLeftHand, $extractedRightHand]]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Files/Search/QueryOptimizer/OrEqualsToIn.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$newParts]]></code>
+      <code><![CDATA[$values]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Files/Search/QueryOptimizer/PathPrefixOptimizer.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$equal->getValue()]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Files/Search/QueryOptimizer/SplitLargeIn.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$values]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$operator->getValue()]]></code>
+      <code><![CDATA[$operator->getValue()]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Files/Search/SearchBinaryOperator.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$arguments]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Files/SetupManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getScanner]]></code>
+      <code><![CDATA[mkdir]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Files/SetupManagerFactory.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->mountProviderCollection]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="lib/private/Files/Storage/Common.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA[$type]]></code>
+    </ArgumentTypeCoercion>
     <InvalidOperand>
       <code><![CDATA[!$permissions]]></code>
       <code><![CDATA[$this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file)]]></code>
     </InvalidOperand>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$dh]]></code>
+      <code><![CDATA[$dir]]></code>
+      <code><![CDATA[$dir]]></code>
+      <code><![CDATA[$dir]]></code>
+      <code><![CDATA[$sourceStream]]></code>
+      <code><![CDATA[$targetStream]]></code>
+      <code><![CDATA[$tmp]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$result]]></code>
+    </PossiblyInvalidOperand>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[getWrapperStorage]]></code>
+    </PossiblyUndefinedMethod>
   </file>
   <file src="lib/private/Files/Storage/DAV.php">
     <InvalidClass>
       <code><![CDATA[ArrayCache]]></code>
       <code><![CDATA[ArrayCache]]></code>
     </InvalidClass>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[strrpos($path, '.')]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/Storage/FailedStorage.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+      <code><![CDATA[$this->e->getCode()]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/Files/Storage/Local.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['OCA\GroupFolders\ACL\ACLStorageWrapper']]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->stat($path)]]></code>
+    </PossiblyFalseArgument>
     <TypeDoesNotContainNull>
       <code><![CDATA[$space === false || is_null($space)]]></code>
       <code><![CDATA[is_null($space)]]></code>
@@ -3909,7 +7643,33 @@
       <code><![CDATA[$stat === false]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="lib/private/Files/Storage/LocalTempFileTrait.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/Storage/PolyFill/CopyDirectory.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$dh]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/Storage/StorageFactory.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[new $class($arguments)]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Files/Storage/Wrapper/Encoding.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$handle]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$otherFormPath]]></code>
+    </PossiblyFalseOperand>
+  </file>
   <file src="lib/private/Files/Storage/Wrapper/Encryption.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->fileHelper]]></code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement>
       <code><![CDATA[$result]]></code>
     </InvalidReturnStatement>
@@ -3920,32 +7680,243 @@
       <code><![CDATA[$lastChunkPos]]></code>
       <code><![CDATA[$size]]></code>
     </InvalidScalarArgument>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$size]]></code>
+      <code><![CDATA[$sourceStorage->filemtime($sourceInternalPath)]]></code>
+      <code><![CDATA[$unencryptedSize]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseReference>
+      <code><![CDATA[$entry]]></code>
+      <code><![CDATA[$info]]></code>
+      <code><![CDATA[$info]]></code>
+      <code><![CDATA[$info]]></code>
+      <code><![CDATA[$info]]></code>
+      <code><![CDATA[$sourceCacheEntry]]></code>
+      <code><![CDATA[getId]]></code>
+    </PossiblyFalseReference>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$entry['fileid']]]></code>
+      <code><![CDATA[$sourceCacheEntry['encryptedVersion']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->uid]]></code>
+      <code><![CDATA[$this->uid]]></code>
+      <code><![CDATA[$this->uid]]></code>
+      <code><![CDATA[$this->uid]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUnencryptedBlockSize]]></code>
+      <code><![CDATA[isReadable]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Files/Storage/Wrapper/Jail.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$sourceWatcher]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$target]]></code>
+      <code><![CDATA[$target]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/Storage/Wrapper/Quota.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$free]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Files/Storage/Wrapper/Wrapper.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA['\OCP\Files\Storage\ILockingStorage']]></code>
+      <code><![CDATA['\OCP\Files\Storage\ILockingStorage']]></code>
+      <code><![CDATA['\OCP\Files\Storage\ILockingStorage']]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$target]]></code>
+      <code><![CDATA[$target]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/Stream/Encryption.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$chunk]]></code>
+      <code><![CDATA[$oldFilePosition]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[$bytesWritten]]></code>
+      <code><![CDATA[$chunk]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$protocol]]></code>
+      <code><![CDATA[$this->uid]]></code>
+      <code><![CDATA[$this->unencryptedSize]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Files/Stream/HashWrapper.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$result]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/Stream/Quota.php">
+    <PossiblyFalseOperand>
+      <code><![CDATA[$oldOffset]]></code>
+      <code><![CDATA[$this->stream_tell()]]></code>
+      <code><![CDATA[$this->stream_tell()]]></code>
+    </PossiblyFalseOperand>
   </file>
   <file src="lib/private/Files/Stream/SeekableHttpStream.php">
     <InvalidReturnType>
       <code><![CDATA[stream_close]]></code>
       <code><![CDATA[stream_flush]]></code>
     </InvalidReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->getCurrent()]]></code>
+      <code><![CDATA[$this->getCurrent()]]></code>
+      <code><![CDATA[$this->getCurrent()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="lib/private/Files/Template/TemplateManager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$templateFile]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullReference>
+      <code><![CDATA[getTemplateProviders]]></code>
+    </PossiblyNullReference>
     <RedundantCondition>
       <code><![CDATA[!$isDefaultTemplates]]></code>
     </RedundantCondition>
   </file>
+  <file src="lib/private/Files/Type/Detection.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[strpos($icon, '-')]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Files/Utils/Scanner.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$mount]]></code>
+      <code><![CDATA[$mount]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$e->getReadablePath()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$db]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getScanner]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="lib/private/Files/View.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage]]></code>
+      <code><![CDATA[$storage1]]></code>
+      <code><![CDATA[$storage1]]></code>
+      <code><![CDATA[$storage2]]></code>
+      <code><![CDATA[$storage2]]></code>
+      <code><![CDATA[$storage2]]></code>
+      <code><![CDATA[$subStorage]]></code>
+      <code><![CDATA['\OCP\Files\Storage\ILockingStorage']]></code>
+      <code><![CDATA['\OCP\Files\Storage\ILockingStorage']]></code>
+      <code><![CDATA['\OCP\Files\Storage\ILockingStorage']]></code>
+    </ArgumentTypeCoercion>
     <InvalidScalarArgument>
       <code><![CDATA[$mtime]]></code>
     </InvalidScalarArgument>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$tmpFile]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$folderId]]></code>
+      <code><![CDATA[$storage1]]></code>
+      <code><![CDATA[$storage1]]></code>
+      <code><![CDATA[$storage1]]></code>
+      <code><![CDATA[$storage1]]></code>
+      <code><![CDATA[$storage2]]></code>
+      <code><![CDATA[$storage2]]></code>
+      <code><![CDATA[$storage2]]></code>
+      <code><![CDATA[$target]]></code>
+      <code><![CDATA[$targetUser]]></code>
+      <code><![CDATA[$targetUser]]></code>
+      <code><![CDATA[$targetUser]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[copyFromStorage]]></code>
+      <code><![CDATA[file_exists]]></code>
+      <code><![CDATA[getCache]]></code>
+      <code><![CDATA[getOwner]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUpdater]]></code>
+      <code><![CDATA[getUpdater]]></code>
+      <code><![CDATA[instanceOfStorage]]></code>
+      <code><![CDATA[moveFromStorage]]></code>
+      <code><![CDATA[verifyPath]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[getMountPoint]]></code>
+      <code><![CDATA[getMountPoint]]></code>
+      <code><![CDATA[moveMount]]></code>
+    </PossiblyUndefinedMethod>
     <UndefinedInterfaceMethod>
       <code><![CDATA[acquireLock]]></code>
       <code><![CDATA[changeLock]]></code>
       <code><![CDATA[releaseLock]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/FilesMetadata/Model/MetadataValueWrapper.php">
+    <PossiblyInvalidCast>
+      <code><![CDATA[$this->value]]></code>
+    </PossiblyInvalidCast>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <RiskyCast>
+      <code><![CDATA[$this->value]]></code>
+      <code><![CDATA[$this->value]]></code>
+    </RiskyCast>
+  </file>
   <file src="lib/private/FullTextSearch/Model/IndexDocument.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$access]]></code>
+    </PropertyTypeCoercion>
     <TypeDoesNotContainNull>
       <code><![CDATA[is_null($this->getContent())]]></code>
     </TypeDoesNotContainNull>
+  </file>
+  <file src="lib/private/FullTextSearch/Model/SearchTemplate.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->navigationOptions]]></code>
+      <code><![CDATA[$this->panelOptions]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/private/Group/Database.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+      <code><![CDATA[getQueryBuilder]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/private/Group/Group.php">
     <LessSpecificReturnStatement>
@@ -3954,6 +7925,13 @@
     <MoreSpecificReturnType>
       <code><![CDATA[\OC\User\User[]]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$emitter]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->users]]></code>
+      <code><![CDATA[$this->users]]></code>
+    </PropertyTypeCoercion>
     <RedundantCondition>
       <code><![CDATA[$this->emitter]]></code>
       <code><![CDATA[$this->emitter]]></code>
@@ -3967,17 +7945,40 @@
     </UndefinedMethod>
   </file>
   <file src="lib/private/Group/Manager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$groupIds]]></code>
+    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement>
       <code><![CDATA[$groups]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[\OC\Group\Group[]]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$gid]]></code>
+      <code><![CDATA[$group]]></code>
+      <code><![CDATA[$group]]></code>
+      <code><![CDATA[$groupName]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
     <UndefinedInterfaceMethod>
       <code><![CDATA[createGroup]]></code>
       <code><![CDATA[getGroupDetails]]></code>
       <code><![CDATA[isAdmin]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/private/Hooks/EmitterTrait.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parts[1]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Http/Client/DnsPinMiddleware.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[idn_to_utf8($hostName)]]></code>
+    </PossiblyFalseArgument>
   </file>
   <file src="lib/private/InitialStateService.php">
     <UndefinedInterfaceMethod>
@@ -3990,6 +7991,12 @@
       <code><![CDATA[$x509->getDN(X509::DN_OPENSSL)['CN']]]></code>
       <code><![CDATA[$x509->getDN(true)['CN']]]></code>
     </InvalidArrayAccess>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$rootCertificatePublicKey]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[deleteKey]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getOnlyDefaultAliases]]></code>
     </UndefinedInterfaceMethod>
@@ -4011,11 +8018,32 @@
     <LessSpecificImplementedReturnType>
       <code><![CDATA[array|mixed]]></code>
     </LessSpecificImplementedReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$locale]]></code>
+      <code><![CDATA[$locale]]></code>
+      <code><![CDATA[$locale]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/L10N/L10NString.php">
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$text]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
   </file>
   <file src="lib/private/LargeFileHelper.php">
     <InvalidOperand>
       <code><![CDATA[$matches[1]]]></code>
     </InvalidOperand>
+    <PossiblyFalseArgument>
+      <code><![CDATA[exec($cmd)]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$data]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/Lockdown/Filesystem/NullCache.php">
     <InvalidReturnStatement>
@@ -4032,6 +8060,11 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$sessionCallback]]></code>
     </InvalidPropertyAssignmentValue>
+  </file>
+  <file src="lib/private/Log.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getSensitiveMethods]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/private/Log/File.php">
     <TypeDoesNotContainNull>
@@ -4050,6 +8083,16 @@
 			'MESSAGE=' . $this->logDetailsAsJSON($app, $message, $level))]]></code>
     </UndefinedFunction>
   </file>
+  <file src="lib/private/Mail/Attachment.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->body]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Mail/Message.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getBodyAsString]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="lib/private/Memcache/APCu.php">
     <InvalidReturnStatement>
       <code><![CDATA[apcu_add($this->getPrefix() . $key, $value, $ttl)]]></code>
@@ -4057,6 +8100,9 @@
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$iter]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/Memcache/Cache.php">
     <LessSpecificImplementedReturnType>
@@ -4065,11 +8111,225 @@
       <code><![CDATA[mixed]]></code>
       <code><![CDATA[mixed]]></code>
     </LessSpecificImplementedReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Memcache/Factory.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$cache]]></code>
+      <code><![CDATA[$cache]]></code>
+      <code><![CDATA[$cache]]></code>
+      <code><![CDATA[$cache]]></code>
+      <code><![CDATA[$cache]]></code>
+      <code><![CDATA[$cache]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Memcache/Memcached.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/private/Memcache/ProfilerWrapperCache.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$offset]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Memcache/Redis.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[del]]></code>
+      <code><![CDATA[eval]]></code>
+      <code><![CDATA[evalSha]]></code>
+      <code><![CDATA[exists]]></code>
+      <code><![CDATA[expire]]></code>
+      <code><![CDATA[get]]></code>
+      <code><![CDATA[incrBy]]></code>
+      <code><![CDATA[keys]]></code>
+      <code><![CDATA[set]]></code>
+      <code><![CDATA[setex]]></code>
+      <code><![CDATA[ttl]]></code>
+      <code><![CDATA[unlink]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/NavigationManager.php">
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$entry['id']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyInvalidArrayAssignment>
+      <code><![CDATA[$entry['active']]]></code>
+      <code><![CDATA[$entry['app']]]></code>
+      <code><![CDATA[$entry['classes']]]></code>
+      <code><![CDATA[$entry['icon']]]></code>
+      <code><![CDATA[$entry['order']]]></code>
+      <code><![CDATA[$entry['type']]]></code>
+      <code><![CDATA[$entry['unread']]]></code>
+    </PossiblyInvalidArrayAssignment>
+    <PossiblyNullArgument>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$groupManager]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/private/Notification/Manager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getNotifierServices]]></code>
+      <code><![CDATA[getNotifierServices]]></code>
+    </PossiblyNullReference>
     <UndefinedClass>
       <code><![CDATA[\OCA\Notifications\App]]></code>
     </UndefinedClass>
+  </file>
+  <file src="lib/private/OCM/OCMDiscoveryService.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$body]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$response]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/private/OCS/ApiHelper.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$statusCode]]></code>
+      <code><![CDATA[$statusCode]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/OCS/DiscoveryService.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Preview/Bitmap.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->getAllowedMimeTypes()]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$previewWidth]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Preview/Bundled.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$sourceTmp]]></code>
+      <code><![CDATA[$sourceTmp]]></code>
+      <code><![CDATA[$targetTmp]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Preview/Generator.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$mode]]></code>
+      <code><![CDATA[$supportedMimeType]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$preview->resource()]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$file->getMountPoint()->getNumericStorageId()]]></code>
+      <code><![CDATA[$file->getMountPoint()->getNumericStorageId()]]></code>
+      <code><![CDATA[$preview->data()]]></code>
+      <code><![CDATA[$preview->data()]]></code>
+      <code><![CDATA[$preview->dataMimeType()]]></code>
+      <code><![CDATA[$preview->dataMimeType()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Preview/HEIC.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$previewWidth]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Preview/Imaginary.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$response->getBody()]]></code>
+      <code><![CDATA[$response->getBody()]]></code>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Preview/MarkDown.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$textColor]]></code>
+      <code><![CDATA[$textColor]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Preview/Movie.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$content]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$size]]></code>
+      <code><![CDATA[$this->binary]]></code>
+      <code><![CDATA[$this->binary]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Preview/SVG.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->getMimeType()]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$file->fopen('r')]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Preview/Storage/LocalPreviewStorage.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$dirName]]></code>
+      <code><![CDATA[$relativePath]]></code>
+      <code><![CDATA[$relativePath]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Preview/Storage/ObjectStorePreviewStorage.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$countStream]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$objectStoreName]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Preview/TXT.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$textColor]]></code>
+      <code><![CDATA[$textColor]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/PreviewManager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$supportedMimeType]]></code>
+      <code><![CDATA[$supportedMimeType]]></code>
+      <code><![CDATA[function () use ($class, $options) {
+				return new $class($options);
+			}]]></code>
+    </ArgumentTypeCoercion>
+    <PropertyTypeCoercion>
+      <code><![CDATA[array_merge($this->defaultProviders, $imageProviders)]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/private/Profile/Actions/FediverseAction.php">
     <NoValue>
@@ -4078,6 +8338,23 @@
     <RedundantCondition>
       <code><![CDATA[$instance === '']]></code>
     </RedundantCondition>
+  </file>
+  <file src="lib/private/Profiler/FileProfilerStorage.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[[
+				$profile->getToken(),
+				$profile->getMethod(),
+				$profile->getUrl(),
+				$profile->getTime(),
+				$profile->getParentToken(),
+				$profile->getStatusCode(),
+			]]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Profiler/Profiler.php">
+    <PossiblyNullReference>
+      <code><![CDATA[purge]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/private/RedisFactory.php">
     <InvalidArgument>
@@ -4088,29 +8365,156 @@
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[array]]></code>
     </ImplementedReturnTypeMismatch>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[parent::request($method, 'ocs/v2.php/' . $url, $body, $query, $headers)]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/Remote/Instance.php">
     <InvalidScalarArgument>
       <code><![CDATA[$response]]></code>
     </InvalidScalarArgument>
   </file>
+  <file src="lib/private/Repair/NC16/ClearCollectionsAccessCache.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$manager]]></code>
+    </PropertyTypeCoercion>
+  </file>
   <file src="lib/private/Repair/Owncloud/CleanPreviews.php">
     <InvalidArgument>
       <code><![CDATA[false]]></code>
     </InvalidArgument>
   </file>
+  <file src="lib/private/Repair/Owncloud/MoveAvatarsBackgroundJob.php">
+    <PossiblyNullReference>
+      <code><![CDATA[file_exists]]></code>
+      <code><![CDATA[fopen]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Repair/RemoveBrokenProperties.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[str_replace('\x00', chr(0), $entry['propertyvalue'])]]></code>
+    </PossiblyInvalidArgument>
+  </file>
   <file src="lib/private/Repair/RemoveLinkShares.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->userToNotify]]></code>
     </InvalidPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getUsers]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Repair/RepairDavShares.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$logParameters]]></code>
+      <code><![CDATA[$logParameters]]></code>
+      <code><![CDATA[$logParameters]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/private/Repair/RepairLogoDimension.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$image]]></code>
+      <code><![CDATA[$image]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/RichObjectStrings/RichTextFormatter.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parameter['name']]]></code>
+      <code><![CDATA[$parameter['name']]]></code>
+      <code><![CDATA[$parameter['name']]]></code>
+      <code><![CDATA[$parameter['type']]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Route/CachingRouter.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->root]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Route/Route.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$method]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/Route/Router.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$appNameSpace . '\\Controller\\' . basename($file->getPathname(), '.php')]]></code>
+    </ArgumentTypeCoercion>
     <InvalidNullableReturnType>
       <code><![CDATA[string]]></code>
     </InvalidNullableReturnType>
     <NullableReturnStatement>
       <code><![CDATA[$this->collectionName]]></code>
     </NullableReturnStatement>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->root]]></code>
+      <code><![CDATA[$this->root]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[add]]></code>
+      <code><![CDATA[addCollection]]></code>
+      <code><![CDATA[addCollection]]></code>
+      <code><![CDATA[addCollection]]></code>
+      <code><![CDATA[addCollection]]></code>
+      <code><![CDATA[addCollection]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$other]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Search/Filter/FloatFilter.php">
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[filter_var($value, FILTER_VALIDATE_FLOAT)]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+  </file>
+  <file src="lib/private/Search/Filter/IntegerFilter.php">
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[filter_var($value, FILTER_VALIDATE_INT)]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
+  </file>
+  <file src="lib/private/Search/FilterFactory.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$filter]]></code>
+      <code><![CDATA[$filter]]></code>
+      <code><![CDATA[$filter]]></code>
+      <code><![CDATA[$filter]]></code>
+      <code><![CDATA[$filter]]></code>
+      <code><![CDATA[$filter]]></code>
+      <code><![CDATA[$filter]]></code>
+      <code><![CDATA[$filter]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Search/SearchComposer.php">
+    <PossiblyNullReference>
+      <code><![CDATA[type]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Security/Bruteforce/Backend/DatabaseBackend.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$value]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/private/Security/Bruteforce/Backend/MemoryCacheBackend.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$identifier]]></code>
+      <code><![CDATA[$identifier]]></code>
+      <code><![CDATA[$identifier]]></code>
+      <code><![CDATA[$identifier]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$attemptAction]]></code>
+      <code><![CDATA[$attemptAction]]></code>
+      <code><![CDATA[$attemptMetadata]]></code>
+      <code><![CDATA[$attemptMetadata]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Security/Bruteforce/Throttler.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$delay * 1000]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Security/CSP/ContentSecurityPolicyManager.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->policies]]></code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php">
     <NoInterfaceProperties>
@@ -4122,7 +8526,16 @@
       <code><![CDATA[\strlen($this->value)]]></code>
     </InvalidArgument>
   </file>
+  <file src="lib/private/Security/CertificateManager.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$systemCertificates]]></code>
+    </PossiblyFalseArgument>
+  </file>
   <file src="lib/private/Security/Crypto.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->ivLength]]></code>
+    </ArgumentTypeCoercion>
     <InternalMethod>
       <code><![CDATA[decrypt]]></code>
       <code><![CDATA[encrypt]]></code>
@@ -4131,8 +8544,62 @@
       <code><![CDATA[setPassword]]></code>
       <code><![CDATA[setPassword]]></code>
     </InternalMethod>
+    <PossiblyNullArgument>
+      <code><![CDATA[$iv]]></code>
+      <code><![CDATA[$iv]]></code>
+      <code><![CDATA[$parts[2]]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$parts[1]]]></code>
+      <code><![CDATA[$parts[2]]]></code>
+      <code><![CDATA[$parts[3]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Security/IdentityProof/Signer.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$location]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/Security/Ip/Range.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[Factory::parseAddressString((string)$address, ParseStringFlag::MAY_INCLUDE_ZONEID)]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Security/Normalizer/IpAddress.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[~$mask]]></code>
+    </PossiblyInvalidOperand>
+  </file>
+  <file src="lib/private/Security/Signature/Model/IncomingSignedRequest.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$v]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Security/VerificationToken/CleanUpJob.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->pwdPrefix]]></code>
+      <code><![CDATA[$this->subject]]></code>
+      <code><![CDATA[$this->subject]]></code>
+      <code><![CDATA[$this->userId]]></code>
+      <code><![CDATA[$this->userId]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Security/VerificationToken/VerificationToken.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$splitToken[1]]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$splitToken[1]]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/private/Server.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$manager]]></code>
+      <code><![CDATA[$this->get(IUserManager::class)]]></code>
+    </ArgumentTypeCoercion>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[\OCP\Files\Folder|null]]></code>
     </ImplementedReturnTypeMismatch>
@@ -4150,6 +8617,9 @@
       <code><![CDATA[\OC\User\Manager]]></code>
       <code><![CDATA[\OC\User\Session]]></code>
     </MoreSpecificReturnType>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$class]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/private/ServerContainer.php">
     <InvalidPropertyAssignmentValue>
@@ -4158,18 +8628,36 @@
     <NoValue>
       <code><![CDATA[return $this->appContainers[$namespace];]]></code>
     </NoValue>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($appNamespace, '\\')]]></code>
+    </PossiblyFalseOperand>
   </file>
   <file src="lib/private/Session/Internal.php">
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
+    <PossiblyInvalidArrayOffset>
+      <code><![CDATA[$_SESSION[$key]]]></code>
+    </PossiblyInvalidArrayOffset>
+    <PossiblyNullArgument>
+      <code><![CDATA[$oldId]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="lib/private/Session/Memory.php">
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="lib/private/Settings/DeclarativeManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getDeclarativeSettings]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="lib/private/Setup.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$password]]></code>
+      <code><![CDATA[$username]]></code>
+    </PossiblyUndefinedVariable>
     <RedundantCondition>
       <code><![CDATA[$type === 'pdo']]></code>
     </RedundantCondition>
@@ -4178,6 +8666,9 @@
     </UndefinedVariable>
   </file>
   <file src="lib/private/Setup/AbstractDatabase.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$portOrSocket]]></code>
+    </PossiblyUndefinedArrayOffset>
     <TypeDoesNotContainType>
       <code><![CDATA[ctype_digit($this->dbPort)]]></code>
     </TypeDoesNotContainType>
@@ -4188,17 +8679,131 @@
       <code><![CDATA[$this->dbprettyname]]></code>
     </UndefinedThisPropertyFetch>
   </file>
+  <file src="lib/private/Setup/OCI.php">
+    <PossiblyFalseOperand>
+      <code><![CDATA[getenv('LD_LIBRARY_PATH')]]></code>
+      <code><![CDATA[getenv('LD_LIBRARY_PATH')]]></code>
+      <code><![CDATA[getenv('NLS_LANG')]]></code>
+      <code><![CDATA[getenv('NLS_LANG')]]></code>
+      <code><![CDATA[getenv('ORACLE_HOME')]]></code>
+      <code><![CDATA[getenv('ORACLE_HOME')]]></code>
+      <code><![CDATA[getenv('ORACLE_HOME')]]></code>
+      <code><![CDATA[getenv('ORACLE_HOME')]]></code>
+      <code><![CDATA[getenv('ORACLE_SID')]]></code>
+      <code><![CDATA[getenv('ORACLE_SID')]]></code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="lib/private/Setup/PostgreSQL.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$canCreateRoles]]></code>
+      <code><![CDATA[$connectionMainDatabase]]></code>
+      <code><![CDATA[$connectionMainDatabase]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/private/SetupCheck/SetupCheckManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getSetupChecks]]></code>
+    </PossiblyNullReference>
+  </file>
   <file src="lib/private/Share20/DefaultShareProvider.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$shares2]]></code>
+      <code><![CDATA[[(int)$share->getId() => $share]]]></code>
+    </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$pathSections[1]]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUsers]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$pathSections[1]]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/private/Share20/Manager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['OCA\Files_Sharing\External\Storage']]></code>
+      <code><![CDATA['OCA\Files_Sharing\External\Storage']]></code>
+      <code><![CDATA['\OCA\Files_Sharing\ISharedStorage']]></code>
+    </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[$id]]></code>
     </InvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$event->getError()]]></code>
+      <code><![CDATA[$originalShare->getPassword()]]></code>
+      <code><![CDATA[$path]]></code>
+      <code><![CDATA[$recipient]]></code>
+      <code><![CDATA[$share->getPassword()]]></code>
+      <code><![CDATA[$share->getPassword()]]></code>
+      <code><![CDATA[$share->getPassword()]]></code>
+      <code><![CDATA[$share->getPassword()]]></code>
+      <code><![CDATA[$share->getPassword()]]></code>
+      <code><![CDATA[$share->getPassword()]]></code>
+      <code><![CDATA[$sharedBy]]></code>
+      <code><![CDATA[$sharedBy]]></code>
+      <code><![CDATA[$sharedWith]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[instanceOfStorage]]></code>
+      <code><![CDATA[n]]></code>
+      <code><![CDATA[n]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[t]]></code>
+      <code><![CDATA[toArray]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$plainTextPassword]]></code>
+    </PossiblyUndefinedVariable>
     <UndefinedClass>
       <code><![CDATA[\OCA\Circles\Api\v1\Circles]]></code>
     </UndefinedClass>
@@ -4219,8 +8824,28 @@
     <MoreSpecificReturnType>
       <code><![CDATA[getNode]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$attributes]]></code>
+      <code><![CDATA[$expireDate]]></code>
+      <code><![CDATA[$password]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getMimeType]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/SpeechToText/SpeechToTextManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/private/Streamer.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[Filesystem::getRoot()]]></code>
+    </PossiblyNullArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[get]]></code>
     </UndefinedInterfaceMethod>
@@ -4232,9 +8857,36 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/Support/Subscription/Registry.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getSupportedApps]]></code>
+      <code><![CDATA[getUsers]]></code>
+      <code><![CDATA[hasExtendedSupport]]></code>
+      <code><![CDATA[hasValidSubscription]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getSupportedApps]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/private/SystemConfig.php">
+    <PossiblyFalseIterator>
+      <code><![CDATA[$keysToRemove]]></code>
+    </PossiblyFalseIterator>
+  </file>
+  <file src="lib/private/SystemTag/SystemTagObjectMapper.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$tagIds]]></code>
+      <code><![CDATA[array_map(fn ($objectId) => (string)$objectId, $addedObjectIds)]]></code>
+      <code><![CDATA[array_map(fn ($objectId) => (string)$objectId, $removedObjectIds)]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/SystemTag/SystemTagsInFilesDetector.php">
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$caches]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/private/TagManager.php">
     <InvalidNullableReturnType>
@@ -4243,6 +8895,16 @@
     <NullableReturnStatement>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+    <PossiblyNullReference>
+      <code><![CDATA[getUId]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/Tagging/Tag.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$owner]]></code>
+      <code><![CDATA[$type]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="lib/private/Tags.php">
     <InvalidScalarArgument>
@@ -4252,16 +8914,180 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$tag]]></code>
     </MoreSpecificImplementedParamType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+      <code><![CDATA[$this->userSession->getUser()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/private/Talk/Broker.php">
+    <PossiblyNullReference>
+      <code><![CDATA[createConversation]]></code>
+      <code><![CDATA[deleteConversation]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/private/TaskProcessing/Db/Task.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->getStatus()]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/TaskProcessing/Manager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$output]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$input['input']]]></code>
+      <code><![CDATA[$input['input']]]></code>
+      <code><![CDATA[$input['input']]]></code>
+      <code><![CDATA[$input['input']]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidIterator>
+      <code><![CDATA[$input[$key]]]></code>
+    </PossiblyInvalidIterator>
+    <PossiblyNullArgument>
+      <code><![CDATA[$error]]></code>
+      <code><![CDATA[$task->getId()]]></code>
+      <code><![CDATA[$task->getId()]]></code>
+      <code><![CDATA[$task->getId()]]></code>
+      <code><![CDATA[$task->getId()]]></code>
+      <code><![CDATA[$task->getId()]]></code>
+      <code><![CDATA[$task->getId()]]></code>
+      <code><![CDATA[$task->getId()]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getBackend]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$exAppId]]></code>
+      <code><![CDATA[$httpMethod]]></code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->_getProviders()]]></code>
+    </PropertyTypeCoercion>
+    <RiskyCast>
+      <code><![CDATA[$input[$key]]]></code>
+    </RiskyCast>
   </file>
   <file src="lib/private/Teams/TeamManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getCircle]]></code>
+      <code><![CDATA[getCirclesByIds]]></code>
+      <code><![CDATA[getFederatedUser]]></code>
+      <code><![CDATA[getFederatedUser]]></code>
+      <code><![CDATA[getTeamResourceProviders]]></code>
+      <code><![CDATA[startSession]]></code>
+      <code><![CDATA[startSession]]></code>
+    </PossiblyNullReference>
     <UndefinedDocblockClass>
       <code><![CDATA[Circle]]></code>
     </UndefinedDocblockClass>
+  </file>
+  <file src="lib/private/Template/Template.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[Util::sanitizeHTML($header['tag'])]]></code>
+      <code><![CDATA[Util::sanitizeHTML($header['tag'])]]></code>
+      <code><![CDATA[Util::sanitizeHTML($header['text'])]]></code>
+      <code><![CDATA[Util::sanitizeHTML($name)]]></code>
+      <code><![CDATA[Util::sanitizeHTML($value)]]></code>
+    </PossiblyInvalidOperand>
+  </file>
+  <file src="lib/private/Template/TemplateManager.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$statusCode]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Template/functions.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[Util::sanitizeHTML($label)]]></code>
+      <code><![CDATA[Util::sanitizeHTML($value)]]></code>
+    </PossiblyInvalidOperand>
+  </file>
+  <file src="lib/private/TemplateLayout.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[\OC::$SERVERROOT]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$pathInfo]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="lib/private/TextProcessing/Db/Task.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->getStatus()]]></code>
+      <code><![CDATA[$this->getType()]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/TextToImage/Db/Task.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->getStatus()]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/private/Translation/TranslationManager.php">
+    <PossiblyNullReference>
+      <code><![CDATA[getTranslationProviders]]></code>
+      <code><![CDATA[getTranslationProviders]]></code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/private/URLGenerator.php">
     <InvalidReturnStatement>
       <code><![CDATA[$path]]></code>
     </InvalidReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$_REQUEST['redirect_url']]]></code>
+      <code><![CDATA[$_REQUEST['redirect_url']]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$entry['href']]]></code>
+    </PossiblyNullArrayAccess>
+  </file>
+  <file src="lib/private/Updater.php">
+    <PossiblyNullReference>
+      <code><![CDATA[debug]]></code>
+      <code><![CDATA[debug]]></code>
+      <code><![CDATA[debug]]></code>
+      <code><![CDATA[error]]></code>
+      <code><![CDATA[error]]></code>
+      <code><![CDATA[error]]></code>
+      <code><![CDATA[error]]></code>
+      <code><![CDATA[error]]></code>
+      <code><![CDATA[error]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[info]]></code>
+      <code><![CDATA[warning]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$stacks[$type]]]></code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/private/Updater/ChangesCheck.php">
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$xml->changelog['href']]]></code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullIterator>
+      <code><![CDATA[$xml->whatsNew]]></code>
+    </PossiblyNullIterator>
+  </file>
+  <file src="lib/private/Updater/ReleaseMetadata.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$response->getBody()]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/private/User/Database.php">
     <FalsableReturnStatement>
@@ -4275,12 +9101,26 @@
     <InvalidArgument>
       <code><![CDATA[$backend]]></code>
     </InvalidArgument>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$backend]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[checkPassword]]></code>
+      <code><![CDATA[countUsers]]></code>
+    </PossiblyUndefinedMethod>
     <UndefinedInterfaceMethod>
       <code><![CDATA[createUser]]></code>
       <code><![CDATA[getUsersForUserValueCaseInsensitive]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/User/Session.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$dbToken]]></code>
+      <code><![CDATA[$dbToken]]></code>
+      <code><![CDATA[$dbToken]]></code>
+      <code><![CDATA[$dbToken]]></code>
+      <code><![CDATA[$token]]></code>
+    </ArgumentTypeCoercion>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[boolean|null]]></code>
     </ImplementedReturnTypeMismatch>
@@ -4288,11 +9128,60 @@
       <code><![CDATA[$request->server]]></code>
       <code><![CDATA[$request->server]]></code>
     </NoInterfaceProperties>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$name]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$password]]></code>
+      <code><![CDATA[$this->getUser()]]></code>
+      <code><![CDATA[$userFolder]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$this->manager->get($uid)]]></code>
+      <code><![CDATA[$this->manager->get($uid)]]></code>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[getEMailAddress]]></code>
+      <code><![CDATA[getPassword]]></code>
+      <code><![CDATA[getToken]]></code>
+      <code><![CDATA[getToken]]></code>
+      <code><![CDATA[getToken]]></code>
+      <code><![CDATA[getToken]]></code>
+      <code><![CDATA[getToken]]></code>
+      <code><![CDATA[getToken]]></code>
+      <code><![CDATA[getToken]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[getUID]]></code>
+      <code><![CDATA[invalidateToken]]></code>
+      <code><![CDATA[invalidateToken]]></code>
+      <code><![CDATA[invalidateToken]]></code>
+      <code><![CDATA[renewSessionToken]]></code>
+      <code><![CDATA[updatePasswords]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$user]]></code>
+    </PropertyTypeCoercion>
     <RedundantCondition>
       <code><![CDATA[$this->manager instanceof PublicEmitter]]></code>
     </RedundantCondition>
   </file>
   <file src="lib/private/User/User.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$mailAddress]]></code>
+      <code><![CDATA[$this->backend]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getHome]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[emit]]></code>
       <code><![CDATA[emit]]></code>
@@ -4301,12 +9190,36 @@
       <code><![CDATA[emit]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/UserStatus/Manager.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$class]]></code>
+    </PropertyTypeCoercion>
+  </file>
   <file src="lib/private/legacy/OC_App.php">
     <InvalidArgument>
       <code><![CDATA[$groupsList]]></code>
     </InvalidArgument>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strpos($path_info, '/', 1)]]></code>
+      <code><![CDATA[strpos($script, '/', $length + 1)]]></code>
+    </PossiblyFalseOperand>
+    <PossiblyNullReference>
+      <code><![CDATA[getAlternativeLogins]]></code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$provider]]></code>
+      <code><![CDATA[$provider]]></code>
+      <code><![CDATA[$provider]]></code>
+      <code><![CDATA[$provider]]></code>
+    </PossiblyUndefinedVariable>
   </file>
   <file src="lib/private/legacy/OC_Helper.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA['\OCA\Files_Sharing\SharedStorage']]></code>
+      <code><![CDATA['\OC\Files\ObjectStore\HomeObjectStoreStorage']]></code>
+      <code><![CDATA['\OC\Files\Storage\Home']]></code>
+      <code><![CDATA['\OC\Files\Storage\Wrapper\Quota']]></code>
+    </ArgumentTypeCoercion>
     <InternalMethod>
       <code><![CDATA[file_exists]]></code>
       <code><![CDATA[file_exists]]></code>
@@ -4316,14 +9229,141 @@
       <code><![CDATA[$matches[0][$last_match]]]></code>
       <code><![CDATA[$matches[1][$last_match]]]></code>
     </InvalidArrayOffset>
+    <PossiblyFalseReference>
+      <code><![CDATA[$rootInfo]]></code>
+    </PossiblyFalseReference>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$rootInfo['size']]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyNullArgument>
+      <code><![CDATA[$obd]]></code>
+      <code><![CDATA[$user]]></code>
+      <code><![CDATA[$view]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[instanceOfStorage]]></code>
+      <code><![CDATA[instanceOfStorage]]></code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getQuota]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/legacy/OC_JSON.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[OC_User::getUser()]]></code>
+    </PossiblyFalseArgument>
+  </file>
   <file src="lib/private/legacy/OC_User.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$backend]]></code>
+      <code><![CDATA[new $className()]]></code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument>
+      <code><![CDATA[$userSession->getUser()]]></code>
+      <code><![CDATA[\OC::$server->get(IUserManager::class)->get($uid)]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[isEnabled]]></code>
+    </PossiblyNullReference>
     <UndefinedClass>
       <code><![CDATA[\Test\Util\User\Dummy]]></code>
     </UndefinedClass>
+  </file>
+  <file src="lib/private/legacy/OC_Util.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[OC_User::getUser()]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$iniWrapper->getString($setting)]]></code>
+      <code><![CDATA[$user]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/public/App/ManagerEvent.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->groups]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/public/AppFramework/App.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->container]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/public/AppFramework/AuthPublicShareController.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$params]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->getPasswordHash()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/public/AppFramework/Controller.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$data->getData()]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/public/AppFramework/Db/Entity.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$value]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/public/AppFramework/Db/QBMapper.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$idType]]></code>
+      <code><![CDATA[$idType]]></code>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA[$type]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/public/AppFramework/Http/Attribute/ApiRoute.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$verb]]></code>
+    </ArgumentTypeCoercion>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$defaults]]></code>
+      <code><![CDATA[$requirements]]></code>
+      <code><![CDATA[$verb]]></code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/public/AppFramework/Http/Attribute/FrontpageRoute.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$verb]]></code>
+    </ArgumentTypeCoercion>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$defaults]]></code>
+      <code><![CDATA[$requirements]]></code>
+      <code><![CDATA[$verb]]></code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/public/AppFramework/Http/EmptyFeaturePolicy.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/public/AppFramework/Http/Response.php">
     <LessSpecificReturnStatement>
@@ -4332,6 +9372,104 @@
     <MoreSpecificReturnType>
       <code><![CDATA[array{X-Request-Id: string, Cache-Control: string, Content-Security-Policy: string, Feature-Policy: string, X-Robots-Tag: string, Last-Modified?: string, ETag?: string, ...H}]]></code>
     </MoreSpecificReturnType>
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->headers]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[buildPolicy]]></code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$csp]]></code>
+      <code><![CDATA[$featurePolicy]]></code>
+      <code><![CDATA[$status]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/public/AppFramework/Http/StreamResponse.php">
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$filePath]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
+  </file>
+  <file src="lib/public/AppFramework/PublicShareController.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->getPasswordHash()]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/public/BackgroundJob/Job.php">
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$jobDetails]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/public/Collaboration/Reference/LinkReferenceProvider.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$object->images[0]->url]]></code>
+      <code><![CDATA[$object->images[0]->url]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/public/DB/Events/AddMissingColumnsEvent.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->missingColumns]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/public/DB/Events/AddMissingIndicesEvent.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->missingIndices]]></code>
+      <code><![CDATA[$this->missingIndices]]></code>
+      <code><![CDATA[$this->toReplaceIndices]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/public/Files/DavUtil.php">
+    <PossiblyFalseReference>
+      <code><![CDATA[getPermissions]]></code>
+    </PossiblyFalseReference>
+  </file>
+  <file src="lib/public/Files/SimpleFS/InMemoryFile.php">
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[$data]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
+  </file>
+  <file src="lib/public/Migration/Attributes/AddColumn.php">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->getType()->value]]></code>
+    </PossiblyNullPropertyFetch>
+  </file>
+  <file src="lib/public/Migration/Attributes/AddIndex.php">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->getType()->value]]></code>
+    </PossiblyNullPropertyFetch>
+  </file>
+  <file src="lib/public/Migration/Attributes/ModifyColumn.php">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$this->getType()->value]]></code>
+    </PossiblyNullPropertyFetch>
+  </file>
+  <file src="lib/public/ServerVersion.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$OC_Channel]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/public/SetupCheck/SetupResult.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$descriptionParameters]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/public/SystemTag/ManagerEvent.php">
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$beforeTag]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/public/TextToImage/Task.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[$folder->getFile((string)$i)->read()]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyNullReference>
+      <code><![CDATA[getTimestamp]]></code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/public/Util.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$ini->get('post_max_size')]]></code>
+      <code><![CDATA[$ini->get('upload_max_filesize')]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="ocs-provider/index.php">
     <DeprecatedMethod>

--- a/build/stubs/sysvsem.php
+++ b/build/stubs/sysvsem.php
@@ -1,0 +1,23 @@
+<?php
+
+// SPDX-FileCopyrightText: The PHP Group
+// SPDX-License-Identifier: PHP-3.01
+// https://github.com/php/php-src/blob/master/ext/sysvsem/sysvsem.stub.php
+
+/** @generate-class-entries */
+
+/**
+ * @strict-properties
+ * @not-serializable
+ */
+final class SysvSemaphore
+{
+}
+
+function sem_get(int $key, int $max_acquire = 1, int $permissions = 0666, bool $auto_release = true): SysvSemaphore|false {}
+
+function sem_acquire(SysvSemaphore $semaphore, bool $non_blocking = false): bool {}
+
+function sem_release(SysvSemaphore $semaphore): bool {}
+
+function sem_remove(SysvSemaphore $semaphore): bool {}

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,7 +4,7 @@
  - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <psalm
-	errorLevel="4"
+	errorLevel="3"
 	resolveFromConfigFile="true"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="https://getpsalm.org/schema/config"
@@ -72,27 +72,28 @@
 		<directory name="3rdparty"/>
 	</extraFiles>
 	<stubs>
+		<file name="3rdparty/sabre/uri/lib/functions.php" />
+		<file name="build/stubs/IntlChar.php"/>
+		<file name="build/stubs/SensitiveParameter.phpstub"/>
 		<file name="build/stubs/apcu.php"/>
+		<file name="build/stubs/app_api.php" />
 		<file name="build/stubs/excimer.php"/>
+		<file name="build/stubs/ftp.php"/>
 		<file name="build/stubs/gd.php"/>
 		<file name="build/stubs/imagick.php"/>
 		<file name="build/stubs/intl.php"/>
-		<file name="build/stubs/IntlChar.php"/>
-		<file name="build/stubs/SensitiveParameter.phpstub"/>
 		<file name="build/stubs/ldap.php"/>
 		<file name="build/stubs/memcached.php"/>
+		<file name="build/stubs/pcntl.php"/>
+		<file name="build/stubs/php-polyfill.php" />
+		<file name="build/stubs/psr_container.php"/>
 		<file name="build/stubs/redis.php"/>
 		<file name="build/stubs/redis_cluster.php"/>
 		<file name="build/stubs/sftp.php"/>
 		<file name="build/stubs/ssh2.php"/>
+		<file name="build/stubs/sysvsem.php"/>
 		<file name="build/stubs/xsl.php"/>
-		<file name="build/stubs/ftp.php"/>
-		<file name="build/stubs/pcntl.php"/>
 		<file name="build/stubs/zip.php"/>
-		<file name="build/stubs/psr_container.php"/>
-		<file name="3rdparty/sabre/uri/lib/functions.php" />
-		<file name="build/stubs/app_api.php" />
-		<file name="build/stubs/php-polyfill.php" />
 	</stubs>
 	<issueHandlers>
 		<LessSpecificReturnStatement errorLevel="error"/>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Make psalm stricter.

The main advantage of lowering the level and adding all existing issues to the baseline is that we can enforce the stricter rules for new code.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
