### PR TITLE
fix(contacts): allow address book to be local but not system

### DIFF
--- a/apps/files/lib/Activity/Provider.php
+++ b/apps/files/lib/Activity/Provider.php
@@ -501,7 +501,7 @@ class Provider implements IProvider {
 			'strict_search' => true,
 		]);
 		foreach ($addressBookContacts as $contact) {
-			if (isset($contact['isLocalSystemBook'])) {
+			if (isset($contact['isLocalSystemBook']) || isset($contact['isVirtualAddressbook'])) {
 				continue;
 			}
 

--- a/apps/files_sharing/lib/Activity/Providers/Base.php
+++ b/apps/files_sharing/lib/Activity/Providers/Base.php
@@ -160,7 +160,7 @@ abstract class Base implements IProvider {
 			'strict_search' => true,
 		]);
 		foreach ($addressBookContacts as $contact) {
-			if (isset($contact['isLocalSystemBook'])) {
+			if (isset($contact['isLocalSystemBook']) || isset($contact['isVirtualAddressbook'])) {
 				continue;
 			}
 

--- a/apps/sharebymail/lib/Activity.php
+++ b/apps/sharebymail/lib/Activity.php
@@ -287,7 +287,7 @@ class Activity implements IProvider {
 		]);
 
 		foreach ($addressBookContacts as $contact) {
-			if (isset($contact['isLocalSystemBook'])) {
+			if (isset($contact['isLocalSystemBook']) || isset($contact['isVirtualAddressbook'])) {
 				continue;
 			}
 

--- a/lib/private/Collaboration/Collaborators/RemotePlugin.php
+++ b/lib/private/Collaboration/Collaborators/RemotePlugin.php
@@ -49,7 +49,7 @@ class RemotePlugin implements ISearchPlugin {
 			'fullmatch' => false,
 		]);
 		foreach ($addressBookContacts as $contact) {
-			if (isset($contact['isLocalSystemBook'])) {
+			if (isset($contact['isLocalSystemBook']) || isset($contact['isVirtualAddressbook'])) {
 				continue;
 			}
 			if (isset($contact['CLOUD'])) {

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -305,8 +305,7 @@ class ContactsStore implements IContactsStore {
 				}
 			}
 			if ($shareType === 0 || $shareType === 6) {
-				$isLocal = $contact['isLocalSystemBook'] ?? false;
-				if ($contact['UID'] === $shareWith && $isLocal === true) {
+				if (($contact['isLocalSystemBook'] ?? false) === true && $contact['UID'] === $shareWith) {
 					$match = $contact;
 					break;
 				}


### PR DESCRIPTION
if set as _local system address book_, a userId is expected in some place like 
https://github.com/nextcloud/server/blob/77194d5232bd3e27758d7b20145c43e13e180594/lib/private/Collaboration/Collaborators/MailPlugin.php#L114-L134

This fix allow app like `ldap_contacts_backend` to using a new configuration key to set itself as a local non-system address book

https://github.com/nextcloud/ldap_contacts_backend/pull/350