### PR TITLE
refactor(LazyFolder): drop redundant normalizePath call in getFullPath

### DIFF
--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -17,29 +17,22 @@ use OCP\Files\NotPermittedException;
 use Override;
 
 /**
- * Class LazyFolder
+ * Folder implementation that defers instantiation of the underlying folder object until needed.
  *
- * This is a lazy wrapper around a folder. So only
- * once it is needed this will get initialized.
+ * Useful for optimizing performance and resource usage by loading folder data only on demand.
+ * Supports transparent delegation of most Folder interface methods.
  *
  * @package OC\Files\Node
  */
 class LazyFolder implements Folder {
-	/** @var \Closure(): Folder */
-	private \Closure $folderClosure;
 	protected ?Folder $folder = null;
-	protected IRootFolder $rootFolder;
-	protected array $data;
 
-	/**
-	 * @param IRootFolder $rootFolder
-	 * @param \Closure(): Folder $folderClosure
-	 * @param array $data
-	 */
-	public function __construct(IRootFolder $rootFolder, \Closure $folderClosure, array $data = []) {
-		$this->rootFolder = $rootFolder;
-		$this->folderClosure = $folderClosure;
-		$this->data = $data;
+	public function __construct(
+		protected readonly IRootFolder $rootFolder,
+		/** @var \Closure(): Folder */
+		private \Closure $folderClosure,
+		protected array $data = []
+	) {
 	}
 
 	protected function getRootFolder(): IRootFolder {
@@ -399,7 +392,6 @@ class LazyFolder implements Folder {
 	 */
 	public function getFullPath($path) {
 		if (isset($this->data['path'])) {
-			$path = PathHelper::normalizePath($path);
 			if (!Filesystem::isValidPath($path)) {
 				throw new NotPermittedException('Invalid path "' . $path . '"');
 			}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`isValidPath()` already calls `normalizePath()` internally.

* Drops unnecessary extra call to `PathHelper::normalizePath()` in `getFullPath()`
* Switches class to constructor property promotion
* Updates class docblock

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
