### PR TITLE
refactor(share): Remove code related to science mesh integration

### DIFF
--- a/apps/admin_audit/lib/Listener/SharingEventListener.php
+++ b/apps/admin_audit/lib/Listener/SharingEventListener.php
@@ -148,18 +148,6 @@ class SharingEventListener extends Action implements IEventListener {
 					'id',
 				]
 			),
-			IShare::TYPE_SCIENCEMESH => $this->log(
-				'The %s "%s" with ID "%s" has been shared to the sciencemesh user "%s" with permissions "%s" (Share ID: %s)',
-				$params,
-				[
-					'itemType',
-					'path',
-					'itemSource',
-					'shareWith',
-					'permissions',
-					'id',
-				]
-			),
 			default => null
 		};
 	}
@@ -265,17 +253,6 @@ class SharingEventListener extends Action implements IEventListener {
 			),
 			IShare::TYPE_DECK => $this->log(
 				'The %s "%s" with ID "%s" has been unshared from the deck card "%s" (Share ID: %s)',
-				$params,
-				[
-					'itemType',
-					'fileTarget',
-					'itemSource',
-					'shareWith',
-					'id',
-				]
-			),
-			IShare::TYPE_SCIENCEMESH => $this->log(
-				'The %s "%s" with ID "%s" has been unshared from the sciencemesh user "%s" (Share ID: %s)',
 				$params,
 				[
 					'itemType',

--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -99,7 +99,6 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 			IShare::TYPE_ROOM,
 			IShare::TYPE_CIRCLE,
 			IShare::TYPE_DECK,
-			IShare::TYPE_SCIENCEMESH,
 		];
 
 		foreach ($requestedShareTypes as $requestedShareType) {

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -253,7 +253,6 @@ class SharesPluginTest extends \Test\TestCase {
 			[[IShare::TYPE_REMOTE]],
 			[[IShare::TYPE_ROOM]],
 			[[IShare::TYPE_DECK]],
-			[[IShare::TYPE_SCIENCEMESH]],
 			[[IShare::TYPE_USER, IShare::TYPE_GROUP]],
 			[[IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_LINK]],
 			[[IShare::TYPE_USER, IShare::TYPE_LINK]],

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -198,7 +198,6 @@ class ApiController extends Controller {
 			IShare::TYPE_EMAIL,
 			IShare::TYPE_ROOM,
 			IShare::TYPE_DECK,
-			IShare::TYPE_SCIENCEMESH,
 		];
 		$shareTypes = [];
 

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -319,7 +319,6 @@ class OwnershipTransferService {
 			IShare::TYPE_EMAIL,
 			IShare::TYPE_CIRCLE,
 			IShare::TYPE_DECK,
-			IShare::TYPE_SCIENCEMESH,
 		];
 
 		foreach ($supportedShareTypes as $shareType) {

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -146,10 +146,6 @@ class ShareesAPIController extends OCSController {
 			if ($this->shareManager->shareProviderExists(IShare::TYPE_ROOM)) {
 				$shareTypes[] = IShare::TYPE_ROOM;
 			}
-
-			if ($this->shareManager->shareProviderExists(IShare::TYPE_SCIENCEMESH)) {
-				$shareTypes[] = IShare::TYPE_SCIENCEMESH;
-			}
 		} else {
 			if ($this->shareManager->allowGroupSharing()) {
 				$shareTypes[] = IShare::TYPE_GROUP;
@@ -160,10 +156,6 @@ class ShareesAPIController extends OCSController {
 		// FIXME: DI
 		if (Server::get(IAppManager::class)->isEnabledForUser('circles') && class_exists('\OCA\Circles\ShareByCircleProvider')) {
 			$shareTypes[] = IShare::TYPE_CIRCLE;
-		}
-
-		if ($this->shareManager->shareProviderExists(IShare::TYPE_SCIENCEMESH)) {
-			$shareTypes[] = IShare::TYPE_SCIENCEMESH;
 		}
 
 		if ($itemType === 'calendar') {

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -57,7 +57,6 @@ class MountProvider implements IMountProvider {
 			$this->shareManager->getSharedWith($userId, IShare::TYPE_CIRCLE, null, -1),
 			$this->shareManager->getSharedWith($userId, IShare::TYPE_ROOM, null, -1),
 			$this->shareManager->getSharedWith($userId, IShare::TYPE_DECK, null, -1),
-			$this->shareManager->getSharedWith($userId, IShare::TYPE_SCIENCEMESH, null, -1),
 		);
 
 		$shares = $this->filterShares($shares, $userId);

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -217,10 +217,10 @@ class ShareAPIControllerTest extends TestCase {
 		$this->expectExceptionMessage('Wrong share ID, share does not exist');
 
 		$this->shareManager
-			->expects($this->exactly(7))
+			->expects($this->exactly(6))
 			->method('getShareById')
 			->willReturnCallback(function ($id): void {
-				if ($id === 'ocinternal:42' || $id === 'ocRoomShare:42' || $id === 'ocFederatedSharing:42' || $id === 'ocCircleShare:42' || $id === 'ocMailShare:42' || $id === 'deck:42' || $id === 'sciencemesh:42') {
+				if ($id === 'ocinternal:42' || $id === 'ocRoomShare:42' || $id === 'ocFederatedSharing:42' || $id === 'ocCircleShare:42' || $id === 'ocMailShare:42' || $id === 'deck:42') {
 					throw new ShareNotFound();
 				} else {
 					throw new \Exception();

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -140,7 +140,7 @@ class MountProviderTest extends \Test\TestCase {
 		$this->user->expects($this->any())
 			->method('getUID')
 			->willReturn('user1');
-		$this->shareManager->expects($this->exactly(6))
+		$this->shareManager->expects($this->exactly(5))
 			->method('getSharedWith')
 			->willReturnMap([
 				['user1', IShare::TYPE_USER, null, -1, 0, $userShares],
@@ -148,7 +148,6 @@ class MountProviderTest extends \Test\TestCase {
 				['user1', IShare::TYPE_CIRCLE, null, -1, 0, $circleShares],
 				['user1', IShare::TYPE_ROOM, null, -1, 0, $roomShares],
 				['user1', IShare::TYPE_DECK, null, -1, 0, $deckShares],
-				['user1', IShare::TYPE_SCIENCEMESH, null, -1, 0, $scienceMeshShares],
 			]);
 
 		$this->shareManager->expects($this->any())
@@ -337,7 +336,7 @@ class MountProviderTest extends \Test\TestCase {
 	 * @param array $expectedShares array of expected supershare specs
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('mergeSharesDataProvider')]
-	public function testMergeShares($userShares, $groupShares, $expectedShares, $moveFails = false): void {
+	public function testMergeShares(array $userShares, array $groupShares, array $expectedShares, bool $moveFails = false): void {
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userManager = $this->createMock(IUserManager::class);
 
@@ -357,7 +356,7 @@ class MountProviderTest extends \Test\TestCase {
 		$roomShares = [];
 		$deckShares = [];
 		$scienceMeshShares = [];
-		$this->shareManager->expects($this->exactly(6))
+		$this->shareManager->expects($this->exactly(5))
 			->method('getSharedWith')
 			->willReturnMap([
 				['user1', IShare::TYPE_USER, null, -1, 0, $userShares],
@@ -365,7 +364,6 @@ class MountProviderTest extends \Test\TestCase {
 				['user1', IShare::TYPE_CIRCLE, null, -1, 0, $circleShares],
 				['user1', IShare::TYPE_ROOM, null, -1, 0, $roomShares],
 				['user1', IShare::TYPE_DECK, null, -1, 0, $deckShares],
-				['user1', IShare::TYPE_SCIENCEMESH, null, -1, 0, $scienceMeshShares],
 			]);
 
 		$this->shareManager->expects($this->any())

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1548,7 +1548,6 @@
     <DeprecatedClass>
       <code><![CDATA[new QueryException()]]></code>
       <code><![CDATA[new QueryException()]]></code>
-      <code><![CDATA[new QueryException()]]></code>
     </DeprecatedClass>
   </file>
   <file src="apps/files_sharing/lib/Controller/RemoteController.php">

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1874,7 +1874,6 @@ class View {
 			IShare::TYPE_CIRCLE,
 			IShare::TYPE_ROOM,
 			IShare::TYPE_DECK,
-			IShare::TYPE_SCIENCEMESH
 		];
 		$shareManager = Server::get(IManager::class);
 		/** @var IShare[] $shares */

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -171,10 +171,7 @@ class Manager implements IManager {
 			if ($circle === null) {
 				throw new \InvalidArgumentException($this->l->t('Share recipient is not a valid circle'));
 			}
-		} elseif ($share->getShareType() === IShare::TYPE_ROOM) {
-		} elseif ($share->getShareType() === IShare::TYPE_DECK) {
-		} elseif ($share->getShareType() === IShare::TYPE_SCIENCEMESH) {
-		} else {
+		} elseif ($share->getShareType() !== IShare::TYPE_ROOM && $share->getShareType() !== IShare::TYPE_DECK) {
 			// We cannot handle other types yet
 			throw new \InvalidArgumentException($this->l->t('Unknown share type'));
 		}

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -189,8 +189,6 @@ class ProviderFactory implements IProviderFactory {
 			$provider = $this->getRoomShareProvider();
 		} elseif ($shareType === IShare::TYPE_DECK) {
 			$provider = $this->getProvider('deck');
-		} elseif ($shareType === IShare::TYPE_SCIENCEMESH) {
-			$provider = $this->getProvider('sciencemesh');
 		}
 
 

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -98,6 +98,7 @@ interface IShare {
 
 	/**
 	 * @since 26.0.0
+	 * @deprecated 33.0.0 The app is abandonned.
 	 */
 	public const TYPE_SCIENCEMESH = 15;
 


### PR DESCRIPTION
## Summary

The app was not updated for the past 2 years, we can bring it back if needed but at the moment this is just dead code

Cc @michielbdejong

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
