### PR TITLE
Fix caching routes by users with an active session

### DIFF
--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -63,5 +63,10 @@ return [
 				'type' => null
 			]
 		],
+		[
+			'name' => 'Routes#getRoutesInRoutesPhp',
+			'url' => '/api/v1/routes/routesphp/{app}',
+			'verb' => 'GET',
+		],
 	],
 ];

--- a/apps/testing/clean_apcu_cache.php
+++ b/apps/testing/clean_apcu_cache.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+apcu_clear_cache();

--- a/apps/testing/composer/composer/autoload_classmap.php
+++ b/apps/testing/composer/composer/autoload_classmap.php
@@ -12,6 +12,7 @@ return array(
     'OCA\\Testing\\Controller\\ConfigController' => $baseDir . '/../lib/Controller/ConfigController.php',
     'OCA\\Testing\\Controller\\LockingController' => $baseDir . '/../lib/Controller/LockingController.php',
     'OCA\\Testing\\Controller\\RateLimitTestController' => $baseDir . '/../lib/Controller/RateLimitTestController.php',
+    'OCA\\Testing\\Controller\\RoutesController' => $baseDir . '/../lib/Controller/RoutesController.php',
     'OCA\\Testing\\Conversion\\ConversionProvider' => $baseDir . '/../lib/Conversion/ConversionProvider.php',
     'OCA\\Testing\\HiddenGroupBackend' => $baseDir . '/../lib/HiddenGroupBackend.php',
     'OCA\\Testing\\Listener\\GetDeclarativeSettingsValueListener' => $baseDir . '/../lib/Listener/GetDeclarativeSettingsValueListener.php',

--- a/apps/testing/composer/composer/autoload_static.php
+++ b/apps/testing/composer/composer/autoload_static.php
@@ -27,6 +27,7 @@ class ComposerStaticInitTesting
         'OCA\\Testing\\Controller\\ConfigController' => __DIR__ . '/..' . '/../lib/Controller/ConfigController.php',
         'OCA\\Testing\\Controller\\LockingController' => __DIR__ . '/..' . '/../lib/Controller/LockingController.php',
         'OCA\\Testing\\Controller\\RateLimitTestController' => __DIR__ . '/..' . '/../lib/Controller/RateLimitTestController.php',
+        'OCA\\Testing\\Controller\\RoutesController' => __DIR__ . '/..' . '/../lib/Controller/RoutesController.php',
         'OCA\\Testing\\Conversion\\ConversionProvider' => __DIR__ . '/..' . '/../lib/Conversion/ConversionProvider.php',
         'OCA\\Testing\\HiddenGroupBackend' => __DIR__ . '/..' . '/../lib/HiddenGroupBackend.php',
         'OCA\\Testing\\Listener\\GetDeclarativeSettingsValueListener' => __DIR__ . '/..' . '/../lib/Listener/GetDeclarativeSettingsValueListener.php',

--- a/apps/testing/lib/Controller/RoutesController.php
+++ b/apps/testing/lib/Controller/RoutesController.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Testing\Controller;
+
+use OCP\App\AppPathNotFoundException;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+
+class RoutesController extends OCSController {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IAppManager $appManager,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	public function getRoutesInRoutesPhp(string $app): DataResponse {
+		try {
+			$appPath = $this->appManager->getAppPath($app);
+		} catch (AppPathNotFoundException) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$file = $appPath . '/appinfo/routes.php';
+		if (!file_exists($file)) {
+			return new DataResponse();
+		}
+
+		$routes = include $file;
+
+		return new DataResponse($routes);
+	}
+}

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -827,6 +827,9 @@ trait Provisioning {
 	 * @param string $app
 	 */
 	public function appEnabledStateWillBeRestoredOnceTheScenarioFinishes($app) {
+		$previousUser = $this->currentUser;
+		$this->currentUser = 'admin';
+
 		if (in_array($app, $this->getAppsWithFilter('enabled'))) {
 			$this->appsToEnableAfterScenario[] = $app;
 		} elseif (in_array($app, $this->getAppsWithFilter('disabled'))) {
@@ -835,6 +838,8 @@ trait Provisioning {
 
 		// Apps that were not installed before the scenario will not be
 		// disabled nor uninstalled after the scenario.
+
+		$this->currentUser = $previousUser;
 	}
 
 	private function getAppsWithFilter($filter) {

--- a/build/integration/features/bootstrap/RoutingContext.php
+++ b/build/integration/features/bootstrap/RoutingContext.php
@@ -6,6 +6,7 @@
  */
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use PHPUnit\Framework\Assert;
 
 require __DIR__ . '/autoload.php';
 
@@ -15,5 +16,27 @@ class RoutingContext implements Context, SnippetAcceptingContext {
 	use CommandLine;
 
 	protected function resetAppConfigs(): void {
+	}
+
+	/**
+	 * @AfterScenario
+	 */
+	public function deleteMemcacheSetting(): void {
+		$this->invokingTheCommand('config:system:delete memcache.local');
+	}
+
+	/**
+	 * @Given /^route "([^"]*)" of app "([^"]*)" is defined in routes.php$/
+	 */
+	public function routeOfAppIsDefinedInRoutesPhP(string $route, string $app): void {
+		$previousUser = $this->currentUser;
+		$this->currentUser = 'admin';
+
+		$this->sendingTo('GET', "/apps/testing/api/v1/routes/routesphp/{$app}");
+		$this->theHTTPStatusCodeShouldBe('200');
+
+		Assert::assertStringContainsString($route, $this->response->getBody()->getContents());
+
+		$this->currentUser = $previousUser;
 	}
 }

--- a/build/integration/routing_features/apps-and-routes.feature
+++ b/build/integration/routing_features/apps-and-routes.feature
@@ -50,3 +50,22 @@ Feature: appmanagement
     Given As an "admin"
     And sending "DELETE" to "/cloud/apps/weather_status"
     And app "weather_status" is disabled
+
+  Scenario: Cache routes from routes.php with a user in a group without some apps enabled
+    Given invoking occ with "config:system:set memcache.local --value \OC\Memcache\APCu"
+    And the command was successful
+    And route "api/v1/location" of app "weather_status" is defined in routes.php
+    And app "weather_status" enabled state will be restored once the scenario finishes
+    And invoking occ with "app:enable weather_status --groups group1"
+    And the command was successful
+    When Logging in using web as "user2"
+    And sending "GET" with exact url to "/apps/testing/clean_apcu_cache.php"
+    And Sending a "GET" to "/index.php/apps/files" with requesttoken
+    And the HTTP status code should be "200"
+    Then As an "user2"
+    And sending "GET" to "/apps/weather_status/api/v1/location"
+    And the HTTP status code should be "412"
+    And As an "user1"
+    And sending "GET" to "/apps/weather_status/api/v1/location"
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -74,8 +74,6 @@ class CachingRouter extends Router {
 	 * @return array
 	 */
 	public function findMatchingRoute(string $url): array {
-		return parent::findMatchingRoute($url);
-
 		$this->eventLogger->start('cacheroute:match', 'Match route');
 		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . '#rootCollection';
 		$cachedRoutes = $this->cache->get($key);

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -78,6 +78,13 @@ class CachingRouter extends Router {
 		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . '#rootCollection';
 		$cachedRoutes = $this->cache->get($key);
 		if (!$cachedRoutes) {
+			// Ensure that all apps are loaded, as for users with an active
+			// session only the apps that are enabled for that user might have
+			// been loaded.
+			$enabledApps = $this->appManager->getEnabledApps();
+			foreach ($enabledApps as $app) {
+				$this->appManager->loadApp($app);
+			}
 			parent::loadRoutes();
 			$cachedRoutes = $this->serializeRouteCollection($this->root);
 			$this->cache->set($key, $cachedRoutes, ($this->config->getSystemValueBool('debug') ? 3 : 3600));


### PR DESCRIPTION
Fixes #56789, which is a regression introduced in #52793

When a user has an active session only the apps that are enabled for the user are initially loaded*. In order to cache the routes [the routes for all apps are loaded](https://github.com/nextcloud/server/blob/b188fad8e84491b0631a7e33a28c55ccecbecaf4/lib/private/Route/CachingRouter.php#L80-L81), but [routes defined in _routes.php_ are taken into account only if the app was already loaded](https://github.com/nextcloud/server/blob/a98ba27a0f3439521c03464f1454b9e9f5032832/lib/private/Route/Router.php#L156-L161). Therefore, when the routes were cached in a request by a user with an active session only the routes for apps enabled for that user were cached, and those routes were used by any other user, independently of which apps they had access to. To solve that now all the enabled apps are explicitly loaded before caching the routes.

Note that this did not affect routes defined using annotations on the controller files; in that case the loaded routes do not depend on the previously loaded apps, as [it explicitly checks all the enabled apps](https://github.com/nextcloud/server/blob/a98ba27a0f3439521c03464f1454b9e9f5032832/lib/private/Route/Router.php#L128-L130).

*[As soon as the session is initialized](https://github.com/nextcloud/server/blob/eb54143c2d6ccc9ad4220207f1be617abb6e71e4/lib/base.php#L734), which happens [when loading _base.php_](https://github.com/nextcloud/server/blob/eb54143c2d6ccc9ad4220207f1be617abb6e71e4/lib/base.php#L1227), the legacy `OC_APP::getEnabledApps` [will return only the apps enabled for the user](https://github.com/nextcloud/server/blob/bdff12361c227c8ba71e3f8739a90a10a0fd9dec/lib/private/legacy/OC_App.php#L188). That method [is used by `AppManager::loadApps`](https://github.com/nextcloud/server/blob/ab9a92fac850b41da6ac3285360275ba34db0488/lib/private/App/AppManager.php#L250), so once the session is initialized any load of (several) apps will be restricted to those enabled for the user (explicitly loading a single app still works as expected). Therefore, when `$appManager->loadApps()` is called from the [OCS handler](https://github.com/nextcloud/server/blob/7127ac4b43bad98f91855fb74428748e47d032fb/ocs/v1.php#L52) or from the [_index.php_ handler (through `handleRequest` in _base.php_)](https://github.com/nextcloud/server/blob/eb54143c2d6ccc9ad4220207f1be617abb6e71e4/lib/base.php#L1056) only the apps for the user are loaded.

## Steps to reproduce

- Use a development server and ensure that no other requests than the ones below are handled
- Enable APCu cache (add `'memcache.local' => '\\OC\\Memcache\\APCu'`, to _config.php_) if not enabled already
- Enable the `weather_status` app only for a specific group (for simplicity admin is used here)
```
occ app:enable --groups admin weather_status`
```

- Adjust the variables below as needed for your setup and run the following Bash code:
```
export ADMIN_NAME=admin
export ADMIN_PASSWORD=admin
export USER_NAME=user0
export USER_PASSWORD=user0
export SERVER_URL=http://127.0.0.1:8000

function extractRequestToken() {
	echo $(echo $1 | grep --perl-regexp --only-matching 'data-requesttoken="\K([^"]*)')
}

function extractAuthenticationToken() {
	echo $(echo $1 | grep --perl-regexp --only-matching '"token":"\K([^"]*)')
}

# Open login page to get the request token
loginPage=$(curl --silent --cookie-jar "/tmp/cookie-jar-$USER_NAME" "$SERVER_URL/index.php/login")

requestToken=$(extractRequestToken "$loginPage")

# Perform actual login
loginPost=$(curl --silent --location --cookie "/tmp/cookie-jar-$USER_NAME" --cookie-jar "/tmp/cookie-jar-$USER_NAME" --header "Origin: $SERVER_URL" --data-urlencode "user=$USER_NAME" --data-urlencode "password=$USER_PASSWORD" --data-urlencode "requesttoken=$requestToken" "$SERVER_URL/index.php/login")

requestToken=$(extractRequestToken "$loginPost")
```

- Clear the APCu cache (call `apcu_clear_cache()` somehow, for example using https://github.com/krakjoe/apcu/blob/master/apc.php or the helper apps/testing/clean_apcu_cache.php added in this pull request; restarting the web server would reset the APCu cache, but it might also kill the user session and make the test invalid)

- In the same Bash terminal as before, do a request with the logged in user, for example:
```
curl --silent --location --cookie "/tmp/cookie-jar-$USER_NAME" --cookie-jar "/tmp/cookie-jar-$USER_NAME" --header "requesttoken: $requestToken" "$SERVER_URL/ocs/v1.php/cloud/user?format=json"
```

- Now request an endpoint in the `weather_status` app by a user member of the group that it is enabled for (again for simplicity admin is used here):
```
curl --user "$ADMIN_NAME:$ADMIN_PASSWORD" --header "OCS-ApiRequest: true" "$SERVER_URL/ocs/v2.php/apps/weather_status/api/v1/location"
```

### Result with this pull request

The query succeeded

### Result without this pull request

Invalid query returned; if the APCu cache is cleared again and the request repeated then it will now succeed (as the routes will be regenerated by the admin, which has access to the app)
