### PR TITLE
feat(rate-limit): Allow overwriting the rate limit

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -474,6 +474,30 @@ $CONFIG = [
 	'ratelimit.protection.enabled' => true,
 
 	/**
+	 * Overwrite the individual rate limit for a specific route
+	 *
+	 * From time to time it can be necessary to extend the rate limit of a specific route,
+	 * depending on your usage pattern or when you script some actions.
+	 * Instead of completely disabling the rate limit or excluding an IP address from the
+	 * rate limit, the following config allows to overwrite the rate limit duration and period.
+	 *
+	 * The first level key is the name of the route. You can find the route name from a URL
+	 * using the ``occ router:list`` command of your server.
+	 *
+	 * You can also specify different limits for logged-in users with the ``user`` key
+	 * and not-logged-in users with the ``anon`` key. However, if there is no specific ``user`` limit,
+	 * the ``anon`` limit is also applied for logged-in users.
+	 *
+	 * Defaults to empty array ``[]``
+	 */
+	'ratelimit_overwrite' => [
+		'profile.profilepage.index' => [
+			'user' => ['limit' => 300, 'period' => 3600],
+			'anon' => ['limit' => 1, 'period' => 300],
+		]
+	],
+
+	/**
 	 * Size of subnet used to normalize IPv6
 	 *
 	 * For Brute Force Protection and Rate Limiting, IPv6 addresses are truncated using subnet size.

--- a/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
@@ -17,11 +17,13 @@ use OC\Security\RateLimiting\Limiter;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IAppConfig;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\AppFramework\Middleware\Security\Mock\RateLimitingMiddlewareController;
 use Test\TestCase;
 
@@ -33,7 +35,9 @@ class RateLimitingMiddlewareTest extends TestCase {
 	private Limiter|MockObject $limiter;
 	private ISession|MockObject $session;
 	private IAppConfig|MockObject $appConfig;
+	private IConfig|MockObject $serverConfig;
 	private BruteforceAllowList|MockObject $bruteForceAllowList;
+	private LoggerInterface|MockObject $logger;
 	private RateLimitingMiddleware $rateLimitingMiddleware;
 
 	protected function setUp(): void {
@@ -45,7 +49,9 @@ class RateLimitingMiddlewareTest extends TestCase {
 		$this->limiter = $this->createMock(Limiter::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->serverConfig = $this->createMock(IConfig::class);
 		$this->bruteForceAllowList = $this->createMock(BruteforceAllowList::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->rateLimitingMiddleware = new RateLimitingMiddleware(
 			$this->request,
@@ -54,7 +60,9 @@ class RateLimitingMiddlewareTest extends TestCase {
 			$this->limiter,
 			$this->session,
 			$this->appConfig,
+			$this->serverConfig,
 			$this->bruteForceAllowList,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
- Allow admins to overwrite the rate-limit of a specific controller method

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
