### PR TITLE
refactor(Filesystem): delegate canonical normalization to PathHelper

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -645,6 +645,13 @@ class Filesystem {
 			$normalized = \rtrim($normalized, '/');
 		}
 
+		// Add a trailing slash only if requested (and not root), and ONLY if not already present
+		if ($normalized === '') {
+			$normalized = '/';
+		} elseif (!$stripTrailingSlash && substr($normalized, -1) !== '/') {
+			$normalized .= '/';
+		}
+
 		self::$normalizedPathCache[$cacheKey] = $normalized;
 		return $normalized;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

* Delegates canonical normalization to `PathHelper::normalizePath` to avoid duplicate implementations
* Adds parameter and return type hinting
* Adds some possible optimization via additional early return + dropping of no longer necessary `preg*` usage
* Updated docs

Shouldn't introduce a BC. Retains existing checks:

- Though null byte removal is added as a result of delegating to `PathHelper`.  I don't believe this is a BC, but noting.
- `PathHelper's` implementation doesn't normalize out single dot paths `/./`; I retained that here in Filesystem's implementation, but we may want to add it to the PathHelper implementation for consistency (we could remove it from this implementation here when we do so).



Couple notes:

- There are various `normalizePath()` implementations. Some of these unique ones may be valid/necessary, but an audit to make sure we're not either duplicating more logic or assuming checks that aren't actually there in some code paths would probably be a good idea.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
