### PR TITLE
chore: don't assume bash in /bin in build/demi.sh

### DIFF
--- a/build/demi.sh
+++ b/build/demi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
While it's usually there, it's not always (like on NixOS), `/usr/bin/env` is however a standard path that *should* exist on all unix systems