### PR TITLE
fix(View): Normalize path in getAbsolutePath

### DIFF
--- a/lib/private/Collaboration/Reference/File/FileReferenceEventListener.php
+++ b/lib/private/Collaboration/Reference/File/FileReferenceEventListener.php
@@ -8,21 +8,22 @@ declare(strict_types=1);
 
 namespace OC\Collaboration\Reference\File;
 
-use OC\Files\Node\NonExistingFile;
-use OC\Files\Node\NonExistingFolder;
 use OCP\Collaboration\Reference\IReferenceManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Events\Node\NodeRenamedEvent;
+use OCP\Files\NotFoundException;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareDeletedEvent;
+use Psr\Log\LoggerInterface;
 
 /** @template-implements IEventListener<Event|NodeDeletedEvent|ShareDeletedEvent|ShareCreatedEvent> */
 class FileReferenceEventListener implements IEventListener {
 	public function __construct(
 		private IReferenceManager $manager,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -38,11 +39,12 @@ class FileReferenceEventListener implements IEventListener {
 	 */
 	public function handle(Event $event): void {
 		if ($event instanceof NodeDeletedEvent) {
-			if ($event->getNode() instanceof NonExistingFolder || $event->getNode() instanceof NonExistingFile) {
-				return;
+			try {
+				$this->manager->invalidateCache((string)$event->getNode()->getId());
+			} catch (NotFoundException $e) {
+				// Non existing node might not have an id
+				$this->logger->debug('Could not invalidate reference cache for deleted node', ['exception' => $e]);
 			}
-
-			$this->manager->invalidateCache((string)$event->getNode()->getId());
 		}
 		if ($event instanceof NodeRenamedEvent) {
 			$this->manager->invalidateCache((string)$event->getTarget()->getId());

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -11,6 +11,7 @@ use Icewind\Streams\CallbackWrapper;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\Wrapper\Quota;
+use OC\Files\Utils\PathHelper;
 use OC\Share\Share;
 use OC\User\LazyUser;
 use OC\User\Manager as UserManager;
@@ -92,13 +93,7 @@ class View {
 			return null;
 		}
 		$this->assertPathLength($path);
-		if ($path === '') {
-			$path = '/';
-		}
-		if ($path[0] !== '/') {
-			$path = '/' . $path;
-		}
-		return $this->fakeRoot . $path;
+		return PathHelper::normalizePath($this->fakeRoot . '/' . $path);
 	}
 
 	/**

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -917,11 +917,11 @@ class ViewTest extends \Test\TestCase {
 
 	public static function absolutePathProvider(): array {
 		return [
-			['/files/', ''],
+			['/files', ''],
 			['/files/0', '0'],
 			['/files/false', 'false'],
 			['/files/true', 'true'],
-			['/files/', '/'],
+			['/files', '/'],
 			['/files/test', 'test'],
 			['/files/test', '/test'],
 		];


### PR DESCRIPTION
Initially was only to remove what seems to be an unnecessary check in `NodeDeletedEvent`, but CI highlighted some issue with path management.

Previously, the method was happily returning path with trailing `/`, this is not the case now. I am a bit afraid of side effects.

Fix https://github.com/nextcloud/server/issues/53667