### PR TITLE
fix(lexicon): using userconfig on value set in lexicon

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -12,6 +12,7 @@ namespace OCA\Provisioning_API\Controller;
 
 use InvalidArgumentException;
 use OC\Authentication\Token\RemoteWipe;
+use OC\Core\AppInfo\ConfigLexicon;
 use OC\Group\Group;
 use OC\KnownUser\KnownUserService;
 use OC\User\Backend;
@@ -32,6 +33,7 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
+use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Group\ISubAdmin;
@@ -81,6 +83,7 @@ class UsersController extends AUserDataOCSController {
 		private IEventDispatcher $eventDispatcher,
 		private IPhoneNumberUtil $phoneNumberUtil,
 		private IAppManager $appManager,
+		private readonly IUserConfig $userConfig,
 	) {
 		parent::__construct(
 			$appName,
@@ -1116,19 +1119,19 @@ class UsersController extends AUserDataOCSController {
 				if (!in_array($value, $languagesCodes, true) && $value !== 'en') {
 					throw new OCSException($this->l10n->t('Invalid language'), 101);
 				}
-				$this->config->setUserValue($targetUser->getUID(), 'core', 'lang', $value);
+				$this->userConfig->setValueString($targetUser->getUID(), 'core', ConfigLexicon::USER_LANGUAGE, $value);
 				break;
 			case self::USER_FIELD_LOCALE:
 				if (!$this->l10nFactory->localeExists($value)) {
 					throw new OCSException($this->l10n->t('Invalid locale'), 101);
 				}
-				$this->config->setUserValue($targetUser->getUID(), 'core', 'locale', $value);
+				$this->userConfig->setValueString($targetUser->getUID(), 'core', ConfigLexicon::USER_LOCALE, $value);
 				break;
 			case self::USER_FIELD_TIMEZONE:
 				if (!in_array($value, \DateTimeZone::listIdentifiers())) {
 					throw new OCSException($this->l10n->t('Invalid timezone'), 101);
 				}
-				$this->config->setUserValue($targetUser->getUID(), 'core', 'timezone', $value);
+				$this->userConfig->setValueString($targetUser->getUID(), 'core', ConfigLexicon::USER_TIMEZONE, $value);
 				break;
 			case self::USER_FIELD_FIRST_DAY_OF_WEEK:
 				$intValue = (int)$value;

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -23,6 +23,7 @@ use OCP\Accounts\IAccountPropertyCollection;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
+use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Group\ISubAdmin;
@@ -66,6 +67,7 @@ class UsersControllerTest extends TestCase {
 	private IRootFolder $rootFolder;
 	private IPhoneNumberUtil $phoneNumberUtil;
 	private IAppManager $appManager;
+	private IUserConfig $userConfig;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -88,6 +90,7 @@ class UsersControllerTest extends TestCase {
 		$this->phoneNumberUtil = new PhoneNumberUtil();
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
 
 		$l10n = $this->createMock(IL10N::class);
 		$l10n->method('t')->willReturnCallback(fn (string $txt, array $replacement = []) => sprintf($txt, ...$replacement));
@@ -114,6 +117,7 @@ class UsersControllerTest extends TestCase {
 				$this->eventDispatcher,
 				$this->phoneNumberUtil,
 				$this->appManager,
+				$this->userConfig,
 			])
 			->onlyMethods(['fillStorageInfo'])
 			->getMock();
@@ -503,6 +507,7 @@ class UsersControllerTest extends TestCase {
 				$this->eventDispatcher,
 				$this->phoneNumberUtil,
 				$this->appManager,
+				$this->userConfig,
 			])
 			->onlyMethods(['editUser'])
 			->getMock();
@@ -2288,8 +2293,8 @@ class UsersControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('UserToEdit');
 		$targetUser = $this->createMock(IUser::class);
-		$this->config->expects($this->once())
-			->method('setUserValue')
+		$this->userConfig->expects($this->once())
+			->method('setValueString')
 			->with('UserToEdit', 'core', 'lang', 'de');
 		$this->userSession
 			->expects($this->once())
@@ -2343,8 +2348,8 @@ class UsersControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('UserToEdit');
 		$targetUser = $this->createMock(IUser::class);
-		$this->config->expects($this->never())
-			->method('setUserValue');
+		$this->userConfig->expects($this->never())
+			->method('setValueString');
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -2384,8 +2389,8 @@ class UsersControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('admin');
 		$targetUser = $this->createMock(IUser::class);
-		$this->config->expects($this->once())
-			->method('setUserValue')
+		$this->userConfig->expects($this->once())
+			->method('setValueString')
 			->with('UserToEdit', 'core', 'lang', 'de');
 		$this->userSession
 			->expects($this->once())
@@ -3847,6 +3852,7 @@ class UsersControllerTest extends TestCase {
 				$this->eventDispatcher,
 				$this->phoneNumberUtil,
 				$this->appManager,
+				$this->userConfig,
 			])
 			->onlyMethods(['getUserData'])
 			->getMock();
@@ -3941,6 +3947,7 @@ class UsersControllerTest extends TestCase {
 				$this->eventDispatcher,
 				$this->phoneNumberUtil,
 				$this->appManager,
+				$this->userConfig,
 			])
 			->onlyMethods(['getUserData'])
 			->getMock();

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
  */
 namespace OC\L10N;
 
+use OC\Core\AppInfo\ConfigLexicon;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
+use OCP\Config\IUserConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -71,6 +73,7 @@ class Factory implements IFactory {
 	];
 
 	private ICache $cache;
+	private IUserConfig $userConfig;
 
 	public function __construct(
 		protected IConfig $config,
@@ -220,7 +223,8 @@ class Factory implements IFactory {
 			// Try to get the language from the Request
 			$lang = $this->getLanguageFromRequest($appId);
 			if ($userId !== null && $appId === null && !$userLang) {
-				$this->config->setUserValue($userId, 'core', 'lang', $lang);
+				$userConfig = \OCP\Server::get(IUserConfig::class);
+				$userConfig->setValueString($userId, 'core', ConfigLexicon::USER_LANGUAGE, $lang);
 			}
 			return $lang;
 		} catch (LanguageNotFoundException $e) {


### PR DESCRIPTION
Upgrade/Migration will now update metadata about config values based on lexicon.
Code setting config values defined in lexicon now needs to call typed method