### PR TITLE
fix: allow `occ maintenance:update:htaccess` to create .htaccess file in case it doesn't exist yet

### DIFF
--- a/core/Command/Maintenance/UpdateHtaccess.php
+++ b/core/Command/Maintenance/UpdateHtaccess.php
@@ -24,7 +24,7 @@ class UpdateHtaccess extends Command {
 			$output->writeln('.htaccess has been updated');
 			return 0;
 		} else {
-			$output->writeln('<error>Error updating .htaccess file, not enough permissions, not enough free space or "overwrite.cli.url" set to an invalid URL?</error>');
+			$output->writeln('<error>Error updating (or creating) .htaccess file, not enough permissions, not enough free space or "overwrite.cli.url" set to an invalid URL?</error>');
 			return 1;
 		}
 	}

--- a/core/Command/Maintenance/UpdateHtaccess.php
+++ b/core/Command/Maintenance/UpdateHtaccess.php
@@ -29,7 +29,7 @@ class UpdateHtaccess extends Command {
 			$output->writeln('.htaccess has been updated');
 			return 0;
 		} else {
-			$output->writeln('<error>Error updating .htaccess file, not enough permissions, not enough free space or "overwrite.cli.url" set to an invalid URL?</error>');
+			$output->writeln('<error>Error updating (or creating) .htaccess file, not enough permissions, not enough free space or "overwrite.cli.url" set to an invalid URL?</error>');
 			return 1;
 		}
 	}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -556,6 +556,15 @@ class Setup {
 
 		$setupHelper = Server::get(\OC\Setup::class);
 
+		// Note: The .htaccess file also needs to exist, otherwise `is_writable()`
+		// will return false, even though the file could be written.
+		// This function writes the .htaccess file in that case.
+		if (!file_exists($setupHelper->pathToHtaccess())) {
+			if (!touch($setupHelper->pathToHtaccess())) {
+				return false;
+			}
+		}
+
 		if (!is_writable($setupHelper->pathToHtaccess())) {
 			return false;
 		}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -580,6 +580,15 @@ class Setup {
 
 		$setupHelper = Server::get(Setup::class);
 
+		// Note: The .htaccess file also needs to exist, otherwise `is_writable()`
+		// will return false, even though the file could be written.
+		// This function writes the .htaccess file in that case.
+		if (!file_exists($setupHelper->pathToHtaccess())) {
+			if (!touch($setupHelper->pathToHtaccess())) {
+				return false;
+			}
+		}
+
 		if (!is_writable($setupHelper->pathToHtaccess())) {
 			return false;
 		}


### PR DESCRIPTION
Currently, the `updateHtaccess()` function can't deal with a missing .htaccess file, it assumes at least an empty .htaccess file.

In some cases, the file may be missing though, and this PR adds functionality for creating it when this edgecase occurs.

Before this PR, executing `occ maintenance:update:htaccess` can fail without the error message being explicit about this edgecase.

* Resolves: # Many issues that complain about `occ maintenance:update:htaccess` not working.

## Summary

`occ maintenance:update:htaccess` can now also create .htaccess files, instead of relying on them being present.

## TODO

- Nothing I can think of

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
