### PR TITLE
feat(redis): Allow to use global default_certificates_bundle_path in ssl_context

### DIFF
--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -135,6 +135,8 @@ class RedisFactory {
 					self::REDIS_EXTRA_PARAMETERS_MINIMAL_VERSION
 				));
 			}
+			$rootCertPath = $config['ssl_context']['cafile'] ?? $this->config->getValue('default_certificates_bundle_path', null) ?? '';
+			$config['ssl_context']['cafile'] = $rootCertPath;
 			return $config['ssl_context'];
 		}
 		return null;


### PR DESCRIPTION
- Follow-up to https://github.com/nextcloud/server/pull/52749