### PR TITLE
fix(l10n): Nicer capitalization for generic messages

### DIFF
--- a/apps/files/src/components/FilesListTableHeaderActions.vue
+++ b/apps/files/src/components/FilesListTableHeaderActions.vue
@@ -316,16 +316,16 @@ export default defineComponent({
 						return
 					}
 
-					showError(this.t('files', '{displayName}: failed on some elements', { displayName }))
+					showError(this.t('files', '{displayName}: Failed on some elements', { displayName }))
 					return
 				}
 
 				// Show success message and clear selection
-				showSuccess(this.t('files', '{displayName}: done', { displayName }))
+				showSuccess(this.t('files', '{displayName}: Done', { displayName }))
 				this.selectionStore.reset()
 			} catch (e) {
 				logger.error('Error while executing action', { action, e })
-				showError(this.t('files', '{displayName}: failed', { displayName }))
+				showError(this.t('files', '{displayName}: Failed', { displayName }))
 			} finally {
 				// Remove loading markers
 				this.loading = null

--- a/apps/files/src/utils/actionUtils.ts
+++ b/apps/files/src/utils/actionUtils.ts
@@ -58,13 +58,13 @@ export async function executeAction(action: FileAction) {
 		}
 
 		if (success) {
-			showSuccess(t('files', '{displayName}: done', { displayName }))
+			showSuccess(t('files', '{displayName}: Done', { displayName }))
 			return
 		}
-		showError(t('files', '{displayName}: failed', { displayName }))
+		showError(t('files', '{displayName}: Failed', { displayName }))
 	} catch (error) {
 		logger.error('Error while executing action', { action, error })
-		showError(t('files', '{displayName}: failed', { displayName }))
+		showError(t('files', '{displayName}: Failed', { displayName }))
 	} finally {
 		// Reset the loading marker
 		Vue.set(currentNode, 'status', undefined)

--- a/apps/files/src/views/FilesList.vue
+++ b/apps/files/src/views/FilesList.vue
@@ -830,13 +830,13 @@ export default defineComponent({
 				}
 
 				if (success) {
-					showSuccess(t('files', '{displayName}: done', { displayName }))
+					showSuccess(t('files', '{displayName}: Done', { displayName }))
 					return
 				}
-				showError(t('files', '{displayName}: failed', { displayName }))
+				showError(t('files', '{displayName}: Failed', { displayName }))
 			} catch (error) {
 				logger.error('Error while executing action', { action, error })
-				showError(t('files', '{displayName}: failed', { displayName }))
+				showError(t('files', '{displayName}: Failed', { displayName }))
 			} finally {
 				this.loadingAction = null
 			}


### PR DESCRIPTION
Follow-up to #54202

## Summary

Actually seeing these in production made me realize that they look awkward without a capital letter at the start.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)

