### PR TITLE
fix(activity): do not loop affected userIDs twice

### DIFF
--- a/lib/private/Activity/Manager.php
+++ b/lib/private/Activity/Manager.php
@@ -124,10 +124,8 @@ class Manager implements IManager {
 			throw new IncompleteActivityException('The given event is invalid');
 		}
 
-		if ($event->getAuthor() === '') {
-			if ($this->session->getUser() instanceof IUser) {
-				$event->setAuthor($this->session->getUser()->getUID());
-			}
+		if (($event->getAuthor() === '') && $this->session->getUser() instanceof IUser) {
+			$event->setAuthor($this->session->getUser()->getUID());
 		}
 
 		if (!$event->getTimestamp()) {
@@ -141,6 +139,7 @@ class Manager implements IManager {
 		foreach ($this->getConsumers() as $c) {
 			if ($c instanceof IBulkConsumer) {
 				$c->bulkReceive($event, $affectedUserIds, $setting);
+				continue;
 			}
 			foreach ($affectedUserIds as $affectedUserId) {
 				$event->setAffectedUser($affectedUserId);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
