### PR TITLE
perf: Prepend the app as a whole

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -168,6 +168,15 @@ class Util {
 		}
 
 		if ($prepend) {
+			// Make sure the scripts of prepended applications are prepended within
+			// the apps as well, so that e.g. Talk can prepend itself on `/call/123456`
+			// URLs within it's template file, instead of being at the end, because
+			// other apps already queued after `core` using an earlier event or the
+			// `Application::boot()` method.
+			$appDeps = self::$scriptDeps[$application] ?? [];
+			unset(self::$scriptDeps[$application]);
+			self::$scriptDeps = [$application => $appDeps] + self::$scriptDeps;
+
 			array_unshift(self::$scripts[$application], $path);
 		} else {
 			self::$scripts[$application][] = $path;


### PR DESCRIPTION
- We noticed that on Talk quite many assets are loaded before Talk
- So we tested to add prepend https://github.com/nextcloud/spreed/pull/16375
- But turns out that only prepends the file within talks list
- It still loaded the 25 reference widgets app in alphabetical order before the main UI of Talk 🙈

Before | After
---|---
<img width="706" height="600" alt="grafik" src="https://github.com/user-attachments/assets/be0e3e52-9bb8-43cb-8f55-75bcb24d3503" /> | <img width="706" height="600" alt="grafik" src="https://github.com/user-attachments/assets/38da0c20-31bf-4e81-a12d-87c5680b1b7e" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
