### PR TITLE
feat(app): allow removing installed-but-disabled apps; improve help & logging

### DIFF
--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -35,11 +35,11 @@ class Remove extends Command implements CompletionAwareInterface {
 			->setName('app:remove')
 			->setDescription('Remove an app from this Nextcloud instance')
 			->setHelp(
-				"Removes the specified app and, if present, runs the app's uninstall steps.\n" .
-				"\n" .
-				"By default, this command runs the app's uninstall steps (which may delete data) and then removes the app files.\n" .
-				"Use `--keep-data` to skip uninstall steps and preserve app data (database tables, configuration, and stored files).\n" .
-				"Note: Some apps may still preserve data either way, depending on their uninstall implementation.\n"
+				"Removes the specified app and, if present, runs the app's uninstall steps.\n"
+				. "\n"
+				. "By default, this command runs the app's uninstall steps (which may delete data) and then removes the app files.\n"
+				. "Use `--keep-data` to skip uninstall steps and preserve app data (database tables, configuration, and stored files).\n"
+				. "Note: Some apps may still preserve data either way, depending on their uninstall implementation.\n"
 			)
 			->addArgument(
 				'app-id',
@@ -55,8 +55,8 @@ class Remove extends Command implements CompletionAwareInterface {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$appId = (string) $input->getArgument('app-id');
-		$keepData  = (bool) $input->getOption('keep-data');
+		$appId = (string)$input->getArgument('app-id');
+		$keepData = (bool)$input->getOption('keep-data');
 
 		// Prevent removal of shipped/core apps
 		if ($this->manager->isShipped($appId)) {
@@ -111,7 +111,7 @@ class Remove extends Command implements CompletionAwareInterface {
 			$this->logger->error($message, [ 'app' => 'CLI', ]);
 			return self::FAILURE;
 		}
-		
+
 		$message = "Removed app '$appId' (version $appVersion).";
 		$output->writeln($message);
 		$this->logger->info($message, [ 'app' => 'CLI', ]);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #49689 <!-- related github issue -->

## Summary

- Allow removal of apps that are installed but currently disabled
 - Add explicit installed check (getAppPath) with clear message when not installed
- Expand help text to document uninstall behavior and --keep-data
 - Mirror console messages to logs for key events and consolidate exception logging
- miscellaneous code tidying

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
