### PR TITLE
fix(Memcache): use different cache key when in maintenance mode

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -113,12 +113,16 @@ class Factory implements ICacheFactory {
 	protected function getGlobalPrefix(): string {
 		if ($this->globalPrefix === null) {
 			$config = \OCP\Server::get(SystemConfig::class);
+			$maintenanceMode = $config->getValue('maintenance', false);
 			$versions = [];
-			if ($config->getValue('installed', false)) {
+			if ($config->getValue('installed', false) && !$maintenanceMode) {
 				$appConfig = \OCP\Server::get(IAppConfig::class);
 				// only get the enabled apps to clear the cache in case an app is enabled or disabled (e.g. clear routes)
 				$versions = $appConfig->getAppInstalledVersions(true);
 				ksort($versions);
+			} else {
+				// if not installed or in maintenance mode, we should distinguish between both states.
+				$versions['core:maintenance'] = $maintenanceMode ? '1' : '0';
 			}
 			$versions['core'] = implode('.', $this->serverVersion->getVersion());
 


### PR DESCRIPTION
* resolves https://github.com/nextcloud/server/pull/56033#issuecomment-3510444743

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
