### PR TITLE
fix(TaskProcessing): Adjust OCR task type to allow for multiple files and pdfs

### DIFF
--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -611,6 +611,7 @@ class Manager implements IManager {
 			\OCP\TaskProcessing\TaskTypes\AudioToAudioChat::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\AudioToAudioChat::class),
 			\OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction::class),
 			\OCP\TaskProcessing\TaskTypes\AnalyzeImages::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\AnalyzeImages::class),
+			\OCP\TaskProcessing\TaskTypes\ImageToTextOpticalCharacterRecognition::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\ImageToTextOpticalCharacterRecognition::class),
 		];
 
 		foreach ($context->getTaskProcessingTaskTypes() as $providerServiceRegistration) {

--- a/lib/public/TaskProcessing/TaskTypes/ImageToTextOpticalCharacterRecognition.php
+++ b/lib/public/TaskProcessing/TaskTypes/ImageToTextOpticalCharacterRecognition.php
@@ -48,7 +48,7 @@ class ImageToTextOpticalCharacterRecognition implements ITaskType {
 	 * @since 33.0.0
 	 */
 	public function getDescription(): string {
-		return $this->l->t('Extract text from an image');
+		return $this->l->t('Extract text from files like images or PDFs');
 	}
 
 	/**
@@ -65,9 +65,9 @@ class ImageToTextOpticalCharacterRecognition implements ITaskType {
 	public function getInputShape(): array {
 		return [
 			'input' => new ShapeDescriptor(
-				$this->l->t('Input Image'),
-				$this->l->t('The image to extract text from'),
-				EShapeType::Image
+				$this->l->t('Input files'),
+				$this->l->t('The files to extract text from'),
+				EShapeType::ListOfFiles
 			),
 		];
 	}
@@ -79,9 +79,9 @@ class ImageToTextOpticalCharacterRecognition implements ITaskType {
 	public function getOutputShape(): array {
 		return [
 			'output' => new ShapeDescriptor(
-				$this->l->t('Output text'),
-				$this->l->t('The text that was extracted from the image'),
-				EShapeType::Text
+				$this->l->t('Output texts'),
+				$this->l->t('The texts that were extracted from the files'),
+				EShapeType::ListOfTexts
 			),
 		];
 	}


### PR DESCRIPTION
... and actually register it

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) will be updated once the PR is merged
-  [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
