### PR TITLE
refactor(admin_audit): improve type safety and clarity in Action logging

### DIFF
--- a/apps/admin_audit/tests/Actions/ActionTest.php
+++ b/apps/admin_audit/tests/Actions/ActionTest.php
@@ -1,0 +1,113 @@
+<?php
+// apps/admin_audit/tests/Actions/ActionTest.php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2016-2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\AdminAudit\Tests\Actions;
+
+use OCA\AdminAudit\Actions\Action;
+use OCA\AdminAudit\IAuditLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class ActionTest extends TestCase {
+    private IAuditLogger&MockObject $logger;
+    private Action $action;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->logger = $this->createMock(IAuditLogger:: class);
+        $this->action = new Action($this->logger);
+    }
+
+    public function testLogWithBooleanTrue(): void {
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Setting enabled: true', ['app' => 'admin_audit']);
+
+        $this->action->log(
+            'Setting enabled: %s',
+            ['enabled' => true],
+            ['enabled']
+        );
+    }
+
+    public function testLogWithBooleanFalse(): void {
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Setting enabled: false', ['app' => 'admin_audit']);
+
+        $this->action->log(
+            'Setting enabled: %s',
+            ['enabled' => false],
+            ['enabled']
+        );
+    }
+
+    public function testLogWithNull(): void {
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Value is: null', ['app' => 'admin_audit']);
+
+        $this->action->log(
+            'Value is: %s',
+            ['value' => null],
+            ['value']
+        );
+    }
+
+    public function testLogWithMissingKey(): void {
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->with(
+                'Required audit parameters missing: {missing_keys}',
+                $this->callback(function ($context) {
+                    return $context['app'] === 'admin_audit'
+                        && $context['missing_keys'] === ['missing_key']
+                        && isset($context['provided_keys']);
+                })
+            );
+
+        $this->action->log(
+            'Value: %s',
+            ['other_key' => 'value'],
+            ['missing_key']
+        );
+    }
+
+    public function testLogWithDateTimeValue(): void {
+        $date = new \DateTime('2026-01-02 15:30:45');
+        
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Date: 2026-01-02 15:30:45', ['app' => 'admin_audit']);
+
+        $this->action->log(
+            'Date: %s',
+            ['date' => $date],
+            ['date']
+        );
+    }
+
+    public function testLogWithFormatMismatch(): void {
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->with(
+                'Audit log format string mismatch: {error}',
+                $this->callback(function ($context) {
+                    return $context['app'] === 'admin_audit'
+                        && isset($context['error'])
+                        && $context['format'] === 'Too many:  %s %s %s';
+                })
+            );
+
+        $this->action->log(
+            'Too many: %s %s %s',
+            ['one' => '1', 'two' => '2'],
+            ['one', 'two']  // Only 2 values for 3 placeholders
+        );
+    }
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Changes:

* Improved type safety and robustness
* Enhanced error reporting
* Improved code clarity
* Better audit log output
* Unit tests for `Action`

The original implementation had several edge cases that could produce unclear audit logs:

* Boolean `false` values appeared as empty strings (invisible in logs)
* Null values were indistinguishable from empty strings
* Format string mismatches would crash rather than log the error
* Variable names (`$elements`, `$text`) didn't clearly convey their purpose
* Missing keys were reported one at a time rather than all at once

This refactoring makes the audit logging more defensive, maintainable, and produces clearer output for security auditing purposes.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
