### PR TITLE
chore: add /remove-skip-ci command for backport workflows

### DIFF
--- a/.github/workflows/command-remove-skip-ci.yml
+++ b/.github/workflows/command-remove-skip-ci.yml
@@ -1,0 +1,97 @@
+name: Remove Skip CI Command
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/remove-skip-ci')
+
+    outputs:
+      head_ref: ${{ steps.comment-branch.outputs.head_ref }}
+
+    steps:
+      - name: Get repository from pull request comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: get-repository
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pull = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            return pull.data.head?.repo?.full_name
+
+      - name: Disabled on forks
+        if: ${{ fromJSON(steps.get-repository.outputs.result) != github.repository }}
+        run: |
+          echo 'Can not execute /remove-skip-ci on forks'
+          exit 1
+
+      - name: Check actor permission
+        uses: skjnldsv/check-actor-permission@69e92a3c4711150929bca9fcf34448c5bf5526e7 # v2
+        with:
+          require: write
+
+      - name: Add reaction on start
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '+1'
+
+      - name: Init branch
+        uses: xt0rted/pull-request-comment-branch@e8b8daa837e8ea7331c0003c9c316a64c6d8b0b1 # v3.0.0
+        id: comment-branch
+
+      - name: Add reaction on failure
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: failure()
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '-1'
+
+  process:
+    runs-on: ubuntu-latest
+    needs: init
+
+    steps:
+      - name: Checkout ${{ needs.init.outputs.head_ref }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: true
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          fetch-depth: 0
+          ref: ${{ needs.init.outputs.head_ref }}
+
+      - name: Setup git
+        run: |
+          git config --local user.email 'nextcloud-command@users.noreply.github.com'
+          git config --local user.name 'nextcloud-command'
+
+      - name: Amend commit and remove skip-ci
+        run: |
+          git commit --amend -m "$(git log -1 --format='%B' | sed '/\[skip ci\]/d')"
+
+      - name: Force push
+        env:
+          HEAD_REF: ${{ needs.init.outputs.head_ref }}
+        run: git push --force-with-lease origin "$HEAD_REF"
+
+      - name: Add reaction on failure
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: failure()
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '-1'


### PR DESCRIPTION
The existing /compile amend command removes [skip ci] but merges the compile step with the changes themselves which is not ideal to maintain a cleaner history. Sometimes GitHub reviews are sufficient to confirm a backport without need to pull and ammend locally in the case where the developer prefers not to squash the compile step.

This new command allows removing [skip ci] from commits without triggering asset compilation.