### PR TITLE
fix: Run integration tests in debug mode

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -162,8 +162,7 @@ class ServerFactory {
 					$this->userSession,
 					\OCP\Server::get(IFilenameValidator::class),
 					\OCP\Server::get(IAccountManager::class),
-					$isPublicShare,
-					!$debugEnabled
+					$isPublicShare
 				)
 			);
 			$server->addPlugin(new QuotaPlugin($view));

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -301,7 +301,6 @@ class Server {
 						\OCP\Server::get(IFilenameValidator::class),
 						\OCP\Server::get(IAccountManager::class),
 						false,
-						$config->getSystemValueBool('debug', false) === false,
 					)
 				);
 				$this->server->addPlugin(new ChecksumUpdatePlugin());

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -26,6 +26,8 @@ INSTALLED=$($OCC status | grep installed: | cut -d " " -f 5)
 if [ "$INSTALLED" == "true" ]; then
     # Disable appstore to avoid spamming from CI
     $OCC config:system:set appstoreenabled --value=false --type=boolean
+    # Enable debug mode
+    $OCC config:system:set debug --value=true --type=boolean
     # Disable bruteforce protection because the integration tests do trigger them
     $OCC config:system:set auth.bruteforce.protection.enabled --value false --type bool
     # Disable rate limit protection because the integration tests do trigger them


### PR DESCRIPTION
## Summary

And ensure all headers are available in debug mode

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
