### PR TITLE
ci(32bit): use custom image to run PHP unit tests on 32bit

### DIFF
--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -26,12 +26,10 @@ jobs:
 
     if: ${{ github.repository_owner != 'nextcloud-gmbh' }}
 
-    container: shivammathur/node:latest-i386
-
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.2", "8.3", "8.4"]
+        php-versions: ["8.4"]
 
     steps:
       - name: Checkout server
@@ -40,32 +38,24 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - name: Install tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg imagemagick libmagickcore-6.q16-3-extra
-
-      - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f #v2.35.5
-        with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite, apcu, ldap
-          coverage: none
-          ini-file: development
-          ini-values: apc.enabled=on, apc.enable_cli=on, disable_functions= # https://github.com/shivammathur/setup-php/discussions/573
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up dependencies
-        run: composer i
+        uses: docker://ghcr.io/nextcloud/continuous-integration-php8.4-32bit:latest
+        with:
+          args: /bin/sh -c "
+            apt-get update &&
+            apt-get install -y unzip &&
+            git config --global --add safe.directory /github/workspace &&
+            composer install --no-interaction"
 
       - name: Set up Nextcloud
-        env:
-          DB_PORT: 4444
-        run: |
-          mkdir data
-          ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php
+        uses: docker://ghcr.io/nextcloud/continuous-integration-php8.4-32bit:latest
+        with:
+          args: /bin/sh -c "
+            mkdir data &&
+            ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-user=autotest --database-pass=rootpassword --admin-user admin --admin-pass admin &&
+            php -f tests/enable_all.php"
 
       - name: PHPUnit
-        run: composer run test -- --exclude-group PRIMARY-azure --exclude-group PRIMARY-s3 --exclude-group PRIMARY-swift --exclude-group Memcached --exclude-group Redis --exclude-group RoutingWeirdness
+        uses: docker://ghcr.io/nextcloud/continuous-integration-php8.4-32bit:latest
+        with:
+          args: /bin/sh -c "composer run test -- --exclude-group PRIMARY-azure,PRIMARY-s3,PRIMARY-swift,Memcached,Redis,RoutingWeirdness"

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -42,8 +42,6 @@ jobs:
         uses: docker://ghcr.io/nextcloud/continuous-integration-php8.4-32bit:latest
         with:
           args: /bin/sh -c "
-            apt-get update &&
-            apt-get install -y unzip &&
             git config --global --add safe.directory /github/workspace &&
             composer install --no-interaction"
 

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,10 @@
 			"Composer\\Config::disableProcessTimeout",
 			"PHP_CLI_SERVER_WORKERS=${NEXTCLOUD_WORKERS:=4} php -S ${NEXTCLOUD_HOST:=localhost}:${NEXTCLOUD_PORT:=8080} -t ./"
 		],
-		"test": "phpunit --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration tests/phpunit-autotest.xml",
+		"test": [
+			"Composer\\Config::disableProcessTimeout",
+			"phpunit --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration tests/phpunit-autotest.xml"
+		],
 		"test:db": "@composer run test -- --group DB --group SLOWDB",
 		"test:files_external": "phpunit --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration tests/phpunit-autotest-external.xml",
 		"rector": "rector --config=build/rector.php && composer cs:fix",


### PR DESCRIPTION
Bring back 32bit unit tests. It fails currently related, see that same PR works fine on stable32:

https://github.com/nextcloud/server/pull/57050