### PR TITLE
feat: don't gate perBucket object store configuration behind multibucket

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -39,7 +39,7 @@ trait S3ConnectionTrait {
 			throw new \Exception('Bucket has to be configured.');
 		}
 
-		if (isset($params['multibucket']) && $params['multibucket'] === true && isset($params['perBucket'][$params['bucket']])) {
+		if (isset($params['perBucket'][$params['bucket']])) {
 			$params = array_merge($params, $params['perBucket'][$params['bucket']]);
 		}
 


### PR DESCRIPTION
a setup can have multiple bucket without having `multibucket` enabled trough things like per-groupfolder buckets

See https://github.com/nextcloud/server/pull/56772 for context