### PR TITLE
occ commands for listing and refreshing mounts

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -48,6 +48,7 @@
 		<command>OCA\Files\Command\Move</command>
 		<command>OCA\Files\Command\SanitizeFilenames</command>
 		<command>OCA\Files\Command\Mount\Refresh</command>
+		<command>OCA\Files\Command\Mount\ListMounts</command>
 		<command>OCA\Files\Command\Object\Delete</command>
 		<command>OCA\Files\Command\Object\Get</command>
 		<command>OCA\Files\Command\Object\Put</command>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -47,6 +47,7 @@
 		<command>OCA\Files\Command\Copy</command>
 		<command>OCA\Files\Command\Move</command>
 		<command>OCA\Files\Command\SanitizeFilenames</command>
+		<command>OCA\Files\Command\Mount\Refresh</command>
 		<command>OCA\Files\Command\Object\Delete</command>
 		<command>OCA\Files\Command\Object\Get</command>
 		<command>OCA\Files\Command\Object\Put</command>

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -33,6 +33,7 @@ return array(
     'OCA\\Files\\Command\\Delete' => $baseDir . '/../lib/Command/Delete.php',
     'OCA\\Files\\Command\\DeleteOrphanedFiles' => $baseDir . '/../lib/Command/DeleteOrphanedFiles.php',
     'OCA\\Files\\Command\\Get' => $baseDir . '/../lib/Command/Get.php',
+    'OCA\\Files\\Command\\Mount\\ListMounts' => $baseDir . '/../lib/Command/Mount/ListMounts.php',
     'OCA\\Files\\Command\\Mount\\Refresh' => $baseDir . '/../lib/Command/Mount/Refresh.php',
     'OCA\\Files\\Command\\Move' => $baseDir . '/../lib/Command/Move.php',
     'OCA\\Files\\Command\\Object\\Delete' => $baseDir . '/../lib/Command/Object/Delete.php',

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -33,6 +33,7 @@ return array(
     'OCA\\Files\\Command\\Delete' => $baseDir . '/../lib/Command/Delete.php',
     'OCA\\Files\\Command\\DeleteOrphanedFiles' => $baseDir . '/../lib/Command/DeleteOrphanedFiles.php',
     'OCA\\Files\\Command\\Get' => $baseDir . '/../lib/Command/Get.php',
+    'OCA\\Files\\Command\\Mount\\Refresh' => $baseDir . '/../lib/Command/Mount/Refresh.php',
     'OCA\\Files\\Command\\Move' => $baseDir . '/../lib/Command/Move.php',
     'OCA\\Files\\Command\\Object\\Delete' => $baseDir . '/../lib/Command/Object/Delete.php',
     'OCA\\Files\\Command\\Object\\Get' => $baseDir . '/../lib/Command/Object/Get.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -48,6 +48,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Command\\Delete' => __DIR__ . '/..' . '/../lib/Command/Delete.php',
         'OCA\\Files\\Command\\DeleteOrphanedFiles' => __DIR__ . '/..' . '/../lib/Command/DeleteOrphanedFiles.php',
         'OCA\\Files\\Command\\Get' => __DIR__ . '/..' . '/../lib/Command/Get.php',
+        'OCA\\Files\\Command\\Mount\\Refresh' => __DIR__ . '/..' . '/../lib/Command/Mount/Refresh.php',
         'OCA\\Files\\Command\\Move' => __DIR__ . '/..' . '/../lib/Command/Move.php',
         'OCA\\Files\\Command\\Object\\Delete' => __DIR__ . '/..' . '/../lib/Command/Object/Delete.php',
         'OCA\\Files\\Command\\Object\\Get' => __DIR__ . '/..' . '/../lib/Command/Object/Get.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -48,6 +48,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Command\\Delete' => __DIR__ . '/..' . '/../lib/Command/Delete.php',
         'OCA\\Files\\Command\\DeleteOrphanedFiles' => __DIR__ . '/..' . '/../lib/Command/DeleteOrphanedFiles.php',
         'OCA\\Files\\Command\\Get' => __DIR__ . '/..' . '/../lib/Command/Get.php',
+        'OCA\\Files\\Command\\Mount\\ListMounts' => __DIR__ . '/..' . '/../lib/Command/Mount/ListMounts.php',
         'OCA\\Files\\Command\\Mount\\Refresh' => __DIR__ . '/..' . '/../lib/Command/Mount/Refresh.php',
         'OCA\\Files\\Command\\Move' => __DIR__ . '/..' . '/../lib/Command/Move.php',
         'OCA\\Files\\Command\\Object\\Delete' => __DIR__ . '/..' . '/../lib/Command/Object/Delete.php',

--- a/apps/files/lib/Command/Mount/ListMounts.php
+++ b/apps/files/lib/Command/Mount/ListMounts.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files\Command\Mount;
+
+use OCP\Files\Config\ICachedMountInfo;
+use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\Config\IUserMountCache;
+use OCP\Files\Mount\IMountPoint;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListMounts extends Command {
+	public function __construct(
+		private readonly IUserManager $userManager,
+		private readonly IUserMountCache $userMountCache,
+		private readonly IMountProviderCollection $mountProviderCollection,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('files:mount:list')
+			->setDescription('List of mounts for a user')
+			->addArgument('user', InputArgument::REQUIRED, 'User to list mounts for');
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$userId = $input->getArgument('user');
+		$user = $this->userManager->get($userId);
+		if (!$user) {
+			$output->writeln("<error>User $userId not found</error>");
+			return 1;
+		}
+
+		$mounts = $this->mountProviderCollection->getMountsForUser($user);
+		$mounts[] = $this->mountProviderCollection->getHomeMountForUser($user);
+		/** @var array<string, IMountPoint> $cachedByMountpoint */
+		$mountsByMountpoint = array_combine(array_map(fn (IMountPoint $mount) => $mount->getMountPoint(), $mounts), $mounts);
+		usort($mounts, fn (IMountPoint $a, IMountPoint $b) => $a->getMountPoint() <=> $b->getMountPoint());
+
+		$cachedMounts = $this->userMountCache->getMountsForUser($user);
+		usort($cachedMounts, fn (ICachedMountInfo $a, ICachedMountInfo $b) => $a->getMountPoint() <=> $b->getMountPoint());
+		/** @var array<string, ICachedMountInfo> $cachedByMountpoint */
+		$cachedByMountpoint = array_combine(array_map(fn (ICachedMountInfo $mount) => $mount->getMountPoint(), $cachedMounts), $cachedMounts);
+
+		foreach ($mounts as $mount) {
+			$output->writeln('<info>' . $mount->getMountPoint() . '</info>: ' . $mount->getStorageId());
+			if (isset($cachedByMountpoint[$mount->getMountPoint()])) {
+				$cached = $cachedByMountpoint[$mount->getMountPoint()];
+				$output->writeln("\t- provider: " . $cached->getMountProvider());
+				$output->writeln("\t- storage id: " . $cached->getStorageId());
+				$output->writeln("\t- root id: " . $cached->getRootId());
+			} else {
+				$output->writeln("\t<error>not registered</error>");
+			}
+		}
+		foreach ($cachedMounts as $cachedMount) {
+			if (!isset($mountsByMountpoint[$cachedMount->getMountPoint()])) {
+				$output->writeln('<info>' . $cachedMount->getMountPoint() . '</info>:');
+				$output->writeln("\t<error>registered but no longer provided</error>");
+				$output->writeln("\t- provider: " . $cachedMount->getMountProvider());
+				$output->writeln("\t- storage id: " . $cachedMount->getStorageId());
+				$output->writeln("\t- root id: " . $cachedMount->getRootId());
+			}
+		}
+
+		return 0;
+	}
+
+}

--- a/apps/files/lib/Command/Mount/Refresh.php
+++ b/apps/files/lib/Command/Mount/Refresh.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files\Command\Mount;
+
+use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\Config\IUserMountCache;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Refresh extends Command {
+	public function __construct(
+		private readonly IUserManager $userManager,
+		private readonly IUserMountCache $userMountCache,
+		private readonly IMountProviderCollection $mountProviderCollection,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('files:mount:refresh')
+			->setDescription('Refresh the list of mounts for a user')
+			->addArgument('user', InputArgument::REQUIRED, 'User to refresh mounts for');
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$userId = $input->getArgument('user');
+		$user = $this->userManager->get($userId);
+		if (!$user) {
+			$output->writeln("<error>User $userId not found</error>");
+			return 1;
+		}
+
+		$mounts = $this->mountProviderCollection->getMountsForUser($user);
+		$mounts[] = $this->mountProviderCollection->getHomeMountForUser($user);
+
+		$this->userMountCache->registerMounts($user, $mounts);
+
+		$output->writeln('Registered <info>' . count($mounts) . '</info> mounts');
+
+		return 0;
+	}
+
+}


### PR DESCRIPTION
Add commands to list mounts (both cached and provided) and command to refresh the cached mounts for a user.

primarily intended for helping during authoritative mountpoint debugging, but might be useful outside of it.