### PR TITLE
docs(IUserSession): Improve interface docs

### DIFF
--- a/lib/public/IUserSession.php
+++ b/lib/public/IUserSession.php
@@ -1,33 +1,35 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal Nextcloud classes
 
 namespace OCP;
 
 /**
- * User session
+ * Interface for managing and querying user session state.
+ *
+ * Provides methods for authenticating users, accessing the active user,
+ * and handling login/logout functionality in a Nextcloud server session.
  * @since 6.0.0
  */
 interface IUserSession {
 	/**
-	 * Do a user login
+	 * Attempts to authenticate the given user and start a session.
 	 *
-	 * @param string $uid the username
-	 * @param string $password the password
-	 * @return bool true if successful
+	 * @param string $uid The user's unique identifier (username).
+	 * @param string $password The user's plain-text password.
+	 * @return bool True on successful login, false otherwise.
 	 * @since 6.0.0
 	 */
 	public function login($uid, $password);
 
 	/**
-	 * Logs the user out including all the session data
-	 * Logout, destroys session
+	 * Logs out the current user and terminates their session.
+	 *
+	 * Clears authentication tokens and user-related session data.
 	 *
 	 * @return void
 	 * @since 6.0.0
@@ -35,48 +37,58 @@ interface IUserSession {
 	public function logout();
 
 	/**
-	 * set the currently active user
+	 * Sets the current active user for this session.
 	 *
-	 * @param \OCP\IUser|null $user
+	 * Pass null to clear the active user and log out any existing session.
+	 *
+	 * @param \OCP\IUser|null $user The user to set as active, or null to unset.
 	 * @since 8.0.0
 	 */
 	public function setUser($user);
 
 	/**
-	 * Temporarily set the currently active user without persisting in the session
+	 * Temporarily sets the active user for this session without persisting it in the session storage.
 	 *
-	 * @param IUser|null $user
+	 * Useful for request-scoped user overrides that do not affect the actual session state.
+	 *
+	 * @param \OCP\IUser|null $user The user to set as active, or null to clear.
 	 * @since 29.0.0
 	 */
 	public function setVolatileActiveUser(?IUser $user): void;
 
 	/**
-	 * get the current active user
+	 * Returns the currently authenticated user for this session, or null if the session has no active user.
 	 *
-	 * @return \OCP\IUser|null Current user, otherwise null
+	 * @return \OCP\IUser|null The active user, or null if the session is anonymous, expired, or in incognito mode.
 	 * @since 8.0.0
 	 */
 	public function getUser();
 
 	/**
-	 * Checks whether the user is logged in
+	 * Checks whether a user is currently logged in for this session.
 	 *
-	 * @return bool if logged in
+	 * @return bool True if a user is authenticated and enabled, false otherwise.
 	 * @since 8.0.0
 	 */
 	public function isLoggedIn();
 
 	/**
-	 * get getImpersonatingUserID
+	 * Returns the user ID of the impersonator if another user is being impersonated.
 	 *
-	 * @return string|null
+	 * @return string|null The impersonating user's ID, or null if not impersonating.
 	 * @since 18.0.0
 	 */
 	public function getImpersonatingUserID(): ?string;
 
 	/**
-	 * set setImpersonatingUserID
+	 * Sets or clears the impersonator's user ID in the current session.
 	 *
+	 * Note: This does not initiate impersonation, but only records the identity of the impersonator in the session.
+	 *
+	 * If $useCurrentUser is true (default), records the current user's ID as the impersonator.
+	 * If false, removes any impersonator information from the session.
+	 *
+	 * @param bool $useCurrentUser Whether to assign the current user as the impersonator or to clear it.
 	 * @since 18.0.0
 	 */
 	public function setImpersonatingUserID(bool $useCurrentUser = true): void;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Just some clarifications and improvements to the existing IUserSession interface docs.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
