### PR TITLE
fix(preview/bundled): copy content not resource id and improve error handling

### DIFF
--- a/lib/private/Preview/Bundled.php
+++ b/lib/private/Preview/Bundled.php
@@ -34,6 +34,7 @@ abstract class Bundled extends ProviderV2 {
 		$this->tmpFiles[] = $targetTmp;
 
 		try {
+			/** @var resource|false|null */
 			$src = $file->fopen('r');
 			if ($src === false) {
 				Server::get(LoggerInterface::class)->debug(
@@ -42,7 +43,8 @@ abstract class Bundled extends ProviderV2 {
 				);
 				return null;
 			}
-			
+
+			/** @var resource|false|null */
 			$dst = fopen($sourceTmp, 'wb');
 			if ($dst === false) {
 				Server::get(LoggerInterface::class)->debug(
@@ -51,7 +53,7 @@ abstract class Bundled extends ProviderV2 {
 				);
 				return null;
 			}
-			
+
 			$bytes = stream_copy_to_stream($src, $dst);
 			if ($bytes === false || $bytes === 0) {
 				Server::get(LoggerInterface::class)->debug(
@@ -82,10 +84,10 @@ abstract class Bundled extends ProviderV2 {
 
 			return $image;
 		} catch (\Throwable $e) {
-				Server::get(LoggerInterface::class)->debug(
-					'Unable to extract thumbnail - exception while extracting',
-					['message' => $e->getMessage(), 'path' => $path]
-				);
+			Server::get(LoggerInterface::class)->debug(
+				'Unable to extract thumbnail - exception while extracting',
+				['message' => $e->getMessage(), 'path' => $path]
+			);
 			return null;
 		} finally {
 			if (isset($dst) && is_resource($dst)) {

--- a/lib/private/Preview/Bundled.php
+++ b/lib/private/Preview/Bundled.php
@@ -8,28 +8,73 @@ namespace OC\Preview;
 
 use OC\Archive\ZIP;
 use OCP\Files\File;
+use OCP\IConfig;
 use OCP\IImage;
+use OCP\ITempManager;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 /**
  * Extracts a preview from files that embed them in an ZIP archive
  */
 abstract class Bundled extends ProviderV2 {
 	protected function extractThumbnail(File $file, string $path): ?IImage {
-		if ($file->getSize() === 0) {
+		$previewMaxFilesize = Server::get(IConfig::class)->getSystemValueInt('preview_max_filesize_image', 50);
+		$size = $file->getSize();
+		if ($size === 0) {
+			return null;
+		}
+		if ($previewMaxFilesize !== -1 && $size > ($previewMaxFilesize * 1024 * 1024)) {
 			return null;
 		}
 
-		$sourceTmp = \OC::$server->getTempManager()->getTemporaryFile();
-		$targetTmp = \OC::$server->getTempManager()->getTemporaryFile();
+		$sourceTmp = Server::get(ITempManager::class)->getTemporaryFile();
+		$targetTmp = Server::get(ITempManager::class)->getTemporaryFile();
 		$this->tmpFiles[] = $sourceTmp;
 		$this->tmpFiles[] = $targetTmp;
 
 		try {
-			$content = $file->fopen('r');
-			file_put_contents($sourceTmp, $content);
+			$src = $file->fopen('r');
+			if ($src === false) {
+				Server::get(LoggerInterface::class)->debug(
+					'Unable to extract thumbnail - fopen source failed',
+					['path' => $path]
+				);
+				return null;
+			}
+			
+			$dst = fopen($sourceTmp, 'wb');
+			if ($dst === false) {
+				Server::get(LoggerInterface::class)->debug(
+					'Unable to extract thumbnail - fopen destination failed',
+					['path' => $path]
+				);
+				return null;
+			}
+			
+			$bytes = stream_copy_to_stream($src, $dst);
+			if ($bytes === false || $bytes === 0) {
+				Server::get(LoggerInterface::class)->debug(
+					'Unable to extract thumbnail - copy returned 0 bytes',
+					['path' => $path]
+				);
+				return null;
+			}
+
+			fclose($dst);
+			$dst = null;
+			fclose($src);
+			$src = null;
 
 			$zip = new ZIP($sourceTmp);
-			$zip->extractFile($path, $targetTmp);
+			$result = $zip->extractFile($path, $targetTmp);
+			if ($result === false || !file_exists($targetTmp) || filesize($targetTmp) === 0) {
+				Server::get(LoggerInterface::class)->debug(
+					'Unable to extract thumbnail - extractFile failed or target missing/empty',
+					['path' => $path]
+				);
+				return null;
+			}
 
 			$image = new \OCP\Image();
 			$image->loadFromFile($targetTmp);
@@ -37,7 +82,19 @@ abstract class Bundled extends ProviderV2 {
 
 			return $image;
 		} catch (\Throwable $e) {
+				Server::get(LoggerInterface::class)->debug(
+					'Unable to extract thumbnail - exception while extracting',
+					['message' => $e->getMessage(), 'path' => $path]
+				);
 			return null;
+		} finally {
+			if (isset($dst) && is_resource($dst)) {
+				fclose($dst);
+			}
+			if (isset($src) && is_resource($src)) {
+				fclose($src);
+			}
+			$this->cleanTmpFiles();
 		}
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

The main change here was old lines 28-29, which wrote the resource identifier string (e.g. "`Resource id #...`") rather than copying the data.

The original implementation (PR #20319) had a `$contents = stream_get_contents`  during review from what I can tell, but the merged version never had it. Not sure what happened in between. I can't see how this ever worked in practice.

Other than that I just added more error handling, logging, and resource cleanup.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
