### PR TITLE
Refactor mount providers files_sharing app

### DIFF
--- a/apps/files_sharing/lib/External/MountProvider.php
+++ b/apps/files_sharing/lib/External/MountProvider.php
@@ -15,6 +15,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\Server;
+use OCP\Share\IShare;
 
 class MountProvider implements IMountProvider {
 	public const STORAGE = '\OCA\Files_Sharing\External\Storage';
@@ -54,7 +55,7 @@ class MountProvider implements IMountProvider {
 		$qb->select('remote', 'share_token', 'password', 'mountpoint', 'owner')
 			->from('share_external')
 			->where($qb->expr()->eq('user', $qb->createNamedParameter($user->getUID())))
-			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
+			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(IShare::STATUS_ACCEPTED, IQueryBuilder::PARAM_INT)));
 		$result = $qb->executeQuery();
 		$mounts = [];
 		while ($row = $result->fetchAssociative()) {

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -171,7 +171,7 @@ class MountProvider implements IMountProvider {
 			$result[] = $tmp2;
 		}
 
-		return array_values($result);
+		return $result;
 	}
 
 	/**

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\Files_Sharing;
 
+use Exception;
 use InvalidArgumentException;
 use OC\Files\View;
 use OCA\Files_Sharing\Event\ShareMountedEvent;
@@ -23,6 +24,7 @@ use OCP\Share\IAttributes;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
+use function count;
 
 class MountProvider implements IMountProvider {
 	/**
@@ -58,85 +60,10 @@ class MountProvider implements IMountProvider {
 			$this->shareManager->getSharedWith($userId, IShare::TYPE_SCIENCEMESH, null, -1),
 		);
 
-		// filter out shares owned or shared by the user and ones for which
-		// the user has no permissions
-		$shares = array_filter($shares, function (IShare $share) use ($userId) {
-			return $share->getPermissions() > 0 && $share->getShareOwner() !== $userId && $share->getSharedBy() !== $userId;
-		});
-
+		$shares = $this->filterShares($shares, $userId);
 		$superShares = $this->buildSuperShares($shares, $user);
 
-		$allMounts = $this->mountManager->getAll();
-		$mounts = [];
-		$view = new View('/' . $userId . '/files');
-		$ownerViews = [];
-		$sharingDisabledForUser = $this->shareManager->sharingDisabledForUser($userId);
-		/** @var CappedMemoryCache<bool> $folderExistCache */
-		$foldersExistCache = new CappedMemoryCache();
-
-		$validShareCache = $this->cacheFactory->createLocal('share-valid-mountpoint-max');
-		$maxValidatedShare = $validShareCache->get($userId) ?? 0;
-		$newMaxValidatedShare = $maxValidatedShare;
-
-		foreach ($superShares as $share) {
-			[$parentShare, $groupedShares] = $share;
-			try {
-				if ($parentShare->getStatus() !== IShare::STATUS_ACCEPTED
-					&& ($parentShare->getShareType() === IShare::TYPE_GROUP
-						|| $parentShare->getShareType() === IShare::TYPE_USERGROUP
-						|| $parentShare->getShareType() === IShare::TYPE_USER)) {
-					continue;
-				}
-
-				$owner = $parentShare->getShareOwner();
-				if (!isset($ownerViews[$owner])) {
-					$ownerViews[$owner] = new View('/' . $owner . '/files');
-				}
-				$shareId = (int)$parentShare->getId();
-				$mount = new SharedMount(
-					'\OCA\Files_Sharing\SharedStorage',
-					$allMounts,
-					[
-						'user' => $userId,
-						// parent share
-						'superShare' => $parentShare,
-						// children/component of the superShare
-						'groupedShares' => $groupedShares,
-						'ownerView' => $ownerViews[$owner],
-						'sharingDisabledForUser' => $sharingDisabledForUser
-					],
-					$loader,
-					$view,
-					$foldersExistCache,
-					$this->eventDispatcher,
-					$user,
-					($shareId <= $maxValidatedShare),
-				);
-
-				$newMaxValidatedShare = max($shareId, $newMaxValidatedShare);
-
-				$event = new ShareMountedEvent($mount);
-				$this->eventDispatcher->dispatchTyped($event);
-
-				$mounts[$mount->getMountPoint()] = $allMounts[$mount->getMountPoint()] = $mount;
-				foreach ($event->getAdditionalMounts() as $additionalMount) {
-					$allMounts[$additionalMount->getMountPoint()] = $mounts[$additionalMount->getMountPoint()] = $additionalMount;
-				}
-			} catch (\Exception $e) {
-				$this->logger->error(
-					'Error while trying to create shared mount',
-					[
-						'app' => 'files_sharing',
-						'exception' => $e,
-					],
-				);
-			}
-		}
-
-		$validShareCache->set($userId, $newMaxValidatedShare, 24 * 60 * 60);
-
-		// array_filter removes the null values from the array
-		return array_values(array_filter($mounts));
+		return $this->getMountsFromSuperShares($userId, $superShares, $loader, $user);
 	}
 
 	/**
@@ -192,7 +119,7 @@ class MountProvider implements IMountProvider {
 		$groupedShares = $this->groupShares($allShares);
 
 		foreach ($groupedShares as $shares) {
-			if (\count($shares) === 0) {
+			if (count($shares) === 0) {
 				continue;
 			}
 
@@ -316,5 +243,115 @@ class MountProvider implements IMountProvider {
 				['app' => 'files_sharing']
 			);
 		}
+	}
+	/**
+	 * @param string $userId
+	 * @param array $superShares
+	 * @param IStorageFactory $loader
+	 * @param IUser $user
+	 * @return array
+	 * @throws Exception
+	 */
+	private function getMountsFromSuperShares(
+		string $userId,
+		array $superShares,
+		IStorageFactory $loader,
+		IUser $user,
+	): array {
+		$allMounts = $this->mountManager->getAll();
+		$mounts = [];
+		$view = new View('/' . $userId . '/files');
+		$ownerViews = [];
+		$sharingDisabledForUser
+			= $this->shareManager->sharingDisabledForUser($userId);
+		/** @var CappedMemoryCache<bool> $folderExistCache */
+		$foldersExistCache = new CappedMemoryCache();
+
+		$validShareCache
+			= $this->cacheFactory->createLocal('share-valid-mountpoint-max');
+		$maxValidatedShare = $validShareCache->get($userId) ?? 0;
+		$newMaxValidatedShare = $maxValidatedShare;
+
+		foreach ($superShares as $share) {
+			[$parentShare, $groupedShares] = $share;
+			try {
+				if ($parentShare->getStatus() !== IShare::STATUS_ACCEPTED
+					&& ($parentShare->getShareType() === IShare::TYPE_GROUP
+						|| $parentShare->getShareType() === IShare::TYPE_USERGROUP
+						|| $parentShare->getShareType() === IShare::TYPE_USER)
+				) {
+					continue;
+				}
+
+				$owner = $parentShare->getShareOwner();
+				if (!isset($ownerViews[$owner])) {
+					$ownerViews[$owner] = new View('/' . $owner . '/files');
+				}
+				$shareId = (int)$parentShare->getId();
+				$mount = new SharedMount(
+					'\OCA\Files_Sharing\SharedStorage',
+					$allMounts,
+					[
+						'user' => $userId,
+						// parent share
+						'superShare' => $parentShare,
+						// children/component of the superShare
+						'groupedShares' => $groupedShares,
+						'ownerView' => $ownerViews[$owner],
+						'sharingDisabledForUser' => $sharingDisabledForUser
+					],
+					$loader,
+					$view,
+					$foldersExistCache,
+					$this->eventDispatcher,
+					$user,
+					$shareId <= $maxValidatedShare,
+				);
+
+				$newMaxValidatedShare = max($shareId, $newMaxValidatedShare);
+
+				$event = new ShareMountedEvent($mount);
+				$this->eventDispatcher->dispatchTyped($event);
+
+				$mounts[$mount->getMountPoint()]
+				= $allMounts[$mount->getMountPoint()] = $mount;
+				foreach ($event->getAdditionalMounts() as $additionalMount) {
+					$allMounts[$additionalMount->getMountPoint()]
+					= $mounts[$additionalMount->getMountPoint()]
+						= $additionalMount;
+				}
+			} catch (Exception $e) {
+				$this->logger->error(
+					'Error while trying to create shared mount',
+					[
+						'app' => 'files_sharing',
+						'exception' => $e,
+					],
+				);
+			}
+		}
+
+		$validShareCache->set($userId, $newMaxValidatedShare, 24 * 60 * 60);
+
+		// array_filter removes the null values from the array
+		return array_values(array_filter($mounts));
+	}
+
+	/**
+	 * Filters out shares owned or shared by the user and ones for which the
+	 * user has no permissions.
+	 *
+	 * @param IShare[] $shares
+	 * @return IShare[]
+	 */
+	private function filterShares(array $shares, string $userId): array {
+		return array_filter(
+			$shares,
+			static function (IShare $share) use ($userId) {
+				return $share->getPermissions() > 0
+					&& $share->getShareOwner() !== $userId
+					&& $share->getSharedBy() !== $userId;
+			}
+		);
 	}
 }

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -79,10 +79,8 @@ class MountProvider implements IMountProvider {
 		$newMaxValidatedShare = $maxValidatedShare;
 
 		foreach ($superShares as $share) {
+			[$parentShare, $groupedShares] = $share;
 			try {
-				/** @var IShare $parentShare */
-				$parentShare = $share[0];
-
 				if ($parentShare->getStatus() !== IShare::STATUS_ACCEPTED
 					&& ($parentShare->getShareType() === IShare::TYPE_GROUP
 						|| $parentShare->getShareType() === IShare::TYPE_USERGROUP
@@ -92,7 +90,7 @@ class MountProvider implements IMountProvider {
 
 				$owner = $parentShare->getShareOwner();
 				if (!isset($ownerViews[$owner])) {
-					$ownerViews[$owner] = new View('/' . $parentShare->getShareOwner() . '/files');
+					$ownerViews[$owner] = new View('/' . $owner . '/files');
 				}
 				$shareId = (int)$parentShare->getId();
 				$mount = new SharedMount(
@@ -103,7 +101,7 @@ class MountProvider implements IMountProvider {
 						// parent share
 						'superShare' => $parentShare,
 						// children/component of the superShare
-						'groupedShares' => $share[1],
+						'groupedShares' => $groupedShares,
 						'ownerView' => $ownerViews[$owner],
 						'sharingDisabledForUser' => $sharingDisabledForUser
 					],

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1685,11 +1685,11 @@
   </file>
   <file src="apps/files_sharing/lib/MountProvider.php">
     <InternalClass>
-      <code><![CDATA[new View('/' . $parentShare->getShareOwner() . '/files')]]></code>
+      <code><![CDATA[new View('/' . $owner . '/files')]]></code>
       <code><![CDATA[new View('/' . $userId . '/files')]]></code>
     </InternalClass>
     <InternalMethod>
-      <code><![CDATA[new View('/' . $parentShare->getShareOwner() . '/files')]]></code>
+      <code><![CDATA[new View('/' . $owner . '/files')]]></code>
       <code><![CDATA[new View('/' . $userId . '/files')]]></code>
     </InternalMethod>
   </file>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1686,11 +1686,11 @@
   <file src="apps/files_sharing/lib/MountProvider.php">
     <InternalClass>
       <code><![CDATA[new View('/' . $parentShare->getShareOwner() . '/files')]]></code>
-      <code><![CDATA[new View('/' . $user->getUID() . '/files')]]></code>
+      <code><![CDATA[new View('/' . $userId . '/files')]]></code>
     </InternalClass>
     <InternalMethod>
       <code><![CDATA[new View('/' . $parentShare->getShareOwner() . '/files')]]></code>
-      <code><![CDATA[new View('/' . $user->getUID() . '/files')]]></code>
+      <code><![CDATA[new View('/' . $userId . '/files')]]></code>
     </InternalMethod>
     <RedundantFunctionCall>
       <code><![CDATA[array_values]]></code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1692,9 +1692,6 @@
       <code><![CDATA[new View('/' . $parentShare->getShareOwner() . '/files')]]></code>
       <code><![CDATA[new View('/' . $userId . '/files')]]></code>
     </InternalMethod>
-    <RedundantFunctionCall>
-      <code><![CDATA[array_values]]></code>
-    </RedundantFunctionCall>
   </file>
   <file src="apps/files_sharing/lib/Scanner.php">
     <DeprecatedInterface>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This branch contains some changes to clean up the two mount providers of the app:

- applies DRY in some of the most used functions
- removes unnecessary array_values
- splits big functions into multiple smaller functions to ease code navigation

The branch is part of this set of branches:

- master
  - #56537 :point_left:
    - #54441   
      - #55072 
        - #56538

## TODO

- [x] Consider removing the `$validateShares` flag, as technically it is a change needed for a child branch and is not a refactoring

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
