### PR TITLE
fix(FileSequence): Check whether temp dir still exists before using it

### DIFF
--- a/lib/private/Snowflake/FileSequence.php
+++ b/lib/private/Snowflake/FileSequence.php
@@ -20,12 +20,11 @@ class FileSequence implements ISequence {
 	/** Delete sequences after SEQUENCE_TTL seconds **/
 	private const SEQUENCE_TTL = 30;
 
-	private string $workDir;
+	private ?string $workDir = null;
 
 	public function __construct(
-		ITempManager $tempManager,
+		private ITempManager $tempManager,
 	) {
-		$this->workDir = $tempManager->getTemporaryFolder('.snowflakes');
 	}
 
 	#[Override]
@@ -84,6 +83,13 @@ class FileSequence implements ISequence {
 	}
 
 	private function getFilePath(int $fileId): string {
-		return $this->workDir . sprintf(self::LOCK_FILE_FORMAT, $fileId);
+		return $this->getWorkDir() . sprintf(self::LOCK_FILE_FORMAT, $fileId);
+	}
+
+	private function getWorkDir(): string {
+		if ($this->workDir === null || !is_dir($this->workDir)) {
+			$this->workDir = $this->tempManager->getTemporaryFolder('.snowflakes');
+		}
+		return $this->workDir;
 	}
 }


### PR DESCRIPTION
## Summary
When running long running tasks in background jobs or unit tests the temp dir may be cleaned up and is then no longer available.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
