### PR TITLE
fix(LDAP): unblock a cached id from a deleted user or group

### DIFF
--- a/apps/user_ldap/lib/AccessFactory.php
+++ b/apps/user_ldap/lib/AccessFactory.php
@@ -10,6 +10,7 @@ use OCA\User_LDAP\User\Manager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
@@ -22,6 +23,7 @@ class AccessFactory {
 		private IConfig $config,
 		private IAppConfig $appConfig,
 		private IUserManager $ncUserManager,
+		private IGroupManager $ncGroupManager,
 		private LoggerInterface $logger,
 		private IEventDispatcher $dispatcher,
 	) {
@@ -36,6 +38,7 @@ class AccessFactory {
 			$this->helper,
 			$this->config,
 			$this->ncUserManager,
+			$this->ncGroupManager,
 			$this->logger,
 			$this->appConfig,
 			$this->dispatcher,

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -25,6 +25,7 @@ use OCP\HintException;
 use OCP\IAppConfig;
 use OCP\IAvatarManager;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\Image;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
@@ -51,6 +52,7 @@ class AccessTest extends TestCase {
 	private Helper&MockObject $helper;
 	private IConfig&MockObject $config;
 	private IUserManager&MockObject $ncUserManager;
+	private IGroupManager&MockObject $ncGroupManager;
 	private LoggerInterface&MockObject $logger;
 	private IAppConfig&MockObject $appConfig;
 	private IEventDispatcher&MockObject $dispatcher;
@@ -67,6 +69,7 @@ class AccessTest extends TestCase {
 		$this->userMapper = $this->createMock(UserMapping::class);
 		$this->groupMapper = $this->createMock(GroupMapping::class);
 		$this->ncUserManager = $this->createMock(IUserManager::class);
+		$this->ncGroupManager = $this->createMock(IGroupManager::class);
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
@@ -79,6 +82,7 @@ class AccessTest extends TestCase {
 			$this->helper,
 			$this->config,
 			$this->ncUserManager,
+			$this->ncGroupManager,
 			$this->logger,
 			$this->appConfig,
 			$this->dispatcher,
@@ -224,7 +228,7 @@ class AccessTest extends TestCase {
 		[$lw, $con, $um, $helper] = $this->getConnectorAndLdapMock();
 		/** @var IConfig&MockObject $config */
 		$config = $this->createMock(IConfig::class);
-		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
+		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->ncGroupManager, $this->logger, $this->appConfig, $this->dispatcher);
 
 		$lw->expects($this->exactly(1))
 			->method('explodeDN')
@@ -244,7 +248,7 @@ class AccessTest extends TestCase {
 		/** @var IConfig&MockObject $config */
 		$config = $this->createMock(IConfig::class);
 		$lw = new LDAP();
-		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
+		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->ncGroupManager, $this->logger, $this->appConfig, $this->dispatcher);
 
 		if (!function_exists('ldap_explode_dn')) {
 			$this->markTestSkipped('LDAP Module not available');
@@ -427,7 +431,7 @@ class AccessTest extends TestCase {
 				$attribute => ['count' => 1, $dnFromServer]
 			]);
 
-		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
+		$access = new Access($lw, $con, $um, $helper, $config, $this->ncUserManager, $this->ncGroupManager, $this->logger, $this->appConfig, $this->dispatcher);
 		$values = $access->readAttribute('uid=whoever,dc=example,dc=org', $attribute);
 		$this->assertSame($values[0], strtolower($dnFromServer));
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

As of 155b75027c8b1dd78863e0814f91070c9916f095 we cache the user id and LDAP DN for a month, because they are highly requested, but rarely change and we have a working repair mechanism.

But if an LDAP user is deleted, the information is still cached. So a user that is being regenerated with the same target user ID will get a _xxxx suffix, when the data is still in local cache.

The error case can be reproduced:

1. memcache.local is set to ACPu
2. Log in and out with an LDAP user: 88ce7e0d-cd84-46ab-99c9-d49c1b2aba48
3. `occ user:info 88ce7e0d-cd84-46ab-99c9-d49c1b2aba48` shows info about that user
4. Locally delete that user: `occ ldap:reset-user 88ce7e0d-cd84-46ab-99c9-d49c1b2aba48`
5. Log in with that user again
6. `occ user:info 88ce7e0d-cd84-46ab-99c9-d49c1b2aba48` shows that the user does not exist
7. When you look into `oc_ldap_user_mapping`, you will find a mapping with a _1234 suffix.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
