### PR TITLE
ci: Disable always failing tests in users-group-admin.cy.ts

### DIFF
--- a/cypress/e2e/settings/users-group-admin.cy.ts
+++ b/cypress/e2e/settings/users-group-admin.cy.ts
@@ -87,7 +87,8 @@ describe('Settings: Create accounts as a group admin', function() {
 			.contains(john.userId).should('exist')
 	})
 
-	it('Can create a new user when member of multiple groups', () => {
+	// Skiping as this crash the webengine in the CI
+	it.skip('Can create a new user when member of multiple groups', () => {
 		const group2 = randomString(7)
 		cy.runOccCommand(`group:add '${group2}'`)
 		cy.runOccCommand(`group:adduser '${group2}' '${subadmin.userId}'`)
@@ -152,7 +153,7 @@ describe('Settings: Create accounts as a group admin', function() {
 			.contains(john.userId).should('exist')
 	})
 
-	it('Only sees groups they are subadmin of', () => {
+	it.skip('Only sees groups they are subadmin of', () => {
 		const group2 = randomString(7)
 		cy.runOccCommand(`group:add '${group2}'`)
 		cy.runOccCommand(`group:adduser '${group2}' '${subadmin.userId}'`)


### PR DESCRIPTION


## Summary

They keep failing with the Electron Renderer process crashing for weeks now, so disable them.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
