### PR TITLE
fix(user_ldap): Do not use variables directly in translation strings

### DIFF
--- a/apps/user_ldap/lib/Controller/WizardController.php
+++ b/apps/user_ldap/lib/Controller/WizardController.php
@@ -104,7 +104,7 @@ class WizardController extends OCSController {
 					throw new OCSException();
 
 				default:
-					throw new OCSException($this->l->t('Action does not exist'));
+					throw new OCSException('Action ' . $wizardAction . 'does not exist');
 					break;
 			}
 		} catch (OCSException $e) {
@@ -149,7 +149,7 @@ class WizardController extends OCSController {
 				$mapping = Server::get(GroupMapping::class);
 				$result = $mapping->clear();
 			} else {
-				throw new OCSException($this->l->t('Unsupported subject ' . $subject));
+				throw new OCSException('Unsupported subject ' . $subject);
 			}
 
 			if (!$result) {


### PR DESCRIPTION
* Resolves: #56669

## Summary

I simply removed translations for exceptions which are never supposed to
 happen apart from API misuse or code bug.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
