### PR TITLE
fix(DnsPinMiddlware): only pass punycode/ASCII hostname to `dns_get_record`

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -113,7 +113,7 @@ class DnsPinMiddleware {
 					$ports[] = (string)$port;
 				}
 
-				$targetIps = $this->dnsResolve(idn_to_ascii($hostName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46), 0);
+				$targetIps = $this->dnsResolve(idn_to_ascii($hostName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46, null), 0);
 
 				if (empty($targetIps)) {
 					throw new LocalServerException('No DNS record found for ' . $hostName);

--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -113,7 +113,7 @@ class DnsPinMiddleware {
 					$ports[] = (string)$port;
 				}
 
-				$targetIps = $this->dnsResolve(idn_to_ascii($hostName), 0);
+				$targetIps = $this->dnsResolve(idn_to_ascii($hostName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46), 0);
 
 				if (empty($targetIps)) {
 					throw new LocalServerException('No DNS record found for ' . $hostName);

--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -113,7 +113,7 @@ class DnsPinMiddleware {
 					$ports[] = (string)$port;
 				}
 
-				$targetIps = $this->dnsResolve(idn_to_utf8($hostName), 0);
+				$targetIps = $this->dnsResolve(idn_to_ascii($hostName), 0);
 
 				if (empty($targetIps)) {
 					throw new LocalServerException('No DNS record found for ' . $hostName);

--- a/tests/lib/Http/Client/DnsPinMiddlewareTest.php
+++ b/tests/lib/Http/Client/DnsPinMiddlewareTest.php
@@ -544,4 +544,112 @@ class DnsPinMiddlewareTest extends TestCase {
 		// CNAME should not be queried if A or AAAA succeeded already
 		$this->assertNotContains('subsubdomain.subdomain.example.com' . DNS_CNAME, $dnsQueries);
 	}
+
+	public function testDnsGetRecordCalledWithPunycode() {
+		// Unicode hostname with umlaut (IDN)
+		$unicodeHost = 'bücher.com';
+		$punycodeHost = idn_to_ascii($unicodeHost, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+
+		// We expect that the middleware will call dnsGetRecord with the Punycode (not Unicode)
+		$this->dnsPinMiddleware
+			->expects($this->atLeastOnce())
+			->method('dnsGetRecord')
+			->with(
+				$this->callback(function ($hostname) use ($punycodeHost) {
+					// Should never be raw Unicode here!
+					$this->assertEquals($punycodeHost, $hostname, "dnsGetRecord should be called with Punycode ASCII host");
+					return true;
+				}),
+				$this->anything()
+			)
+			->willReturn([
+				[
+					'host' => $punycodeHost,
+					'class' => 'IN',
+					'ttl' => 1800,
+					'type' => 'A',
+					'ip' => '203.0.113.5'
+				]
+			]);
+
+		$stack = new HandlerStack(new MockHandler([
+			static fn () => new Response(200)
+		]));
+		$stack->push($this->dnsPinMiddleware->addDnsPinning());
+		$handler = $stack->resolve();
+
+		$handler(
+			new Request('GET', "https://$unicodeHost"),
+			['nextcloud' => ['allow_local_address' => false]]
+		);
+	}
+
+	public function testDnsGetRecordWithRawUnicodeFailsGracefully() {
+		// Simulate a middleware bug where Unicode is passed to dns_get_record
+		$unicodeHost = 'bücher.com';
+
+		$this->dnsPinMiddleware
+			->method('dnsGetRecord')
+			->willReturnCallback(function ($hostname, $type) use ($unicodeHost) {
+				if ($hostname === $unicodeHost) {
+					// Simulate real dns_get_record failure (returns false)
+					return false;
+				}
+				return [
+					[
+						'host' => $hostname,
+						'class' => 'IN',
+						'ttl' => 1800,
+						'type' => 'A',
+						'ip' => '203.0.113.5'
+					]
+				];
+			});
+
+		$stack = new HandlerStack(new MockHandler([
+			static fn () => new Response(200)
+		]));
+		$stack->push($this->dnsPinMiddleware->addDnsPinning());
+		$handler = $stack->resolve();
+
+		$this->expectException(LocalServerException::class);
+		$this->expectExceptionMessage('No DNS record found for ' . $unicodeHost);
+
+		$handler(
+			new Request('GET', "https://$unicodeHost"),
+			['nextcloud' => ['allow_local_address' => false]]
+		);
+	}
+
+	public function testDnsPinMiddlewareAcceptsPunycodeDirectly() {
+		$punycodeHost = 'xn--bcher-kva.com';
+
+		$this->dnsPinMiddleware
+			->expects($this->atLeastOnce())
+			->method('dnsGetRecord')
+			->with(
+				$punycodeHost,
+				$this->anything()
+			)
+			->willReturn([
+				[
+					'host' => $punycodeHost,
+					'class' => 'IN',
+					'ttl' => 1800,
+					'type' => 'A',
+					'ip' => '203.0.113.80'
+				]
+			]);
+
+		$stack = new HandlerStack(new MockHandler([
+			static fn () => new Response(200)
+		]));
+		$stack->push($this->dnsPinMiddleware->addDnsPinning());
+		$handler = $stack->resolve();
+
+		$handler(
+			new Request('GET', "https://$punycodeHost"),
+			['nextcloud' => ['allow_local_address' => false]]
+		);
+	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #53185 <!-- related github issue -->

## Summary

tldr: The current use of `idn_to_utf8()` in this context breaks DNS resolution for both Unicode IDNs and explicit punycode hostnames. It also doesn't seem to match the intention.

Likely also fixes #53185

### Details

`dns_get_record()` only supports ASCII/Punycode input. `idn_to_utf8()` converts Punycode/ASCII hostnames to their Unicode form. 

If we pass it raw Unicode (e.g., "bücher.com"), it returns it unchanged. If you give it Punycode (e.g., "xn--bcher-kva.com"), it returns the Unicode (e.g., "bücher.com"). 

Neither of which will work with `dns_get_record()`. 

Passing either raw Unicode or the output of `idn_to_utf8()` on a punycode string to `dns_get_record()` will result in DNS resolution failure for IDNs. Only ASCII/punycode should be passed to the resolver.

Not caught by unit tests previously due to ASCII-only hostnames, mocked DNS, etc.

## TODO

- [ ] Same thing should be done in RemoteHostValidator here: https://github.com/nextcloud/server/blob/9581230b56f1e6dd300c157da349da1adb22a638/lib/private/Security/RemoteHostValidator.php#L38

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
