### PR TITLE
perf(dav): always use zip64 for directory downloads, removing upfront file enumeration

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -39,7 +39,7 @@ class Streamer {
 	 *                                 please migrate to `Streamer::isUserAgentPreferTar()` instead.
 	 * @param int|float $size The size of the files in bytes
 	 * @param int $numberOfFiles The number of files (and directories) that will
-	 *                           be included in the streamed file
+	 *                           be included in the streamed file, used to detect if zip32 or zip64 should be used, can be set to -1 to enforce zip64
 	 */
 	public function __construct(
 		IRequest|bool $preferTar,
@@ -80,7 +80,7 @@ class Streamer {
 		if ($preferTar) {
 			// If TAR ball is preferred use it
 			$this->streamerInstance = new TarStreamer();
-		} elseif ($size > 0 && $size < 4 * 1000 * 1000 * 1000 && $numberOfFiles < 65536) {
+		} elseif ($size > 0 && $size < 4 * 1000 * 1000 * 1000 && $numberOfFiles < 65536 && $numberOfFiles >= 0) {
 			$this->streamerInstance = new ZipStreamer(['zip64' => false]);
 		} else {
 			$this->streamerInstance = new ZipStreamer(['zip64' => true]);


### PR DESCRIPTION
When downloading large amount of files as ZIP, we may spend time counting files and holding them in memory. The only reason for this is to determine if zip32 or zip64 shall be used.

We can take a shortcut to always use zip64. Support for zip32 can be dropped as all clients should support opening zip64 these days