### PR TITLE
feat(files_sharing): implement partial mount providers

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -14,7 +14,7 @@
 Turning the feature off removes shared files and folders on the server for all share recipients, and also on the sync clients and mobile apps. More information is available in the Nextcloud Documentation.
 
 	</description>
-	<version>1.25.1</version>
+	<version>1.25.2</version>
 	<licence>agpl</licence>
 	<author>Michael Gapczynski</author>
 	<author>Bjoern Schiessle</author>

--- a/apps/files_sharing/lib/External/MountProvider.php
+++ b/apps/files_sharing/lib/External/MountProvider.php
@@ -13,6 +13,7 @@ use OCA\Files_Sharing\External\Storage as ExternalShareStorage;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\Config\IMountProvider;
+use OCP\Files\Config\IPartialMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
@@ -21,7 +22,7 @@ use OCP\IUser;
 use OCP\Server;
 use OCP\Share\IShare;
 
-class MountProvider implements IMountProvider {
+class MountProvider implements IMountProvider, IPartialMountProvider {
 	public const STORAGE = ExternalShareStorage::class;
 
 	/**
@@ -67,6 +68,56 @@ class MountProvider implements IMountProvider {
 			$mounts[] = $this->getMount($user, $row, $loader);
 		}
 		$result->closeCursor();
+		return $mounts;
+	}
+
+	public function getMountsForPath(
+		string $setupPathHint,
+		bool $forChildren,
+		array $mountProviderArgs,
+		IStorageFactory $loader,
+	): array {
+		$user = $mountProviderArgs[0]->mountInfo->getUser();
+		$userId = $user->getUID();
+
+		if (!$forChildren) {
+			// override path with mount point when fetching without children
+			$setupPathHint = $mountProviderArgs[0]->mountInfo->getMountPoint();
+		}
+
+		// remove /uid/files as the target is stored without
+		$setupPathHint = \substr($setupPathHint, \strlen('/' . $userId . '/files'));
+		// remove trailing slash
+		$setupPathHint = \rtrim($setupPathHint, '/');
+
+		// make sure trailing slash is present when loading children
+		if ($forChildren || $setupPathHint === '') {
+			$setupPathHint .= '/';
+		}
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id', 'remote', 'share_token', 'password', 'mountpoint', 'owner')
+			->from('share_external')
+			->where($qb->expr()->eq('user', $qb->createNamedParameter($user->getUID())))
+			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(IShare::STATUS_ACCEPTED, IQueryBuilder::PARAM_INT)));
+
+		if ($forChildren) {
+			$qb->andWhere($qb->expr()->like('mountpoint', $qb->createNamedParameter($this->connection->escapeLikeParameter($setupPathHint) . '_%')));
+		} else {
+			$qb->andWhere($qb->expr()->eq('mountpoint', $qb->createNamedParameter($setupPathHint)));
+		}
+
+		$result = $qb->executeQuery();
+
+		$mounts = [];
+		while ($row = $result->fetchAssociative()) {
+			$row['manager'] = $this;
+			$row['token'] = $row['share_token'];
+			$mount = $this->getMount($user, $row, $loader);
+			$mounts[$mount->getMountPoint()] = $mount;
+		}
+		$result->closeCursor();
+
 		return $mounts;
 	}
 }

--- a/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
+++ b/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
@@ -85,6 +85,7 @@ class Version11300Date20201120141438 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['id']);
 			$table->addUniqueIndex(['user', 'mountpoint_hash'], 'sh_external_mp');
+			$table->addIndex(['user', 'mountpoint'], 'user_mountpoint_index', [], ['lengths' => [null, 128]]);
 		} else {
 			$table = $schema->getTable('share_external');
 			$remoteIdColumn = $table->getColumn('remote_id');

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -7,14 +7,17 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
-use OC\Memcache\NullCache;
 use OC\Share20\Share;
 use OCA\Files_Sharing\MountProvider;
 use OCA\Files_Sharing\SharedMount;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Config\ICachedMountInfo;
+use OCP\Files\Config\MountProviderArgs;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorageFactory;
+use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IUser;
@@ -35,6 +38,7 @@ class MountProviderTest extends \Test\TestCase {
 	protected IManager&MockObject $shareManager;
 	protected IStorageFactory&MockObject $loader;
 	protected LoggerInterface&MockObject $logger;
+	private ICache&MockObject $cache;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -45,9 +49,10 @@ class MountProviderTest extends \Test\TestCase {
 		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->cache = $this->createMock(ICache::class);
+		$this->cache->method('get')->willReturn(true);
 		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$cacheFactory->method('createLocal')
-			->willReturn(new NullCache());
+		$cacheFactory->method('createLocal')->willReturn($this->cache);
 		$mountManager = $this->createMock(IMountManager::class);
 
 		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger, $eventDispatcher, $cacheFactory, $mountManager);
@@ -355,7 +360,6 @@ class MountProviderTest extends \Test\TestCase {
 		$circleShares = [];
 		$roomShares = [];
 		$deckShares = [];
-		$scienceMeshShares = [];
 		$this->shareManager->expects($this->exactly(5))
 			->method('getSharedWith')
 			->willReturnMap([
@@ -383,6 +387,92 @@ class MountProviderTest extends \Test\TestCase {
 		$this->assertCount(count($expectedShares), $mounts);
 
 		foreach ($mounts as $index => $mount) {
+			$expectedShare = $expectedShares[$index];
+			$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mount);
+
+			// supershare
+			/** @var SharedMount $mount */
+			$share = $mount->getShare();
+
+			$this->assertEquals($expectedShare[0], $share->getId());
+			$this->assertEquals($expectedShare[1], $share->getNodeId());
+			$this->assertEquals($expectedShare[2], $share->getShareOwner());
+			$this->assertEquals($expectedShare[3], $share->getTarget());
+			$this->assertEquals($expectedShare[4], $share->getPermissions());
+			if ($expectedShare[5] === null) {
+				$this->assertNull($share->getAttributes());
+			} else {
+				$this->assertEquals($expectedShare[5], $share->getAttributes()->toArray());
+			}
+		}
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'mergeSharesDataProvider')]
+	public function testMergeSharesInGetMountsForPath(array $userShares, array $groupShares, array $expectedShares, bool $moveFails = false): void {
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$userManager = $this->createMock(IUserManager::class);
+
+		$userShares = array_map(function ($shareSpec) {
+			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4], $shareSpec[5]);
+		}, $userShares);
+		$groupShares = array_map(function ($shareSpec) {
+			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4], $shareSpec[5]);
+		}, $groupShares);
+
+		$this->user->expects($this->any())
+			->method('getUID')
+			->willReturn('user1');
+
+		// tests regarding circles are made in the app itself.
+		$circleShares = [];
+		$roomShares = [];
+		$deckShares = [];
+		$path = '/';
+
+		// no expected shares? then no calls are performed to providers
+		$expectedProviderCalls = \count($expectedShares) ? 5 : 0;
+		$this->shareManager->expects($this->exactly($expectedProviderCalls))
+			->method('getSharedWithByPath')
+			->willReturnMap([
+				['user1', IShare::TYPE_USER, $path, true, -1, 0, $userShares],
+				['user1', IShare::TYPE_GROUP, $path, true, -1, 0, $groupShares],
+				['user1', IShare::TYPE_CIRCLE, $path, true, -1, 0, $circleShares],
+				['user1', IShare::TYPE_ROOM, $path, true, -1, 0, $roomShares],
+				['user1', IShare::TYPE_DECK, $path, true, -1, 0, $deckShares],
+			]);
+
+		$this->shareManager->expects($this->any())
+			->method('newShare')
+			->willReturnCallback(function () use ($rootFolder, $userManager) {
+				return new Share($rootFolder, $userManager);
+			});
+
+		if ($moveFails) {
+			$this->shareManager->expects($this->any())
+				->method('moveShare')
+				->willThrowException(new \InvalidArgumentException());
+		}
+
+		$mountArgs = [];
+		foreach ($expectedShares as $share) {
+			$mountInfo = $this->createMock(ICachedMountInfo::class);
+			$mountInfo->method('getUser')->willReturn($this->user);
+			$mountInfo->method('getRootId')->willReturn($share[1]);
+			$rootCacheEntry = $this->createMock(ICacheEntry::class);
+			$mountArg = new MountProviderArgs($mountInfo, $rootCacheEntry);
+			$mountArgs[] = $mountArg;
+		}
+
+		if (count($mountArgs) === 0) {
+			$mounts = [];
+		} else {
+			$mounts = $this->provider->getMountsForPath('/', true, $mountArgs, $this->loader);
+		}
+
+
+		$this->assertCount(\count($expectedShares), $mounts);
+
+		foreach (array_values($mounts) as $index => $mount) {
 			$expectedShare = $expectedShares[$index];
 			$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mount);
 

--- a/core/Listener/AddMissingIndicesListener.php
+++ b/core/Listener/AddMissingIndicesListener.php
@@ -210,5 +210,19 @@ class AddMissingIndicesListener implements IEventListener {
 			'unique_category_per_user',
 			['uid', 'type', 'category']
 		);
+
+		$event->addMissingIndex(
+			'share',
+			'share_with_file_target_index',
+			['share_with', 'file_target'],
+			['lengths' => [null, 128]]
+		);
+
+		$event->addMissingIndex(
+			'share_external',
+			'user_mountpoint_index',
+			['user', 'mountpoint'],
+			['lengths' => [null, 128]]
+		);
 	}
 }

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -454,6 +454,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['file_source'], 'file_source_index');
 			$table->addIndex(['token'], 'token_index');
 			$table->addIndex(['share_with'], 'share_with_index');
+			$table->addIndex(['share_with', 'file_target'], 'share_with_file_target_index', [], ['lengths' => [null, 128]]);
 			$table->addIndex(['parent'], 'parent_index');
 			$table->addIndex(['uid_owner'], 'owner_index');
 			$table->addIndex(['uid_initiator'], 'initiator_index');

--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -111,6 +111,17 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 			);
 		}
 
+		$userId = null;
+		$user = null;
+		foreach ($mountProviderArgs as $mountProviderArg) {
+			if ($userId === null) {
+				$user = $mountProviderArg->mountInfo->getUser();
+				$userId = $user->getUID();
+			} elseif ($userId !== $mountProviderArg->mountInfo->getUser()->getUID()) {
+				throw new \LogicException('Mounts must belong to the same user!');
+			}
+		}
+
 		return $provider->getMountsForPath(
 			$path,
 			$forChildren,

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -507,8 +507,7 @@ class SetupManager {
 		$mountProvider = $cachedMount->getMountProvider();
 		$mountPoint = $cachedMount->getMountPoint();
 		$isMountProviderSetup = in_array($mountProvider, $setupProviders);
-		$isPathSetupAsAuthoritative
-			= $this->isPathSetup($mountPoint);
+		$isPathSetupAsAuthoritative = $this->isPathSetup($mountPoint);
 		if (!$isMountProviderSetup && !$isPathSetupAsAuthoritative) {
 			if ($mountProvider === '') {
 				$this->logger->debug('mount at ' . $cachedMount->getMountPoint() . ' has no provider set, performing full setup');
@@ -539,8 +538,7 @@ class SetupManager {
 			} else {
 				$currentProviders[] = $mountProvider;
 				$setupProviders[] = $mountProvider;
-				$fullProviderMounts[]
-					= $this->mountProviderCollection->getUserMountsForProviderClasses($user, [$mountProvider]);
+				$fullProviderMounts[] = $this->mountProviderCollection->getUserMountsForProviderClasses($user, [$mountProvider]);
 			}
 		}
 
@@ -721,6 +719,7 @@ class SetupManager {
 		$this->fullSetupRequired = [];
 		$this->rootSetup = false;
 		$this->mountManager->clear();
+		$this->userMountCache->clear();
 		$this->eventDispatcher->dispatchTyped(new FilesystemTornDownEvent());
 	}
 

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -964,12 +964,12 @@ class DefaultShareProvider implements
 
 				$groups = array_filter($groups);
 
-				$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
-					->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter(
+				$qb->andWhere($qb->expr()->eq('s.share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
+					->andWhere($qb->expr()->in('s.share_with', $qb->createNamedParameter(
 						$groups,
 						IQueryBuilder::PARAM_STR_ARRAY
 					)))
-					->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
+					->andWhere($qb->expr()->in('s.item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
 
 				$cursor = $qb->executeQuery();
 				while ($data = $cursor->fetch()) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1299,16 +1299,19 @@ class Manager implements IManager {
 			throw new \RuntimeException(\get_class($provider) . ' must implement IPartialShareProvider');
 		}
 
-		$shares = $provider->getSharedWithByPath($userId,
+		$shares = $provider->getSharedWithByPath(
+			$userId,
 			$shareType,
 			$path,
 			$forChildren,
 			$limit,
-			$offset
+			$offset,
 		);
 
 		if (\is_array($shares)) {
 			$shares = new ArrayIterator($shares);
+		} elseif (!$shares instanceof \Iterator) {
+			$shares = new \IteratorIterator($shares);
 		}
 
 		return new \CallbackFilterIterator($shares, function (IShare $share) {


### PR DESCRIPTION
## Summary

Implements `IPartialMountProvider` in `MountProvider` for external `files_sharing`.

This PR depends on:
- [x] #57289
- [x] #57286

Once this PR is merged, all providers that do not implement `IPartialShareProvider` will stop being called during the setup and shares will disappear. It is important this is merged after all share providers implement https://github.com/nextcloud/server/pull/57285
- [x] https://github.com/nextcloud/deck/pull/7501
- [x] https://github.com/nextcloud/circles/pull/2275
- [x] https://github.com/nextcloud/spreed/pull/16655

## TODO

- [x] Add tests
- [x] Add indexes for target on oc_share and oc_share_external