### PR TITLE
fix(tests): Fix files_external tests

### DIFF
--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -53,7 +53,13 @@ jobs:
 
     services:
       samba:
-        image: ghcr.io/nextcloud/continuous-integration-samba:latest # zizmor: ignore[unpinned-images]
+        image: ghcr.io/servercontainers/samba:smbd-only-a3.18.0-s4.18.2-r0
+        env:
+          ACCOUNT_test: test
+          UID_test: 1000
+          SAMBA_VOLUME_CONFIG_test: "[public]; path=/tmp; valid users = test; guest ok = no; read only = no; browseable = yes"
+        options: >-
+          --health-cmd=true
         ports:
           - 445:445
 

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -25,7 +25,7 @@ class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->loadConfig('files_external/tests/config.amazons3.php');
+		$this->loadConfig(__DIR__ . '/../config.amazons3.php');
 
 		$this->instance = new AmazonS3($this->config + [
 			'putSizeLimit' => 1,

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -26,7 +26,7 @@ class Amazons3Test extends \Test\Files\Storage\Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->loadConfig('files_external/tests/config.amazons3.php');
+		$this->loadConfig(__DIR__ . '/../config.amazons3.php');
 		$this->instance = new AmazonS3($this->config);
 	}
 

--- a/apps/files_external/tests/Storage/FtpTest.php
+++ b/apps/files_external/tests/Storage/FtpTest.php
@@ -24,7 +24,7 @@ class FtpTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->loadConfig('files_external/tests/config.ftp.php');
+		$this->loadConfig(__DIR__ . '/../config.ftp.php');
 
 		$rootInstance = new FTP($this->config);
 		$rootInstance->mkdir($id);

--- a/apps/files_external/tests/Storage/OwncloudTest.php
+++ b/apps/files_external/tests/Storage/OwncloudTest.php
@@ -24,7 +24,7 @@ class OwncloudTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->loadConfig('files_external/tests/config.php');
+		$this->loadConfig(__DIR__ . '/../config.php');
 		$this->config['owncloud']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new OwnCloud($this->config['owncloud']);
 		$this->instance->mkdir('/');

--- a/apps/files_external/tests/Storage/SFTP_KeyTest.php
+++ b/apps/files_external/tests/Storage/SFTP_KeyTest.php
@@ -24,7 +24,7 @@ class SFTP_KeyTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->loadConfig('files_external/tests/config.php');
+		$this->loadConfig(__DIR__ . '/../config.php');
 		// Make sure we have an new empty folder to work in
 		$this->config['sftp_key']['root'] .= '/' . $id;
 		$this->instance = new SFTP_Key($this->config['sftp_key']);

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -28,7 +28,7 @@ class SftpTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->loadConfig('files_external/tests/config.sftp.php');
+		$this->loadConfig(__DIR__ . '/../config.sftp.php');
 		$this->config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new SFTP($this->config);
 		$this->instance->mkdir('/');

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -32,7 +32,7 @@ class SmbTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->loadConfig('files_external/tests/config.smb.php');
+		$this->loadConfig(__DIR__ . '/../config.smb.php');
 		if (substr($this->config['root'], -1, 1) != '/') {
 			$this->config['root'] .= '/';
 		}

--- a/apps/files_external/tests/Storage/SwiftTest.php
+++ b/apps/files_external/tests/Storage/SwiftTest.php
@@ -29,7 +29,7 @@ class SwiftTest extends \Test\Files\Storage\Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->loadConfig('files_external/tests/config.swift.php');
+		$this->loadConfig(__DIR__ . '/../config.swift.php');
 		$this->instance = new Swift($this->config);
 	}
 

--- a/apps/files_external/tests/Storage/WebdavTest.php
+++ b/apps/files_external/tests/Storage/WebdavTest.php
@@ -27,7 +27,7 @@ class WebdavTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->loadConfig('files_external/tests/config.webdav.php');
+		$this->loadConfig(__DIR__ . '/../config.webdav.php');
 		if (isset($this->config['wait'])) {
 			$this->waitDelay = $this->config['wait'];
 		}


### PR DESCRIPTION
## Summary

files_external tests are currently all skipped, possibly since https://github.com/nextcloud/server/pull/54905 was merged.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
