### PR TITLE
feat(apps): Make app enabling atomic

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -591,10 +591,18 @@ class AppManager implements IAppManager {
 
 		$this->enabledAppsCache[$appId] = 'yes';
 		$this->getAppConfig()->setValue($appId, 'enabled', 'yes');
-		$this->dispatcher->dispatchTyped(new AppEnableEvent($appId));
-		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE, new ManagerEvent(
-			ManagerEvent::EVENT_APP_ENABLE, $appId
-		));
+
+		try {
+			$this->dispatcher->dispatchTyped(new AppEnableEvent($appId));
+			$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE, new ManagerEvent(
+				ManagerEvent::EVENT_APP_ENABLE, $appId
+			));
+		} catch (\Throwable $e) {
+			$this->getAppConfig()->setValue($appId, 'enabled', 'no');
+			unset($this->enabledAppsCache[$appId]);
+			throw $e;
+		}
+
 		$this->clearAppsCache();
 
 		$this->configManager->migrateConfigLexiconKeys($appId);


### PR DESCRIPTION
Previously, if an app failed during its enabling process, it could leave the instance in a broken state. This was because the app was marked as enabled before its
initialization code was executed, but the state was not rolled back upon failure.

This change wraps the app enabling logic in a try/catch block. If the app's initialization fails, the 'enabled' state is reverted in the database, and the in-memory app cache is cleared. This ensures that a faulty app cannot take down the entire Nextcloud instance.

