### PR TITLE
test: Fix PHPUnit 11 use in Behat

### DIFF
--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -478,6 +478,13 @@ trait BasicStructure {
 	/**
 	 * @BeforeSuite
 	 */
+	public static function createPHPUnitConfiguration(): void {
+		(new \PHPUnit\TextUI\Configuration\Builder())->build([]);
+	}
+
+	/**
+	 * @BeforeSuite
+	 */
 	public static function addFilesToSkeleton() {
 		for ($i = 0; $i < 5; $i++) {
 			file_put_contents('../../core/skeleton/' . 'textfile' . "$i" . '.txt', "Nextcloud test text file\n");


### PR DESCRIPTION
Follow up to #55870

Starting with PHPUnit 11.3, some complex outputs of certain asserts (like `assertStringContainsString`) [require the output of PHPUnit to be explicitly setup](https://redirect.github.com/Behat/Behat/issues/1618). Otherwise when the assert fails a type error is thrown (although it does not seem to affect asserts with simpler outputs, like `assertEquals`).

[Note that PHPUnit asserts have never been intended to be used as standalone methods](https://redirect.github.com/sebastianbergmann/phpunit/issues/6175), even if it worked and it was recommended by Behat. In the future it might be needed to move to a different library, but for now this adjustment seems to be enough.

## How to test

- Modify any integration test with the "the command output contains the text XXX" so the check fails
- Run the integration test

### Result with this pull request

The output shows the actual and expected texts

### Result without this pull request

A type error is thrown: ` Type error: PHPUnit\TextUI\Configuration\Registry::get(): Return value must be of type PHPUnit\TextUI\Configuration\Configuration, null returned (Behat\Testwork\Call\Exception\FatalThrowableError)`