### PR TITLE
fix: Set correct sequences converting MySQL to PostgreSQL

### DIFF
--- a/lib/private/DB/PgSqlTools.php
+++ b/lib/private/DB/PgSqlTools.php
@@ -44,7 +44,11 @@ class PgSqlTools {
 		});
 
 		foreach ($conn->createSchemaManager()->listSequences() as $sequence) {
-			$sequenceName = $sequence->getName();
+			$longSequenceName = $sequence->getName();
+			// We need to strip away the preceding database prefix.
+			// Example: oc_circles_circle_id_seq, not nextcloud.oc_circles_circle_id_seq
+			$sequenceName = preg_replace('/^.*\./', '', $longSequenceName);
+
 			$sqlInfo = 'SELECT table_schema, table_name, column_name
 				FROM information_schema.columns
 				WHERE column_default = ? AND table_catalog = ?';


### PR DESCRIPTION
Fixes the bug:56128 https://github.com/nextcloud/server/issues/56128

While migrating to PostgreSQL users suffer an issue where the sequence variables aren't set.

After making this fix, the sequences are set correctly and migration succeeds.