### PR TITLE
chore(legacy): Remove deprecated getUserQuota method

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -94,24 +94,6 @@ class OC_Util {
 	}
 
 	/**
-	 * Get the quota of a user
-	 *
-	 * @param IUser|null $user
-	 * @return int|\OCP\Files\FileInfo::SPACE_UNLIMITED|false|float Quota bytes
-	 * @deprecated 9.0.0 - Use \OCP\IUser::getQuota or \OCP\IUser::getQuotaBytes
-	 */
-	public static function getUserQuota(?IUser $user) {
-		if (is_null($user)) {
-			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
-		}
-		$userQuota = $user->getQuota();
-		if ($userQuota === 'none') {
-			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
-		}
-		return \OCP\Util::computerFileSize($userQuota);
-	}
-
-	/**
 	 * copies the skeleton to the users /files
 	 *
 	 * @param string $userId
@@ -297,7 +279,7 @@ class OC_Util {
 	}
 
 	/**
-	 * check if the current server configuration is suitable for ownCloud
+	 * Check if the current server environment configuration is suitable for Nextcloud
 	 *
 	 * @return array arrays with error messages and hints
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Formally deprecated with 9.0.0 and we dropped final uses of it in #53045 best as I can tell.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
