### PR TITLE
feat(group): Sanitize group names and ids on creation

### DIFF
--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -67,6 +67,7 @@ class Database extends ABackend implements
 	public function createGroup(string $name): ?string {
 		$this->fixDI();
 
+		$name = $this->sanitizeGroupName($name);
 		$gid = $this->computeGid($name);
 		try {
 			// Add group
@@ -587,11 +588,20 @@ class Database extends ABackend implements
 	}
 
 	/**
+	 * Merge any white spaces to a single space in group name, then trim it.
+	 */
+	private function sanitizeGroupName(string $displayName): string {
+		$cleanedDisplayName = preg_replace('/\s+/', ' ', $displayName);
+		return trim($cleanedDisplayName);
+	}
+
+	/**
 	 * Compute group ID from display name (GIDs are limited to 64 characters in database)
 	 */
 	private function computeGid(string $displayName): string {
-		return mb_strlen($displayName) > 64
-			? hash('sha256', $displayName)
-			: $displayName;
+		$displayNameWithoutWhitespace = preg_replace('/\s+/', '_', $displayName);
+		return mb_strlen($displayNameWithoutWhitespace) > 64
+			? hash('sha256', $displayNameWithoutWhitespace)
+			: $displayNameWithoutWhitespace;
 	}
 }

--- a/tests/lib/Group/DatabaseTest.php
+++ b/tests/lib/Group/DatabaseTest.php
@@ -57,4 +57,17 @@ class DatabaseTest extends Backend {
 		$group = $this->backend->getGroupDetails($gidCreated);
 		$this->assertEquals(['displayName' => $groupName], $group);
 	}
+
+	public function testWhiteSpaceInGroupName(): void {
+		$randomId = $this->getUniqueID('test_', 10);
+		$groupName = " 	group  name	with  	weird spaces \n" . $randomId;
+		$expectedGroupName = 'group name with weird spaces ' . $randomId;
+		$expectedGroupId = 'group_name_with_weird_spaces_' . $randomId;
+
+		$gidCreated = $this->backend->createGroup($groupName);
+		$this->assertEquals($expectedGroupId, $gidCreated);
+
+		$group = $this->backend->getGroupDetails($gidCreated);
+		$this->assertEquals(['displayName' => $expectedGroupName], $group);
+	}
 }


### PR DESCRIPTION
It does not make sense to allow group name with weird white space sequence going forward.

Same for group ids, in which we do not really want white space.
