### PR TITLE
feat(files_sharing): Improve user experience when user attempts to download folder with non-downloadable files

### DIFF
--- a/apps/files/lib/Controller/ConversionApiController.php
+++ b/apps/files/lib/Controller/ConversionApiController.php
@@ -21,9 +21,7 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Conversion\IConversionManager;
-use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\File;
 use OCP\Files\GenericFileException;
 use OCP\Files\IRootFolder;
@@ -39,7 +37,6 @@ class ConversionApiController extends OCSController {
 		private IRootFolder $rootFolder,
 		private IL10N $l10n,
 		private ?string $userId,
-		private IEventDispatcher $eventDispatcher,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -68,13 +65,6 @@ class ConversionApiController extends OCSController {
 		// Also throw a 404 if the file is not readable to not leak information
 		if (!($file instanceof File) || $file->isReadable() === false) {
 			throw new OCSNotFoundException($this->l10n->t('The file cannot be found'));
-		}
-
-		$event = new BeforeDirectFileDownloadEvent($userFolder->getRelativePath($file->getPath()));
-		$this->eventDispatcher->dispatchTyped($event);
-
-		if ($event->isSuccessful() === false) {
-			throw new OCSForbiddenException('Permission denied to download file');
 		}
 
 		if ($destination !== null) {

--- a/apps/files/lib/Controller/ConversionApiController.php
+++ b/apps/files/lib/Controller/ConversionApiController.php
@@ -21,7 +21,9 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Conversion\IConversionManager;
+use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\File;
 use OCP\Files\GenericFileException;
 use OCP\Files\IRootFolder;
@@ -37,6 +39,7 @@ class ConversionApiController extends OCSController {
 		private IRootFolder $rootFolder,
 		private IL10N $l10n,
 		private ?string $userId,
+		private IEventDispatcher $eventDispatcher,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -65,6 +68,13 @@ class ConversionApiController extends OCSController {
 		// Also throw a 404 if the file is not readable to not leak information
 		if (!($file instanceof File) || $file->isReadable() === false) {
 			throw new OCSNotFoundException($this->l10n->t('The file cannot be found'));
+		}
+
+		$event = new BeforeDirectFileDownloadEvent($userFolder->getRelativePath($file->getPath()));
+		$this->eventDispatcher->dispatchTyped($event);
+
+		if ($event->isSuccessful() === false) {
+			throw new OCSForbiddenException('Permission denied to download file');
 		}
 
 		if ($destination !== null) {

--- a/apps/files_sharing/lib/ViewOnly.php
+++ b/apps/files_sharing/lib/ViewOnly.php
@@ -8,80 +8,15 @@
 
 namespace OCA\Files_Sharing;
 
-use OCP\Files\File;
-use OCP\Files\Folder;
 use OCP\Files\Node;
-use OCP\Files\NotFoundException;
 
 /**
  * Handles restricting for download of files
  */
 class ViewOnly {
-
-	public function __construct(
-		private Folder $userFolder,
-	) {
-	}
-
-	/**
-	 * @param string[] $pathsToCheck paths to check, relative to the user folder
-	 * @return bool
-	 */
-	public function check(array $pathsToCheck): bool {
-		// If any of elements cannot be downloaded, prevent whole download
-		foreach ($pathsToCheck as $file) {
-			try {
-				$info = $this->userFolder->get($file);
-				if ($info instanceof File) {
-					// access to filecache is expensive in the loop
-					if (!$this->checkFileInfo($info)) {
-						return false;
-					}
-				} elseif ($info instanceof Folder) {
-					// get directory content is rather cheap query
-					if (!$this->dirRecursiveCheck($info)) {
-						return false;
-					}
-				}
-			} catch (NotFoundException $e) {
-				continue;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * @param Folder $dirInfo
-	 * @return bool
-	 * @throws NotFoundException
-	 */
-	private function dirRecursiveCheck(Folder $dirInfo): bool {
-		if (!$this->checkFileInfo($dirInfo)) {
-			return false;
-		}
-		// If any of elements cannot be downloaded, prevent whole download
-		$files = $dirInfo->getDirectoryListing();
-		foreach ($files as $file) {
-			if ($file instanceof File) {
-				if (!$this->checkFileInfo($file)) {
-					return false;
-				}
-			} elseif ($file instanceof Folder) {
-				return $this->dirRecursiveCheck($file);
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * @param Node $fileInfo
-	 * @return bool
-	 * @throws NotFoundException
-	 */
-	private function checkFileInfo(Node $fileInfo): bool {
+	public function isNodeCanBeDownloaded(Node $node): bool {
 		// Restrict view-only to nodes which are shared
-		$storage = $fileInfo->getStorage();
+		$storage = $node->getStorage();
 		if (!$storage->instanceOfStorage(SharedStorage::class)) {
 			return true;
 		}

--- a/lib/public/Files/Events/BeforeZipCreatedEvent.php
+++ b/lib/public/Files/Events/BeforeZipCreatedEvent.php
@@ -11,6 +11,7 @@ namespace OCP\Files\Events;
 
 use OCP\EventDispatcher\Event;
 use OCP\Files\Folder;
+use OCP\Files\Node;
 
 /**
  * This event is triggered before a archive is created when a user requested
@@ -29,12 +30,15 @@ class BeforeZipCreatedEvent extends Event {
 	/**
 	 * @param string|Folder $directory Folder instance, or (deprecated) string path relative to user folder
 	 * @param list<string> $files
+	 * @param list<string> $files Selected files, empty for folder selection
+	 * @param list<Node> $nodes Recursively collected nodes
 	 * @since 25.0.0
 	 * @since 31.0.0 support `OCP\Files\Folder` as `$directory` parameter - passing a string is deprecated now
 	 */
 	public function __construct(
 		string|Folder $directory,
 		private array $files,
+		private array $nodes = [],
 	) {
 		parent::__construct();
 		if ($directory instanceof Folder) {
@@ -68,6 +72,20 @@ class BeforeZipCreatedEvent extends Event {
 	 */
 	public function getFiles(): array {
 		return $this->files;
+	}
+
+	/**
+	 * @return Node[]
+	 */
+	public function getNodes(): array {
+		return $this->nodes;
+	}
+
+	/**
+	 * @param Node[] $nodes
+	 */
+	public function setNodes(array $nodes): void {
+		$this->nodes = $nodes;
 	}
 
 	/**


### PR DESCRIPTION
This PR is continuation of the recently merged #57573. 

Current `master` branch requires to perform recursive iteration twice:
- 1st time when we check can node to be downloaded
- 2nd time when we actually populate zip archive

With this PR we recursively iterating only once as checks performed right before node added to archive.

But that's not all. Current `master` branch not allows download anything if downloaded folder contains at least 1 non-downloadable file. With this PR non-downloadable files are just excluded from the archive. At the same downloadable files added to it.

## TODO
- [x] Check more edge-cases (e.g. shared and own files located in nested folder)
- [ ] Actualize tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
