### PR TITLE
perf(UserMountCache): Start transaction earlier to prevent unnecessary queries

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -69,6 +69,8 @@ class UserMountCache implements IUserMountCache {
 			}
 		}
 
+		$this->connection->beginTransaction();
+
 		$cachedMounts = $this->getMountsForUser($user);
 		if (is_array($mountProviderClasses)) {
 			$cachedMounts = array_filter($cachedMounts, function (ICachedMountInfo $mountInfo) use ($mountProviderClasses, $newMounts) {
@@ -99,7 +101,6 @@ class UserMountCache implements IUserMountCache {
 		$changedMounts = $this->findChangedMounts($newMounts, $cachedMounts);
 
 		if ($addedMounts || $removedMounts || $changedMounts) {
-			$this->connection->beginTransaction();
 			$userUID = $user->getUID();
 			try {
 				foreach ($addedMounts as $mount) {
@@ -136,7 +137,11 @@ class UserMountCache implements IUserMountCache {
 			foreach ($changedMounts as $mountPair) {
 				$this->eventDispatcher->dispatchTyped(new UserMountUpdatedEvent($mountPair[0], $mountPair[1]));
 			}
+		} else {
+			// No changes were made, but we still need to get rid of the transaction
+			$this->connection->rollBack();
 		}
+
 		$this->eventLogger->end('fs:setup:user:register');
 	}
 


### PR DESCRIPTION
Because the SELECTs are not happening in the transaction, a competing request might have updated the oc_mounts already and the INSERT/DELETE/UPDATE queries are not necessary anymore. Starting the transaction before the SELECTs happen, removes these queries.