### PR TITLE
fix(setup): normalize canonical webroot consistently

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -517,26 +517,41 @@ class Setup {
 	}
 
 	/**
-	 * Find webroot from config
+	 * Determine the canonical web base path for the installation.
 	 *
-	 * @throws InvalidArgumentException when invalid value for overwrite.cli.url
+	 * Returns '' for root installs or '/subpath' (leading slash, no trailing slash) for subdir installs.
+	 *
+	 * When running in CLI the value is derived from 'overwrite.cli.url'.
+	 *
+	 * @return string Canonical webroot ('' or '/subpath')
+	 * @throws \InvalidArgumentException If running in CLI and overwrite.cli.url is empty or invalid
 	 */
 	private static function findWebRoot(SystemConfig $config): string {
-		// For CLI read the value from overwrite.cli.url
 		if (\OC::$CLI) {
-			$webRoot = $config->getValue('overwrite.cli.url', '');
-			if ($webRoot === '') {
-				throw new InvalidArgumentException('overwrite.cli.url is empty');
-			}
-			if (!filter_var($webRoot, FILTER_VALIDATE_URL)) {
-				throw new InvalidArgumentException('invalid value for overwrite.cli.url');
-			}
-			$webRoot = rtrim((parse_url($webRoot, PHP_URL_PATH) ?? ''), '/');
+			$rawPath = self::getWebRootFromCliConfig($config);
 		} else {
-			$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';
+			$rawPath = (string)\OC::$WEBROOT;
 		}
 
+		// normalize to canonical form regardless of source and initial form
+		$webRoot = rtrim((string)$rawPath, '/');
+
 		return $webRoot;
+	}
+
+	private static function getWebRootFromCliConfig(SystemConfig $config): string {
+		$overwriteCliUrl = $config->getValue('overwrite.cli.url', '');
+
+		if ($overwriteCliUrl === '') {
+			throw new \InvalidArgumentException('overwrite.cli.url is empty');
+		}
+
+		if (!filter_var($overwriteCliUrl, FILTER_VALIDATE_URL)) {
+			throw new \InvalidArgumentException('overwrite.cli.url is not a valid URL');
+		}
+
+		// parse_url may return null for no path -> coalesce to ''
+		return parse_url($overwriteCliUrl, PHP_URL_PATH) ?? '';
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Prevent double-slash artifacts caused when non-CLI returned '/' for root. And make the underlying implementation consistent.

- Ensure non‑CLI branch returns the canonical webroot (`''` for root installs, `'/subpath'` for subdirectory installs)
- Extract CLI parsing into helper
- Centralize normalization to avoid duplicated/conflicting logic

For ease of review (since I also did a refactor to streamline things), the problematic lines were 534 & 536 in master. CLI mode always made sure to drop the trailing slash and thus handled a root installation fine by returning '`'` (correct behavior):

```
$webRoot = rtrim((parse_url($webRoot, PHP_URL_PATH) ?? ''), '/');
```

But the non-CLI mode code path would return `'/'` (inconsistent with CLI mode and also incorrect) for the same root installation:

```
$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';
```

Often not a serious problem, but was technically incorrect nonetheless.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
