### PR TITLE
fix: calendar subscription memory exhaustion

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1066,9 +1066,9 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @param int $calendarType
 	 * @return array
 	 */
-	public function getLimitedCalendarObjects(int $calendarId, int $calendarType = self::CALENDAR_TYPE_CALENDAR):array {
+	public function getLimitedCalendarObjects(int $calendarId, int $calendarType = self::CALENDAR_TYPE_CALENDAR, array $fields = []):array {
 		$query = $this->db->getQueryBuilder();
-		$query->select(['id','uid', 'etag', 'uri', 'calendardata'])
+		$query->select($fields ?: ['id', 'uid', 'etag', 'uri', 'calendardata'])
 			->from('calendarobjects')
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)))
@@ -1077,12 +1077,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		$result = [];
 		while (($row = $stmt->fetchAssociative()) !== false) {
-			$result[$row['uid']] = [
-				'id' => $row['id'],
-				'etag' => $row['etag'],
-				'uri' => $row['uri'],
-				'calendardata' => $row['calendardata'],
-			];
+			$result[$row['uid']] = $row;
 		}
 		$stmt->closeCursor();
 

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\CalDAV\WebcalCaching;
 
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\Import\ImportService;
 use OCA\DAV\CalDAV\WebcalCaching\Connection;
 use OCA\DAV\CalDAV\WebcalCaching\RefreshWebcalService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -23,7 +24,8 @@ class RefreshWebcalServiceTest extends TestCase {
 	private CalDavBackend&MockObject $caldavBackend;
 	private Connection&MockObject $connection;
 	private LoggerInterface&MockObject $logger;
-	private ITimeFactory&MockObject $time;
+	private ImportService&MockObject $importService;
+	private ITimeFactory&MockObject $timeFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -31,19 +33,32 @@ class RefreshWebcalServiceTest extends TestCase {
 		$this->caldavBackend = $this->createMock(CalDavBackend::class);
 		$this->connection = $this->createMock(Connection::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->time = $this->createMock(ITimeFactory::class);
+		$this->importService = $this->createMock(ImportService::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		// Default time factory behavior: current time is far in the future so refresh always happens
+		$this->timeFactory->method('getTime')->willReturn(PHP_INT_MAX);
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime());
+	}
+
+	/**
+	 * Helper to create a resource stream from string content
+	 */
+	private function createStreamFromString(string $content) {
+		$stream = fopen('php://temp', 'r+');
+		fwrite($stream, $content);
+		rewind($stream);
+		return $stream;
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
-	public function testRun(string $body, string $contentType, string $result): void {
-		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
-			->onlyMethods(['getRandomCalendarObjectUri'])
-			->setConstructorArgs([$this->caldavBackend, $this->logger, $this->connection, $this->time])
-			->getMock();
-
-		$refreshWebcalService
-			->method('getRandomCalendarObjectUri')
-			->willReturn('uri-1.ics');
+	public function testRun(string $body, string $format, string $result): void {
+		$refreshWebcalService = new RefreshWebcalService(
+			$this->caldavBackend,
+			$this->logger,
+			$this->connection,
+			$this->timeFactory,
+			$this->importService
+		);
 
 		$this->caldavBackend->expects(self::once())
 			->method('getSubscriptionsForUser')
@@ -71,26 +86,48 @@ class RefreshWebcalServiceTest extends TestCase {
 				],
 			]);
 
+		$stream = $this->createStreamFromString($body);
+
 		$this->connection->expects(self::once())
 			->method('queryWebcalFeed')
-			->willReturn($result);
+			->willReturn(['data' => $stream, 'format' => $format]);
+
+		$this->caldavBackend->expects(self::once())
+			->method('getLimitedCalendarObjects')
+			->willReturn([]);
+
+		// Create a VCalendar object that will be yielded by the import service
+		$vCalendar = VObject\Reader::read($result);
+
+		$generator = function () use ($vCalendar) {
+			yield $vCalendar;
+		};
+
+		$this->importService->expects(self::once())
+			->method('importText')
+			->willReturn($generator());
+
 		$this->caldavBackend->expects(self::once())
 			->method('createCalendarObject')
-			->with(42, 'uri-1.ics', $result, 1);
+			->with(
+				'42',
+				self::matchesRegularExpression('/^[a-f0-9-]+\.ics$/'),
+				$result,
+				CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION
+			);
 
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('identicalDataProvider')]
-	public function testRunIdentical(string $uid, array $calendarObject, string $body, string $contentType, string $result): void {
-		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
-			->onlyMethods(['getRandomCalendarObjectUri'])
-			->setConstructorArgs([$this->caldavBackend, $this->logger, $this->connection, $this->time])
-			->getMock();
-
-		$refreshWebcalService
-			->method('getRandomCalendarObjectUri')
-			->willReturn('uri-1.ics');
+	public function testRunIdentical(string $uid, array $calendarObject, string $body, string $format, string $result): void {
+		$refreshWebcalService = new RefreshWebcalService(
+			$this->caldavBackend,
+			$this->logger,
+			$this->connection,
+			$this->timeFactory,
+			$this->importService
+		);
 
 		$this->caldavBackend->expects(self::once())
 			->method('getSubscriptionsForUser')
@@ -110,6 +147,77 @@ class RefreshWebcalServiceTest extends TestCase {
 					'id' => '42',
 					'uri' => 'sub123',
 					RefreshWebcalService::REFRESH_RATE => 'PT1H',
+					RefreshWebcalService::STRIP_TODOS => '1',
+					RefreshWebcalService::STRIP_ALARMS => '1',
+					RefreshWebcalService::STRIP_ATTACHMENTS => '1',
+					'source' => 'webcal://foo.bar/bla2',
+					'lastmodified' => 0,
+				],
+			]);
+
+		$stream = $this->createStreamFromString($body);
+
+		$this->connection->expects(self::once())
+			->method('queryWebcalFeed')
+			->willReturn(['data' => $stream, 'format' => $format]);
+
+		$this->caldavBackend->expects(self::once())
+			->method('getLimitedCalendarObjects')
+			->willReturn($calendarObject);
+
+		// Create a VCalendar object that will be yielded by the import service
+		$vCalendar = VObject\Reader::read($result);
+
+		$generator = function () use ($vCalendar) {
+			yield $vCalendar;
+		};
+
+		$this->importService->expects(self::once())
+			->method('importText')
+			->willReturn($generator());
+
+		$this->caldavBackend->expects(self::never())
+			->method('createCalendarObject');
+
+		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
+	}
+
+	public function testSubscriptionNotFound(): void {
+		$refreshWebcalService = new RefreshWebcalService(
+			$this->caldavBackend,
+			$this->logger,
+			$this->connection,
+			$this->timeFactory,
+			$this->importService
+		);
+
+		$this->caldavBackend->expects(self::once())
+			->method('getSubscriptionsForUser')
+			->with('principals/users/testuser')
+			->willReturn([]);
+
+		$this->connection->expects(self::never())
+			->method('queryWebcalFeed');
+
+		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
+	}
+
+	public function testConnectionReturnsNull(): void {
+		$refreshWebcalService = new RefreshWebcalService(
+			$this->caldavBackend,
+			$this->logger,
+			$this->connection,
+			$this->timeFactory,
+			$this->importService
+		);
+
+		$this->caldavBackend->expects(self::once())
+			->method('getSubscriptionsForUser')
+			->with('principals/users/testuser')
+			->willReturn([
+				[
+					'id' => '42',
+					'uri' => 'sub123',
 					RefreshWebcalService::STRIP_TODOS => '1',
 					RefreshWebcalService::STRIP_ALARMS => '1',
 					RefreshWebcalService::STRIP_ATTACHMENTS => '1',
@@ -120,76 +228,126 @@ class RefreshWebcalServiceTest extends TestCase {
 
 		$this->connection->expects(self::once())
 			->method('queryWebcalFeed')
-			->willReturn($result);
+			->willReturn(null);
 
-		$this->caldavBackend->expects(self::once())
-			->method('getLimitedCalendarObjects')
-			->willReturn($calendarObject);
-
-		$denormalised = [
-			'etag' => 100,
-			'size' => strlen($calendarObject[$uid]['calendardata']),
-			'uid' => 'sub456'
-		];
-
-		$this->caldavBackend->expects(self::once())
-			->method('getDenormalizedData')
-			->willReturn($denormalised);
+		$this->importService->expects(self::never())
+			->method('importText');
 
 		$this->caldavBackend->expects(self::never())
 			->method('createCalendarObject');
 
-		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub456');
+		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
-	public function testRunJustUpdated(): void {
-		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
-			->onlyMethods(['getRandomCalendarObjectUri'])
-			->setConstructorArgs([$this->caldavBackend, $this->logger, $this->connection, $this->time])
-			->getMock();
-
-		$refreshWebcalService
-			->method('getRandomCalendarObjectUri')
-			->willReturn('uri-1.ics');
+	public function testDeletedObjectsArePurged(): void {
+		$refreshWebcalService = new RefreshWebcalService(
+			$this->caldavBackend,
+			$this->logger,
+			$this->connection,
+			$this->timeFactory,
+			$this->importService
+		);
 
 		$this->caldavBackend->expects(self::once())
 			->method('getSubscriptionsForUser')
 			->with('principals/users/testuser')
 			->willReturn([
 				[
-					'id' => '99',
-					'uri' => 'sub456',
-					RefreshWebcalService::REFRESH_RATE => 'P1D',
-					RefreshWebcalService::STRIP_TODOS => '1',
-					RefreshWebcalService::STRIP_ALARMS => '1',
-					RefreshWebcalService::STRIP_ATTACHMENTS => '1',
-					'source' => 'webcal://foo.bar/bla',
-					'lastmodified' => time(),
-				],
-				[
 					'id' => '42',
 					'uri' => 'sub123',
-					RefreshWebcalService::REFRESH_RATE => 'PT1H',
 					RefreshWebcalService::STRIP_TODOS => '1',
 					RefreshWebcalService::STRIP_ALARMS => '1',
 					RefreshWebcalService::STRIP_ATTACHMENTS => '1',
 					'source' => 'webcal://foo.bar/bla2',
-					'lastmodified' => time(),
+					'lastmodified' => 0,
 				],
 			]);
 
-		$timeMock = $this->createMock(\DateTime::class);
-		$this->time->expects(self::once())
-			->method('getDateTime')
-			->willReturn($timeMock);
-		$timeMock->expects(self::once())
-			->method('getTimestamp')
-			->willReturn(2101724667);
-		$this->time->expects(self::once())
-			->method('getTime')
-			->willReturn(time());
-		$this->connection->expects(self::never())
-			->method('queryWebcalFeed');
+		$body = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nBEGIN:VEVENT\r\nUID:new-event\r\nDTSTAMP:20160218T133704Z\r\nDTSTART:20160218T133704Z\r\nSUMMARY:New Event\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+		$stream = $this->createStreamFromString($body);
+
+		$this->connection->expects(self::once())
+			->method('queryWebcalFeed')
+			->willReturn(['data' => $stream, 'format' => 'ical']);
+
+		// Existing objects include one that won't be in the feed
+		$this->caldavBackend->expects(self::once())
+			->method('getLimitedCalendarObjects')
+			->willReturn([
+				'old-deleted-event' => [
+					'id' => 99,
+					'uid' => 'old-deleted-event',
+					'etag' => 'old-etag',
+					'uri' => 'old-event.ics',
+				],
+			]);
+
+		$vCalendar = VObject\Reader::read($body);
+		$generator = function () use ($vCalendar) {
+			yield $vCalendar;
+		};
+
+		$this->importService->expects(self::once())
+			->method('importText')
+			->willReturn($generator());
+
+		$this->caldavBackend->expects(self::once())
+			->method('createCalendarObject');
+
+		$this->caldavBackend->expects(self::once())
+			->method('purgeCachedEventsForSubscription')
+			->with(42, [99], ['old-event.ics']);
+
+		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
+	}
+
+	public function testLongUidIsSkipped(): void {
+		$refreshWebcalService = new RefreshWebcalService(
+			$this->caldavBackend,
+			$this->logger,
+			$this->connection,
+			$this->timeFactory,
+			$this->importService
+		);
+
+		$this->caldavBackend->expects(self::once())
+			->method('getSubscriptionsForUser')
+			->with('principals/users/testuser')
+			->willReturn([
+				[
+					'id' => '42',
+					'uri' => 'sub123',
+					RefreshWebcalService::STRIP_TODOS => '1',
+					RefreshWebcalService::STRIP_ALARMS => '1',
+					RefreshWebcalService::STRIP_ATTACHMENTS => '1',
+					'source' => 'webcal://foo.bar/bla2',
+					'lastmodified' => 0,
+				],
+			]);
+
+		// Create a UID that is longer than 512 characters
+		$longUid = str_repeat('a', 513);
+		$body = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nBEGIN:VEVENT\r\nUID:$longUid\r\nDTSTAMP:20160218T133704Z\r\nDTSTART:20160218T133704Z\r\nSUMMARY:Event with long UID\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+		$stream = $this->createStreamFromString($body);
+
+		$this->connection->expects(self::once())
+			->method('queryWebcalFeed')
+			->willReturn(['data' => $stream, 'format' => 'ical']);
+
+		$this->caldavBackend->expects(self::once())
+			->method('getLimitedCalendarObjects')
+			->willReturn([]);
+
+		$vCalendar = VObject\Reader::read($body);
+		$generator = function () use ($vCalendar) {
+			yield $vCalendar;
+		};
+
+		$this->importService->expects(self::once())
+			->method('importText')
+			->willReturn($generator());
+
+		// Event with long UID should be skipped, so createCalendarObject should never be called
 		$this->caldavBackend->expects(self::never())
 			->method('createCalendarObject');
 
@@ -197,15 +355,11 @@ class RefreshWebcalServiceTest extends TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
-	public function testRunCreateCalendarNoException(string $body, string $contentType, string $result): void {
+	public function testRunCreateCalendarNoException(string $body, string $format, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
-			->onlyMethods(['getRandomCalendarObjectUri', 'getSubscription',])
-			->setConstructorArgs([$this->caldavBackend, $this->logger, $this->connection, $this->time])
+			->onlyMethods(['getSubscription'])
+			->setConstructorArgs([$this->caldavBackend, $this->logger, $this->connection, $this->timeFactory, $this->importService])
 			->getMock();
-
-		$refreshWebcalService
-			->method('getRandomCalendarObjectUri')
-			->willReturn('uri-1.ics');
 
 		$refreshWebcalService
 			->method('getSubscription')
@@ -220,13 +374,26 @@ class RefreshWebcalServiceTest extends TestCase {
 				'lastmodified' => 0,
 			]);
 
+		$stream = $this->createStreamFromString($body);
+
 		$this->connection->expects(self::once())
 			->method('queryWebcalFeed')
-			->willReturn($result);
+			->willReturn(['data' => $stream, 'format' => $format]);
 
 		$this->caldavBackend->expects(self::once())
-			->method('createCalendarObject')
-			->with(42, 'uri-1.ics', $result, 1);
+			->method('getLimitedCalendarObjects')
+			->willReturn([]);
+
+		// Create a VCalendar object that will be yielded by the import service
+		$vCalendar = VObject\Reader::read($result);
+
+		$generator = function () use ($vCalendar) {
+			yield $vCalendar;
+		};
+
+		$this->importService->expects(self::once())
+			->method('importText')
+			->willReturn($generator());
 
 		$noInstanceException = new NoInstancesException("can't add calendar object");
 		$this->caldavBackend->expects(self::once())
@@ -241,15 +408,11 @@ class RefreshWebcalServiceTest extends TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
-	public function testRunCreateCalendarBadRequest(string $body, string $contentType, string $result): void {
+	public function testRunCreateCalendarBadRequest(string $body, string $format, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
-			->onlyMethods(['getRandomCalendarObjectUri', 'getSubscription'])
-			->setConstructorArgs([$this->caldavBackend, $this->logger, $this->connection, $this->time])
+			->onlyMethods(['getSubscription'])
+			->setConstructorArgs([$this->caldavBackend, $this->logger, $this->connection, $this->timeFactory, $this->importService])
 			->getMock();
-
-		$refreshWebcalService
-			->method('getRandomCalendarObjectUri')
-			->willReturn('uri-1.ics');
 
 		$refreshWebcalService
 			->method('getSubscription')
@@ -264,13 +427,26 @@ class RefreshWebcalServiceTest extends TestCase {
 				'lastmodified' => 0,
 			]);
 
+		$stream = $this->createStreamFromString($body);
+
 		$this->connection->expects(self::once())
 			->method('queryWebcalFeed')
-			->willReturn($result);
+			->willReturn(['data' => $stream, 'format' => $format]);
 
 		$this->caldavBackend->expects(self::once())
-			->method('createCalendarObject')
-			->with(42, 'uri-1.ics', $result, 1);
+			->method('getLimitedCalendarObjects')
+			->willReturn([]);
+
+		// Create a VCalendar object that will be yielded by the import service
+		$vCalendar = VObject\Reader::read($result);
+
+		$generator = function () use ($vCalendar) {
+			yield $vCalendar;
+		};
+
+		$this->importService->expects(self::once())
+			->method('importText')
+			->willReturn($generator());
 
 		$badRequestException = new BadRequest("can't add reach calendar url");
 		$this->caldavBackend->expects(self::once())
@@ -285,20 +461,22 @@ class RefreshWebcalServiceTest extends TestCase {
 	}
 
 	public static function identicalDataProvider(): array {
+		$icalBody = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject " . VObject\Version::VERSION . "//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VEVENT\r\nUID:12345\r\nDTSTAMP:20160218T133704Z\r\nDTSTART;VALUE=DATE:19000101\r\nDTEND;VALUE=DATE:19000102\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:12345's Birthday (1900)\r\nTRANSP:TRANSPARENT\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+		$etag = md5($icalBody);
+
 		return [
 			[
 				'12345',
 				[
 					'12345' => [
 						'id' => 42,
-						'etag' => 100,
-						'uri' => 'sub456',
-						'calendardata' => "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VEVENT\r\nUID:12345\r\nDTSTAMP:20160218T133704Z\r\nDTSTART;VALUE=DATE:19000101\r\nDTEND;VALUE=DATE:19000102\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:12345's Birthday (1900)\r\nTRANSP:TRANSPARENT\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+						'etag' => $etag,
+						'uri' => 'sub456.ics',
 					],
 				],
 				"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VEVENT\r\nUID:12345\r\nDTSTAMP:20160218T133704Z\r\nDTSTART;VALUE=DATE:19000101\r\nDTEND;VALUE=DATE:19000102\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:12345's Birthday (1900)\r\nTRANSP:TRANSPARENT\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-				'text/calendar;charset=utf8',
-				"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VEVENT\r\nUID:12345\r\nDTSTAMP:20180218T133704Z\r\nDTSTART;VALUE=DATE:19000101\r\nDTEND;VALUE=DATE:19000102\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:12345's Birthday (1900)\r\nTRANSP:TRANSPARENT\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+				'ical',
+				$icalBody,
 			],
 		];
 	}
@@ -307,19 +485,9 @@ class RefreshWebcalServiceTest extends TestCase {
 		return [
 			[
 				"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VEVENT\r\nUID:12345\r\nDTSTAMP:20160218T133704Z\r\nDTSTART;VALUE=DATE:19000101\r\nDTEND;VALUE=DATE:19000102\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:12345's Birthday (1900)\r\nTRANSP:TRANSPARENT\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-				'text/calendar;charset=utf8',
+				'ical',
 				"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject " . VObject\Version::VERSION . "//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VEVENT\r\nUID:12345\r\nDTSTAMP:20160218T133704Z\r\nDTSTART;VALUE=DATE:19000101\r\nDTEND;VALUE=DATE:19000102\r\nRRULE:FREQ=YEARLY\r\nSUMMARY:12345's Birthday (1900)\r\nTRANSP:TRANSPARENT\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
 			],
-			[
-				'["vcalendar",[["prodid",{},"text","-//Example Corp.//Example Client//EN"],["version",{},"text","2.0"]],[["vtimezone",[["last-modified",{},"date-time","2004-01-10T03:28:45Z"],["tzid",{},"text","US/Eastern"]],[["daylight",[["dtstart",{},"date-time","2000-04-04T02:00:00"],["rrule",{},"recur",{"freq":"YEARLY","byday":"1SU","bymonth":4}],["tzname",{},"text","EDT"],["tzoffsetfrom",{},"utc-offset","-05:00"],["tzoffsetto",{},"utc-offset","-04:00"]],[]],["standard",[["dtstart",{},"date-time","2000-10-26T02:00:00"],["rrule",{},"recur",{"freq":"YEARLY","byday":"1SU","bymonth":10}],["tzname",{},"text","EST"],["tzoffsetfrom",{},"utc-offset","-04:00"],["tzoffsetto",{},"utc-offset","-05:00"]],[]]]],["vevent",[["dtstamp",{},"date-time","2006-02-06T00:11:21Z"],["dtstart",{"tzid":"US/Eastern"},"date-time","2006-01-02T14:00:00"],["duration",{},"duration","PT1H"],["recurrence-id",{"tzid":"US/Eastern"},"date-time","2006-01-04T12:00:00"],["summary",{},"text","Event #2"],["uid",{},"text","12345"]],[]]]]',
-				'application/calendar+json',
-				"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject " . VObject\Version::VERSION . "//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VTIMEZONE\r\nLAST-MODIFIED:20040110T032845Z\r\nTZID:US/Eastern\r\nBEGIN:DAYLIGHT\r\nDTSTART:20000404T020000\r\nRRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4\r\nTZNAME:EDT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20001026T020000\r\nRRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=10\r\nTZNAME:EST\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20060206T001121Z\r\nDTSTART;TZID=US/Eastern:20060102T140000\r\nDURATION:PT1H\r\nRECURRENCE-ID;TZID=US/Eastern:20060104T120000\r\nSUMMARY:Event #2\r\nUID:12345\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
-			],
-			[
-				'<?xml version="1.0" encoding="utf-8" ?><icalendar xmlns="urn:ietf:params:xml:ns:icalendar-2.0"><vcalendar><properties><prodid><text>-//Example Inc.//Example Client//EN</text></prodid><version><text>2.0</text></version></properties><components><vevent><properties><dtstamp><date-time>2006-02-06T00:11:21Z</date-time></dtstamp><dtstart><parameters><tzid><text>US/Eastern</text></tzid></parameters><date-time>2006-01-04T14:00:00</date-time></dtstart><duration><duration>PT1H</duration></duration><recurrence-id><parameters><tzid><text>US/Eastern</text></tzid></parameters><date-time>2006-01-04T12:00:00</date-time></recurrence-id><summary><text>Event #2 bis</text></summary><uid><text>12345</text></uid></properties></vevent></components></vcalendar></icalendar>',
-				'application/calendar+xml',
-				"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Sabre//Sabre VObject " . VObject\Version::VERSION . "//EN\r\nCALSCALE:GREGORIAN\r\nBEGIN:VEVENT\r\nDTSTAMP:20060206T001121Z\r\nDTSTART;TZID=US/Eastern:20060104T140000\r\nDURATION:PT1H\r\nRECURRENCE-ID;TZID=US/Eastern:20060104T120000\r\nSUMMARY:Event #2 bis\r\nUID:12345\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
-			]
 		];
 	}
 }

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -433,11 +433,6 @@
       <code><![CDATA[!isset($newProps['filters']['props']) || !is_array($newProps['filters']['props'])]]></code>
     </TypeDoesNotContainType>
   </file>
-  <file src="apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php">
-    <InvalidArgument>
-      <code><![CDATA[$webcalData]]></code>
-    </InvalidArgument>
-  </file>
   <file src="apps/dav/lib/CardDAV/AddressBookImpl.php">
     <InvalidArgument>
       <code><![CDATA[$this->getKey()]]></code>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # Client Ticket

## Summary
- Refactored subscription sync to address memory exhaustion issue

### Issue
- Calendar subscription was building the entire calendar import file several times. Building an ics file in memory of around 8/10k of events exhausts all memory. 
- Calendar subscription was loading all existing calendar object in to memory to compare etags

### Solution
- Don't build the entire calendar in memory, use the import stream reader to read one event at a time.
- Don't load all existing events with data when all we need is the etag
 
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
