### PR TITLE
fix(files): translate keyboard shortcuts section title

### DIFF
--- a/apps/files/src/components/FilesAppSettings/FilesAppSettingsShortcuts.vue
+++ b/apps/files/src/components/FilesAppSettings/FilesAppSettingsShortcuts.vue
@@ -8,7 +8,7 @@ import type { IHotkeyConfig } from '@nextcloud/files'
 
 import { getFileActions } from '@nextcloud/files'
 import { t } from '@nextcloud/l10n'
-import NcAppSettingsShortcutsSection from '@nextcloud/vue/components/NcAppSettingsShortcutsSection'
+import NcAppSettingsSection from '@nextcloud/vue/components/NcAppSettingsSection'
 import NcHotkey from '@nextcloud/vue/components/NcHotkey'
 import NcHotkeyList from '@nextcloud/vue/components/NcHotkeyList'
 
@@ -43,7 +43,10 @@ function hotkeyToString(hotkey: IHotkeyConfig): string {
 </script>
 
 <template>
-	<NcAppSettingsShortcutsSection>
+	<NcAppSettingsSection
+		id="keyboard-shortcuts"
+		:name="t('files', 'Keyboard shortcuts')"
+	>
 		<NcHotkeyList :label="t('files', 'Actions')">
 			<NcHotkey :label="t('files', 'File actions')" hotkey="A" />
 
@@ -74,5 +77,5 @@ function hotkeyToString(hotkey: IHotkeyConfig): string {
 			<NcHotkey :label="t('files', 'Open file sidebar')" hotkey="D" />
 			<NcHotkey :label="t('files', 'Show those shortcuts')" hotkey="?" />
 		</NcHotkeyList>
-	</NcAppSettingsShortcutsSection>
+	</NcAppSettingsSection>
 </template>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #57083

## Summary

Fixes an issue where the **Keyboard shortcuts** section title in the Files settings was always displayed in English, even when translations were available.  
The section title is now rendered using the Files app translation domain so existing localized strings are correctly applied.

## TODO

- [x] Ensure section title uses Files app translation domain
- [x] Verify UI manually with a non-English language

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version
