### PR TITLE
fix(lib): include headers from OC\Template\Template as well in produced HTML

### DIFF
--- a/lib/private/Template/Template.php
+++ b/lib/private/Template/Template.php
@@ -122,7 +122,7 @@ class Template extends Base implements ITemplate {
 
 			// Add custom headers
 			$headers = '';
-			foreach (\OC_Util::$headers as $header) {
+			foreach (array_merge(\OC_Util::$headers, $this->headers) as $header) {
 				$headers .= '<' . Util::sanitizeHTML($header['tag']);
 				if (strcasecmp($header['tag'], 'script') === 0 && in_array('src', array_map('strtolower', array_keys($header['attributes'])))) {
 					$headers .= ' defer';


### PR DESCRIPTION
Otherwise we only take those added through deprecated method `OC_Util::addHeader`, not those of `OC\Template\Template::addHeader`, which does nothing.

Too complicated to add tests unfortunately.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
