### PR TITLE
feat(user_ldap): add function to find a user in ldap

### DIFF
--- a/apps/user_ldap/lib/LDAPProvider.php
+++ b/apps/user_ldap/lib/LDAPProvider.php
@@ -11,6 +11,7 @@ use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCP\IServerContainer;
 use OCP\LDAP\IDeletionFlagSupport;
 use OCP\LDAP\ILDAPProvider;
+use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -326,5 +327,15 @@ class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
 
 		$connection->writeToCache($key, $values);
 		return $values;
+	}
+
+	/**
+	 * Search for a single user in ldap
+	 *
+	 * @return IUser|null Returns a IUser if found in ldap using the configured ldap filter
+	 * @throws \Exception if multiple users has been found (search query should not allow this)
+	 */
+	public function findOneUser(string $filter, string $attribute, string $searchTerm): ?IUser {
+		return $this->userBackend->getUserFromCustomAttribute($filter, $attribute, $searchTerm);
 	}
 }

--- a/apps/user_ldap/lib/LDAPProvider.php
+++ b/apps/user_ldap/lib/LDAPProvider.php
@@ -329,12 +329,6 @@ class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
 		return $values;
 	}
 
-	/**
-	 * Search for a single user in ldap
-	 *
-	 * @return IUser|null Returns a IUser if found in ldap using the configured ldap filter
-	 * @throws \Exception if multiple users has been found (search query should not allow this)
-	 */
 	public function findOneUser(string $filter, string $attribute, string $searchTerm): ?IUser {
 		return $this->userBackend->getUserFromCustomAttribute($filter, $attribute, $searchTerm);
 	}

--- a/apps/user_ldap/lib/LDAPProvider.php
+++ b/apps/user_ldap/lib/LDAPProvider.php
@@ -9,9 +9,9 @@ namespace OCA\User_LDAP;
 
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCP\IServerContainer;
+use OCP\IUser;
 use OCP\LDAP\IDeletionFlagSupport;
 use OCP\LDAP\ILDAPProvider;
-use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -14,6 +14,8 @@ use OCA\User_LDAP\Exceptions\NotOnLDAP;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserBackend;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\ICountMappedUsersBackend;
@@ -29,6 +31,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 		protected UserPluginManager $userPluginManager,
 		protected LoggerInterface $logger,
 		protected DeletedUsersIndex $deletedUsersIndex,
+		protected IUserManager $userManager,
 	) {
 		parent::__construct($access);
 	}
@@ -642,5 +645,39 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 
 	public function getDisabledUserList(?int $limit = null, int $offset = 0, string $search = ''): array {
 		throw new \Exception('This is implemented directly in User_Proxy');
+	}
+
+	/**
+	 * Fetches one user from LDAP based on a filter or a custom attribute and search term.
+	 *
+	 * If no custom filter is provided or the filter is empty, it creates a simple equality filter with the given attribute.
+	 * If a custom filter is provided, it uses that filter directly and the attribute and search term are ignored.
+	 * 
+	 * @throws \Exception if multiple users have been found (search query should not allow this)
+	 * 
+	 * @param string $filter The LDAP filter to use. If null or empty string, a default filter is constructed.
+	 * @param string $attribute The LDAP attribute name to search against (e.g., 'mail', 'cn', 'uid').
+	 * @param string $searchTerm The search term to match against the attribute. Will be escaped for LDAP filter safety.
+	 * 
+	 * @return IUser |null Returns an IUser if found in LDAP using the configured LDAP filter, or null if no user is found.
+	 */
+	public function getUserFromCustomAttribute(string $filter, string $attribute, string $searchTerm): ?IUser {
+		if ($filter === null || $filter === '') {
+			$searchTerm = $this->access->escapeFilterPart($searchTerm);
+			$filter = "($attribute=$searchTerm)";
+		}
+		$records = $this->access->searchUsers($filter, ['dn']);
+		if (count($records) === 1) {
+			$ldapUser = $this->access->userManager->get($records[0]['dn'][0]);
+			$user = $this->userManager->get($ldapUser->getUsername());
+			return $user;
+		} elseif (count($records) > 1) {
+			$this->logger->error(
+				'Multiple users found for filter: ' . $filter,
+				['app' => 'user_ldap']
+			);
+			throw new \Exception('Multiple users found for single user search');
+		}
+		return null;
 	}
 }

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -17,6 +17,7 @@ use OCA\User_LDAP\User\User;
 use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\IUserManager;
+use OCP\LDAP\MultipleUsersReturnedException;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\ICountMappedUsersBackend;
 use OCP\User\Backend\ILimitAwareCountUsersBackend;
@@ -653,7 +654,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 * If no custom filter is provided or the filter is empty, it creates a simple equality filter with the given attribute.
 	 * If a custom filter is provided, it uses that filter directly and the attribute and search term are ignored.
 	 *
-	 * @throws \Exception if multiple users have been found (search query should not allow this)
+	 * @throws MultipleUsersReturnedException if multiple users have been found (search query should not allow this)
 	 *
 	 * @param string $filter The LDAP filter to use. If null or empty string, a default filter is constructed.
 	 * @param string $attribute The LDAP attribute name to search against (e.g., 'mail', 'cn', 'uid').
@@ -676,7 +677,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 				'Multiple users found for filter: ' . $filter,
 				['app' => 'user_ldap']
 			);
-			throw new \Exception('Multiple users found for single user search');
+			throw new MultipleUsersReturnedException();
 		}
 		return null;
 	}

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -15,8 +15,8 @@ use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
 use OCP\IUser;
-use OCP\IUserManager;
 use OCP\IUserBackend;
+use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\ICountMappedUsersBackend;
 use OCP\User\Backend\ILimitAwareCountUsersBackend;
@@ -652,13 +652,13 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 *
 	 * If no custom filter is provided or the filter is empty, it creates a simple equality filter with the given attribute.
 	 * If a custom filter is provided, it uses that filter directly and the attribute and search term are ignored.
-	 * 
+	 *
 	 * @throws \Exception if multiple users have been found (search query should not allow this)
-	 * 
+	 *
 	 * @param string $filter The LDAP filter to use. If null or empty string, a default filter is constructed.
 	 * @param string $attribute The LDAP attribute name to search against (e.g., 'mail', 'cn', 'uid').
 	 * @param string $searchTerm The search term to match against the attribute. Will be escaped for LDAP filter safety.
-	 * 
+	 *
 	 * @return IUser |null Returns an IUser if found in LDAP using the configured LDAP filter, or null if no user is found.
 	 */
 	public function getUserFromCustomAttribute(string $filter, string $attribute, string $searchTerm): ?IUser {

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -10,6 +10,8 @@ namespace OCA\User_LDAP;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserBackend;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\ICountMappedUsersBackend;
@@ -30,6 +32,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 		private UserPluginManager $userPluginManager,
 		private LoggerInterface $logger,
 		private DeletedUsersIndex $deletedUsersIndex,
+		private IUserManager $userManager,
 	) {
 		parent::__construct($helper, $ldap, $accessFactory);
 	}
@@ -41,6 +44,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 			$this->userPluginManager,
 			$this->logger,
 			$this->deletedUsersIndex,
+			$this->userManager,
 		);
 	}
 
@@ -431,4 +435,15 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 			)
 		);
 	}
+
+	public function getUserFromCustomAttribute(string $filter, string $attribute, string $searchTerm): ?IUser {
+		$this->setup();
+		foreach ($this->backends as $backend) {
+			if (method_exists($backend, 'getUserFromCustomAttribute')) {
+				$user = $backend->getUserFromCustomAttribute($filter, $attribute, $searchTerm);
+				return $user;
+			}
+		}		
+		return null;
+	}	
 }

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -11,8 +11,8 @@ use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
 use OCP\IUser;
-use OCP\IUserManager;
 use OCP\IUserBackend;
+use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\ICountMappedUsersBackend;
 use OCP\User\Backend\ILimitAwareCountUsersBackend;
@@ -443,7 +443,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 				$user = $backend->getUserFromCustomAttribute($filter, $attribute, $searchTerm);
 				return $user;
 			}
-		}		
+		}
 		return null;
-	}	
+	}
 }

--- a/lib/public/LDAP/ILDAPProvider.php
+++ b/lib/public/LDAP/ILDAPProvider.php
@@ -159,6 +159,7 @@ interface ILDAPProvider {
 	 *
 	 * @return IUser|null Returns a IUser if found in ldap using the configured ldap filter
 	 * @throws MultipleUsersReturnedException if multiple users has been found (search query should not allow this)
+	 * @since 33.0.0
 	 */
 	public function findOneUser(string $filter, string $attribute, string $searchTerm): ?IUser;
 }

--- a/lib/public/LDAP/ILDAPProvider.php
+++ b/lib/public/LDAP/ILDAPProvider.php
@@ -158,7 +158,7 @@ interface ILDAPProvider {
 	 * Search for a single user in ldap
 	 *
 	 * @return IUser|null Returns a IUser if found in ldap using the configured ldap filter
-	 * @throws \Exception if multiple users has been found (search query should not allow this)
+	 * @throws MultipleUsersReturnedException if multiple users has been found (search query should not allow this)
 	 */
 	public function findOneUser(string $filter, string $attribute, string $searchTerm): ?IUser;
 }

--- a/lib/public/LDAP/ILDAPProvider.php
+++ b/lib/public/LDAP/ILDAPProvider.php
@@ -6,6 +6,8 @@
  */
 namespace OCP\LDAP;
 
+use OCP\IUser;
+
 /**
  * Interface ILDAPProvider
  *
@@ -151,4 +153,12 @@ interface ILDAPProvider {
 	 * @since 22.0.0
 	 */
 	public function getMultiValueUserAttribute(string $uid, string $attribute): array;
+
+	/**
+	 * Search for a single user in ldap
+	 *
+	 * @return IUser|null Returns a IUser if found in ldap using the configured ldap filter
+	 * @throws \Exception if multiple users has been found (search query should not allow this)
+	 */
+	public function findOneUser(string $filter, string $attribute, string $searchTerm): ?IUser;
 }

--- a/lib/public/LDAP/MultipleUsersReturnedException.php
+++ b/lib/public/LDAP/MultipleUsersReturnedException.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\LDAP;
+
+/**
+ * Exception for a ldap search that unexpectedly returns multiple users.
+ * @since 33.0.0
+ */
+class MultipleUsersReturnedException extends \Exception {
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* linked to: nextcloud/server#55284

## Summary
Add a findOneUser function to LDAPProvider

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
