### PR TITLE
feat(files): add --use-user-id option to transfer-ownership command

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -76,6 +76,12 @@ class TransferOwnership extends Command {
 				null,
 				InputOption::VALUE_NONE,
 				'don\'t ask for confirmation for transferring external storages',
+			)
+			->addOption(
+				'use-user-id',
+				null,
+				InputOption::VALUE_NONE,
+				'use user ID instead of display name in the transferred folder name',
 			);
 	}
 
@@ -137,6 +143,7 @@ class TransferOwnership extends Command {
 				$input->getOption('move') === true,
 				false,
 				$includeExternalStorage,
+				$input->getOption('use-user-id') === true,
 			);
 		} catch (TransferOwnershipException $e) {
 			$output->writeln('<error>' . $e->getMessage() . '</error>');

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -73,6 +73,7 @@ class OwnershipTransferService {
 		bool $move = false,
 		bool $firstLogin = false,
 		bool $includeExternalStorage = false,
+		bool $useUserId = false,
 	): void {
 		$output = $output ?? new NullOutput();
 		$sourceUid = $sourceUser->getUID();
@@ -104,7 +105,12 @@ class OwnershipTransferService {
 			$l = $this->l10nFactory->get('files', $this->l10nFactory->getUserLanguage($destinationUser));
 			$date = date('Y-m-d H-i-s');
 
-			$cleanUserName = $this->sanitizeFolderName($sourceUser->getDisplayName()) ?: $sourceUid;
+			if ($useUserId) {
+				$cleanUserName = $sourceUid;
+			} else {
+				$cleanUserName = $this->sanitizeFolderName($sourceUser->getDisplayName()) ?: $sourceUid;
+			}
+			
 			$finalTarget = "$destinationUid/files/" . $this->sanitizeFolderName($l->t('Transferred from %1$s on %2$s', [$cleanUserName, $date]));
 			try {
 				$view->verifyPath(dirname($finalTarget), basename($finalTarget));

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -108,9 +108,12 @@ class OwnershipTransferService {
 			if ($useUserId) {
 				$cleanUserName = $sourceUid;
 			} else {
-				$cleanUserName = $this->sanitizeFolderName($sourceUser->getDisplayName()) ?: $sourceUid;
+				$cleanUserName = $this->sanitizeFolderName($sourceUser->getDisplayName());
+				if (empty($cleanUserName)) {
+					$cleanUserName = $sourceUid;
+				}
 			}
-			
+
 			$finalTarget = "$destinationUid/files/" . $this->sanitizeFolderName($l->t('Transferred from %1$s on %2$s', [$cleanUserName, $date]));
 			try {
 				$view->verifyPath(dirname($finalTarget), basename($finalTarget));

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -109,7 +109,7 @@ class OwnershipTransferService {
 				$cleanUserName = $sourceUid;
 			} else {
 				$cleanUserName = $this->sanitizeFolderName($sourceUser->getDisplayName());
-				if (empty($cleanUserName)) {
+				if ($cleanUserName === '') {
 					$cleanUserName = $sourceUid;
 				}
 			}


### PR DESCRIPTION
- Resolves: #54790

## Summary

Adds the `--use-user-id` option to the `occ files:transfer-ownership` command, allowing administrators to use user IDs instead of display names when generating target folder names during ownership transfers.

This avoids ambiguity in environments where multiple users share the same display name, ensuring clear and consistent identification.

## Changes

- Added the `--use-user-id` option to the `occ files:transfer-ownership` command
- Backward compatible: default behavior (using display names) remains unchanged

## Behavior

**Default (without flag):**  
Command: `occ files:transfer-ownership source_user dest_user`  
<img width="529" height="252" alt="default" src="https://github.com/user-attachments/assets/6b878117-4771-415f-883f-99a8c4df6365" />

**With `--use-user-id` flag:**  
Command: `occ files:transfer-ownership source_user dest_user --use-user-id`  
<img width="529" height="252" alt="with_flag" src="https://github.com/user-attachments/assets/9b4c09a2-a22f-4db5-8ccc-35a0c0ca7e82" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
