### PR TITLE
fix(logger): add back lost params for logger methods

### DIFF
--- a/lib/private/Log/PsrLoggerAdapter.php
+++ b/lib/private/Log/PsrLoggerAdapter.php
@@ -15,6 +15,7 @@ use OCP\Log\IDataLogger;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Stringable;
 use Throwable;
 use function array_key_exists;
 use function array_merge;
@@ -27,14 +28,14 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 
 	public static function logLevelToInt(string $level): int {
 		return match ($level) {
-			LogLevel::ALERT => ILogger::ERROR,
-			LogLevel::CRITICAL => ILogger::ERROR,
-			LogLevel::DEBUG => ILogger::DEBUG,
 			LogLevel::EMERGENCY => ILogger::FATAL,
-			LogLevel::ERROR => ILogger::ERROR,
-			LogLevel::INFO => ILogger::INFO,
-			LogLevel::NOTICE => ILogger::INFO,
+			LogLevel::ALERT,
+			LogLevel::ERROR,
+			LogLevel::CRITICAL => ILogger::ERROR,
 			LogLevel::WARNING => ILogger::WARN,
+			LogLevel::INFO,
+			LogLevel::NOTICE => ILogger::INFO,
+			LogLevel::DEBUG => ILogger::DEBUG,
 			default => throw new InvalidArgumentException('Unsupported custom log level'),
 		};
 	}
@@ -50,10 +51,9 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	/**
 	 * System is unusable.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function emergency($message, array $context = []): void {
+	public function emergency(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::EMERGENCY, (string)$message, $context);
 	}
 
@@ -63,10 +63,9 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Example: Entire website down, database unavailable, etc. This should
 	 * trigger the SMS alerts and wake you up.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function alert($message, array $context = []): void {
+	public function alert(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::ALERT, (string)$message, $context);
 	}
 
@@ -75,10 +74,9 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 *
 	 * Example: Application component unavailable, unexpected exception.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function critical($message, array $context = []): void {
+	public function critical(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::CRITICAL, (string)$message, $context);
 	}
 
@@ -86,10 +84,9 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Runtime errors that do not require immediate action but should typically
 	 * be logged and monitored.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function error($message, array $context = []): void {
+	public function error(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::ERROR, (string)$message, $context);
 	}
 
@@ -99,20 +96,18 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
 	 * that are not necessarily wrong.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function warning($message, array $context = []): void {
+	public function warning(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::WARNING, (string)$message, $context);
 	}
 
 	/**
 	 * Normal but significant events.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function notice($message, array $context = []): void {
+	public function notice(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::NOTICE, (string)$message, $context);
 	}
 
@@ -121,20 +116,18 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 *
 	 * Example: User logs in, SQL logs.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function info($message, array $context = []): void {
+	public function info(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::INFO, (string)$message, $context);
 	}
 
 	/**
 	 * Detailed debug information.
 	 *
-	 * @param $message
 	 * @param mixed[] $context
 	 */
-	public function debug($message, array $context = []): void {
+	public function debug(string|Stringable $message, array $context = []): void {
 		$this->log(LogLevel::DEBUG, (string)$message, $context);
 	}
 
@@ -142,7 +135,6 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Logs with an arbitrary level.
 	 *
 	 * @param mixed $level
-	 * @param $message
 	 * @param mixed[] $context
 	 *
 	 * @throws InvalidArgumentException


### PR DESCRIPTION
Originally added in 
https://github.com/nextcloud/server/pull/44761
https://github.com/nextcloud/server/pull/47293

Lost in https://github.com/nextcloud/server/pull/45094

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
