### PR TITLE
fix(trashbin): deletedBy of a file from a federated folder

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -40,12 +40,16 @@ use OCP\Files\Storage\IStorage;
 use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Server;
+use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Util;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
 
 /** @template-implements IEventListener<BeforeNodeDeletedEvent> */
@@ -326,13 +330,16 @@ class Trashbin implements IEventListener {
 		}
 
 		if ($moveSuccessful) {
+			// there is still a possibility that the file has been deleted by a remote user
+			$deletedBy = self::overwriteDeletedBy($user);
+
 			$query = Server::get(IDBConnection::class)->getQueryBuilder();
 			$query->insert('files_trash')
 				->setValue('id', $query->createNamedParameter($filename))
 				->setValue('timestamp', $query->createNamedParameter($timestamp))
 				->setValue('location', $query->createNamedParameter($location))
 				->setValue('user', $query->createNamedParameter($owner))
-				->setValue('deleted_by', $query->createNamedParameter($user));
+				->setValue('deleted_by', $query->createNamedParameter($deletedBy));
 			$result = $query->executeStatement();
 			if (!$result) {
 				Server::get(LoggerInterface::class)->error('trash bin database couldn\'t be updated', ['app' => 'files_trashbin']);
@@ -1180,6 +1187,29 @@ class Trashbin implements IEventListener {
 		} else {
 			return new NonExistingFile($rootFolder, $view, $fullPath);
 		}
+	}
+
+	/**
+	 * in case the request is authed, and user token is from a federated share
+	 * we use shared_with as initiator of the deletion
+	 */
+	private static function overwriteDeletedBy(string $user) {
+		try {
+			$request = Server::get(IRequest::class);
+			/** @psalm-suppress NoInterfaceProperties */
+			$token = $request->server['PHP_AUTH_USER'] ?? '';
+			if ($token === '') {
+				return $user;
+			}
+
+			$federatedShareProvider = Server::get(\OCA\FederatedFileSharing\FederatedShareProvider::class);
+			$share = $federatedShareProvider->getShareByToken($token);
+
+			return $share->getSharedWith();
+		} catch (NotFoundExceptionInterface|ContainerExceptionInterface|ShareNotFound) {
+		}
+
+		return $user;
 	}
 
 	public function handle(Event $event): void {


### PR DESCRIPTION
If coming from a federated folder, the share token is used to auth the webdav delete request.
Before creating new entry in the trashbin table, checking if file was deleted remotely using `IRequest`.
In case the token is a valid share token, using sharedWith to set deletedBy.
However deletedBy is now a remote entity but front-end will still displays _'Unknown'_, which is still better than _'You'_

<img width="809" height="275" alt="image" src="https://github.com/user-attachments/assets/2dc2070b-d14d-432c-a4d1-9ab787b013c2" />
