### PR TITLE
fix(files_external): Fix registration of listeners with PHP >= 8.4

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -89,7 +89,11 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 
 		// force-load auth mechanisms since some will register hooks
 		// TODO: obsolete these and use the TokenProvider to get the user's password from the session
-		$this->getAuthMechanisms();
+		$objects = $this->getAuthMechanisms();
+		foreach ($objects as $object) {
+			/* Use the object to trigger DI on PHP >= 8.4 */
+			get_object_vars($object);
+		}
 	}
 
 	/**

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -42,6 +42,7 @@ use OCA\Files_External\Lib\Config\IAuthMechanismProvider;
 use OCA\Files_External\Lib\Config\IBackendProvider;
 use OCA\Files_External\Listener\GroupDeletedListener;
 use OCA\Files_External\Listener\LoadAdditionalListener;
+use OCA\Files_External\Listener\StorePasswordListener;
 use OCA\Files_External\Listener\UserDeletedListener;
 use OCA\Files_External\Service\BackendService;
 use OCP\AppFramework\App;
@@ -51,7 +52,9 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\QueryException;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Group\Events\GroupDeletedEvent;
+use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\UserDeletedEvent;
+use OCP\User\Events\UserLoggedInEvent;
 
 /**
  * @package OCA\Files_External\AppInfo
@@ -72,6 +75,8 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
 		$context->registerEventListener(GroupDeletedEvent::class, GroupDeletedListener::class);
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalListener::class);
+		$context->registerEventListener(UserLoggedInEvent::class, StorePasswordListener::class);
+		$context->registerEventListener(PasswordUpdatedEvent::class, StorePasswordListener::class);
 		$context->registerConfigLexicon(ConfigLexicon::class);
 	}
 
@@ -86,14 +91,6 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 				return $userConfigHandler;
 			});
 		});
-
-		// force-load auth mechanisms since some will register hooks
-		// TODO: obsolete these and use the TokenProvider to get the user's password from the session
-		$objects = $this->getAuthMechanisms();
-		foreach ($objects as $object) {
-			/* Use the object to trigger DI on PHP >= 8.4 */
-			get_object_vars($object);
-		}
 	}
 
 	/**

--- a/apps/files_external/lib/Lib/Auth/Password/LoginCredentials.php
+++ b/apps/files_external/lib/Lib/Auth/Password/LoginCredentials.php
@@ -11,18 +11,14 @@ use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\DefinitionParameter;
 use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
 use OCA\Files_External\Lib\StorageConfig;
-use OCA\Files_External\Listener\StorePasswordListener;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\Authentication\LoginCredentials\IStore as CredentialsStore;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
 use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\LDAP\ILDAPProviderFactory;
 use OCP\Security\ICredentialsManager;
-use OCP\User\Events\PasswordUpdatedEvent;
-use OCP\User\Events\UserLoggedInEvent;
 
 /**
  * Username and password from login credentials, saved in DB
@@ -35,7 +31,6 @@ class LoginCredentials extends AuthMechanism {
 		protected ISession $session,
 		protected ICredentialsManager $credentialsManager,
 		private CredentialsStore $credentialsStore,
-		IEventDispatcher $eventDispatcher,
 		private ILDAPProviderFactory $ldapFactory,
 	) {
 		$this
@@ -48,9 +43,6 @@ class LoginCredentials extends AuthMechanism {
 					->setFlag(DefinitionParameter::FLAG_HIDDEN)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			]);
-
-		$eventDispatcher->addServiceListener(UserLoggedInEvent::class, StorePasswordListener::class);
-		$eventDispatcher->addServiceListener(PasswordUpdatedEvent::class, StorePasswordListener::class);
 	}
 
 	private function getCredentials(IUser $user): array {


### PR DESCRIPTION
## Summary

With the lazy ghosts the constructor is not always called in files_external boot. 
Instead I moved the code out of the constructors and to the boot method.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
