### PR TITLE
fix(s3): make data integrity protections opt-in

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1980,6 +1980,12 @@ $CONFIG = [
 			// optional: Maximum number of retry attempts for failed S3 requests
 			// Default: 5
 			'retriesMaxAttempts' => 5,
+			// Data Integrity Protections for Amazon S3 (https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html)
+			// Valid values are "when_required" (default) and "when_supported".
+			// To ensure compatibility with 3rd party S3 implementations, Nextcloud disables it by default. However, if you are
+			// using Amazon S3 (or any other implementation that supports it) we recommend enabling it by using "when_supported".
+			'request_checksum_calculation' => 'when_required',
+			'response_checksum_validation' => 'when_required',
 		],
 	],
 

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -137,10 +137,14 @@ trait S3ConnectionTrait {
 
 		if (isset($this->params['request_checksum_calculation'])) {
 			$options['request_checksum_calculation'] = $this->params['request_checksum_calculation'];
+		} else {
+			$options['request_checksum_calculation'] = 'when_required';
 		}
 
 		if (isset($this->params['response_checksum_validation'])) {
 			$options['response_checksum_validation'] = $this->params['response_checksum_validation'];
+		} else {
+			$options['response_checksum_validation'] = 'when_required';
 		}
 
 		if ($this->getProxy()) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Follow up for https://github.com/nextcloud/documentation/pull/13875, https://github.com/nextcloud/server/pull/56096 and https://github.com/nextcloud/server/pull/56078.

The AWS SDK shipped with Nextcloud 32 does enable it by default. That only works if your S3 implementation does support it. Otherwise, you are unable to upload new files. Therefore we are turning it off by default.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
