### PR TITLE
fix(templates): deduplicate provider templates

### DIFF
--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -213,12 +213,13 @@ class TemplateManager implements ITemplateManager {
 		foreach ($this->getRegisteredProviders() as $provider) {
 			foreach ($type->getMimetypes() as $mimetype) {
 				foreach ($provider->getCustomTemplates($mimetype) as $template) {
-					$templates[] = $template;
+					$templateId = $template->jsonSerialize()['templateId'];
+					$templates[$templateId] = $template;
 				}
 			}
 		}
 
-		return $templates;
+		return array_values($templates);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR de-duplicates provider templates. This will prevent the same global template from showing up twice in the template picker, as you can see in the screenshots. The reason this happens is because apps can provide the same template for several MIME types and there does not seem to be a way for an app to de-duplicate them itself. It is given one MIME type at a time when called by the server, so it is just expected to return the matching templates for that type and cannot know whether a given template has already been returned.

## Screenshots

<details>
<summary>Before</summary>

<img width="1298" height="716" alt="image" src="https://github.com/user-attachments/assets/863a0f74-321b-4602-b154-c50c3c2d5156" />
</details>


<details>
<summary>After</summary>

<img width="1066" height="716" alt="image" src="https://github.com/user-attachments/assets/98ccc3c7-1491-4676-bac6-8ae6c198173f" />
</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
