### PR TITLE
[stable32] Do not fail on missing sidebar in files list

### DIFF
--- a/apps/files/src/actions/sidebarAction.ts
+++ b/apps/files/src/actions/sidebarAction.ts
@@ -45,15 +45,15 @@ export const action = new FileAction({
 	async exec(node: Node, view: View, dir: string) {
 		try {
 			// If the sidebar is already open for the current file, do nothing
-			if (window.OCA.Files.Sidebar.file === node.path) {
+			if (window?.OCA?.Files?.Sidebar.file === node.path) {
 				logger.debug('Sidebar already open for this file', { node })
 				return null
 			}
 			// Open sidebar and set active tab to sharing by default
-			window.OCA.Files.Sidebar.setActiveTab('sharing')
+			window?.OCA?.Files?.Sidebar.setActiveTab('sharing')
 
 			// TODO: migrate Sidebar to use a Node instead
-			await window.OCA.Files.Sidebar.open(node.path)
+			await window?.OCA?.Files?.Sidebar?.open(node.path)
 
 			// Silently update current fileid
 			window.OCP?.Files?.Router?.goToRoute(


### PR DESCRIPTION
When using richdocuments it was failing in case of shared links or when user with opened file did a wheel click on a refresh page. Then new tab appeared but instead opening the file it was doing nothing (showing the list of files) or downloading the file.

Make code more defensive. I found these logs while debugging: OCA.Files.Settings initialized
```
Sidebar.js:19 OCA.Files.Sidebar initialized
ShareSearch.js:16 OCA.Sharing.ShareSearch initialized comments-app.js:15 OCA.Comments.View initialized
index.mjs:54 [ERROR] files: Error while opening sidebar Object log @ index.mjs:54
index.mjs:54 [ERROR] files: Error while opening sidebar Objectapp: "files"error: TypeError: window.OCA.Files.Sidebar.open is not a function
    at h.exec (http://nc/dist/files-main.js?v=106d16db-0:1:70123)
    at o.openSidebarForFile (http://nc/dist/files-main.js?v=106d16db-0:1:163422)
    at o.handleOpenQueries (http://nc/dist/files-main.js?v=106d16db-0:1:163167)
    at o.openDetails (http://nc/dist/files-main.js?v=106d16db-0:1:162349)
    at fn (http://nc/dist/core-common.js?v=106d16db-0:1:3942538)
    at e.run (http://nc/dist/core-common.js?v=106d16db-0:1:3946900)
    at sa (http://nc/dist/core-common.js?v=106d16db-0:1:3948728)
    at Array.<anonymous> (http://nc/dist/core-common.js?v=106d16db-0:1:3943585)
    at bn (http://nc/dist/core-common.js?v=106d16db-0:1:3942986)level: 2uid: "admin"[[Prototype]]: Object
log @ index.mjs:54
```
Possibly regression from
https://github.com/nextcloud/server/commit/e7001022c75b3a818356378bb53bbfe5129a10fe

Fixes https://github.com/nextcloud/richdocuments/issues/3815
