### PR TITLE
feat(objectstore): add configurable S3 retry attempts

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1965,6 +1965,25 @@ $CONFIG = [
 	],
 
 	/**
+	 * To use S3 object storage
+	 */
+	'objectstore' => [
+		'class' => 'OC\\Files\\ObjectStore\\S3',
+		'arguments' => [
+			'bucket' => 'nextcloud',
+			'key' => 'your-access-key',
+			'secret' => 'your-secret-key',
+			'hostname' => 's3.example.com',
+			'port' => 443,
+			'use_ssl' => true,
+			'region' => 'us-east-1',
+			// optional: Maximum number of retry attempts for failed S3 requests
+			// Default: 5
+			'retriesMaxAttempts' => 5,
+		],
+	],
+
+	/**
 	 * If this is set to true and a multibucket object store is configured, then
 	 * newly created previews are put into 256 dedicated buckets.
 	 *

--- a/lib/private/Files/ObjectStore/S3ConfigTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConfigTrait.php
@@ -38,4 +38,6 @@ trait S3ConfigTrait {
 	private int|float $copySizeLimit;
 
 	private bool $useMultipartCopy = true;
+
+	protected int $retriesMaxAttempts;
 }

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -47,6 +47,7 @@ trait S3ConnectionTrait {
 		$this->putSizeLimit = $params['putSizeLimit'] ?? 104857600;
 		$this->copySizeLimit = $params['copySizeLimit'] ?? 5242880000;
 		$this->useMultipartCopy = (bool)($params['useMultipartCopy'] ?? true);
+		$this->retriesMaxAttempts = $params['retriesMaxAttempts'] ?? 5;
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.' . $params['region'] . '.amazonaws.com' : $params['hostname'];
 		$params['s3-accelerate'] = $params['hostname'] === 's3-accelerate.amazonaws.com' || $params['hostname'] === 's3-accelerate.dualstack.amazonaws.com';
@@ -109,7 +110,7 @@ trait S3ConnectionTrait {
 			'use_aws_shared_config_files' => false,
 			'retries' => [
 				'mode' => 'standard',
-				'max_attempts' => 5,
+				'max_attempts' => $this->retriesMaxAttempts,
 			],
 		];
 


### PR DESCRIPTION
Add retriesMaxAttempts parameter to S3 objectstore configuration to allow customization of AWS SDK retry behavior for handling unreliable network conditions or proxy issues.

Defaults to 5 retries (AWS SDK default) if not specified.

