### PR TITLE
[stable32] fix(ocm): normalize protocol to support multi with webdav option

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -106,6 +106,18 @@ class RequestHandlerController extends Controller {
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'receiveFederatedShare')]
 	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
+		// quick patch to flatten the protocol entry 'multi' to the previous 'webdav'. this is 32 only and a better implementation is expected for 33
+		/** @psalm-suppress InvalidArrayOffset */
+		if ((($protocol['name'] ?? '') === 'multi') && (is_array($protocol['webdav'] ?? ''))) {
+			$protocol = [
+				'name' => 'webdav',
+				'options' => [
+					'sharedSecret' => $protocol['webdav']['sharedSecret'] ?? '',
+					'permissions' => '{http://open-cloud-mesh.org/ns}share-permissions',
+				],
+			];
+		}
+
 		try {
 			// if request is signed and well signed, no exception are thrown
 			// if request is not signed and host is known for not supporting signed request, no exception are thrown


### PR DESCRIPTION
Co-authored with @mickenordin based on https://github.com/nextcloud/server/pull/55752

This is a `stable32` only patch, better implementation of the 'multi' protocol is expected on `master`
