### PR TITLE
Encode s3 metadata as base64 if needed

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -480,7 +480,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$metadata = [
 			'mimetype' => $mimetype,
 			'original-storage' => $this->getId(),
-			'original-path' => rawurlencode($path),
+			'original-path' => $path,
 		];
 		if ($size) {
 			$metadata['size'] = $size;

--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -100,6 +100,9 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload, IObjectStoreMetaD
 		$result = [];
 		foreach ($metadata as $key => $value) {
 			if (str_starts_with($key, 'x-amz-meta-')) {
+				if (str_starts_with($value, 'base64:')) {
+					$value = base64_decode(substr($value, 7));
+				}
 				$result[substr($key, strlen('x-amz-meta-'))] = $value;
 			}
 		}

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -82,7 +82,11 @@ trait S3ObjectTrait {
 	private function buildS3Metadata(array $metadata): array {
 		$result = [];
 		foreach ($metadata as $key => $value) {
-			$result['x-amz-meta-' . $key] = $value;
+			if (mb_check_encoding($value, 'ASCII')) {
+				$result['x-amz-meta-' . $key] = $value;
+			} else {
+				$result['x-amz-meta-' . $key] = 'base64:' . base64_encode($value);
+			}
 		}
 		return $result;
 	}


### PR DESCRIPTION
While https://github.com/nextcloud/server/pull/55717 fixes the same issue by urlencoding the path (which is currently the only field that can have non-ascii characters), this introduces a more generic approach and ensures that we can reliably recover the original encoding of the path.