### PR TITLE
Revert "feat(group): Sanitize group names and ids on creation"

### DIFF
--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -67,7 +67,6 @@ class Database extends ABackend implements
 	public function createGroup(string $name): ?string {
 		$this->fixDI();
 
-		$name = $this->sanitizeGroupName($name);
 		$gid = $this->computeGid($name);
 		try {
 			// Add group
@@ -588,20 +587,11 @@ class Database extends ABackend implements
 	}
 
 	/**
-	 * Merge any white spaces to a single space in group name, then trim it.
-	 */
-	private function sanitizeGroupName(string $displayName): string {
-		$cleanedDisplayName = preg_replace('/\s+/', ' ', $displayName);
-		return trim($cleanedDisplayName);
-	}
-
-	/**
 	 * Compute group ID from display name (GIDs are limited to 64 characters in database)
 	 */
 	private function computeGid(string $displayName): string {
-		$displayNameWithoutWhitespace = preg_replace('/\s+/', '_', $displayName);
-		return mb_strlen($displayNameWithoutWhitespace) > 64
-			? hash('sha256', $displayNameWithoutWhitespace)
-			: $displayNameWithoutWhitespace;
+		return mb_strlen($displayName) > 64
+			? hash('sha256', $displayName)
+			: $displayName;
 	}
 }

--- a/tests/lib/Group/DatabaseTest.php
+++ b/tests/lib/Group/DatabaseTest.php
@@ -57,17 +57,4 @@ class DatabaseTest extends Backend {
 		$group = $this->backend->getGroupDetails($gidCreated);
 		$this->assertEquals(['displayName' => $groupName], $group);
 	}
-
-	public function testWhiteSpaceInGroupName(): void {
-		$randomId = $this->getUniqueID('test_', 10);
-		$groupName = " 	group  name	with  	weird spaces \n" . $randomId;
-		$expectedGroupName = 'group name with weird spaces ' . $randomId;
-		$expectedGroupId = 'group_name_with_weird_spaces_' . $randomId;
-
-		$gidCreated = $this->backend->createGroup($groupName);
-		$this->assertEquals($expectedGroupId, $gidCreated);
-
-		$group = $this->backend->getGroupDetails($gidCreated);
-		$this->assertEquals(['displayName' => $expectedGroupName], $group);
-	}
 }


### PR DESCRIPTION
Reverts nextcloud/server#56222

As it is a hard behavorial change, without big necessity, after discussion with @artonge. To reduce risk, potential bug reports and support tickets for a fairly small gain, let's revert it (also cf. https://github.com/nextcloud/server/pull/56222#issuecomment-3499223877). 