### PR TITLE
fix(NewUserDialog): update group selection to prevent admin group from being assigned as subadmin

### DIFF
--- a/apps/settings/src/components/Users/NewUserDialog.vue
+++ b/apps/settings/src/components/Users/NewUserDialog.vue
@@ -96,7 +96,7 @@
 					:input-label="t('settings', 'Admin of the following groups')"
 					:placeholder="t('settings', 'Set account as admin for …')"
 					:disabled="loading.groups || loading.all"
-					:options="availableGroups"
+					:options="availableSubAdminGroups"
 					keep-open
 					:multiple="true"
 					label="name"
@@ -229,6 +229,10 @@ export default {
 				: this.$store.getters.getSubAdminGroups
 
 			return groups.filter((group) => group.id !== '__nc_internal_recent' && group.id !== 'disabled')
+		},
+
+		availableSubAdminGroups() {
+			return this.availableGroups.filter(group => group.id !== 'admin')
 		},
 
 		languages() {


### PR DESCRIPTION

## Summary
This pull request makes a small but important adjustment to the new user dialog in the settings app. The main change is to exclude the `admin` group from the list of groups that can be assigned as sub-admin groups when creating a new user.

Group selection logic updates:

* Added a new computed property `availableSubAdminGroups` in `NewUserDialog.vue` that filters out the `admin` group from the available groups.
* Updated the group selection dropdown to use `availableSubAdminGroups` instead of `availableGroups`, preventing the `admin` group from being assigned as a sub-admin group.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
