### PR TITLE
feat(mail_smtpstreamoptions): Allow to use global default_certificates_bundle_path in mail_smtpstreamoptions

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -293,6 +293,8 @@ class Mailer implements IMailer {
 
 		$streamingOptions = $this->config->getSystemValue('mail_smtpstreamoptions', []);
 		if (is_array($streamingOptions) && !empty($streamingOptions)) {
+			$rootCertPath = $streamingOptions['ssl']['cafile'] ?? $this->config->getValue('default_certificates_bundle_path', null) ?? '';
+			$streamingOptions['ssl']['cafile'] = $rootCertPath;
 			/** @psalm-suppress InternalMethod */
 			$currentStreamingOptions = $stream->getStreamOptions();
 


### PR DESCRIPTION
- Follow-up to https://github.com/nextcloud/server/pull/52749