### PR TITLE
fix(settings): update all button only updates a single app

### DIFF
--- a/apps/settings/src/components/AppList.vue
+++ b/apps/settings/src/components/AppList.vue
@@ -351,13 +351,14 @@ export default {
 				})
 		},
 
-		updateAll() {
+		async updateAll() {
 			const limit = pLimit(1)
-			this.apps
+			const updateTasks = this.apps
 				.filter((app) => app.update)
 				.map((app) => limit(() => {
 					this.update(app.id)
 				}))
+			await Promise.all(updateTasks)
 		},
 	},
 }

--- a/apps/settings/src/mixins/AppManagement.js
+++ b/apps/settings/src/mixins/AppManagement.js
@@ -255,11 +255,11 @@ export default {
 		},
 		update(appId) {
 			if (this.app?.app_api) {
-				this.appApiStore.updateApp(appId)
+				return this.appApiStore.updateApp(appId)
 					.then(() => { rebuildNavigation() })
 					.catch((error) => { showError(error) })
 			} else {
-				this.$store.dispatch('updateApp', { appId })
+				return this.$store.dispatch('updateApp', { appId })
 					.catch((error) => { showError(error) })
 					.then(() => {
 						rebuildNavigation()


### PR DESCRIPTION
* Resolves: #51318

## Summary

Previously, the chain of functions involved in the "update all apps" routine were not properly setup up with regards to asynchronism: 
- The promises generated by `updateAll()` were not awaited or managed properly
- The `update` function fed to `p-limit`'s `limit()` utility was returning void and not a promise, as it expects (see [docs](https://github.com/sindresorhus/p-limit?tab=readme-ov-file#fn))

This was causing the mechanism driving the updates to potentially end prematurely. 

This PR fixes this by:
- Properly using `async/await` and `Promises.all` in `updateAll()` to ensure all promises generated by p-limit are awaited and executed completely before the function finishes. 
- Making `update()` return the promises it involves

This would prevent the function from exiting prematurely and ensure all updates are processed automatically.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
