### PR TITLE
refactor: move share unique path generation from view api to node api

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -12,6 +12,7 @@ use OCA\Files_Sharing\Event\ShareMountedEvent;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
+use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IStorageFactory;
@@ -35,6 +36,7 @@ class MountProvider implements IMountProvider {
 		protected IEventDispatcher $eventDispatcher,
 		protected ICacheFactory $cacheFactory,
 		protected IMountManager $mountManager,
+		protected IRootFolder $rootFolder,
 	) {
 	}
 
@@ -64,7 +66,6 @@ class MountProvider implements IMountProvider {
 
 		$allMounts = $this->mountManager->getAll();
 		$mounts = [];
-		$view = new View('/' . $user->getUID() . '/files');
 		$ownerViews = [];
 		$sharingDisabledForUser = $this->shareManager->sharingDisabledForUser($user->getUID());
 		/** @var CappedMemoryCache<bool> $folderExistCache */
@@ -100,14 +101,13 @@ class MountProvider implements IMountProvider {
 						'superShare' => $parentShare,
 						// children/component of the superShare
 						'groupedShares' => $share[1],
-						'ownerView' => $ownerViews[$owner],
 						'sharingDisabledForUser' => $sharingDisabledForUser
 					],
 					$loader,
-					$view,
 					$foldersExistCache,
 					$this->eventDispatcher,
 					$user,
+					$this->rootFolder,
 					($shareId <= $maxValidatedShare),
 				);
 

--- a/lib/public/Share/Events/VerifyMountPointEvent.php
+++ b/lib/public/Share/Events/VerifyMountPointEvent.php
@@ -10,30 +10,22 @@ namespace OCP\Share\Events;
 
 use OC\Files\View;
 use OCP\EventDispatcher\Event;
+use OCP\IUser;
 use OCP\Share\IShare;
 
 /**
  * @since 19.0.0
  */
 class VerifyMountPointEvent extends Event {
-	/** @var IShare */
-	private $share;
-	/** @var View */
-	private $view;
-	/** @var string */
-	private $parent;
-
 	/**
 	 * @since 19.0.0
 	 */
-	public function __construct(IShare $share,
-		View $view,
-		string $parent) {
+	public function __construct(
+		private IShare $share,
+		private readonly IUser $recipient,
+		private string $parent
+	) {
 		parent::__construct();
-
-		$this->share = $share;
-		$this->view = $view;
-		$this->parent = $parent;
 	}
 
 	/**
@@ -45,9 +37,17 @@ class VerifyMountPointEvent extends Event {
 
 	/**
 	 * @since 19.0.0
+	 * @depreacted 33.0.0 use getRecipient instead to get the user folder
 	 */
 	public function getView(): View {
-		return $this->view;
+		return new View('/' . $this->recipient->getUID() . '/files');
+	}
+
+	/**
+	 * @since 33.0.0
+	 */
+	public function getRecipient(): IUser {
+		return $this->recipient;
 	}
 
 	/**


### PR DESCRIPTION
Still need to use the view sometimes for compatibility, but the main code path is off it now