### PR TITLE
fix(team-manager): team is already teamid

### DIFF
--- a/core/Controller/TeamsApiController.php
+++ b/core/Controller/TeamsApiController.php
@@ -66,8 +66,8 @@ class TeamsApiController extends OCSController {
 	public function listTeams(string $providerId, string $resourceId): DataResponse {
 		/** @psalm-suppress PossiblyNullArgument The route is limited to logged-in users */
 		$teams = $this->teamManager->getTeamsForResource($providerId, $resourceId, $this->userId);
-		$sharesPerTeams = $this->teamManager->getSharedWithList(array_map(fn (Team $team): string => $team->getId(), $teams), $this->userId);
-		$listTeams = array_values(array_map(function (Team $team) use ($sharesPerTeams) {
+		$sharesPerTeams = $this->teamManager->getSharedWithList(array_map(static fn (Team $team): string => $team->getId(), $teams), $this->userId);
+		$listTeams = array_values(array_map(static function (Team $team) use ($sharesPerTeams) {
 			$response = $team->jsonSerialize();
 			$response['resources'] = array_map(static fn (TeamResource $resource) => $resource->jsonSerialize(), $sharesPerTeams[$team->getId()] ?? []);
 			return $response;

--- a/lib/private/Teams/TeamManager.php
+++ b/lib/private/Teams/TeamManager.php
@@ -95,7 +95,7 @@ class TeamManager implements ITeamManager {
 				$resources[] = $provider->getSharedWithList($teams, $userId);
 			} else {
 				foreach ($teams as $team) {
-					$resources[] = [$team->getId() => $provider->getSharedWith($team->getId())];
+					$resources[] = [$team => $provider->getSharedWith($team)];
 				}
 			}
 		}

--- a/lib/public/Teams/ITeamManager.php
+++ b/lib/public/Teams/ITeamManager.php
@@ -42,7 +42,7 @@ interface ITeamManager {
 	public function getTeamsForResource(string $providerId, string $resourceId, string $userId): array;
 
 	/**
-	 * @param list<Team> $teams
+	 * @param string[] $teams
 	 * @return array<string, list<TeamResource>>
 	 *
 	 * @since 33.0.0


### PR DESCRIPTION
regression from https://github.com/nextcloud/server/pull/54953
`$team` is already an id: 

https://github.com/nextcloud/server/blob/9ba3ce27cb3f38da46183a458421ba1008eeea01/core/Controller/TeamsApiController.php#L69