### PR TITLE
fix(installer): make isDownloaded robust + unify parameter naming

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -416,15 +416,16 @@ class Installer {
 	 * Check if app is already downloaded
 	 *
 	 * The function will check if the app is already downloaded in the apps repository
+	 * and has a valid appinfo/info.xml file.
+	 *
+	 * @return bool True if the app directory exists
 	 */
-	public function isDownloaded(string $name): bool {
+	public function isDownloaded(string $appId): bool {
 		foreach (\OC::$APPSROOTS as $dir) {
-			$dirToTest = $dir['path'];
-			$dirToTest .= '/';
-			$dirToTest .= $name;
-			$dirToTest .= '/';
+			$appPath = $dir['path'] . '/' .  $appId;
 
-			if (is_dir($dirToTest)) {
+			// An app is considered "downloaded" if the directory exists with info.xml
+			if (is_dir($appPath) && file_exists($appPath . '/appinfo/info.xml')) {
 				return true;
 			}
 		}
@@ -587,18 +588,22 @@ class Installer {
 	}
 
 	/**
-	 * install an app already placed in the app folder
+	 * Install an app already placed in the app folder
+	 *
+	 * @param string $appId The app ID to install
+	 * @param IOutput|null $output Optional output handler for logging installation progress
+	 * @return string|false App ID on success, false on failure
 	 */
-	public function installShippedApp(string $app, ?IOutput $output = null): string|false {
+	public function installShippedApp(string $appId, ?IOutput $output = null): string|false {
 		if ($output instanceof IOutput) {
-			$output->debug('Installing ' . $app);
+			$output->debug('Installing ' . $appId);
 		}
-		$info = $this->appManager->getAppInfo($app);
-		if (is_null($info) || $info['id'] !== $app) {
+		$info = $this->appManager->getAppInfo($appId);
+		if (is_null($info) || $info['id'] !== $appId) {
 			return false;
 		}
 
-		$appPath = $this->appManager->getAppPath($app);
+		$appPath = $this->appManager->getAppPath($appId);
 
 		return $this->installAppLastSteps($appPath, $info, $output, 'yes');
 	}

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -422,7 +422,7 @@ class Installer {
 	 */
 	public function isDownloaded(string $appId): bool {
 		foreach (\OC::$APPSROOTS as $dir) {
-			$appPath = $dir['path'] . '/' .  $appId;
+			$appPath = $dir['path'] . '/' . $appId;
 
 			// An app is considered "downloaded" if the directory exists with info.xml
 			if (is_dir($appPath) && file_exists($appPath . '/appinfo/info.xml')) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Related: #8505

## Summary

* Check for presence of `info.xml` in app folder, not just the presence of an app folder (which could be empty/incomplete/etc)
* Unify parameter names for the "appId" for all functions in the class

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
