### PR TITLE
fix(Preview): Add file type check for mime fallback

### DIFF
--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -15,6 +15,7 @@ use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\PublicShareController;
 use OCP\Constants;
+use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
 use OCP\IPreview;
@@ -132,7 +133,7 @@ class PublicPreviewController extends PublicShareController {
 			return $response;
 		} catch (NotFoundException $e) {
 			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($mimeFallback) {
+			if ($mimeFallback && $file instanceof File) {
 				if ($url = $this->mimeIconProvider->getMimeIconUrl($file->getMimeType())) {
 					return new RedirectResponse($url);
 				}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fix `Call to a member function getMimeType() on string`

<details>

<summary>Error stack</summary>

```
{
  "reqId": "w4lxlb2usOySbOXZl2bO",
  "level": 3,
  "time": "2025-12-18T10:46:59+01:00",
  "remoteAddr": "14.24.5.97",
  "user": "--",
  "app": "index",
  "method": "GET",
  "url": "/apps/files_sharing/publicpreview/8LYrm86HSwmCGCX?file=%2F2026%2FJANVIER+2026%2FVariables+paies%2F1_EMBAUCHE+ET+AVENANTS%2FLOPES+Diana%2FDoss+admin+1.jpg&x=32&y=32&mimeFallback=true&v=506c18&a=0",
  "message": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0",
  "version": "31.0.12.3",
  "exception": {
    "Exception": "Exception",
    "Message": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files_Sharing\\Controller\\PublicPreviewController"
          },
          "getPreview"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 315,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Files_Sharing\\Controller\\PublicPreviewController",
          "getPreview",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "token": "8LYrm86HSwmCGCX",
            "_route": "files_sharing.publicpreview.getpreview"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/base.php",
        "line": 1063,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/files_sharing/publicpreview/8LYrm86HSwmCGCX"
        ]
      },
      {
        "file": "/var/www/nextcloud/index.php",
        "line": 24,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
    "Line": 146,
    "Previous": {
      "Exception": "Error",
      "Message": "Call to a member function getMimeType() on string",
      "Code": 0,
      "Trace": [
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 200,
          "function": "getPreview",
          "class": "OCA\\Files_Sharing\\Controller\\PublicPreviewController",
          "type": "->",
          "args": [
            "8LYrm86HSwmCGCX",
            "/2026/JANVIER 2026/Variables paies/1_EMBAUCHE ET AVENANTS/LOPES Diana/Doss admin 1.jpg",
            32,
            32,
            false,
            true
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 114,
          "function": "executeController",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Files_Sharing\\Controller\\PublicPreviewController"
            },
            "getPreview"
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
          "line": 161,
          "function": "dispatch",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Files_Sharing\\Controller\\PublicPreviewController"
            },
            "getPreview"
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/Route/Router.php",
          "line": 315,
          "function": "main",
          "class": "OC\\AppFramework\\App",
          "type": "::",
          "args": [
            "OCA\\Files_Sharing\\Controller\\PublicPreviewController",
            "getPreview",
            {
              "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
            },
            {
              "token": "8LYrm86HSwmCGCX",
              "_route": "files_sharing.publicpreview.getpreview"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/base.php",
          "line": 1063,
          "function": "match",
          "class": "OC\\Route\\Router",
          "type": "->",
          "args": [
            "/apps/files_sharing/publicpreview/8LYrm86HSwmCGCX"
          ]
        },
        {
          "file": "/var/www/nextcloud/index.php",
          "line": 24,
          "function": "handleRequest",
          "class": "OC",
          "type": "::",
          "args": []
        }
      ],
      "File": "/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php",
      "Line": 135
    },
    "message": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135",
    "exception": [],
    "CustomMessage": "Call to a member function getMimeType() on string in file '/var/www/nextcloud/apps/files_sharing/lib/Controller/PublicPreviewController.php' line 135"
  },
  "id": "6943cddd68ee5"
}
```

</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
