### PR TITLE
ci(cypress): split test suite to avoid runner crash

### DIFF
--- a/cypress/e2e/settings/users-group-admin-1.cy.ts
+++ b/cypress/e2e/settings/users-group-admin-1.cy.ts
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { User } from '@nextcloud/e2e-test-server/cypress'
+import { randomString } from '../../support/utils/randomString.ts'
+import { admin, makeSubAdmin } from '../../support/utils/settings.ts'
+import { getUserListRow, handlePasswordConfirmation } from './usersUtils.ts'
+
+const john = new User('john', '123456')
+
+// This test suite is split as otherwise Cypress crashes
+describe('Settings: Create accounts as a group admin', function() {
+	let subadmin: User
+	let group: string
+
+	beforeEach(() => {
+		group = randomString(7)
+		cy.deleteUser(john)
+		cy.createRandomUser().then((user) => {
+			subadmin = user
+			cy.runOccCommand(`group:add '${group}'`)
+			cy.runOccCommand(`group:adduser '${group}' '${subadmin.userId}'`)
+			makeSubAdmin(subadmin, group)
+		})
+	})
+
+	it('Can create a user with prefilled single group', () => {
+		cy.login(subadmin)
+		// open the User settings
+		cy.visit('/settings/users')
+
+		// open the New user modal
+		cy.get('button#new-user-button').click()
+
+		cy.get('form[data-test="form"]').within(() => {
+			// see that the correct group is preselected
+			cy.contains('[data-test="groups"] .vs__selected', group).should('be.visible')
+			// see that the username is ""
+			cy.get('input[data-test="username"]').should('exist').and('have.value', '')
+			// set the username to john
+			cy.get('input[data-test="username"]').type(john.userId)
+			// see that the username is john
+			cy.get('input[data-test="username"]').should('have.value', john.userId)
+			// see that the password is ""
+			cy.get('input[type="password"]').should('exist').and('have.value', '')
+			// set the password to 123456
+			cy.get('input[type="password"]').type(john.password)
+			// see that the password is 123456
+			cy.get('input[type="password"]').should('have.value', john.password)
+		})
+
+		cy.get('form[data-test="form"]').parents('[role="dialog"]').within(() => {
+			// submit the new user form
+			cy.get('button[type="submit"]').click({ force: true })
+		})
+
+		// Make sure no confirmation modal is shown
+		handlePasswordConfirmation(admin.password)
+
+		// see that the created user is in the list
+		getUserListRow(john.userId)
+			// see that the list of users contains the user john
+			.contains(john.userId).should('exist')
+	})
+})

--- a/cypress/e2e/settings/users-group-admin-2.cy.ts
+++ b/cypress/e2e/settings/users-group-admin-2.cy.ts
@@ -5,34 +5,12 @@
 
 import { User } from '@nextcloud/e2e-test-server/cypress'
 import { randomString } from '../../support/utils/randomString.ts'
+import { admin, makeSubAdmin } from '../../support/utils/settings.ts'
 import { getUserListRow, handlePasswordConfirmation } from './usersUtils.ts'
 
-const admin = new User('admin', 'admin')
 const john = new User('john', '123456')
 
-/**
- * Make a user subadmin of a group.
- *
- * @param user - The user to make subadmin
- * @param group - The group the user should be subadmin of
- */
-function makeSubAdmin(user: User, group: string): void {
-	cy.request({
-		url: `${Cypress.config('baseUrl')!.replace('/index.php', '')}/ocs/v2.php/cloud/users/${user.userId}/subadmins`,
-		method: 'POST',
-		auth: {
-			user: admin.userId,
-			password: admin.userId,
-		},
-		headers: {
-			'OCS-ApiRequest': 'true',
-		},
-		body: {
-			groupid: group,
-		},
-	})
-}
-
+// This test suite is split as otherwise Cypress crashes
 describe('Settings: Create accounts as a group admin', function() {
 	let subadmin: User
 	let group: string
@@ -46,45 +24,6 @@ describe('Settings: Create accounts as a group admin', function() {
 			cy.runOccCommand(`group:adduser '${group}' '${subadmin.userId}'`)
 			makeSubAdmin(subadmin, group)
 		})
-	})
-
-	it('Can create a user with prefilled single group', () => {
-		cy.login(subadmin)
-		// open the User settings
-		cy.visit('/settings/users')
-
-		// open the New user modal
-		cy.get('button#new-user-button').click()
-
-		cy.get('form[data-test="form"]').within(() => {
-			// see that the correct group is preselected
-			cy.contains('[data-test="groups"] .vs__selected', group).should('be.visible')
-			// see that the username is ""
-			cy.get('input[data-test="username"]').should('exist').and('have.value', '')
-			// set the username to john
-			cy.get('input[data-test="username"]').type(john.userId)
-			// see that the username is john
-			cy.get('input[data-test="username"]').should('have.value', john.userId)
-			// see that the password is ""
-			cy.get('input[type="password"]').should('exist').and('have.value', '')
-			// set the password to 123456
-			cy.get('input[type="password"]').type(john.password)
-			// see that the password is 123456
-			cy.get('input[type="password"]').should('have.value', john.password)
-		})
-
-		cy.get('form[data-test="form"]').parents('[role="dialog"]').within(() => {
-			// submit the new user form
-			cy.get('button[type="submit"]').click({ force: true })
-		})
-
-		// Make sure no confirmation modal is shown
-		handlePasswordConfirmation(admin.password)
-
-		// see that the created user is in the list
-		getUserListRow(john.userId)
-			// see that the list of users contains the user john
-			.contains(john.userId).should('exist')
 	})
 
 	it('Can create a new user when member of multiple groups', () => {
@@ -150,35 +89,5 @@ describe('Settings: Create accounts as a group admin', function() {
 		getUserListRow(john.userId)
 			// see that the list of users contains the user john
 			.contains(john.userId).should('exist')
-	})
-
-	it('Only sees groups they are subadmin of', () => {
-		const group2 = randomString(7)
-		cy.runOccCommand(`group:add '${group2}'`)
-		cy.runOccCommand(`group:adduser '${group2}' '${subadmin.userId}'`)
-		// not a subadmin!
-
-		cy.login(subadmin)
-		// open the User settings
-		cy.visit('/settings/users')
-
-		// open the New user modal
-		cy.get('button#new-user-button').click()
-
-		cy.get('form[data-test="form"]').within(() => {
-			// see that the subadmin group is pre-selected
-			cy.contains('[data-test="groups"] .vs__selected', group).should('be.visible')
-			// see only the subadmin group is available
-			cy.findByRole('combobox', { name: /member of the following groups/i })
-				.should('be.visible')
-				.click()
-			// can select both groups
-			cy.document().its('body')
-				.findByRole('listbox', { name: 'Options' })
-				.should('be.visible')
-				.as('options')
-				.findAllByRole('option')
-				.should('have.length', 1)
-		})
 	})
 })

--- a/cypress/e2e/settings/users-group-admin-3.cy.ts
+++ b/cypress/e2e/settings/users-group-admin-3.cy.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { User } from '@nextcloud/e2e-test-server/cypress'
+import { randomString } from '../../support/utils/randomString.ts'
+import { makeSubAdmin } from '../../support/utils/settings.ts'
+
+const john = new User('john', '123456')
+
+// This test suite is split as otherwise Cypress crashes
+describe('Settings: Create accounts as a group admin', function() {
+	let subadmin: User
+	let group: string
+
+	beforeEach(() => {
+		group = randomString(7)
+		cy.deleteUser(john)
+		cy.createRandomUser().then((user) => {
+			subadmin = user
+			cy.runOccCommand(`group:add '${group}'`)
+			cy.runOccCommand(`group:adduser '${group}' '${subadmin.userId}'`)
+			makeSubAdmin(subadmin, group)
+		})
+	})
+
+	it('Only sees groups they are subadmin of', () => {
+		const group2 = randomString(7)
+		cy.runOccCommand(`group:add '${group2}'`)
+		cy.runOccCommand(`group:adduser '${group2}' '${subadmin.userId}'`)
+		// not a subadmin!
+
+		cy.login(subadmin)
+		// open the User settings
+		cy.visit('/settings/users')
+
+		// open the New user modal
+		cy.get('button#new-user-button').click()
+
+		cy.get('form[data-test="form"]').within(() => {
+			// see that the subadmin group is pre-selected
+			cy.contains('[data-test="groups"] .vs__selected', group).should('be.visible')
+			// see only the subadmin group is available
+			cy.findByRole('combobox', { name: /member of the following groups/i })
+				.should('be.visible')
+				.click()
+			// can select both groups
+			cy.document().its('body')
+				.findByRole('listbox', { name: 'Options' })
+				.should('be.visible')
+				.as('options')
+				.findAllByRole('option')
+				.should('have.length', 1)
+		})
+	})
+})

--- a/cypress/support/utils/settings.ts
+++ b/cypress/support/utils/settings.ts
@@ -1,0 +1,31 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { User } from '@nextcloud/e2e-test-server/cypress'
+
+export const admin = new User('admin', 'admin')
+
+/**
+ * Make a user subadmin of a group.
+ *
+ * @param user - The user to make subadmin
+ * @param group - The group the user should be subadmin of
+ */
+export function makeSubAdmin(user: User, group: string): void {
+	cy.request({
+		url: `${Cypress.config('baseUrl')!.replace('/index.php', '')}/ocs/v2.php/cloud/users/${user.userId}/subadmins`,
+		method: 'POST',
+		auth: {
+			user: admin.userId,
+			password: admin.userId,
+		},
+		headers: {
+			'OCS-ApiRequest': 'true',
+		},
+		body: {
+			groupid: group,
+		},
+	})
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
