### PR TITLE
fix(comments): Check comment object

### DIFF
--- a/apps/dav/lib/Comments/EntityCollection.php
+++ b/apps/dav/lib/Comments/EntityCollection.php
@@ -77,6 +77,10 @@ class EntityCollection extends RootCollection implements IProperties {
 	public function getChild($name) {
 		try {
 			$comment = $this->commentsManager->get($name);
+			if ($comment->getObjectType() !== $this->name
+				|| $comment->getObjectId() !== $this->id) {
+				throw new NotFound();
+			}
 			return new CommentNode(
 				$this->commentsManager,
 				$comment,
@@ -130,8 +134,9 @@ class EntityCollection extends RootCollection implements IProperties {
 	 */
 	public function childExists($name) {
 		try {
-			$this->commentsManager->get($name);
-			return true;
+			$comment = $this->commentsManager->get($name);
+			return $comment->getObjectType() === $this->name
+				&& $comment->getObjectId() === $this->id;
 		} catch (NotFoundException $e) {
 			return false;
 		}

--- a/apps/dav/tests/unit/Comments/EntityCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityCollectionTest.php
@@ -48,14 +48,16 @@ class EntityCollectionTest extends \Test\TestCase {
 	}
 
 	public function testGetChild(): void {
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')
+			->willReturn('files');
+		$comment->method('getObjectId')
+			->willReturn('19');
+
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('55')
-			->willReturn(
-				$this->getMockBuilder(IComment::class)
-					->disableOriginalConstructor()
-					->getMock()
-			);
+			->willReturn($comment);
 
 		$node = $this->collection->getChild('55');
 		$this->assertInstanceOf(CommentNode::class, $node);
@@ -107,6 +109,17 @@ class EntityCollectionTest extends \Test\TestCase {
 	}
 
 	public function testChildExistsTrue(): void {
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')
+			->willReturn('files');
+		$comment->method('getObjectId')
+			->willReturn('19');
+
+		$this->commentsManager->expects($this->once())
+			->method('get')
+			->with('44')
+			->willReturn($comment);
+
 		$this->assertTrue($this->collection->childExists('44'));
 	}
 

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -1094,6 +1094,10 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function orderBy($sort, $order = null) {
+		if ($order !== null && !in_array(strtoupper((string)$order), ['ASC', 'DESC'], true)) {
+			$order = null;
+		}
+
 		$this->queryBuilder->orderBy(
 			$this->helper->quoteColumnName($sort),
 			$order
@@ -1111,6 +1115,10 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function addOrderBy($sort, $order = null) {
+		if ($order !== null && !in_array(strtoupper((string)$order), ['ASC', 'DESC'], true)) {
+			$order = null;
+		}
+
 		$this->queryBuilder->addOrderBy(
 			$this->helper->quoteColumnName($sort),
 			$order

--- a/lib/private/DB/QueryBuilder/Sharded/ShardedQueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardedQueryBuilder.php
@@ -280,13 +280,21 @@ class ShardedQueryBuilder extends ExtendedQueryBuilder {
 	}
 
 	public function addOrderBy($sort, $order = null) {
-		$this->registerOrder((string)$sort, (string)$order ?? 'ASC');
+		if ($order !== null && !in_array(strtoupper((string)$order), ['ASC', 'DESC'], true)) {
+			$order = null;
+		}
+
+		$this->registerOrder((string)$sort, (string)($order ?? 'ASC'));
 		return parent::addOrderBy($sort, $order);
 	}
 
 	public function orderBy($sort, $order = null) {
+		if ($order !== null && !in_array(strtoupper((string)$order), ['ASC', 'DESC'], true)) {
+			$order = null;
+		}
+
 		$this->sortList = [];
-		$this->registerOrder((string)$sort, (string)$order ?? 'ASC');
+		$this->registerOrder((string)$sort, (string)($order ?? 'ASC'));
 		return parent::orderBy($sort, $order);
 	}
 


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
