### PR TITLE
fix: allow moving from of non-resharable to other share if the user has delete permissions

### DIFF
--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -262,6 +262,14 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 					return true;
 				}
 			}
+
+			// if the share recipient is allow to delete from the share, they are allowed to move the file out of the share
+			// the user moving the file out of the share to their home storage would give them share permissions and allow moving into the share
+			//
+			// since the 2-step move is allowed, we also allow both steps at once
+			if ($sourceNode->isDeletable()) {
+				return true;
+			}
 		}
 
 		throw new Forbidden('You cannot move a non-shareable node into a share');

--- a/build/integration/sharing_features/sharing-v1-part4.feature
+++ b/build/integration/sharing_features/sharing-v1-part4.feature
@@ -193,7 +193,7 @@ Scenario: Cannot copy files from share without share permission into other share
       | path        | share |
       | shareType   |     0 |
       | shareWith   | user1 |
-      | permissions |    15 |
+      | permissions |    7 |
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And User "user0" uploads file with content "test" to "/share/test.txt"
@@ -219,7 +219,7 @@ Scenario: Cannot move files from share without share permission into other share
       | path        | share |
       | shareType   |     0 |
       | shareWith   | user1 |
-      | permissions |    15 |
+      | permissions |    7 |
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And User "user0" uploads file with content "test" to "/share/test.txt"
@@ -235,6 +235,32 @@ Scenario: Cannot move files from share without share permission into other share
     When User "user1" moves file "/share/test.txt" to "/re-share/movetest.txt"
     Then the HTTP status code should be "403"
 
+	Scenario: Can move files from share without share permission but with delete permissions into other share
+		Given user "user0" exists
+		Given user "user1" exists
+		Given user "user2" exists
+		And As an "user0"
+		And user "user0" created a folder "/share"
+		When creating a share with
+			| path        | share |
+			| shareType   |     0 |
+			| shareWith   | user1 |
+			| permissions |    15 |
+		Then the HTTP status code should be "200"
+		And the OCS status code should be "100"
+		And User "user0" uploads file with content "test" to "/share/test.txt"
+		And As an "user1"
+		And user "user1" created a folder "/re-share"
+		When creating a share with
+			| path        | re-share |
+			| shareType   |        0 |
+			| shareWith   |    user2 |
+			| permissions |       31 |
+		Then the HTTP status code should be "200"
+		And the OCS status code should be "100"
+		When User "user1" moves file "/share/test.txt" to "/re-share/movetest.txt"
+		Then the HTTP status code should be "201"
+
 Scenario: Cannot move folder containing share without share permission into other share
     Given user "user0" exists
     Given user "user1" exists
@@ -245,7 +271,7 @@ Scenario: Cannot move folder containing share without share permission into othe
       | path        | share |
       | shareType   |     0 |
       | shareWith   | user1 |
-      | permissions |    15 |
+      | permissions |    7 |
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And User "user0" uploads file with content "test" to "/share/test.txt"


### PR DESCRIPTION
This adds another carve-out for the check added in https://github.com/nextcloud/server/pull/54801

Moving from a share with "read+delete" permissions to another share is blocked since https://github.com/nextcloud/server/pull/54801 since the recipient doesn't have share permissions.

However, it's possible for the recipient to move the file out of the share (since they have delete permissions) and then move it into a share afterwards.

Since the 2-step process is allowed, it makes sense to allow the user doing both steps in one step.