### PR TITLE
refactor(federatedfilesharing): remove use of IAppContainer in favor of ContainerInterface

### DIFF
--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -7,7 +7,6 @@
  */
 namespace OCA\FederatedFileSharing\AppInfo;
 
-use Closure;
 use OCA\FederatedFileSharing\Listeners\LoadAdditionalScriptsListener;
 use OCA\FederatedFileSharing\Notifier;
 use OCA\FederatedFileSharing\OCM\CloudFederationProviderFiles;
@@ -16,8 +15,8 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\IAppContainer;
 use OCP\Federation\ICloudFederationProviderManager;
+use Psr\Container\ContainerInterface;
 
 class Application extends App implements IBootstrap {
 	public function __construct() {
@@ -30,11 +29,11 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(Closure::fromCallable([$this, 'registerCloudFederationProvider']));
+		$context->injectFn($this->registerCloudFederationProvider(...));
 	}
 
 	private function registerCloudFederationProvider(ICloudFederationProviderManager $manager,
-		IAppContainer $appContainer): void {
+		ContainerInterface $appContainer): void {
 		$fileResourceTypes = ['file', 'folder'];
 		foreach ($fileResourceTypes as $type) {
 			$manager->addCloudFederationProvider($type,

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1216,11 +1216,6 @@
 			)]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/federatedfilesharing/lib/AppInfo/Application.php">
-    <DeprecatedInterface>
-      <code><![CDATA[IAppContainer]]></code>
-    </DeprecatedInterface>
-  </file>
   <file src="apps/federatedfilesharing/lib/Controller/RequestHandlerController.php">
     <InvalidArgument>
       <code><![CDATA[$id]]></code>


### PR DESCRIPTION
## Summary

Yet another small cleanup.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
