### PR TITLE
feat(entity): Attributes for Entity

### DIFF
--- a/apps/twofactor_backupcodes/lib/Db/BackupCode.php
+++ b/apps/twofactor_backupcodes/lib/Db/BackupCode.php
@@ -8,9 +8,14 @@ declare(strict_types=1);
  */
 namespace OCA\TwoFactorBackupCodes\Db;
 
+use OCP\AppFramework\Db\Attribute\Column;
+use OCP\AppFramework\Db\Attribute\Table;
 use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
 
 /**
+ * @method string getId()
+ * @method void setId(string $id)
  * @method string getUserId()
  * @method void setUserId(string $userId)
  * @method string getCode()
@@ -18,14 +23,14 @@ use OCP\AppFramework\Db\Entity;
  * @method int getUsed()
  * @method void setUsed(int $code)
  */
+#[Table(name: 'twofactor_backupcodes', useSnowflakeId: true)]
 class BackupCode extends Entity {
+	#[Column(name: 'user_id', type: Types::STRING, length: 64, nullable: false)]
+	protected ?string $userId = null;
 
-	/** @var string */
-	protected $userId;
+	#[Column(name: 'code', type: Types::STRING, length: 128, nullable: false)]
+	protected ?string $code = null;
 
-	/** @var string */
-	protected $code;
-
-	/** @var int */
-	protected $used;
+	#[Column(name: 'used', type: Types::SMALLINT, nullable: false)]
+	protected ?int $used = null;
 }

--- a/lib/private/Tagging/Tag.php
+++ b/lib/private/Tagging/Tag.php
@@ -7,11 +7,16 @@
  */
 namespace OC\Tagging;
 
+use OCP\AppFramework\Db\Attribute\Column;
+use OCP\AppFramework\Db\Attribute\Table;
 use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
 
 /**
  * Class to represent a tag.
  *
+ * @method string getId()
+ * @method void setId(string $id)
  * @method string getOwner()
  * @method void setOwner(string $owner)
  * @method string getType()
@@ -19,59 +24,29 @@ use OCP\AppFramework\Db\Entity;
  * @method string getName()
  * @method void setName(string $name)
  */
+#[Table(name: 'vcategory', useSnowflakeId: true)]
 class Tag extends Entity {
-	protected $owner;
-	protected $type;
-	protected $name;
+	#[Column(name: 'uid', type: Types::STRING, length: 64, nullable: false)]
+	protected ?string $owner = null;
+
+	#[Column(name: 'type', type: Types::STRING, length: 64, nullable: false)]
+	protected ?string $type = null;
+
+	#[Column(name: 'category', type: Types::STRING, length: 255, nullable: false)]
+	protected ?string $name = null;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param string $owner The tag's owner
-	 * @param string $type The type of item this tag is used for
-	 * @param string $name The tag's name
+	 * @param ?string $owner The tag's owner
+	 * @param ?string $type The type of item this tag is used for
+	 * @param ?string $name The tag's name
 	 */
-	public function __construct($owner = null, $type = null, $name = null) {
+	public function __construct(?string $owner = null, ?string $type = null, ?string $name = null) {
+		parent::__construct();
+
 		$this->setOwner($owner);
 		$this->setType($type);
 		$this->setName($name);
-	}
-
-	/**
-	 * Transform a database columnname to a property
-	 *
-	 * @param string $columnName the name of the column
-	 * @return string the property name
-	 * @todo migrate existing database columns to the correct names
-	 * to be able to drop this direct mapping
-	 */
-	public function columnToProperty(string $columnName): string {
-		if ($columnName === 'category') {
-			return 'name';
-		}
-
-		if ($columnName === 'uid') {
-			return 'owner';
-		}
-
-		return parent::columnToProperty($columnName);
-	}
-
-	/**
-	 * Transform a property to a database column name
-	 *
-	 * @param string $property the name of the property
-	 * @return string the column name
-	 */
-	public function propertyToColumn(string $property): string {
-		if ($property === 'name') {
-			return 'category';
-		}
-
-		if ($property === 'owner') {
-			return 'uid';
-		}
-
-		return parent::propertyToColumn($property);
 	}
 }

--- a/lib/public/AppFramework/Db/Attribute/Column.php
+++ b/lib/public/AppFramework/Db/Attribute/Column.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH
+ * SPDX-FileContributor: Carl Schwan
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\AppFramework\Db\Attribute;
+
+use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+#[Consumable(since: '33.0.0')]
+final readonly class Column {
+	public function __construct(
+		public string $name,
+		public string|null $type,
+		public int|null $length = null,
+		public bool $nullable = false,
+	) {
+	}
+}

--- a/lib/public/AppFramework/Db/Attribute/Table.php
+++ b/lib/public/AppFramework/Db/Attribute/Table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH
+ * SPDX-FileContributor: Carl Schwan
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\AppFramework\Db\Attribute;
+
+use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+#[Consumable(since: '33.0.0')]
+final readonly class Table {
+	public function __construct(
+		public string $name,
+		public bool $useSnowflakeId = false,
+	) {
+	}
+}


### PR DESCRIPTION
## Summary

Add attributes to the Entity class which serves mostly as doc but it also replace the existing mapping via `columnToProperty`/`propertyToColumn` and `setType`

```php
#[Table(name: 'twofactor_backupcodes')]
final class BackupCode extends Entity {
	#[Id(generatorClass: IGenerator::class)]
	#[Column(name: 'id', type: Types::STRING, length: 64, nullable: false)]
	public ?string $id = null;

	#[Column(name: 'user_id', type: Types::STRING, length: 64, nullable: false)]
	public ?string $userId = null;

	#[Column(name: 'code', type: Types::STRING, length: 128, nullable: false)]
	public ?string $code = null;

	#[Column(name: 'used', type: Types::SMALLINT, nullable: false, default: 0)]
	public int $used = 0;
}
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
