### PR TITLE
refactor(ServerVersion): Add missing type hinting

### DIFF
--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up php8.1
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2.35.4
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/lib/public/ServerVersion.php
+++ b/lib/public/ServerVersion.php
@@ -9,11 +9,15 @@ declare(strict_types=1);
 
 namespace OCP;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * @since 31.0.0
  */
-class ServerVersion {
+#[Consumable(since: '31.0.0')]
+readonly class ServerVersion {
 
+	/** @var int[] */
 	private array $version;
 	private string $versionString;
 	private string $build;
@@ -59,6 +63,7 @@ class ServerVersion {
 	}
 
 	/**
+	 * @return int[]
 	 * @since 31.0.0
 	 */
 	public function getVersion(): array {
@@ -103,6 +108,5 @@ class ServerVersion {
 			$version .= ' Build:' . $build;
 		}
 		return $version;
-
 	}
 }


### PR DESCRIPTION
## Summary

And mark the class as consumable and readonly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
