### PR TITLE
refactor: Migrate away from \OCP\IDBConnection::insertIfNotExist

### DIFF
--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.5']
         mysql-versions: ['8.4']
 
     name: Sharding - MySQL ${{ matrix.mysql-versions }} (PHP ${{ matrix.php-versions }}) - database tests

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2754,7 +2754,6 @@
   <file src="apps/user_ldap/lib/Mapping/AbstractMapping.php">
     <DeprecatedMethod>
       <code><![CDATA[getDatabasePlatform]]></code>
-      <code><![CDATA[insertIfNotExist]]></code>
     </DeprecatedMethod>
     <RedundantCondition>
       <code><![CDATA[isset($qb)]]></code>

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -8,7 +8,6 @@
 namespace OC\DB;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\DB\Exceptions\DbalException;
 
 /**
@@ -62,54 +61,6 @@ class Adapter {
 	 */
 	public function unlockTable() {
 		$this->conn->commit();
-	}
-
-	/**
-	 * Insert a row if the matching row does not exists. To accomplish proper race condition avoidance
-	 * it is needed that there is also a unique constraint on the values. Then this method will
-	 * catch the exception and return 0.
-	 *
-	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
-	 * @param array $input data that should be inserted into the table  (column name => value)
-	 * @param array|null $compare List of values that should be checked for "if not exists"
-	 *                            If this is null or an empty array, all keys of $input will be compared
-	 *                            Please note: text fields (clob) must not be used in the compare array
-	 * @return int number of inserted rows
-	 * @throws Exception
-	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (UniqueConstraintViolationException $e) {}" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
-	 */
-	public function insertIfNotExist($table, $input, ?array $compare = null) {
-		$compare = $compare ?: array_keys($input);
-
-		// Prepare column names and generate placeholders
-		$columns = '`' . implode('`,`', array_keys($input)) . '`';
-		$placeholders = implode(', ', array_fill(0, count($input), '?'));
-
-		$query = 'INSERT INTO `' . $table . '` (' . $columns . ') '
-			. 'SELECT ' . $placeholders . ' '
-			. 'FROM `' . $table . '` WHERE ';
-
-		$inserts = array_values($input);
-		foreach ($compare as $key) {
-			$query .= '`' . $key . '`';
-			if (is_null($input[$key])) {
-				$query .= ' IS NULL AND ';
-			} else {
-				$inserts[] = $input[$key];
-				$query .= ' = ? AND ';
-			}
-		}
-		$query = substr($query, 0, -5);
-		$query .= ' HAVING COUNT(*) = 0';
-
-		try {
-			return $this->conn->executeUpdate($query, $inserts);
-		} catch (UniqueConstraintViolationException $e) {
-			// This exception indicates a concurrent insert happened between
-			// the insert and the sub-select in the insert, which is safe to ignore.
-			// More details: https://github.com/nextcloud/server/pull/12315
-			return 0;
-		}
 	}
 
 	/**

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -7,8 +7,6 @@
  */
 namespace OC\DB;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-
 class AdapterSqlite extends Adapter {
 	/**
 	 * @param string $tableName
@@ -28,53 +26,6 @@ class AdapterSqlite extends Adapter {
 		$statement = str_ireplace('GREATEST(', 'MAX(', $statement);
 		$statement = str_ireplace('UNIX_TIMESTAMP()', 'strftime(\'%s\',\'now\')', $statement);
 		return $statement;
-	}
-
-	/**
-	 * Insert a row if the matching row does not exists. To accomplish proper race condition avoidance
-	 * it is needed that there is also a unique constraint on the values. Then this method will
-	 * catch the exception and return 0.
-	 *
-	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
-	 * @param array $input data that should be inserted into the table  (column name => value)
-	 * @param array|null $compare List of values that should be checked for "if not exists"
-	 *                            If this is null or an empty array, all keys of $input will be compared
-	 *                            Please note: text fields (clob) must not be used in the compare array
-	 * @return int number of inserted rows
-	 * @throws \Doctrine\DBAL\Exception
-	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (UniqueConstraintViolationException $e) {}" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
-	 */
-	public function insertIfNotExist($table, $input, ?array $compare = null) {
-		if (empty($compare)) {
-			$compare = array_keys($input);
-		}
-		$fieldList = '`' . implode('`,`', array_keys($input)) . '`';
-		$query = "INSERT INTO `$table` ($fieldList) SELECT "
-			. str_repeat('?,', count($input) - 1) . '? '
-			. " WHERE NOT EXISTS (SELECT 1 FROM `$table` WHERE ";
-
-		$inserts = array_values($input);
-		foreach ($compare as $key) {
-			$query .= '`' . $key . '`';
-			if (is_null($input[$key])) {
-				$query .= ' IS NULL AND ';
-			} else {
-				$inserts[] = $input[$key];
-				$query .= ' = ? AND ';
-			}
-		}
-		$query = substr($query, 0, -5);
-		$query .= ')';
-
-		try {
-			return $this->conn->executeUpdate($query, $inserts);
-		} catch (UniqueConstraintViolationException $e) {
-			// if this is thrown then a concurrent insert happened between the insert and the sub-select in the insert, that should have avoided it
-			// it's fine to ignore this then
-			//
-			// more discussions about this can be found at https://github.com/nextcloud/server/pull/12315
-			return 0;
-		}
 	}
 
 	public function insertIgnoreConflict(string $table, array $values): int {

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -531,29 +531,6 @@ class Connection extends PrimaryReadReplicaConnection {
 		return parent::lastInsertId($seqName);
 	}
 
-	/**
-	 * Insert a row if the matching row does not exists. To accomplish proper race condition avoidance
-	 * it is needed that there is also a unique constraint on the values. Then this method will
-	 * catch the exception and return 0.
-	 *
-	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
-	 * @param array $input data that should be inserted into the table  (column name => value)
-	 * @param array|null $compare List of values that should be checked for "if not exists"
-	 *                            If this is null or an empty array, all keys of $input will be compared
-	 *                            Please note: text fields (clob) must not be used in the compare array
-	 * @return int number of inserted rows
-	 * @throws \Doctrine\DBAL\Exception
-	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (UniqueConstraintViolationException $e) {}" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
-	 */
-	public function insertIfNotExist($table, $input, ?array $compare = null) {
-		try {
-			return $this->adapter->insertIfNotExist($table, $input, $compare);
-		} catch (\Exception $e) {
-			$this->logDatabaseException($e);
-			throw $e;
-		}
-	}
-
 	public function insertIgnoreConflict(string $table, array $values) : int {
 		try {
 			return $this->adapter->insertIgnoreConflict($table, $values);

--- a/lib/private/DB/ConnectionAdapter.php
+++ b/lib/private/DB/ConnectionAdapter.php
@@ -78,14 +78,6 @@ class ConnectionAdapter implements IDBConnection {
 		}
 	}
 
-	public function insertIfNotExist(string $table, array $input, ?array $compare = null) {
-		try {
-			return $this->inner->insertIfNotExist($table, $input, $compare);
-		} catch (Exception $e) {
-			throw DbalException::wrap($e);
-		}
-	}
-
 	public function insertIgnoreConflict(string $table, array $values): int {
 		try {
 			return $this->inner->insertIgnoreConflict($table, $values);

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -17,6 +17,7 @@ use OC\App\InfoParser;
 use OC\Migration\SimpleOutput;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
+use OCP\DB\Exception;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
 use OCP\IConfig;
@@ -285,10 +286,20 @@ class MigrationService {
 	 * @param string $version
 	 */
 	private function markAsExecuted($version): void {
-		$this->connection->insertIfNotExist('*PREFIX*migrations', [
-			'app' => $this->appName,
-			'version' => $version
-		]);
+		$qb = $this->connection->getQueryBuilder();
+		$qb
+			->insert('migrations')
+			->values([
+				'app' => $qb->createNamedParameter($this->appName),
+				'version' => $qb->createNamedParameter($version),
+			]);
+		try {
+			$qb->executeStatement();
+		} catch (Exception $e) {
+			if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				throw $e;
+			}
+		}
 	}
 
 	/**

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -7,6 +7,7 @@
  */
 namespace OC\Files\Cache;
 
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
@@ -56,9 +57,22 @@ class Storage {
 			$this->numericId = (int)$row['numeric_id'];
 		} else {
 			$available = $isAvailable ? 1 : 0;
-			if ($connection->insertIfNotExist('*PREFIX*storages', ['id' => $this->storageId, 'available' => $available])) {
-				$this->numericId = $connection->lastInsertId('*PREFIX*storages');
-			} else {
+			$qb = $connection->getQueryBuilder();
+			$qb
+				->insert('storages')
+				->values([
+					'id' => $qb->createNamedParameter($this->storageId),
+					'available' => $qb->createNamedParameter($available, IQueryBuilder::PARAM_INT),
+				]);
+
+			try {
+				$qb->executeStatement();
+				$this->numericId = $qb->getLastInsertId();
+			} catch (Exception $e) {
+				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					throw $e;
+				}
+
 				if ($row = self::getStorageById($this->storageId)) {
 					$this->numericId = (int)$row['numeric_id'];
 				} else {

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -134,24 +134,6 @@ interface IDBConnection {
 	public function lastInsertId(string $table): int;
 
 	/**
-	 * Insert a row if the matching row does not exists. To accomplish proper race condition avoidance
-	 * it is needed that there is also a unique constraint on the values. Then this method will
-	 * catch the exception and return 0.
-	 *
-	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
-	 * @param array $input data that should be inserted into the table  (column name => value)
-	 * @param array|null $compare List of values that should be checked for "if not exists"
-	 *                            If this is null or an empty array, all keys of $input will be compared
-	 *                            Please note: text fields (clob) must not be used in the compare array
-	 * @return int number of inserted rows
-	 * @throws Exception used to be the removed dbal exception, since 21.0.0 it's \OCP\DB\Exception
-	 * @since 6.0.0 - parameter $compare was added in 8.1.0, return type changed from boolean in 8.1.0
-	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (\OCP\DB\Exception $e) { if ($e->getReason() === \OCP\DB\Exception::REASON_CONSTRAINT_VIOLATION) {} }" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
-	 */
-	public function insertIfNotExist(string $table, array $input, ?array $compare = null);
-
-
-	/**
 	 *
 	 * Insert a row if the row does not exist. Eventual conflicts during insert will be ignored.
 	 *

--- a/tests/lib/DB/MigrationServiceTest.php
+++ b/tests/lib/DB/MigrationServiceTest.php
@@ -20,6 +20,7 @@ use OC\DB\Connection;
 use OC\DB\MigrationService;
 use OC\DB\SchemaWrapper;
 use OCP\App\AppPathNotFoundException;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Migration\IMigrationStep;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -102,6 +103,17 @@ class MigrationServiceTest extends \Test\TestCase {
 		$this->db->expects($this->once())
 			->method('migrateToSchema');
 
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb
+			->expects($this->once())
+			->method('insert')
+			->willReturn($qb);
+
+		$this->db
+			->expects($this->once())
+			->method('getQueryBuilder')
+			->willReturn($qb);
+
 		$wrappedSchema = $this->createMock(Schema::class);
 		$wrappedSchema->expects($this->atLeast(2))
 			->method('getTables')
@@ -145,6 +157,17 @@ class MigrationServiceTest extends \Test\TestCase {
 
 		$this->db->expects($this->never())
 			->method('migrateToSchema');
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb
+			->expects($this->once())
+			->method('insert')
+			->willReturn($qb);
+
+		$this->db
+			->expects($this->once())
+			->method('getQueryBuilder')
+			->willReturn($qb);
 
 		$step = $this->createMock(IMigrationStep::class);
 		$step->expects($this->once())


### PR DESCRIPTION
A unique index must be used to actually guarantee no duplicates, as this method is not even transaction safe (with READ_COMMITTED)