### PR TITLE
feat(EphemeralSessions): Introduce lax period

### DIFF
--- a/lib/private/AppFramework/Middleware/FlowV2EphemeralSessionsMiddleware.php
+++ b/lib/private/AppFramework/Middleware/FlowV2EphemeralSessionsMiddleware.php
@@ -13,6 +13,7 @@ use OC\Core\Controller\TwoFactorChallengeController;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Middleware;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\TwoFactorAuth\ALoginSetupController;
 use OCP\ISession;
 use OCP\IUserSession;
@@ -22,19 +23,32 @@ use ReflectionMethod;
 // Will close the session if the user session is ephemeral.
 // Happens when the user logs in via the login flow v2.
 class FlowV2EphemeralSessionsMiddleware extends Middleware {
+
+	private const EPHEMERAL_SESSION_TTL = 5 * 60; // 5 minutes
+
 	public function __construct(
 		private ISession $session,
 		private IUserSession $userSession,
 		private ControllerMethodReflector $reflector,
 		private LoggerInterface $logger,
+		private ITimeFactory $timeFactory,
 	) {
 	}
 
 	public function beforeController(Controller $controller, string $methodName) {
-		if (!$this->session->get(ClientFlowLoginV2Controller::EPHEMERAL_NAME)) {
+		$sessionCreationTime = $this->session->get(ClientFlowLoginV2Controller::EPHEMERAL_NAME);
+
+		// Not an ephemeral session.
+		if ($sessionCreationTime === null) {
 			return;
 		}
 
+		// Lax enforcement until TTL is reached.
+		if ($this->timeFactory->getTime() < $sessionCreationTime + self::EPHEMERAL_SESSION_TTL) {
+			return;
+		}
+
+		// Allow certain controllers/methods to proceed without logging out.
 		if (
 			$controller instanceof ClientFlowLoginV2Controller
 			&& ($methodName === 'grantPage' || $methodName === 'generateAppPassword')

--- a/lib/private/Authentication/Login/FlowV2EphemeralSessionsCommand.php
+++ b/lib/private/Authentication/Login/FlowV2EphemeralSessionsCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\Authentication\Login;
 
 use OC\Core\Controller\ClientFlowLoginV2Controller;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\ISession;
 use OCP\IURLGenerator;
 
@@ -16,13 +17,14 @@ class FlowV2EphemeralSessionsCommand extends ALoginCommand {
 	public function __construct(
 		private ISession $session,
 		private IURLGenerator $urlGenerator,
+		private ITimeFactory $timeFactory,
 	) {
 	}
 
 	public function process(LoginData $loginData): LoginResult {
 		$loginV2GrantRoute = $this->urlGenerator->linkToRoute('core.ClientFlowLoginV2.grantPage');
 		if (str_starts_with($loginData->getRedirectUrl() ?? '', $loginV2GrantRoute)) {
-			$this->session->set(ClientFlowLoginV2Controller::EPHEMERAL_NAME, true);
+			$this->session->set(ClientFlowLoginV2Controller::EPHEMERAL_NAME, $this->timeFactory->getTime());
 		}
 
 		return $this->processNextOrFinishSuccessfully($loginData);


### PR DESCRIPTION
In an attempt to fix the numerous number of issues with ephemeral session, I suggest that we introduce a lax period of 60 seconds during which no request will close the session.

For the record, we had/have the following problematic requests:

- side menu https://gitnet.fr/deblan/side_menu/issues/443
- encryption https://github.com/nextcloud/server/pull/56104
- custom background: https://github.com/nextcloud/server/issues/56131
- two factor https://github.com/nextcloud/server/pull/54605
- and I think a last one that I cannot remember.