### PR TITLE
refactor(console): register commands by state and simplify CLI command-loading

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -359,6 +359,7 @@ $debugCommands = [
  * Will abort registering if any app/service fails to load.
  * 
  */
+/** @var \Symfony\Component\Console\Application $application */
 $addCommands = function (array $classes) use ($application) {
 	foreach ($classes as $class) {
 		// CompletionCommand is instantiated directly (not resolved from container).

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -125,7 +125,7 @@ use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
  *
  * TODO (maybe): 
  * - Refactor this into a real class/service provider w/ clear dependency handling/etc.
- * - Make each core command a tagged service and have the container or a dedicated service aggregator register them automatically.
+ * - Make each core command a tagged service and have the container or a service aggregator auto-register them.
  */
 
 $config = Server::get(IConfig::class);
@@ -161,6 +161,7 @@ $alwaysCommands = [
  * Commands required when an upgrade is needed (besides _completion)
  */
 $upgradeCommands = [
+	Command\Maintenance\Mode::class,
 	Upgrade::class,
 ];
 
@@ -176,7 +177,6 @@ $installerCommands = [
  */
 $maintenanceCommands = [
 	Command\Maintenance\Mode::class,
-	// Also Status::class, but already an "always" command
 ];
 
 /*
@@ -372,18 +372,21 @@ $addCommands = function (array $classes) use ($application) {
 	}
 };
 
-// Register commands according to state
+/*
+ * Register commands according to state
+ */
 
+// Register always available commands
 $addCommands($alwaysCommands);
 
 if ($needUpgrade) {
-	// Register minimal extra commands needed to perform or diagnose the upgrade,
-	// then return early so the including loader can throw NeedsUpdateException
+	// Register minimal extra commands needed to perform or diagnose the upgrade.
 	$addCommands($upgradeCommands);
 	return;
 }
 
 if (!$installed) {
+	// Register pre-install only commands
 	$addCommands($installerCommands);
 	return;
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2013-2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -110,157 +110,292 @@ use OCP\IConfig;
 use OCP\Server;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 
-$application->add(new CompletionCommand());
-$application->add(Server::get(Status::class));
-$application->add(Server::get(Check::class));
-$application->add(Server::get(CreateJs::class));
-$application->add(Server::get(SignApp::class));
-$application->add(Server::get(SignCore::class));
-$application->add(Server::get(CheckApp::class));
-$application->add(Server::get(CheckCore::class));
-$application->add(Server::get(ListRoutes::class));
-$application->add(Server::get(MatchRoute::class));
+/**
+ * This file registers Nextcloud core console commands for Nextcloud's CLI application (OCC).
+ *
+ * Core commands are explicitly added in this file, resolving them from the DI container via 
+ * Server::get(...).
+ *
+ * Some commands are always registered; many are only registered when the instance is already 
+ * installed. Other commands are only registered when `occ` is executed in debug mode. A 
+ * single "install" command is registered when the instance is not yet installed.
+ *
+ * The Symfony Console `$application` instance ris provided by the including scope (see 
+ * OC\Console\Application::loadCommands).
+ *
+ * TODO (maybe): 
+ * - Refactor this into a real class/service provider w/ clear dependency handling/etc.
+ * - Make each core command a tagged service and have the container or a dedicated service aggregator register them automatically.
+ */
 
 $config = Server::get(IConfig::class);
 
-if ($config->getSystemValueBool('installed', false)) {
-	$application->add(Server::get(Disable::class));
-	$application->add(Server::get(Enable::class));
-	$application->add(Server::get(Install::class));
-	$application->add(Server::get(GetPath::class));
-	$application->add(Server::get(ListApps::class));
-	$application->add(Server::get(Remove::class));
-	$application->add(Server::get(Update::class));
+// State lifecycle flags
+$installed = $config->getSystemValueBool('installed', false);
+$maintenance = $installed && $config->getSystemValueBool('maintenance', false);
+$needUpgrade = $installed && \OCP\Util::needUpgrade();
+$debug = $config->getSystemValueBool('debug', false);
 
-	$application->add(Server::get(Cleanup::class));
-	$application->add(Server::get(Enforce::class));
-	$application->add(Server::get(Command\TwoFactorAuth\Enable::class));
-	$application->add(Server::get(Command\TwoFactorAuth\Disable::class));
-	$application->add(Server::get(State::class));
+/*
+ * Commands that should always be registered.
+ *
+ * In addition availability in normal operating mode, these commands are to be available:
+ * - pre-install
+ * - in maintenance mode
+ * - when an upgrade is needed
+*/
+$alwaysCommands = [
+	CompletionCommand::class,
+	Status::class,
+	Check::class,
+	CreateJs::class,
+	SignApp::class,
+	SignCore::class,
+	CheckApp::class,
+	CheckCore::class,
+	ListRoutes::class,
+	MatchRoute::class,
+];
 
-	$application->add(Server::get(Mode::class));
-	$application->add(Server::get(Job::class));
-	$application->add(Server::get(ListCommand::class));
-	$application->add(Server::get(Delete::class));
-	$application->add(Server::get(JobWorker::class));
+/*
+ * Commands required when an upgrade is needed (besides _completion)
+ */
+$upgradeCommands = [
+	Upgrade::class,
+];
 
-	$application->add(Server::get(Test::class));
+/*
+ * Commands available only when not installed (installer)
+ */
+$installerCommands = [
+	Command\Maintenance\Install::class,
+];
 
-	$application->add(Server::get(DeleteConfig::class));
-	$application->add(Server::get(GetConfig::class));
-	$application->add(Server::get(SetConfig::class));
-	$application->add(Server::get(Import::class));
-	$application->add(Server::get(ListConfigs::class));
-	$application->add(Server::get(Preset::class));
-	$application->add(Server::get(Command\Config\System\DeleteConfig::class));
-	$application->add(Server::get(Command\Config\System\GetConfig::class));
-	$application->add(Server::get(Command\Config\System\SetConfig::class));
+/*
+ * Small set of commands allowed in maintenance mode (no apps loaded)
+ */
+$maintenanceCommands = [
+	Command\Maintenance\Mode::class,
+	// Also Status::class, but already an "always" command
+];
 
-	$application->add(Server::get(File::class));
-	$application->add(Server::get(Space::class));
-	$application->add(Server::get(Storage::class));
-	$application->add(Server::get(Storages::class));
+/*
+ * Commands for a normal installed instance
+ */
+$installedCommands = [
+	// "app"
+	Disable::class,
+	Enable::class,
+	GetPath::class,
+	Install::class,
+	ListApps::class,
+	Remove::class,
+	Update::class,
 
-	$application->add(Server::get(ConvertType::class));
-	$application->add(Server::get(ConvertMysqlToMB4::class));
-	$application->add(Server::get(ConvertFilecacheBigInt::class));
-	$application->add(Server::get(AddMissingColumns::class));
-	$application->add(Server::get(AddMissingIndices::class));
-	$application->add(Server::get(AddMissingPrimaryKeys::class));
-	$application->add(Server::get(ExpectedSchema::class));
-	$application->add(Server::get(ExportSchema::class));
+	// "background"
+	Mode::class,
 
-	$application->add(Server::get(GenerateMetadataCommand::class));
-	$application->add(Server::get(PreviewCommand::class));
-	if ($config->getSystemValueBool('debug', false)) {
-		$application->add(Server::get(StatusCommand::class));
-		$application->add(Server::get(MigrateCommand::class));
-		$application->add(Server::get(GenerateCommand::class));
-		$application->add(Server::get(ExecuteCommand::class));
+	// "background-job"
+	Delete::class,
+	Job::class,
+	JobWorker::class,
+	ListCommand::class,
+
+	// "broadcast"
+	Test::class,
+
+	// "config"
+	Import::class,
+	ListConfigs::class,
+	Preset::class,
+
+	// "config:app"
+	DeleteConfig::class,
+	GetConfig::class,
+	SetConfig::class,
+
+	// "config:system"
+	Command\Config\System\DeleteConfig::class,
+	Command\Config\System\GetConfig::class,
+	Command\Config\System\SetConfig::class,
+
+	// "db"
+	AddMissingColumns::class,
+	AddMissingIndices::class,
+	AddMissingPrimaryKeys::class,
+	ConvertFilecacheBigInt::class,
+	ConvertMysqlToMB4::class,
+	ConvertType::class,
+	ExpectedSchema::class,
+	ExportSchema::class,
+
+	// "encryption"
+	ChangeKeyStorageRoot::class,
+	DecryptAll::class,
+	Command\Encryption\Disable::class,
+	Command\Encryption\Enable::class,
+	EncryptAll::class,
+	ListModules::class,
+	MigrateKeyStorage::class,
+	SetDefaultModule::class,
+	ShowKeyStorageRoot::class,
+	Command\Encryption\Status::class,
+
+	// "group"
+	Command\Group\Add::class,
+	AddUser::class,
+	Command\Group\Delete::class,
+	Command\Group\Info::class,
+	Command\Group\ListCommand::class,
+	RemoveUser::class,
+
+	// "info"
+	File::class,
+	Space::class,
+	Storage::class,
+	Storages::class,
+
+	// "log"
+	Command\Log\File::class,
+	Manage::class,
+
+	// "maintenance"
+	DataFingerprint::class,
+	Command\Maintenance\Mode::class,
+	Repair::class,
+	RepairShareOwnership::class,
+	UpdateTheme::class,
+	UpdateHtaccess::class,
+
+	// "maintenance:mimetype"
+	UpdateDB::class,
+	UpdateJS::class,
+
+	// "memcache""
+	RedisCommand::class,		// TODO: Should probably be moved under debug; it's not currently gated
+	DistributedClear::class,	// ditto
+	DistributedDelete::class,	// ditto
+	DistributedGet::class,		// ditto probably
+	DistributedSet::class,		// ditto
+
+	// "metadata"
+	Get::class,
+
+	// "migrations"
+	GenerateMetadataCommand::class,
+	PreviewCommand::class,
+
+	// "preview"
+	Command\Preview\Cleanup::class,
+	Generate::class,
+	ResetRenderedTexts::class,
+
+	// "tag"
+	Command\SystemTag\Add::class,
+	Command\SystemTag\Delete::class,
+	Edit::class,
+	Command\SystemTag\ListCommand::class,
+
+	// "twofactorauth"
+	Cleanup::class,
+	Command\TwoFactorAuth\Disable::class,
+	Command\TwoFactorAuth\Enable::class,
+	Enforce::class,
+	State::class,
+
+	// "security:bruteforce"
+	BruteforceAttempts::class,
+	BruteforceResetAttempts::class,
+
+	// "security:certificates"
+	ListCertificates::class,
+	ExportCertificates::class,
+	ImportCertificate::class,
+	RemoveCertificate::class,
+
+	// "setupchecks"
+	SetupChecks::class,
+
+	// "snowflake"
+	SnowflakeDecodeId::class,
+
+	// "taskprocessing"
+	EnabledCommand::class,
+	Command\TaskProcessing\Cleanup::class,
+	GetCommand::class,
+	Command\TaskProcessing\ListCommand::class,
+	Statistics::class,
+
+	// "user"
+	Add::class,
+	Command\User\AuthTokens\Add::class,
+	Command\User\AuthTokens\Delete::class,
+	Command\User\AuthTokens\ListCommand::class,
+	ClearGeneratedAvatarCacheCommand::class,
+	Command\User\Delete::class,
+	Command\User\Disable::class,
+	Command\User\Enable::class,
+	Info::class,
+	Verify::class,
+	LastSeen::class,
+	Command\User\ListCommand::class,
+	Profile::class,
+	Report::class,
+	ResetPassword::class,
+	Setting::class,
+	SyncAccountDataCommand::class,
+	Welcome::class,
+];
+
+/*
+ * Debug-mode only commands
+ */
+$debugCommands = [
+	// "migrations"
+	ExecuteCommand::class,
+	GenerateCommand::class,
+	MigrateCommand::class,
+	StatusCommand::class,
+];
+
+/** @var \Symfony\Component\Console\Application $application */
+
+// Helper to resolve & add a list of command classes.
+$addCommands = function (array $classes) use ($application) {
+	foreach ($classes as $class) {
+		// CompletionCommand is instantiated directly (not resolved from container).
+		if ($class === CompletionCommand::class) {
+			$application->add(new CompletionCommand());
+		} else {
+			$application->add(Server::get($class));
+		}
 	}
+};
 
-	$application->add(Server::get(Command\Encryption\Disable::class));
-	$application->add(Server::get(Command\Encryption\Enable::class));
-	$application->add(Server::get(ListModules::class));
-	$application->add(Server::get(SetDefaultModule::class));
-	$application->add(Server::get(Command\Encryption\Status::class));
-	$application->add(Server::get(EncryptAll::class));
-	$application->add(Server::get(DecryptAll::class));
+// Register commands according to state
 
-	$application->add(Server::get(Manage::class));
-	$application->add(Server::get(Command\Log\File::class));
+$addCommands($alwaysCommands);
 
-	$application->add(Server::get(ChangeKeyStorageRoot::class));
-	$application->add(Server::get(ShowKeyStorageRoot::class));
-	$application->add(Server::get(MigrateKeyStorage::class));
+if ($needUpgrade) {
+	// Register minimal extra commands needed to perform or diagnose the upgrade,
+	// then return early so the including loader can throw NeedsUpdateException
+	$addCommands($upgradeCommands);
+	return;
+}
 
-	$application->add(Server::get(DataFingerprint::class));
-	$application->add(Server::get(UpdateDB::class));
-	$application->add(Server::get(UpdateJS::class));
-	$application->add(Server::get(Command\Maintenance\Mode::class));
-	$application->add(Server::get(UpdateHtaccess::class));
-	$application->add(Server::get(UpdateTheme::class));
+if (!$installed) {
+	$addCommands($installerCommands);
+	return;
+}
 
-	$application->add(Server::get(Upgrade::class));
-	$application->add(Server::get(Repair::class));
-	$application->add(Server::get(RepairShareOwnership::class));
+if ($maintenance) {
+	$addCommands($maintenanceCommands);
+	return;
+}
 
-	$application->add(Server::get(Command\Preview\Cleanup::class));
-	$application->add(Server::get(Generate::class));
-	$application->add(Server::get(ResetRenderedTexts::class));
+// Normal installed & not maintenance path
+$addCommands($installedCommands);
 
-	$application->add(Server::get(Add::class));
-	$application->add(Server::get(Command\User\Delete::class));
-	$application->add(Server::get(Command\User\Disable::class));
-	$application->add(Server::get(Command\User\Enable::class));
-	$application->add(Server::get(LastSeen::class));
-	$application->add(Server::get(Report::class));
-	$application->add(Server::get(ResetPassword::class));
-	$application->add(Server::get(Setting::class));
-	$application->add(Server::get(Profile::class));
-	$application->add(Server::get(Command\User\ListCommand::class));
-	$application->add(Server::get(ClearGeneratedAvatarCacheCommand::class));
-	$application->add(Server::get(Info::class));
-	$application->add(Server::get(SyncAccountDataCommand::class));
-	$application->add(Server::get(Command\User\AuthTokens\Add::class));
-	$application->add(Server::get(Command\User\AuthTokens\ListCommand::class));
-	$application->add(Server::get(Command\User\AuthTokens\Delete::class));
-	$application->add(Server::get(Verify::class));
-	$application->add(Server::get(Welcome::class));
-
-	$application->add(Server::get(Command\Group\Add::class));
-	$application->add(Server::get(Command\Group\Delete::class));
-	$application->add(Server::get(Command\Group\ListCommand::class));
-	$application->add(Server::get(AddUser::class));
-	$application->add(Server::get(RemoveUser::class));
-	$application->add(Server::get(Command\Group\Info::class));
-
-	$application->add(Server::get(Command\SystemTag\ListCommand::class));
-	$application->add(Server::get(Command\SystemTag\Delete::class));
-	$application->add(Server::get(Command\SystemTag\Add::class));
-	$application->add(Server::get(Edit::class));
-
-	$application->add(Server::get(ListCertificates::class));
-	$application->add(Server::get(ExportCertificates::class));
-	$application->add(Server::get(ImportCertificate::class));
-	$application->add(Server::get(RemoveCertificate::class));
-	$application->add(Server::get(BruteforceAttempts::class));
-	$application->add(Server::get(BruteforceResetAttempts::class));
-	$application->add(Server::get(SetupChecks::class));
-	$application->add(Server::get(SnowflakeDecodeId::class));
-	$application->add(Server::get(Get::class));
-
-	$application->add(Server::get(GetCommand::class));
-	$application->add(Server::get(EnabledCommand::class));
-	$application->add(Server::get(Command\TaskProcessing\ListCommand::class));
-	$application->add(Server::get(Statistics::class));
-	$application->add(Server::get(Command\TaskProcessing\Cleanup::class));
-
-	$application->add(Server::get(RedisCommand::class));
-	$application->add(Server::get(DistributedClear::class));
-	$application->add(Server::get(DistributedDelete::class));
-	$application->add(Server::get(DistributedGet::class));
-	$application->add(Server::get(DistributedSet::class));
-} else {
-	$application->add(Server::get(Command\Maintenance\Install::class));
+if ($debug) {
+	$addCommands($debugCommands);
 }

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -41,7 +41,10 @@ class Application {
 		private IAppManager $appManager,
 		private Defaults $defaults,
 	) {
-		$this->application = new SymfonyApplication($defaults->getName(), $serverVersion->getVersionString());
+		$this->application = new SymfonyApplication(
+			$defaults->getName(),
+			$serverVersion->getVersionString()
+		);
 	}
 
 	/**
@@ -72,8 +75,7 @@ class Application {
 			$output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
 		}
 
-		// TODO: This check should probably be moved to \OC_Util::checkServer() (which is already called below) 
-		// or somewhere else more suitable (albeit w/o an exception)
+		// TODO: move to \OC_Util::checkServer() (which is already called below) or similar (albeit w/o an exception)
 		if ($this->memoryInfo->isMemoryLimitSufficient() === false) {
 			$output->getErrorOutput()->writeln(
 				'<comment>The current PHP memory limit '
@@ -81,15 +83,15 @@ class Application {
 			);
 		}
 
-		$installed = $config->getSystemValueBool('installed', false);
-		$maintenance = $installed && $config->getSystemValueBool('maintenance', false);
+		$installed = $this->config->getSystemValueBool('installed', false);
+		$maintenance = $installed && $this->config->getSystemValueBool('maintenance', false);
 		$needUpgrade = $installed && \OCP\Util::needUpgrade();
 
 		require_once __DIR__ . '/../../../core/register_command.php';
 
 		if ($needUpgrade) {
 			$this->writeNeedsUpdateInfo($input, $output);
-		} elseif (!$installed)
+		} elseif (!$installed) {
 			$this->writeNotInstalledInfo($input, $output);
 		} elseif ($maintenance) {
 			$this->writeMaintenanceModeInfo($input, $output);

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -60,15 +60,15 @@ class Application {
 		// Variables utilized by downstream `require_once */register_command.php` files (i.e. core)
 		$application = $this->application;
 		// State flags used to determine which commands to load, checks to do, and warnings/errors to show.
-		$installed = $this->config->getSystemValueBool('installed', false);
-		$maintenance = $installed && $this->config->getSystemValueBool('maintenance', false);
-		$needUpgrade = $installed && \OCP\Util::needUpgrade();
+		$installed = (bool) $this->config->getSystemValueBool('installed', false);
+		$maintenance = (bool) ($installed && $this->config->getSystemValueBool('maintenance', false));
+		$needUpgrade = (bool) ($installed && \OCP\Util::needUpgrade());
 		/**
 		 * @var bool $debug Used by core/register_command.php (required file reads this local)
 		 * @psalm-suppress UnusedVariable
 		 * @noinspection PhpUnusedLocalVariableInspection
 		 */ 
-		$debug = $this->config->getSystemValueBool('debug', false);
+		$debug = (bool) $this->config->getSystemValueBool('debug', false);
 
 		// Add and handle `--no-warnings` by default regardless of command
 		$inputDefinition = $application->getDefinition();
@@ -98,7 +98,8 @@ class Application {
 			$this->writeNotInstalledInfo($input, $output);
 		} elseif ($maintenance) {
 			$this->writeMaintenanceModeInfo($input, $output);
-		} elseif ($installed) {
+		} else {
+			// Normal installed path
 			$this->loadAppCommands($input, $output);
 		}
 	}

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -9,7 +9,6 @@ namespace OC\Console;
 
 use ArgumentCountError;
 use OC\MemoryInfo;
-use OC\NeedsUpdateException;
 use OC\SystemConfig;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
@@ -48,14 +47,30 @@ class Application {
 	}
 
 	/**
+	 * Loads relevant core and, if applicable, app commands.
+	 *
 	 * @throws \Exception
 	 */
 	public function loadCommands(
 		InputInterface $input,
 		ConsoleOutputInterface $output,
 	): void {
-		// $application is required to be defined in the register_command scripts
+		$this->checkEnvironmentEssentials($input, $output);
+
+		// Variables utilized by downstream `require_once */register_command.php` files (i.e. core)
 		$application = $this->application;
+		// State flags used to determine which commands to load, checks to do, and warnings/errors to show.
+		$installed = $this->config->getSystemValueBool('installed', false);
+		$maintenance = $installed && $this->config->getSystemValueBool('maintenance', false);
+		$needUpgrade = $installed && \OCP\Util::needUpgrade();
+		/**
+		 * @var bool $debug Used by core/register_command.php (required file reads this local)
+		 * @psalm-suppress UnusedVariable
+		 * @noinspection PhpUnusedLocalVariableInspection
+		 */ 
+		$debug = $this->config->getSystemValueBool('debug', false);
+
+		// Add and handle `--no-warnings` by default regardless of command
 		$inputDefinition = $application->getDefinition();
 		$inputDefinition->addOption(
 			new InputOption(
@@ -66,27 +81,15 @@ class Application {
 				null
 			)
 		);
-		try {
-			$input->bind($inputDefinition);
-		} catch (\RuntimeException $e) {
-			//expected if there are extra options
-		}
-		if ($input->getOption('no-warnings')) {
+		// Note: environment errors (above) are still shown
+		if ($input->hasParameterOption('--no-warnings', true)) {
 			$output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
 		}
 
-		// TODO: move to \OC_Util::checkServer() (which is already called below) or similar (albeit w/o an exception)
-		if ($this->memoryInfo->isMemoryLimitSufficient() === false) {
-			$output->getErrorOutput()->writeln(
-				'<comment>The current PHP memory limit '
-				. 'is below the recommended value of 512MB.</comment>'
-			);
-		}
+		$this->writeMemoryCheckInfoIfLow($input, $output);
 
-		$installed = $this->config->getSystemValueBool('installed', false);
-		$maintenance = $installed && $this->config->getSystemValueBool('maintenance', false);
-		$needUpgrade = $installed && \OCP\Util::needUpgrade();
-
+		// Load core commands
+		/** @var \Symfony\Component\Console\Application $application */
 		require_once __DIR__ . '/../../../core/register_command.php';
 
 		if ($needUpgrade) {
@@ -96,79 +99,119 @@ class Application {
 		} elseif ($maintenance) {
 			$this->writeMaintenanceModeInfo($input, $output);
 		} elseif ($installed) {
-			$this->appManager->loadApps();
-			foreach ($this->appManager->getEnabledApps() as $app) {
-				try {
-					$appPath = $this->appManager->getAppPath($app);
-				} catch (AppPathNotFoundException) {
-					continue;
-				}
-				// load commands using info.xml
-				$info = $this->appManager->getAppInfo($app);
-				if (isset($info['commands'])) {
-					try {
-						$this->loadCommandsFromInfoXml($info['commands']);
-					} catch (\Throwable $e) {
-						$output->writeln('<error>' . $e->getMessage() . '</error>');
-						$this->logger->error($e->getMessage(), [ 'exception' => $e, ]);
-					}
-				}
-				// load from register_command.php
-				\OC_App::registerAutoloading($app, $appPath);
-				$file = $appPath . '/appinfo/register_command.php';
-				if (file_exists($file)) {
-					try {
-						require $file;
-					} catch (\Exception $e) {
-						$this->logger->error($e->getMessage(), [ 'exception' => $e, ]);
-					}
-				}
-			}
-		}
-
-		if ($input->getFirstArgument() !== 'check') {
-			$errors = \OC_Util::checkServer(Server::get(SystemConfig::class));
-			if (!empty($errors)) {
-				foreach ($errors as $error) {
-					$output->writeln((string)$error['error']);
-					$output->writeln((string)$error['hint']);
-					$output->writeln('');
-				}
-				throw new \Exception('Environment not properly prepared.');
-			}
-		}
-	}
-
-	private function writeNeedsUpdateInfo(InputInterface $input, ConsoleOutputInterface $output): void {
-		if ($input->getArgument('command') !== '_completion'
-			&& $input->getArgument('command') !== 'upgrade'
-		   ) {
-			$errorOutput = $output->getErrorOutput();
-			$errorOutput->writeln('Nextcloud or one of the apps require upgrade - only a limited number of commands are available');
-			$errorOutput->writeln('You may use your browser or the occ upgrade command to do the upgrade');
-		}
-	}
-
-	private function writeNotInstalledInfo(InputInterface $input, ConsoleOutputInterface $output): void {
-		if ($input->getArgument('command') !== '_completion'
-			&& $input->getArgument('command') !== 'maintenance:install'
-		   ) {
-			$errorOutput = $output->getErrorOutput();
-			$errorOutput->writeln('Nextcloud is not installed - only a limited number of commands are available');
+			$this->loadAppCommands($input, $output);
 		}
 	}
 
 	/**
-	 * Write a maintenance mode info.
+	 * Essential environment checks that must pass except in rare cases.
+	 *
+	 * @throws \Exception if checks fail and command isn't whitelisted.
 	 */
+	private function checkEnvironmentEssentials(InputInterface $input, ConsoleOutputInterface $output): void {
+		$cmd = (string)$input->getFirstArgument();
+		$errors = \OC_Util::checkServer(Server::get(SystemConfig::class));
+		if (!empty($errors)) {
+			foreach ($errors as $error) {
+				$errorOutput = $output->getErrorOutput();
+				$errorOutput->writeln('<error>' . (string)$error['error'] . '</error>');
+				$errorOutput->writeln('<comment>' . (string)$error['hint'] . '</comment>');
+				$errorOutput->writeln('');
+			}
+
+			// Command exceptions we let proceed even if environment fails essential checks
+			// Note: For (conservative) backwards compatibility; other than 'check' most of these are likely unnecessary...
+			// ...they can't be used to fix these types of errors anyhow!
+			//
+			// TODO: Remove all but 'check'.
+			$whitelist = [ 'check', 'upgrade', 'maintenance:mode', 'status', '_completion' ];
+			if (!in_array($cmd, $whitelist, true)) {
+				throw new \Exception(
+					'Environment not properly prepared for Nextcloud. Errors should be fixed before proceeding. ' .
+					'Please refer to the Admin Manual to correct the above error(s) then retry your "occ" command.');
+			}
+		}
+	}
+	
+	private function writeMemoryCheckInfoIfLow(InputInterface $input, ConsoleOutputInterface $output): void {
+		if ($this->memoryInfo->isMemoryLimitSufficient() === false) {
+			$currentLimit = trim((string)ini_get('memory_limit')); // we want the nearly raw ini value to show bogus values too
+			$recommendedLimit = '512M';
+			$errorOutput = $output->getErrorOutput();
+			$errorOutput->writeln(
+				'<comment>The PHP-CLI memory limit (' . $currentLimit . ') is below the recommended ' . $recommendedLimit .
+				'. Some functions may fail.</comment>');
+			$errorOutput->writeln(
+				'<comment>Please adjust your "memory_limit" setting in the relevant php.ini file to at least ' .
+				$recommendedLimit . ' to prevent potential errors.</comment>');
+		}
+	}
+
+	/**
+	 * @throws \Throwable if unable to load commands specified in an app's info.xml
+	 */
+	private function loadAppCommands(InputInterface $input, ConsoleOutputInterface $output): void {
+		$this->appManager->loadApps();
+
+		foreach ($this->appManager->getEnabledApps() as $app) {
+			try {
+				$appPath = $this->appManager->getAppPath($app);
+			} catch (AppPathNotFoundException) {
+				continue;
+			}
+
+			// load commands using info.xml
+			$info = $this->appManager->getAppInfo($app);
+			if (isset($info['commands'])) {
+				try {
+					$this->loadCommandsFromInfoXml($info['commands']);
+				} catch (\Throwable $e) {
+					$errorOutput = $output->getErrorOutput();
+					$errorOutput->writeln('<error>' . $e->getMessage() . '</error>');
+					$this->logger->error($e->getMessage(), [ 'exception' => $e, ]);
+				}
+			}
+
+			// load from app's register_command.php if present
+			\OC_App::registerAutoloading($app, $appPath);
+			$file = $appPath . '/appinfo/register_command.php';
+			if (file_exists($file)) {
+				try {
+					require $file;
+				} catch (\Throwable $e) {
+					$errorOutput = $output->getErrorOutput();
+					$errorOutput->writeln('<error>' . $e->getMessage() . '</error>');
+					$this->logger->error($e->getMessage(), [ 'exception' => $e, ]);
+				}
+			}
+		}
+	}
+	
+	private function writeNeedsUpdateInfo(InputInterface $input, ConsoleOutputInterface $output): void {
+		$cmd = (string)$input->getFirstArgument();
+		if ($cmd !== '_completion' && $cmd !== 'upgrade') {
+			$errorOutput = $output->getErrorOutput();
+			$errorOutput->writeln('<error>Nextcloud or one of its apps requires an upgrade. Only a limited number of commands are available.</error>');
+			$errorOutput->writeln('<comment>Please use your browser or the "occ upgrade" command to finish the upgrade.</comment>');
+		}
+	}
+
+	private function writeNotInstalledInfo(InputInterface $input, ConsoleOutputInterface $output): void {
+		$cmd = (string)$input->getFirstArgument();
+		if ($cmd !== '_completion' && $cmd !== 'maintenance:install') {
+			$errorOutput = $output->getErrorOutput();
+			$errorOutput->writeln('<error>Nextcloud is not installed. Only a limited number of commands are available.</error>');
+			$errorOutput->writeln('<comment>Please use your browser or the "occ maintenance:install" command to proceed with installation.</comment>');
+		}
+	}
+
 	private function writeMaintenanceModeInfo(InputInterface $input, ConsoleOutputInterface $output): void {
-		if ($input->getArgument('command') !== '_completion'
-			&& $input->getArgument('command') !== 'maintenance:mode'
-			&& $input->getArgument('command') !== 'status'
-		   ) {
-			$errOutput = $output->getErrorOutput();
-			$errOutput->writeln('<comment>Nextcloud is in maintenance mode, no apps are loaded.</comment>');
-			$errOutput->writeln('<comment>Commands provided by apps are unavailable.</comment>');
+		$cmd = (string)$input->getFirstArgument();
+		if ($cmd !== '_completion' && $cmd !== 'maintenance:mode' && $cmd !== 'status') {
+			$errorOutput = $output->getErrorOutput();
+			$errorOutput->writeln('<error>Nextcloud is in maintenance mode. Only a limited number of commands are available.</error>');
+			$errorOutput->writeln('<comment>In maintenance mode logins are blocked and events may not be triggered since apps are not loaded.</comment>');
+			$errorOutput->writeln('<comment>Proceed with maintenance activities then use the "occ maintenance:mode --off" to disable maintenance mode.</comment>');
 		}
 	}
 
@@ -182,10 +225,9 @@ class Application {
 	}
 
 	/**
-	 * @return int
 	 * @throws \Exception
 	 */
-	public function run(?InputInterface $input = null, ?OutputInterface $output = null) {
+	public function run(?InputInterface $input = null, ?OutputInterface $output = null): int {
 		$event = new ConsoleEvent(
 			ConsoleEvent::EVENT_RUN,
 			$this->request->server['argv']
@@ -206,8 +248,8 @@ class Application {
 				if (class_exists($command)) {
 					try {
 						$c = new $command();
-					} catch (ArgumentCountError) {
-						throw new \Exception("Failed to construct console command '$command': " . $e->getMessage(), 0, $e);
+					} catch (ArgumentCountError $ace) {
+						throw new \Exception("Failed to construct console command '$command': " . $ace->getMessage(), 0, $ace);
 					}
 				} else {
 					throw new \Exception("Console command '$command' is unknown and could not be loaded");


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

### What

* Register only the commands that are valid for the current global state (installed / uninstalled / maintenance / upgrade-needed).
* Move early CLI environment validation into Application::checkEnvironmentEssentials() and run OC_Util::checkServer(...) before loading apps.
* Simplify core/register_command.php with explicit per-state command lists and reduced boilerplate.
* Explicit command lists for each state in `core/register_command.php`.
* Simpler, clearer control flow in `Application.php`.
* Miscellaneous robustness/UX improvements in `Application.php`

### Why

* Fail fast: avoid loading many apps when the PHP/environment is clearly unsuitable.
* UX: administrators only see commands that actually work in the current server state.
* Safety: reduces accidental invocations of commands that would be unsafe in the current state.
* Maintainability: clearer control flow. delegation of details to private functions, and explicit command lists make it easier to reason about code

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
