### PR TITLE
refactor(core): improve readability and robustness of FeedBackHandler

### DIFF
--- a/core/Listener/FeedBackHandler.php
+++ b/core/Listener/FeedBackHandler.php
@@ -21,10 +21,14 @@ use OCP\EventDispatcher\Event;
 use OCP\IEventSource;
 use OCP\IL10N;
 
+/**
+ * Handles repair feedback events and sends localized progress, info, warnings,
+ * and error messages to the UI/event source during system repair operations.
+ */
 class FeedBackHandler {
-	private int $progressStateMax = 100;
-	private int $progressStateStep = 0;
-	private string $currentStep = '';
+	private int $totalSteps = 100;
+	private int $completedSteps = 0;
+	private string $currentStepName = '';
 
 	public function __construct(
 		private IEventSource $eventSource,
@@ -32,29 +36,75 @@ class FeedBackHandler {
 	) {
 	}
 
+	/**
+	 * Handles feedback events and dispatches localized messages.
+	 */
 	public function handleRepairFeedback(Event $event): void {
 		if ($event instanceof RepairStartEvent) {
-			$this->progressStateMax = $event->getMaxStep();
-			$this->progressStateStep = 0;
-			$this->currentStep = $event->getCurrentStepName();
+			$this->onStart($event);
 		} elseif ($event instanceof RepairAdvanceEvent) {
-			$this->progressStateStep += $event->getIncrement();
-			$desc = $event->getDescription();
-			if (empty($desc)) {
-				$desc = $this->currentStep;
-			}
-			$this->eventSource->send('success', $this->l10n->t('[%d / %d]: %s', [$this->progressStateStep, $this->progressStateMax, $desc]));
+			$this->onAdvance($event);
 		} elseif ($event instanceof RepairFinishEvent) {
-			$this->progressStateMax = $this->progressStateStep;
-			$this->eventSource->send('success', $this->l10n->t('[%d / %d]: %s', [$this->progressStateStep, $this->progressStateMax, $this->currentStep]));
+			$this->onFinish($event);
 		} elseif ($event instanceof RepairStepEvent) {
-			$this->eventSource->send('success', $this->l10n->t('Repair step:') . ' ' . $event->getStepName());
+			$this->onStep($event);
 		} elseif ($event instanceof RepairInfoEvent) {
-			$this->eventSource->send('success', $this->l10n->t('Repair info:') . ' ' . $event->getMessage());
+			$this->onInfo($event);
 		} elseif ($event instanceof RepairWarningEvent) {
-			$this->eventSource->send('notice', $this->l10n->t('Repair warning:') . ' ' . $event->getMessage());
+			$this->onWarning($event);
 		} elseif ($event instanceof RepairErrorEvent) {
-			$this->eventSource->send('error', $this->l10n->t('Repair error:') . ' ' . $event->getMessage());
+			$this->onError($event);
 		}
+		// TODO: handle unknown event types
+		// e.g., log or $this->eventSource->send('notice', $this->l10n->t('Unknown repair event type: %s', [get_class($event)]));
+
+	}
+
+	private function onStart(RepairStartEvent $event): void {
+		$this->totalSteps = $event->getMaxStep();
+		$this->completedSteps = 0;
+		$this->currentStepName = (string)$event->getCurrentStepName();
+	}
+
+	private function onAdvance(RepairAdvanceEvent $event): void {
+		$this->completedSteps += $event->getIncrement();
+		$description = trim((string)$event->getDescription()) ?: $this->currentStepName;
+		$message = $this->l10n->t(
+			'[%d / %d]: %s',
+			[$this->completedSteps, $this->totalSteps, $description]
+		);
+		$this->eventSource->send('success', (string)$message);
+	}
+
+	private function onFinish(RepairFinishEvent $event): void {
+		$message = $this->l10n->t(
+			'[%d / %d]: %s',
+			[$this->completedSteps, $this->totalSteps, $this->currentStepName]
+		);
+		$this->eventSource->send('success', (string)$message);
+	}
+
+	private function onStep(RepairStepEvent $event): void {
+		$stepName = trim((string)$event->getStepName());
+		$message = $this->l10n->t('Repair step:') . ' ' . $stepName;
+		$this->eventSource->send('success', (string)$message);
+	}
+
+	private function onInfo(RepairInfoEvent $event): void {
+		$info = trim((string)$event->getMessage());
+		$message = $this->l10n->t('Repair info:') . ' ' . $info;
+		$this->eventSource->send('success', (string)$message);
+	}
+
+	private function onWarning(RepairWarningEvent $event): void {
+		$warning = trim((string)$event->getMessage());
+		$message = $this->l10n->t('Repair warning:') . ' ' . $warning;
+		$this->eventSource->send('notice', (string)$message);
+	}
+
+	private function onError(RepairErrorEvent $event): void {
+		$error = trim((string)$event->getMessage());
+		$message = $this->l10n->t('Repair error:') . ' ' . $error;
+		$this->eventSource->send('error', (string)$message);
 	}
 }

--- a/core/Listener/FeedBackHandler.php
+++ b/core/Listener/FeedBackHandler.php
@@ -63,17 +63,17 @@ class FeedBackHandler {
 	private function onStart(RepairStartEvent $event): void {
 		$this->totalSteps = $event->getMaxStep();
 		$this->completedSteps = 0;
-		$this->currentStepName = (string)$event->getCurrentStepName();
+		$this->currentStepName = $event->getCurrentStepName();
 	}
 
 	private function onAdvance(RepairAdvanceEvent $event): void {
 		$this->completedSteps += $event->getIncrement();
-		$description = trim((string)$event->getDescription()) ?: $this->currentStepName;
+		$description = trim($event->getDescription()) ?: $this->currentStepName;
 		$message = $this->l10n->t(
 			'[%d / %d]: %s',
 			[$this->completedSteps, $this->totalSteps, $description]
 		);
-		$this->eventSource->send('success', (string)$message);
+		$this->eventSource->send('success', $message);
 	}
 
 	private function onFinish(RepairFinishEvent $event): void {
@@ -81,30 +81,30 @@ class FeedBackHandler {
 			'[%d / %d]: %s',
 			[$this->completedSteps, $this->totalSteps, $this->currentStepName]
 		);
-		$this->eventSource->send('success', (string)$message);
+		$this->eventSource->send('success', $message);
 	}
 
 	private function onStep(RepairStepEvent $event): void {
-		$stepName = trim((string)$event->getStepName());
+		$stepName = trim($event->getStepName());
 		$message = $this->l10n->t('Repair step:') . ' ' . $stepName;
-		$this->eventSource->send('success', (string)$message);
+		$this->eventSource->send('success', $message);
 	}
 
 	private function onInfo(RepairInfoEvent $event): void {
-		$info = trim((string)$event->getMessage());
+		$info = trim($event->getMessage());
 		$message = $this->l10n->t('Repair info:') . ' ' . $info;
-		$this->eventSource->send('success', (string)$message);
+		$this->eventSource->send('success', $message);
 	}
 
 	private function onWarning(RepairWarningEvent $event): void {
-		$warning = trim((string)$event->getMessage());
+		$warning = trim($event->getMessage());
 		$message = $this->l10n->t('Repair warning:') . ' ' . $warning;
-		$this->eventSource->send('notice', (string)$message);
+		$this->eventSource->send('notice', $message);
 	}
 
 	private function onError(RepairErrorEvent $event): void {
-		$error = trim((string)$event->getMessage());
+		$error = trim($event->getMessage());
 		$message = $this->l10n->t('Repair error:') . ' ' . $error;
-		$this->eventSource->send('error', (string)$message);
+		$this->eventSource->send('error', $message);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

* Fix/robustness: The progress reporting is now consistent: both advance/progress and finish messages use the same variable for total steps (there was a risk previously, albeit a small one, that the most recent would be reported as the total step denominator)
* Fix/robustness: Each message construction trims and safely defaults the description or message field so that empty values are handled gracefully.
* Readability: Each event type is now dispatched to a dedicated private handler method
* Readability: Variable names adjusted to make the intent of the variables much clearer
* Maintainability: More descriptive class-level and method comments help clarify intended use and logic.

Retains original behavior/business logic. Only potential user-facing output changes are the fix/robustness items noted above, which are only applicable in rare edge cases and are ultimately fixes for bugs.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
