### PR TITLE
make failed availability check apply in the same request 

### DIFF
--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -126,7 +126,7 @@ class Storage {
 	}
 
 	/**
-	 * @return array [ available, last_checked ]
+	 * @return array{available: bool, last_checked: int}
 	 */
 	public function getAvailability() {
 		if ($row = self::getStorageById($this->storageId)) {

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -711,7 +711,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	}
 
 	/**
-	 * @return array [ available, last_checked ]
+	 * @return array{available: bool, last_checked: int}
 	 */
 	public function getAvailability(): array {
 		return $this->getStorageCache()->getAvailability();

--- a/lib/private/Files/Storage/Wrapper/Availability.php
+++ b/lib/private/Files/Storage/Wrapper/Availability.php
@@ -22,6 +22,7 @@ class Availability extends Wrapper {
 
 	/** @var IConfig */
 	protected $config;
+	protected ?bool $available = null;
 
 	public function __construct(array $parameters) {
 		$this->config = $parameters['config'] ?? \OCP\Server::get(IConfig::class);
@@ -54,11 +55,14 @@ class Availability extends Wrapper {
 	}
 
 	private function isAvailable(): bool {
-		$availability = $this->getAvailability();
-		if (self::shouldRecheck($availability)) {
-			return $this->updateAvailability();
+		if (is_null($this->available)) {
+			$availability = $this->getAvailability();
+			if (self::shouldRecheck($availability)) {
+				return $this->updateAvailability();
+			}
+			$this->available = $availability['available'];
 		}
-		return $availability['available'];
+		return $this->available;
 	}
 
 	/**
@@ -257,6 +261,7 @@ class Availability extends Wrapper {
 				self::RECHECK_TTL_SEC
 			);
 		}
+		$this->available = false;
 		$this->getStorageCache()->setAvailability(false, $delay);
 		if ($e !== null) {
 			throw $e;

--- a/tests/lib/Files/Storage/Wrapper/AvailabilityTest.php
+++ b/tests/lib/Files/Storage/Wrapper/AvailabilityTest.php
@@ -155,4 +155,30 @@ class AvailabilityTest extends \Test\TestCase {
 
 		$this->wrapper->mkdir('foobar');
 	}
+
+	public function testUnavailableMultiple(): void {
+		$this->storage->expects($this->once())
+			->method('getAvailability')
+			->willReturn(['available' => true, 'last_checked' => 0]);
+		$this->storage->expects($this->never())
+			->method('test');
+		$this->storage
+			->expects($this->once()) // load-bearing `once`
+			->method('mkdir')
+			->willThrowException(new StorageNotAvailableException());
+
+		try {
+			$this->wrapper->mkdir('foobar');
+			$this->fail();
+		} catch (StorageNotAvailableException) {
+		}
+
+		$this->storage->expects($this->never())->method('file_exists');
+
+		try {
+			$this->wrapper->mkdir('foobar');
+			$this->fail();
+		} catch (StorageNotAvailableException) {
+		}
+	}
 }


### PR DESCRIPTION
Currently, marking the storage as available won't be noticed by the availability wrapper until the next request.

This can lead to issues as some request can have a high number of storage calls, and repeated failures can lead to things like the instance being bruteforce protected.