### PR TITLE
fix(files/type): preserve numeric keys (follow-up)

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -97,7 +97,7 @@ class Detection implements IMimeTypeDetector {
 		if (file_exists($this->customConfigDir . '/' . $fileName)) {
 			$custom = json_decode(file_get_contents($this->customConfigDir . '/' . $fileName), true);
 			if (json_last_error() === JSON_ERROR_NONE) {
-				$definitions = array_merge($definitions, $custom);
+				$definitions = array_replace($definitions, $custom);
 			} else {
 				$this->logger->warning('Failed to parse ' . $fileName . ': ' . json_last_error_msg());
 			}

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -117,24 +117,72 @@ class DetectionTest extends \Test\TestCase {
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataMimeTypeCustom')]
 	public function testDetectMimeTypeCustom(string $ext, string $mime): void {
-		$confDir = sys_get_temp_dir();
-		file_put_contents($confDir . '/mimetypemapping.dist.json', json_encode([]));
+		$tmpDir = sys_get_temp_dir() . '/nc-detect-' . uniqid('', true);
+		mkdir($tmpDir, 0700);
 
-		/** @var IURLGenerator $urlGenerator */
-		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
-			->disableOriginalConstructor()
-			->getMock();
+		try {
+			// Create a default / shipped mapping file (dist)
+			file_put_contents($tmpDir . '/mimetypemapping.dist.json', json_encode([]));
+			
+			// Create new custom mapping file that should be picked up by Detection
+			file_put_contents($tmpDir . '/mimetypemapping.json', json_encode([$ext => [$mime]]));
 
-		/** @var LoggerInterface $logger */
-		$logger = $this->createMock(LoggerInterface::class);
+			/** @var IURLGenerator $urlGenerator */
+			$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
+				->disableOriginalConstructor()
+				->getMock();
 
-		// Create new mapping file
-		file_put_contents($confDir . '/mimetypemapping.dist.json', json_encode([$ext => [$mime]]));
+			/** @var LoggerInterface $logger */
+			$logger = $this->createMock(LoggerInterface::class);
 
-		$detection = new Detection($urlGenerator, $logger, $confDir, $confDir);
-		$mappings = $detection->getAllMappings();
-		$this->assertArrayHasKey($ext, $mappings);
-		$this->assertEquals($mime, $detection->detectPath('foo.' . $ext));
+			$detection = new Detection($urlGenerator, $logger, $tmpDir, $tmpDir);
+			$mappings = $detection->getAllMappings();
+
+			$this->assertArrayHasKey($ext, $mappings);
+			$this->assertEquals($mime, $detection->detectPath('foo.' . $ext));
+		} finally {
+			// cleanup
+			@unlink($tmpDir . '/mimetypemapping.json');
+			@unlink($tmpDir . '/mimetypemapping.dist.json');
+			@rmdir($tmpDir);
+		}
+	}
+
+	public function testDetectMimeTypePreservesLeadingZeroKeys(): void {
+		$tmpDir = sys_get_temp_dir() . '/nc-detect-' . uniqid();
+		mkdir($tmpDir, 0700);
+		try {
+			// Create a default / shipped mapping file (dist)
+			file_put_contents($tmpDir . '/mimetypemapping.dist.json', json_encode([]));
+
+			// Create new custom mapping file with potentially problematic keys
+			$mappings = [
+				'001' => ['application/x-zeroone', null],
+				'1'   => ['application/x-one', null],
+			];
+			file_put_contents($tmpDir . '/mimetypemapping.json', json_encode($mappings));
+
+			/** @var IURLGenerator $urlGenerator */
+			$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
+				->disableOriginalConstructor()
+				->getMock();
+			
+			/** @var LoggerInterface $logger */
+			$logger = $this->createMock(LoggerInterface::class);
+
+			$detection = new Detection($urlGenerator, $logger, $tmpDir, $tmpDir);
+			$mappings = $detection->getAllMappings();
+
+			$this->assertArrayHasKey('001', $mappings, 'Expected mapping to contain key "001"');
+			$this->assertArrayHasKey('1', $mappings, 'Expected mapping to contain key "1"');
+			
+			$this->assertEquals('application/x-zeroone', $detection->detectPath('foo.001'));
+			$this->assertEquals('application/x-one', $detection->detectPath('foo.1'));
+		} finally {
+			@unlink($tmpDir . '/mimetypemapping.json');
+			@unlink($tmpDir . '/mimetypemapping.dist.json');
+			@rmdir($tmpDir);
+		}
 	}
 
 	public static function dataGetSecureMimeType(): array {

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -123,7 +123,7 @@ class DetectionTest extends \Test\TestCase {
 		try {
 			// Create a default / shipped mapping file (dist)
 			file_put_contents($tmpDir . '/mimetypemapping.dist.json', json_encode([]));
-			
+
 			// Create new custom mapping file that should be picked up by Detection
 			file_put_contents($tmpDir . '/mimetypemapping.json', json_encode([$ext => [$mime]]));
 
@@ -158,7 +158,7 @@ class DetectionTest extends \Test\TestCase {
 			// Create new custom mapping file with potentially problematic keys
 			$mappings = [
 				'001' => ['application/x-zeroone', null],
-				'1'   => ['application/x-one', null],
+				'1' => ['application/x-one', null],
 			];
 			file_put_contents($tmpDir . '/mimetypemapping.json', json_encode($mappings));
 
@@ -166,7 +166,7 @@ class DetectionTest extends \Test\TestCase {
 			$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 				->disableOriginalConstructor()
 				->getMock();
-			
+
 			/** @var LoggerInterface $logger */
 			$logger = $this->createMock(LoggerInterface::class);
 
@@ -175,7 +175,7 @@ class DetectionTest extends \Test\TestCase {
 
 			$this->assertArrayHasKey('001', $mappings, 'Expected mapping to contain key "001"');
 			$this->assertArrayHasKey('1', $mappings, 'Expected mapping to contain key "1"');
-			
+
 			$this->assertEquals('application/x-zeroone', $detection->detectPath('foo.001'));
 			$this->assertEquals('application/x-one', $detection->detectPath('foo.1'));
 		} finally {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Expands on #50660 which was for #42902

## Summary

Primary changes:

- Fixes implementation for custom mappings to preserve numeric keys (which was passing the prior unit test)
- Fixes test that wasn't testing the custom mappings code path

Secondary changes:

- Refactors tests to use an isolated temp dir with proper cleanup
- Adds a focused test to see if numeric-looking keys (e.g. "001") are preserved
  - (the current implementation is brittle and can break if we aren't careful with how we manage keys)

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
