### PR TITLE
refactor: drop need for an obscure (and legacy) `OC_Util` method... `runningOnMac()` ;-)

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -185,10 +185,11 @@ class Setup {
 			}
 		}
 
-		if (\OC_Util::runningOnMac()) {
+		// Check if running directly on macOS (note: Linux containers on macOS will not trigger this)
+		if (PHP_OS_FAMILY === 'Darwin') {
 			$errors[] = [
 				'error' => $this->l10n->t(
-					'Mac OS X is not supported and %s will not work properly on this platform. '
+					'macOS is not supported and %s will not work properly on this platform. '
 					. 'Use it at your own risk!',
 					[$this->defaults->getProductName()]
 				),

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -733,9 +733,9 @@ class OC_Util {
 	}
 
 	/**
-	 * Checks whether PHP is running directly on macOS. 
+	 * Checks whether PHP is running directly on macOS.
 	 *
-	 * Note: In a Linux container, this will be false even on a macOS host 
+	 * Note: In a Linux container, this will be false even on a macOS host
 	 * (PHP just sees "Linux").
 	 *
 	 * @return bool true if running on Mac OS X, false otherwise

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -733,19 +733,6 @@ class OC_Util {
 	}
 
 	/**
-	 * Checks whether PHP is running directly on macOS.
-	 *
-	 * Note: In a Linux container, this will be false even on a macOS host
-	 * (PHP just sees "Linux").
-	 *
-	 * @return bool true if running on Mac OS X, false otherwise
-	 * @deprecated 33.0.0 Query PHP_OS_FAMILY directly.
-	 */
-	public static function runningOnMac() {
-		return (PHP_OS_FAMILY === 'Darwin');
-	}
-
-	/**
 	 * Handles the case that there may not be a theme, then check if a "default"
 	 * theme exists and take that one
 	 *

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -733,12 +733,16 @@ class OC_Util {
 	}
 
 	/**
-	 * Checks whether the server is running on Mac OS X
+	 * Checks whether PHP is running directly on macOS. 
+	 *
+	 * Note: In a Linux container, this will be false even on a macOS host 
+	 * (PHP just sees "Linux").
 	 *
 	 * @return bool true if running on Mac OS X, false otherwise
+	 * @deprecated 33.0.0 Query PHP_OS_FAMILY directly.
 	 */
 	public static function runningOnMac() {
-		return (strtoupper(substr(PHP_OS, 0, 6)) === 'DARWIN');
+		return (PHP_OS_FAMILY === 'Darwin');
 	}
 
 	/**

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -805,15 +805,11 @@ class ViewTest extends \Test\TestCase {
 		$ds = DIRECTORY_SEPARATOR;
 		/*
 		 * 4096 is the maximum path length in file_cache.path in *nix
-		 * 1024 is the max path length in mac
 		 */
 		$folderName = 'abcdefghijklmnopqrstuvwxyz012345678901234567890123456789';
 		$tmpdirLength = strlen(Server::get(ITempManager::class)->getTemporaryFolder());
-		if (PHP_OS_FAMILY === 'Darwin') { // macOS
-			$depth = ((1024 - $tmpdirLength) / 57);
-		} else {
-			$depth = ((4000 - $tmpdirLength) / 57);
-		}
+		$depth = ((4000 - $tmpdirLength) / 57);
+
 		foreach (range(0, $depth - 1) as $i) {
 			$longPath .= $ds . $folderName;
 			$result = $rootView->mkdir($longPath);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -809,7 +809,7 @@ class ViewTest extends \Test\TestCase {
 		 */
 		$folderName = 'abcdefghijklmnopqrstuvwxyz012345678901234567890123456789';
 		$tmpdirLength = strlen(Server::get(ITempManager::class)->getTemporaryFolder());
-		if (\OC_Util::runningOnMac()) {
+		if (PHP_OS_FAMILY === 'Darwin') { // macOS
 			$depth = ((1024 - $tmpdirLength) / 57);
 		} else {
 			$depth = ((4000 - $tmpdirLength) / 57);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- Standard PHP constant available
- One less legacy (OC_Util) function[^deprecated]
- Easier to read
- Nobody was using it anyway
- Technically more robust

[^deprecated]: Once we feel comfortable removing it. Not really sure if it's considered a public API or not. I guess kinda sorta. So `@deprecated` it (and changed its implementation to use the constant meanwhile too).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
