### PR TITLE
feat: Add option to update the public key of a user

### DIFF
--- a/lib/private/Security/IdentityProof/Manager.php
+++ b/lib/private/Security/IdentityProof/Manager.php
@@ -136,6 +136,18 @@ class Manager {
 	}
 
 	/**
+	 * Set public key for $user
+	 */
+	public function setPublicKey(IUser $user, string $publicKey): void {
+		$id = 'user-' . $user->getUID();
+
+		$folder = $this->appData->getFolder($id);
+		$folder->newFile('public', $publicKey);
+
+		$this->cache->set($id . '-public', $publicKey);
+	}
+
+	/**
 	 * Get instance wide public and private key
 	 *
 	 * @throws \RuntimeException

--- a/tests/lib/Security/IdentityProof/ManagerTest.php
+++ b/tests/lib/Security/IdentityProof/ManagerTest.php
@@ -153,6 +153,33 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($expected, $this->manager->getKey($user));
 	}
 
+	public function testSetPublicKey(): void {
+		$user = $this->createMock(IUser::class);
+		$user
+			->expects($this->exactly(1))
+			->method('getUID')
+			->willReturn('MyUid');
+		$publicFile = $this->createMock(ISimpleFile::class);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder
+			->expects($this->once())
+			->method('newFile')
+			->willReturnMap([
+				['public', 'MyNewPublicKey', $publicFile],
+			]);
+		$this->appData
+			->expects($this->once())
+			->method('getFolder')
+			->with('user-MyUid')
+			->willReturn($folder);
+		$this->cache
+			->expects($this->once())
+			->method('set')
+			->with('user-MyUid-public', 'MyNewPublicKey');
+
+		$this->manager->setPublicKey($user, 'MyNewPublicKey');
+	}
+
 	public function testGetKeyWithNotExistingKey(): void {
 		$user = $this->createMock(IUser::class);
 		$user


### PR DESCRIPTION
Add `--update` option to `occ user:keys:verify` to allow updating the public key, in case it's different from the derived public key.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
