### PR TITLE
fix(PublicPreview): Call getMimetype() on File objects

### DIFF
--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -132,7 +132,7 @@ class PublicPreviewController extends PublicShareController {
 			return $response;
 		} catch (NotFoundException $e) {
 			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($mimeFallback) {
+			if ($file instanceof \OCP\Files\File && $mimeFallback) {
 				if ($url = $this->mimeIconProvider->getMimeIconUrl($file->getMimeType())) {
 					return new RedirectResponse($url);
 				}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -136,7 +136,7 @@ class PublicPreviewController extends PublicShareController {
 			return $response;
 		} catch (NotFoundException $e) {
 			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($mimeFallback) {
+			if ($file instanceof \OCP\Files\File && $mimeFallback) {
 				if ($url = $this->mimeIconProvider->getMimeIconUrl($file->getMimeType())) {
 					return new RedirectResponse($url);
 				}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The broad `try-catch` block catches `NotFoundException` from multiple points: `$share->getNode()`, `$node->get($file)`, or `previewManager->getPreview()`.

If the exception occurs before `$file` is reassigned to a valid `\OCP\Files\File` object (e.g., during `$node->get($file)`), `$file` remains the original string parameter.

The catch block then attempts `$file->getMimeType()`, causing "`Call to a member function getMimeType() on string`".

<details>
<summary>Error stack</summary>

```
{
  "reqId": "OYwlO7qQFhBGGteXcWwU",
  "level": 3,
  "time": "2025-11-04T15:26:56+01:00",
  "remoteAddr": "19.24.6.97",
  "user": "--",
  "app": "index",
  "method": "GET",
  "url": "/apps/files_sharing/publicpreview/rNrMYxDyDcyHo4i?file=%2F2025%2F11-Novembre+2025_PSL%2FVarles+pa+du+ms+PSL%2F3.+Abses%2FBORG+-+Arr%C3%AAt+du+0211+au+0411.jpeg&x=32&y=32&mimeFallback=true&v=382f42&a=0",
  "message": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
  "version": "31.0.10.2",
  "exception": {
    "Exception": "Exception",
    "Message": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files_Sharing\\Controller\\PublicPreviewController"
          },
          "getPreview"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 315,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Files_Sharing\\Controller\\PublicPreviewController",
          "getPreview",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "token": "rNrMYxDyDcyHo4i",
            "_route": "files_sharing.publicpreview.getpreview"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/base.php",
        "line": 1063,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/files_sharing/publicpreview/rNrMYxDyDcyHo4i"
        ]
      },
      {
        "file": "/var/www/nextcloud/index.php",
        "line": 24,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
    "Line": 146,
    "Previous": {
      "Exception": "Error",
      "Message": "Call to a member function getMimeType() on string",
      "Code": 0,
      "Trace": [
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 200,
          "function": "getPreview",
          "class": "OCA\\Files_Sharing\\Controller\\PublicPreviewController",
          "type": "->",
          "args": [
            "rNrMYxDyDcyHo4i",
            "/2025/11-Novembre 2025_PSL/Variables paie du mois PSL/3. Absences/BORGES - Arrêt du 0211 au 0411.jpeg",
            32,
            32,
            false,
            true
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 114,
          "function": "executeController",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Files_Sharing\\Controller\\PublicPreviewController"
            },
            "getPreview"
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
          "line": 161,
          "function": "dispatch",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Files_Sharing\\Controller\\PublicPreviewController"
            },
            "getPreview"
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/Route/Router.php",
          "line": 315,
          "function": "main",
          "class": "OC\\AppFramework\\App",
          "type": "::",
          "args": [
            "OCA\\Files_Sharing\\Controller\\PublicPreviewController",
            "getPreview",
            {
              "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
            },
            {
              "token": "rNrMYxDyDcyHo4i",
              "_route": "files_sharing.publicpreview.getpreview"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/base.php",
          "line": 1063,
          "function": "match",
          "class": "OC\\Route\\Router",
          "type": "->",
          "args": [
            "/apps/files_sharing/publicpreview/rNrMYxDyDcyHo4i"
          ]
        },
        {
          "file": "/var/www/nextcloud/index.php",
          "line": 24,
          "function": "handleRequest",
          "class": "OC",
          "type": "::",
          "args": []
        }
      ],
      "File": "/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php",
      "Line": 135
    },
    "message": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135",
    "exception": [],
    "CustomMessage": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135"
  },
  "id": "690a30525b5c6"
}
```

</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
