### PR TITLE
Improve wording for login throttle warning

### DIFF
--- a/core/src/components/login/LoginForm.vue
+++ b/core/src/components/login/LoginForm.vue
@@ -249,7 +249,7 @@ export default {
 				return t('core', 'This account is disabled')
 			}
 			if (this.throttleDelay > 5000) {
-				return t('core', 'We have detected multiple invalid login attempts from your IP. Therefore your next login is throttled up to 30 seconds.')
+				return t('core', 'Too many incorrent login attempts. Please try again in 30 seconds.')
 			}
 			return undefined
 		},

--- a/core/src/components/login/LoginForm.vue
+++ b/core/src/components/login/LoginForm.vue
@@ -249,7 +249,7 @@ export default {
 				return t('core', 'This account is disabled')
 			}
 			if (this.throttleDelay > 5000) {
-				return t('core', 'Too many incorrent login attempts. Please try again in 30 seconds.')
+				return t('core', 'Too many incorrect login attempts. Please try again in 30 seconds.')
 			}
 			return undefined
 		},


### PR DESCRIPTION
* Resolves: #56429

## Summary

Simplify the login throttling warning message shown after multiple failed login attempts.  
The original message was long and potentially confusing. This update replaces it with a concise, user-friendly version.

## TODO

- [x] Update the message in `LoginForm.vue`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] Sign-off message is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] Labels added (ex: bug/enhancement, `3. to review`, feature component)
- [x] Milestone added for target branch/version (e.g., `32.x` for `stable32`)
