### PR TITLE
ci(psalm): Add a checker against logical operators

### DIFF
--- a/build/psalm/LogicalOperatorChecker.php
+++ b/build/psalm/LogicalOperatorChecker.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+
+class LogicalOperatorChecker implements AfterExpressionAnalysisInterface {
+	public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool {
+		$stmt = $event->getExpr();
+		if ($stmt instanceof PhpParser\Node\Expr\BinaryOp\LogicalAnd
+			|| $stmt instanceof PhpParser\Node\Expr\BinaryOp\LogicalOr) {
+			IssueBuffer::maybeAdd(
+				new \Psalm\Issue\UnrecognizedExpression(
+					'Logical binary operators AND and OR are not allowed in the Nextcloud codebase',
+					new CodeLocation($event->getStatementsSource()->getSource(), $stmt),
+				),
+				$event->getStatementsSource()->getSuppressedIssues(),
+			);
+		}
+		return null;
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,7 @@
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />
 		<plugin filename="build/psalm/AttributeNamedParameters.php" />
+		<plugin filename="build/psalm/LogicalOperatorChecker.php" />
 	</plugins>
 	<projectFiles>
 		<directory name="apps/admin_audit"/>


### PR DESCRIPTION
Test run with manipulated code in Talk
<img width="1300" height="317" alt="Bildschirmfoto vom 2025-11-07 12-04-26" src="https://github.com/user-attachments/assets/6f5f3e97-2314-4000-8642-9a49c20e4248" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
