### PR TITLE
fix(NavigationManager): Remove break to return all defaultEntryIds

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -474,7 +474,6 @@ class NavigationManager implements INavigationManager {
 		foreach ($storedIds as $id) {
 			if (in_array($id, $entryIds, true)) {
 				$ids[] = $id;
-				break;
 			}
 		}
 		return array_filter($ids);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #57356

## Summary
Remove break to return all defaultEntryIds in NavigationManager.
Otherwise, only the first entry id is returned, breaking loading the value for the "Global Default App" option

Before:
<img width="530" height="218" alt="Screenshot 2026-01-06 at 02 30 46" src="https://github.com/user-attachments/assets/247c03ec-f86c-419f-8ad3-2b8adb92852a" />
After:
<img width="538" height="250" alt="Screenshot 2026-01-06 at 02 30 54" src="https://github.com/user-attachments/assets/08915d58-c8eb-4e3d-a9de-ed5e46906a0c" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
