### PR TITLE
fix: add $forChildren parameter to IPartialMountProvider

### DIFF
--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -91,6 +91,7 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 	public function getUserMountsFromProviderByPath(
 		string $providerClass,
 		string $path,
+		bool $forChildren,
 		array $mountProviderArgs,
 	): array {
 		$provider = $this->providers[$providerClass] ?? null;
@@ -107,6 +108,7 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 		/** @var IPartialMountProvider $provider */
 		return $provider->getMountsForPath(
 			$path,
+			$forChildren,
 			$mountProviderArgs,
 			$this->loader,
 		);

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -486,6 +486,7 @@ class SetupManager {
 					$this->mountProviderCollection->getUserMountsFromProviderByPath(
 						$mountProvider,
 						$path,
+						false,
 						[$providerArgs]
 					)
 				);
@@ -573,6 +574,7 @@ class SetupManager {
 						= $this->mountProviderCollection->getUserMountsFromProviderByPath(
 							$providerClass,
 							$path,
+							true,
 							$providerArgs,
 						);
 				}

--- a/lib/public/Files/Config/IPartialMountProvider.php
+++ b/lib/public/Files/Config/IPartialMountProvider.php
@@ -30,6 +30,7 @@ interface IPartialMountProvider extends IMountProvider {
 	 * corresponding IMountPoint instances.
 	 *
 	 * @param string $path path for which the mounts are set up
+	 * @param bool $forChildren when true, only child mounts for path should be returned
 	 * @param IMountProviderArgs[] $mountProviderArgs
 	 * @param IStorageFactory $loader
 	 * @return array<string, IMountPoint> IMountPoint instances, indexed by
@@ -37,6 +38,7 @@ interface IPartialMountProvider extends IMountProvider {
 	 */
 	public function getMountsForPath(
 		string $path,
+		bool $forChildren,
 		array $mountProviderArgs,
 		IStorageFactory $loader,
 	): array;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Adds a $forChildren parameter to `IPartialMountProvider` so that providers have clear information about when they should load a single mount or all mounts in a path.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
