### PR TITLE
Improve IResult

### DIFF
--- a/apps/contactsinteraction/lib/Db/RecentContactMapper.php
+++ b/apps/contactsinteraction/lib/Db/RecentContactMapper.php
@@ -94,7 +94,7 @@ class RecentContactMapper extends QBMapper {
 			->setMaxResults(1);
 
 		$cursor = $select->executeQuery();
-		$row = $cursor->fetch();
+		$row = $cursor->fetchAssociative();
 
 		if ($row === false) {
 			return null;

--- a/apps/contactsinteraction/lib/Migration/FixVcardCategory.php
+++ b/apps/contactsinteraction/lib/Migration/FixVcardCategory.php
@@ -53,7 +53,7 @@ class FixVcardCategory implements IRepairStep {
 			->set('card', $query->createParameter('card'))
 			->where($query->expr()->eq('id', $query->createParameter('id')));
 
-		while ($card = $cardsWithTranslatedCategory->fetch()) {
+		while ($card = $cardsWithTranslatedCategory->fetchAssociative()) {
 			$output->advance(1);
 
 			try {

--- a/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
+++ b/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
@@ -74,7 +74,7 @@ class BuildReminderIndexBackgroundJob extends QueuedJob {
 			->orderBy('id', 'ASC');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch(\PDO::FETCH_ASSOC)) {
+		while ($row = $result->fetchAssociative()) {
 			$offset = (int)$row['id'];
 			if (is_resource($row['calendardata'])) {
 				$row['calendardata'] = stream_get_contents($row['calendardata']);

--- a/apps/dav/lib/BackgroundJob/CleanupOrphanedChildrenJob.php
+++ b/apps/dav/lib/BackgroundJob/CleanupOrphanedChildrenJob.php
@@ -72,7 +72,7 @@ class CleanupOrphanedChildrenJob extends QueuedJob {
 		}
 
 		$result = $selectQb->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 		if (empty($rows)) {
 			return 0;

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -283,7 +283,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->andWhere($qb->expr()->lt('deleted_at', $qb->createNamedParameter($deletedBefore)));
 		$result = $qb->executeQuery();
 		$calendars = [];
-		while (($row = $result->fetch()) !== false) {
+		while (($row = $result->fetchAssociative()) !== false) {
 			$calendars[] = [
 				'id' => (int)$row['id'],
 				'deleted_at' => (int)$row['deleted_at'],
@@ -345,7 +345,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$result = $query->executeQuery();
 
 			$calendars = [];
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$row['principaluri'] = (string)$row['principaluri'];
 				$components = [];
 				if ($row['components']) {
@@ -408,7 +408,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$results = $select->executeQuery();
 
 			$readOnlyPropertyName = '{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only';
-			while ($row = $results->fetch()) {
+			while ($row = $results->fetchAssociative()) {
 				$row['principaluri'] = (string)$row['principaluri'];
 				if ($row['principaluri'] === $principalUri) {
 					continue;
@@ -478,7 +478,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->orderBy('calendarorder', 'ASC');
 		$stmt = $query->executeQuery();
 		$calendars = [];
-		while ($row = $stmt->fetch()) {
+		while ($row = $stmt->fetchAssociative()) {
 			$row['principaluri'] = (string)$row['principaluri'];
 			$components = [];
 			if ($row['components']) {
@@ -528,7 +528,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->andWhere($query->expr()->eq('s.type', $query->createNamedParameter('calendar')))
 			->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$row['principaluri'] = (string)$row['principaluri'];
 			[, $name] = Uri\split($row['principaluri']);
 			$row['displayname'] = $row['displayname'] . "($name)";
@@ -586,7 +586,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->andWhere($query->expr()->eq('s.publicuri', $query->createNamedParameter($uri)))
 			->executeQuery();
 
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 
 		$result->closeCursor();
 
@@ -643,7 +643,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->setMaxResults(1);
 		$stmt = $query->executeQuery();
 
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 		if ($row === false) {
 			return null;
@@ -692,7 +692,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->setMaxResults(1);
 		$stmt = $query->executeQuery();
 
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 		if ($row === false) {
 			return null;
@@ -740,7 +740,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->orderBy('calendarorder', 'asc');
 		$stmt = $query->executeQuery();
 
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 		if ($row === false) {
 			return null;
@@ -777,7 +777,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->setMaxResults(1);
 		$stmt = $query->executeQuery();
 
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 		if ($row === false) {
 			return null;
@@ -1044,7 +1044,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$rs = $qb->executeQuery();
 		// iterate through results
 		try {
-			while (($row = $rs->fetch()) !== false) {
+			while (($row = $rs->fetchAssociative()) !== false) {
 				yield $row;
 			}
 		} finally {
@@ -1076,7 +1076,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt = $query->executeQuery();
 
 		$result = [];
-		while (($row = $stmt->fetch()) !== false) {
+		while (($row = $stmt->fetchAssociative()) !== false) {
 			$result[$row['uid']] = [
 				'id' => $row['id'],
 				'etag' => $row['etag'],
@@ -1141,7 +1141,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt = $query->executeQuery();
 
 		$result = [];
-		while (($row = $stmt->fetch()) !== false) {
+		while (($row = $stmt->fetchAssociative()) !== false) {
 			$result[] = [
 				'id' => $row['id'],
 				'uri' => $row['uri'],
@@ -1168,7 +1168,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt = $query->executeQuery();
 
 		$result = [];
-		while (($row = $stmt->fetch()) !== false) {
+		while (($row = $stmt->fetchAssociative()) !== false) {
 			$result[] = [
 				'id' => $row['id'],
 				'uri' => $row['uri'],
@@ -1207,7 +1207,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt = $query->executeQuery();
 
 		$result = [];
-		while ($row = $stmt->fetch()) {
+		while ($row = $stmt->fetchAssociative()) {
 			$result[] = [
 				'id' => $row['id'],
 				'uri' => $row['uri'],
@@ -1255,7 +1255,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->andWhere($query->expr()->eq('uri', $query->createNamedParameter($objectUri)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)));
 		$stmt = $query->executeQuery();
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 
 		if (!$row) {
@@ -1316,7 +1316,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$query->setParameter('uri', $uris, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $query->executeQuery();
 
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$objects[] = [
 					'id' => $row['id'],
 					'uri' => $row['uri'],
@@ -1383,7 +1383,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				->andWhere($qbDel->expr()->eq('calendartype', $qbDel->createNamedParameter($calendarType)))
 				->andWhere($qbDel->expr()->isNotNull('deleted_at'));
 			$result = $qbDel->executeQuery();
-			$found = $result->fetch();
+			$found = $result->fetchAssociative();
 			$result->closeCursor();
 			if ($found !== false) {
 				// the object existed previously but has been deleted
@@ -1675,7 +1675,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				->from('calendarobjects')
 				->where($qb2->expr()->eq('id', $qb2->createNamedParameter($id, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT));
 			$result = $selectObject->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 			if ($row === false) {
 				// Welp, this should possibly not have happened, but let's ignore
@@ -1798,7 +1798,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt = $query->executeQuery();
 
 		$result = [];
-		while ($row = $stmt->fetch()) {
+		while ($row = $stmt->fetchAssociative()) {
 			// if we leave it as a blob we can't read it both from the post filter and the rowToCalendarObject
 			if (isset($row['calendardata'])) {
 				$row['calendardata'] = $this->readBlob($row['calendardata']);
@@ -1958,7 +1958,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$stmt = $query->executeQuery();
 
 			$result = [];
-			while ($row = $stmt->fetch()) {
+			while ($row = $stmt->fetchAssociative()) {
 				$path = $uriMapper[$row['calendarid']] . '/' . $row['uri'];
 				if (!in_array($path, $result)) {
 					$result[] = $path;
@@ -2171,7 +2171,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		$result = $query->executeQuery();
 
-		while (($row = $result->fetch()) !== false) {
+		while (($row = $result->fetchAssociative()) !== false) {
 			if ($filterByTimeRange === false) {
 				// No filter required
 				$calendarObjects[] = $row;
@@ -2399,7 +2399,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 			$result = $calendarObjectIdQuery->executeQuery();
 			$matches = [];
-			while (($row = $result->fetch()) !== false) {
+			while (($row = $result->fetchAssociative()) !== false) {
 				$matches[] = (int)$row['objectid'];
 			}
 			$result->closeCursor();
@@ -2411,7 +2411,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 			$result = $query->executeQuery();
 			$calendarObjects = [];
-			while (($array = $result->fetch()) !== false) {
+			while (($array = $result->fetchAssociative()) !== false) {
 				$array['calendarid'] = (int)$array['calendarid'];
 				$array['calendartype'] = (int)$array['calendartype'];
 				$array['calendardata'] = $this->readBlob($array['calendardata']);
@@ -2456,7 +2456,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		}
 
 		$stmt = $query->executeQuery();
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 		if ($row) {
 			return $row['calendaruri'] . '/' . $row['objecturi'];
@@ -2474,7 +2474,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->where($query->expr()->eq('c.principaluri', $query->createNamedParameter($principalUri)))
 			->andWhere($query->expr()->eq('co.id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT));
 		$stmt = $query->executeQuery();
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 
 		if (!$row) {
@@ -2600,11 +2600,11 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$result = ['syncToken' => $currentToken, 'added' => [], 'modified' => [], 'deleted' => []];
 			// retrieve results
 			if ($initialSync) {
-				$result['added'] = $stmt->fetchAll(\PDO::FETCH_COLUMN);
+				$result['added'] = $stmt->fetchFirstColumn();
 			} else {
 				// \PDO::FETCH_NUM is needed due to the inconsistent field names
 				// produced by doctrine for MAX() with different databases
-				while ($entry = $stmt->fetch(\PDO::FETCH_NUM)) {
+				while ($entry = $stmt->fetchNumeric()) {
 					// assign uri (column 0) to appropriate mutation based on operation (column 1)
 					// forced (int) is needed as doctrine with OCI returns the operation field as string not integer
 					match ((int)$entry[1]) {
@@ -2670,7 +2670,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt = $query->executeQuery();
 
 		$subscriptions = [];
-		while ($row = $stmt->fetch()) {
+		while ($row = $stmt->fetchAssociative()) {
 			$subscription = [
 				'id' => $row['id'],
 				'uri' => $row['uri'],
@@ -2855,7 +2855,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->andWhere($query->expr()->eq('uri', $query->createNamedParameter($objectUri)))
 			->executeQuery();
 
-		$row = $stmt->fetch();
+		$row = $stmt->fetchAssociative();
 
 		if (!$row) {
 			return null;
@@ -2889,7 +2889,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->executeQuery();
 
 		$results = [];
-		while (($row = $stmt->fetch()) !== false) {
+		while (($row = $stmt->fetchAssociative()) !== false) {
 			$results[] = [
 				'calendardata' => $row['calendardata'],
 				'uri' => $row['uri'],
@@ -2939,7 +2939,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		}
 		$ids = array_map(static function (array $id) {
 			return (int)$id[0];
-		}, $result->fetchAll(\PDO::FETCH_NUM));
+		}, $result->fetchAllNumeric());
 		$result->closeCursor();
 
 		$numDeleted = 0;
@@ -3040,7 +3040,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 					)
 				);
 			$resultAdded = $qbAdded->executeQuery();
-			$addedUris = $resultAdded->fetchAll(\PDO::FETCH_COLUMN);
+			$addedUris = $resultAdded->fetchFirstColumn();
 			$resultAdded->closeCursor();
 			// Track everything as changed
 			// Tracking the creation is not necessary because \OCA\DAV\CalDAV\CalDavBackend::getChangesForCalendar
@@ -3060,7 +3060,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$resultDeleted = $qbDeleted->executeQuery();
 			$deletedUris = array_map(function (string $uri) {
 				return str_replace('-deleted.ics', '.ics', $uri);
-			}, $resultDeleted->fetchAll(\PDO::FETCH_COLUMN));
+			}, $resultDeleted->fetchFirstColumn());
 			$resultDeleted->closeCursor();
 			$this->addChanges($calendarId, $deletedUris, 3, $calendarType);
 		}, $this->db);
@@ -3306,7 +3306,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->executeQuery();
 
 		$hasPublishStatuses = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$this->publishStatusCache->set((string)$row['resourceid'], $row['publicuri']);
 			$hasPublishStatuses[(int)$row['resourceid']] = true;
 		}
@@ -3419,7 +3419,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				->where($query->expr()->eq('uri', $query->createNamedParameter(BirthdayService::BIRTHDAY_CALENDAR_URI)))
 				->executeQuery();
 
-			while (($row = $result->fetch()) !== false) {
+			while (($row = $result->fetchAssociative()) !== false) {
 				$this->deleteCalendar(
 					$row['id'],
 					true // No data to keep in the trashbin, if the user re-enables then we regenerate
@@ -3442,7 +3442,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$stmt = $query->executeQuery();
 
 			$uris = [];
-			while (($row = $stmt->fetch()) !== false) {
+			while (($row = $stmt->fetchAssociative()) !== false) {
 				$uris[] = $row['uri'];
 			}
 			$stmt->closeCursor();
@@ -3568,7 +3568,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)));
 
 		$result = $query->executeQuery();
-		$objectIds = $result->fetch();
+		$objectIds = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!isset($objectIds['id'])) {
@@ -3713,7 +3713,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$cmd->select('uid')
 			->from($this->dbObjectsTable)
 			->where($cmd->expr()->eq('calendarid', $cmd->createNamedParameter($calendarId)));
-		$allIds = $cmd->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		$allIds = $cmd->executeQuery()->fetchFirstColumn();
 		// delete all links that match object uid's
 		$cmd = $this->db->getQueryBuilder();
 		$cmd->delete($this->dbObjectInvitationsTable)

--- a/apps/dav/lib/CalDAV/Federation/FederatedCalendarMapper.php
+++ b/apps/dav/lib/CalDAV/Federation/FederatedCalendarMapper.php
@@ -148,7 +148,7 @@ class FederatedCalendarMapper extends QBMapper {
 			->from(self::TABLE_NAME);
 
 		$result = $qb->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			yield $this->mapRowToEntity($row);
 		}
 		$result->closeCursor();

--- a/apps/dav/lib/CalDAV/Reminder/Backend.php
+++ b/apps/dav/lib/CalDAV/Reminder/Backend.php
@@ -48,7 +48,7 @@ class Backend {
 
 		return array_map(
 			[$this, 'fixRowTyping'],
-			$stmt->fetchAll()
+			$stmt->fetchAllAssociative()
 		);
 	}
 
@@ -67,7 +67,7 @@ class Backend {
 
 		return array_map(
 			[$this, 'fixRowTyping'],
-			$stmt->fetchAll()
+			$stmt->fetchAllAssociative()
 		);
 	}
 

--- a/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
+++ b/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
@@ -78,7 +78,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 			$metaDataQuery->select([$this->dbForeignKeyName, 'key', 'value'])
 				->from($this->dbMetaDataTableName);
 			$metaDataStmt = $metaDataQuery->executeQuery();
-			$metaDataRows = $metaDataStmt->fetchAll(\PDO::FETCH_ASSOC);
+			$metaDataRows = $metaDataStmt->fetchAllAssociative();
 
 			$metaDataById = [];
 			foreach ($metaDataRows as $metaDataRow) {
@@ -90,7 +90,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 					= $metaDataRow['value'];
 			}
 
-			while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+			while ($row = $stmt->fetchAssociative()) {
 				$id = $row['id'];
 
 				if (isset($metaDataById[$id])) {
@@ -129,7 +129,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 			->where($query->expr()->eq('backend_id', $query->createNamedParameter($backendId)))
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($resourceId)));
 		$stmt = $query->executeQuery();
-		$row = $stmt->fetch(\PDO::FETCH_ASSOC);
+		$row = $stmt->fetchAssociative();
 
 		if (!$row) {
 			return null;
@@ -140,7 +140,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 			->from($this->dbMetaDataTableName)
 			->where($metaDataQuery->expr()->eq($this->dbForeignKeyName, $metaDataQuery->createNamedParameter($row['id'])));
 		$metaDataStmt = $metaDataQuery->executeQuery();
-		$metaDataRows = $metaDataStmt->fetchAll(\PDO::FETCH_ASSOC);
+		$metaDataRows = $metaDataStmt->fetchAllAssociative();
 		$metadata = [];
 
 		foreach ($metaDataRows as $metaDataRow) {
@@ -160,7 +160,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 			->from($this->dbTableName)
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 		$stmt = $query->executeQuery();
-		$row = $stmt->fetch(\PDO::FETCH_ASSOC);
+		$row = $stmt->fetchAssociative();
 
 		if (!$row) {
 			return null;
@@ -171,7 +171,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 			->from($this->dbMetaDataTableName)
 			->where($metaDataQuery->expr()->eq($this->dbForeignKeyName, $metaDataQuery->createNamedParameter($row['id'])));
 		$metaDataStmt = $metaDataQuery->executeQuery();
-		$metaDataRows = $metaDataStmt->fetchAll(\PDO::FETCH_ASSOC);
+		$metaDataRows = $metaDataStmt->fetchAllAssociative();
 		$metadata = [];
 
 		foreach ($metaDataRows as $metaDataRow) {
@@ -221,7 +221,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 
 					$stmt = $query->executeQuery();
 					$principals = [];
-					while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+					while ($row = $stmt->fetchAssociative()) {
 						if (!$this->isAllowedToAccessResource($row, $usersGroups)) {
 							continue;
 						}
@@ -240,7 +240,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 
 					$stmt = $query->executeQuery();
 					$principals = [];
-					while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+					while ($row = $stmt->fetchAssociative()) {
 						if (!$this->isAllowedToAccessResource($row, $usersGroups)) {
 							continue;
 						}
@@ -366,7 +366,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 		}
 
 		$rows = [];
-		while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+		while ($row = $stmt->fetchAssociative()) {
 			$principalRow = $this->getPrincipalById($row[$this->dbForeignKeyName]);
 			if (!$principalRow) {
 				continue;
@@ -407,7 +407,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 				->where($query->expr()->eq('email', $query->createNamedParameter($email)));
 
 			$stmt = $query->executeQuery();
-			$row = $stmt->fetch(\PDO::FETCH_ASSOC);
+			$row = $stmt->fetchAssociative();
 
 			if (!$row) {
 				return null;
@@ -434,7 +434,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 				->where($query->expr()->eq('backend_id', $query->createNamedParameter($backendId)))
 				->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($resourceId)));
 			$stmt = $query->executeQuery();
-			$row = $stmt->fetch(\PDO::FETCH_ASSOC);
+			$row = $stmt->fetchAssociative();
 
 			if (!$row) {
 				return null;

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -26,7 +26,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
-use PDO;
 use Sabre\CardDAV\Backend\BackendInterface;
 use Sabre\CardDAV\Backend\SyncSupport;
 use Sabre\CardDAV\Plugin;
@@ -112,7 +111,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			$addressBooks = [];
 
 			$result = $select->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$addressBooks[$row['id']] = [
 					'id' => $row['id'],
 					'uri' => $row['uri'],
@@ -150,7 +149,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			$result = $select->executeQuery();
 
 			$readOnlyPropertyName = '{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only';
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				if ($row['principaluri'] === $principalUri) {
 					continue;
 				}
@@ -202,7 +201,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$addressBooks = [];
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$addressBooks[$row['id']] = [
 				'id' => $row['id'],
 				'uri' => $row['uri'],
@@ -229,7 +228,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->from('addressbooks')
 			->where($query->expr()->eq('id', $query->createNamedParameter($addressBookId, IQueryBuilder::PARAM_INT)))
 			->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 		if (!$row) {
 			return null;
@@ -259,7 +258,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->setMaxResults(1)
 			->executeQuery();
 
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 		if ($row === false) {
 			return null;
@@ -482,7 +481,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$cards = [];
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$row['etag'] = '"' . $row['etag'] . '"';
 
 			$modified = false;
@@ -519,7 +518,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->setMaxResults(1);
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		if (!$row) {
 			return false;
 		}
@@ -564,7 +563,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			$query->setParameter('uri', $uris, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $query->executeQuery();
 
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$row['etag'] = '"' . $row['etag'] . '"';
 
 				$modified = false;
@@ -891,7 +890,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 					)->orderBy('id')
 					->setMaxResults($limit);
 				$stmt = $qb->executeQuery();
-				$values = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+				$values = $stmt->fetchAllAssociative();
 				$stmt->closeCursor();
 				if (count($values) === 0) {
 					$result['syncToken'] = $initialSyncToken;
@@ -928,7 +927,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 				// This loop ensures that any duplicates are overwritten, only the
 				// last change on a node is relevant.
-				while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+				while ($row = $stmt->fetchAssociative()) {
 					$changes[$row['uri']] = $row['operation'];
 					$highestSyncToken = $row['synctoken'];
 				}
@@ -977,7 +976,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 				// No synctoken supplied, this is the initial sync.
 				$qb->setMaxResults($limit);
 				$stmt = $qb->executeQuery();
-				$values = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+				$values = $stmt->fetchAllAssociative();
 				if (empty($values)) {
 					$result['added'] = [];
 					return $result;
@@ -1239,7 +1238,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		}
 
 		$result = $query2->executeQuery();
-		$matches = $result->fetchAll();
+		$matches = $result->fetchAllAssociative();
 		$result->closeCursor();
 		$matches = array_map(function ($match) {
 			return (int)$match['cardid'];
@@ -1254,7 +1253,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		foreach (array_chunk($matches, 1000) as $matchesChunk) {
 			$query->setParameter('matches', $matchesChunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$result = $query->executeQuery();
-			$cardResults[] = $result->fetchAll();
+			$cardResults[] = $result->fetchAllAssociative();
 			$result->closeCursor();
 		}
 
@@ -1283,7 +1282,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->andWhere($query->expr()->eq('addressbookid', $query->createNamedParameter($bookId)))
 			->executeQuery();
 
-		$all = $result->fetchAll(PDO::FETCH_COLUMN);
+		$all = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		return $all;
@@ -1302,7 +1301,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->setParameter('id', $id);
 
 		$result = $query->executeQuery();
-		$uri = $result->fetch();
+		$uri = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!isset($uri['uri'])) {
@@ -1326,7 +1325,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->where($query->expr()->eq('uri', $query->createNamedParameter($uri)))
 			->andWhere($query->expr()->eq('addressbookid', $query->createNamedParameter($addressBookId)));
 		$queryResult = $query->executeQuery();
-		$contact = $queryResult->fetch();
+		$contact = $queryResult->fetchAssociative();
 		$queryResult->closeCursor();
 
 		if (is_array($contact)) {
@@ -1437,7 +1436,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->andWhere($query->expr()->eq('addressbookid', $query->createNamedParameter($addressBookId)));
 
 		$result = $query->executeQuery();
-		$cardIds = $result->fetch();
+		$cardIds = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!isset($cardIds['id'])) {

--- a/apps/dav/lib/Command/RemoveInvalidShares.php
+++ b/apps/dav/lib/Command/RemoveInvalidShares.php
@@ -42,7 +42,7 @@ class RemoveInvalidShares extends Command {
 			->from('dav_shares')
 			->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$principaluri = $row['principaluri'];
 			$p = $this->principalBackend->getPrincipalByPath($principaluri)
 				?? $this->remoteUserPrincipalBackend->getPrincipalByPath($principaluri);

--- a/apps/dav/lib/Controller/InvitationResponseController.php
+++ b/apps/dav/lib/Controller/InvitationResponseController.php
@@ -140,7 +140,7 @@ class InvitationResponseController extends Controller {
 			->from('calendar_invitations')
 			->where($query->expr()->eq('token', $query->createNamedParameter($token)));
 		$stmt = $query->executeQuery();
-		$row = $stmt->fetch(\PDO::FETCH_ASSOC);
+		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 
 		if (!$row) {

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -345,7 +345,7 @@ class CustomPropertiesBackend implements BackendInterface {
 			->where($qb->expr()->eq('propertypath', $qb->createNamedParameter($path)));
 		$result = $qb->executeQuery();
 		$props = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$props[$row['propertyname']] = $this->decodeValueFromDatabase($row['propertyvalue'], $row['valuetype']);
 		}
 		$result->closeCursor();
@@ -376,7 +376,7 @@ class CustomPropertiesBackend implements BackendInterface {
 
 		$propsByPath = [];
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$childPath = $prefix . $row['name'];
 			if (!isset($propsByPath[$childPath])) {
 				$propsByPath[$childPath] = [];
@@ -474,13 +474,13 @@ class CustomPropertiesBackend implements BackendInterface {
 			foreach ($chunks as $chunk) {
 				$qb->setParameter('requestedProperties', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 				$result = $qb->executeQuery();
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					$props[$row['propertyname']] = $this->decodeValueFromDatabase($row['propertyvalue'], $row['valuetype']);
 				}
 			}
 		} else {
 			$result = $qb->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$props[$row['propertyname']] = $this->decodeValueFromDatabase($row['propertyvalue'], $row['valuetype']);
 			}
 		}

--- a/apps/dav/lib/DAV/Sharing/SharingMapper.php
+++ b/apps/dav/lib/DAV/Sharing/SharingMapper.php
@@ -31,7 +31,7 @@ class SharingMapper {
 		}
 
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 		return $rows;
 	}
@@ -54,7 +54,7 @@ class SharingMapper {
 			->groupBy(['principaluri', 'access', 'resourceid'])
 			->executeQuery();
 
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 		return $rows;
 	}
@@ -133,7 +133,7 @@ class SharingMapper {
 			->orderBy('id')
 			->executeQuery();
 
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $rows;
@@ -149,7 +149,7 @@ class SharingMapper {
 	}
 
 	/**
-	 * @return array{principaluri: string}[]
+	 * @return list<array{principaluri: string}>
 	 * @throws \OCP\DB\Exception
 	 */
 	public function getPrincipalUrisByPrefix(string $resourceType, string $prefix): array {
@@ -168,14 +168,15 @@ class SharingMapper {
 			)
 			->executeQuery();
 
-		$rows = $result->fetchAll();
+		/** @var list<array{principaluri: string}> $rows */
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $rows;
 	}
 
 	/**
-	 * @psalm-return array{uri: string, principaluri: string}[]
+	 * @psalm-return list<array{uri: string, principaluri: string}>
 	 * @throws \OCP\DB\Exception
 	 */
 	public function getSharedCalendarsForRemoteUser(
@@ -206,7 +207,8 @@ class SharingMapper {
 				IQueryBuilder::PARAM_STR,
 			));
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll();
+		/** @var list<array{uri: string, principaluri: string}> $rows */
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $rows;
@@ -241,7 +243,7 @@ class SharingMapper {
 				IQueryBuilder::PARAM_STR,
 			));
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $rows;

--- a/apps/dav/lib/Migration/BuildCalendarSearchIndexBackgroundJob.php
+++ b/apps/dav/lib/Migration/BuildCalendarSearchIndexBackgroundJob.php
@@ -66,7 +66,7 @@ class BuildCalendarSearchIndexBackgroundJob extends QueuedJob {
 			->setMaxResults(500);
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch(\PDO::FETCH_ASSOC)) {
+		while ($row = $result->fetchAssociative()) {
 			$offset = $row['id'];
 
 			$calendarData = $row['calendardata'];

--- a/apps/dav/lib/Migration/BuildSocialSearchIndexBackgroundJob.php
+++ b/apps/dav/lib/Migration/BuildSocialSearchIndexBackgroundJob.php
@@ -62,7 +62,7 @@ class BuildSocialSearchIndexBackgroundJob extends QueuedJob {
 			->where($query->expr()->like('carddata', $query->createNamedParameter('%SOCIALPROFILE%')))
 			->andWhere($query->expr()->gt('id', $query->createNamedParameter((int)$offset, IQueryBuilder::PARAM_INT)))
 			->setMaxResults(100);
-		$social_cards = $query->executeQuery()->fetchAll();
+		$social_cards = $query->executeQuery()->fetchAllAssociative();
 
 		if (empty($social_cards)) {
 			return $stopAt;

--- a/apps/dav/lib/Migration/CalDAVRemoveEmptyValue.php
+++ b/apps/dav/lib/Migration/CalDAVRemoveEmptyValue.php
@@ -88,7 +88,7 @@ class CalDAVRemoveEmptyValue implements IRepairStep {
 				$query->setFirstResult($chunk * $chunkSize);
 				$result = $query->executeQuery();
 
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					if (mb_strpos($row['calendardata'], $pattern) !== false) {
 						unset($row['calendardata']);
 						$rows[] = $row;
@@ -112,7 +112,7 @@ class CalDAVRemoveEmptyValue implements IRepairStep {
 			));
 
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $rows;

--- a/apps/dav/lib/Migration/RefreshWebcalJobRegistrar.php
+++ b/apps/dav/lib/Migration/RefreshWebcalJobRegistrar.php
@@ -45,7 +45,7 @@ class RefreshWebcalJobRegistrar implements IRepairStep {
 		$stmt = $query->executeQuery();
 
 		$count = 0;
-		while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+		while ($row = $stmt->fetchAssociative()) {
 			$args = [
 				'principaluri' => $row['principaluri'],
 				'uri' => $row['uri'],

--- a/apps/dav/lib/Migration/RemoveClassifiedEventActivity.php
+++ b/apps/dav/lib/Migration/RemoveClassifiedEventActivity.php
@@ -58,7 +58,7 @@ class RemoveClassifiedEventActivity implements IRepairStep {
 			->where($query->expr()->eq('o.classification', $query->createNamedParameter(CalDavBackend::CLASSIFICATION_PRIVATE)));
 		$result = $query->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			if ($row['principaluri'] === null) {
 				continue;
 			}
@@ -92,7 +92,7 @@ class RemoveClassifiedEventActivity implements IRepairStep {
 			->where($query->expr()->eq('o.classification', $query->createNamedParameter(CalDavBackend::CLASSIFICATION_CONFIDENTIAL)));
 		$result = $query->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			if ($row['principaluri'] === null) {
 				continue;
 			}

--- a/apps/dav/lib/Migration/RemoveDeletedUsersCalendarSubscriptions.php
+++ b/apps/dav/lib/Migration/RemoveDeletedUsersCalendarSubscriptions.php
@@ -88,7 +88,7 @@ class RemoveDeletedUsersCalendarSubscriptions implements IRepairStep {
 			->setFirstResult($this->progress);
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$username = $this->getPrincipal($row['principaluri']);
 			if (!$this->userManager->userExists($username)) {
 				$this->orphanSubscriptionIds[] = (int)$row['id'];

--- a/apps/dav/lib/Migration/Version1025Date20240308063933.php
+++ b/apps/dav/lib/Migration/Version1025Date20240308063933.php
@@ -64,7 +64,7 @@ class Version1025Date20240308063933 extends SimpleMigrationStep {
 				->setFirstResult($limit)
 				->setMaxResults(1);
 			$oldestIdResult = $thresholdSelect->executeQuery();
-			$oldestId = $oldestIdResult->fetchColumn();
+			$oldestId = $oldestIdResult->fetchOne();
 			$oldestIdResult->closeCursor();
 
 			$qb = $this->db->getQueryBuilder();

--- a/apps/dav/lib/Settings/AvailabilitySettings.php
+++ b/apps/dav/lib/Settings/AvailabilitySettings.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
 use OCP\User\IAvailabilityCoordinator;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class AvailabilitySettings implements ISettings {
@@ -56,8 +57,8 @@ class AvailabilitySettings implements ISettings {
 			}
 		}
 
-		\OCP\Util::addStyle(Application::APP_ID, 'settings-personal-availability');
-		\OCP\Util::addScript(Application::APP_ID, 'settings-personal-availability');
+		Util::addStyle(Application::APP_ID, 'settings-personal-availability');
+		Util::addScript(Application::APP_ID, 'settings-personal-availability');
 		return new TemplateResponse(Application::APP_ID, 'settings-personal-availability');
 	}
 

--- a/apps/dav/lib/Settings/CalDAVSettings.php
+++ b/apps/dav/lib/Settings/CalDAVSettings.php
@@ -13,6 +13,7 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\Settings\IDelegatedSettings;
+use OCP\Util;
 
 class CalDAVSettings implements IDelegatedSettings {
 
@@ -45,8 +46,8 @@ class CalDAVSettings implements IDelegatedSettings {
 			$this->initialState->provideInitialState($key, $value === 'yes');
 		}
 
-		\OCP\Util::addScript(Application::APP_ID, 'settings-admin-caldav');
-		\OCP\Util::addStyle(Application::APP_ID, 'settings-admin-caldav');
+		Util::addScript(Application::APP_ID, 'settings-admin-caldav');
+		Util::addStyle(Application::APP_ID, 'settings-admin-caldav');
 		return new TemplateResponse(Application::APP_ID, 'settings-admin-caldav');
 	}
 

--- a/apps/dav/lib/Settings/ExampleContentSettings.php
+++ b/apps/dav/lib/Settings/ExampleContentSettings.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Settings\ISettings;
+use OCP\Util;
 
 class ExampleContentSettings implements ISettings {
 	public function __construct(
@@ -53,8 +54,8 @@ class ExampleContentSettings implements ISettings {
 			);
 		}
 
-		\OCP\Util::addStyle(Application::APP_ID, 'settings-admin-example-content');
-		\OCP\Util::addScript(Application::APP_ID, 'settings-admin-example-content');
+		Util::addStyle(Application::APP_ID, 'settings-admin-example-content');
+		Util::addScript(Application::APP_ID, 'settings-admin-example-content');
 		return new TemplateResponse(Application::APP_ID, 'settings-admin-example-content');
 	}
 

--- a/apps/dav/tests/unit/BackgroundJob/CleanupOrphanedChildrenJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanupOrphanedChildrenJobTest.php
@@ -87,7 +87,7 @@ class CleanupOrphanedChildrenJobTest extends TestCase {
 			->method('executeQuery')
 			->willReturn($result);
 		$result->expects(self::once())
-			->method('fetchAll')
+			->method('fetchAllAssociative')
 			->willReturn([]);
 		$result->expects(self::once())
 			->method('closeCursor');
@@ -115,7 +115,7 @@ class CleanupOrphanedChildrenJobTest extends TestCase {
 			->method('executeQuery')
 			->willReturn($result);
 		$result->expects(self::once())
-			->method('fetchAll')
+			->method('fetchAllAssociative')
 			->willReturn([
 				['id' => 42],
 				['id' => 43],
@@ -152,7 +152,7 @@ class CleanupOrphanedChildrenJobTest extends TestCase {
 			->method('executeQuery')
 			->willReturn($result);
 		$result->expects(self::once())
-			->method('fetchAll')
+			->method('fetchAllAssociative')
 			->willReturn(array_map(static fn ($i) => ['id' => 42 + $i], range(0, 999)));
 		$result->expects(self::once())
 			->method('closeCursor');

--- a/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
@@ -46,7 +46,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(4, $rows);
 
@@ -56,7 +56,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(2, $rows);
 	}
@@ -66,7 +66,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(4, $rows);
 
@@ -76,7 +76,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(1, $rows);
 	}
@@ -86,7 +86,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(4, $rows);
 
@@ -96,7 +96,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(3, $rows);
 	}
@@ -193,7 +193,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(4, $rows);
 
@@ -204,7 +204,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(5, $rows);
 
@@ -231,7 +231,7 @@ class BackendTest extends TestCase {
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(4, $rows);
 
@@ -247,7 +247,7 @@ class BackendTest extends TestCase {
 			->from('calendar_reminders')
 			->where($query->expr()->eq('id', $query->createNamedParameter($reminderId)))
 			->executeQuery()
-			->fetch();
+			->fetchAssociative();
 
 		$this->assertEquals((int)$row['notification_date'], 123700);
 	}

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -550,7 +550,7 @@ class CardDavBackendTest extends TestCase {
 			->orderBy('name');
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 
 		$this->assertSame(2, count($result));
@@ -575,7 +575,7 @@ class CardDavBackendTest extends TestCase {
 			->from('cards_properties');
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 
 		$this->assertSame(1, count($result));
@@ -620,7 +620,7 @@ class CardDavBackendTest extends TestCase {
 			->from('cards_properties');
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 
 		$this->assertSame(1, count($result));

--- a/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
@@ -71,7 +71,7 @@ class RemoveInvalidSharesTest extends TestCase {
 				),
 			));
 		$result = $query->executeQuery();
-		$data = $result->fetchAll();
+		$data = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $data;

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -422,7 +422,7 @@ EOF;
 
 		$stmt->expects($this->once())
 			->method('fetchAssociative')
-			->willReturn($return);
+			->willReturn($return ?? false);
 		$stmt->expects($this->once())
 			->method('closeCursor');
 

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -421,8 +421,7 @@ EOF;
 			]);
 
 		$stmt->expects($this->once())
-			->method('fetch')
-			->with(\PDO::FETCH_ASSOC)
+			->method('fetchAssociative')
 			->willReturn($return);
 		$stmt->expects($this->once())
 			->method('closeCursor');

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -112,7 +112,7 @@ class CustomPropertiesBackendTest extends TestCase {
 
 		$result = $query->executeQuery();
 		$data = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$value = $row['propertyvalue'];
 			if ((int)$row['valuetype'] === CustomPropertiesBackend::PROPERTY_TYPE_HREF) {
 				$value = new Href($value);

--- a/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
+++ b/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
@@ -58,8 +58,7 @@ class RefreshWebcalJobRegistrarTest extends TestCase {
 			->willReturn($statement);
 
 		$statement->expects($this->exactly(4))
-			->method('fetch')
-			->with(\PDO::FETCH_ASSOC)
+			->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				[
 					'principaluri' => 'foo1',
@@ -73,7 +72,7 @@ class RefreshWebcalJobRegistrarTest extends TestCase {
 					'principaluri' => 'foo3',
 					'uri' => 'bar3',
 				],
-				null
+				false,
 			);
 
 		$this->jobList->expects($this->exactly(3))

--- a/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
+++ b/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
@@ -80,7 +80,7 @@ class RemoveDeletedUsersCalendarSubscriptionsTest extends TestCase {
 			->willReturn(count($subscriptions));
 
 		$result
-			->method('fetch')
+			->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(...$subscriptions);
 
 		$qb->method('delete')

--- a/apps/dav/tests/unit/Paginate/PaginatePluginTest.php
+++ b/apps/dav/tests/unit/Paginate/PaginatePluginTest.php
@@ -134,7 +134,7 @@ class PaginatePluginTest extends TestCase {
 	private function expectSequentialCalls(MockObject $mock, string $method, array $expectedCalls): void {
 		$mock->expects(self::exactly(\count($expectedCalls)))
 			->method($method)
-			->willReturnCallback(function (...$args) use (&$expectedCalls) {
+			->willReturnCallback(function (...$args) use (&$expectedCalls): void {
 				$expected = array_shift($expectedCalls);
 				self::assertNotNull($expected);
 				self::assertSame($expected, $args);

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -271,7 +271,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			->where($query->expr()->eq('user', $query->createNamedParameter($share->getShareOwner())))
 			->andWhere($query->expr()->eq('mountpoint', $query->createNamedParameter($share->getTarget())));
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 
 		if (isset($result[0]) && (int)$result[0]['remote_id'] > 0) {
@@ -410,7 +410,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 		$query->select('remote_id')->from('federated_reshares')
 			->where($query->expr()->eq('share_id', $query->createNamedParameter((int)$share->getId())));
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!is_array($data) || !isset($data['remote_id'])) {
@@ -442,7 +442,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			->orderBy('id');
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$children[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -591,7 +591,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 
 		$cursor = $qb->executeQuery();
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[$data['fileid']][] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -647,7 +647,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 
 		$cursor = $qb->executeQuery();
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -667,7 +667,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			->andWhere($qb->expr()->in('share_type', $qb->createNamedParameter($this->supportedShareType, IQueryBuilder::PARAM_INT_ARRAY)));
 
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($data === false) {
@@ -700,7 +700,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			->executeQuery();
 
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -739,7 +739,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 
 		$cursor = $qb->executeQuery();
 
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -764,7 +764,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			->andWhere($qb->expr()->eq('token', $qb->createNamedParameter($token)))
 			->executeQuery();
 
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 
 		if ($data === false) {
 			throw new ShareNotFound('Share not found', $this->l->t('Could not find share'));
@@ -794,7 +794,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($data === false) {
@@ -907,7 +907,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			// This is not a typo, the group ID is really stored in the 'user' column
 			->andWhere($qb->expr()->eq('user', $qb->createNamedParameter($gid)));
 		$cursor = $qb->executeQuery();
-		$parentShareIds = $cursor->fetchAll(\PDO::FETCH_COLUMN);
+		$parentShareIds = $cursor->fetchFirstColumn();
 		$cursor->closeCursor();
 		if ($parentShareIds === []) {
 			return;
@@ -929,7 +929,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			// This is not a typo, the group ID is really stored in the 'user' column
 			->andWhere($qb->expr()->eq('user', $qb->createNamedParameter($gid)));
 		$cursor = $qb->executeQuery();
-		$parentShareIds = $cursor->fetchAll(\PDO::FETCH_COLUMN);
+		$parentShareIds = $cursor->fetchFirstColumn();
 		$cursor->closeCursor();
 		if ($parentShareIds === []) {
 			return;
@@ -1047,14 +1047,14 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 		$cursor = $qb->executeQuery();
 
 		if ($currentAccess === false) {
-			$remote = $cursor->fetch() !== false;
+			$remote = $cursor->fetchAssociative() !== false;
 			$cursor->closeCursor();
 
 			return ['remote' => $remote];
 		}
 
 		$remote = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$remote[$row['share_with']] = [
 				'node_id' => $row['file_source'],
 				'token' => $row['token'],
@@ -1073,7 +1073,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			->where($qb->expr()->in('share_type', $qb->createNamedParameter([IShare::TYPE_REMOTE_GROUP, IShare::TYPE_REMOTE], IQueryBuilder::PARAM_INT_ARRAY)));
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			try {
 				$share = $this->createShareObject($data);
 			} catch (InvalidShare $e) {

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -482,7 +482,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 			);
 
 		$result = $qb->executeQuery();
-		$share = $result->fetch();
+		$share = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($token && $id && !empty($share)) {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -169,7 +169,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
 			->executeQuery();
 
-		$data = $stmt->fetch();
+		$data = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 
 		$expected = [
@@ -256,7 +256,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
 			->executeQuery();
 
-		$data = $stmt->fetch();
+		$data = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 
 		$this->assertFalse($data);
@@ -317,7 +317,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
 			->executeQuery();
 
-		$data = $stmt->fetch();
+		$data = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 
 		$this->assertFalse($data);
@@ -360,7 +360,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
 			->executeQuery();
 
-		$data = $stmt->fetch();
+		$data = $stmt->fetchAssociative();
 		$stmt->closeCursor();
 
 		$this->assertFalse($data);
@@ -732,7 +732,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$qb->expr()->eq('id', $qb->createNamedParameter($id))
 			);
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetchAll();
+		$data = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		$this->assertCount($rowDeleted ? 0 : 1, $data);

--- a/apps/federation/lib/DbHandler.php
+++ b/apps/federation/lib/DbHandler.php
@@ -84,14 +84,15 @@ class DbHandler {
 			->setParameter('id', $id, IQueryBuilder::PARAM_INT);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		/** @var array{id: int, url: string, url_hash: string, token: ?string, shared_secret: ?string, status: int, sync_token: ?string} $result */
+		$result = $qResult->fetchAssociative();
 		$qResult->closeCursor();
 
-		if (empty($result)) {
+		if ($result === false) {
 			throw new \Exception('No Server found with ID: ' . $id);
 		}
 
-		return $result[0];
+		return $result;
 	}
 
 	/**
@@ -105,7 +106,7 @@ class DbHandler {
 		$query->select(['url', 'url_hash', 'id', 'status', 'shared_secret', 'sync_token'])
 			->from($this->dbTable);
 		$statement = $query->executeQuery();
-		$result = $statement->fetchAll();
+		$result = $statement->fetchAllAssociative();
 		$statement->closeCursor();
 		return $result;
 	}
@@ -121,7 +122,7 @@ class DbHandler {
 			->where($query->expr()->eq('url_hash', $query->createParameter('url_hash')))
 			->setParameter('url_hash', $hash);
 		$statement = $query->executeQuery();
-		$result = $statement->fetchAll();
+		$result = $statement->fetchAllAssociative();
 		$statement->closeCursor();
 
 		return !empty($result);
@@ -153,7 +154,7 @@ class DbHandler {
 			->setParameter('url_hash', $hash);
 
 		$statement = $query->executeQuery();
-		$result = $statement->fetch();
+		$result = $statement->fetchAssociative();
 		$statement->closeCursor();
 
 		if (!isset($result['token'])) {
@@ -188,7 +189,7 @@ class DbHandler {
 			->setParameter('url_hash', $hash);
 
 		$statement = $query->executeQuery();
-		$result = $statement->fetch();
+		$result = $statement->fetchAssociative();
 		$statement->closeCursor();
 		return (string)$result['shared_secret'];
 	}
@@ -219,7 +220,7 @@ class DbHandler {
 			->setParameter('url_hash', $hash);
 
 		$statement = $query->executeQuery();
-		$result = $statement->fetch();
+		$result = $statement->fetchAssociative();
 		$statement->closeCursor();
 		return (int)$result['status'];
 	}
@@ -259,7 +260,7 @@ class DbHandler {
 			->where($query->expr()->eq('shared_secret', $query->createNamedParameter($password)));
 
 		$statement = $query->executeQuery();
-		$result = $statement->fetch();
+		$result = $statement->fetchAssociative();
 		$statement->closeCursor();
 		return !empty($result);
 	}

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -37,7 +37,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertEmpty($result, 'we need to start with a empty trusted_servers table');
 	}
@@ -62,7 +62,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame($expectedUrl, $result[0]['url']);
@@ -86,7 +86,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(2, $result);
 		$this->assertSame('server1', $result[0]['url']);
@@ -98,7 +98,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame('server1', $result[0]['url']);
@@ -147,7 +147,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame(null, $result[0]['token']);
@@ -155,7 +155,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame('token', $result[0]['token']);
@@ -174,7 +174,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame(null, $result[0]['shared_secret']);
@@ -182,7 +182,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame('secret', $result[0]['shared_secret']);
@@ -201,7 +201,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame(TrustedServers::STATUS_PENDING, (int)$result[0]['status']);
@@ -209,7 +209,7 @@ class DbHandlerTest extends TestCase {
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 
 		$qResult = $query->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertSame(TrustedServers::STATUS_OK, (int)$result[0]['status']);

--- a/apps/files/lib/BackgroundJob/DeleteOrphanedItems.php
+++ b/apps/files/lib/BackgroundJob/DeleteOrphanedItems.php
@@ -81,7 +81,7 @@ class DeleteOrphanedItems extends TimedJob {
 
 			$deletedInLastChunk = self::CHUNK_SIZE;
 			while ($deletedInLastChunk === self::CHUNK_SIZE) {
-				$chunk = $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+				$chunk = $query->executeQuery()->fetchFirstColumn();
 				$deletedInLastChunk = count($chunk);
 
 				$deleteQuery->setParameter('objectid', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
@@ -112,7 +112,7 @@ class DeleteOrphanedItems extends TimedJob {
 		$minId = 0;
 		while (true) {
 			$query->setParameter('min_id', $minId);
-			$rows = $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+			$rows = $query->executeQuery()->fetchFirstColumn();
 			if (count($rows) > 0) {
 				$minId = $rows[count($rows) - 1];
 				yield $rows;
@@ -127,7 +127,7 @@ class DeleteOrphanedItems extends TimedJob {
 		$qb->select('fileid')
 			->from('filecache')
 			->where($qb->expr()->in('fileid', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)));
-		$found = $qb->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		$found = $qb->executeQuery()->fetchFirstColumn();
 		return array_diff($ids, $found);
 	}
 

--- a/apps/files/lib/BackgroundJob/ScanFiles.php
+++ b/apps/files/lib/BackgroundJob/ScanFiles.php
@@ -76,7 +76,7 @@ class ScanFiles extends TimedJob {
 				->runAcrossAllShards();
 
 			$result = $query->executeQuery();
-			while ($res = $result->fetch()) {
+			while ($res = $result->fetchAssociative()) {
 				if ($res['user_id']) {
 					return $res['user_id'];
 				}
@@ -114,7 +114,7 @@ class ScanFiles extends TimedJob {
 		$query = $this->connection->getQueryBuilder();
 		$query->selectDistinct('storage_id')
 			->from('mounts');
-		return $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		return $query->executeQuery()->fetchFirstColumn();
 	}
 
 	/**

--- a/apps/files/lib/Command/RepairTree.php
+++ b/apps/files/lib/Command/RepairTree.php
@@ -78,7 +78,7 @@ class RepairTree extends Command {
 			->from('filecache')
 			->where($query->expr()->eq('storage', $query->createNamedParameter($storage)))
 			->andWhere($query->expr()->eq('path_hash', $query->createNamedParameter(md5($path))));
-		return $query->executeQuery()->fetch(\PDO::FETCH_COLUMN);
+		return $query->executeQuery()->fetchOne();
 	}
 
 	private function deleteById(int $fileId): void {
@@ -108,6 +108,6 @@ class RepairTree extends Command {
 				$query->expr()->neq('f.storage', 'p.storage')
 			));
 
-		return $query->executeQuery()->fetchAll();
+		return $query->executeQuery()->fetchAllAssociative();
 	}
 }

--- a/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
+++ b/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
@@ -44,7 +44,7 @@ class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 		$query->select('*')
 			->from($table);
 		$result = $query->executeQuery();
-		$mapping = $result->fetchAll();
+		$mapping = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $mapping;

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -62,7 +62,7 @@ class DeleteOrphanedFilesTest extends TestCase {
 		$query->select('*')
 			->from('filecache')
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId)));
-		return $query->executeQuery()->fetchAll();
+		return $query->executeQuery()->fetchAllAssociative();
 	}
 
 	protected function getMounts(int $storageId): array {
@@ -70,7 +70,7 @@ class DeleteOrphanedFilesTest extends TestCase {
 		$query->select('*')
 			->from('mounts')
 			->where($query->expr()->eq('storage_id', $query->createNamedParameter($storageId)));
-		return $query->executeQuery()->fetchAll();
+		return $query->executeQuery()->fetchAllAssociative();
 	}
 
 	/**

--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -177,7 +177,7 @@ class Notify extends StorageAuthBase {
 			->where($qb->expr()->eq('mount_id', $qb->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('path_hash', $qb->createNamedParameter($pathHash, IQueryBuilder::PARAM_STR)))
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 	}
 
 	private function updateParent(array $storageIds, string $parent): int {

--- a/apps/files_external/lib/Migration/Version1015Date20211104103506.php
+++ b/apps/files_external/lib/Migration/Version1015Date20211104103506.php
@@ -37,7 +37,7 @@ class Version1015Date20211104103506 extends SimpleMigrationStep {
 			throw new \Exception('Could not fetch existing mounts for migration');
 		}
 
-		while ($mount = $mounts->fetch()) {
+		while ($mount = $mounts->fetchAssociative()) {
 			$config = $this->getStorageConfig((int)$mount['mount_id']);
 			$hostname = $config['hostname'];
 			$bucket = $config['bucket'];
@@ -82,7 +82,7 @@ class Version1015Date20211104103506 extends SimpleMigrationStep {
 			->from('external_config')
 			->where($qb->expr()->eq('mount_id', $qb->createPositionalParameter($mountId)));
 		$config = [];
-		foreach ($qb->executeQuery()->fetchAll() as $row) {
+		foreach ($qb->executeQuery()->fetchAllAssociative() as $row) {
 			$config[$row['key']] = $row['value'];
 		}
 		return $config;

--- a/apps/files_external/lib/Service/DBConfigService.php
+++ b/apps/files_external/lib/Service/DBConfigService.php
@@ -100,7 +100,7 @@ class DBConfigService {
 			)
 			->groupBy(['a.mount_id']);
 		$stmt = $query->executeQuery();
-		$result = $stmt->fetchAll();
+		$result = $stmt->fetchAllAssociative();
 		$stmt->closeCursor();
 
 		foreach ($result as $row) {
@@ -378,7 +378,7 @@ class DBConfigService {
 
 	private function getMountsFromQuery(IQueryBuilder $query) {
 		$result = $query->executeQuery();
-		$mounts = $result->fetchAll();
+		$mounts = $result->fetchAllAssociative();
 		$uniqueMounts = [];
 		foreach ($mounts as $mount) {
 			$id = $mount['mount_id'];
@@ -429,7 +429,7 @@ class DBConfigService {
 			->where($builder->expr()->in('mount_id', $placeHolders));
 
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$result = [];
@@ -519,6 +519,6 @@ class DBConfigService {
 			->where($builder->expr()->eq('mount_point', $builder->createNamedParameter('/')))
 			->setMaxResults(1);
 		$result = $query->executeQuery();
-		return count($result->fetchAll()) > 0;
+		return count($result->fetchAllAssociative()) > 0;
 	}
 }

--- a/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
+++ b/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
@@ -37,7 +37,7 @@ class FederatedSharesDiscoverJob extends TimedJob {
 			->from('share_external');
 
 		$result = $qb->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$this->discoveryService->discover($row['remote'], 'FEDERATED_SHARING', true);
 			try {
 				$this->ocmDiscoveryService->discover($row['remote'], true);

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -140,7 +140,7 @@ class CleanupRemoteStorages extends Command {
 
 		$remoteStorages = [];
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$remoteStorages[$row['id']] = $row['numeric_id'];
 		}
 		$result->closeCursor();
@@ -156,7 +156,7 @@ class CleanupRemoteStorages extends Command {
 
 		$remoteShareIds = [];
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$cloudId = $this->cloudIdManager->getCloudId($row['owner'], $row['remote']);
 			$remote = $cloudId->getRemote();
 

--- a/apps/files_sharing/lib/ExpireSharesJob.php
+++ b/apps/files_sharing/lib/ExpireSharesJob.php
@@ -58,7 +58,7 @@ class ExpireSharesJob extends TimedJob {
 			);
 
 		$shares = $qb->executeQuery();
-		while ($share = $shares->fetch()) {
+		while ($share = $shares->fetchAssociative()) {
 			if ((int)$share['share_type'] === IShare::TYPE_LINK) {
 				$id = 'ocinternal';
 			} elseif ((int)$share['share_type'] === IShare::TYPE_EMAIL) {

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -160,7 +160,7 @@ class Manager {
 			->from('share_external')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
 			->executeQuery();
-		$share = $result->fetch();
+		$share = $result->fetchAssociative();
 		$result->closeCursor();
 		return $share;
 	}
@@ -177,7 +177,7 @@ class Manager {
 			->from('share_external')
 			->where($qb->expr()->eq('share_token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR)))
 			->executeQuery();
-		$share = $result->fetch();
+		$share = $result->fetchAssociative();
 		$result->closeCursor();
 		return $share;
 	}
@@ -191,7 +191,7 @@ class Manager {
 				$qb->expr()->eq('user', $qb->createNamedParameter($uid, IQueryBuilder::PARAM_STR)),
 			))
 			->executeQuery();
-		$share = $result->fetch();
+		$share = $result->fetchAssociative();
 		$result->closeCursor();
 		if ($share !== false) {
 			return $share;
@@ -621,7 +621,7 @@ class Manager {
 				->where($qb->expr()->eq('mountpoint_hash', $qb->createNamedParameter($hash)))
 				->andWhere($qb->expr()->eq('user', $qb->createNamedParameter($this->uid)));
 			$result = $qb->executeQuery();
-			$share = $result->fetch();
+			$share = $result->fetchAssociative();
 			$result->closeCursor();
 			if ($share !== false && (int)$share['share_type'] === IShare::TYPE_USER) {
 				try {
@@ -681,7 +681,7 @@ class Manager {
 				->where($qb->expr()->eq('user', $qb->createNamedParameter($uid)))
 				->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_USER)));
 			$result = $qb->executeQuery();
-			$shares = $result->fetchAll();
+			$shares = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			foreach ($shares as $share) {
@@ -720,7 +720,7 @@ class Manager {
 				->where($qb->expr()->eq('user', $qb->createNamedParameter($gid)))
 				->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)));
 			$result = $qb->executeQuery();
-			$shares = $result->fetchAll();
+			$shares = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			$deletedGroupShares = [];
@@ -799,7 +799,8 @@ class Manager {
 
 		try {
 			$result = $qb->executeQuery();
-			$shares = $result->fetchAll();
+			/** @var list<Files_SharingRemoteShare> $shares */
+			$shares = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			// remove parent group share entry if we have a specific user share entry for the user

--- a/apps/files_sharing/lib/External/MountProvider.php
+++ b/apps/files_sharing/lib/External/MountProvider.php
@@ -57,7 +57,7 @@ class MountProvider implements IMountProvider {
 			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
 		$result = $qb->executeQuery();
 		$mounts = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$row['manager'] = $this;
 			$row['token'] = $row['share_token'];
 			$mounts[] = $this->getMount($user, $row, $loader);

--- a/apps/files_sharing/lib/OrphanHelper.php
+++ b/apps/files_sharing/lib/OrphanHelper.php
@@ -68,7 +68,7 @@ class OrphanHelper {
 		}
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			yield [
 				'id' => (int)$row['id'],
 				'owner' => (string)$row['uid_owner'],

--- a/apps/files_sharing/lib/ShareBackend/File.php
+++ b/apps/files_sharing/lib/ShareBackend/File.php
@@ -191,7 +191,7 @@ class File implements Share_Backend_File_Dependent {
 						$qb->expr()->eq('id', $qb->createNamedParameter($parent))
 					);
 				$result = $qb->executeQuery();
-				$item = $result->fetch();
+				$item = $result->fetchAssociative();
 				$result->closeCursor();
 				if (isset($item['parent'])) {
 					$parent = $item['parent'];

--- a/apps/files_sharing/lib/ShareBackend/Folder.php
+++ b/apps/files_sharing/lib/ShareBackend/Folder.php
@@ -24,7 +24,7 @@ class Folder extends File implements Share_Backend_Collection {
 			);
 		$result = $qb->executeQuery();
 
-		if (($row = $result->fetch()) !== false) {
+		if (($row = $result->fetchAssociative()) !== false) {
 			$mimetype = (int)$row['id'];
 		} else {
 			$mimetype = -1;
@@ -47,7 +47,7 @@ class Folder extends File implements Share_Backend_Collection {
 			$result = $qb->executeQuery();
 
 			$parents = [];
-			while ($file = $result->fetch()) {
+			foreach ($result->iterateAssociative() as $file) {
 				$children[] = ['source' => $file['fileid'], 'file_path' => $file['name']];
 				// If a child folder is found look inside it
 				if ((int)$file['mimetype'] === $mimetype) {

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -255,7 +255,7 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 				->where($builder->expr()->eq('fileid', $builder->createNamedParameter($this->getStorageRootId())));
 
 			$result = $query->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 			if ($row) {
 				return (int)$row['storage'];

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -132,11 +132,11 @@ class SharesReminderJob extends TimedJob {
 			)
 			->setMaxResults(SharesReminderJob::CHUNK_SIZE);
 
-		$shares = $qb->executeQuery()->fetchAll();
-		return array_values(array_map(fn ($share): array => [
+		$shares = $qb->executeQuery()->fetchAllAssociative();
+		return array_map(fn ($share): array => [
 			'id' => (int)$share['id'],
 			'share_type' => (int)$share['share_type'],
-		], $shares));
+		], $shares);
 	}
 
 	/**
@@ -171,12 +171,12 @@ class SharesReminderJob extends TimedJob {
 				)
 			);
 
-		$shares = $qb->executeQuery()->fetchAll();
-		$shares = array_values(array_map(fn ($share): array => [
+		$shares = $qb->executeQuery()->fetchAllAssociative();
+		$shares = array_map(fn ($share): array => [
 			'id' => (int)$share['id'],
 			'share_type' => (int)$share['share_type'],
 			'file_source' => (int)$share['file_source'],
-		], $shares));
+		], $shares);
 		return $this->filterSharesWithEmptyFolders($shares, self::CHUNK_SIZE);
 	}
 
@@ -198,7 +198,7 @@ class SharesReminderJob extends TimedJob {
 			$chunkFileIds = array_map(fn ($share): int => $share['file_source'], $chunk);
 			$chunkByFileId = array_combine($chunkFileIds, $chunk);
 			$query->setParameter('fileids', $chunkFileIds, IQueryBuilder::PARAM_INT_ARRAY);
-			$chunkResults = $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+			$chunkResults = $query->executeQuery()->fetchFirstColumn();
 			foreach ($chunkResults as $folderId) {
 				$results[] = $chunkByFileId[$folderId];
 			}

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -5529,8 +5529,8 @@ class ShareAPIControllerTest extends TestCase {
 		$owner = $this->createMock(IUser::class);
 		$storage = $this->createMock(SharedStorage::class);
 		$originalShare = $this->createMock(IShare::class);
-		$attributes = $this->createMock(\OCP\Share\IAttributes::class);
-		$shareAttributes = $this->createMock(\OCP\Share\IAttributes::class);
+		$attributes = $this->createMock(IShareAttributes::class);
+		$shareAttributes = $this->createMock(IShareAttributes::class);
 
 		$share->method('getSharedBy')->willReturn('sharedByUser');
 		$share->method('getNodeId')->willReturn(42);
@@ -5565,7 +5565,7 @@ class ShareAPIControllerTest extends TestCase {
 		$node = $this->createMock(File::class);
 		$userFolder = $this->createMock(Folder::class);
 		$owner = $this->createMock(IUser::class);
-		$storage = $this->createMock(\OCA\Files_Sharing\External\Storage::class);
+		$storage = $this->createMock(Storage::class);
 
 		$share->method('getSharedBy')->willReturn('sharedByUser');
 		$share->method('getNodeId')->willReturn(42);
@@ -5575,7 +5575,7 @@ class ShareAPIControllerTest extends TestCase {
 		$node->method('getStorage')->willReturn($storage);
 		$storage->method('instanceOfStorage')->willReturnMap([
 			[SharedStorage::class, false],
-			[\OCA\Files_Sharing\External\Storage::class, true]
+			[Storage::class, true]
 		]);
 
 		$userFolder->method('getById')->with(42)->willReturn([$node]);

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -105,7 +105,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 	private function getShares() {
 		$shares = [];
 		$result = $this->connection->executeQuery('SELECT * FROM `*PREFIX*share`');
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$shares[] = $row;
 		}
 		$result->closeCursor();

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -85,7 +85,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 			->from('share')
 			->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$shares[] = $row;
 		}
 		$result->closeCursor();

--- a/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
+++ b/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
@@ -91,7 +91,7 @@ class SetPasswordColumnTest extends TestCase {
 		$query->select('*')
 			->from('share');
 		$result = $query->executeQuery();
-		$allShares = $result->fetchAll();
+		$allShares = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		foreach ($allShares as $share) {

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -112,7 +112,7 @@ class Trashbin implements IEventListener {
 			->where($query->expr()->eq('user', $query->createNamedParameter($user)));
 		$result = $query->executeQuery();
 		$array = [];
-		while ($row = $result->fetch()) {
+		foreach ($result->iterateAssociative() as $row) {
 			$array[$row['id']][$row['timestamp']] = [
 				'location' => (string)$row['location'],
 				'deletedBy' => (string)$row['deleted_by'],
@@ -139,7 +139,7 @@ class Trashbin implements IEventListener {
 			->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (isset($row['location'])) {
@@ -1017,7 +1017,7 @@ class Trashbin implements IEventListener {
 			->andWhere($query->expr()->iLike('name', $query->createNamedParameter($pattern)));
 
 		$result = $query->executeQuery();
-		$entries = $result->fetchAll();
+		$entries = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		/** @var CacheEntry[] $matches */

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -65,7 +65,7 @@ class CleanUpTest extends TestCase {
 		$result = $getAllQuery->select('id')
 			->from($this->trashTable)
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 		$this->assertCount(10, $result);
 	}
 
@@ -97,7 +97,7 @@ class CleanUpTest extends TestCase {
 				->from($this->trashTable);
 
 			$qResult = $query->executeQuery();
-			$result = $qResult->fetchAll();
+			$result = $qResult->fetchAllAssociative();
 			$qResult->closeCursor();
 
 			$this->assertCount(5, $result);
@@ -111,7 +111,7 @@ class CleanUpTest extends TestCase {
 			$result = $getAllQuery->select('id')
 				->from($this->trashTable)
 				->executeQuery()
-				->fetchAll();
+				->fetchAllAssociative();
 			$this->assertCount(10, $result);
 		}
 	}

--- a/apps/files_versions/lib/Db/VersionsMapper.php
+++ b/apps/files_versions/lib/Db/VersionsMapper.php
@@ -95,7 +95,7 @@ class VersionsMapper extends QBMapper {
 
 			$filesIdsSelect->setParameter('offset', $offset, IQueryBuilder::PARAM_INT);
 			$result = $filesIdsSelect->executeQuery();
-			$fileIds = $result->fetchAll(\PDO::FETCH_COLUMN);
+			$fileIds = $result->fetchFirstColumn();
 			$offset = end($fileIds);
 
 			yield $fileIds;

--- a/apps/oauth2/lib/Migration/SetTokenExpiration.php
+++ b/apps/oauth2/lib/Migration/SetTokenExpiration.php
@@ -36,7 +36,7 @@ class SetTokenExpiration implements IRepairStep {
 
 		$cursor = $qb->executeQuery();
 
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$token = AccessToken::fromRow($row);
 			try {
 				$appToken = $this->tokenProvider->getTokenById($token->getTokenId());

--- a/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
+++ b/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
@@ -52,7 +52,7 @@ class Version011601Date20230522143227 extends SimpleMigrationStep {
 		$qbSelect->select('id', 'secret')
 			->from('oauth2_clients');
 		$req = $qbSelect->executeQuery();
-		while ($row = $req->fetch()) {
+		while ($row = $req->fetchAssociative()) {
 			$id = $row['id'];
 			$secret = $row['secret'];
 			$encryptedSecret = $this->crypto->encrypt($secret);

--- a/apps/oauth2/lib/Migration/Version011901Date20240829164356.php
+++ b/apps/oauth2/lib/Migration/Version011901Date20240829164356.php
@@ -35,7 +35,7 @@ class Version011901Date20240829164356 extends SimpleMigrationStep {
 		$qbSelect->select('id', 'secret')
 			->from('oauth2_clients');
 		$req = $qbSelect->executeQuery();
-		while ($row = $req->fetch()) {
+		while ($row = $req->fetchAssociative()) {
 			$id = $row['id'];
 			$storedEncryptedSecret = $row['secret'];
 			$secret = $this->crypto->decrypt($storedEncryptedSecret);

--- a/apps/settings/lib/Settings/Admin/Server.php
+++ b/apps/settings/lib/Settings/Admin/Server.php
@@ -70,7 +70,7 @@ class Server implements IDelegatedSettings {
 			->setMaxResults(1);
 
 		$result = $query->executeQuery();
-		if ($row = $result->fetch()) {
+		if ($row = $result->fetchAssociative()) {
 			$maxAge = (int)$row['last_checked'];
 		} else {
 			$maxAge = $this->timeFactory->getTime();

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -43,7 +43,7 @@ class SupportedDatabase implements ISetupCheck {
 		if ($databasePlatform === IDBConnection::PLATFORM_MYSQL || $databasePlatform === IDBConnection::PLATFORM_MARIADB) {
 			$statement = $this->connection->prepare("SHOW VARIABLES LIKE 'version';");
 			$result = $statement->execute();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$version = $row['Value'];
 			$versionlc = strtolower($version);
 			// we only care about X.Y not X.Y.Z differences
@@ -89,7 +89,7 @@ class SupportedDatabase implements ISetupCheck {
 		} elseif ($databasePlatform === IDBConnection::PLATFORM_POSTGRES) {
 			$statement = $this->connection->prepare('SHOW server_version;');
 			$result = $statement->execute();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$version = $row['server_version'];
 			$versionlc = strtolower($version);
 			// we only care about X not X.Y or X.Y.Z differences

--- a/apps/settings/tests/Command/AdminDelegation/AddTest.php
+++ b/apps/settings/tests/Command/AdminDelegation/AddTest.php
@@ -11,6 +11,7 @@ namespace OCA\Settings\Tests\Command\AdminDelegation;
 use OC\Settings\AuthorizedGroup;
 use OCA\Settings\Command\AdminDelegation\Add;
 use OCA\Settings\Service\AuthorizedGroupService;
+use OCA\Settings\Settings\Admin\Server;
 use OCP\IGroupManager;
 use OCP\Settings\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -45,7 +46,7 @@ class AddTest extends TestCase {
 	}
 
 	public function testExecuteSuccessfulDelegation(): void {
-		$settingClass = \OCA\Settings\Settings\Admin\Server::class;
+		$settingClass = Server::class;
 		$groupId = 'testgroup';
 
 		// Mock valid delegated settings class
@@ -93,7 +94,7 @@ class AddTest extends TestCase {
 	}
 
 	public function testExecuteNonExistentGroup(): void {
-		$settingClass = \OCA\Settings\Settings\Admin\Server::class;
+		$settingClass = Server::class;
 		$groupId = 'nonexistentgroup';
 
 		$this->input->expects($this->exactly(2))

--- a/apps/sharebymail/lib/Settings/Admin.php
+++ b/apps/sharebymail/lib/Settings/Admin.php
@@ -10,6 +10,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IL10N;
 use OCP\Settings\IDelegatedSettings;
+use OCP\Util;
 
 class Admin implements IDelegatedSettings {
 	public function __construct(
@@ -26,8 +27,8 @@ class Admin implements IDelegatedSettings {
 		$this->initialState->provideInitialState('sendPasswordMail', $this->settingsManager->sendPasswordByMail());
 		$this->initialState->provideInitialState('replyToInitiator', $this->settingsManager->replyToInitiator());
 
-		\OCP\Util::addStyle('sharebymail', 'admin-settings');
-		\OCP\Util::addScript('sharebymail', 'admin-settings');
+		Util::addStyle('sharebymail', 'admin-settings');
+		Util::addScript('sharebymail', 'admin-settings');
 		return new TemplateResponse('sharebymail', 'settings-admin', [], '');
 	}
 

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -650,7 +650,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->orderBy('id');
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$children[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -845,7 +845,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 		$cursor = $qb->executeQuery();
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -865,7 +865,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_EMAIL)));
 
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($data === false) {
@@ -896,7 +896,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->executeQuery();
 
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -935,7 +935,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 		$cursor = $qb->executeQuery();
 
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -958,7 +958,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->andWhere($qb->expr()->eq('token', $qb->createNamedParameter($token)))
 			->executeQuery();
 
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 
 		if ($data === false) {
 			throw new ShareNotFound('Share not found', $this->l->t('Could not find share'));
@@ -1099,7 +1099,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($data === false) {
@@ -1153,7 +1153,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 		$cursor = $qb->executeQuery();
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[$data['fileid']][] = $this->createShareObject($data);
 		}
 		$cursor->closeCursor();
@@ -1180,7 +1180,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 		$public = false;
 		$mail = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$public = true;
 			if ($currentAccess === false) {
 				$mail[] = $row['share_with'];
@@ -1208,7 +1208,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			);
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			try {
 				$share = $this->createShareObject($data);
 			} catch (InvalidShare $e) {

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -747,7 +747,7 @@ class ShareByMailProviderTest extends TestCase {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 
 		$qResult = $qb->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 
 		$this->assertSame(1, count($result));
@@ -800,7 +800,7 @@ class ShareByMailProviderTest extends TestCase {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 
 		$qResult = $qb->executeQuery();
-		$result = $qResult->fetchAll();
+		$result = $qResult->fetchAllAssociative();
 		$qResult->closeCursor();
 
 		$this->assertSame(1, count($result));
@@ -1032,7 +1032,7 @@ class ShareByMailProviderTest extends TestCase {
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 
 		$result = $query->executeQuery();
-		$before = $result->fetchAll();
+		$before = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$this->assertTrue(is_array($before));
@@ -1045,7 +1045,7 @@ class ShareByMailProviderTest extends TestCase {
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 
 		$result = $query->executeQuery();
-		$after = $result->fetchAll();
+		$after = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$this->assertTrue(is_array($after));
@@ -1068,7 +1068,7 @@ class ShareByMailProviderTest extends TestCase {
 		$query->select('*')->from('share');
 
 		$result = $query->executeQuery();
-		$before = $result->fetchAll();
+		$before = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$this->assertTrue(is_array($before));
@@ -1083,7 +1083,7 @@ class ShareByMailProviderTest extends TestCase {
 		$query->select('*')->from('share');
 
 		$result = $query->executeQuery();
-		$after = $result->fetchAll();
+		$after = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$this->assertTrue(is_array($after));

--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -68,7 +68,7 @@ class MigrateBackgroundImages extends QueuedJob {
 				->andWhere($selector->expr()->eq('configvalue', $selector->createNamedParameter('custom', IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR))
 				->executeQuery();
 
-			$userIds = $result->fetchAll(\PDO::FETCH_COLUMN);
+			$userIds = $result->fetchFirstColumn();
 			$this->storeUserIdsToProcess($userIds);
 		} catch (\Throwable $t) {
 			$this->jobList->add(self::class, ['stage' => self::STAGE_PREPARE]);

--- a/apps/theming/lib/Jobs/RestoreBackgroundImageColor.php
+++ b/apps/theming/lib/Jobs/RestoreBackgroundImageColor.php
@@ -75,7 +75,7 @@ class RestoreBackgroundImageColor extends QueuedJob {
 				->andWhere($qb2->expr()->isNull('b.userid'))
 				->executeQuery();
 
-			$userIds = $result->fetchAll(\PDO::FETCH_COLUMN);
+			$userIds = $result->fetchFirstColumn();
 			$this->logger->info('Prepare to restore background information for {users} users', ['users' => count($userIds)]);
 			$this->storeUserIdsToProcess($userIds);
 		} catch (\Throwable $t) {

--- a/apps/twofactor_backupcodes/lib/Migration/Version1002Date20170607113030.php
+++ b/apps/twofactor_backupcodes/lib/Migration/Version1002Date20170607113030.php
@@ -55,7 +55,7 @@ class Version1002Date20170607113030 extends SimpleMigrationStep {
 		$result = $query->executeQuery();
 
 		$output->startProgress();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$output->advance();
 
 			$insert

--- a/apps/twofactor_backupcodes/lib/Settings/Personal.php
+++ b/apps/twofactor_backupcodes/lib/Settings/Personal.php
@@ -14,11 +14,12 @@ use OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings;
 use OCP\Server;
 use OCP\Template\ITemplate;
 use OCP\Template\ITemplateManager;
+use OCP\Util;
 
 class Personal implements IPersonalProviderSettings {
 	public function getBody(): ITemplate {
-		\OCP\Util::addScript(Application::APP_ID, 'settings-personal');
-		\OCP\Util::addStyle(Application::APP_ID, 'settings-personal');
+		Util::addScript(Application::APP_ID, 'settings-personal');
+		Util::addStyle(Application::APP_ID, 'settings-personal');
 		return Server::get(ITemplateManager::class)
 			->getTemplate('twofactor_backupcodes', 'personal');
 	}

--- a/apps/user_ldap/lib/Db/GroupMembershipMapper.php
+++ b/apps/user_ldap/lib/Db/GroupMembershipMapper.php
@@ -30,7 +30,7 @@ class GroupMembershipMapper extends QBMapper {
 			->from($this->getTableName())
 			->executeQuery();
 
-		$groups = array_column($result->fetchAll(), 'groupid');
+		$groups = array_column($result->fetchAllAssociative(), 'groupid');
 		$result->closeCursor();
 		return $groups;
 	}

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -98,7 +98,7 @@ abstract class AbstractMapping {
 			->from($this->getTableName());
 		$q->setMaxResults(self::LOCAL_CACHE_OBJECT_THRESHOLD + 1);
 		$result = $q->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		$use = (int)$row['count'] <= self::LOCAL_CACHE_OBJECT_THRESHOLD;
@@ -275,7 +275,7 @@ abstract class AbstractMapping {
 
 	protected function collectResultsFromListOfIdsQuery(IQueryBuilder $qb, array &$results): void {
 		$stmt = $qb->executeQuery();
-		while ($entry = $stmt->fetch(\Doctrine\DBAL\FetchMode::ASSOCIATIVE)) {
+		while ($entry = $stmt->fetchAssociative()) {
 			$results[$entry['ldap_dn']] = $entry['owncloud_name'];
 			$this->cache[$entry['ldap_dn']] = $entry['owncloud_name'];
 		}
@@ -345,7 +345,7 @@ abstract class AbstractMapping {
 			return [];
 		}
 		$names = [];
-		while ($row = $res->fetch()) {
+		while ($row = $res->fetchAssociative()) {
 			$names[] = $row['owncloud_name'];
 		}
 		return $names;
@@ -390,7 +390,7 @@ abstract class AbstractMapping {
 		}
 
 		$result = $select->executeQuery();
-		$entries = $result->fetchAll();
+		$entries = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return $entries;

--- a/apps/user_ldap/lib/Migration/GroupMappingMigration.php
+++ b/apps/user_ldap/lib/Migration/GroupMappingMigration.php
@@ -35,7 +35,7 @@ abstract class GroupMappingMigration extends SimpleMigrationStep {
 
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$insert
 				->setParameter('ldap_dn', $row['ldap_dn'])
 				->setParameter('owncloud_name', $row['owncloud_name'])

--- a/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
+++ b/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
@@ -72,7 +72,7 @@ class Version1120Date20210917155206 extends SimpleMigrationStep {
 		$update = $this->getUpdateQuery($table);
 
 		$result = $select->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$newId = hash('sha256', $row['owncloud_name'], false);
 			if ($emitHooks) {
 				$this->emitUnassign($row['owncloud_name'], true);

--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -137,7 +137,7 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 		$update = $this->getUpdateQuery($table);
 
 		$result = $select->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$dnHash = hash('sha256', $row['ldap_dn'], false);
 			$update->setParameter('name', $row['owncloud_name']);
 			$update->setParameter('dn_hash', $dnHash);

--- a/apps/user_ldap/lib/Migration/Version1190Date20230706134108.php
+++ b/apps/user_ldap/lib/Migration/Version1190Date20230706134108.php
@@ -80,7 +80,7 @@ class Version1190Date20230706134108 extends SimpleMigrationStep {
 			->from('ldap_group_members');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$knownUsers = unserialize($row['owncloudusers']);
 			if (!is_array($knownUsers)) {
 				/* Unserialize failed or data was incorrect in database, ignore */

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -104,7 +104,7 @@ class Manager implements IManager {
 
 		$result = $query->executeQuery();
 		$operations = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$eventNames = \json_decode($row['events']);
 
 			$operation = $row['class'];
@@ -152,7 +152,7 @@ class Manager implements IManager {
 		$result = $query->executeQuery();
 
 		$scopesByOperation[$operationClass] = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$scope = new ScopeContext($row['type'], $row['value']);
 
 			if (!$operation->isAvailableForScope((int)$row['type'])) {
@@ -187,7 +187,7 @@ class Manager implements IManager {
 		$result = $query->executeQuery();
 
 		$this->operations[$scopeContext->getHash()] = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			try {
 				/** @var IOperation $operation */
 				$operation = $this->container->get($row['class']);
@@ -226,7 +226,7 @@ class Manager implements IManager {
 			->from('flow_operations')
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {
@@ -540,7 +540,7 @@ class Manager implements IManager {
 			->where($query->expr()->in('id', $query->createNamedParameter($checkIds, IQueryBuilder::PARAM_INT_ARRAY)));
 		$result = $query->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			/** @var Check $row */
 			$this->checks[(int)$row['id']] = $row;
 			$checks[(int)$row['id']] = $row;
@@ -569,7 +569,7 @@ class Manager implements IManager {
 			->where($query->expr()->eq('hash', $query->createNamedParameter($hash)));
 		$result = $query->executeQuery();
 
-		if ($row = $result->fetch()) {
+		if ($row = $result->fetchAssociative()) {
 			$result->closeCursor();
 			return (int)$row['id'];
 		}

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -879,7 +879,6 @@
   </file>
   <file src="apps/dav/lib/Migration/Version1025Date20240308063933.php">
     <DeprecatedMethod>
-      <code><![CDATA[fetchColumn]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
@@ -2809,9 +2808,6 @@
     </DeprecatedInterface>
   </file>
   <file src="apps/user_ldap/lib/Mapping/AbstractMapping.php">
-    <DeprecatedClass>
-      <code><![CDATA[\Doctrine\DBAL\FetchMode::ASSOCIATIVE]]></code>
-    </DeprecatedClass>
     <DeprecatedMethod>
       <code><![CDATA[getDatabasePlatform]]></code>
       <code><![CDATA[insertIfNotExist]]></code>

--- a/core/BackgroundJobs/MovePreviewJob.php
+++ b/core/BackgroundJobs/MovePreviewJob.php
@@ -94,7 +94,7 @@ class MovePreviewJob extends TimedJob {
 		$foundPreview = false;
 		$fileIds = [];
 		$flatFileIds = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$pathSplit = explode('/', $row['path']);
 			assert(count($pathSplit) >= 2);
 			$fileId = (int)$pathSplit[count($pathSplit) - 2];
@@ -161,7 +161,7 @@ class MovePreviewJob extends TimedJob {
 			->setMaxResults(1);
 
 		$result = $qb->executeQuery();
-		$result = $result->fetchAll();
+		$result = $result->fetchAllAssociative();
 
 		if (count($result) > 0) {
 			foreach ($previewFiles as $previewFile) {

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -342,7 +342,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 			try {
 				$toDB->beginTransaction();
 
-				while ($row = $result->fetch()) {
+				foreach ($result->iterateAssociative() as $row) {
 					$progress->advance();
 					if (!$parametersCreated) {
 						foreach ($row as $key => $value) {

--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -253,7 +253,7 @@ class FileUtils {
 			->leftJoin('s', 'mounts', 'm', $query->expr()->eq('s.numeric_id', 'm.storage_id'))
 			->where($query->expr()->eq('s.numeric_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
 			->groupBy('s.numeric_id', 's.id', 's.available', 's.last_checked', 'mount_id');
-		$row = $query->executeQuery()->fetch();
+		$row = $query->executeQuery()->fetchAssociative();
 		if ($row) {
 			return [
 				'numeric_id' => $row['numeric_id'],
@@ -286,7 +286,7 @@ class FileUtils {
 			$query->setMaxResults($limit);
 		}
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			yield [
 				'numeric_id' => $row['numeric_id'],
 				'id' => $row['id'],

--- a/core/Command/Maintenance/RepairShareOwnership.php
+++ b/core/Command/Maintenance/RepairShareOwnership.php
@@ -92,7 +92,7 @@ class RepairShareOwnership extends Command {
 			->where($qb->expr()->neq('m.user_id', 's.uid_owner'))
 			->andWhere($qb->expr()->eq($qb->func()->concat($qb->expr()->literal('/'), 'm.user_id', $qb->expr()->literal('/')), 'm.mount_point'))
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$found = [];
 
@@ -126,7 +126,7 @@ class RepairShareOwnership extends Command {
 			->andWhere($qb->expr()->eq($qb->func()->concat($qb->expr()->literal('/'), 'm.user_id', $qb->expr()->literal('/')), 'm.mount_point'))
 			->andWhere($qb->expr()->eq('s.share_with', $qb->createNamedParameter($user->getUID())))
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$found = [];
 

--- a/core/Controller/OCMController.php
+++ b/core/Controller/OCMController.php
@@ -20,7 +20,6 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
-use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/core/Listener/PasswordUpdatedListener.php
+++ b/core/Listener/PasswordUpdatedListener.php
@@ -19,7 +19,7 @@ use OCP\User\Events\PasswordUpdatedEvent;
  */
 class PasswordUpdatedListener implements IEventListener {
 	public function __construct(
-		readonly private IVerificationToken $verificationToken,
+		private readonly IVerificationToken $verificationToken,
 	) {
 
 	}

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -1017,7 +1017,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			->setValue('propertyvalue', $insert->createParameter('propertyvalue'))
 			->setValue('userid', $insert->createParameter('userid'));
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			preg_match('/(calendar)\/([A-z0-9-@_]+)\//', $row['propertypath'], $match);
 			$insert->setParameter('propertypath', (string)$row['propertypath'])
 				->setParameter('propertyname', (string)$row['propertyname'])

--- a/core/Migrations/Version20000Date20201109081918.php
+++ b/core/Migrations/Version20000Date20201109081918.php
@@ -78,7 +78,7 @@ class Version20000Date20201109081918 extends SimpleMigrationStep {
 			->setValue('credentials', $insert->createParameter('credentials'));
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$insert->setParameter('user', (string)$row['user'])
 				->setParameter('identifier', (string)$row['identifier'])
 				->setParameter('credentials', (string)$row['credentials']);

--- a/core/Migrations/Version28000Date20240828142927.php
+++ b/core/Migrations/Version28000Date20240828142927.php
@@ -63,7 +63,7 @@ class Version28000Date20240828142927 extends SimpleMigrationStep {
 				->setFirstResult($offset)
 				->executeQuery();
 
-			$jobs = $result->fetchAll();
+			$jobs = $result->fetchAllAssociative();
 			$count = count($jobs);
 
 			foreach ($jobs as $jobRow) {

--- a/core/Migrations/Version32000Date20250731062008.php
+++ b/core/Migrations/Version32000Date20250731062008.php
@@ -61,7 +61,7 @@ class Version32000Date20250731062008 extends SimpleMigrationStep {
 		$seen = [];
 		$duplicateCount = 0;
 
-		while ($category = $result->fetch()) {
+		while ($category = $result->fetchAssociative()) {
 			$key = $category['uid'] . '|' . $category['type'] . '|' . $category['category'];
 			$categoryId = (int)$category['id'];
 
@@ -135,7 +135,7 @@ class Version32000Date20250731062008 extends SimpleMigrationStep {
 
 		$duplicatedAssignments = $selectQb->executeQuery();
 		$count = 0;
-		while ($row = $duplicatedAssignments->fetch()) {
+		while ($row = $duplicatedAssignments->fetchAssociative()) {
 			$deleteQb
 				->setParameters($row)
 				->executeStatement();

--- a/core/Migrations/Version33000Date20251023120529.php
+++ b/core/Migrations/Version33000Date20251023120529.php
@@ -50,7 +50,7 @@ class Version33000Date20251023120529 extends SimpleMigrationStep {
 
 		$set = [];
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			// Iterate over all the rows with duplicated rows
 			$id = $row['id'];
 
@@ -65,7 +65,7 @@ class Version33000Date20251023120529 extends SimpleMigrationStep {
 					->andWhere($qb->expr()->neq('id', $qb->createNamedParameter($authoritativeId)));
 
 				$result = $qb->executeQuery();
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					// Update previews entries to the now de-duplicated id
 					$qb = $this->connection->getQueryBuilder();
 					$qb->update('previews')

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -82,7 +82,7 @@ class AppConfig implements IAppConfig {
 		private readonly PresetManager $presetManager,
 		protected LoggerInterface $logger,
 		protected ICrypto $crypto,
-		readonly CacheFactory $cacheFactory,
+		public readonly CacheFactory $cacheFactory,
 	) {
 		if ($config->getSystemValueBool('cache_app_config', true) && $cacheFactory->isLocalCacheAvailable()) {
 			$cacheFactory->withServerVersionPrefix(function (ICacheFactory $factory) {

--- a/lib/private/DB/ArrayResult.php
+++ b/lib/private/DB/ArrayResult.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\DB;
 
 use OCP\DB\IResult;
+use Override;
 use PDO;
 
 /**
@@ -18,16 +19,19 @@ class ArrayResult implements IResult {
 	protected int $count;
 
 	public function __construct(
+		/** @var array<string, mixed> $rows */
 		protected array $rows,
 	) {
 		$this->count = count($this->rows);
 	}
 
+	#[Override]
 	public function closeCursor(): bool {
 		// noop
 		return true;
 	}
 
+	#[Override]
 	public function fetch(int $fetchMode = PDO::FETCH_ASSOC) {
 		$row = array_shift($this->rows);
 		if (!$row) {
@@ -42,23 +46,22 @@ class ArrayResult implements IResult {
 
 	}
 
+	#[Override]
 	public function fetchAll(int $fetchMode = PDO::FETCH_ASSOC): array {
 		return match ($fetchMode) {
 			PDO::FETCH_ASSOC => $this->rows,
-			PDO::FETCH_NUM => array_map(function ($row) {
-				return array_values($row);
-			}, $this->rows),
-			PDO::FETCH_COLUMN => array_map(function ($row) {
-				return current($row);
-			}, $this->rows),
+			PDO::FETCH_NUM => array_map(static fn (array $row): array => array_values($row), $this->rows),
+			PDO::FETCH_COLUMN => array_map(static fn (array $row): mixed => current($row), $this->rows),
 			default => throw new \InvalidArgumentException('Fetch mode not supported for array result'),
 		};
 	}
 
+	#[Override]
 	public function fetchColumn() {
 		return $this->fetchOne();
 	}
 
+	#[Override]
 	public function fetchOne() {
 		$row = $this->fetch();
 		if ($row) {
@@ -68,7 +71,65 @@ class ArrayResult implements IResult {
 		}
 	}
 
+	#[Override]
+	public function fetchAssociative(): array|false {
+		$row = $this->fetch();
+		if ($row) {
+			/** @var array<string, mixed> $row */
+			return $row;
+		} else {
+			return false;
+		}
+	}
+
+	#[Override]
+	public function fetchNumeric(): array|false {
+		$row = $this->fetch(PDO::FETCH_NUM);
+		if ($row) {
+			/** @var list<mixed> $row */
+			return $row;
+		} else {
+			return false;
+		}
+	}
+
+	#[Override]
+	public function fetchAllNumeric(): array {
+		/** @var list<list<mixed>> $result */
+		$result = $this->fetchAll(PDO::FETCH_NUM);
+		return $result;
+	}
+
+	#[Override]
+	public function fetchAllAssociative(): array {
+		/** @var list<array<string,mixed>> $result */
+		$result = $this->fetchAll();
+		return $result;
+	}
+
+	#[Override]
+	public function fetchFirstColumn(): array {
+		/** @var list<mixed> $result */
+		$result = $this->fetchAll(PDO::FETCH_COLUMN);
+		return $result;
+	}
+
+	#[Override]
 	public function rowCount(): int {
 		return $this->count;
+	}
+
+	#[Override]
+	public function iterateNumeric(): \Traversable {
+		while (($row = $this->fetchNumeric()) !== false) {
+			yield $row;
+		}
+	}
+
+	#[Override]
+	public function iterateAssociative(): \Traversable {
+		while (($row = $this->fetchAssociative()) !== false) {
+			yield $row;
+		}
 	}
 }

--- a/lib/private/DB/ResultAdapter.php
+++ b/lib/private/DB/ResultAdapter.php
@@ -10,25 +10,26 @@ namespace OC\DB;
 
 use Doctrine\DBAL\Result;
 use OCP\DB\IResult;
+use Override;
 use PDO;
 
 /**
  * Adapts DBAL 2.6 API for DBAL 3.x for backwards compatibility of a leaked type
  */
 class ResultAdapter implements IResult {
-	/** @var Result */
-	private $inner;
-
-	public function __construct(Result $inner) {
-		$this->inner = $inner;
+	public function __construct(
+		private readonly Result $inner,
+	) {
 	}
 
+	#[Override]
 	public function closeCursor(): bool {
 		$this->inner->free();
 
 		return true;
 	}
 
+	#[Override]
 	public function fetch(int $fetchMode = PDO::FETCH_ASSOC) {
 		return match ($fetchMode) {
 			PDO::FETCH_ASSOC => $this->inner->fetchAssociative(),
@@ -38,6 +39,22 @@ class ResultAdapter implements IResult {
 		};
 	}
 
+	#[Override]
+	public function fetchAssociative(): array|false {
+		return $this->inner->fetchAssociative();
+	}
+
+	#[Override]
+	public function fetchNumeric(): array|false {
+		return $this->inner->fetchNumeric();
+	}
+
+	#[Override]
+	public function fetchOne(): mixed {
+		return $this->inner->fetchOne();
+	}
+
+	#[Override]
 	public function fetchAll(int $fetchMode = PDO::FETCH_ASSOC): array {
 		return match ($fetchMode) {
 			PDO::FETCH_ASSOC => $this->inner->fetchAllAssociative(),
@@ -47,15 +64,38 @@ class ResultAdapter implements IResult {
 		};
 	}
 
+	#[Override]
 	public function fetchColumn($columnIndex = 0) {
 		return $this->inner->fetchOne();
 	}
 
-	public function fetchOne() {
-		return $this->inner->fetchOne();
-	}
-
+	#[Override]
 	public function rowCount(): int {
 		return $this->inner->rowCount();
+	}
+
+	#[Override]
+	public function fetchAllAssociative(): array {
+		return $this->inner->fetchAllAssociative();
+	}
+
+	#[Override]
+	public function fetchAllNumeric(): array {
+		return $this->inner->fetchAllNumeric();
+	}
+
+	#[Override]
+	public function fetchFirstColumn(): array {
+		return $this->inner->fetchFirstColumn();
+	}
+
+	#[Override]
+	public function iterateNumeric(): \Traversable {
+		yield from $this->inner->iterateNumeric();
+	}
+
+	#[Override]
+	public function iterateAssociative(): \Traversable {
+		yield from $this->inner->iterateAssociative();
 	}
 }

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -22,9 +22,9 @@ class BackgroundCleanupJob extends TimedJob {
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		readonly private IDBConnection $connection,
-		readonly private PreviewService $previewService,
-		readonly private bool $isCLI,
+		private readonly IDBConnection $connection,
+		private readonly PreviewService $previewService,
+		private readonly bool $isCLI,
 	) {
 		parent::__construct($timeFactory);
 		// Run at most once an hour

--- a/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
+++ b/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
@@ -36,7 +36,7 @@ class ObjectStorePreviewStorage implements IPreviewStorage {
 	public function __construct(
 		private readonly PrimaryObjectStoreConfig $objectStoreConfig,
 		IConfig $config,
-		readonly private PreviewMapper $previewMapper,
+		private readonly PreviewMapper $previewMapper,
 	) {
 		$this->isMultibucketPreviewDistributionEnabled = $config->getSystemValueBool('objectstore.multibucket.preview-distribution');
 	}

--- a/lib/public/DB/IResult.php
+++ b/lib/public/DB/IResult.php
@@ -44,7 +44,7 @@ interface IResult {
 	 * @return mixed
 	 *
 	 * @since 21.0.0
-	 * @deprecated Since 33.0.0, use fetchAssociative/fetchNumeric/fetchOne or iterateAssociate/iterateNumeric instead.
+	 * @note Since 33.0.0, prefer using fetchAssociative/fetchNumeric/fetchOne or iterateAssociate/iterateNumeric instead.
 	 */
 	public function fetch(int $fetchMode = PDO::FETCH_ASSOC);
 
@@ -81,7 +81,7 @@ interface IResult {
 	 * @return mixed[]
 	 *
 	 * @since 21.0.0
-	 * @deprecated Since 33.0.0, use fetchAllAssociative/fetchAllNumeric/fetchFirstColumn or iterateAssociate/iterateNumeric instead.
+	 * @note Since 33.0.0, prefer using fetchAllAssociative/fetchAllNumeric/fetchFirstColumn or iterateAssociate/iterateNumeric instead.
 	 */
 	public function fetchAll(int $fetchMode = PDO::FETCH_ASSOC): array;
 
@@ -125,7 +125,7 @@ interface IResult {
 	public function rowCount(): int;
 
 	/**
-	 * Returns the result as an iterator over rows represented as numeric arrays.
+	 * Returns an iterator over rows represented as numeric arrays.
 	 *
 	 * @return Traversable<list<mixed>>
 	 *
@@ -134,7 +134,7 @@ interface IResult {
 	public function iterateNumeric(): Traversable;
 
 	/**
-	 * Returns the result as an iterator over rows represented as associative arrays.
+	 * Returns an iterator over rows represented as associative arrays.
 	 *
 	 * @return Traversable<array<string,mixed>>
 	 *

--- a/lib/public/DB/IResult.php
+++ b/lib/public/DB/IResult.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
  */
 namespace OCP\DB;
 
+use OCP\AppFramework\Attribute\Consumable;
 use PDO;
+use Traversable;
 
 /**
  * This interface represents the result of a database query.
@@ -19,12 +21,15 @@ use PDO;
  * $qb = $this->db->getQueryBuilder();
  * $qb->select(...);
  * $result = $query->executeQuery();
- * ```
  *
- * This interface must not be implemented in your application.
+ * foreach ($result->iterateAssociative() as $row) {
+ *     $id = $row['id'];
+ * }
+ * ```
  *
  * @since 21.0.0
  */
+#[Consumable(since: '21.0.0')]
 interface IResult {
 	/**
 	 * @return true
@@ -39,25 +44,27 @@ interface IResult {
 	 * @return mixed
 	 *
 	 * @since 21.0.0
+	 * @deprecated Since 33.0.0, use fetchAssociative/fetchNumeric/fetchOne or iterateAssociate/iterateNumeric instead.
 	 */
 	public function fetch(int $fetchMode = PDO::FETCH_ASSOC);
 
 	/**
-	 * @param int $fetchMode (one of PDO::FETCH_ASSOC, PDO::FETCH_NUM or PDO::FETCH_COLUMN (2, 3 or 7)
+	 * Returns the next row of the result as an associative array or FALSE if there are no more rows.
 	 *
-	 * @return mixed[]
+	 * @return array<string, mixed>|false
 	 *
-	 * @since 21.0.0
+	 * @since 33.0.0
 	 */
-	public function fetchAll(int $fetchMode = PDO::FETCH_ASSOC): array;
+	public function fetchAssociative(): array|false;
 
 	/**
-	 * @return mixed
+	 * Returns the next row of the result as a numeric array or FALSE if there are no more rows.
 	 *
-	 * @since 21.0.0
-	 * @deprecated 21.0.0 use \OCP\DB\IResult::fetchOne
+	 * @return list<mixed>|false
+	 *
+	 * @since 33.0.0
 	 */
-	public function fetchColumn();
+	public function fetchNumeric(): array|false;
 
 	/**
 	 * Returns the first value of the next row of the result or FALSE if there are no more rows.
@@ -69,9 +76,69 @@ interface IResult {
 	public function fetchOne();
 
 	/**
+	 * @param int $fetchMode (one of PDO::FETCH_ASSOC, PDO::FETCH_NUM or PDO::FETCH_COLUMN (2, 3 or 7)
+	 *
+	 * @return mixed[]
+	 *
+	 * @since 21.0.0
+	 * @deprecated Since 33.0.0, use fetchAllAssociative/fetchAllNumeric/fetchFirstColumn or iterateAssociate/iterateNumeric instead.
+	 */
+	public function fetchAll(int $fetchMode = PDO::FETCH_ASSOC): array;
+
+	/**
+	 * Returns an array containing all the result rows represented as associative arrays.
+	 *
+	 * @return list<array<string,mixed>>
+	 * @since 33.0.0
+	 */
+	public function fetchAllAssociative(): array;
+
+	/**
+	 * Returns an array containing all the result rows represented as numeric arrays.
+	 *
+	 * @return list<list<mixed>>
+	 * @since 33.0.0
+	 */
+	public function fetchAllNumeric(): array;
+
+	/**
+	 * Returns the value of the first column of all rows.
+	 *
+	 * @return list<mixed>
+	 * @since 33.0.0
+	 */
+	public function fetchFirstColumn(): array;
+
+	/**
+	 * @return mixed
+	 *
+	 * @since 21.0.0
+	 * @deprecated 21.0.0 use \OCP\DB\IResult::fetchOne
+	 */
+	public function fetchColumn();
+
+	/**
 	 * @return int
 	 *
 	 * @since 21.0.0
 	 */
 	public function rowCount(): int;
+
+	/**
+	 * Returns the result as an iterator over rows represented as numeric arrays.
+	 *
+	 * @return Traversable<list<mixed>>
+	 *
+	 * @since 33.0.0
+	 */
+	public function iterateNumeric(): Traversable;
+
+	/**
+	 * Returns the result as an iterator over rows represented as associative arrays.
+	 *
+	 * @return Traversable<array<string,mixed>>
+	 *
+	 * @since 33.0.0
+	 */
+	public function iterateAssociative(): Traversable;
 }

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -54,7 +54,7 @@ class AllConfigTest extends \Test\TestCase {
 		$result = $this->connection->executeQuery(
 			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences` WHERE `userid` = ?',
 			['userDelete']
-		)->fetch();
+		)->fetchAssociative();
 		$actualCount = $result['count'];
 
 		$this->assertEquals(0, $actualCount, 'There was one value in the database and after the tests there should be no entry left.');
@@ -66,7 +66,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config->setUserValue('userSet', 'appSet', 'keySet', 'valueSet');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -79,7 +79,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries
 		$config->setUserValue('userSet', 'appSet', 'keySet', 'valueSet2');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -103,7 +103,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config->setUserValue('userSet', 'settings', 'email', 'mixed.CASE@domain.COM');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -121,7 +121,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config->setUserValue('userPreCond', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -134,7 +134,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries with valid precond
 		$config->setUserValue('userPreCond', 'appPreCond', 'keyPreCond', 'valuePreCond2', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -178,7 +178,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -191,7 +191,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries with valid precond
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond2', 'valuePreCond3');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -214,7 +214,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
 
 		$this->assertCount(1, $result);
 		$this->assertEquals([
@@ -227,7 +227,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method throws with invalid precondition when the value is the same
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond', 'valuePreCond3');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAll();
+		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
 
 		$this->assertCount(1, $result);
 		$this->assertEquals([
@@ -278,7 +278,7 @@ class AllConfigTest extends \Test\TestCase {
 		$result = $this->connection->executeQuery(
 			'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?',
 			['userGet']
-		)->fetchAll();
+		)->fetchAllAssociative();
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -299,7 +299,7 @@ class AllConfigTest extends \Test\TestCase {
 		$result = $this->connection->executeQuery(
 			'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?',
 			['userGet']
-		)->fetchAll();
+		)->fetchAllAssociative();
 
 		$this->assertEquals(0, count($result));
 	}
@@ -434,7 +434,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$result = $this->connection->executeQuery(
 			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetch();
+		)->fetchAssociative();
 		$actualCount = $result['count'];
 
 		$this->assertEquals(1, $actualCount, 'After removing `userFetch3` there should be exactly 1 entry left.');
@@ -468,7 +468,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$result = $this->connection->executeQuery(
 			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetch();
+		)->fetchAssociative();
 		$actualCount = $result['count'];
 
 		$this->assertEquals(4, $actualCount, 'After removing `appFetch1` there should be exactly 4 entries left.');
@@ -477,7 +477,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$result = $this->connection->executeQuery(
 			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetch();
+		)->fetchAssociative();
 		$actualCount = $result['count'];
 
 		$this->assertEquals(2, $actualCount, 'After removing `appFetch2` there should be exactly 2 entries left.');

--- a/tests/lib/AppConfigIntegrationTest.php
+++ b/tests/lib/AppConfigIntegrationTest.php
@@ -115,7 +115,7 @@ class AppConfigIntegrationTest extends TestCase {
 		$sql->select('*')
 			->from('appconfig');
 		$result = $sql->executeQuery();
-		$this->originalConfig = $result->fetchAll();
+		$this->originalConfig = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$sql = $this->connection->getQueryBuilder();

--- a/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
@@ -116,7 +116,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 		$result = $qb->select($qb->func()->count('*', 'count'))
 			->from('authtoken')
 			->executeQuery()
-			->fetch();
+			->fetchAssociative();
 		return (int)$result['count'];
 	}
 
@@ -239,7 +239,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206')));
 		$result = $qb->executeQuery();
-		$id = $result->fetch()['id'];
+		$id = $result->fetchAssociative()['id'];
 
 		$token = $this->mapper->getTokenById((int)$id);
 		$this->assertEquals('user1', $token->getUID());
@@ -251,7 +251,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206')));
 		$result = $qb->executeQuery();
-		$name = $result->fetch()['name'];
+		$name = $result->fetchAssociative()['name'];
 		$this->mapper->deleteByName($name);
 		$this->assertEquals(4, $this->getNumberOfTokens());
 	}

--- a/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
@@ -69,7 +69,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(0)));
 		$res = $q->executeQuery();
-		$data = $res->fetchAll();
+		$data = $res->fetchAllAssociative();
 		$res->closeCursor();
 		$this->assertCount(1, $data);
 	}
@@ -87,7 +87,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(1)));
 		$res = $q->executeQuery();
-		$data = $res->fetchAll();
+		$data = $res->fetchAllAssociative();
 		$res->closeCursor();
 
 		$this->assertCount(1, $data);
@@ -106,7 +106,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(1)));
 		$res = $q->executeQuery();
-		$data = $res->fetchAll();
+		$data = $res->fetchAllAssociative();
 		$res->closeCursor();
 
 		$this->assertCount(1, $data);

--- a/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
+++ b/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
@@ -216,7 +216,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 		$rows = [];
 		$ids = [];
 		$stmt = $query->executeQuery();
-		while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+		while ($row = $stmt->fetchAssociative()) {
 			$ids[$row['backend_id'] . '::' . $row['resource_id']] = $row['id'];
 			unset($row['id']);
 			$rows[] = $row;
@@ -286,7 +286,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 
 		$rows2 = [];
 		$stmt = $query2->executeQuery();
-		while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+		while ($row = $stmt->fetchAssociative()) {
 			unset($row['id']);
 			$rows2[] = $row;
 		}

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -1021,7 +1021,7 @@ class MailPluginTest extends TestCase {
 
 		$this->instantiatePlugin(IShare::TYPE_USER);
 
-		/** @var \OCP\IUser | \PHPUnit\Framework\MockObject\MockObject */
+		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
 		$currentUser = $this->createMock('\OCP\IUser');
 
 		$currentUser->expects($this->any())
@@ -1043,7 +1043,7 @@ class MailPluginTest extends TestCase {
 
 		$this->groupManager->expects($this->any())
 			->method('getUserGroupIds')
-			->willReturnCallback(function (\OCP\IUser $user) use ($userToGroupMapping) {
+			->willReturnCallback(function (IUser $user) use ($userToGroupMapping) {
 				return $userToGroupMapping[$user->getUID()];
 			});
 

--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -190,7 +190,7 @@ class UserConfigTest extends TestCase {
 		$sql->select('*')
 			->from('preferences');
 		$result = $sql->executeQuery();
-		$this->originalPreferences = $result->fetchAll();
+		$this->originalPreferences = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$sql = $this->connection->getQueryBuilder();

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -64,6 +64,142 @@ class AdapterTest extends TestCase {
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter($this->appId)))
 			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($configKey)))
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
+	}
+
+	public function fetchAssociative(): void {
+		$insert = $this->connection->getQueryBuilder();
+		$insert->insert('appconfig')
+			->values([
+				'appid' => $this->appId,
+				'configkey' => 'test',
+				'configvalue' => '1',
+			])
+			->executeStatement();
+
+		// fetch all associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+
+		$rows = $result->fetchAllAssociative();
+		$this->assertEquals([
+			[
+				'appid' => $this->appId,
+				'configkey' => 'test',
+				'configvalue' => '1',
+			]
+		], $rows);
+
+		// fetch associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+		$row = $result->fetchAssociative();
+		$this->assertEquals([
+			'appid' => $this->appId,
+			'configkey' => 'test',
+			'configvalue' => '1',
+		], $row);
+
+		// iterate associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+		$row = iterator_to_array($result->iterateAssociative());
+		$this->assertEquals([
+			'appid' => $this->appId,
+			'configkey' => 'test',
+			'configvalue' => '1',
+		], $row);
+	}
+
+	public function fetchNumeric(): void {
+		$insert = $this->connection->getQueryBuilder();
+		$insert->insert('appconfig')
+			->values([
+				'appid' => $this->appId,
+				'configkey' => 'test',
+				'configvalue' => '1',
+			])
+			->executeStatement();
+
+		// fetch all associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+
+		$rows = $result->fetchAllNumeric();
+		$this->assertEquals([
+			[
+				0 => $this->appId,
+				1 => 'test',
+				2 => '1',
+			]
+		], $rows);
+
+		// fetch associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+		$row = $result->fetchNumeric();
+		$this->assertEquals([
+			0 => $this->appId,
+			1 => 'test',
+			2 => '1',
+		], $row);
+
+		// iterate associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+		$row = iterator_to_array($result->iterateNumeric());
+		$this->assertEquals([
+			0 => $this->appId,
+			1 => 'test',
+			2 => '1',
+		], $row);
+	}
+
+	public function fetchOne(): void {
+		$insert = $this->connection->getQueryBuilder();
+		$insert->insert('appconfig')
+			->values([
+				'appid' => $this->appId,
+				'configkey' => 'test',
+				'configvalue' => '1',
+			])
+			->executeStatement();
+
+		// fetch all associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+
+		$rows = $result->fetchFirstColumn();
+		$this->assertEquals($this->appId, $rows);
+
+		// fetch associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+		$row = $result->fetchFirstColumn();
+		$this->assertEquals($this->appId, $row);
+
+		// iterate associative
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['configkey', 'configvalue', 'appid'])
+			->from('appconfig')
+			->executeQuery();
+		$rows = iterator_to_array($result->iterateNumeric());
+		$this->assertEquals([$this->appId], $rows);
 	}
 }

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -135,7 +135,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->andWhere($query->expr()->eq('configvalue', $query->createNamedParameter('myvalue', IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
 
 		$result = $query->executeQuery();
-		$entries = $result->fetchAll();
+		$entries = $result->fetchAllAssociative();
 		$result->closeCursor();
 		self::assertCount(1, $entries);
 		self::assertEquals('myvalue', $entries[0]['configvalue']);
@@ -153,7 +153,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->from('testing')
 			->where($query->expr()->eq('datetime', $query->createNamedParameter($dateTime, IQueryBuilder::PARAM_DATETIME_MUTABLE)))
 			->executeQuery();
-		$entries = $result->fetchAll();
+		$entries = $result->fetchAllAssociative();
 		$result->closeCursor();
 		self::assertCount(1, $entries);
 	}
@@ -171,7 +171,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->from('testing')
 			->where($query->expr()->lt('datetime', $query->createNamedParameter($dateTimeCompare, IQueryBuilder::PARAM_DATETIME_MUTABLE)))
 			->executeQuery();
-		$entries = $result->fetchAll();
+		$entries = $result->fetchAllAssociative();
 		$result->closeCursor();
 		self::assertCount(1, $entries);
 	}
@@ -189,7 +189,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->from('testing')
 			->where($query->expr()->gt('datetime', $query->createNamedParameter($dateTimeCompare, IQueryBuilder::PARAM_DATETIME_MUTABLE)))
 			->executeQuery();
-		$entries = $result->fetchAll();
+		$entries = $result->fetchAllAssociative();
 		$result->closeCursor();
 		self::assertCount(1, $entries);
 	}

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -409,7 +409,7 @@ class ExpressionBuilderTest extends TestCase {
 
 		$result = $query->executeQuery();
 
-		$this->assertEquals(['count' => $expected], $result->fetch());
+		$this->assertEquals(['count' => $expected], $result->fetchAssociative());
 		$result->closeCursor();
 
 		$query = $this->connection->getQueryBuilder();

--- a/tests/lib/Files/Cache/SearchBuilderTest.php
+++ b/tests/lib/Files/Cache/SearchBuilderTest.php
@@ -129,7 +129,7 @@ class SearchBuilderTest extends TestCase {
 		$this->builder->andWhere($dbOperator);
 
 		$result = $this->builder->executeQuery();
-		$rows = $result->fetchAll(\PDO::FETCH_COLUMN);
+		$rows = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		return $rows;

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -413,7 +413,7 @@ class UserMountCacheTest extends TestCase {
 					->from('filecache')
 					->where($query->expr()->eq('storage', $query->createNamedParameter($storageId)))
 					->andWhere($query->expr()->eq('path_hash', $query->createNamedParameter(md5($internalPath))));
-				$id = (int)$query->executeQuery()->fetchColumn();
+				$id = (int)$query->executeQuery()->fetchOne();
 			} else {
 				throw $e;
 			}

--- a/tests/lib/Files/Template/TemplateManagerTest.php
+++ b/tests/lib/Files/Template/TemplateManagerTest.php
@@ -13,6 +13,7 @@ use OC\AppFramework\Bootstrap\Coordinator;
 use OC\AppFramework\Bootstrap\RegistrationContext;
 use OC\Files\FilenameValidator;
 use OC\Files\Template\TemplateManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\GenericFileException;
 use OCP\Files\IRootFolder;
@@ -21,6 +22,9 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IPreview;
+use OCP\IServerContainer;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use Psr\Log\NullLogger;
 use Test\TestCase;
@@ -53,14 +57,14 @@ class TemplateManagerTest extends TestCase {
 			$logger,
 		);
 
-		$serverContainer = $this->createMock(\OCP\IServerContainer::class);
-		$eventDispatcher = $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class);
+		$serverContainer = $this->createMock(IServerContainer::class);
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->bootstrapCoordinator = $this->createMock(Coordinator::class);
 		$this->bootstrapCoordinator->method('getRegistrationContext')
 			->willReturn(new RegistrationContext($logger));
 		$this->rootFolder = $this->createMock(IRootFolder::class);
-		$userSession = $this->createMock(\OCP\IUserSession::class);
-		$userManager = $this->createMock(\OCP\IUserManager::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$userManager = $this->createMock(IUserManager::class);
 		$previewManager = $this->createMock(IPreview::class);
 
 		$this->templateManager = new TemplateManager(

--- a/tests/lib/Files/Type/LoaderTest.php
+++ b/tests/lib/Files/Type/LoaderTest.php
@@ -64,7 +64,7 @@ class LoaderTest extends TestCase {
 			->where($qb->expr()->eq('id', $qb->createPositionalParameter($mimetypeId)));
 
 		$result = $qb->executeQuery();
-		$mimetype = $result->fetch();
+		$mimetype = $result->fetchAssociative();
 		$result->closeCursor();
 		$this->assertEquals('testing/mymimetype', $mimetype['mimetype']);
 

--- a/tests/lib/Repair/OldGroupMembershipSharesTest.php
+++ b/tests/lib/Repair/OldGroupMembershipSharesTest.php
@@ -76,7 +76,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 			->from('share')
 			->orderBy('id', 'ASC')
 			->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member], ['id' => $notAMember]], $rows);
 		$result->closeCursor();
 
@@ -92,7 +92,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 			->from('share')
 			->orderBy('id', 'ASC')
 			->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member]], $rows);
 		$result->closeCursor();
 	}

--- a/tests/lib/Repair/Owncloud/UpdateLanguageCodesTest.php
+++ b/tests/lib/Repair/Owncloud/UpdateLanguageCodesTest.php
@@ -74,7 +74,7 @@ class UpdateLanguageCodesTest extends TestCase {
 			->orderBy('userid')
 			->executeQuery();
 
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$this->assertSame($users, $rows, 'Asserts that the entries are the ones from the test data set');
@@ -115,7 +115,7 @@ class UpdateLanguageCodesTest extends TestCase {
 			->orderBy('userid')
 			->executeQuery();
 
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		// value has changed for one user

--- a/tests/lib/Repair/RepairInvalidSharesTest.php
+++ b/tests/lib/Repair/RepairInvalidSharesTest.php
@@ -104,7 +104,7 @@ class RepairInvalidSharesTest extends TestCase {
 			->from('share')
 			->orderBy('id', 'ASC')
 			->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$this->assertEquals([['id' => $parent], ['id' => $validChild], ['id' => $invalidChild]], $rows);
 		$result->closeCursor();
 
@@ -120,7 +120,7 @@ class RepairInvalidSharesTest extends TestCase {
 			->from('share')
 			->orderBy('id', 'ASC')
 			->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$this->assertEquals([['id' => $parent], ['id' => $validChild]], $rows);
 		$result->closeCursor();
 	}
@@ -180,7 +180,7 @@ class RepairInvalidSharesTest extends TestCase {
 			->from('share')
 			->orderBy('permissions', 'ASC')
 			->executeQuery()
-			->fetchAll();
+			->fetchAllAssociative();
 
 		$this->assertCount(1, $results);
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -494,7 +494,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->from('share');
 
 		$cursor = $qb->executeQuery();
-		$result = $cursor->fetchAll();
+		$result = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		$this->assertEmpty($result);
@@ -527,7 +527,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->from('share');
 
 		$cursor = $qb->executeQuery();
-		$result = $cursor->fetchAll();
+		$result = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		$this->assertEmpty($result);
@@ -592,7 +592,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->from('share');
 
 		$cursor = $qb->executeQuery();
-		$result = $cursor->fetchAll();
+		$result = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		$this->assertEmpty($result);
@@ -1553,7 +1553,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(2)))
 			->executeQuery();
 
-		$shares = $stmt->fetchAll();
+		$shares = $stmt->fetchAllAssociative();
 		$stmt->closeCursor();
 
 		$this->assertCount(1, $shares);
@@ -1625,7 +1625,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(2)))
 			->executeQuery();
 
-		$shares = $stmt->fetchAll();
+		$shares = $stmt->fetchAllAssociative();
 		$stmt->closeCursor();
 
 		$this->assertCount(1, $shares);
@@ -1763,7 +1763,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
 			->executeQuery();
 
-		$shares = $stmt->fetchAll();
+		$shares = $stmt->fetchAllAssociative();
 		$stmt->closeCursor();
 
 		$this->assertCount(0, $shares);
@@ -2188,7 +2188,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->orderBy('id')
 			->executeQuery();
 
-		$shares = $stmt->fetchAll();
+		$shares = $stmt->fetchAllAssociative();
 
 		$this->assertSame('user0', $shares[0]['share_with']);
 		$this->assertSame('user4', $shares[0]['uid_initiator']);
@@ -2329,7 +2329,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				$qb->expr()->eq('id', $qb->createNamedParameter($id))
 			);
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetchAll();
+		$data = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		$this->assertCount($rowDeleted ? 0 : 1, $data);
@@ -2388,7 +2388,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				$qb->expr()->eq('id', $qb->createNamedParameter($userGroupId))
 			);
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetchAll();
+		$data = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 		$this->assertCount($userGroupShareDeleted ? 0 : 1, $data);
 
@@ -2399,7 +2399,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				$qb->expr()->eq('id', $qb->createNamedParameter($groupId))
 			);
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetchAll();
+		$data = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 		$this->assertCount($groupShareDeleted ? 0 : 1, $data);
 	}
@@ -2492,7 +2492,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->from('share')
 			->where($qb->expr()->in('id', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)))
 			->executeQuery();
-		$data = $cursor->fetchAll();
+		$data = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		$this->assertCount($shouldBeDeleted ? 0 : count($ids), $data);
@@ -2550,7 +2550,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->from('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id2)));
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetchAll();
+		$data = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		$this->assertCount($toDelete ? 0 : 1, $data);

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -111,7 +111,7 @@ class SubAdminTest extends \Test\TestCase {
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
 			->executeQuery()
-			->fetch();
+			->fetchAssociative();
 		$this->assertEquals(
 			[
 				'gid' => $this->groups[0]->getGID(),
@@ -137,7 +137,7 @@ class SubAdminTest extends \Test\TestCase {
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
 			->executeQuery()
-			->fetch();
+			->fetchAssociative();
 		$this->assertEmpty($result);
 	}
 


### PR DESCRIPTION
Best to review commit by commit. The last two are automated

## Summary

Expose multiple methods from result from doctrine:

- `fetchAssociative`
- `fetchNumeric`
- `fetchOne`
- `fetchAllAssociate`
- `fetchAllNumeric`
- `fetchFirstColumn`
- `iterateNumeric`
- `iterateAssociate`

Deprecated

- `fetch` and `fetchAll`

A rector rule is also created to automate the transition https://github.com/nextcloud-libraries/rector/pull/63

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
