### PR TITLE
fix: use specified HTTP codes during exceptions on public/remote endpoints

### DIFF
--- a/public.php
+++ b/public.php
@@ -89,9 +89,13 @@ try {
 	$baseuri = OC::$WEBROOT . '/public.php/' . $service . '/';
 	require_once $file;
 } catch (Exception $ex) {
-	$status = 500;
-	if ($ex instanceof ServiceUnavailableException) {
+	if ($ex instanceof ServiceUnavailableException && $ex->getCode === 0) {
 		$status = 503;
+	}
+	if ($ex->getCode() > 0) {
+		$status = $ex->getCode();
+	} else {
+		$status = 500;
 	}
 	//show the user a detailed error page
 	Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'public', 'exception' => $ex]);

--- a/public.php
+++ b/public.php
@@ -89,7 +89,7 @@ try {
 	$baseuri = OC::$WEBROOT . '/public.php/' . $service . '/';
 	require_once $file;
 } catch (Exception $ex) {
-	if ($ex instanceof ServiceUnavailableException && $ex->getCode === 0) {
+	if ($ex instanceof ServiceUnavailableException && $ex->getCode() === 0) {
 		$status = 503;
 	}
 	if ($ex->getCode() > 0) {

--- a/public.php
+++ b/public.php
@@ -89,13 +89,10 @@ try {
 	$baseuri = OC::$WEBROOT . '/public.php/' . $service . '/';
 	require_once $file;
 } catch (Exception $ex) {
-	if ($ex instanceof ServiceUnavailableException && $ex->getCode() === 0) {
-		$status = 503;
-	}
 	if ($ex->getCode() > 0) {
 		$status = $ex->getCode();
 	} else {
-		$status = 500;
+		$status = $ex instanceof ServiceUnavailableException ? 503 : 500;
 	}
 	//show the user a detailed error page
 	Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'public', 'exception' => $ex]);

--- a/remote.php
+++ b/remote.php
@@ -58,7 +58,7 @@ function handleException(Exception|Error $e): void {
 				// we shall not log on RemoteException
 				\OCP\Server::get(ITemplateManager::class)->printErrorPage($e->getMessage(), '', $e->getCode());
 			} else {
-				if ($ex instanceof ServiceUnavailableException && $e->getCode === 0) {
+				if ($e instanceof ServiceUnavailableException && $e->getCode() === 0) {
 					$status = 503;
 				}
 				if ($e->getCode() > 0) {

--- a/remote.php
+++ b/remote.php
@@ -58,13 +58,10 @@ function handleException(Exception|Error $e): void {
 				// we shall not log on RemoteException
 				\OCP\Server::get(ITemplateManager::class)->printErrorPage($e->getMessage(), '', $e->getCode());
 			} else {
-				if ($e instanceof ServiceUnavailableException && $e->getCode() === 0) {
-					$status = 503;
-				}
 				if ($e->getCode() > 0) {
 					$status = $e->getCode();
 				} else {
-					$status = 500;
+					$status = $e instanceof ServiceUnavailableException ? 503 : 500;
 				}
 				\OCP\Server::get(LoggerInterface::class)->error($e->getMessage(), ['app' => 'remote','exception' => $e]);
 				\OCP\Server::get(ITemplateManager::class)->printExceptionErrorPage($e, $status);

--- a/remote.php
+++ b/remote.php
@@ -54,16 +54,20 @@ function handleException(Exception|Error $e): void {
 			});
 			$server->exec();
 		} else {
-			$statusCode = 500;
-			if ($e instanceof ServiceUnavailableException) {
-				$statusCode = 503;
-			}
 			if ($e instanceof RemoteException) {
 				// we shall not log on RemoteException
 				\OCP\Server::get(ITemplateManager::class)->printErrorPage($e->getMessage(), '', $e->getCode());
 			} else {
+				if ($ex instanceof ServiceUnavailableException && $e->getCode === 0) {
+					$status = 503;
+				}
+				if ($e->getCode() > 0) {
+					$status = $e->getCode();
+				} else {
+					$status = 500;
+				}
 				\OCP\Server::get(LoggerInterface::class)->error($e->getMessage(), ['app' => 'remote','exception' => $e]);
-				\OCP\Server::get(ITemplateManager::class)->printExceptionErrorPage($e, $statusCode);
+				\OCP\Server::get(ITemplateManager::class)->printExceptionErrorPage($e, $status);
 			}
 		}
 	} catch (\Exception $e) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #56052 <!-- related github issue -->

## Summary

We're already specifying the HTTP codes, but have been ignoring them.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
