### PR TITLE
fix: drop readable check

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -531,15 +531,6 @@ class Directory extends Node implements
 			throw new InvalidPath($ex->getMessage(), false, $ex);
 		}
 
-		// if not in a public share with no read permissions, throw Forbidden
-		if (!$allowDirectory && !$info->isReadable()) {
-			if (Server::get(IAppManager::class)->isEnabledForAnyone('files_accesscontrol')) {
-				throw new Forbidden('No read permissions. This might be caused by files_accesscontrol, check your configured rules');
-			}
-
-			throw new Forbidden('No read permissions');
-		}
-
 		if ($info->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
 			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info, $this->tree, $this->shareManager);
 		} else {

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -300,9 +300,6 @@ class DirectoryTest extends \Test\TestCase {
 			->method('getPath')
 			->willReturn('/admin/files/my/deep/folder/');
 		$pathNode->expects($this->once())
-			->method('isReadable')
-			->willReturn(true);
-		$pathNode->expects($this->once())
 			->method('getMimetype')
 			->willReturn(FileInfo::MIMETYPE_FOLDER);
 
@@ -353,9 +350,6 @@ class DirectoryTest extends \Test\TestCase {
 			->method('getPath')
 			->willReturn('/admin/files/my/deep/folder/');
 		$pathNode->expects($this->once())
-			->method('isReadable')
-			->willReturn(true);
-		$pathNode->expects($this->once())
 			->method('getMimetype')
 			->willReturn(FileInfo::MIMETYPE_FOLDER);
 
@@ -393,9 +387,15 @@ class DirectoryTest extends \Test\TestCase {
 			->method('instanceOfStorage')
 			->willReturn(false);
 
-		$directoryNode->expects($this->once())
+		$invokedCount = $this->exactly(2);
+		$directoryNode->expects($invokedCount)
 			->method('isReadable')
-			->willReturn(true);
+			->willReturnCallback(function () use ($invokedCount) {
+				return match ($invokedCount->numberOfInvocations()) {
+					1 => true,
+					2 => false,
+				};
+			});
 		$directoryNode->expects($this->once())
 			->method('getPath')
 			->willReturn('/admin/files/');
@@ -403,11 +403,7 @@ class DirectoryTest extends \Test\TestCase {
 			->method('get')
 			->willReturn($pathNode);
 
-		$pathNode->expects($this->once())
-			->method('isReadable')
-			->willReturn(false);
-
-		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
+		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$dir = new Directory($this->view, $directoryNode);
 		$dir->getNodeForPath('/my/deep/folder/');


### PR DESCRIPTION
This check was introduced in a previous PR, causing disruptive changes in PROPFIND responses in some cases.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
## Summary

In #54441 an issue was introduced causing API response differences in certain situations:

- 403 instead of 404 when PROPFINDing an blocked file inside a blocked path (via files_accesscontrol)
- 403 instead of 207 when PROPFINDing a blocked file via files_accesscontrol

## TODO

- [x] Revert https://github.com/nextcloud/files_accesscontrol/pull/837

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
