### PR TITLE
fix(db): Fix JSON handling in WHERE statements for postgres

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2073,6 +2073,11 @@
       <code><![CDATA[new View('/' . $user)]]></code>
     </InternalMethod>
   </file>
+  <file src="apps/files_versions/lib/Db/VersionEntity.php">
+    <DeprecatedConstant>
+      <code><![CDATA[Types::JSON]]></code>
+    </DeprecatedConstant>
+  </file>
   <file src="apps/files_versions/lib/Listener/FileEventsListener.php">
     <InternalClass>
       <code><![CDATA[new View($user . '/files')]]></code>
@@ -2081,6 +2086,11 @@
       <code><![CDATA[file_exists]]></code>
       <code><![CDATA[new View($user . '/files')]]></code>
     </InternalMethod>
+  </file>
+  <file src="apps/files_versions/lib/Migration/Version1020Date20221114144058.php">
+    <DeprecatedConstant>
+      <code><![CDATA[Types::JSON]]></code>
+    </DeprecatedConstant>
   </file>
   <file src="apps/files_versions/lib/Sabre/RestoreFolder.php">
     <InvalidNullableReturnType>
@@ -3279,6 +3289,17 @@
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
+  </file>
+  <file src="core/Migrations/Version25000Date20220515204012.php">
+    <DeprecatedConstant>
+      <code><![CDATA[Types::JSON]]></code>
+    </DeprecatedConstant>
+  </file>
+  <file src="core/Migrations/Version33000Date20251106131209.php">
+    <DeprecatedConstant>
+      <code><![CDATA[IQueryBuilder::PARAM_JSON]]></code>
+      <code><![CDATA[IQueryBuilder::PARAM_JSON]]></code>
+    </DeprecatedConstant>
   </file>
   <file src="core/Service/LoginFlowV2Service.php">
     <DeprecatedClass>

--- a/core/Migrations/Version33000Date20251106131209.php
+++ b/core/Migrations/Version33000Date20251106131209.php
@@ -21,12 +21,19 @@ class Version33000Date20251106131209 extends SimpleMigrationStep {
 		private readonly IDBConnection $connection,
 	) {
 	}
+
 	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->update('share')
 			->set('attributes', $qb->createNamedParameter('[["permissions","download",true]]'))
-			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_CIRCLE, IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq('attributes', $qb->createNamedParameter('[["permissions","download",null]]'), IQueryBuilder::PARAM_JSON));
+			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_CIRCLE, IQueryBuilder::PARAM_INT)));
+
+		if ($this->connection->getDatabaseProvider(true) === IDBConnection::PLATFORM_MYSQL) {
+			$qb->andWhere($qb->expr()->eq('attributes', $qb->createFunction("JSON_ARRAY(JSON_ARRAY('permissions','download',null))"), IQueryBuilder::PARAM_JSON));
+		} else {
+			$qb->andWhere($qb->expr()->eq('attributes', $qb->createNamedParameter('[["permissions","download",null]]'), IQueryBuilder::PARAM_JSON));
+		}
+
 		$qb->executeStatement();
 	}
 }

--- a/core/Migrations/Version33000Date20251106131209.php
+++ b/core/Migrations/Version33000Date20251106131209.php
@@ -26,7 +26,7 @@ class Version33000Date20251106131209 extends SimpleMigrationStep {
 		$qb->update('share')
 			->set('attributes', $qb->createNamedParameter('[["permissions","download",true]]'))
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_CIRCLE, IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq('attributes', $qb->createNamedParameter('[["permissions","download",null]]', IQueryBuilder::PARAM_STR)));
+			->andWhere($qb->expr()->eq('attributes', $qb->createNamedParameter('[["permissions","download",null]]'), IQueryBuilder::PARAM_JSON));
 		$qb->executeStatement();
 	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
@@ -44,6 +44,8 @@ class MySqlExpressionBuilder extends ExpressionBuilder {
 		switch ($type) {
 			case IQueryBuilder::PARAM_STR:
 				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS CHAR)');
+			case IQueryBuilder::PARAM_JSON:
+				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS JSON)');
 			default:
 				return parent::castColumn($column, $type);
 		}

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
@@ -30,6 +30,32 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 	/**
 	 * @inheritdoc
 	 */
+	public function eq($x, $y, $type = null): string {
+		if ($type === IQueryBuilder::PARAM_JSON) {
+			$x = $this->prepareColumn($x, $type);
+			$y = $this->prepareColumn($y, $type);
+			return (string)(new QueryFunction('JSON_EQUAL(' . $x . ',' . $y . ')'));
+		}
+
+		return parent::eq($x, $y, $type);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function neq($x, $y, $type = null): string {
+		if ($type === IQueryBuilder::PARAM_JSON) {
+			$x = $this->prepareColumn($x, $type);
+			$y = $this->prepareColumn($y, $type);
+			return (string)(new QueryFunction('NOT JSON_EQUAL(' . $x . ',' . $y . ')'));
+		}
+
+		return parent::neq($x, $y, $type);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
 	public function in($x, $y, $type = null): string {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
@@ -8,6 +8,8 @@
 namespace OC\DB\QueryBuilder\ExpressionBuilder;
 
 use OC\DB\QueryBuilder\QueryFunction;
+use OCP\DB\QueryBuilder\ILiteral;
+use OCP\DB\QueryBuilder\IParameter;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 
@@ -25,10 +27,22 @@ class PgSqlExpressionBuilder extends ExpressionBuilder {
 			case IQueryBuilder::PARAM_INT:
 				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS BIGINT)');
 			case IQueryBuilder::PARAM_STR:
+			case IQueryBuilder::PARAM_JSON:
 				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS TEXT)');
 			default:
 				return parent::castColumn($column, $type);
 		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	protected function prepareColumn($column, $type) {
+		if ($type === IQueryBuilder::PARAM_JSON && !is_array($column) && !($column instanceof IParameter) && !($column instanceof ILiteral)) {
+			$column = $this->castColumn($column, $type);
+		}
+
+		return parent::prepareColumn($column, $type);
 	}
 
 	/**

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -99,6 +99,8 @@ interface IQueryBuilder {
 
 	/**
 	 * @since 24.0.0
+	 * @deprecated 33.0.0 JSON fields can not properly be used in WHERE statements of Oracle and MySQL.
+	 *                    It is recommended to use a simple STRING field and handle JSON within PHP
 	 */
 	public const PARAM_JSON = 'json';
 

--- a/lib/public/DB/Types.php
+++ b/lib/public/DB/Types.php
@@ -174,6 +174,8 @@ final class Types {
 	/**
 	 * @var string
 	 * @since 24.0.0
+	 * @deprecated 33.0.0 JSON fields can not properly be used in WHERE statements of Oracle and MySQL.
+	 *                    It is recommended to use a simple STRING field and handle JSON within PHP
 	 */
 	public const JSON = 'json';
 }

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -142,6 +142,16 @@ class ExpressionBuilderDBTest extends TestCase {
 	}
 
 	public function testJson(): void {
+		if ($this->connection->getDatabaseProvider(true) === IDBConnection::PLATFORM_ORACLE) {
+			$result = $this->connection->executeQuery('SELECT VERSION FROM PRODUCT_COMPONENT_VERSION');
+			$version = $result->fetchOne();
+			$result->closeCursor();
+			if (str_starts_with($version, '11.')) {
+				$this->markTestSkipped('JSON is not supported on Oracle 11, skipping until deprecation was clarified: ' . $version);
+			}
+		}
+
+
 		$appId = $this->getUniqueID('testing');
 		$query = $this->connection->getQueryBuilder();
 		$query->insert('share')


### PR DESCRIPTION
Fix #56497

cc @julien-nc the WHERE is now at least not throwing an exception anymore, but it is NOT matching in MySQL at least. I added a unit test so you can see the result

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
