### PR TITLE
fix: Allow `num_buckets` to be equal as `min_bucket`

### DIFF
--- a/lib/private/Files/ObjectStore/Mapper.php
+++ b/lib/private/Files/ObjectStore/Mapper.php
@@ -30,6 +30,10 @@ class Mapper {
 			? (int)$this->config['arguments']['min_bucket']
 			: 0;
 
+		if ($minBucket === $numBuckets) {
+			return (string)$minBucket;
+		}
+
 		$hash = md5($this->user->getUID());
 		$num = hexdec(substr($hash, 0, 4));
 		return (string)(($num % ($numBuckets - $minBucket)) + $minBucket);

--- a/tests/lib/Files/ObjectStore/MapperTest.php
+++ b/tests/lib/Files/ObjectStore/MapperTest.php
@@ -24,6 +24,7 @@ class MapperTest extends \Test\TestCase {
 	public static function dataGetBucket(): array {
 		return [
 			['user', 64, 0, '17'],
+			['user', 64, 64, '64'],
 			['USER', 64, 0, '0'],
 			['bc0e8b52-a66c-1035-90c6-d9663bda9e3f', 64, 0, '56'],
 			['user', 8, 0, '1'],
@@ -41,8 +42,7 @@ class MapperTest extends \Test\TestCase {
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetBucket')]
 	public function testGetBucket($username, $numBuckets, $bucketShift, $expectedBucket): void {
 		$mapper = new Mapper($this->user, ['arguments' => ['min_bucket' => $bucketShift]]);
-		$this->user->expects($this->once())
-			->method('getUID')
+		$this->user->method('getUID')
 			->willReturn($username);
 
 		$result = $mapper->getBucket($numBuckets);


### PR DESCRIPTION
## Summary
We have next configuration for Multibucket Object Store
```php
'objectstore_multibucket' => [
        'class' => 'Object\\Storage\\Backend\\Class',
        'arguments' => [
                'min_bucket' => 100,
                'num_buckets' => 100,
        ],
],
```
This needed to separate system files from a user files. So, system files will be stored in `nextcloud-0` and user files in `nextcloud-100`. But the problem is such configuration not works as expected due to division by zero. This PR aims to fix that.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
