### PR TITLE
build(deps): bump reuse from v5 to v6

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest-low
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
 
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5.0.0
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/build/frontend-legacy/WebpackSPDXPlugin.cjs
+++ b/build/frontend-legacy/WebpackSPDXPlugin.cjs
@@ -203,8 +203,10 @@ class WebpackSPDXPlugin {
 					const match = source.match(/asset\/inline\|data:image\/svg\+xml,(.+)/)
 					if (match) {
 						const content = decodeURI(match[1])
+						// REUSE-IgnoreStart
 						const [, license] = content.match(/SPDX-License-Identifier:\s*([^\s]+)/) ?? []
 						const [, author] = content.match(/SPDX-FileCopyrightText:\s*([^-]+)/) ?? []
+						// REUSE-IgnoreEnd
 						if (author && license) {
 							authors.add(author)
 							licenses.add(license)
@@ -219,10 +221,14 @@ class WebpackSPDXPlugin {
 			}
 
 			for (const author of [...authors].sort()) {
+				// REUSE-IgnoreStart
 				output = `SPDX-FileCopyrightText: ${author}\n${output}`
+				// REUSE-IgnoreEnd
 			}
 			for (const license of [...licenses].sort()) {
+				// REUSE-IgnoreStart
 				output = `SPDX-License-Identifier: ${license}\n${output}`
+				// REUSE-IgnoreEnd
 			}
 
 			compilation.emitAsset(


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] merge when reuse action turns green

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
