### PR TITLE
refactor(auth): Use $request->getCookie() instead of $_COOKIE 

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1191,10 +1191,10 @@ class OC {
 			return true;
 		}
 		if (
-			$request->getCookie('nc_username') !== null &&
-			$request->getCookie('nc_token') !== null &&
-			$request->getCookie('nc_session_id') !== null &&
-			$userSession->loginWithCookie(
+			$request->getCookie('nc_username') !== null
+			&& $request->getCookie('nc_token') !== null
+			&& $request->getCookie('nc_session_id') !== null
+			&& $userSession->loginWithCookie(
 				$request->getCookie('nc_username'),
 				$request->getCookie('nc_token'),
 				$request->getCookie('nc_session_id')

--- a/lib/base.php
+++ b/lib/base.php
@@ -1202,7 +1202,7 @@ class OC {
 		) {
 			return true;
 		}
-		if ($userSession->tryBasicAuthLogin($request, $throttler))) {
+		if ($userSession->tryBasicAuthLogin($request, $throttler)) {
 			return true;
 		}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -1190,15 +1190,14 @@ class OC {
 		if ($userSession->tryTokenLogin($request)) {
 			return true;
 		}
+		$username = $request->getCookie('nc_username');
+		$token = $request->getCookie('nc_token');
+		$sessionId = $request->getCookie('nc_session_id');
 		if (
-			$request->getCookie('nc_username') !== null
-			&& $request->getCookie('nc_token') !== null
-			&& $request->getCookie('nc_session_id') !== null
-			&& $userSession->loginWithCookie(
-				$request->getCookie('nc_username'),
-				$request->getCookie('nc_token'),
-				$request->getCookie('nc_session_id')
-			)
+			$username !== null
+			&& $token !== null
+			&& $sessionId !== null
+			&& $userSession->loginWithCookie($username, $token, $sessionId)
 		) {
 			return true;
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Just a minor/tiny refinement for readability, maintainability, and robustness.

- Use $request->getCookie() instead of $_COOKIE directly
- Assign dependencies to variables up front for readability.
- Note exceptions from each login method are possible and are not handled here / must be handled by callers.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
