### PR TITLE
chore: Update minimum supported desktop version to 3.0.82

### DIFF
--- a/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
@@ -49,7 +49,7 @@ class BlockLegacyClientPlugin extends ServerPlugin {
 			return;
 		}
 
-		$minimumSupportedDesktopVersion = $this->config->getSystemValueString('minimum.supported.desktop.version', '3.1.0');
+		$minimumSupportedDesktopVersion = $this->config->getSystemValueString('minimum.supported.desktop.version', '3.0.82');
 		$maximumSupportedDesktopVersion = $this->config->getSystemValueString('maximum.supported.desktop.version', '99.99.99');
 
 		// Check if the client is a desktop client

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2382,9 +2382,9 @@ $CONFIG = [
 	 * Changing this may cause older, unsupported clients to malfunction, potentially
 	 * leading to data loss or unexpected behavior.
 	 *
-	 * Defaults to ``3.1.0``
+	 * Defaults to ``3.0.82``
 	 */
-	'minimum.supported.desktop.version' => '3.1.0',
+	'minimum.supported.desktop.version' => '3.0.82',
 
 	/**
 	 * Specify the maximum Nextcloud desktop client version allowed to sync with this


### PR DESCRIPTION
Auto-generated update of the minimum supported desktop version using last supported version.
https://github.com/nextcloud/desktop/blob/@%7B5.years.ago%7D/VERSION.cmake