### PR TITLE
fix(lexicon): enforce type from lexicon

### DIFF
--- a/apps/dav/lib/ConfigLexicon.php
+++ b/apps/dav/lib/ConfigLexicon.php
@@ -35,6 +35,7 @@ class ConfigLexicon implements ILexicon {
 				defaultRaw: true,
 				definition: 'Whether to not expose the system address book to users',
 				lazy: true,
+				options: Entry::ENFORCE_VALUE_TYPE
 			),
 		];
 	}

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -478,7 +478,9 @@ class AppConfig implements IAppConfig {
 	): string {
 		$this->assertParams($app, $key, valueType: $type);
 		$origKey = $key;
-		$matched = $this->matchAndApplyLexiconDefinition($app, $key, $lazy, $type, $default);
+		/**	@var ?Entry $lexiconEntry */
+		$lexiconEntry = null;
+		$matched = $this->matchAndApplyLexiconDefinition($app, $key, $lazy, $type, $default, $lexiconEntry);
 		if ($default === null) {
 			// there is no logical reason for it to be null
 			throw new \Exception('default cannot be null');
@@ -501,8 +503,12 @@ class AppConfig implements IAppConfig {
 			&& $knownType > 0
 			&& !$this->isTyped(self::VALUE_MIXED, $knownType)
 			&& !$this->isTyped($type, $knownType)) {
-			$this->logger->warning('conflict with value type from database', ['app' => $app, 'key' => $key, 'type' => $type, 'knownType' => $knownType]);
-			throw new AppConfigTypeConflictException('conflict with value type from database');
+			if ($lexiconEntry?->hasOption(Entry::ENFORCE_VALUE_TYPE)) {
+				$this->updateType($app, $key, $lexiconEntry->getValueType()->toAppConfigFlag());
+			} else {
+				$this->logger->warning('conflict with value type from database', ['app' => $app, 'key' => $key, 'type' => $type, 'knownType' => $knownType]);
+				throw new AppConfigTypeConflictException('conflict with value type from database');
+			}
 		}
 
 		/**

--- a/lib/public/Config/Lexicon/Entry.php
+++ b/lib/public/Config/Lexicon/Entry.php
@@ -21,7 +21,8 @@ use OCP\Config\ValueType;
 class Entry {
 	/** @since 32.0.0 */
 	public const RENAME_INVERT_BOOLEAN = 1;
-
+	/** @since 32.0.0 */
+	public const ENFORCE_VALUE_TYPE = 2;
 	private ?string $default = null;
 
 	/**


### PR DESCRIPTION
add an option to `Entry` so that the value type from the lexicon overwrite any previously set value type already available in database

- [ ] add to `setTypedValue`
- [ ] add to `IUserConfig`