### PR TITLE
fix: Use POST instead of GET for multi-file downloads

### DIFF
--- a/apps/files/src/actions/downloadAction.ts
+++ b/apps/files/src/actions/downloadAction.ts
@@ -86,7 +86,25 @@ async function downloadNodes(nodes: Node[]) {
 		// The URL contains the path encoded so we need to decode as the query.append will re-encode it
 		const filenames = nodes.map((node) => decodeURIComponent(node.encodedSource.slice(url.href.length + 1)))
 		url.searchParams.append('accept', 'zip')
-		url.searchParams.append('files', JSON.stringify(filenames))
+
+		if (url.pathname.at(-1) !== '/') {
+			url.pathname = `${url.pathname}/`
+		}
+
+		const formData = new FormData()
+		formData.append('files', JSON.stringify(filenames))
+
+		const response = await axios.post(url.href, formData, {
+			responseType: 'blob',
+		})
+
+		const blobUrl = window.URL.createObjectURL(response.data)
+		try {
+			await triggerDownload(blobUrl)
+		} finally {
+			window.URL.revokeObjectURL(blobUrl)
+		}
+		return
 	}
 
 	if (url.pathname.at(-1) !== '/') {


### PR DESCRIPTION
When downloading multiple files as a ZIP archive, filenames were appended to the URL as query parameters, causing "414 Request-URI Too Long" errors with many files.

Backend now supports POST requests with files in request body. Frontend sends files via FormData in POST body instead of URL params.

Fixes #7935

