### PR TITLE
feat(scanner): enable use of a setting to disable DB transaction

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -19,6 +19,7 @@ use OCP\Files\Storage\IReliableEtagStorage;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Lock\ILockingProvider;
+use OC\Lock\DBLockingProvider;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 
@@ -70,9 +71,10 @@ class Scanner extends BasicEmitter implements IScanner {
 		$this->storage = $storage;
 		$this->storageId = $this->storage->getId();
 		$this->cache = $storage->getCache();
+		/** @var IConfig $config */
 		$config = Server::get(IConfig::class);
 		$this->cacheActive = !$config->getSystemValueBool('filesystem_cache_readonly', false);
-		$this->useTransactions = !$config->getSystemValueBool('filescanner_no_transactions', false);
+		$this->useTransactions = !(Server::get(ILockingProvider::class) instanceof DBLockingProvider) && !$config->getSystemValueBool('filescanner_no_transactions', false);
 		$this->lockingProvider = Server::get(ILockingProvider::class);
 		$this->connection = Server::get(IDBConnection::class);
 	}

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -27,9 +27,11 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -79,8 +81,10 @@ class Scanner extends PublicEmitter {
 		$this->db = $db;
 		$this->dispatcher = $dispatcher;
 		$this->logger = $logger;
+		/** @var IConfig $config */
+		$config = Server::get(IConfig::class);
 		// when DB locking is used, no DB transactions will be used
-		$this->useTransaction = !(\OC::$server->get(ILockingProvider::class) instanceof DBLockingProvider);
+		$this->useTransaction = !(Server::get(ILockingProvider::class) instanceof DBLockingProvider) && !$config->getSystemValueBool('filescanner_no_transactions', false);
 	}
 
 	/**


### PR DESCRIPTION
while doing a files scan from storage, we may want not to use DB transactions

enable the use of a setting for that

define filescanner_no_transactions in system config to enable this (i.e. in config.php)

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
