### PR TITLE
S3 signed url preview

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -9,6 +9,8 @@ namespace OCA\DAV\Connector\Sabre;
 
 use OC\Files\View;
 use OC\KnownUser\KnownUserService;
+use OC\Preview\PreviewService;
+use OC\Preview\Storage\StorageFactory;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
@@ -162,6 +164,8 @@ class ServerFactory {
 					$this->userSession,
 					\OCP\Server::get(IFilenameValidator::class),
 					\OCP\Server::get(IAccountManager::class),
+					\OCP\Server::get(PreviewService::class),
+					\OCP\Server::get(StorageFactory::class),
 					$isPublicShare,
 					!$debugEnabled
 				)

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -8,6 +8,8 @@
 namespace OCA\DAV;
 
 use OC\Files\Filesystem;
+use OC\Preview\PreviewService;
+use OC\Preview\Storage\StorageFactory;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\BulkUpload\BulkUploadPlugin;
 use OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin;
@@ -300,6 +302,8 @@ class Server {
 						\OCP\Server::get(IUserSession::class),
 						\OCP\Server::get(IFilenameValidator::class),
 						\OCP\Server::get(IAccountManager::class),
+						\OCP\Server::get(PreviewService::class),
+						\OCP\Server::get(StorageFactory::class),
 						false,
 						$config->getSystemValueBool('debug', false) === false,
 					)

--- a/apps/files/src/components/FileEntry/FileEntryPreview.vue
+++ b/apps/files/src/components/FileEntry/FileEntryPreview.vue
@@ -52,7 +52,7 @@
 <script lang="ts">
 import type { Node } from '@nextcloud/files'
 import type { PropType } from 'vue'
-import type { UserConfig } from '../../types.ts'
+import type { UserConfig, PreviewMetadata } from '../../types.ts'
 
 import { FileType } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
@@ -162,6 +162,14 @@ export default defineComponent({
 				})
 				const url = new URL(window.location.origin + previewUrl)
 				return url.href
+			}
+
+			if (this.source.attributes['preview-metadata']) {
+				let metadata: PreviewMetadata[] = JSON.parse(this.source.attributes['preview-metadata'])
+				metadata = metadata.filter((preview) => preview.height <= 256 && this.cropPreviews === preview.cropped && preview.preview_url)
+				if (metadata.length > 0) {
+					return metadata[0]?.preview_url;
+				}
 			}
 
 			try {

--- a/apps/files/src/init.ts
+++ b/apps/files/src/init.ts
@@ -75,5 +75,8 @@ registerPreviewServiceWorker()
 registerDavProperty('nc:hidden', { nc: 'http://nextcloud.org/ns' })
 registerDavProperty('nc:is-mount-root', { nc: 'http://nextcloud.org/ns' })
 registerDavProperty('nc:metadata-blurhash', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:preview-metadata', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:download-url-expiration', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('oc:downloadURL', { oc: 'http://owncloud.org/ns' })
 
 initLivePhotos()

--- a/apps/files/src/types.ts
+++ b/apps/files/src/types.ts
@@ -147,3 +147,11 @@ export type Capabilities = {
 		versioning: boolean
 	}
 }
+
+export type PreviewMetadata = {
+	width: int,
+	height: int,
+	cropped: boolean,
+	preview_url: string | null,
+	preview_url_expiration: int | null,
+}

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -34,6 +34,8 @@ trait S3ConnectionTrait {
 	private ?ICache $existingBucketsCache = null;
 	private bool $usePresignedUrl = false;
 
+	private bool $usePresignedUrl = false;
+
 	protected function parseParams($params) {
 		if (empty($params['bucket'])) {
 			throw new \Exception('Bucket has to be configured.');

--- a/lib/private/Preview/Db/Preview.php
+++ b/lib/private/Preview/Db/Preview.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace OC\Preview\Db;
 
+use OC\Preview\Storage\IPreviewStorage;
 use OCP\AppFramework\Db\Entity;
 use OCP\DB\Types;
 use OCP\Files\IMimeTypeDetector;
@@ -178,5 +179,16 @@ class Preview extends Entity {
 
 	public function setSourceMimeType(string $mimeType): void {
 		$this->sourceMimetype = $mimeType;
+	}
+
+	public static function getMetadata(Preview $preview, IPreviewStorage $storage): mixed {
+		$data = $storage->getDirectDownload($preview);
+		return [
+			'width' => $preview->width,
+			'height' => $preview->height,
+			'cropped' => $preview->cropped,
+			'preview_url' => $data === false ? null : $data['url'],
+			'preview_url_expiration' => $data === false ? null : $data['expiration'],
+		];
 	}
 }

--- a/lib/private/Preview/Storage/IPreviewStorage.php
+++ b/lib/private/Preview/Storage/IPreviewStorage.php
@@ -50,4 +50,9 @@ interface IPreviewStorage {
 	 * @throws NotFoundException
 	 */
 	public function scan(): int;
+
+	/**
+	 * See IStorage::getDirectDownload
+	 */
+	public function getDirectDownload(Preview $preview): array|false;
 }

--- a/lib/private/Preview/Storage/LocalPreviewStorage.php
+++ b/lib/private/Preview/Storage/LocalPreviewStorage.php
@@ -241,4 +241,9 @@ class LocalPreviewStorage implements IPreviewStorage {
 			$this->connection->commit();
 		}
 	}
+
+	#[Override]
+	public function getDirectDownload(Preview $preview): array|false {
+		return false;
+	}
 }

--- a/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
+++ b/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
@@ -183,4 +183,20 @@ class ObjectStorePreviewStorage implements IPreviewStorage {
 	public function scan(): int {
 		return 0;
 	}
+
+	#[Override]
+	public function getDirectDownload(Preview $preview): array|false {
+		[
+			'urn' => $urn,
+			'store' => $store,
+		] = $this->getObjectStoreInfoForExistingPreview($preview);
+
+		try {
+			$expiration = new \DateTimeImmutable('+60 minutes');
+			$url = $store->preSignedUrl($urn, $expiration);
+			return $url ? ['url' => $url, 'expiration' => $expiration->getTimestamp()] : false;
+		} catch (\Exception $exception) {
+			throw new NotPermittedException('Unable to read preview from object store with urn:' . $urn, previous: $exception);
+		}
+	}
 }

--- a/lib/private/Preview/Storage/StorageFactory.php
+++ b/lib/private/Preview/Storage/StorageFactory.php
@@ -39,6 +39,21 @@ class StorageFactory implements IPreviewStorage {
 		$this->getBackend()->deletePreview($preview);
 	}
 
+	#[Override]
+	public function migratePreview(Preview $preview, SimpleFile $file): void {
+		$this->getBackend()->migratePreview($preview, $file);
+	}
+
+	#[Override]
+	public function scan(): int {
+		return $this->getBackend()->scan();
+	}
+
+	#[Override]
+	public function getDirectDownload(Preview $preview): array|false {
+		return $this->getBackend()->getDirectDownload($preview);
+	}
+
 	private function getBackend(): IPreviewStorage {
 		if ($this->backend) {
 			return $this->backend;
@@ -51,15 +66,5 @@ class StorageFactory implements IPreviewStorage {
 		}
 
 		return $this->backend;
-	}
-
-	#[Override]
-	public function migratePreview(Preview $preview, SimpleFile $file): void {
-		$this->getBackend()->migratePreview($preview, $file);
-	}
-
-	#[Override]
-	public function scan(): int {
-		return $this->getBackend()->scan();
 	}
 }


### PR DESCRIPTION
## Summary


## TODO

- [ ] CSP
- [ ] Figure out a way to not break the frontend caching of previews

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
