### PR TITLE
feat(userList): Allow to list all users

### DIFF
--- a/core/Command/User/ListCommand.php
+++ b/core/Command/User/ListCommand.php
@@ -35,7 +35,7 @@ class ListCommand extends Base {
 				'limit',
 				'l',
 				InputOption::VALUE_OPTIONAL,
-				'Number of users to retrieve',
+				'Number of users to retrieve (0 for unlimited)',
 				'500'
 			)->addOption(
 				'offset',
@@ -58,10 +58,16 @@ class ListCommand extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$limit = (int)$input->getOption('limit');
+		$offset = (int)$input->getOption('offset');
+
+		// Allow --limit 0 to mean unlimited
+		$actualLimit = ($limit === 0) ? null : $limit;
+
 		if ($input->getOption('disabled')) {
-			$users = $this->userManager->getDisabledUsers((int)$input->getOption('limit'), (int)$input->getOption('offset'));
+			$users = $this->userManager->getDisabledUsers($actualLimit, $offset);
 		} else {
-			$users = $this->userManager->searchDisplayName('', (int)$input->getOption('limit'), (int)$input->getOption('offset'));
+			$users = $this->userManager->searchDisplayName('', $actualLimit, $offset);
 		}
 
 		$this->writeArrayInOutputFormat($input, $output, $this->formatUsers($users, (bool)$input->getOption('info')));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/57120

## Summary

Updated the limit option to allow `--limit=0` for unlimited users listing.

This PR simply passes null to underlying methods since `IUserManager::searchDisplayName()` and `IUserManager::getDisabledUsers()` accept `null` for the limit parameter.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
