### PR TITLE
perf(s3): Cache whether bucket exists

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -155,25 +155,25 @@ trait S3ConnectionTrait {
 				$cacheKey = $this->params['hostname'] . $this->bucket;
 				$exist = $this->existingBucketsCache->get($cacheKey) === 1;
 
-				if (!$exist && !$this->connection->doesBucketExist($this->bucket)) {
-					try {
-						$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
-						if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
-							throw new StorageNotAvailableException('The bucket will not be created because the name is not dns compatible, please correct it: ' . $this->bucket);
-						}
-						$this->connection->createBucket(['Bucket' => $this->bucket]);
-						$this->testTimeout();
-						$this->existingBucketsCache->set($cacheKey, 1);
-					} catch (S3Exception $e) {
-						$logger->debug('Invalid remote storage.', [
-							'exception' => $e,
-							'app' => 'objectstore',
-						]);
-						if ($e->getAwsErrorCode() !== 'BucketAlreadyOwnedByYou') {
-							throw new StorageNotAvailableException('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
+				if (!$exist) {
+					if (!$this->connection->doesBucketExist($this->bucket)) {
+						try {
+							$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
+							if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
+								throw new StorageNotAvailableException('The bucket will not be created because the name is not dns compatible, please correct it: ' . $this->bucket);
+							}
+							$this->connection->createBucket(['Bucket' => $this->bucket]);
+							$this->testTimeout();
+						} catch (S3Exception $e) {
+							$logger->debug('Invalid remote storage.', [
+								'exception' => $e,
+								'app' => 'objectstore',
+							]);
+							if ($e->getAwsErrorCode() !== 'BucketAlreadyOwnedByYou') {
+								throw new StorageNotAvailableException('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
+							}
 						}
 					}
-				} elseif (!$exist) {
 					$this->existingBucketsCache->set($cacheKey, 1);
 				}
 			}

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -15,6 +15,8 @@ use Aws\S3\S3Client;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\RejectedPromise;
 use OCP\Files\StorageNotAvailableException;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\ICertificateManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
@@ -27,6 +29,8 @@ trait S3ConnectionTrait {
 	protected bool $test;
 
 	protected ?S3Client $connection = null;
+
+	private ?ICache $existingBucketsCache = null;
 
 	protected function parseParams($params) {
 		if (empty($params['bucket'])) {
@@ -79,6 +83,11 @@ trait S3ConnectionTrait {
 	public function getConnection() {
 		if ($this->connection !== null) {
 			return $this->connection;
+		}
+
+		if ($this->existingBucketsCache === null) {
+			$this->existingBucketsCache = Server::get(ICacheFactory::class)
+				->createLocal('s3-bucket-exists-cache');
 		}
 
 		$scheme = (isset($this->params['use_ssl']) && $this->params['use_ssl'] === false) ? 'http' : 'https';
@@ -142,22 +151,30 @@ trait S3ConnectionTrait {
 					['app' => 'objectstore']);
 			}
 
-			if ($this->params['verify_bucket_exists'] && !$this->connection->doesBucketExist($this->bucket)) {
-				try {
-					$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
-					if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
-						throw new StorageNotAvailableException('The bucket will not be created because the name is not dns compatible, please correct it: ' . $this->bucket);
+			if ($this->params['verify_bucket_exists']) {
+				$cacheKey = $this->params['hostname'] . $this->bucket;
+				$exist = $this->existingBucketsCache->get($cacheKey) === 1;
+
+				if (!$exist && !$this->connection->doesBucketExist($this->bucket)) {
+					try {
+						$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
+						if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
+							throw new StorageNotAvailableException('The bucket will not be created because the name is not dns compatible, please correct it: ' . $this->bucket);
+						}
+						$this->connection->createBucket(['Bucket' => $this->bucket]);
+						$this->testTimeout();
+						$this->existingBucketsCache->set($cacheKey, 1);
+					} catch (S3Exception $e) {
+						$logger->debug('Invalid remote storage.', [
+							'exception' => $e,
+							'app' => 'objectstore',
+						]);
+						if ($e->getAwsErrorCode() !== 'BucketAlreadyOwnedByYou') {
+							throw new StorageNotAvailableException('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
+						}
 					}
-					$this->connection->createBucket(['Bucket' => $this->bucket]);
-					$this->testTimeout();
-				} catch (S3Exception $e) {
-					$logger->debug('Invalid remote storage.', [
-						'exception' => $e,
-						'app' => 'objectstore',
-					]);
-					if ($e->getAwsErrorCode() !== 'BucketAlreadyOwnedByYou') {
-						throw new StorageNotAvailableException('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
-					}
+				} elseif (!$exist) {
+					$this->existingBucketsCache->set($cacheKey, 1);
 				}
 			}
 


### PR DESCRIPTION
## Summary

Otherwise, we call doesBucketExist all the time which does a network request to the S3 server adding some non-trivial latency when creating a S3 connection object.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
