### PR TITLE
Drop Oracle 11 support

### DIFF
--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -60,8 +60,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - oracle-versions: '11'
-            php-versions: '8.2'
           - oracle-versions: '18'
             php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -22,6 +22,8 @@ class SupportedDatabase implements ISetupCheck {
 	private const MAX_MYSQL = '8.4';
 	private const MIN_POSTGRES = '14';
 	private const MAX_POSTGRES = '18';
+	private const MIN_ORACLE = '12.2';
+	private const MAX_ORACLE = '26';
 
 	public function __construct(
 		private IL10N $l10n,
@@ -107,7 +109,29 @@ class SupportedDatabase implements ISetupCheck {
 				);
 			}
 		} elseif ($databasePlatform === IDBConnection::PLATFORM_ORACLE) {
-			$version = 'Oracle';
+			$result = $this->connection->executeQuery('SELECT VERSION FROM PRODUCT_COMPONENT_VERSION');
+			$version = $result->fetchOne();
+			$result->closeCursor();
+			$versionLower = strtolower($version);
+			// we only care about X.Y not X.Y.Z differences
+			[$major, $minor, ] = explode('.', $versionLower);
+			$versionConcern = $major . '.' . $minor;
+			if (version_compare($versionConcern, self::MIN_ORACLE, '<') || version_compare($versionConcern, self::MAX_ORACLE, '>')) {
+				$extendedWarning = '';
+				if (version_compare($versionConcern, self::MIN_ORACLE, '<')) {
+					$extendedWarning = "\n" . $this->l10n->t('Nextcloud %d does not support your current version, so be sure to update the database before updating your Nextcloud Server.', [33]);
+				}
+				return SetupResult::warning(
+					$this->l10n->t(
+						'Oracle version "%1$s" detected. Oracle >=%2$s and <=%3$s is suggested for best performance, stability and functionality with this version of Nextcloud.',
+						[
+							$version,
+							self::MIN_ORACLE,
+							self::MAX_ORACLE,
+						])
+					. $extendedWarning
+				);
+			}
 		} elseif ($databasePlatform === IDBConnection::PLATFORM_SQLITE) {
 			return SetupResult::warning(
 				$this->l10n->t('SQLite is currently being used as the backend database. For larger installations we recommend that you switch to a different database backend. This is particularly recommended when using the desktop client for file synchronisation. To migrate to another database use the command line tool: "occ db:convert-type".'),

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -142,16 +142,6 @@ class ExpressionBuilderDBTest extends TestCase {
 	}
 
 	public function testJson(): void {
-		if ($this->connection->getDatabaseProvider(true) === IDBConnection::PLATFORM_ORACLE) {
-			$result = $this->connection->executeQuery('SELECT VERSION FROM PRODUCT_COMPONENT_VERSION');
-			$version = $result->fetchOne();
-			$result->closeCursor();
-			if (str_starts_with($version, '11.')) {
-				$this->markTestSkipped('JSON is not supported on Oracle 11, skipping until deprecation was clarified: ' . $version);
-			}
-		}
-
-
 		$appId = $this->getUniqueID('testing');
 		$query = $this->connection->getQueryBuilder();
 		$query->insert('share')


### PR DESCRIPTION
As discussed with @AndyScherzinger 

- [x] First commit shall be backported as far as cleanly possible

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
