### PR TITLE
fix(files): unexpected checksum header in multipart uploads caused by S3 default integrity change in AWS SDK for PHP

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -119,6 +119,14 @@ trait S3ConnectionTrait {
 			$options['endpoint'] = $base_url;
 		}
 
+		if (isset($this->params['request_checksum_calculation'])) {
+			$options['request_checksum_calculation'] = $this->params['request_checksum_calculation'];
+		}
+
+		if (isset($this->params['response_checksum_validation'])) {
+			$options['response_checksum_validation'] = $this->params['response_checksum_validation'];
+		}
+
 		if ($this->getProxy()) {
 			$options['http']['proxy'] = $this->getProxy();
 		}


### PR DESCRIPTION
* Resolves: #56077 

## Summary
This commit makes the configuration settings `request_checksum_calculation` and `response_checksum_validation` of the S3Client from the AWS SDK for PHP configurable via the objectstore S3 configuration section of the `config.php`. Allowed values are `when_required` and `when_supported` (new default since AWS SDK for PHP >= 3.337.0).

Signed-off-by: Fiehe Christoph  <c.fiehe@eurodata.de>
