### PR TITLE
build: correct render build url in Vite for chunks/assets in dist

### DIFF
--- a/build/frontend/vite.config.mts
+++ b/build/frontend/vite.config.mts
@@ -89,5 +89,15 @@ export default createAppConfig(Object.fromEntries(viteModuleEntries), {
 				},
 			},
 		},
+		experimental: {
+			renderBuiltUrl(filename, { hostType }) {
+				if (hostType === 'css') {
+					return `./${filename}`
+				}
+				return {
+					runtime: `window.OC.filePath('', '', 'dist/${filename}')`,
+				}
+			},
+		},
 	},
 })


### PR DESCRIPTION
## Summary

- `@nextcloud/vite-config`'s `renderBuildUrl` is only compatible with apps with assets in `apps/<app-name>/(js|css)`, not in `/dist`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
