### PR TITLE
Fix regex for allowed characters in user ID

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -694,8 +694,8 @@ class Manager extends PublicEmitter implements IUserManager {
 		$l = Server::get(IFactory::class)->get('lib');
 
 		// Check the ID for bad characters
-		// Allowed are: "a-z", "A-Z", "0-9", spaces and "_.@-'"
-		if (preg_match('/[^a-zA-Z0-9 _.@\-\']/', $uid)) {
+		// Allowed are: "a-z", "A-Z", "0-9", spaces and "_.@-'#"
+		if (preg_match(‘/[^a-zA-Z0-9 _.@\-'#]/’, $uid)) {
 			throw new \InvalidArgumentException($l->t('Only the following characters are allowed in an Login:'
 				. ' "a-z", "A-Z", "0-9", spaces and "_.@-\'"'));
 		}


### PR DESCRIPTION
was incorrectly banning # symbols
solves issues regarding SSO with Microsoft 365 accounts

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
nextcloud was preventing users from adding # symbols to usernames,
this prevents Microsoft 365 Guest accounts from being able to work with nextcloud.
this commit fixes the problem server side,
an end user will still need to remove or fix the pattern attribute on the username field

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
