### PR TITLE
Add server version to default crawler user agent

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -18,6 +18,7 @@ use OCP\Http\Client\LocalServerException;
 use OCP\ICertificateManager;
 use OCP\IConfig;
 use OCP\Security\IRemoteHostValidator;
+use OCP\ServerVersion;
 use Psr\Log\LoggerInterface;
 use function parse_url;
 
@@ -41,6 +42,7 @@ class Client implements IClient {
 		GuzzleClient $client,
 		IRemoteHostValidator $remoteHostValidator,
 		protected LoggerInterface $logger,
+		protected ServerVersion $serverVersion,
 	) {
 		$this->config = $config;
 		$this->client = $client;
@@ -81,7 +83,8 @@ class Client implements IClient {
 		$options = array_merge($defaults, $options);
 
 		if (!isset($options[RequestOptions::HEADERS]['User-Agent'])) {
-			$options[RequestOptions::HEADERS]['User-Agent'] = 'Nextcloud Server Crawler';
+			$userAgent = 'Nextcloud-Server-Crawler/' . $this->serverVersion->getVersionString();
+			$options[RequestOptions::HEADERS]['User-Agent'] = $userAgent;
 		}
 
 		if (!isset($options[RequestOptions::HEADERS]['Accept-Encoding'])) {

--- a/lib/private/Http/Client/ClientService.php
+++ b/lib/private/Http/Client/ClientService.php
@@ -18,6 +18,7 @@ use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
 use OCP\IConfig;
 use OCP\Security\IRemoteHostValidator;
+use OCP\ServerVersion;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
@@ -43,6 +44,7 @@ class ClientService implements IClientService {
 		IRemoteHostValidator $remoteHostValidator,
 		IEventLogger $eventLogger,
 		protected LoggerInterface $logger,
+		protected ServerVersion $serverVersion,
 	) {
 		$this->config = $config;
 		$this->certificateManager = $certificateManager;
@@ -74,6 +76,7 @@ class ClientService implements IClientService {
 			$client,
 			$this->remoteHostValidator,
 			$this->logger,
+			$this->serverVersion,
 		);
 	}
 }

--- a/tests/lib/Http/Client/ClientServiceTest.php
+++ b/tests/lib/Http/Client/ClientServiceTest.php
@@ -21,6 +21,7 @@ use OCP\Diagnostics\IEventLogger;
 use OCP\ICertificateManager;
 use OCP\IConfig;
 use OCP\Security\IRemoteHostValidator;
+use OCP\ServerVersion;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
@@ -45,6 +46,7 @@ class ClientServiceTest extends \Test\TestCase {
 		$remoteHostValidator = $this->createMock(IRemoteHostValidator::class);
 		$eventLogger = $this->createMock(IEventLogger::class);
 		$logger = $this->createMock(LoggerInterface::class);
+		$serverVersion = $this->createMock(ServerVersion::class);
 
 		$clientService = new ClientService(
 			$config,
@@ -53,6 +55,7 @@ class ClientServiceTest extends \Test\TestCase {
 			$remoteHostValidator,
 			$eventLogger,
 			$logger,
+			$serverVersion,
 		);
 
 		$handler = new CurlHandler();
@@ -72,6 +75,7 @@ class ClientServiceTest extends \Test\TestCase {
 				$guzzleClient,
 				$remoteHostValidator,
 				$logger,
+				$serverVersion,
 			),
 			$clientService->newClient()
 		);
@@ -94,6 +98,7 @@ class ClientServiceTest extends \Test\TestCase {
 		$remoteHostValidator = $this->createMock(IRemoteHostValidator::class);
 		$eventLogger = $this->createMock(IEventLogger::class);
 		$logger = $this->createMock(LoggerInterface::class);
+		$serverVersion = $this->createMock(ServerVersion::class);
 
 		$clientService = new ClientService(
 			$config,
@@ -102,6 +107,7 @@ class ClientServiceTest extends \Test\TestCase {
 			$remoteHostValidator,
 			$eventLogger,
 			$logger,
+			$serverVersion,
 		);
 
 		$handler = new CurlHandler();
@@ -120,6 +126,7 @@ class ClientServiceTest extends \Test\TestCase {
 				$guzzleClient,
 				$remoteHostValidator,
 				$logger,
+				$serverVersion,
 			),
 			$clientService->newClient()
 		);

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -17,6 +17,7 @@ use OCP\Http\Client\LocalServerException;
 use OCP\ICertificateManager;
 use OCP\IConfig;
 use OCP\Security\IRemoteHostValidator;
+use OCP\ServerVersion;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use function parse_url;
@@ -36,6 +37,7 @@ class ClientTest extends \Test\TestCase {
 	/** @var IRemoteHostValidator|MockObject */
 	private IRemoteHostValidator $remoteHostValidator;
 	private LoggerInterface $logger;
+	private ServerVersion $serverVersion;
 	/** @var array */
 	private $defaultRequestOptions;
 
@@ -46,12 +48,15 @@ class ClientTest extends \Test\TestCase {
 		$this->certificateManager = $this->createMock(ICertificateManager::class);
 		$this->remoteHostValidator = $this->createMock(IRemoteHostValidator::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->serverVersion = $this->createMock(ServerVersion::class);
+
 		$this->client = new Client(
 			$this->config,
 			$this->certificateManager,
 			$this->guzzleClient,
 			$this->remoteHostValidator,
 			$this->logger,
+			$this->serverVersion,
 		);
 	}
 
@@ -276,6 +281,9 @@ class ClientTest extends \Test\TestCase {
 			->with()
 			->willReturn('/my/path.crt');
 
+		$this->serverVersion->method('getVersionString')
+			->willReturn('123.45.6');
+
 		$this->defaultRequestOptions = [
 			'verify' => '/my/path.crt',
 			'proxy' => [
@@ -283,7 +291,7 @@ class ClientTest extends \Test\TestCase {
 				'https' => 'foo'
 			],
 			'headers' => [
-				'User-Agent' => 'Nextcloud Server Crawler',
+				'User-Agent' => 'Nextcloud-Server-Crawler/123.45.6',
 				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,
@@ -466,10 +474,13 @@ class ClientTest extends \Test\TestCase {
 			->expects($this->never())
 			->method('listCertificates');
 
+		$this->serverVersion->method('getVersionString')
+			->willReturn('123.45.6');
+
 		$this->assertEquals([
 			'verify' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',
 			'headers' => [
-				'User-Agent' => 'Nextcloud Server Crawler',
+				'User-Agent' => 'Nextcloud-Server-Crawler/123.45.6',
 				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,
@@ -513,6 +524,9 @@ class ClientTest extends \Test\TestCase {
 			->with()
 			->willReturn('/my/path.crt');
 
+		$this->serverVersion->method('getVersionString')
+			->willReturn('123.45.6');
+
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
 			'proxy' => [
@@ -520,7 +534,7 @@ class ClientTest extends \Test\TestCase {
 				'https' => 'foo'
 			],
 			'headers' => [
-				'User-Agent' => 'Nextcloud Server Crawler',
+				'User-Agent' => 'Nextcloud-Server-Crawler/123.45.6',
 				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,
@@ -564,6 +578,9 @@ class ClientTest extends \Test\TestCase {
 			->with()
 			->willReturn('/my/path.crt');
 
+		$this->serverVersion->method('getVersionString')
+			->willReturn('123.45.6');
+
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
 			'proxy' => [
@@ -572,7 +589,7 @@ class ClientTest extends \Test\TestCase {
 				'no' => ['bar']
 			],
 			'headers' => [
-				'User-Agent' => 'Nextcloud Server Crawler',
+				'User-Agent' => 'Nextcloud-Server-Crawler/123.45.6',
 				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,


### PR DESCRIPTION
## Summary

Add the server version to the default user agent to better diagnose federation related issues on specific versions and align to global standards.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
