### PR TITLE
[stable31] fix(unified-search): Register config lexicon of core so the default i…

### DIFF
--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\AppFramework\Bootstrap;
 
+use OC\Core\AppInfo\ConfigLexicon;
 use OC\Support\CrashReport\Registry;
 use OC_App;
 use OCP\App\AppPathNotFoundException;
@@ -60,6 +61,9 @@ class Coordinator {
 		if ($this->registrationContext === null) {
 			$this->registrationContext = new RegistrationContext($this->logger);
 		}
+
+		$this->registrationContext->registerConfigLexicon('core', ConfigLexicon::class);
+
 		$apps = [];
 		foreach ($appIds as $appId) {
 			$this->eventLogger->start("bootstrap:register_app:$appId", "Register $appId");


### PR DESCRIPTION
…s working

- Regression from https://github.com/nextcloud/server/pull/56344
- Revealed by Talk's :sparkles: integration tests: https://github.com/nextcloud/spreed/actions/runs/19399201000/job/55518098354?pr=16333
