### PR TITLE
fix: adjust public page footer logic

### DIFF
--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -93,7 +93,7 @@ p($theme->getTitle());
 		<?php print_unescaped($_['content']); ?>
 	</div>
 
-	<?php if ((isset($template) && $template->getFooterVisible()) || $theme->getLongFooter() !== '' || $_['showSimpleSignUpLink']) { ?>
+	<?php if ((!isset($template) || $template->getFooterVisible() !== false) && ($theme->getLongFooter() !== '' || $_['showSimpleSignUpLink'])) { ?>
 	<footer class="guest-box">
 		<?php if ($theme->getLongFooter() !== '') { ?>
 		<p class="info">


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # https://github.com/nextcloud/server/pull/55415#issuecomment-3696597542

## Summary
- Adjusted Logic to respect getFooterVisible() - false

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
