### PR TITLE
chore: Bump autoloader files for new composer version

### DIFF
--- a/apps/admin_audit/composer/composer/autoload_static.php
+++ b/apps/admin_audit/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitAdminAudit
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\AdminAudit\\' => 15,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\AdminAudit\\' => 
+        'OCA\\AdminAudit\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/cloud_federation_api/composer/composer/autoload_static.php
+++ b/apps/cloud_federation_api/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitCloudFederationAPI
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\CloudFederationAPI\\' => 23,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\CloudFederationAPI\\' => 
+        'OCA\\CloudFederationAPI\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/comments/composer/composer/autoload_static.php
+++ b/apps/comments/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitComments
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Comments\\' => 13,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Comments\\' => 
+        'OCA\\Comments\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/contactsinteraction/composer/composer/autoload_static.php
+++ b/apps/contactsinteraction/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitContactsInteraction
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\ContactsInteraction\\' => 24,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\ContactsInteraction\\' => 
+        'OCA\\ContactsInteraction\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/dashboard/composer/composer/autoload_static.php
+++ b/apps/dashboard/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitDashboard
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Dashboard\\' => 14,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Dashboard\\' => 
+        'OCA\\Dashboard\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitDAV
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\DAV\\' => 8,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\DAV\\' => 
+        'OCA\\DAV\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/encryption/composer/composer/autoload_static.php
+++ b/apps/encryption/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitEncryption
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Encryption\\' => 15,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Encryption\\' => 
+        'OCA\\Encryption\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/federatedfilesharing/composer/composer/autoload_static.php
+++ b/apps/federatedfilesharing/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFederatedFileSharing
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\FederatedFileSharing\\' => 25,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\FederatedFileSharing\\' => 
+        'OCA\\FederatedFileSharing\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/federation/composer/composer/autoload_static.php
+++ b/apps/federation/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFederation
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Federation\\' => 15,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Federation\\' => 
+        'OCA\\Federation\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFiles
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Files\\' => 10,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Files\\' => 
+        'OCA\\Files\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/files_external/composer/composer/autoload_static.php
+++ b/apps/files_external/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFiles_External
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Files_External\\' => 19,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Files_External\\' => 
+        'OCA\\Files_External\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/files_reminders/composer/composer/autoload_static.php
+++ b/apps/files_reminders/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFilesReminders
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\FilesReminders\\' => 19,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\FilesReminders\\' => 
+        'OCA\\FilesReminders\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFiles_Sharing
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Files_Sharing\\' => 18,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Files_Sharing\\' => 
+        'OCA\\Files_Sharing\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/files_trashbin/composer/composer/autoload_static.php
+++ b/apps/files_trashbin/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFiles_Trashbin
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Files_Trashbin\\' => 19,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Files_Trashbin\\' => 
+        'OCA\\Files_Trashbin\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/files_versions/composer/composer/autoload_static.php
+++ b/apps/files_versions/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFiles_Versions
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Files_Versions\\' => 19,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Files_Versions\\' => 
+        'OCA\\Files_Versions\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/lookup_server_connector/composer/composer/autoload_static.php
+++ b/apps/lookup_server_connector/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitLookupServerConnector
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\LookupServerConnector\\' => 26,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\LookupServerConnector\\' => 
+        'OCA\\LookupServerConnector\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/oauth2/composer/composer/autoload_static.php
+++ b/apps/oauth2/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitOAuth2
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\OAuth2\\' => 11,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\OAuth2\\' => 
+        'OCA\\OAuth2\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/profile/composer/composer/autoload_static.php
+++ b/apps/profile/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitProfile
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Profile\\' => 12,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Profile\\' => 
+        'OCA\\Profile\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/provisioning_api/composer/composer/autoload_static.php
+++ b/apps/provisioning_api/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitProvisioning_API
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Provisioning_API\\' => 21,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Provisioning_API\\' => 
+        'OCA\\Provisioning_API\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitSettings
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Settings\\' => 13,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Settings\\' => 
+        'OCA\\Settings\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/sharebymail/composer/composer/autoload_static.php
+++ b/apps/sharebymail/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitShareByMail
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\ShareByMail\\' => 16,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\ShareByMail\\' => 
+        'OCA\\ShareByMail\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/systemtags/composer/composer/autoload_static.php
+++ b/apps/systemtags/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitSystemTags
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\SystemTags\\' => 15,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\SystemTags\\' => 
+        'OCA\\SystemTags\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/testing/composer/composer/autoload_static.php
+++ b/apps/testing/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitTesting
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Testing\\' => 12,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Testing\\' => 
+        'OCA\\Testing\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/theming/composer/composer/autoload_static.php
+++ b/apps/theming/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitTheming
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Theming\\' => 12,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Theming\\' => 
+        'OCA\\Theming\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/twofactor_backupcodes/composer/composer/autoload_static.php
+++ b/apps/twofactor_backupcodes/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitTwoFactorBackupCodes
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\TwoFactorBackupCodes\\' => 25,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\TwoFactorBackupCodes\\' => 
+        'OCA\\TwoFactorBackupCodes\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/updatenotification/composer/composer/autoload_static.php
+++ b/apps/updatenotification/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitUpdateNotification
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\UpdateNotification\\' => 23,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\UpdateNotification\\' => 
+        'OCA\\UpdateNotification\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/user_ldap/composer/composer/autoload_static.php
+++ b/apps/user_ldap/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitUser_LDAP
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\User_LDAP\\' => 14,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\User_LDAP\\' => 
+        'OCA\\User_LDAP\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/user_status/composer/composer/autoload_static.php
+++ b/apps/user_status/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitUserStatus
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\UserStatus\\' => 15,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\UserStatus\\' => 
+        'OCA\\UserStatus\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/weather_status/composer/composer/autoload_static.php
+++ b/apps/weather_status/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitWeatherStatus
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\WeatherStatus\\' => 18,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\WeatherStatus\\' => 
+        'OCA\\WeatherStatus\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/webhook_listeners/composer/composer/autoload_static.php
+++ b/apps/webhook_listeners/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitWebhookListeners
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\WebhookListeners\\' => 21,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\WebhookListeners\\' => 
+        'OCA\\WebhookListeners\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/apps/workflowengine/composer/composer/autoload_static.php
+++ b/apps/workflowengine/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitWorkflowEngine
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\WorkflowEngine\\' => 19,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\WorkflowEngine\\' => 
+        'OCA\\WorkflowEngine\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),

--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -22,8 +22,8 @@ COMPOSER_MAJOR_VERSION=$(echo "$COMPOSER_VERSION" | cut -d"." -f1)
 COMPOSER_MINOR_VERSION=$(echo "$COMPOSER_VERSION" | cut -d"." -f2)
 COMPOSER_PATCH_VERSION=$(echo "$COMPOSER_VERSION" | cut -d"." -f3)
 
-if ! [ "$COMPOSER_MAJOR_VERSION" -gt 2 -o \( "$COMPOSER_MAJOR_VERSION" -eq 2 -a "$COMPOSER_MINOR_VERSION" -ge 9 \) -o \( "$COMPOSER_MAJOR_VERSION" -eq 2 -a "$COMPOSER_MINOR_VERSION" -eq 8 -a "$COMPOSER_PATCH_VERSION" -ge 12 \) ]; then
-	echo "composer version >= 2.8.12 required. Version found: $COMPOSER_VERSION" >&2
+if ! [ "$COMPOSER_MAJOR_VERSION" -gt 2 -o \( "$COMPOSER_MAJOR_VERSION" -eq 2 -a "$COMPOSER_MINOR_VERSION" -ge 10 \) -o \( "$COMPOSER_MAJOR_VERSION" -eq 2 -a "$COMPOSER_MINOR_VERSION" -eq 9 -a "$COMPOSER_PATCH_VERSION" -ge 2 \) ]; then
+	echo "composer version >= 2.9.2 required. Version found: $COMPOSER_VERSION" >&2
 	exit 1
 fi
 

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -11,32 +11,32 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
     );
 
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OC\\Core\\' => 8,
             'OC\\' => 3,
             'OCP\\' => 4,
         ),
-        'N' => 
+        'N' =>
         array (
             'NCU\\' => 4,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OC\\Core\\' => 
+        'OC\\Core\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/core',
         ),
-        'OC\\' => 
+        'OC\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/lib/private',
         ),
-        'OCP\\' => 
+        'OCP\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/lib/public',
         ),
-        'NCU\\' => 
+        'NCU\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/lib/unstable',
         ),


### PR DESCRIPTION

## Summary

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
