### PR TITLE
chore: Deprecate unused ISystemTagManagerFactory, DI is enough

### DIFF
--- a/lib/public/SystemTag/ISystemTagManagerFactory.php
+++ b/lib/public/SystemTag/ISystemTagManagerFactory.php
@@ -16,6 +16,7 @@ use OCP\IServerContainer;
  * Factory interface for system tag managers
  *
  * @since 9.0.0
+ * @deprecated 33.0.0 use Dependency Injection instead, or \OCP\Server::get
  */
 interface ISystemTagManagerFactory {
 	/**
@@ -23,6 +24,7 @@ interface ISystemTagManagerFactory {
 	 *
 	 * @param IServerContainer $serverContainer server container
 	 * @since 9.0.0
+	 * @deprecated 33.0.0
 	 */
 	public function __construct(IServerContainer $serverContainer);
 
@@ -31,6 +33,7 @@ interface ISystemTagManagerFactory {
 	 *
 	 * @return ISystemTagManager
 	 * @since 9.0.0
+	 * @deprecated 33.0.0
 	 */
 	public function getManager(): ISystemTagManager;
 
@@ -40,6 +43,7 @@ interface ISystemTagManagerFactory {
 	 *
 	 * @return ISystemTagObjectMapper
 	 * @since 9.0.0
+	 * @deprecated 33.0.0
 	 */
 	public function getObjectMapper(): ISystemTagObjectMapper;
 }


### PR DESCRIPTION
## Summary

This interface is useless and unused, it only passed requests through to DI.
Also it refers to IServerContainer which is deprecated already.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
