### PR TITLE
fix(trashbin): keep cache and db consistent

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -352,6 +352,8 @@ class Trashbin implements IEventListener {
 				$sizeDifference = $sourceInfo->getSize();
 				if ($sizeDifference < 0) {
 					$sizeDifference = null;
+				} else {
+					$sizeDifference = (int)$sizeDifference;
 				}
 				$trashStorage->getUpdater()->update($trashInternalPath, null, $sizeDifference);
 			}

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -306,15 +306,6 @@ class Trashbin implements IEventListener {
 		// there is still a possibility that the file has been deleted by a remote user
 		$deletedBy = self::overwriteDeletedBy($user);
 
-		$deleteTrashRow = static function () use ($owner, $filename, $timestamp): void {
-			$query = Server::get(IDBConnection::class)->getQueryBuilder();
-			$query->delete('files_trash')
-				->where($query->expr()->eq('user', $query->createNamedParameter($owner)))
-				->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
-				->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
-			$query->executeStatement();
-		};
-
 		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('files_trash')
 			->setValue('id', $query->createNamedParameter($filename))
@@ -398,7 +389,7 @@ class Trashbin implements IEventListener {
 					'timestamp' => $timestamp,
 				]
 			);
-			$deleteTrashRow();
+			self::deleteTrashRow($user, $filename, $timestamp);
 			if ($trashStorage->file_exists($trashInternalPath)) {
 				if ($trashStorage->is_dir($trashInternalPath)) {
 					$trashStorage->rmdir($trashInternalPath);
@@ -606,12 +597,7 @@ class Trashbin implements IEventListener {
 			self::restoreVersions($view, $file, $filename, $uniqueFilename, $location, $timestamp);
 
 			if ($timestamp) {
-				$query = Server::get(IDBConnection::class)->getQueryBuilder();
-				$query->delete('files_trash')
-					->where($query->expr()->eq('user', $query->createNamedParameter($user)))
-					->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
-					->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
-				$query->executeStatement();
+				self::deleteTrashRow($user, $filename, $timestamp);
 			}
 
 			return true;
@@ -761,12 +747,7 @@ class Trashbin implements IEventListener {
 			$node = $userRoot->get('/files_trashbin/files/' . $file);
 		} catch (NotFoundException $e) {
 			if ($timestamp) {
-				$query = Server::get(IDBConnection::class)->getQueryBuilder();
-				$query->delete('files_trash')
-					->where($query->expr()->eq('user', $query->createNamedParameter($user)))
-					->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
-					->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
-				$query->executeStatement();
+				self::deleteTrashRow($user, $filename, $timestamp);
 			}
 			return $size;
 		}
@@ -782,15 +763,19 @@ class Trashbin implements IEventListener {
 		self::emitTrashbinPostDelete('/files_trashbin/files/' . $file);
 
 		if ($timestamp) {
-			$query = Server::get(IDBConnection::class)->getQueryBuilder();
-			$query->delete('files_trash')
-				->where($query->expr()->eq('user', $query->createNamedParameter($user)))
-				->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
-				->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
-			$query->executeStatement();
+			self::deleteTrashRow($user, $filename, $timestamp);
 		}
 
 		return $size;
+	}
+
+	private static function deleteTrashRow(string $user, string $filename, int $timestamp): void {
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
+		$query->delete('files_trash')
+			->where($query->expr()->eq('user', $query->createNamedParameter($user)))
+			->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
+			->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
+		$query->executeStatement();
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -355,7 +355,7 @@ class Trashbin implements IEventListener {
 				}
 				$trashStorage->getUpdater()->update($trashInternalPath, null, $sizeDifference);
 			}
-		} catch (CopyRecursiveException $e) {
+		} catch (\Exception $e) {
 			$moveSuccessful = false;
 			if ($trashStorage->file_exists($trashInternalPath)) {
 				$trashStorage->unlink($trashInternalPath);

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -309,6 +309,8 @@ class Trashbin implements IEventListener {
 			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 			if ($inCache) {
 				$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
+			} else {
+				$trashStorage->getUpdater()->update($trashInternalPath);
 			}
 		} catch (CopyRecursiveException $e) {
 			$moveSuccessful = false;
@@ -345,18 +347,51 @@ class Trashbin implements IEventListener {
 				->setValue('location', $query->createNamedParameter($location))
 				->setValue('user', $query->createNamedParameter($owner))
 				->setValue('deleted_by', $query->createNamedParameter($deletedBy));
-			$result = $query->executeStatement();
-			if (!$result) {
-				Server::get(LoggerInterface::class)->error('trash bin database couldn\'t be updated', ['app' => 'files_trashbin']);
+			$inserted = false;
+			try {
+				$inserted = ($query->executeStatement() === 1);
+			} catch (\Throwable $e) {
+				Server::get(LoggerInterface::class)->error(
+					'trash bin database insert failed',
+					[
+						'app' => 'files_trashbin',
+						'exception' => $e,
+						'user' => $owner,
+						'filename' => $filename,
+						'timestamp' => $timestamp,
+					]
+				);
 			}
-			Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
-				'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))]);
+			if (!$inserted) {
+				Server::get(LoggerInterface::class)->error(
+					'trash bin database couldn\'t be updated, removing trash payload',
+					[
+						'app' => 'files_trashbin',
+						'user' => $owner,
+						'filename' => $filename,
+						'timestamp' => $timestamp,
+					]
+				);
+				if ($trashStorage->file_exists($trashInternalPath)) {
+					if ($trashStorage->is_dir($trashInternalPath)) {
+						$trashStorage->rmdir($trashInternalPath);
+					} else {
+						$trashStorage->unlink($trashInternalPath);
+					}
+				}
+				$trashStorage->getUpdater()->remove($trashInternalPath);
+				$moveSuccessful = false;
+			}
+			if ($inserted) {
+				Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
+					'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))]);
 
-			self::retainVersions($filename, $owner, $ownerPath, $timestamp);
+				self::retainVersions($filename, $owner, $ownerPath, $timestamp);
 
-			// if owner !== user we need to also add a copy to the users trash
-			if ($user !== $owner && $ownerOnly === false) {
-				self::copyFilesToUser($ownerPath, $owner, $file_path, $user, $timestamp);
+				// if owner !== user we need to also add a copy to the users trash
+				if ($user !== $owner && $ownerOnly === false) {
+					self::copyFilesToUser($ownerPath, $owner, $file_path, $user, $timestamp);
+				}
 			}
 		}
 
@@ -689,13 +724,6 @@ class Trashbin implements IEventListener {
 		$size = 0;
 
 		if ($timestamp) {
-			$query = Server::get(IDBConnection::class)->getQueryBuilder();
-			$query->delete('files_trash')
-				->where($query->expr()->eq('user', $query->createNamedParameter($user)))
-				->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
-				->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
-			$query->executeStatement();
-
 			$file = static::getTrashFilename($filename, $timestamp);
 		} else {
 			$file = $filename;
@@ -706,6 +734,14 @@ class Trashbin implements IEventListener {
 		try {
 			$node = $userRoot->get('/files_trashbin/files/' . $file);
 		} catch (NotFoundException $e) {
+			if ($timestamp) {
+				$query = Server::get(IDBConnection::class)->getQueryBuilder();
+				$query->delete('files_trash')
+					->where($query->expr()->eq('user', $query->createNamedParameter($user)))
+					->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
+					->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
+				$query->executeStatement();
+			}
 			return $size;
 		}
 
@@ -718,6 +754,15 @@ class Trashbin implements IEventListener {
 		self::emitTrashbinPreDelete('/files_trashbin/files/' . $file);
 		$node->delete();
 		self::emitTrashbinPostDelete('/files_trashbin/files/' . $file);
+
+		if ($timestamp) {
+			$query = Server::get(IDBConnection::class)->getQueryBuilder();
+			$query->delete('files_trash')
+				->where($query->expr()->eq('user', $query->createNamedParameter($user)))
+				->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
+				->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
+			$query->executeStatement();
+		}
 
 		return $size;
 	}

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -358,7 +358,11 @@ class Trashbin implements IEventListener {
 			if ($inCache) {
 				$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 			} else {
-				$trashStorage->getUpdater()->update($trashInternalPath);
+				$sizeDifference = $sourceInfo->getSize();
+				if ($sizeDifference < 0) {
+					$sizeDifference = null;
+				}
+				$trashStorage->getUpdater()->update($trashInternalPath, null, $sizeDifference);
 			}
 		} catch (CopyRecursiveException $e) {
 			$moveSuccessful = false;

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -299,12 +299,60 @@ class Trashbin implements IEventListener {
 
 		$configuredTrashbinSize = static::getConfiguredTrashbinSize($owner);
 		if ($configuredTrashbinSize >= 0 && $sourceInfo->getSize() >= $configuredTrashbinSize) {
+			$trashStorage->releaseLock($trashInternalPath, ILockingProvider::LOCK_EXCLUSIVE, $lockingProvider);
 			return false;
 		}
 
-		try {
-			$moveSuccessful = true;
+		// there is still a possibility that the file has been deleted by a remote user
+		$deletedBy = self::overwriteDeletedBy($user);
 
+		$deleteTrashRow = static function () use ($owner, $filename, $timestamp): void {
+			$query = Server::get(IDBConnection::class)->getQueryBuilder();
+			$query->delete('files_trash')
+				->where($query->expr()->eq('user', $query->createNamedParameter($owner)))
+				->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
+				->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
+			$query->executeStatement();
+		};
+
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
+		$query->insert('files_trash')
+			->setValue('id', $query->createNamedParameter($filename))
+			->setValue('timestamp', $query->createNamedParameter($timestamp))
+			->setValue('location', $query->createNamedParameter($location))
+			->setValue('user', $query->createNamedParameter($owner))
+			->setValue('deleted_by', $query->createNamedParameter($deletedBy));
+		$inserted = false;
+		try {
+			$inserted = ($query->executeStatement() === 1);
+		} catch (\Throwable $e) {
+			Server::get(LoggerInterface::class)->error(
+				'trash bin database insert failed',
+				[
+					'app' => 'files_trashbin',
+					'exception' => $e,
+					'user' => $owner,
+					'filename' => $filename,
+					'timestamp' => $timestamp,
+				]
+			);
+		}
+		if (!$inserted) {
+			Server::get(LoggerInterface::class)->error(
+				'trash bin database couldn\'t be updated, skipping trash move',
+				[
+					'app' => 'files_trashbin',
+					'user' => $owner,
+					'filename' => $filename,
+					'timestamp' => $timestamp,
+				]
+			);
+			$trashStorage->releaseLock($trashInternalPath, ILockingProvider::LOCK_EXCLUSIVE, $lockingProvider);
+			return false;
+		}
+
+		$moveSuccessful = true;
+		try {
 			$inCache = $sourceStorage->getCache()->inCache($sourceInternalPath);
 			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 			if ($inCache) {
@@ -333,65 +381,39 @@ class Trashbin implements IEventListener {
 			} else {
 				$trashStorage->getUpdater()->remove($trashInternalPath);
 			}
-			return false;
+			$moveSuccessful = false;
+		}
+
+		if (!$moveSuccessful) {
+			Server::get(LoggerInterface::class)->error(
+				'trash move failed, removing trash metadata and payload',
+				[
+					'app' => 'files_trashbin',
+					'user' => $owner,
+					'filename' => $filename,
+					'timestamp' => $timestamp,
+				]
+			);
+			$deleteTrashRow();
+			if ($trashStorage->file_exists($trashInternalPath)) {
+				if ($trashStorage->is_dir($trashInternalPath)) {
+					$trashStorage->rmdir($trashInternalPath);
+				} else {
+					$trashStorage->unlink($trashInternalPath);
+				}
+			}
+			$trashStorage->getUpdater()->remove($trashInternalPath);
 		}
 
 		if ($moveSuccessful) {
-			// there is still a possibility that the file has been deleted by a remote user
-			$deletedBy = self::overwriteDeletedBy($user);
+			Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
+				'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))]);
 
-			$query = Server::get(IDBConnection::class)->getQueryBuilder();
-			$query->insert('files_trash')
-				->setValue('id', $query->createNamedParameter($filename))
-				->setValue('timestamp', $query->createNamedParameter($timestamp))
-				->setValue('location', $query->createNamedParameter($location))
-				->setValue('user', $query->createNamedParameter($owner))
-				->setValue('deleted_by', $query->createNamedParameter($deletedBy));
-			$inserted = false;
-			try {
-				$inserted = ($query->executeStatement() === 1);
-			} catch (\Throwable $e) {
-				Server::get(LoggerInterface::class)->error(
-					'trash bin database insert failed',
-					[
-						'app' => 'files_trashbin',
-						'exception' => $e,
-						'user' => $owner,
-						'filename' => $filename,
-						'timestamp' => $timestamp,
-					]
-				);
-			}
-			if (!$inserted) {
-				Server::get(LoggerInterface::class)->error(
-					'trash bin database couldn\'t be updated, removing trash payload',
-					[
-						'app' => 'files_trashbin',
-						'user' => $owner,
-						'filename' => $filename,
-						'timestamp' => $timestamp,
-					]
-				);
-				if ($trashStorage->file_exists($trashInternalPath)) {
-					if ($trashStorage->is_dir($trashInternalPath)) {
-						$trashStorage->rmdir($trashInternalPath);
-					} else {
-						$trashStorage->unlink($trashInternalPath);
-					}
-				}
-				$trashStorage->getUpdater()->remove($trashInternalPath);
-				$moveSuccessful = false;
-			}
-			if ($inserted) {
-				Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
-					'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))]);
+			self::retainVersions($filename, $owner, $ownerPath, $timestamp);
 
-				self::retainVersions($filename, $owner, $ownerPath, $timestamp);
-
-				// if owner !== user we need to also add a copy to the users trash
-				if ($user !== $owner && $ownerOnly === false) {
-					self::copyFilesToUser($ownerPath, $owner, $file_path, $user, $timestamp);
-				}
+			// if owner !== user we need to also add a copy to the users trash
+			if ($user !== $owner && $ownerOnly === false) {
+				self::copyFilesToUser($ownerPath, $owner, $file_path, $user, $timestamp);
 			}
 		}
 

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -6,16 +6,20 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Files_Trashbin\Tests;
 
+use OC\Files\Cache\Updater;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Common;
+use OC\Files\Storage\Local;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Events\MoveToTrashEvent;
 use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashManager;
+use OCA\Files_Trashbin\Trashbin;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
@@ -135,6 +139,62 @@ class StorageTest extends \Test\TestCase {
 
 		[$trashStorage, $trashInternalPath] = $this->rootView->resolvePath('/' . $this->user . '/files_trashbin/files/' . $name);
 		$this->assertTrue($trashStorage->getCache()->inCache($trashInternalPath));
+	}
+
+	public function testTrashEntryNotCreatedWhenDeleteFailed(): void {
+		$storage2 = $this->getMockBuilder(Temporary::class)
+			->setConstructorArgs([])
+			->onlyMethods(['unlink', 'instanceOfStorage'])
+			->getMock();
+		$storage2->method('unlink')
+			->willReturn(false);
+
+		// disable same-storage move optimization
+		$storage2->method('instanceOfStorage')
+			->willReturnCallback(fn (string $class) => ($class !== Local::class) && (new Temporary([]))->instanceOfStorage($class));
+
+
+		Filesystem::mount($storage2, [], $this->user . '/files/substorage');
+		$this->userView->file_put_contents('substorage/test.txt', 'foo');
+
+		$this->assertFalse($this->userView->unlink('substorage/test.txt'));
+
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files/');
+		$this->assertEmpty($results);
+
+		$trashData = Trashbin::getExtraData($this->user);
+		$this->assertEmpty($trashData);
+	}
+
+	public function testTrashEntryNotCreatedWhenCacheRowFailed(): void {
+		$trashStorage = $this->getMockBuilder(Temporary::class)
+			->setConstructorArgs([])
+			->onlyMethods(['getUpdater'])
+			->getMock();
+		$updater = $this->getMockBuilder(Updater::class)
+			->setConstructorArgs([$trashStorage])
+			->onlyMethods(['renameFromStorage'])
+			->getMock();
+		$trashStorage->method('getUpdater')
+			->willReturn($updater);
+		$updater->method('renameFromStorage')
+			->willThrowException(new \Exception());
+
+		Filesystem::mount($trashStorage, [], $this->user . '/files_trashbin');
+		$this->userView->file_put_contents('test.txt', 'foo');
+
+		try {
+			$this->assertFalse($this->userView->unlink('test.txt'));
+			$this->fail();
+		} catch (\Exception) {
+			// expected
+		}
+
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files/');
+		$this->assertEmpty($results);
+
+		$trashData = Trashbin::getExtraData($this->user);
+		$this->assertEmpty($trashData);
 	}
 
 	/**

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -11,6 +11,7 @@ namespace OCA\Files_Trashbin\Tests;
 
 use OC\Files\Cache\Updater;
 use OC\Files\Filesystem;
+use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\Common;
 use OC\Files\Storage\Local;
 use OC\Files\Storage\Temporary;
@@ -126,6 +127,9 @@ class StorageTest extends \Test\TestCase {
 		$this->userView->file_put_contents('uncached.txt', 'foo');
 
 		[$storage, $internalPath] = $this->userView->resolvePath('uncached.txt');
+		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
+			$this->markTestSkipped('object store always has the file in cache');
+		}
 		$cache = $storage->getCache();
 		$cache->remove($internalPath);
 		$this->assertFalse($cache->inCache($internalPath));


### PR DESCRIPTION
## Summary
- insert files_trash row before payload move and remove it (and payload/cache) on move failure
- update trash cache for uncached sources using size delta to avoid full folder scan
- delete files_trash row after payload delete
- add regression test for uncached delete

## Testing
- not run (phpunit bootstrap requires installed instance)

Fixes #56493