### PR TITLE
fix(updatenotification): Fix log spam from ResetToken job

### DIFF
--- a/apps/updatenotification/lib/BackgroundJob/ResetToken.php
+++ b/apps/updatenotification/lib/BackgroundJob/ResetToken.php
@@ -43,7 +43,17 @@ class ResetToken extends TimedJob {
 			return;
 		}
 
-		$secretCreated = $this->appConfig->getValueInt('core', 'updater.secret.created');
+		$secretCreated = $this->appConfig->getValueInt('core', 'updater.secret.created', 0);
+
+		if ($secretCreated === 0) {
+			if ($this->config->getSystemValueString('updater.secret') !== '') {
+				$this->logger->error('Cleared old `updater.secret` with unknown creation date', ['app' => 'updatenotification']);
+				$this->config->deleteSystemValue('updater.secret');
+			}
+			$this->logger->debug('Skipping `updater.secret` reset since there is none', ['app' => 'updatenotification']);
+			return;
+		}
+
 		// Delete old tokens after 2 days and also tokens without any created date
 		$secretCreatedDiff = $this->time->getTime() - $secretCreated;
 		if ($secretCreatedDiff >= 172800) {


### PR DESCRIPTION
* Follow-up: https://github.com/nextcloud/server/pull/49578

## Summary

See https://github.com/nextcloud/server/pull/49578#issuecomment-3568253017

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
