### PR TITLE
Adapt to OCM spec for remote shares

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -9,6 +9,7 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\PermissionsMask;
 use OC\Files\View;
 use OCA\DAV\Connector\LegacyPublicAuth;
+use OCA\DAV\Connector\Sabre\BearerAuth;
 use OCA\DAV\Connector\Sabre\ServerFactory;
 use OCA\DAV\Files\Sharing\FilesDropPlugin;
 use OCA\DAV\Files\Sharing\PublicLinkCheckPlugin;
@@ -45,7 +46,14 @@ $authBackend = new LegacyPublicAuth(
 	Server::get(ISession::class),
 	Server::get(IThrottler::class)
 );
+$bearerAuthBackend = new BearerAuth(
+	Server::get(IUserSession::class),
+	Server::get(ISession::class),
+	Server::get(IRequest::class),
+	Server::get(IConfig::class),
+);
 $authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);
+$authPlugin->addBackend($bearerAuthBackend);
 
 /** @var IEventDispatcher $eventDispatcher */
 $eventDispatcher = Server::get(IEventDispatcher::class);
@@ -75,6 +83,7 @@ $server = $serverFactory->createServer(
 	$authPlugin,
 	function (\Sabre\DAV\Server $server) use (
 		$authBackend,
+		$bearerAuthBackend,
 		$linkCheckPlugin,
 		$filesDropPlugin
 	) {
@@ -85,8 +94,11 @@ $server = $serverFactory->createServer(
 			// this is what is thrown when trying to access a non-existing share
 			throw new \Sabre\DAV\Exception\NotAuthenticated();
 		}
-
-		$share = $authBackend->getShare();
+		try {
+			$share = $authBackend->getShare();
+		} catch (AssertionError $e) {
+			$share = $bearerAuthBackend->getShare();
+		}
 		$owner = $share->getShareOwner();
 		$isReadable = $share->getPermissions() & Constants::PERMISSION_READ;
 		$fileId = $share->getNodeId();

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -260,6 +260,7 @@ return array(
     'OCA\\DAV\\Controller\\ExampleContentController' => $baseDir . '/../lib/Controller/ExampleContentController.php',
     'OCA\\DAV\\Controller\\InvitationResponseController' => $baseDir . '/../lib/Controller/InvitationResponseController.php',
     'OCA\\DAV\\Controller\\OutOfOfficeController' => $baseDir . '/../lib/Controller/OutOfOfficeController.php',
+    'OCA\\DAV\\Controller\\TokenController' => $baseDir . '/../lib/Controller/TokenController.php',
     'OCA\\DAV\\Controller\\UpcomingEventsController' => $baseDir . '/../lib/Controller/UpcomingEventsController.php',
     'OCA\\DAV\\DAV\\CustomPropertiesBackend' => $baseDir . '/../lib/DAV/CustomPropertiesBackend.php',
     'OCA\\DAV\\DAV\\GroupPrincipalBackend' => $baseDir . '/../lib/DAV/GroupPrincipalBackend.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -275,6 +275,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Controller\\ExampleContentController' => __DIR__ . '/..' . '/../lib/Controller/ExampleContentController.php',
         'OCA\\DAV\\Controller\\InvitationResponseController' => __DIR__ . '/..' . '/../lib/Controller/InvitationResponseController.php',
         'OCA\\DAV\\Controller\\OutOfOfficeController' => __DIR__ . '/..' . '/../lib/Controller/OutOfOfficeController.php',
+        'OCA\\DAV\\Controller\\TokenController' => __DIR__ . '/..' . '/../lib/Controller/TokenController.php',
         'OCA\\DAV\\Controller\\UpcomingEventsController' => __DIR__ . '/..' . '/../lib/Controller/UpcomingEventsController.php',
         'OCA\\DAV\\DAV\\CustomPropertiesBackend' => __DIR__ . '/..' . '/../lib/DAV/CustomPropertiesBackend.php',
         'OCA\\DAV\\DAV\\GroupPrincipalBackend' => __DIR__ . '/..' . '/../lib/DAV/GroupPrincipalBackend.php',

--- a/apps/dav/lib/Connector/Sabre/BearerAuth.php
+++ b/apps/dav/lib/Connector/Sabre/BearerAuth.php
@@ -12,6 +12,9 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
+use OCP\Server;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
 use Sabre\DAV\Auth\Backend\AbstractBearer;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
@@ -23,6 +26,7 @@ class BearerAuth extends AbstractBearer {
 		private IRequest $request,
 		private IConfig $config,
 		private string $principalPrefix = 'principals/users/',
+		private string $token = '',
 	) {
 		// setup realm
 		$defaults = new Defaults();
@@ -40,6 +44,7 @@ class BearerAuth extends AbstractBearer {
 	 */
 	public function validateBearerToken($bearerToken) {
 		\OC_Util::setupFS();
+		$this->token = $bearerToken;
 
 		if (!$this->userSession->isLoggedIn()) {
 			$this->userSession->tryTokenLogin($this->request);
@@ -49,6 +54,13 @@ class BearerAuth extends AbstractBearer {
 		}
 
 		return false;
+	}
+
+	public function getShare(): IShare {
+		$shareManager = Server::get(IManager::class);
+		$share = $shareManager->getShareByToken($this->token);
+		assert($share !== null);
+		return $share;
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/BearerAuth.php
+++ b/apps/dav/lib/Connector/Sabre/BearerAuth.php
@@ -49,6 +49,9 @@ class BearerAuth extends AbstractBearer {
 		if (!$this->userSession->isLoggedIn()) {
 			$this->userSession->tryTokenLogin($this->request);
 		}
+		if (!$this->userSession->isLoggedIn()) {
+			$this->userSession->doTryTokenLogin($bearerToken);
+		}
 		if ($this->userSession->isLoggedIn()) {
 			return $this->setupUserFs($this->userSession->getUser()->getUID());
 		}

--- a/apps/dav/lib/Controller/TokenController.php
+++ b/apps/dav/lib/Controller/TokenController.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Controller;
+
+use OC\Authentication\Token\IProvider;
+use OCP\AppFramework\ApiController;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Token\IToken;
+use OCP\IRequest;
+use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
+use OCP\IAppConfig;
+use OC\OCM\OCMSignatoryManager;
+use NCU\Security\Signature\ISignatureManager;
+use NCU\Security\Signature\Exceptions\SignatureNotFoundException;
+use NCU\Security\Signature\Exceptions\SignatureException;
+use NCU\Security\Signature\Exceptions\SignatoryNotFoundException;
+use NCU\Security\Signature\Model\IIncomingSignedRequest;
+use NCU\Security\Signature\Exceptions\IncomingRequestException;
+use OC\Security\Signature\Model\IncomingSignedRequest;
+
+/**
+ * Controller for the /token endpoint
+ * Exchanges long-lived refresh tokens for short-lived access tokens
+ *
+ * @since 32.0.0
+ */
+class TokenController extends ApiController {
+	public function __construct(
+		IRequest $request,
+		private readonly IProvider $tokenProvider,
+		private readonly ISecureRandom $random,
+		private readonly ITimeFactory $timeFactory,
+		private readonly LoggerInterface $logger,
+		private readonly ISignatureManager $signatureManager,
+		private readonly OCMSignatoryManager $signatoryManager,
+		private readonly IAppConfig $appConfig,
+	) {
+		parent::__construct('dav', $request);
+	}
+
+	/**
+	 * Verify the signature of incoming request if available
+	 *
+	 * @return IncomingSignedRequest|null null if remote does not support signed requests
+	 * @throws IncomingRequestException if signature is required but invalid
+	 */
+	private function verifySignedRequest(): ?IncomingSignedRequest {
+		try {
+			$signedRequest = $this->signatureManager->getIncomingSignedRequest($this->signatoryManager);
+			$this->logger->debug('Token request signature verified', [
+				'origin' => $signedRequest->getOrigin()
+			]);
+			return $signedRequest;
+		} catch (SignatureNotFoundException|SignatoryNotFoundException $e) {
+			$this->logger->debug('Token request not signed', ['exception' => $e]);
+
+			if ($this->appConfig->getValueBool('core', OCMSignatoryManager::APPCONFIG_SIGN_ENFORCED, lazy: true)) {
+				$this->logger->notice('Rejected unsigned token request', ['exception' => $e]);
+				throw new IncomingRequestException('Unsigned request not allowed');
+			}
+			return null;
+		} catch (SignatureException $e) {
+			$this->logger->warning('Invalid token request signature', ['exception' => $e]);
+			throw new IncomingRequestException('Invalid signature');
+		}
+	}
+
+	/**
+	 * Exchange a refresh token for a short-lived access token
+	 *
+	 * @return DataResponse<Http::STATUS_OK, array{access_token: string, token_type: string, expires_in: int}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED|Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
+	 *
+	 * 200: Access token successfully generated
+	 * 400: Bad request - missing refresh token or invalid request format
+	 * 401: Unauthorized - invalid or expired refresh token, or invalid signature
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[FrontpageRoute(verb: 'POST', url: '/api/v1/access-token')]
+	public function accessToken(): DataResponse {
+		try {
+			$signedRequest = $this->verifySignedRequest();
+		} catch (IncomingRequestException $e) {
+			$this->logger->warning('Token request signature verification failed', [
+				'exception' => $e
+			]);
+			return new DataResponse(
+				['error' => 'invalid_request'],
+				Http::STATUS_UNAUTHORIZED
+			);
+		}
+
+		$body = file_get_contents('php://input');
+		$data = json_decode($body, true);
+
+		if (!is_array($data)) {
+			return new DataResponse(
+				['error' => 'invalid_request'],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		$refreshToken = $data['code'] ?? '';
+		$grantType = $data['grant_type'] ?? '';
+
+		if ($grantType !== 'authorization_code') {
+			return new DataResponse(
+				['error' => 'unsupported_grant_type'],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		if (empty($refreshToken)) {
+			return new DataResponse(
+				['error' => 'refresh_token is required'],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		try {
+			$token = $this->tokenProvider->getToken($refreshToken);
+
+			if ($token->getType() !== IToken::PERMANENT_TOKEN) {
+				$this->logger->warning('Attempted to use non-permanent token as refresh token', [
+					'tokenId' => $token->getId(),
+				]);
+				return new DataResponse(
+					['error' => 'invalid_grant'],
+					Http::STATUS_UNAUTHORIZED
+				);
+			}
+
+			$accessTokenString = $this->random->generate(
+				72,
+				ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS
+			);
+
+			$expiresIn = 3600; // 1 hour in seconds
+			$expiresAt = $this->timeFactory->getTime() + $expiresIn;
+
+			$accessToken = $this->tokenProvider->generateToken(
+				$accessTokenString,
+				$refreshToken, // Keep refresh token with access token as UID
+				$token->getLoginName(),
+				null, // No password for access tokens
+				'OCM Access Token',
+				IToken::TEMPORARY_TOKEN,
+				IToken::DO_NOT_REMEMBER
+			);
+
+			$accessToken->setExpires($expiresAt);
+			$this->tokenProvider->updateToken($accessToken);
+
+			return new DataResponse([
+				'access_token' => $accessTokenString,
+				'token_type' => 'Bearer',
+				'expires_in' => $expiresIn,
+			], Http::STATUS_OK);
+		} catch (InvalidTokenException $e) {
+			$this->logger->info('Invalid refresh token provided', [
+				'exception' => $e,
+			]);
+			return new DataResponse(
+				['error' => 'invalid_grant'],
+				Http::STATUS_UNAUTHORIZED
+			);
+		} catch (ExpiredTokenException $e) {
+			$this->logger->info('Expired refresh token provided', [
+				'exception' => $e,
+			]);
+			return new DataResponse(
+				['error' => 'invalid_grant'],
+				Http::STATUS_UNAUTHORIZED
+			);
+		} catch (\Exception $e) {
+			$this->logger->error('Error generating access token', [
+				'exception' => $e,
+			]);
+			return new DataResponse(
+				['error' => 'server_error'],
+				Http::STATUS_INTERNAL_SERVER_ERROR
+			);
+		}
+	}
+}

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -752,6 +752,20 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 		$data = $cursor->fetchAssociative();
 
 		if ($data === false) {
+
+			$provider = Server::get(PublicKeyTokenProvider::class);
+			$accessTokenDb = $provider->getToken($token);
+			$refreshToken = $accessTokenDb->getUID();
+
+			$cursor = $qb->select('*')
+				->from('share')
+				->where($qb->expr()->in('share_type', $qb->createNamedParameter($this->supportedShareType, IQueryBuilder::PARAM_INT_ARRAY)))
+				->andWhere($qb->expr()->eq('token', $qb->createNamedParameter($refreshToken)))
+				->executeQuery();
+
+			$data = $cursor->fetch();
+		}
+		if ($data === false) {
 			throw new ShareNotFound('Share not found', $this->l->t('Could not find share'));
 		}
 

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -33,6 +33,41 @@ use Sabre\DAV\Xml\Property\ResourceType;
 use Sabre\HTTP\ClientException;
 use Sabre\HTTP\ClientHttpException;
 use Sabre\HTTP\RequestInterface;
+ * Class BearerAuthAwareSabreClient
+ *
+ * This is an extension of the Sabre HTTP Client
+ * to provide it with the ability to make bearer authn requests.
+ *
+ * @package OC\Files\Storage
+ */
+class BearerAuthAwareSabreClient extends Client
+{
+    /**
+     * Bearer authentication.
+     */
+    const AUTH_BEARER = 8;
+
+    /**
+     * Constructor.
+	 *
+	 * See Sabre\DAV\Client
+	 *
+     */
+    public function __construct(array $settings)
+    {
+        parent::__construct($settings);
+
+        if (isset($settings['userName']) && isset($settings['authType']) && ($settings['authType'] & self::AUTH_BEARER)) {
+            $userName = $settings['userName'];
+
+            $curlType = $this->curlSettings[CURLOPT_HTTPAUTH];
+            $curlType |= CURLAUTH_BEARER;
+
+            $this->addCurlSetting(CURLOPT_HTTPAUTH, $curlType);
+            $this->addCurlSetting(CURLOPT_XOAUTH2_BEARER, $userName);
+        }
+    }
+}
 
 /**
  * Class DAV

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -10,8 +10,10 @@ namespace OC\Files\Storage;
 use Exception;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
+use NCU\Security\Signature\ISignatureManager;
 use OC\Files\Filesystem;
 use OC\MemCache\ArrayCache;
+use OC\OCM\OCMSignatoryManager;
 use OCP\AppFramework\Http;
 use OCP\Constants;
 use OCP\Diagnostics\IEventLogger;
@@ -22,8 +24,12 @@ use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
 use OCP\ICertificateManager;
 use OCP\IConfig;
+use OCP\OCM\Exceptions\OCMArgumentException;
+use OCP\OCM\Exceptions\OCMProviderException;
+use OCP\OCM\IOCMDiscoveryService;
 use OCP\Server;
 use OCP\Util;
 use Psr\Http\Message\ResponseInterface;
@@ -33,6 +39,9 @@ use Sabre\DAV\Xml\Property\ResourceType;
 use Sabre\HTTP\ClientException;
 use Sabre\HTTP\ClientHttpException;
 use Sabre\HTTP\RequestInterface;
+
+
+/**
  * Class BearerAuthAwareSabreClient
  *
  * This is an extension of the Sabre HTTP Client
@@ -102,6 +111,10 @@ class DAV extends Common {
 	protected LoggerInterface $logger;
 	protected IEventLogger $eventLogger;
 	protected IMimeTypeDetector $mimeTypeDetector;
+	protected IOCMDiscoveryService $discoveryService;
+	protected ISignatureManager $signatureManager;
+	protected OCMSignatoryManager $signatoryManager;
+	protected IAppConfig $appConfig;
 
 	/** @var int */
 	private $timeout;
@@ -124,6 +137,11 @@ class DAV extends Common {
 	public function __construct(array $parameters) {
 		$this->statCache = new ArrayCache();
 		$this->httpClientService = Server::get(IClientService::class);
+		if (isset($parameters['discoveryService'])) {
+			$this->discoveryService = $parameters['discoveryService'];
+		} else {
+			$this->discoveryService = Server::get(IOCMDiscoveryService::class);
+		}
 		if (isset($parameters['host']) && isset($parameters['user']) && isset($parameters['password'])) {
 			$host = $parameters['host'];
 			//remove leading http[s], will be generated in createBaseUri()
@@ -162,6 +180,9 @@ class DAV extends Common {
 		// This timeout value will be used for the download and upload of files
 		$this->timeout = Server::get(IConfig::class)->getSystemValueInt('davstorage.request_timeout', IClient::DEFAULT_REQUEST_TIMEOUT);
 		$this->mimeTypeDetector = \OC::$server->getMimeTypeDetector();
+		$this->signatureManager = Server::get(ISignatureManager::class);
+		$this->signatoryManager = Server::get(OCMSignatoryManager::class);
+		$this->appConfig = Server::get(IAppConfig::class);
 	}
 
 	protected function init(): void {
@@ -170,9 +191,82 @@ class DAV extends Common {
 		}
 		$this->ready = true;
 
+		// If using Bearer auth, exchange refresh token for access token
+		$userName = $this->user;
+		if ($this->authType !== null && ($this->authType & BearerAuthAwareSabreClient::AUTH_BEARER)) {
+			try {
+				$host = 'https://' . $this->host;
+				$ocmProvider = $this->discoveryService->discover($host);
+				$tokenEndpoint = $ocmProvider->getTokenEndPoint();
+
+				if ($tokenEndPoint === '') {
+					$this->logger->error('OCM provider response missing tokenEndPoint', ['app' => 'dav']);
+					throw new StorageNotAvailableException('Could not discover token endpoint');
+				}
+
+				$client = $this->httpClientService->newClient();
+				$payload = [
+					'grant_type' => 'authorization_code',
+					'client_id' => 'receiver.example.org',
+					'code' => $this->user,
+				];
+
+				$options = [
+					'body' => json_encode($payload),
+					'headers' => [
+						'Content-Type' => 'application/json',
+					],
+					'timeout' => 10,
+					'connect_timeout' => 10,
+				];
+
+				// Try signing the request
+				if (!$this->appConfig->getValueBool('core', OCMSignatoryManager::APPCONFIG_SIGN_DISABLED, lazy: true)) {
+					try {
+						$options = $this->signatureManager->signOutgoingRequestIClientPayload(
+							$this->signatoryManager,
+							$options,
+							'post',
+							$tokenEndpoint
+						);
+						$this->logger->debug('Token request signed successfully', ['app' => 'dav']);
+					} catch (\Exception $e) {
+						$this->logger->warning('Failed to sign token request, continuing without signature', [
+							'app' => 'dav',
+							'exception' => $e,
+							'endpoint' => $tokenEndpoint,
+						]);
+					}
+				}
+
+				$response = $client->post($tokenEndpoint, $options);
+
+				$body = $response->getBody();
+				$data = json_decode($body, true);
+
+				if (isset($data['access_token'])) {
+					$userName = $data['access_token'];
+					$this->user = $userName;
+					$this->logger->debug('Successfully exchanged refresh token for access token', ['app' => 'dav']);
+				} else {
+					$this->logger->error('Failed to get access token from response', ['app' => 'dav']);
+					throw new StorageNotAvailableException('Could not obtain access token');
+				}
+			} catch (OCMProviderException|OCMArgumentException $e) {
+				$this->logger->error('OCM provider response missing tokenEndPoint', ['app' => 'dav']);
+				throw new StorageNotAvailableException('Could not discover token endpoint');
+			} catch (\Exception $e) {
+				$this->logger->error('Error exchanging refresh token for access token: ' . $e->getMessage(), [
+					'app' => 'dav',
+					'exception' => $e,
+				]);
+				throw new StorageNotAvailableException('Could not obtain access token: ' . $e->getMessage());
+			}
+		}
+
 		$settings = [
 			'baseUri' => $this->createBaseUri(),
-			'userName' => $this->user,
+			'userName' => $userName,
 			'password' => $this->password,
 		];
 		if ($this->authType !== null) {
@@ -184,7 +278,7 @@ class DAV extends Common {
 			$settings['proxy'] = $proxy;
 		}
 
-		$this->client = new Client($settings);
+		$this->client = new BearerAuthAwareSabreClient($settings);
 		$this->client->setThrowExceptions(true);
 
 		if ($this->secure === true) {
@@ -360,10 +454,14 @@ class DAV extends Common {
 			case 'r':
 			case 'rb':
 				try {
+					$auth = [$this->user, $this->password];
+					if ($this->authType === BearerAuthAwareSabreClient::AUTH_BEARER) {
+						$auth = [$this->user, '', 'bearer'];
+					}
 					$response = $this->httpClientService
 						->newClient()
 						->get($this->createBaseUri() . $this->encodePath($path), [
-							'auth' => [$this->user, $this->password],
+							'auth' => $auth,
 							'stream' => true,
 							// set download timeout for users with slow connections or large files
 							'timeout' => $this->timeout
@@ -510,11 +608,15 @@ class DAV extends Common {
 		$this->statCache->remove($target);
 		$source = fopen($path, 'r');
 
+		$auth = [$this->user, $this->password];
+		if ($this->authType === BearerAuthAwareSabreClient::AUTH_BEARER) {
+			$auth = [$this->user, '', 'bearer'];
+		}
 		$this->httpClientService
 			->newClient()
 			->put($this->createBaseUri() . $this->encodePath($target), [
 				'body' => $source,
-				'auth' => [$this->user, $this->password],
+				'auth' => $auth,
 				// set upload timeout for users with slow connections or large files
 				'timeout' => $this->timeout
 			]);

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -24,6 +24,7 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 	private string $inviteAcceptDialog = '';
 	private array $capabilities = [];
 	private string $endPoint = '';
+	private string $tokenEndPoint = '';
 	/** @var IOCMResource[] */
 	private array $resourceTypes = [];
 	private ?Signatory $signatory = null;
@@ -109,6 +110,27 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 	 */
 	public function getEndPoint(): string {
 		return $this->endPoint;
+	}
+
+	/**
+	 * @param string $tokenEndPoint
+	 *
+	 * @return $this
+	 */
+	public function setTokenEndPoint(string $endPoint): static {
+		$this->tokenEndPoint = $endPoint;
+
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTokenEndPoint(): string {
+		if (in_array('exchange-token', $this->capabilities)) {
+			return $this->tokenEndPoint;
+		}
+		return '';
 	}
 
 	/**
@@ -238,6 +260,12 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 				$this->setSignatory($signatory);
 			}
 		}
+		if (isset($data['capabilities'])) {
+			$this->setCapabilities($data['capabilities']);
+		}
+		if (isset($data['tokenEndPoint'])) {
+			$this->setTokenEndPoint($data['tokenEndPoint']);
+		}
 
 		if (!$this->looksValid()) {
 			throw new OCMProviderException('remote provider does not look valid');
@@ -276,6 +304,10 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 		$capabilities = $this->getCapabilities();
 		if ($capabilities) {
 			$response['capabilities'] = $capabilities;
+		}
+		$tokenEndpoint = $this->getTokenEndPoint();
+		if ($tokenEndpoint) {
+			$response['tokenEndPoint'] = $tokenEndpoint;
 		}
 		$inviteAcceptDialog = $this->getInviteAcceptDialog();
 		if ($inviteAcceptDialog !== '') {

--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -34,7 +34,7 @@ use Psr\Log\LoggerInterface;
  */
 class OCMDiscoveryService implements IOCMDiscoveryService {
 	private ICache $cache;
-	public const API_VERSION = '1.1.0';
+	public const API_VERSION = '1.1.2';
 
 	private ?ICapabilityAwareOCMProvider $localProvider = null;
 	/** @var array<string, ICapabilityAwareOCMProvider> */
@@ -72,6 +72,7 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 		}
 
 		if (array_key_exists($remote, $this->remoteProviders)) {
+
 			return $this->remoteProviders[$remote];
 		}
 
@@ -107,7 +108,6 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 				$remote . '/.well-known/ocm',
 				$remote . '/ocm-provider',
 			];
-
 
 			foreach ($urls as $url) {
 				$exception = null;
@@ -167,6 +167,7 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 		}
 
 		$url = $this->urlGenerator->linkToRouteAbsolute('cloud_federation_api.requesthandlercontroller.addShare');
+		$tokenUrl = $this->urlGenerator->linkToRouteAbsolute('dav.Token.accessToken');
 		$pos = strrpos($url, '/');
 		if ($pos === false) {
 			$this->logger->debug('generated route should contain a slash character');
@@ -176,7 +177,8 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 		$provider->setEnabled(true);
 		$provider->setApiVersion(self::API_VERSION);
 		$provider->setEndPoint(substr($url, 0, $pos));
-		$provider->setCapabilities(['/invite-accepted', '/notifications', '/shares']);
+		$provider->setCapabilities(['/invite-accepted', '/notifications', '/shares', 'exchange-token']);
+		$provider->setTokenEndPoint($tokenUrl);
 
 		// The inviteAcceptDialog is available from the contacts app, if this config value is set
 		$inviteAcceptDialog = $this->appConfig->getValueString('core', ConfigLexicon::OCM_INVITE_ACCEPT_DIALOG);

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -820,6 +820,10 @@ class Session implements IUserSession, Emitter {
 		} else {
 			return false;
 		}
+		return $this->doTryTokenLogin($token);
+	}
+
+	public function doTryTokenLogin($token) {
 
 		if (!$this->loginWithToken($token)) {
 			return false;

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -609,14 +609,35 @@ class Session implements IUserSession, Emitter {
 			// Ignore and use empty string instead
 		}
 
-		$this->manager->emit('\OC\User', 'preLogin', [$dbToken->getLoginName(), $password]);
-
 		$user = $this->manager->get($uid);
 		if (is_null($user)) {
+			// Maybe this is an access token. We keep the refresh tokens as UID of access tokens
+			try {
+				$token = $uid;
+				$dbToken = $this->tokenProvider->getToken($token);
+			} catch (InvalidTokenException $ex) {
+				return false;
+			}
+			$uid = $dbToken->getUID();
+
+			// When logging in with token, the password must be decrypted first before passing to login hook
+			$password = '';
+			try {
+				$password = $this->tokenProvider->getPassword($dbToken, $token);
+			} catch (PasswordlessTokenException $ex) {
+				// Ignore and use empty string instead
+			}
 			// user does not exist
-			return false;
+			$user = $this->manager->get($uid);
+			if (is_null($user)) {
+				return false;
+			}
 		}
 
+		$this->manager->emit('\OC\User', 'preLogin', [$dbToken->getLoginName(), $password]);
+
+		// See line 173 in this module, needed for completeLogin
+		OC_User::setIncognitoMode(false);
 		return $this->completeLogin(
 			$user,
 			[


### PR DESCRIPTION

* See: #57152

## Summary

This is a preliminary PR for discussion. If this goes through there are some things missing with which we'll be grateful to get some guidance:

- docs and tests
- keeping retrieved access tokens in the db
- removing tokens when removing shares (will depend on the previous point)

Also this depends on a pending PR for Guzzle:

https://github.com/guzzle/guzzle/pull/3310