### PR TITLE
feat(pgsql_ssl): Allow to use global `default_certificates_bundle_path` for pgsql

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -202,7 +202,8 @@ class ConnectionFactory {
 			$pgsqlSsl = $this->config->getValue('pgsql_ssl', false);
 			if (is_array($pgsqlSsl)) {
 				$connectionParams['sslmode'] = $pgsqlSsl['mode'] ?? '';
-				$connectionParams['sslrootcert'] = $pgsqlSsl['rootcert'] ?? '';
+				$rootCertPath = $pgsqlSsl['rootcert'] ?? $this->config->getValue('default_certificates_bundle_path', null) ?? '';
+				$connectionParams['sslrootcert'] = $rootCertPath;
 				$connectionParams['sslcert'] = $pgsqlSsl['cert'] ?? '';
 				$connectionParams['sslkey'] = $pgsqlSsl['key'] ?? '';
 				$connectionParams['sslcrl'] = $pgsqlSsl['crl'] ?? '';


### PR DESCRIPTION
- Follow-up to https://github.com/nextcloud/server/pull/52749