### PR TITLE
patch the version file to allow upgrading from owncloud  > v10.13

### DIFF
--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@ $OC_VersionCanBeUpgradedFrom = [
 		'10.13' => true,
 		'10.14' => true,
 		'10.15' => true,
-    	'10.16' => true,
+		'10.16' => true,
 	],
 ];
 

--- a/version.php
+++ b/version.php
@@ -21,6 +21,9 @@ $OC_VersionCanBeUpgradedFrom = [
 	],
 	'owncloud' => [
 		'10.13' => true,
+		'10.14' => true,
+		'10.15' => true,
+    	'10.16' => true,
 	],
 ];
 


### PR DESCRIPTION
Some customers already migrated from 10.15.3 and needed to edit the version.php file before the migration. 10.16 was recently published and it seems migration from there also works fine.

https://github.com/nextcloud/documentation/pull/13910

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
