### PR TITLE
feat: add api to get users for share

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -824,6 +824,7 @@ return array(
     'OCP\\Share\\IShare' => $baseDir . '/lib/public/Share/IShare.php',
     'OCP\\Share\\IShareHelper' => $baseDir . '/lib/public/Share/IShareHelper.php',
     'OCP\\Share\\IShareProvider' => $baseDir . '/lib/public/Share/IShareProvider.php',
+    'OCP\\Share\\IShareProviderGetUsers' => $baseDir . '/lib/public/Share/IShareProviderGetUsers.php',
     'OCP\\Share\\IShareProviderSupportsAccept' => $baseDir . '/lib/public/Share/IShareProviderSupportsAccept.php',
     'OCP\\Share\\IShareProviderSupportsAllSharesInFolder' => $baseDir . '/lib/public/Share/IShareProviderSupportsAllSharesInFolder.php',
     'OCP\\Share\\IShareProviderWithNotification' => $baseDir . '/lib/public/Share/IShareProviderWithNotification.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -865,6 +865,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Share\\IShare' => __DIR__ . '/../../..' . '/lib/public/Share/IShare.php',
         'OCP\\Share\\IShareHelper' => __DIR__ . '/../../..' . '/lib/public/Share/IShareHelper.php',
         'OCP\\Share\\IShareProvider' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProvider.php',
+        'OCP\\Share\\IShareProviderGetUsers' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderGetUsers.php',
         'OCP\\Share\\IShareProviderSupportsAccept' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderSupportsAccept.php',
         'OCP\\Share\\IShareProviderSupportsAllSharesInFolder' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderSupportsAllSharesInFolder.php',
         'OCP\\Share\\IShareProviderWithNotification' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderWithNotification.php',

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1884,4 +1884,13 @@ class Manager implements IManager {
 			$this->logger->error("Error while sending ' . $name . ' event", ['exception' => $e]);
 		}
 	}
+
+	public function getUsersForShare(IShare $share): iterable {
+		$provider = $this->factory->getProviderForType($share->getShareType());
+		if ($provider instanceof Share\IShareProviderGetUsers) {
+			return $provider->getUsersForShare($share);
+		} else {
+			return [];
+		}
+	}
 }

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -518,4 +518,13 @@ interface IManager {
 	 * @since 31.0.0
 	 */
 	public function generateToken(): string;
+
+	/**
+	 * Get all users with access to a share
+	 *
+	 * @param IShare $share
+	 * @return iterable<IUser>
+	 * @since 33.0.0
+	 */
+	public function getUsersForShare(IShare $share): iterable;
 }

--- a/lib/public/Share/IShareProviderGetUsers.php
+++ b/lib/public/Share/IShareProviderGetUsers.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Share;
+
+use OCP\IUser;
+
+/**
+ * Interface IShareProviderSupportsAccept
+ *
+ * This interface allows to define IShareProvider that can list users for share with the getUsersForShare method,
+ * which is available since Nextcloud 17.
+ *
+ * @since 33.0.0
+ */
+interface IShareProviderGetUsers extends IShareProvider {
+	/**
+	 * Get all users with access to a share
+	 *
+	 * @param IShare $share
+	 * @return iterable<IUser>
+	 * @since 33.0.0
+	 */
+	public function getUsersForShare(IShare $share): iterable;
+}


### PR DESCRIPTION
Allows getting a list of all users that have access to a share.

This is required to be able to actively update things like mount points when a share is created.

Open question:

- [ ] Since there isn't really a good way to do a fallback, should this maybe be required of implementations and be part of the base interface

cc @nickvergessen @juliusknorr @ArtificialOwl for the talk, deck and circles backends that would need to implement this.