### PR TITLE
feat: track overly long activities

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -634,13 +634,15 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(\OCP\Activity\IManager::class, function (Server $c) {
 			$l10n = $this->get(IFactory::class)->get('lib');
 			return new \OC\Activity\Manager(
-				$c->getRequest(),
+				$c->get(IRequest::class),
 				$c->get(IUserSession::class),
 				$c->get(\OCP\IConfig::class),
 				$c->get(IValidator::class),
 				$c->get(IRichTextFormatter::class),
 				$l10n,
 				$c->get(ITimeFactory::class),
+				$c->get(IAppConfig::class),
+				$c->get(LoggerInterface::class),
 			);
 		});
 

--- a/tests/lib/Activity/ManagerTest.php
+++ b/tests/lib/Activity/ManagerTest.php
@@ -10,11 +10,13 @@ declare(strict_types=1);
 
 namespace Test\Activity;
 
+use OC;
 use OC\Activity\Manager;
 use OCP\Activity\Exceptions\IncompleteActivityException;
 use OCP\Activity\IConsumer;
 use OCP\Activity\IEvent;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -23,6 +25,7 @@ use OCP\IUserSession;
 use OCP\RichObjectStrings\IRichTextFormatter;
 use OCP\RichObjectStrings\IValidator;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
@@ -34,6 +37,8 @@ class ManagerTest extends TestCase {
 	protected IValidator&MockObject $validator;
 	protected IRichTextFormatter&MockObject $richTextFormatter;
 	private ITimeFactory&MockObject $time;
+	private IAppConfig $appConfig;
+	private LoggerInterface&MockObject $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -44,6 +49,8 @@ class ManagerTest extends TestCase {
 		$this->validator = $this->createMock(IValidator::class);
 		$this->richTextFormatter = $this->createMock(IRichTextFormatter::class);
 		$this->time = $this->createMock(ITimeFactory::class);
+		$this->appConfig = OC::$server->get(IAppConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->activityManager = new Manager(
 			$this->request,
@@ -53,6 +60,8 @@ class ManagerTest extends TestCase {
 			$this->richTextFormatter,
 			$this->createMock(IL10N::class),
 			$this->time,
+			$this->appConfig,
+			$this->logger,
 		);
 
 		$this->assertSame([], self::invokePrivate($this->activityManager, 'getConsumers'));
@@ -290,6 +299,101 @@ class ManagerTest extends TestCase {
 		});
 
 		$this->activityManager->publish($event);
+	}
+
+	public function testPublishWithSuperLongNestedParams(): void {
+		$this->appConfig->setValueInt('activity', 'overly_long_activities', 0);
+		$params = [
+			'level_one' => [
+				'title' => 'Lorem ipsum dolor sit amet',
+				'intro' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+				'level_two' => [
+					[
+						'heading' => 'Sed ut perspiciatis unde omnis',
+						'body' => 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.'
+					],
+					[
+						'heading' => 'Neque porro quisquam est',
+						'body' => 'Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam.'
+					]
+				]
+			],
+			'level_three' => [
+				'section_a' => [
+					'text' => 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.',
+					'more_text' => 'Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus.'
+				],
+				'section_b' => [
+					'paragraphs' => [
+						'Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus.',
+						'Ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+						'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.'
+					]
+				]
+			],
+			'level_four' => [
+				'deep' => [
+					'deeper' => [
+						'block_one' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam.',
+						'block_two' => 'Eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.',
+						'block_three' => 'Sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.'
+					]
+				]
+			],
+			'level_five' => [
+				'massive_text' => 'Sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur. At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus.'
+			],
+			'level_six' => [
+				'repeat_blocks' => [
+					[
+						'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+					],
+					[
+						'text' => 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollitia animi.'
+					],
+					[
+						'text' => 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.'
+					]
+				]
+			]
+		];
+
+		$event = $event2 = $this->activityManager->generateEvent();
+		$event->setApp('test_app')
+			->setType('test_type')
+			->setAffectedUser('test_affected')
+			->setAuthor('test_author')
+			->setTimestamp(1337)
+			->setSubject('test_subject', $params)
+			->setMessage('test_message', ['test_message_params'])
+			->setObject('test_object_type', 42, 'test_object_name')
+			->setLink('test_link');
+
+		$this->assertEquals(1, $this->appConfig->getValueInt('activity', 'overly_long_activities'));
+
+		$event2->setApp('test_app')
+			->setType('test_type')
+			->setAffectedUser('test_affected')
+			->setAuthor('test_author')
+			->setTimestamp(1337)
+			->setSubject('test_subject', $params)
+			->setMessage('test_message', ['test_message_params'])
+			->setObject('test_object_type', 42, 'test_object_name')
+			->setLink('test_link');
+
+		$consumer = $this->getMockBuilder('OCP\Activity\IConsumer')
+			->disableOriginalConstructor()
+			->getMock();
+		$consumer->method('receive');
+		$this->activityManager->registerConsumer(function () use ($consumer) {
+			return $consumer;
+		});
+
+		$this->activityManager->publish($event);
+		$this->activityManager->publish($event2);
+		$this->assertEquals(2, $this->appConfig->getValueInt('activity', 'overly_long_activities'));
+		$this->appConfig->setValueInt('activity', 'overly_long_activities', 0);
+
 	}
 }
 


### PR DESCRIPTION
For activities with very long content, track them and add them to the setup check

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
