### PR TITLE
feat: Update supported PostgreSQL versions

### DIFF
--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -61,13 +61,13 @@ jobs:
       matrix:
         php-versions: ['8.2']
         # To keep the matrix smaller we ignore PostgreSQL versions in between as we already test the minimum and the maximum
-        postgres-versions: ['13', '17']
+        postgres-versions: ['14', '18']
         include:
           - php-versions: '8.3'
-            postgres-versions: '17'
+            postgres-versions: '18'
             coverage: ${{ github.event_name != 'pull_request' }}
           - php-versions: '8.4'
-            postgres-versions: '17'
+            postgres-versions: '18'
 
     name: PostgreSQL ${{ matrix.postgres-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 
@@ -86,7 +86,7 @@ jobs:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: rootpassword
           POSTGRES_DB: nextcloud
-        options: --mount type=tmpfs,destination=/var/lib/postgresql/data --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
+        options: --mount type=tmpfs,destination=/var/lib/postgresql --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
 
     steps:
       - name: Checkout server

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -20,8 +20,8 @@ class SupportedDatabase implements ISetupCheck {
 	private const MAX_MARIADB = '11.8';
 	private const MIN_MYSQL = '8.0';
 	private const MAX_MYSQL = '8.4';
-	private const MIN_POSTGRES = '13';
-	private const MAX_POSTGRES = '17';
+	private const MIN_POSTGRES = '14';
+	private const MAX_POSTGRES = '18';
 
 	public function __construct(
 		private IL10N $l10n,


### PR DESCRIPTION
Depends on https://github.com/nextcloud/docker-ci/pull/841

PostgreSQL 13 is EOL in one week, so we can remove it for 33 already.