### PR TITLE
[stable31] fix(unified-search): Remove hard-coded search result limit 

### DIFF
--- a/core/AppInfo/ConfigLexicon.php
+++ b/core/AppInfo/ConfigLexicon.php
@@ -20,6 +20,7 @@ use NCU\Config\ValueType;
  */
 class ConfigLexicon implements IConfigLexicon {
 	public const UNIFIED_SEARCH_MIN_SEARCH_LENGTH = 'unified_search_min_search_length';
+	public const UNIFIED_SEARCH_MAX_RESULTS_PER_REQUEST = 'unified_search_max_results_per_request';
 
 	public function getStrictness(): ConfigLexiconStrictness {
 		return ConfigLexiconStrictness::IGNORE;
@@ -28,6 +29,7 @@ class ConfigLexicon implements IConfigLexicon {
 	public function getAppConfigs(): array {
 		return [
 			new ConfigLexiconEntry(self::UNIFIED_SEARCH_MIN_SEARCH_LENGTH, ValueType::INT, 1, 'Minimum search length to trigger the request', lazy: false),
+			new ConfigLexiconEntry(self::UNIFIED_SEARCH_MAX_RESULTS_PER_REQUEST, ValueType::INT, 25, 'Maximum number of results returned per request', lazy: false),
 		];
 	}
 

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -7407,7 +7407,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries, limited to 25",
+                        "description": "Maximum amount of entries (capped by configurable unified-search.max-results-per-request, default: 25)",
                         "schema": {
                             "type": "integer",
                             "format": "int64",

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -7407,7 +7407,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Maximum amount of entries, limited to 25",
+                        "description": "Maximum amount of entries (capped by configurable unified-search.max-results-per-request, default: 25)",
                         "schema": {
                             "type": "integer",
                             "format": "int64",


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/55434


---


A change added in https://github.com/nextcloud/server/pull/45317 introduced a hard stop (25) that prevents full search results from showing up.

If there are more than 25 search results for a query only 25 can be seen.

So two main issues:

- Only 25 results can be seen in total no matter what.
- Breaks web client pagination, which typically adds 5 results per request.

