### PR TITLE
fix: support -n option to encrypt-all command to allow to run in non-interactive mode

### DIFF
--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -278,12 +278,8 @@ class EncryptAll {
 		$this->writePasswordsToFile($newPasswords);
 
 		$this->output->writeln('');
-		if ($this->input->isInteractive()) {
-			$question = new ConfirmationQuestion('Do you want to send the passwords directly to the users by mail? (y/n) ', false);
-			if ($this->questionHelper->ask($this->input, $this->output, $question)) {
-				$this->sendPasswordsByMail();
-			}
-		} elseif (!$this->input->isInteractive() && $this->input->getOption('no-interaction')) {
+		$question = new ConfirmationQuestion('Do you want to send the passwords directly to the users by mail? (y/n) ', true);
+		if ($this->questionHelper->ask($this->input, $this->output, $question)) {
 			$this->sendPasswordsByMail();
 		}
 	}

--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -278,8 +278,12 @@ class EncryptAll {
 		$this->writePasswordsToFile($newPasswords);
 
 		$this->output->writeln('');
-		$question = new ConfirmationQuestion('Do you want to send the passwords directly to the users by mail? (y/n) ', false);
-		if ($this->questionHelper->ask($this->input, $this->output, $question)) {
+		if ($this->input->isInteractive()) {
+			$question = new ConfirmationQuestion('Do you want to send the passwords directly to the users by mail? (y/n) ', false);
+			if ($this->questionHelper->ask($this->input, $this->output, $question)) {
+				$this->sendPasswordsByMail();
+			}
+		} elseif (!$this->input->isInteractive() && $this->input->getOption('no-interaction')) {
 			$this->sendPasswordsByMail();
 		}
 	}

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -13,6 +13,7 @@ use OCP\IConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -55,6 +56,11 @@ class EncryptAll extends Command {
 		$this->setHelp(
 			'This will encrypt all files for all users. '
 			. 'Please make sure that no user access his files during this process!'
+		)->addOption(
+			'no-interaction',
+			'n',
+			InputOption::VALUE_NONE,
+			'Do not ask any interactive question'
 		);
 	}
 
@@ -77,11 +83,12 @@ class EncryptAll extends Command {
 		$output->writeln('Please ensure that no user accesses their files during this time!');
 		$output->writeln('Note: The encryption module you use determines which files get encrypted.');
 		$output->writeln('');
+		$isNoInteraction = $input->getOption('no-interaction');
 		$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', false);
 		if ($input->isInteractive() && $this->questionHelper->ask($input, $output, $question)) {
 			//run encryption with the answer yes in interactive mode
 			return $this->runEncryption($input, $output);
-		} elseif (!$input->isInteractive()) {
+		} elseif (!$input->isInteractive() && $isNoInteraction) {
 			//run encryption without the question in non-interactive mode if -n option is available
 			return $this->runEncryption($input, $output);
 		}

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -58,16 +58,10 @@ class EncryptAll extends Command {
 		);
 	}
 
+	/**
+	 * @throws \Exception
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		if (!$input->isInteractive()) {
-			$output->writeln('Invalid TTY.');
-			$output->writeln('If you are trying to execute the command in a Docker ');
-			$output->writeln("container, do not forget to execute 'docker exec' with");
-			$output->writeln("the '-i' and '-t' options.");
-			$output->writeln('');
-			return 1;
-		}
-
 		if ($this->encryptionManager->isEnabled() === false) {
 			throw new \Exception('Server side encryption is not enabled');
 		}
@@ -84,21 +78,30 @@ class EncryptAll extends Command {
 		$output->writeln('Note: The encryption module you use determines which files get encrypted.');
 		$output->writeln('');
 		$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', false);
-		if ($this->questionHelper->ask($input, $output, $question)) {
-			$this->forceMaintenanceAndTrashbin();
-
-			try {
-				$defaultModule = $this->encryptionManager->getEncryptionModule();
-				$defaultModule->encryptAll($input, $output);
-			} catch (\Exception $ex) {
-				$this->resetMaintenanceAndTrashbin();
-				throw $ex;
-			}
-
-			$this->resetMaintenanceAndTrashbin();
-			return self::SUCCESS;
+		if ($input->isInteractive() && $this->questionHelper->ask($input, $output, $question)) {
+			//run encryption with the answer yes in interactive mode
+			return $this->runEncryption($input, $output);
+		} elseif (!$input->isInteractive()) {
+			//run encryption without the question in non-interactive mode if -n option is available
+			return $this->runEncryption($input, $output);
 		}
+		//abort on no in interactive mode
 		$output->writeln('aborted');
 		return self::FAILURE;
+	}
+
+	private function runEncryption(InputInterface $input, OutputInterface $output): int {
+		$this->forceMaintenanceAndTrashbin();
+
+		try {
+			$defaultModule = $this->encryptionManager->getEncryptionModule();
+			$defaultModule->encryptAll($input, $output);
+		} catch (\Exception $ex) {
+			$this->resetMaintenanceAndTrashbin();
+			throw $ex;
+		}
+
+		$this->resetMaintenanceAndTrashbin();
+		return self::SUCCESS;
 	}
 }

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -90,25 +90,21 @@ class EncryptAll extends Command {
 		$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', true);
 		if ($this->questionHelper->ask($input, $output, $question)) {
 			//run encryption with the answer yes in interactive mode
-			return $this->runEncryption($input, $output);
+			$this->forceMaintenanceAndTrashbin();
+
+			try {
+				$defaultModule = $this->encryptionManager->getEncryptionModule();
+				$defaultModule->encryptAll($input, $output);
+			} catch (\Exception $ex) {
+				$this->resetMaintenanceAndTrashbin();
+				throw $ex;
+			}
+
+			$this->resetMaintenanceAndTrashbin();
+			return self::SUCCESS;
 		}
 		//abort on no in interactive mode
 		$output->writeln('aborted');
 		return self::FAILURE;
-	}
-
-	private function runEncryption(InputInterface $input, OutputInterface $output): int {
-		$this->forceMaintenanceAndTrashbin();
-
-		try {
-			$defaultModule = $this->encryptionManager->getEncryptionModule();
-			$defaultModule->encryptAll($input, $output);
-		} catch (\Exception $ex) {
-			$this->resetMaintenanceAndTrashbin();
-			throw $ex;
-		}
-
-		$this->resetMaintenanceAndTrashbin();
-		return self::SUCCESS;
 	}
 }

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -13,7 +13,6 @@ use OCP\IConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 


### PR DESCRIPTION
possible options now are

occ encryption:encrypt-all

will ask the confirmation question before proceeding with encryption

occ encryption:encrypt-all -n 

will not ask the question and run the encryption directly

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
