### PR TITLE
fix: Allow installation on macOS CI

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -58,12 +58,7 @@ class Install extends Command {
 		$errors = $sysInfo['errors'];
 		if (count($errors) > 0) {
 			$this->printErrors($output, $errors);
-
-			// ignore the OS X setup warning
-			if (count($errors) !== 1
-				|| (string)$errors[0]['error'] !== 'Mac OS X is not supported and Nextcloud will not work properly on this platform. Use it at your own risk!') {
-				return 1;
-			}
+			return 1;
 		}
 
 		// validate user input

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -186,11 +186,10 @@ class Setup {
 		}
 
 		// Check if running directly on macOS (note: Linux containers on macOS will not trigger this)
-		if (PHP_OS_FAMILY === 'Darwin') {
+		if (!getenv('CI') && PHP_OS_FAMILY === 'Darwin') {
 			$errors[] = [
 				'error' => $this->l10n->t(
-					'macOS is not supported and %s will not work properly on this platform. '
-					. 'Use it at your own risk!',
+					'macOS is not supported and %s will not work properly on this platform.',
 					[$this->defaults->getProductName()]
 				),
 				'hint' => $this->l10n->t('For the best results, please consider using a GNU/Linux server instead.'),


### PR DESCRIPTION
* Follow up to https://github.com/nextcloud/server/pull/56816

## Summary

Because of the string change in the mentioned PR, installation on macOS is not possible anymore. Since the current macOS runner on GitHub do not support nested virtualization (therefore something like Docker will not work), we currently require being able to run on macOS.
Thanks @nickvergessen for preparation!

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
