### PR TITLE
fix(user_ldap): Remove usages of deprecated IServerContainer

### DIFF
--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -53,11 +53,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
-		$context->registerService(ILDAPWrapper::class, function (ContainerInterface $c) {
-			return new LDAP(
-				$c->get(IConfig::class)->getSystemValueString('ldap_log_file')
-			);
-		});
+		$context->registerServiceAlias(ILDAPWrapper::class, LDAP::class);
 
 		$context->registerNotifierService(Notifier::class);
 

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -8,7 +10,6 @@ namespace OCA\User_LDAP\AppInfo;
 
 use Closure;
 use OCA\Files_External\Service\BackendService;
-use OCA\User_LDAP\Controller\RenewPasswordController;
 use OCA\User_LDAP\Events\GroupBackendRegistered;
 use OCA\User_LDAP\Events\UserBackendRegistered;
 use OCA\User_LDAP\Group_Proxy;
@@ -30,16 +31,12 @@ use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\Services\IAppConfig;
-use OCP\AppFramework\Services\IInitialState;
 use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
-use OCP\IL10N;
 use OCP\Image;
-use OCP\IRequest;
-use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\IManager as IShareManager;
@@ -53,33 +50,15 @@ class Application extends App implements IBootstrap {
 
 	public function __construct() {
 		parent::__construct(self::APP_ID);
-		$container = $this->getContainer();
-
-		/**
-		 * Controller
-		 */
-		$container->registerService('RenewPasswordController', function (ContainerInterface $appContainer) {
-			return new RenewPasswordController(
-				$appContainer->get('AppName'),
-				$appContainer->get(IRequest::class),
-				$appContainer->get(IUserManager::class),
-				$appContainer->get(IConfig::class),
-				$appContainer->get(IUserConfig::class),
-				$appContainer->get(IL10N::class),
-				$appContainer->get('Session'),
-				$appContainer->get(IURLGenerator::class),
-				$appContainer->get(IInitialState::class),
-			);
-		});
-
-		$container->registerService(ILDAPWrapper::class, function (ContainerInterface $appContainer) {
-			return new LDAP(
-				$appContainer->get(IConfig::class)->getSystemValueString('ldap_log_file')
-			);
-		});
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerService(ILDAPWrapper::class, function (ContainerInterface $c) {
+			return new LDAP(
+				$c->get(IConfig::class)->getSystemValueString('ldap_log_file')
+			);
+		});
+
 		$context->registerNotifierService(Notifier::class);
 
 		$context->registerService(

--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -8,11 +8,8 @@
 namespace OCA\User_LDAP\Command;
 
 use OCA\User_LDAP\Group_Proxy;
-use OCA\User_LDAP\Helper;
-use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\User_Proxy;
 use OCP\IConfig;
-use OCP\Server;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -82,10 +79,6 @@ class Search extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$helper = Server::get(Helper::class);
-		$configPrefixes = $helper->getServerConfigurationPrefixes(true);
-		$ldapWrapper = new LDAP();
-
 		$offset = (int)$input->getOption('offset');
 		$limit = (int)$input->getOption('limit');
 		$this->validateOffsetAndLimit($offset, $limit);

--- a/apps/user_ldap/lib/Command/SetConfig.php
+++ b/apps/user_ldap/lib/Command/SetConfig.php
@@ -10,14 +10,19 @@ namespace OCA\User_LDAP\Command;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\ConnectionFactory;
 use OCA\User_LDAP\Helper;
-use OCA\User_LDAP\LDAP;
-use OCP\Server;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SetConfig extends Command {
+	public function __construct(
+		private readonly Helper $helper,
+		private readonly ConnectionFactory $connectionFactory,
+	) {
+		parent::__construct();
+	}
+
 	protected function configure(): void {
 		$this
 			->setName('ldap:set-config')
@@ -41,8 +46,7 @@ class SetConfig extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$helper = Server::get(Helper::class);
-		$availableConfigs = $helper->getServerConfigurationPrefixes();
+		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if (!in_array($configID, $availableConfigs)) {
 			$output->writeln('Invalid configID');
@@ -65,7 +69,6 @@ class SetConfig extends Command {
 		$configHolder->$key = $value;
 		$configHolder->saveConfiguration();
 
-		$connectionFactory = new ConnectionFactory(new LDAP());
-		$connectionFactory->get($configID)->clearCache();
+		$this->connectionFactory->get($configID)->clearCache();
 	}
 }

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -23,8 +23,6 @@ class Sync extends TimedJob {
 	public const MAX_INTERVAL = 12 * 60 * 60; // 12h
 	public const MIN_INTERVAL = 30 * 60; // 30min
 
-	protected LDAP $ldap;
-
 	public function __construct(
 		ITimeFactory $timeFactory,
 		private IConfig $config,
@@ -42,7 +40,6 @@ class Sync extends TimedJob {
 				self::MIN_INTERVAL
 			)
 		);
-		$this->ldap = new LDAP($this->config->getSystemValueString('ldap_log_file'));
 	}
 
 	/**
@@ -252,12 +249,5 @@ class Sync extends TimedJob {
 			$i = 0;
 		}
 		return $prefixes[$i];
-	}
-
-	/**
-	 * Only used in tests
-	 */
-	public function overwritePropertiesForTest(LDAP $ldapWrapper): void {
-		$this->ldap = $ldapWrapper;
 	}
 }

--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -18,23 +18,21 @@ use Psr\Log\LoggerInterface;
 
 class LDAP implements ILDAPWrapper {
 	protected array $curArgs = [];
-	protected LoggerInterface $logger;
-	protected IConfig $config;
 
 	private ?LdapDataCollector $dataCollector = null;
 
+	protected string $logFile = '';
+
 	public function __construct(
-		protected string $logFile = '',
+		IProfiler $profiler,
+		protected IConfig $config,
+		protected LoggerInterface $logger,
 	) {
-		/** @var IProfiler $profiler */
-		$profiler = Server::get(IProfiler::class);
 		if ($profiler->isEnabled()) {
 			$this->dataCollector = new LdapDataCollector();
 			$profiler->add($this->dataCollector);
 		}
-
-		$this->logger = Server::get(LoggerInterface::class);
-		$this->config = Server::get(IConfig::class);
+		$this->logFile = $this->config->getSystemValueString('ldap_log_file');
 	}
 
 	/**

--- a/apps/user_ldap/lib/LDAPProvider.php
+++ b/apps/user_ldap/lib/LDAPProvider.php
@@ -5,38 +5,38 @@
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\User_LDAP;
 
 use OCA\User_LDAP\User\DeletedUsersIndex;
-use OCP\IServerContainer;
+use OCP\GroupInterface;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use OCP\LDAP\IDeletionFlagSupport;
 use OCP\LDAP\ILDAPProvider;
+use OCP\UserInterface;
 use Psr\Log\LoggerInterface;
 
 /**
  * LDAP provider for public access to the LDAP backend.
  */
 class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
-	private $userBackend;
-	private $groupBackend;
-	private $logger;
+	private IUserLDAP&UserInterface $userBackend;
+	private IGroupLDAP&GroupInterface $groupBackend;
 
 	/**
-	 * Create new LDAPProvider
-	 * @param IServerContainer $serverContainer
-	 * @param Helper $helper
-	 * @param DeletedUsersIndex $deletedUsersIndex
 	 * @throws \Exception if user_ldap app was not enabled
 	 */
 	public function __construct(
-		IServerContainer $serverContainer,
+		IUserManager $userManager,
+		IGroupManager $groupManager,
 		private Helper $helper,
 		private DeletedUsersIndex $deletedUsersIndex,
+		private LoggerInterface $logger,
 	) {
-		$this->logger = $serverContainer->get(LoggerInterface::class);
 		$userBackendFound = false;
 		$groupBackendFound = false;
-		foreach ($serverContainer->getUserManager()->getBackends() as $backend) {
+		foreach ($userManager->getBackends() as $backend) {
 			$this->logger->debug('instance ' . get_class($backend) . ' user backend.', ['app' => 'user_ldap']);
 			if ($backend instanceof IUserLDAP) {
 				$this->userBackend = $backend;
@@ -44,7 +44,7 @@ class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
 				break;
 			}
 		}
-		foreach ($serverContainer->getGroupManager()->getBackends() as $backend) {
+		foreach ($groupManager->getBackends() as $backend) {
 			$this->logger->debug('instance ' . get_class($backend) . ' group backend.', ['app' => 'user_ldap']);
 			if ($backend instanceof IGroupLDAP) {
 				$this->groupBackend = $backend;

--- a/apps/user_ldap/lib/LDAPProviderFactory.php
+++ b/apps/user_ldap/lib/LDAPProviderFactory.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\User_LDAP;
 
-use OCP\IServerContainer;
 use OCP\LDAP\ILDAPProvider;
 use OCP\LDAP\ILDAPProviderFactory;
+use Psr\Container\ContainerInterface;
 
 class LDAPProviderFactory implements ILDAPProviderFactory {
 	public function __construct(
-		/** * @var IServerContainer */
-		private IServerContainer $serverContainer,
+		private ContainerInterface $serverContainer,
 	) {
 	}
 

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -29,6 +29,7 @@ use OCP\IConfig;
 use OCP\Image;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Profiler\IProfiler;
 use OCP\Server;
 use OCP\Share\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -242,7 +243,11 @@ class AccessTest extends TestCase {
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dnInputDataProvider')]
 	public function testStringResemblesDNLDAPmod(string $input, array|bool $interResult, bool $expectedResult): void {
 		[, $con, $um, $helper] = $this->getConnectorAndLdapMock();
-		$lw = new LDAP();
+		$lw = new LDAP(
+			$this->createMock(IProfiler::class),
+			$this->createMock(IConfig::class),
+			$this->createMock(LoggerInterface::class),
+		);
 		$access = new Access($lw, $con, $um, $helper, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
 
 		if (!function_exists('ldap_explode_dn')) {

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -76,8 +76,6 @@ class SyncTest extends TestCase {
 			$this->connectionFactory,
 			$this->accessFactory,
 		);
-
-		$this->sync->overwritePropertiesForTest($this->ldapWrapper);
 	}
 
 	public static function intervalDataProvider(): array {

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -67,7 +67,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		return $groupBackend;
 	}
 
-	private function getLDAPProvider(IUserLDAP $userBackend, IGroupLDAP $groupBackend) {
+	private function getLDAPProvider(IUserLDAP $userBackend, IGroupLDAP $groupBackend): LDAPProvider {
 		return new LDAPProvider(
 			$this->getUserManagerMock($userBackend),
 			$this->getGroupManagerMock($groupBackend),

--- a/apps/user_ldap/tests/LDAPTest.php
+++ b/apps/user_ldap/tests/LDAPTest.php
@@ -8,7 +8,10 @@ declare(strict_types=1);
 namespace OCA\User_LDAP\Tests;
 
 use OCA\User_LDAP\LDAP;
+use OCP\IConfig;
+use OCP\Profiler\IProfiler;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class LDAPTest extends TestCase {
@@ -18,6 +21,11 @@ class LDAPTest extends TestCase {
 		parent::setUp();
 		$this->ldap = $this->getMockBuilder(LDAP::class)
 			->onlyMethods(['invokeLDAPMethod'])
+			->setConstructorArgs([
+				$this->createMock(IProfiler::class),
+				$this->createMock(IConfig::class),
+				$this->createMock(LoggerInterface::class),
+			])
 			->getMock();
 	}
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2575,8 +2575,6 @@
 			'loginName2UserName'
 		)]]></code>
       <code><![CDATA[dispatch]]></code>
-      <code><![CDATA[registerService]]></code>
-      <code><![CDATA[registerService]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/Configuration.php">
@@ -2616,20 +2614,6 @@
     <InvalidOperand>
       <code><![CDATA[$i]]></code>
     </InvalidOperand>
-  </file>
-  <file src="apps/user_ldap/lib/LDAPProvider.php">
-    <DeprecatedInterface>
-      <code><![CDATA[IServerContainer]]></code>
-    </DeprecatedInterface>
-    <DeprecatedMethod>
-      <code><![CDATA[getGroupManager]]></code>
-      <code><![CDATA[getUserManager]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/user_ldap/lib/LDAPProviderFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[private]]></code>
-    </DeprecatedInterface>
   </file>
   <file src="apps/user_ldap/lib/Mapping/AbstractMapping.php">
     <DeprecatedMethod>


### PR DESCRIPTION
## Summary



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
