### PR TITLE
fix(snowflakes): fix APCu cache restarted detection

### DIFF
--- a/lib/private/Snowflake/APCuSequence.php
+++ b/lib/private/Snowflake/APCuSequence.php
@@ -19,7 +19,7 @@ class APCuSequence implements ISequence {
 
 	#[Override]
 	public function nextId(int $serverId, int $seconds, int $milliseconds): int|false {
-		if ((int)apcu_cache_info(true)['creation_time'] === $seconds) {
+		if ((int)apcu_cache_info(true)['start_time'] === $seconds) {
 			// APCu cache was just started
 			// It means a sequence was maybe deleted
 			return false;


### PR DESCRIPTION
apcu_cache_info use `start_time` and not `creation_time`.
Example: 
```
array(15) {
  'num_slots' => int(16411)
  'ttl' => int(0)
  'num_hits' => double(0)
  'num_misses' => double(0)
  'num_inserts' => double(0)
  'num_entries' => int(0)
  'cleanups' => int(0)
  'defragmentations' => int(0)
  'expunges' => int(0)
  'start_time' => int(1761836495)
  'mem_size' => double(0)
  'memory_type' => string(4) "mmap"
}