### PR TITLE
fix(UserMountCache): Set transaction isolation level to REPEATABLE_READ before executing insertIfNotExist without unique index

### DIFF
--- a/lib/private/DB/ConnectionAdapter.php
+++ b/lib/private/DB/ConnectionAdapter.php
@@ -26,6 +26,13 @@ class ConnectionAdapter implements IDBConnection {
 	/** @var Connection */
 	private $inner;
 
+	/**
+	 * The currently active transaction isolation level or NULL before it has been determined.
+	 *
+	 * @var \Doctrine\DBAL\TransactionIsolationLevel::*|null
+	 */
+	private ?int $transactionIsolationLevel = null;
+
 	public function __construct(Connection $inner) {
 		$this->inner = $inner;
 	}
@@ -261,5 +268,15 @@ class ConnectionAdapter implements IDBConnection {
 
 	public function getCrossShardMoveHelper(): CrossShardMoveHelper {
 		return $this->inner->getCrossShardMoveHelper();
+	}
+
+	public function setTransactionIsolation(int $level): int {
+		$this->transactionIsolationLevel = $level;
+
+		return $this->executeStatement($this->getDatabasePlatform()->getSetTransactionIsolationSQL($level));
+	}
+
+	public function getTransactionIsolation(): int {
+		return $this->transactionIsolationLevel ??= $this->getDatabasePlatform()->getDefaultTransactionIsolationLevel();
 	}
 }

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -388,4 +388,26 @@ interface IDBConnection {
 	 * @since 30.0.0
 	 */
 	public function getCrossShardMoveHelper(): CrossShardMoveHelper;
+
+	/**
+	 * Sets the transaction isolation level.
+	 *
+	 * @param \Doctrine\DBAL\TransactionIsolationLevel::* $level The level to set.
+	 *
+	 * @throws \Doctrine\DBAL\Exception
+	 *
+	 * @since 33.0.0
+	 */
+	public function setTransactionIsolation(int $level): int;
+
+	/**
+	 * Gets the currently active transaction isolation level.
+	 *
+	 * @return \Doctrine\DBAL\TransactionIsolationLevel::* The current transaction isolation level.
+	 *
+	 * @throws \Doctrine\DBAL\Exception
+	 *
+	 * @since 33.0.0
+	 */
+	public function getTransactionIsolation(): int;
 }


### PR DESCRIPTION
`oc_mounts` no longer has a unique index since https://github.com/nextcloud/server/pull/32877, so the `insertIfNotExist` does not work properly and depends on consistent reads always getting the same data, which is not possible with `READ_COMMITTED` (https://dev.mysql.com/doc/refman/9.2/en/innodb-transaction-isolation-levels.html).

The proper fix is to add back the unique index, but with a hash of the mountpoint column (which was too long for the index and was the reason the unique index was removed). This type of workaround is already used for the `share_external` table.

All other `insertIfNotExist` in server are fine, because they operate on tables with a unique index.