### PR TITLE
fix: Reduce deprecation warnings in phpunit_nodb CI jobs

### DIFF
--- a/apps/dav/tests/unit/CalDAV/Integration/ExternalCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Integration/ExternalCalendarTest.php
@@ -18,7 +18,9 @@ class ExternalCalendarTest extends TestCase {
 		parent::setUp();
 
 		$this->abstractExternalCalendar
-			= $this->getMockForAbstractClass(ExternalCalendar::class, ['example-app-id', 'calendar-uri-in-backend']);
+			= $this->getMockBuilder(ExternalCalendar::class)
+				->setConstructorArgs(['example-app-id', 'calendar-uri-in-backend'])
+				->getMock();
 	}
 
 	public function testGetName():void {

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -103,10 +103,10 @@ class EncryptAllTest extends TestCase {
 		$this->user2 = $this->createMock(IUser::class);
 		$this->user2->method('getUID')->willReturn('user2');
 
-		$this->userManager->expects($this->any())->method('getSeenUsers')->will($this->returnCallback(function () {
+		$this->userManager->expects($this->any())->method('getSeenUsers')->willReturnCallback(function () {
 			yield $this->user1;
 			yield $this->user2;
-		}));
+		});
 		$this->secureRandom = $this->getMockBuilder(ISecureRandom::class)->disableOriginalConstructor()->getMock();
 		$this->secureRandom->expects($this->any())->method('generate')->willReturn('12345678');
 

--- a/apps/files_external/tests/FrontendDefinitionTraitTest.php
+++ b/apps/files_external/tests/FrontendDefinitionTraitTest.php
@@ -11,6 +11,10 @@ use OCA\Files_External\Lib\DefinitionParameter;
 use OCA\Files_External\Lib\FrontendDefinitionTrait;
 use OCA\Files_External\Lib\StorageConfig;
 
+class MockFrontendDefinitionTrait {
+	use FrontendDefinitionTrait;
+}
+
 class FrontendDefinitionTraitTest extends \Test\TestCase {
 	public function testJsonSerialization(): void {
 		$param = $this->getMockBuilder(DefinitionParameter::class)
@@ -18,7 +22,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->getMock();
 		$param->method('getName')->willReturn('foo');
 
-		$trait = $this->getMockForTrait(FrontendDefinitionTrait::class);
+		$trait = new MockFrontendDefinitionTrait();
 		$trait->setText('test');
 		$trait->addParameters([$param]);
 		$trait->addCustomJs('foo/bar.js');
@@ -67,7 +71,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 		$storageConfig->expects($this->any())
 			->method('setBackendOption');
 
-		$trait = $this->getMockForTrait(FrontendDefinitionTrait::class);
+		$trait = new MockFrontendDefinitionTrait();
 		$trait->setText('test');
 		$trait->addParameters($backendParams);
 
@@ -98,7 +102,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->method('setBackendOption')
 			->with('param', 'foobar');
 
-		$trait = $this->getMockForTrait(FrontendDefinitionTrait::class);
+		$trait = new MockFrontendDefinitionTrait();
 		$trait->setText('test');
 		$trait->addParameter($param);
 

--- a/apps/files_external/tests/FrontendDefinitionTraitTest.php
+++ b/apps/files_external/tests/FrontendDefinitionTraitTest.php
@@ -11,7 +11,7 @@ use OCA\Files_External\Lib\DefinitionParameter;
 use OCA\Files_External\Lib\FrontendDefinitionTrait;
 use OCA\Files_External\Lib\StorageConfig;
 
-class MockFrontendDefinitionTrait {
+class MockFrontendDefinitionTraitClass {
 	use FrontendDefinitionTrait;
 }
 
@@ -22,7 +22,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->getMock();
 		$param->method('getName')->willReturn('foo');
 
-		$trait = new MockFrontendDefinitionTrait();
+		$trait = new MockFrontendDefinitionTraitClass();
 		$trait->setText('test');
 		$trait->addParameters([$param]);
 		$trait->addCustomJs('foo/bar.js');
@@ -71,7 +71,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 		$storageConfig->expects($this->any())
 			->method('setBackendOption');
 
-		$trait = new MockFrontendDefinitionTrait();
+		$trait = new MockFrontendDefinitionTraitClass();
 		$trait->setText('test');
 		$trait->addParameters($backendParams);
 
@@ -102,7 +102,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->method('setBackendOption')
 			->with('param', 'foobar');
 
-		$trait = new MockFrontendDefinitionTrait();
+		$trait = new MockFrontendDefinitionTraitClass();
 		$trait->setText('test');
 		$trait->addParameter($param);
 

--- a/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
+++ b/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
@@ -11,7 +11,7 @@ namespace OCA\Files_External\Tests;
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCA\Files_External\Lib\MissingDependency;
 
-class MockLegacyDependencyCheckPolyfill {
+class MockLegacyDependencyCheckPolyfillClass {
 	use LegacyDependencyCheckPolyfill;
 
 	public function getStorageClass(): string {
@@ -32,7 +32,7 @@ class LegacyDependencyCheckPolyfillTest extends \Test\TestCase {
 	}
 
 	public function testCheckDependencies(): void {
-		$trait = new MockLegacyDependencyCheckPolyfill();
+		$trait = new MockLegacyDependencyCheckPolyfillClass();
 
 		$dependencies = $trait->checkDependencies();
 		$this->assertCount(2, $dependencies);

--- a/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
+++ b/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
@@ -11,6 +11,14 @@ namespace OCA\Files_External\Tests;
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCA\Files_External\Lib\MissingDependency;
 
+class MockLegacyDependencyCheckPolyfill {
+	use LegacyDependencyCheckPolyfill;
+
+	public function getStorageClass(): string {
+		return LegacyDependencyCheckPolyfillTest::class;
+	}
+}
+
 class LegacyDependencyCheckPolyfillTest extends \Test\TestCase {
 
 	/**
@@ -24,10 +32,7 @@ class LegacyDependencyCheckPolyfillTest extends \Test\TestCase {
 	}
 
 	public function testCheckDependencies(): void {
-		$trait = $this->getMockForTrait(LegacyDependencyCheckPolyfill::class);
-		$trait->expects($this->once())
-			->method('getStorageClass')
-			->willReturn(self::class);
+		$trait = new MockLegacyDependencyCheckPolyfill();
 
 		$dependencies = $trait->checkDependencies();
 		$this->assertCount(2, $dependencies);

--- a/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
+++ b/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
@@ -66,7 +66,7 @@ class DataDirectoryProtectedTest extends TestCase {
 		$this->setupcheck
 			->expects($this->once())
 			->method('runRequest')
-			->will($this->generate($responses));
+			->willReturn($this->generate($responses));
 
 		$this->config
 			->expects($this->once())
@@ -94,7 +94,7 @@ class DataDirectoryProtectedTest extends TestCase {
 		$this->setupcheck
 			->expects($this->once())
 			->method('runRequest')
-			->will($this->generate([]));
+			->willReturn($this->generate([]));
 
 		$this->config
 			->expects($this->once())
@@ -110,8 +110,6 @@ class DataDirectoryProtectedTest extends TestCase {
 	 * Helper function creates a nicer interface for mocking Generator behavior
 	 */
 	protected function generate(array $yield_values) {
-		return $this->returnCallback(function () use ($yield_values) {
-			yield from $yield_values;
-		});
+		yield from $yield_values;
 	}
 }

--- a/apps/settings/tests/SetupChecks/OcxProvicersTest.php
+++ b/apps/settings/tests/SetupChecks/OcxProvicersTest.php
@@ -144,8 +144,6 @@ class OcxProvicersTest extends TestCase {
 	 * Helper function creates a nicer interface for mocking Generator behavior
 	 */
 	protected function generate(array $yield_values) {
-		return $this->returnCallback(function () use ($yield_values) {
-			yield from $yield_values;
-		});
+		yield from $yield_values;
 	}
 }

--- a/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
@@ -182,15 +182,13 @@ class SecurityHeadersTest extends TestCase {
 		$this->setupcheck
 			->expects($this->atLeastOnce())
 			->method('runRequest')
-			->willReturnOnConsecutiveCalls($this->generate([$response]));
+			->willReturn($this->generate([$response]));	
 	}
 
 	/**
 	 * Helper function creates a nicer interface for mocking Generator behavior
 	 */
 	protected function generate(array $yield_values) {
-		return $this->returnCallback(function () use ($yield_values) {
-			yield from $yield_values;
-		});
+		yield from $yield_values;
 	}
 }

--- a/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
@@ -182,7 +182,7 @@ class SecurityHeadersTest extends TestCase {
 		$this->setupcheck
 			->expects($this->atLeastOnce())
 			->method('runRequest')
-			->willReturn($this->generate([$response]));	
+			->willReturn($this->generate([$response]));
 	}
 
 	/**

--- a/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
+++ b/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
@@ -87,7 +87,7 @@ class WellKnownUrlsTest extends TestCase {
 		$this->setupcheck
 			->expects($this->once())
 			->method('runRequest')
-			->will($this->generate([]));
+			->willReturn($this->generate([]));
 
 		$result = $this->setupcheck->run();
 		$this->assertEquals(SetupResult::INFO, $result->getSeverity());
@@ -219,8 +219,6 @@ class WellKnownUrlsTest extends TestCase {
 	 * Helper function creates a nicer interface for mocking Generator behavior
 	 */
 	protected function generate(array $yield_values) {
-		return $this->returnCallback(function () use ($yield_values) {
-			yield from $yield_values;
-		});
+		yield from $yield_values;
 	}
 }


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/57019

## Summary
 This PR addresses the high volume of deprecation warnings appearing in the phpunit_nodb logs making it difficult to spot actual failures and potential issues.

Relevant links:
- https://github.com/sebastianbergmann/phpunit/issues/5241
- https://github.com/sebastianbergmann/phpunit/issues/5423
- https://github.com/sebastianbergmann/phpunit/issues/5243

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
