### PR TITLE
Remove mandatory upper version constraints of nextcloud dependency in validator schema for apps

### DIFF
--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -600,7 +600,7 @@
 
     <xs:complexType name="nextcloud">
         <xs:attribute name="min-version" type="version" use="required"/>
-        <xs:attribute name="max-version" type="version" use="required"/>
+        <xs:attribute name="max-version" type="version" use="optional"/>
     </xs:complexType>
 
     <xs:simpleType name="shell-command">

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -588,7 +588,7 @@
 
     <xs:complexType name="nextcloud">
         <xs:attribute name="min-version" type="version" use="required"/>
-        <xs:attribute name="max-version" type="version" use="required"/>
+        <xs:attribute name="max-version" type="version" use="optional"/>
     </xs:complexType>
 
     <xs:simpleType name="shell-command">


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: nextcloud/documentation#13892

## Summary
ccording to the docs, the Nextcloud max-version is optional for the apps.
Please remove the upper version mandatory constraint.

<img width="693" height="157" alt="image" src="https://github.com/user-attachments/assets/b77c899b-8ca0-496a-9b1d-426802ae6a6e" />


 Ref: https://docs.nextcloud.com/server/latest/developer_manual/app_development/info.html

## TODO



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
