### PR TITLE
fix(Scanner): Use time based limit for the transaction

### DIFF
--- a/apps/files/lib/BackgroundJob/ScanFiles.php
+++ b/apps/files/lib/BackgroundJob/ScanFiles.php
@@ -8,6 +8,7 @@
 
 namespace OCA\Files\BackgroundJob;
 
+use OC\Files\SetupManager;
 use OC\Files\Utils\Scanner;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -15,6 +16,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -33,6 +35,9 @@ class ScanFiles extends TimedJob {
 		private LoggerInterface $logger,
 		private IDBConnection $connection,
 		ITimeFactory $time,
+		private readonly SetupManager $setupManager,
+		private readonly IUserManager $userManager,
+		private readonly IEventDispatcher $eventDispatcher,
 	) {
 		parent::__construct($time);
 		// Run once per 10 minutes
@@ -45,7 +50,10 @@ class ScanFiles extends TimedJob {
 				$user,
 				null,
 				$this->dispatcher,
-				$this->logger
+				$this->logger,
+				$this->setupManager,
+				$this->userManager,
+				$this->time,
 			);
 			$scanner->backgroundScan('');
 		} catch (\Exception $e) {

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -11,10 +11,12 @@ use OC\Core\Command\Base;
 use OC\Core\Command\InterruptedException;
 use OC\DB\Connection;
 use OC\DB\ConnectionAdapter;
+use OC\Files\SetupManager;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Utils\Scanner;
 use OC\FilesMetadata\FilesMetadataManager;
 use OC\ForbiddenException;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\FileCacheUpdated;
 use OCP\Files\Events\NodeAddedToCache;
@@ -114,7 +116,10 @@ class Scan extends Base {
 			$user,
 			new ConnectionAdapter($connection),
 			Server::get(IEventDispatcher::class),
-			Server::get(LoggerInterface::class)
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
 		);
 
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -10,9 +10,11 @@ use OC\Core\Command\Base;
 use OC\Core\Command\InterruptedException;
 use OC\DB\Connection;
 use OC\DB\ConnectionAdapter;
+use OC\Files\SetupManager;
 use OC\Files\Utils\Scanner;
 use OC\ForbiddenException;
 use OC\Preview\Storage\StorageFactory;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -20,6 +22,7 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
+use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\Table;
@@ -60,6 +63,9 @@ class ScanAppData extends Base {
 			new ConnectionAdapter($connection),
 			Server::get(IEventDispatcher::class),
 			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
 		);
 	}
 

--- a/apps/files/tests/BackgroundJob/ScanFilesTest.php
+++ b/apps/files/tests/BackgroundJob/ScanFilesTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Files\Tests\BackgroundJob;
 
 use OC\Files\Mount\MountPoint;
+use OC\Files\SetupManager;
 use OC\Files\Storage\Temporary;
 use OCA\Files\BackgroundJob\ScanFiles;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -17,6 +18,7 @@ use OCP\Files\Config\IUserMountCache;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -51,7 +53,10 @@ class ScanFilesTest extends TestCase {
 				$dispatcher,
 				$logger,
 				$connection,
-				$this->createMock(ITimeFactory::class)
+				$this->createMock(ITimeFactory::class),
+				$this->createMock(SetupManager::class),
+				$this->createMock(IUserManager::class),
+				$this->createMock(IEventDispatcher::class),
 			])
 			->onlyMethods(['runScanner'])
 			->getMock();

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -237,6 +237,12 @@ class Scanner extends PublicEmitter {
 					$this->eventDispatcher->dispatchTyped(new NodeAddedToCache($storage, $path));
 				}
 			});
+			$scanner->listen('\OC\Files\Cache\Scanner', 'postScanFile', function ($file, $storageId) use ($storage): void {
+				$this->postProcessEntry($storage);
+			});
+			$scanner->listen('\OC\Files\Cache\Scanner', 'postScanFolder', function ($path, $storageId) use ($storage): void {
+				$this->postProcessEntry($storage);
+			});
 
 			if (!$storage->file_exists($relativePath)) {
 				throw new NotFoundException($dir);
@@ -278,10 +284,14 @@ class Scanner extends PublicEmitter {
 		$storage->getPropagator()->propagateChange($internalPath, time());
 	}
 
-	private function postProcessEntry(IStorage $storage, $internalPath) {
-		$this->triggerPropagator($storage, $internalPath);
+	private function postProcessEntry(IStorage $storage, ?string $internalPath = null): void {
+		if ($internalPath !== null) {
+			$this->triggerPropagator($storage, $internalPath);
+		}
 		if ($this->useTransaction) {
-			$this->entriesToCommit++;
+			if ($internalPath !== null) {
+				$this->entriesToCommit++;
+			}
 			if ($this->entriesToCommit >= self::MAX_ENTRIES_TO_COMMIT
 				|| $this->transactionStartTime + self::TRANSACTION_SECOND_TIMEOUT <= $this->timeFactory->getTime()
 			) {

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -10,6 +10,7 @@ namespace OC\Files\Utils;
 use OC\Files\Cache\Cache;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
+use OC\Files\SetupManager;
 use OC\Files\Storage\FailedStorage;
 use OC\Files\Storage\Home;
 use OC\ForbiddenException;
@@ -29,6 +30,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Server;
@@ -57,10 +59,12 @@ class Scanner extends PublicEmitter {
 	protected int $entriesToCommit = 0;
 
 	public function __construct(
-		private ?string $user,
-		protected ?IDBConnection $db,
-		private IEventDispatcher $dispatcher,
-		protected LoggerInterface $logger,
+		private readonly ?string $user,
+		protected readonly ?IDBConnection $db,
+		private readonly IEventDispatcher $eventDispatcher,
+		protected readonly LoggerInterface $logger,
+		private readonly SetupManager $setupManager,
+		private readonly IUserManager $userManager,
 	) {
 		// when DB locking is used, no DB transactions will be used
 		$this->useTransaction = !(Server::get(ILockingProvider::class) instanceof DBLockingProvider);
@@ -74,8 +78,14 @@ class Scanner extends PublicEmitter {
 	 */
 	protected function getMounts($dir) {
 		//TODO: move to the node based fileapi once that's done
-		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($this->user);
+		$this->setupManager->tearDown();
+
+		$userObject = $this->userManager->get($this->user);
+		if ($userObject === null) {
+			throw new \InvalidArgumentException("User {$this->user} does not exist");
+		}
+
+		$this->setupManager->setupForUser($userObject);
 
 		$mountManager = Filesystem::getMountManager();
 		$mounts = $mountManager->findIn($dir);
@@ -88,37 +98,32 @@ class Scanner extends PublicEmitter {
 
 	/**
 	 * attach listeners to the scanner
-	 *
-	 * @param MountPoint $mount
 	 */
-	protected function attachListener($mount) {
+	protected function attachListener(MountPoint $mount) {
 		/** @var \OC\Files\Cache\Scanner $scanner */
 		$scanner = $mount->getStorage()->getScanner();
 		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount): void {
 			$this->emit('\OC\Files\Utils\Scanner', 'scanFile', [$mount->getMountPoint() . $path]);
-			$this->dispatcher->dispatchTyped(new BeforeFileScannedEvent($mount->getMountPoint() . $path));
+			$this->eventDispatcher->dispatchTyped(new BeforeFileScannedEvent($mount->getMountPoint() . $path));
 		});
 		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function ($path) use ($mount): void {
 			$this->emit('\OC\Files\Utils\Scanner', 'scanFolder', [$mount->getMountPoint() . $path]);
-			$this->dispatcher->dispatchTyped(new BeforeFolderScannedEvent($mount->getMountPoint() . $path));
+			$this->eventDispatcher->dispatchTyped(new BeforeFolderScannedEvent($mount->getMountPoint() . $path));
 		});
 		$scanner->listen('\OC\Files\Cache\Scanner', 'postScanFile', function ($path) use ($mount): void {
 			$this->emit('\OC\Files\Utils\Scanner', 'postScanFile', [$mount->getMountPoint() . $path]);
-			$this->dispatcher->dispatchTyped(new FileScannedEvent($mount->getMountPoint() . $path));
+			$this->eventDispatcher->dispatchTyped(new FileScannedEvent($mount->getMountPoint() . $path));
 		});
 		$scanner->listen('\OC\Files\Cache\Scanner', 'postScanFolder', function ($path) use ($mount): void {
 			$this->emit('\OC\Files\Utils\Scanner', 'postScanFolder', [$mount->getMountPoint() . $path]);
-			$this->dispatcher->dispatchTyped(new FolderScannedEvent($mount->getMountPoint() . $path));
+			$this->eventDispatcher->dispatchTyped(new FolderScannedEvent($mount->getMountPoint() . $path));
 		});
 		$scanner->listen('\OC\Files\Cache\Scanner', 'normalizedNameMismatch', function ($path) use ($mount): void {
 			$this->emit('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', [$path]);
 		});
 	}
 
-	/**
-	 * @param string $dir
-	 */
-	public function backgroundScan($dir) {
+	public function backgroundScan(string $dir) {
 		$mounts = $this->getMounts($dir);
 		foreach ($mounts as $mount) {
 			try {
@@ -157,13 +162,10 @@ class Scanner extends PublicEmitter {
 	}
 
 	/**
-	 * @param string $dir
-	 * @param $recursive
-	 * @param callable|null $mountFilter
 	 * @throws ForbiddenException
 	 * @throws NotFoundException
 	 */
-	public function scan($dir = '', $recursive = \OC\Files\Cache\Scanner::SCAN_RECURSIVE, ?callable $mountFilter = null) {
+	public function scan(string $dir = '', $recursive = \OC\Files\Cache\Scanner::SCAN_RECURSIVE, ?callable $mountFilter = null) {
 		if (!Filesystem::isValidPath($dir)) {
 			throw new \InvalidArgumentException('Invalid path to scan');
 		}
@@ -219,18 +221,18 @@ class Scanner extends PublicEmitter {
 
 			$scanner->listen('\OC\Files\Cache\Scanner', 'removeFromCache', function ($path) use ($storage): void {
 				$this->postProcessEntry($storage, $path);
-				$this->dispatcher->dispatchTyped(new NodeRemovedFromCache($storage, $path));
+				$this->eventDispatcher->dispatchTyped(new NodeRemovedFromCache($storage, $path));
 			});
 			$scanner->listen('\OC\Files\Cache\Scanner', 'updateCache', function ($path) use ($storage): void {
 				$this->postProcessEntry($storage, $path);
-				$this->dispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
+				$this->eventDispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
 			});
 			$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function ($path, $storageId, $data, $fileId) use ($storage): void {
 				$this->postProcessEntry($storage, $path);
 				if ($fileId) {
-					$this->dispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
+					$this->eventDispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
 				} else {
-					$this->dispatcher->dispatchTyped(new NodeAddedToCache($storage, $path));
+					$this->eventDispatcher->dispatchTyped(new NodeAddedToCache($storage, $path));
 				}
 			});
 

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -17,6 +17,7 @@ use OC\ForbiddenException;
 use OC\Hooks\PublicEmitter;
 use OC\Lock\DBLockingProvider;
 use OCA\Files_Sharing\SharedStorage;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\BeforeFileScannedEvent;
 use OCP\Files\Events\BeforeFolderScannedEvent;
@@ -47,6 +48,7 @@ use Psr\Log\LoggerInterface;
  */
 class Scanner extends PublicEmitter {
 	public const MAX_ENTRIES_TO_COMMIT = 10000;
+	private const TRANSACTION_SECOND_TIMEOUT = 5;
 
 	/**
 	 * Whether to use a DB transaction
@@ -57,6 +59,7 @@ class Scanner extends PublicEmitter {
 	 * Number of entries scanned to commit
 	 */
 	protected int $entriesToCommit = 0;
+	protected int $transactionStartTime;
 
 	public function __construct(
 		private readonly ?string $user,
@@ -65,6 +68,7 @@ class Scanner extends PublicEmitter {
 		protected readonly LoggerInterface $logger,
 		private readonly SetupManager $setupManager,
 		private readonly IUserManager $userManager,
+		private readonly ITimeFactory $timeFactory,
 	) {
 		// when DB locking is used, no DB transactions will be used
 		$this->useTransaction = !(Server::get(ILockingProvider::class) instanceof DBLockingProvider);
@@ -80,12 +84,10 @@ class Scanner extends PublicEmitter {
 		//TODO: move to the node based fileapi once that's done
 		$this->setupManager->tearDown();
 
-		$userObject = $this->userManager->get($this->user);
-		if ($userObject === null) {
-			throw new \InvalidArgumentException("User {$this->user} does not exist");
+		if ($this->user !== null) {
+			$userObject = $this->userManager->get($this->user);
+			$this->setupManager->setupForUser($userObject);
 		}
-
-		$this->setupManager->setupForUser($userObject);
 
 		$mountManager = Filesystem::getMountManager();
 		$mounts = $mountManager->findIn($dir);
@@ -241,6 +243,7 @@ class Scanner extends PublicEmitter {
 			}
 
 			if ($this->useTransaction) {
+				$this->transactionStartTime = $this->timeFactory->getTime();
 				$this->db->beginTransaction();
 			}
 			try {
@@ -279,9 +282,12 @@ class Scanner extends PublicEmitter {
 		$this->triggerPropagator($storage, $internalPath);
 		if ($this->useTransaction) {
 			$this->entriesToCommit++;
-			if ($this->entriesToCommit >= self::MAX_ENTRIES_TO_COMMIT) {
+			if ($this->entriesToCommit >= self::MAX_ENTRIES_TO_COMMIT
+				|| $this->transactionStartTime + self::TRANSACTION_SECOND_TIMEOUT <= $this->timeFactory->getTime()
+			) {
 				$propagator = $storage->getPropagator();
 				$this->entriesToCommit = 0;
+				$this->transactionStartTime = $this->timeFactory->getTime();
 				$this->db->commit();
 				$propagator->commitBatch();
 				$this->db->beginTransaction();

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -47,7 +47,7 @@ use Psr\Log\LoggerInterface;
  * @package OC\Files\Utils
  */
 class Scanner extends PublicEmitter {
-	public const MAX_ENTRIES_TO_COMMIT = 10000;
+	public const MAX_ENTRIES_TO_COMMIT = 1000;
 	private const TRANSACTION_SECOND_TIMEOUT = 5;
 
 	/**

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -9,8 +9,10 @@
 namespace Test\Files;
 
 use OC\Files\Filesystem;
+use OC\Files\SetupManager;
 use OC\Files\Utils\Scanner;
 use OCA\Files_Sharing\AppInfo\Application;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -73,7 +75,15 @@ class EtagTest extends \Test\TestCase {
 		$files = ['/foo.txt', '/folder/bar.txt', '/folder/subfolder', '/folder/subfolder/qwerty.txt'];
 		$originalEtags = $this->getEtags($files);
 
-		$scanner = new Scanner($user1, Server::get(IDBConnection::class), Server::get(IEventDispatcher::class), Server::get(LoggerInterface::class));
+		$scanner = new Scanner(
+			$user1,
+			Server::get(IDBConnection::class),
+			Server::get(IEventDispatcher::class),
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class)
+		);
 		$scanner->backgroundScan('/');
 
 		$newEtags = $this->getEtags($files);

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -10,8 +10,10 @@ namespace Test\Files\Utils;
 
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
+use OC\Files\SetupManager;
 use OC\Files\Storage\Temporary;
 use OC\Files\Utils\Scanner;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IMountProviderCollection;
@@ -77,7 +79,15 @@ class ScannerTest extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('', Server::get(IDBConnection::class), $this->createMock(IEventDispatcher::class), Server::get(LoggerInterface::class));
+		$scanner = new TestScanner(
+			'',
+			Server::get(IDBConnection::class),
+			$this->createMock(IEventDispatcher::class),
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
+		);
 		$scanner->addMount($mount);
 
 		$scanner->scan('');
@@ -99,7 +109,15 @@ class ScannerTest extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('', Server::get(IDBConnection::class), $this->createMock(IEventDispatcher::class), Server::get(LoggerInterface::class));
+		$scanner = new TestScanner(
+			'',
+			Server::get(IDBConnection::class),
+			$this->createMock(IEventDispatcher::class),
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
+		);
 		$scanner->addMount($mount);
 
 		$scanner->scan('');
@@ -137,7 +155,15 @@ class ScannerTest extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new Scanner($uid, Server::get(IDBConnection::class), Server::get(IEventDispatcher::class), Server::get(LoggerInterface::class));
+		$scanner = new Scanner(
+			$uid,
+			Server::get(IDBConnection::class),
+			Server::get(IEventDispatcher::class),
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
+		);
 
 		$this->assertFalse($cache->inCache('folder/bar.txt'));
 		$scanner->scan('/' . $uid . '/files/foo');
@@ -166,7 +192,15 @@ class ScannerTest extends \Test\TestCase {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid path to scan');
 
-		$scanner = new TestScanner('', Server::get(IDBConnection::class), $this->createMock(IEventDispatcher::class), Server::get(LoggerInterface::class));
+		$scanner = new TestScanner(
+			'',
+			Server::get(IDBConnection::class),
+			$this->createMock(IEventDispatcher::class),
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
+		);
 		$scanner->scan($invalidPath);
 	}
 
@@ -180,7 +214,15 @@ class ScannerTest extends \Test\TestCase {
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 		$storage->touch('folder/bar.txt', time() - 200);
 
-		$scanner = new TestScanner('', Server::get(IDBConnection::class), $this->createMock(IEventDispatcher::class), Server::get(LoggerInterface::class));
+		$scanner = new TestScanner(
+			'',
+			Server::get(IDBConnection::class),
+			$this->createMock(IEventDispatcher::class),
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
+		);
 		$scanner->addMount($mount);
 
 		$scanner->scan('');
@@ -206,7 +248,15 @@ class ScannerTest extends \Test\TestCase {
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 		$storage->file_put_contents('folder/subfolder/foobar.txt', 'qwerty');
 
-		$scanner = new TestScanner('', Server::get(IDBConnection::class), $this->createMock(IEventDispatcher::class), Server::get(LoggerInterface::class));
+		$scanner = new TestScanner(
+			'',
+			Server::get(IDBConnection::class),
+			$this->createMock(IEventDispatcher::class),
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+			Server::get(IUserManager::class),
+			Server::get(ITimeFactory::class),
+		);
 		$scanner->addMount($mount);
 
 		$scanner->scan('', $recusive = false);


### PR DESCRIPTION
Using the node count does not help if handling a node is slow.

This prevent locking the database for unknown amount of time.

10 seconds is arbitrary, but I don't see any reason to no go even lower.