### PR TITLE
test(upload): add unit tests for UploadHome

### DIFF
--- a/apps/dav/tests/unit/Upload/UploadHomeTest.php
+++ b/apps/dav/tests/unit/Upload/UploadHomeTest.php
@@ -1,0 +1,302 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OCA\DAV\Tests\unit\Upload;
+
+use OCA\DAV\Upload\UploadHome;
+use OCA\DAV\Upload\CleanupService;
+use OCA\DAV\Upload\UploadFolder;
+use OCA\DAV\Connector\Sabre\Directory;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\Storage\IStorage;
+use OCP\IUserSession;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use OCP\UserInterface;
+use PHPUnit\Framework\TestCase;
+use Sabre\DAV\Exception\Forbidden;
+
+class UploadHomeTest extends TestCase {
+	private array $principalInfo;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->principalInfo = [
+			'uri' => 'principals/users/testuser'
+		];
+	}
+
+	private function getMockedUploadHomeUser(): UploadHome {
+		$cleanup = $this->createMock(CleanupService::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$shareManager = $this->createMock(IManager::class);
+
+		$user = $this->createMock(UserInterface::class);
+		$user->method('getUID')->willReturn('testuser');
+		$userSession->method('getUser')->willReturn($user);
+
+		return new UploadHome(
+			$this->principalInfo,
+			$cleanup,
+			$rootFolder,
+			$userSession,
+			$shareManager
+		);
+	}
+
+	private function getMockedUploadHomeShare(): UploadHome {
+		$cleanup = $this->createMock(CleanupService::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$shareManager = $this->createMock(IManager::class);
+
+		$principalInfo = [
+			'uri' => 'principals/shares/sometoken'
+		];
+
+		$shareMock = $this->createMock(IShare::class);
+		$shareMock->method('getShareOwner')->willReturn('shareowner');
+		$shareManager->method('getShareByToken')->with('sometoken')->willReturn($shareMock);
+
+		return new UploadHome(
+			$principalInfo,
+			$cleanup,
+			$rootFolder,
+			$userSession,
+			$shareManager
+		);
+	}
+
+	public function testUserConstructorSetsUid(): void {
+		$uploadHome = $this->getMockedUploadHomeUser();
+		$reflector = new \ReflectionClass($uploadHome);
+		$uidProp = $reflector->getProperty('uid');
+		$uidProp->setAccessible(true);
+		$this->assertEquals('testuser', $uidProp->getValue($uploadHome));
+	}
+
+	public function testShareConstructorSetsUid(): void {
+		$uploadHome = $this->getMockedUploadHomeShare();
+		$ref = new \ReflectionClass($uploadHome);
+		$uidProp = $ref->getProperty('uid');
+		$uidProp->setAccessible(true);
+		$this->assertEquals('shareowner', $uidProp->getValue($uploadHome));
+	}
+
+	public function testConstructorThrowsIfUserMissing(): void {
+		$cleanup = $this->createMock(CleanupService::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn(null);
+		$shareManager = $this->createMock(IManager::class);
+
+		$this->expectException(Forbidden::class);
+		new UploadHome(
+			$this->principalInfo,
+			$cleanup,
+			$rootFolder,
+			$userSession,
+			$shareManager
+		);
+	}
+
+	public function testCreateFileThrowsForbidden(): void {
+		$uploadHome = $this->getMockedUploadHomeUser();
+		$this->expectException(Forbidden::class);
+		$uploadHome->createFile('denied.txt');
+	}
+
+	public function testSetNameThrowsForbidden(): void {
+		$uploadHome = $this->getMockedUploadHomeUser();
+		$this->expectException(Forbidden::class);
+		$uploadHome->setName('denied');
+	}
+
+	public function testCreateDirectoryAddsCleanupJob(): void {
+		$cleanup = $this->createMock(CleanupService::class);
+		$directory = $this->createMock(Directory::class);
+		$directory->expects($this->once())->method('createDirectory')->with('foo');
+		$cleanup->expects($this->once())->method('addJob')->with('testuser', 'foo');
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$user = $this->createMock(UserInterface::class);
+		$user->method('getUID')->willReturn('testuser');
+		$userSession->method('getUser')->willReturn($user);
+		$shareManager = $this->createMock(IManager::class);
+
+		$uploadHome = $this->getMockBuilder(UploadHome::class)
+			->setConstructorArgs([
+				$this->principalInfo,
+				$cleanup,
+				$rootFolder,
+				$userSession,
+				$shareManager,
+			])
+			->onlyMethods(['impl'])
+			->getMock();
+
+		$uploadHome->method('impl')->willReturn($directory);
+
+		$uploadHome->createDirectory('foo');
+	}
+
+	public function testGetChildReturnsUploadFolder(): void {
+		$cleanup = $this->createMock(CleanupService::class);
+		$directoryChild = $this->createMock(Folder::class);
+
+		$directory = $this->createMock(Directory::class);
+		$directory->method('getChild')->with('childname')->willReturn($directoryChild);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$user = $this->createMock(UserInterface::class);
+		$user->method('getUID')->willReturn('testuser');
+		$userSession->method('getUser')->willReturn($user);
+		$shareManager = $this->createMock(IManager::class);
+
+		$storage = $this->createMock(IStorage::class);
+
+		$uploadHome = $this->getMockBuilder(UploadHome::class)
+			->setConstructorArgs([
+				$this->principalInfo,
+				$cleanup,
+				$rootFolder,
+				$userSession,
+				$shareManager,
+			])
+			->onlyMethods(['impl', 'getStorage'])
+			->getMock();
+
+		$uploadHome->method('impl')->willReturn($directory);
+		$uploadHome->method('getStorage')->willReturn($storage);
+
+		$result = $uploadHome->getChild('childname');
+		$this->assertInstanceOf(UploadFolder::class, $result);
+	}
+
+	public function testGetChildrenReturnsUploadFolders(): void {
+		$cleanup = $this->createMock(CleanupService::class);
+		$directoryChild1 = $this->createMock(Folder::class);
+		$directoryChild2 = $this->createMock(Folder::class);
+
+		$directory = $this->createMock(Directory::class);
+		$directory->method('getChildren')->willReturn([$directoryChild1, $directoryChild2]);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$user = $this->createMock(UserInterface::class);
+		$user->method('getUID')->willReturn('testuser');
+		$userSession->method('getUser')->willReturn($user);
+		$shareManager = $this->createMock(IManager::class);
+
+		$storage = $this->createMock(IStorage::class);
+
+		$uploadHome = $this->getMockBuilder(UploadHome::class)
+			->setConstructorArgs([
+				$this->principalInfo,
+				$cleanup,
+				$rootFolder,
+				$userSession,
+				$shareManager,
+			])
+			->onlyMethods(['impl', 'getStorage'])
+			->getMock();
+
+		$uploadHome->method('impl')->willReturn($directory);
+		$uploadHome->method('getStorage')->willReturn($storage);
+
+		$children = $uploadHome->getChildren();
+		$this->assertIsArray($children);
+		$this->assertContainsOnlyInstancesOf(UploadFolder::class, $children);
+	}
+
+	public function testChildExistsReturnsTrueIfChildExists(): void {
+		$child = $this->createMock(UploadFolder::class);
+		$mock = $this->getMockBuilder(UploadHome::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['getChild'])
+			->getMock();
+		$mock->method('getChild')->with('child')->willReturn($child);
+
+		$this->assertTrue($mock->childExists('child'));
+	}
+
+	public function testChildExistsReturnsFalseIfNoChild(): void {
+		$mock = $this->getMockBuilder(UploadHome::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['getChild'])
+			->getMock();
+		$mock->method('getChild')->with('nochil')->willReturn(null);
+
+		$this->assertFalse($mock->childExists('nochil'));
+	}
+
+	public function testDeleteProxiesToImplDelete(): void {
+		$cleanup = $this->createMock(CleanupService::class);
+		$directory = $this->createMock(Directory::class);
+		$directory->expects($this->once())->method('delete');
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$user = $this->createMock(UserInterface::class);
+		$user->method('getUID')->willReturn('testuser');
+		$userSession->method('getUser')->willReturn($user);
+		$shareManager = $this->createMock(IManager::class);
+
+		$uploadHome = $this->getMockBuilder(UploadHome::class)
+			->setConstructorArgs([
+				$this->principalInfo,
+				$cleanup,
+				$rootFolder,
+				$userSession,
+				$shareManager,
+			])
+			->onlyMethods(['impl'])
+			->getMock();
+
+		$uploadHome->method('impl')->willReturn($directory);
+
+		$uploadHome->delete();
+	}
+
+	public function testGetNameReturnsPrincipalName(): void {
+		$uploadHome = $this->getMockedUploadHomeUser();
+		$this->assertEquals('testuser', $uploadHome->getName());
+	}
+
+	public function testGetLastModifiedProxiesToImpl(): void {
+		$cleanup = $this->createMock(CleanupService::class);
+		$directory = $this->createMock(Directory::class);
+		$directory->method('getLastModified')->willReturn(1234567890);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$user = $this->createMock(UserInterface::class);
+		$user->method('getUID')->willReturn('testuser');
+		$userSession->method('getUser')->willReturn($user);
+		$shareManager = $this->createMock(IManager::class);
+
+		$uploadHome = $this->getMockBuilder(UploadHome::class)
+			->setConstructorArgs([
+				$this->principalInfo,
+				$cleanup,
+				$rootFolder,
+				$userSession,
+				$shareManager,
+			])
+			->onlyMethods(['impl'])
+			->getMock();
+
+		$uploadHome->method('impl')->willReturn($directory);
+
+		$this->assertEquals(1234567890, $uploadHome->getLastModified());
+	}
+}

--- a/apps/dav/tests/unit/Upload/UploadHomeTest.php
+++ b/apps/dav/tests/unit/Upload/UploadHomeTest.php
@@ -133,18 +133,16 @@ class UploadHomeTest extends TestCase {
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
-		$uploadHome = $this->getMockBuilder(UploadHome::class)
-			->setConstructorArgs([
-				$this->principalInfo,
-				$cleanup,
-				$rootFolder,
-				$userSession,
-				$shareManager,
-			])
-			->onlyMethods(['impl'])
-			->getMock();
+		// make getUserFolder('testuser') return $directory, so impl() works as expected
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
 
-		$uploadHome->method('impl')->willReturn($directory);
+		$uploadHome = new UploadHome(
+			$this->principalInfo,
+			$cleanup,
+			$rootFolder,
+			$userSession,
+			$shareManager
+		);
 
 		$uploadHome->createDirectory('foo');
 	}
@@ -164,6 +162,8 @@ class UploadHomeTest extends TestCase {
 
 		$storage = $this->createMock(IStorage::class);
 
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
+
 		$uploadHome = $this->getMockBuilder(UploadHome::class)
 			->setConstructorArgs([
 				$this->principalInfo,
@@ -172,10 +172,9 @@ class UploadHomeTest extends TestCase {
 				$userSession,
 				$shareManager,
 			])
-			->onlyMethods(['impl', 'getStorage'])
+			->onlyMethods(['getStorage'])
 			->getMock();
 
-		$uploadHome->method('impl')->willReturn($directory);
 		$uploadHome->method('getStorage')->willReturn($storage);
 
 		$result = $uploadHome->getChild('childname');
@@ -196,6 +195,8 @@ class UploadHomeTest extends TestCase {
 
 		$storage = $this->createMock(IStorage::class);
 
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
+
 		$uploadHome = $this->getMockBuilder(UploadHome::class)
 			->setConstructorArgs([
 				$this->principalInfo,
@@ -204,10 +205,9 @@ class UploadHomeTest extends TestCase {
 				$userSession,
 				$shareManager,
 			])
-			->onlyMethods(['impl', 'getStorage'])
+			->onlyMethods(['getStorage'])
 			->getMock();
 
-		$uploadHome->method('impl')->willReturn($directory);
 		$uploadHome->method('getStorage')->willReturn($storage);
 
 		$this->expectException(SabreNotFound::class);
@@ -230,6 +230,8 @@ class UploadHomeTest extends TestCase {
 
 		$storage = $this->createMock(IStorage::class);
 
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
+
 		$uploadHome = $this->getMockBuilder(UploadHome::class)
 			->setConstructorArgs([
 				$this->principalInfo,
@@ -238,10 +240,9 @@ class UploadHomeTest extends TestCase {
 				$userSession,
 				$shareManager,
 			])
-			->onlyMethods(['impl', 'getStorage'])
+			->onlyMethods(['getStorage'])
 			->getMock();
 
-		$uploadHome->method('impl')->willReturn($directory);
 		$uploadHome->method('getStorage')->willReturn($storage);
 
 		$children = $uploadHome->getChildren();
@@ -287,18 +288,15 @@ class UploadHomeTest extends TestCase {
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
-		$uploadHome = $this->getMockBuilder(UploadHome::class)
-			->setConstructorArgs([
-				$this->principalInfo,
-				$cleanup,
-				$rootFolder,
-				$userSession,
-				$shareManager,
-			])
-			->onlyMethods(['impl'])
-			->getMock();
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
 
-		$uploadHome->method('impl')->willReturn($directory);
+		$uploadHome = new UploadHome(
+			$this->principalInfo,
+			$cleanup,
+			$rootFolder,
+			$userSession,
+			$shareManager
+		);
 
 		$uploadHome->delete();
 	}
@@ -319,18 +317,15 @@ class UploadHomeTest extends TestCase {
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
-		$uploadHome = $this->getMockBuilder(UploadHome::class)
-			->setConstructorArgs([
-				$this->principalInfo,
-				$cleanup,
-				$rootFolder,
-				$userSession,
-				$shareManager,
-			])
-			->onlyMethods(['impl'])
-			->getMock();
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
 
-		$uploadHome->method('impl')->willReturn($directory);
+		$uploadHome = new UploadHome(
+			$this->principalInfo,
+			$cleanup,
+			$rootFolder,
+			$userSession,
+			$shareManager
+		);
 
 		$this->assertEquals(1234567890, $uploadHome->getLastModified());
 	}

--- a/apps/dav/tests/unit/Upload/UploadHomeTest.php
+++ b/apps/dav/tests/unit/Upload/UploadHomeTest.php
@@ -41,7 +41,7 @@ class UploadHomeTest extends TestCase {
 		$userSession = $this->createMock(IUserSession::class);
 		$shareManager = $this->createMock(IManager::class);
 
-		$user = $this->createUser('testuser');
+		$user = $this->createUser('testuser', 'testpass');
 		$userSession->method('getUser')->willReturn($user);
 
 		return new UploadHome(
@@ -129,7 +129,7 @@ class UploadHomeTest extends TestCase {
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userSession = $this->createMock(IUserSession::class);
-		$user = $this->createUser('testuser');
+		$user = $this->createUser('testuser', 'testpass');
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
@@ -158,7 +158,7 @@ class UploadHomeTest extends TestCase {
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userSession = $this->createMock(IUserSession::class);
-		$user = $this->createUser('testuser');
+		$user = $this->createUser('testuser', 'testpass');
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
@@ -190,7 +190,7 @@ class UploadHomeTest extends TestCase {
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userSession = $this->createMock(IUserSession::class);
-		$user = $this->createUser('testuser');
+		$user = $this->createUser('testuser', 'testpass');
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
@@ -224,7 +224,7 @@ class UploadHomeTest extends TestCase {
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userSession = $this->createMock(IUserSession::class);
-		$user = $this->createUser('testuser');
+		$user = $this->createUser('testuser', 'testpass');
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
@@ -261,7 +261,7 @@ class UploadHomeTest extends TestCase {
 	}
 
 	public function testChildExistsReturnsFalseIfNoChild(): void {
-		// This test documents (and asserts) the current broken implementation of childExists(): 
+		// This test documents (and asserts) the current broken implementation of childExists():
 		// Instead of returning false, it throws if the child is missing, due to not catching the NotFound exception.
 		// This matches the current UploadHome implementation, but should be fixed.
 
@@ -283,7 +283,7 @@ class UploadHomeTest extends TestCase {
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userSession = $this->createMock(IUserSession::class);
-		$user = $this->createUser('testuser');
+		$user = $this->createUser('testuser', 'testpass');
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
@@ -315,7 +315,7 @@ class UploadHomeTest extends TestCase {
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userSession = $this->createMock(IUserSession::class);
-		$user = $this->createUser('testuser');
+		$user = $this->createUser('testuser', 'testpass');
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 

--- a/apps/dav/tests/unit/Upload/UploadHomeTest.php
+++ b/apps/dav/tests/unit/Upload/UploadHomeTest.php
@@ -124,10 +124,8 @@ class UploadHomeTest extends TestCase {
 	public function testCreateDirectoryAddsCleanupJob(): void {
 		$cleanup = $this->createMock(CleanupService::class);
 
-		$directory = $this->createMock(Directory::class);
-		$directory->expects($this->once())->method('createDirectory')->with('foo');
-		$directory->method('getType')->willReturn('dir');
-		$directory->method('isDirectory')->willReturn(true);
+		$folder = $this->createMock(Folder::class);
+		$folder->expects($this->once())->method('createDirectory')->with('foo');
 
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userSession = $this->createMock(IUserSession::class);
@@ -135,8 +133,8 @@ class UploadHomeTest extends TestCase {
 		$userSession->method('getUser')->willReturn($user);
 		$shareManager = $this->createMock(IManager::class);
 
-		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
-		$rootFolder->method('get')->willReturn($directory);
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($folder);
+		$rootFolder->method('get')->willReturn($folder);
 
 		$cleanup->expects($this->once())->method('addJob')->with('testuser', 'foo');
 
@@ -153,20 +151,14 @@ class UploadHomeTest extends TestCase {
 
 	public function testGetChildReturnsUploadFolder(): void {
 		$cleanup = $this->createMock(CleanupService::class);
-		$directoryChild = $this->createMock(Folder::class);
+		$folderChild = $this->createMock(Folder::class);
 
-		$directoryChild->method('getType')->willReturn('dir');
-		$directoryChild->method('isDirectory')->willReturn(true);
-
-		$directory = $this->createMock(Directory::class);
-		$directory->method('getChild')->with('childname')->willReturn($directoryChild);
-
-		$directory->method('getType')->willReturn('dir');
-		$directory->method('isDirectory')->willReturn(true);
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getChild')->with('childname')->willReturn($folderChild);
 
 		$rootFolder = $this->createMock(IRootFolder::class);
-		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
-		$rootFolder->method('get')->willReturn($directory);
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($folder);
+		$rootFolder->method('get')->willReturn($folder);
 
 		$userSession = $this->createMock(IUserSession::class);
 		$user = $this->createUser('testuser', 'testpass');
@@ -184,8 +176,6 @@ class UploadHomeTest extends TestCase {
 			$shareManager
 		);
 
-		// Patch UploadHome if necessary so getStorage() will work for the test context
-
 		$result = $uploadHome->getChild('childname');
 		$this->assertInstanceOf(UploadFolder::class, $result);
 	}
@@ -193,14 +183,12 @@ class UploadHomeTest extends TestCase {
 	public function testGetChildThrowsExceptionIfNotFound(): void {
 		$cleanup = $this->createMock(CleanupService::class);
 
-		$directory = $this->createMock(Directory::class);
-		$directory->method('getChild')->with('missing')->willThrowException(new SabreNotFound());
-		$directory->method('getType')->willReturn('dir');
-		$directory->method('isDirectory')->willReturn(true);
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getChild')->with('missing')->willThrowException(new SabreNotFound());
 
 		$rootFolder = $this->createMock(IRootFolder::class);
-		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
-		$rootFolder->method('get')->willReturn($directory);
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($folder);
+		$rootFolder->method('get')->willReturn($folder);
 
 		$userSession = $this->createMock(IUserSession::class);
 		$user = $this->createUser('testuser', 'testpass');
@@ -223,21 +211,15 @@ class UploadHomeTest extends TestCase {
 	public function testGetChildrenReturnsUploadFolders(): void {
 		$cleanup = $this->createMock(CleanupService::class);
 
-		$directoryChild1 = $this->createMock(Folder::class);
-		$directoryChild2 = $this->createMock(Folder::class);
-		$directoryChild1->method('getType')->willReturn('dir');
-		$directoryChild1->method('isDirectory')->willReturn(true);
-		$directoryChild2->method('getType')->willReturn('dir');
-		$directoryChild2->method('isDirectory')->willReturn(true);
+		$folderChild1 = $this->createMock(Folder::class);
+		$folderChild2 = $this->createMock(Folder::class);
 
-		$directory = $this->createMock(Directory::class);
-		$directory->method('getChildren')->willReturn([$directoryChild1, $directoryChild2]);
-		$directory->method('getType')->willReturn('dir');
-		$directory->method('isDirectory')->willReturn(true);
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getChildren')->willReturn([$folderChild1, $folderChild2]);
 
 		$rootFolder = $this->createMock(IRootFolder::class);
-		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
-		$rootFolder->method('get')->willReturn($directory);
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($folder);
+		$rootFolder->method('get')->willReturn($folder);
 
 		$userSession = $this->createMock(IUserSession::class);
 		$user = $this->createUser('testuser', 'testpass');
@@ -287,15 +269,14 @@ class UploadHomeTest extends TestCase {
 
 	public function testDeleteProxiesToImplDelete(): void {
 		$cleanup = $this->createMock(CleanupService::class);
-		$directory = $this->createMock(Directory::class);
+		$folder = $this->createMock(Folder::class);
 
+		$directory = $this->createMock(Directory::class);
 		$directory->expects($this->once())->method('delete');
-		$directory->method('getType')->willReturn('dir');
-		$directory->method('isDirectory')->willReturn(true);
 
 		$rootFolder = $this->createMock(IRootFolder::class);
-		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
-		$rootFolder->method('get')->willReturn($directory);
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($folder);
+		$rootFolder->method('get')->willReturn($folder);
 
 		$userSession = $this->createMock(IUserSession::class);
 		$user = $this->createUser('testuser', 'testpass');
@@ -303,13 +284,22 @@ class UploadHomeTest extends TestCase {
 
 		$shareManager = $this->createMock(IManager::class);
 
-		$uploadHome = new UploadHome(
-			$this->principalInfo,
-			$cleanup,
-			$rootFolder,
-			$userSession,
-			$shareManager
-		);
+		// Patch impl() so Directory is built from a Folder
+		$directoryReflect = new \ReflectionClass(Directory::class);
+		$directoryInstance = $directoryReflect->newInstanceWithoutConstructor();
+
+		$uploadHome = $this->getMockBuilder(UploadHome::class)
+			->setConstructorArgs([
+				$this->principalInfo,
+				$cleanup,
+				$rootFolder,
+				$userSession,
+				$shareManager
+			])
+			->onlyMethods(['impl'])
+			->getMock();
+
+		$uploadHome->method('impl')->willReturn($directory);
 
 		$uploadHome->delete();
 	}
@@ -322,14 +312,14 @@ class UploadHomeTest extends TestCase {
 	public function testGetLastModifiedProxiesToImpl(): void {
 		$cleanup = $this->createMock(CleanupService::class);
 
+		$folder = $this->createMock(Folder::class);
+
 		$directory = $this->createMock(Directory::class);
 		$directory->method('getLastModified')->willReturn(1234567890);
-		$directory->method('getType')->willReturn('dir');
-		$directory->method('isDirectory')->willReturn(true);
 
 		$rootFolder = $this->createMock(IRootFolder::class);
-		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($directory);
-		$rootFolder->method('get')->willReturn($directory);
+		$rootFolder->method('getUserFolder')->with('testuser')->willReturn($folder);
+		$rootFolder->method('get')->willReturn($folder);
 
 		$userSession = $this->createMock(IUserSession::class);
 		$user = $this->createUser('testuser', 'testpass');
@@ -337,13 +327,18 @@ class UploadHomeTest extends TestCase {
 
 		$shareManager = $this->createMock(IManager::class);
 
-		$uploadHome = new UploadHome(
-			$this->principalInfo,
-			$cleanup,
-			$rootFolder,
-			$userSession,
-			$shareManager
-		);
+		$uploadHome = $this->getMockBuilder(UploadHome::class)
+			->setConstructorArgs([
+				$this->principalInfo,
+				$cleanup,
+				$rootFolder,
+				$userSession,
+				$shareManager
+			])
+			->onlyMethods(['impl'])
+			->getMock();
+
+		$uploadHome->method('impl')->willReturn($directory);
 
 		$this->assertEquals(1234567890, $uploadHome->getLastModified());
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

...covering constructor logic, permissions, directory, and child methods

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
