### PR TITLE
feat(lexicon): add FLAG_INTERNAL

### DIFF
--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -61,6 +61,12 @@ class SetConfig extends Base {
 				'Set value as sensitive',
 			)
 			->addOption(
+				'internal',
+				null,
+				InputOption::VALUE_NONE,
+				'Confirm the edit of an internal value',
+			)
+			->addOption(
 				'update-only',
 				null,
 				InputOption::VALUE_NONE,
@@ -157,6 +163,12 @@ class SetConfig extends Base {
 				}
 			} catch (AppConfigUnknownKeyException) {
 				$sensitive = $sensitive ?? false;
+			}
+
+			if (!$input->getOption('internal') && ($this->appConfig->getKeyDetails($appName, $configName)['internal'] ?? false)) {
+				$output->writeln('<error>Config key is set as INTERNAL and modifying it might induce strange behavior or break user experience.</error>');
+				$output->writeln('please use option <comment>--internal</comment> to confirm your action');
+				return self::FAILURE;
 			}
 
 			$value = (string)$input->getOption('value');

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1115,7 +1115,7 @@ class AppConfig implements IAppConfig {
 	 * @param string $app id of the app
 	 * @param string $key config key
 	 *
-	 * @return array{app: string, key: string, lazy?: bool, valueType?: ValueType, valueTypeName?: string, sensitive?: bool, default?: string, definition?: string, note?: string}
+	 * @return array{app: string, key: string, lazy?: bool, valueType?: ValueType, valueTypeName?: string, sensitive?: bool, internal?: bool, default?: string, definition?: string, note?: string}
 	 * @since 32.0.0
 	 */
 	public function getKeyDetails(string $app, string $key): array {
@@ -1143,6 +1143,7 @@ class AppConfig implements IAppConfig {
 				'valueType' => $lexiconEntry->getValueType(),
 				'valueTypeName' => $lexiconEntry->getValueType()->name,
 				'sensitive' => $lexiconEntry->isFlagged(self::FLAG_SENSITIVE),
+				'internal' => $lexiconEntry->isFlagged(self::FLAG_INTERNAL),
 				'default' => $lexiconEntry->getDefault($this->presetManager->getLexiconPreset()),
 				'definition' => $lexiconEntry->getDefinition(),
 				'note' => $lexiconEntry->getNote(),

--- a/lib/public/Config/IUserConfig.php
+++ b/lib/public/Config/IUserConfig.php
@@ -38,6 +38,10 @@ interface IUserConfig {
 	 * @since 32.0.0
 	 */
 	public const FLAG_INDEXED = 2;    // value should be indexed
+	/**
+	 * @since 33.0.0
+	 */
+	public const FLAG_INTERNAL = 4;   // value is considered internal and can be hidden from listing
 
 	/**
 	 * Get list of all userIds with config stored in database.

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -48,6 +48,10 @@ interface IAppConfig {
 
 	/** @since 31.0.0 */
 	public const FLAG_SENSITIVE = 1;   // value is sensitive
+	/**
+	 * @since 33.0.0
+	 */
+	public const FLAG_INTERNAL = 4;   // value is considered internal and can be hidden from listing
 
 	/**
 	 * Get list of all apps that have at least one config value stored in database
@@ -472,7 +476,7 @@ interface IAppConfig {
 	 * @param string $app id of the app
 	 * @param string $key config key
 	 *
-	 * @return array{app: string, key: string, lazy?: bool, valueType?: ValueType, valueTypeName?: string, sensitive?: bool, default?: string, definition?: string, note?: string}
+	 * @return array{app: string, key: string, lazy?: bool, valueType?: ValueType, valueTypeName?: string, sensitive?: bool, internal?: bool, default?: string, definition?: string, note?: string}
 	 * @since 32.0.0
 	 */
 	public function getKeyDetails(string $app, string $key): array;


### PR DESCRIPTION
This PR is a duplicate of https://github.com/nextcloud/server/pull/55477 which is locked in a strange state.

---
We use the appconfig/userconfig to store data others than real configuration value (ie timestamp and status) which should not be changed without a real knowledge of its implication.

This allow to define a config key in the Lexicon as INTERNAL:

```
	new Entry('test', ValueType::INT, 1, 'my test', lazy: false, flags: IAppConfig::FLAG_INTERNAL),
```

One of its application is to warn users that this is not a real config value.

<img width="1144" height="98" alt="image" src="https://github.com/user-attachments/assets/1b07e1b8-29fc-411d-8090-444f585bc6bd" />
