### PR TITLE
fix(theme): fix looking for core template in themes

### DIFF
--- a/lib/private/Template/Template.php
+++ b/lib/private/Template/Template.php
@@ -73,7 +73,7 @@ class Template extends Base implements ITemplate {
 	 */
 	protected function findTemplate(string $theme, string $app, string $name): array {
 		// Check if it is a app template or not.
-		if ($app !== '') {
+		if ($app !== 'core' && $app !== '') {
 			try {
 				$appDir = Server::get(IAppManager::class)->getAppPath($app);
 			} catch (AppPathNotFoundException) {


### PR DESCRIPTION
It seems now the appname is set to `'core'` and not empty. Still keeping the check on `''` just in case.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
