### PR TITLE
feat(sharebymail): Use initiator's email as sender if mail providers enabled

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -380,7 +380,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				]
 			);
 		}
-		$message->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$message->setFrom([Util::getEmailAddressForUser($initiatorUser, $instanceName) => $senderName]);
 
 		// The "Reply-To" is set to the sharer if an mail address is configured
 		// also the default footer contains a "Do not reply" which needs to be adjusted.

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -39,6 +39,8 @@ use OCP\Share\IShare;
 use OCP\Share\IShareProviderWithNotification;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
+use OCP\IAppConfig;
+use OCP\Mail\Provider\IManager as IMailManager;
 
 /**
  * Class ShareByMail
@@ -57,6 +59,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 	public function __construct(
 		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IDBConnection $dbConnection,
 		private ISecureRandom $secureRandom,
 		private IUserManager $userManager,
@@ -72,6 +75,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		private IEventDispatcher $eventDispatcher,
 		private IShareManager $shareManager,
 		private IEmailValidator $emailValidator,
+		private IMailManager $mailManager,
 	) {
 	}
 
@@ -322,6 +326,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 		$initiatorUser = $this->userManager->get($initiator);
 		$initiatorDisplayName = ($initiatorUser instanceof IUser) ? $initiatorUser->getDisplayName() : $initiator;
+		$initiatorEmail = ($initiatorUser instanceof IUser) ? $initiatorUser->getEMailAddress() : null;
 		$message = $this->mailer->createMessage();
 
 		$emailTemplate = $this->mailer->createEMailTemplate('sharebymail.RecipientNotification', [
@@ -380,7 +385,17 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				]
 			);
 		}
-		$message->setFrom([Util::getEmailAddressForUser($initiatorUser, $instanceName) => $senderName]);
+		$fromAddress = Util::getDefaultEmailAddress(user_part: $instanceName);
+		$mailProvidersEnabled = $this->appConfig->getValueBool('core', 'mail_providers_enabled');
+		if ($mailProvidersEnabled && $this->mailManager->has()) {
+			if ($initiatorEmail !== null) {
+				$service = $this->mailManager->findServiceByAddress($initiator, $initiatorEmail);
+				if ($service !== null) {
+					$fromAddress = $service->getPrimaryAddress()->getAddress();
+				}
+			}
+		}
+		$message->setFrom([$fromAddress => $senderName]);
 
 		// The "Reply-To" is set to the sharer if an mail address is configured
 		// also the default footer contains a "Do not reply" which needs to be adjusted.

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -315,38 +315,6 @@ class Util {
 	}
 
 	/**
-	 * Returns the email address for the given user
-	 * @param IUser|null $user
-	 * @param string $fallback_user_part the fallback address part
-	 * @return string the email address
-	 *
-	 * If mail providers are enabled, uses the specified user's email address.
-	 * If disabled or the user has no valid email, falls back to the system default.
-	 * @since 31.0.12
-	 */
-	public static function getEmailAddressForUser(?IUser $user, string $fallback_user_part): string {
-		if ($user === null) {
-			return self::getDefaultEmailAddress($fallback_user_part);
-		}
-
-		$config = \OCP\Server::get(serviceName: IConfig::class);
-
-		$mailProvidersEnabled = $config->getAppValue('core', 'mail_providers_enabled', '0') === '1';
-
-		if ($mailProvidersEnabled) {
-			$userEmail = $user->getEMailAddress();
-
-			if ($userEmail !== null) {
-				$emailValidator = \OCP\Server::get(IEmailValidator::class);
-				if ($emailValidator->isValid($userEmail)) {
-					return $userEmail;
-				}
-			}
-		}
-		return self::getDefaultEmailAddress($fallback_user_part);
-	}
-
-	/**
 	 * Converts string to int of float depending on if it fits an int
 	 * @param numeric-string|float|int $number numeric string
 	 * @return int|float int if it fits, float if it is too big

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -315,6 +315,38 @@ class Util {
 	}
 
 	/**
+	 * Returns the email address for the given user
+	 * @param IUser|null $user
+	 * @param string $fallback_user_part the fallback address part
+	 * @return string the email address
+	 *
+	 * If mail providers are enabled, uses the specified user's email address.
+	 * If disabled or the user has no valid email, falls back to the system default.
+	 * @since 31.0.12
+	 */
+	public static function getEmailAddressForUser(?IUser $user, string $fallback_user_part): string {
+		if ($user === null) {
+			return self::getDefaultEmailAddress($fallback_user_part);
+		}
+
+		$config = \OCP\Server::get(serviceName: IConfig::class);
+
+		$mailProvidersEnabled = $config->getAppValue('core', 'mail_providers_enabled', '0') === '1';
+
+		if ($mailProvidersEnabled) {
+			$userEmail = $user->getEMailAddress();
+
+			if ($userEmail !== null) {
+				$emailValidator = \OCP\Server::get(IEmailValidator::class);
+				if ($emailValidator->isValid($userEmail)) {
+					return $userEmail;
+				}
+			}
+		}
+		return self::getDefaultEmailAddress($fallback_user_part);
+	}
+
+	/**
 	 * Converts string to int of float depending on if it fits an int
 	 * @param numeric-string|float|int $number numeric string
 	 * @return int|float int if it fits, float if it is too big


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/56904

## Summary
This change allows to use the initiator's personal email as the sender email when sending share notifications, provided that the mail_providers_enabled configuration is active.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
