### PR TITLE
fix(TaskProcessing): Increase EShapeType::Text limit to 512 KB

### DIFF
--- a/lib/public/TaskProcessing/EShapeType.php
+++ b/lib/public/TaskProcessing/EShapeType.php
@@ -82,7 +82,7 @@ enum EShapeType: int {
 	 */
 	public function validateInput(mixed $value): void {
 		$this->validateNonFileType($value);
-		if ($this === EShapeType::Text && is_string($value) && strlen($value) > 64_000) {
+		if ($this === EShapeType::Text && is_string($value) && strlen($value) > 512_000) {
 			throw new ValidationException('Text is too long');
 		}
 		if ($this === EShapeType::Image && !is_numeric($value)) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/context_agent/issues/91

## Summary
Context agent keeps track of its internal state across task invocations using a state field. 64KB for this field give us space for ~24 large messages. The new 512KB give us space for ~200 large messages.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
