### PR TITLE
fix(snowflakes): FileSequence generator must always use the same dir

### DIFF
--- a/tests/lib/Snowflake/FileSequenceTest.php
+++ b/tests/lib/Snowflake/FileSequenceTest.php
@@ -20,16 +20,16 @@ class FileSequenceTest extends ISequenceBase {
 
 	public function setUp():void {
 		$tempManager = $this->createMock(ITempManager::class);
-		$this->path = uniqid(sys_get_temp_dir() . '/php_test_seq_', true);
-		mkdir($this->path);
-		$tempManager->method('getTemporaryFolder')->willReturn($this->path);
+		$this->path = sys_get_temp_dir();
+		$tempManager->method('getTempBaseDir')->willReturn($this->path);
 		$this->sequence = new FileSequence($tempManager);
 	}
 
 	public function tearDown():void {
-		foreach (glob($this->path . '/*') as $file) {
+		$lockDirectory = $this->path . '/' . FileSequence::LOCK_FILE_DIRECTORY;
+		foreach (glob($lockDirectory . '/*') as $file) {
 			unlink($file);
 		}
-		rmdir($this->path);
+		rmdir($lockDirectory);
 	}
 }


### PR DESCRIPTION
## Summary
`TempManager::getTemporaryFolder` is returning a random directory. 
FileSequence needs always the same directory, even if different processes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
