### PR TITLE
feat(driverOptions): Allow to use global default_certificates_bundle_path as driverOptions

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -189,6 +189,8 @@ class ConnectionFactory {
 		//additional driver options, eg. for mysql ssl
 		$driverOptions = $this->config->getValue($configPrefix . 'dbdriveroptions', $this->config->getValue('dbdriveroptions', null));
 		if ($driverOptions) {
+			$rootCertPath = $driverOptions[PDO::MYSQL_ATTR_SSL_CA] ?? $this->config->getValue('default_certificates_bundle_path', null) ?? '';
+			$driverOptions[PDO::MYSQL_ATTR_SSL_CA] = $rootCertPath;
 			$connectionParams['driverOptions'] = $driverOptions;
 		}
 


### PR DESCRIPTION
- Follow-up to https://github.com/nextcloud/server/pull/52749