### PR TITLE
refactor(psalm): Enable psalm for comments unit tests

### DIFF
--- a/apps/webhook_listeners/lib/Service/TokenService.php
+++ b/apps/webhook_listeners/lib/Service/TokenService.php
@@ -65,7 +65,11 @@ class TokenService {
 	 *
 	 * @param WebhookListener $webhookListener
 	 * @param ?string $triggerUserId the user that triggered the webhook call
-	 * @return array{user_ids?:array<string,string>,user_roles?:array{owner?:array<string,string>,trigger?:array<string,string>}}
+	 * @return array{
+	 *     user_ids?: array<string, array{baseUrl: string, token: string, userId: mixed}>,
+	 *     trigger?: array{baseUrl: string, token: string, userId: string},
+	 *     owner?: array{baseUrl: string, token: string, userId: string},
+	 * }
 	 */
 	public function getTokens(WebhookListener $webhookListener, ?string $triggerUserId): array {
 		$tokens = [];

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4306,4 +4306,13 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="tests/lib/TestCase.php">
+    <DeprecatedMethod>
+      <code><![CDATA[$container]]></code>
+    </DeprecatedMethod>
+    <InternalMethod>
+      <code><![CDATA[lockFile]]></code>
+      <code><![CDATA[unlockFile]]></code>
+    </InternalMethod>
+  </file>
 </files>

--- a/lib/private/OpenMetrics/Exporters/FilesByType.php
+++ b/lib/private/OpenMetrics/Exporters/FilesByType.php
@@ -72,7 +72,7 @@ class FilesByType extends Cached {
 		foreach ($metrics->iterateAssociative() as $count) {
 			yield new Metric(
 				$count['count'],
-				['mimetype' => $this->mimetypeLoader->getMimetypeById($count['mimetype'])],
+				['mimetype' => $this->mimetypeLoader->getMimetypeById($count['mimetype']) ?? ''],
 				$now,
 			);
 		}

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -438,6 +438,7 @@ interface ICommentsManager {
 	 * to consumers of the comments infrastructure
 	 *
 	 * @param \Closure $closure
+	 * @return void
 	 * @since 11.0.0
 	 */
 	public function registerEventHandler(\Closure $closure);
@@ -447,6 +448,7 @@ interface ICommentsManager {
 	 *
 	 * @param string $type
 	 * @param \Closure $closure
+	 * @return void
 	 * @throws \OutOfBoundsException
 	 * @since 11.0.0
 	 *

--- a/psalm.xml
+++ b/psalm.xml
@@ -54,6 +54,7 @@
 		<directory name="core"/>
 		<directory name="lib"/>
 		<directory name="ocs"/>
+		<directory name="tests/lib/Comments"/>
 		<directory name="ocs-provider"/>
 		<file name="cron.php"/>
 		<file name="index.php"/>
@@ -61,6 +62,7 @@
 		<file name="remote.php"/>
 		<file name="status.php"/>
 		<file name="version.php"/>
+		<file name="tests/lib/TestCase.php"/>
 		<ignoreFiles>
 			<directory name="apps/**/composer"/>
 			<directory name="apps/**/tests"/>
@@ -71,6 +73,7 @@
 	</projectFiles>
 	<extraFiles>
 		<directory name="3rdparty"/>
+		<directory name="vendor-bin/phpunit/vendor/phpunit"/>
 	</extraFiles>
 	<stubs>
 		<file name="build/stubs/apcu.php"/>

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -11,6 +11,7 @@ use OC\Comments\Comment;
 use OCP\Comments\IComment;
 use OCP\Comments\IllegalIDChangeException;
 use OCP\Comments\MessageTooLongException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\TestCase;
 
 class CommentTest extends TestCase {
@@ -96,7 +97,7 @@ class CommentTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('simpleSetterProvider')]
+	#[DataProvider(methodName: 'simpleSetterProvider')]
 	public function testSimpleSetterInvalidInput($field, $input): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -119,7 +120,7 @@ class CommentTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('roleSetterProvider')]
+	#[DataProvider(methodName: 'roleSetterProvider')]
 	public function testSetRoleInvalidInput($role, $type, $id): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -204,13 +205,7 @@ class CommentTest extends TestCase {
 		];
 	}
 
-	/**
-	 *
-	 * @param string $message
-	 * @param array $expectedMentions
-	 * @param ?string $author
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('mentionsProvider')]
+	#[DataProvider(methodName: 'mentionsProvider')]
 	public function testMentions(string $message, array $expectedMentions, ?string $author = null): void {
 		$comment = new Comment();
 		$comment->setMessage($message);

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -16,10 +16,12 @@ use OCP\IUser;
  * Class FakeManager
  */
 class FakeManager implements ICommentsManager {
-	public function get($id) {
+	public function get($id): IComment {
+		throw new \Exception('Not implemented');
 	}
 
-	public function getTree($id, $limit = 0, $offset = 0) {
+	public function getTree($id, $limit = 0, $offset = 0): array {
+		return ['comment' => new Comment(), 'replies' => []];
 	}
 
 	public function getForObject(
@@ -28,7 +30,8 @@ class FakeManager implements ICommentsManager {
 		$limit = 0,
 		$offset = 0,
 		?\DateTime $notOlderThan = null,
-	) {
+	): array {
+		return [];
 	}
 
 	public function getForObjectSince(
@@ -57,6 +60,7 @@ class FakeManager implements ICommentsManager {
 	}
 
 	public function getNumberOfCommentsForObject($objectType, $objectId, ?\DateTime $notOlderThan = null, $verb = ''): int {
+		return 0;
 	}
 
 	public function getNumberOfCommentsForObjects(string $objectType, array $objectIds, ?\DateTime $notOlderThan = null, string $verb = ''): array {
@@ -67,10 +71,12 @@ class FakeManager implements ICommentsManager {
 		return [];
 	}
 
-	public function create($actorType, $actorId, $objectType, $objectId) {
+	public function create($actorType, $actorId, $objectType, $objectId): IComment {
+		return new Comment();
 	}
 
-	public function delete($id) {
+	public function delete($id): bool {
+		return false;
 	}
 
 	public function getReactionComment(int $parentId, string $actorType, string $actorId, string $reaction): IComment {
@@ -89,45 +95,50 @@ class FakeManager implements ICommentsManager {
 		return false;
 	}
 
-	public function save(IComment $comment) {
+	public function save(IComment $comment): bool {
+		return false;
 	}
 
-	public function deleteReferencesOfActor($actorType, $actorId) {
+	public function deleteReferencesOfActor($actorType, $actorId): bool {
+		return false;
 	}
 
-	public function deleteCommentsAtObject($objectType, $objectId) {
+	public function deleteCommentsAtObject($objectType, $objectId): bool {
+		return false;
 	}
 
-	public function setReadMark($objectType, $objectId, \DateTime $dateTime, IUser $user) {
+	public function setReadMark($objectType, $objectId, \DateTime $dateTime, IUser $user): bool {
+		return false;
 	}
 
-	public function getReadMark($objectType, $objectId, IUser $user) {
+	public function getReadMark($objectType, $objectId, IUser $user): bool {
+		return false;
 	}
 
-	public function deleteReadMarksFromUser(IUser $user) {
+	public function deleteReadMarksFromUser(IUser $user): bool {
+		return false;
 	}
 
-	public function deleteReadMarksOnObject($objectType, $objectId) {
+	public function deleteReadMarksOnObject($objectType, $objectId): bool {
+		return false;
 	}
 
-	public function registerEventHandler(\Closure $closure) {
+	public function registerEventHandler(\Closure $closure): void {
 	}
 
-	public function registerDisplayNameResolver($type, \Closure $closure) {
+	public function registerDisplayNameResolver($type, \Closure $closure): void {
 	}
 
-	public function resolveDisplayName($type, $id) {
+	public function resolveDisplayName($type, $id): string {
+		return '';
 	}
 
-	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user) {
+	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user): array {
+		return [];
 	}
 
 	public function getNumberOfUnreadCommentsForObjects(string $objectType, array $objectIds, IUser $user, $verb = ''): array {
 		return [];
-	}
-
-
-	public function getActorsInTree($id) {
 	}
 
 	public function load(): void {

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -8,8 +8,6 @@
 
 namespace Test;
 
-use DOMDocument;
-use DOMNode;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\Command\QueueBus;
 use OC\Files\AppData\Factory;
@@ -23,15 +21,12 @@ use OC\Files\ObjectStore\PrimaryObjectStoreConfig;
 use OC\Files\SetupManager;
 use OC\Files\View;
 use OC\Installer;
-use OC\Template\Base;
 use OC\Updater;
-use OCP\AppFramework\QueryException;
 use OCP\Command\IBus;
 use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\Defaults;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
-use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Lock\ILockingProvider;
@@ -39,69 +34,39 @@ use OCP\Lock\LockedException;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
 use PHPUnit\Framework\Attributes\Group;
-
-if (version_compare(\PHPUnit\Runner\Version::id(), 10, '>=')) {
-	trait OnNotSuccessfulTestTrait {
-		protected function onNotSuccessfulTest(\Throwable $t): never {
-			$this->restoreAllServices();
-
-			// restore database connection
-			if (!$this->IsDatabaseAccessAllowed()) {
-				\OC::$server->registerService(IDBConnection::class, function () {
-					return self::$realDatabase;
-				});
-			}
-
-			parent::onNotSuccessfulTest($t);
-		}
-	}
-} else {
-	trait OnNotSuccessfulTestTrait {
-		protected function onNotSuccessfulTest(\Throwable $t): void {
-			$this->restoreAllServices();
-
-			// restore database connection
-			if (!$this->IsDatabaseAccessAllowed()) {
-				\OC::$server->registerService(IDBConnection::class, function () {
-					return self::$realDatabase;
-				});
-			}
-
-			parent::onNotSuccessfulTest($t);
-		}
-	}
-}
+use Psr\Container\ContainerExceptionInterface;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase {
-	/** @var \OC\Command\QueueBus */
-	private $commandBus;
+	private QueueBus $commandBus;
 
-	/** @var IDBConnection */
-	protected static $realDatabase = null;
+	protected static ?IDBConnection $realDatabase = null;
+	private static bool $wasDatabaseAllowed = false;
+	protected array $services = [];
 
-	/** @var bool */
-	private static $wasDatabaseAllowed = false;
+	protected function onNotSuccessfulTest(\Throwable $t): never {
+		$this->restoreAllServices();
 
-	/** @var array */
-	protected $services = [];
+		// restore database connection
+		if (!$this->IsDatabaseAccessAllowed()) {
+			\OC::$server->registerService(IDBConnection::class, function () {
+				return self::$realDatabase;
+			});
+		}
 
-	use OnNotSuccessfulTestTrait;
+		parent::onNotSuccessfulTest($t);
+	}
 
-	/**
-	 * @param string $name
-	 * @param mixed $newService
-	 * @return bool
-	 */
-	public function overwriteService(string $name, $newService): bool {
+	public function overwriteService(string $name, mixed $newService): bool {
 		if (isset($this->services[$name])) {
 			return false;
 		}
 
 		try {
 			$this->services[$name] = Server::get($name);
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface $e) {
 			$this->services[$name] = false;
 		}
+		/** @psalm-suppress InternalMethod */
 		$container = \OC::$server->getAppContainerForService($name);
 		$container = $container ?? \OC::$server;
 
@@ -112,14 +77,11 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		return true;
 	}
 
-	/**
-	 * @param string $name
-	 * @return bool
-	 */
 	public function restoreService(string $name): bool {
 		if (isset($this->services[$name])) {
 			$oldService = $this->services[$name];
 
+			/** @psalm-suppress InternalMethod */
 			$container = \OC::$server->getAppContainerForService($name);
 			$container = $container ?? \OC::$server;
 
@@ -139,17 +101,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		return false;
 	}
 
-	public function restoreAllServices() {
-		if (!empty($this->services)) {
-			if (!empty($this->services)) {
-				foreach ($this->services as $name => $service) {
-					$this->restoreService($name);
-				}
-			}
+	public function restoreAllServices(): void {
+		foreach ($this->services as $name => $service) {
+			$this->restoreService($name);
 		}
 	}
 
-	protected function getTestTraits() {
+	protected function getTestTraits(): array {
 		$traits = [];
 		$class = $this;
 		do {
@@ -177,6 +135,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 			if (is_null(self::$realDatabase)) {
 				self::$realDatabase = Server::get(IDBConnection::class);
 			}
+			/** @psalm-suppress InternalMethod */
 			\OC::$server->registerService(IDBConnection::class, function (): void {
 				$this->fail('Your test case is not allowed to access the database.');
 			});
@@ -196,6 +155,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 		// restore database connection
 		if (!$this->IsDatabaseAccessAllowed()) {
+			/** @psalm-suppress InternalMethod */
 			\OC::$server->registerService(IDBConnection::class, function () {
 				return self::$realDatabase;
 			});
@@ -337,9 +297,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		self::tearDownAfterClassCleanStrayLocks();
 
 		// Ensure we start with fresh instances of some classes to reduce side-effects between tests
+		/** @psalm-suppress DeprecatedMethod */
 		unset(\OC::$server[Factory::class]);
+		/** @psalm-suppress DeprecatedMethod */
 		unset(\OC::$server[AppFetcher::class]);
+		/** @psalm-suppress DeprecatedMethod */
 		unset(\OC::$server[Installer::class]);
+		/** @psalm-suppress DeprecatedMethod */
 		unset(\OC::$server[Updater::class]);
 
 		/** @var SetupManager $setupManager */
@@ -364,30 +328,24 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 	/**
 	 * Remove all entries from the share table
-	 *
-	 * @param IQueryBuilder $queryBuilder
 	 */
-	protected static function tearDownAfterClassCleanShares(IQueryBuilder $queryBuilder) {
+	protected static function tearDownAfterClassCleanShares(IQueryBuilder $queryBuilder): void {
 		$queryBuilder->delete('share')
 			->executeStatement();
 	}
 
 	/**
 	 * Remove all entries from the storages table
-	 *
-	 * @param IQueryBuilder $queryBuilder
 	 */
-	protected static function tearDownAfterClassCleanStorages(IQueryBuilder $queryBuilder) {
+	protected static function tearDownAfterClassCleanStorages(IQueryBuilder $queryBuilder): void {
 		$queryBuilder->delete('storages')
 			->executeStatement();
 	}
 
 	/**
 	 * Remove all entries from the filecache table
-	 *
-	 * @param IQueryBuilder $queryBuilder
 	 */
-	protected static function tearDownAfterClassCleanFileCache(IQueryBuilder $queryBuilder) {
+	protected static function tearDownAfterClassCleanFileCache(IQueryBuilder $queryBuilder): void {
 		$queryBuilder->delete('filecache')
 			->runAcrossAllShards()
 			->executeStatement();
@@ -398,7 +356,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 *
 	 * @param string $dataDir
 	 */
-	protected static function tearDownAfterClassCleanStrayDataFiles($dataDir) {
+	protected static function tearDownAfterClassCleanStrayDataFiles(string $dataDir): void {
 		$knownEntries = [
 			'nextcloud.log' => true,
 			'audit.log' => true,
@@ -423,7 +381,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 *
 	 * @param string $dir
 	 */
-	protected static function tearDownAfterClassCleanStrayDataUnlinkDir($dir) {
+	protected static function tearDownAfterClassCleanStrayDataUnlinkDir(string $dir): void {
 		if ($dh = @opendir($dir)) {
 			while (($file = readdir($dh)) !== false) {
 				if (Filesystem::isIgnoredDir($file)) {
@@ -444,14 +402,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Clean up the list of hooks
 	 */
-	protected static function tearDownAfterClassCleanStrayHooks() {
+	protected static function tearDownAfterClassCleanStrayHooks(): void {
 		\OC_Hook::clear();
 	}
 
 	/**
 	 * Clean up the list of locks
 	 */
-	protected static function tearDownAfterClassCleanStrayLocks() {
+	protected static function tearDownAfterClassCleanStrayLocks(): void {
 		Server::get(ILockingProvider::class)->releaseAll();
 	}
 
@@ -461,48 +419,46 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 *
 	 * @param string $user user id or empty for a generic FS
 	 */
-	protected static function loginAsUser($user = '') {
+	protected static function loginAsUser(string $user = ''): void {
 		self::logout();
 		Filesystem::tearDown();
 		\OC_User::setUserId($user);
-		$userObject = Server::get(IUserManager::class)->get($user);
+		$userManager = Server::get(IUserManager::class);
+		$setupManager = Server::get(SetupManager::class);
+		$userObject = $userManager->get($user);
 		if (!is_null($userObject)) {
 			$userObject->updateLastLoginTimestamp();
-		}
-		\OC_Util::setupFS($user);
-		if (Server::get(IUserManager::class)->userExists($user)) {
-			\OC::$server->getUserFolder($user);
+			$setupManager->setupForUser($userObject);
+			$rootFolder = Server::get(IRootFolder::class);
+			$rootFolder->getUserFolder($user);
 		}
 	}
 
 	/**
 	 * Logout the current user and tear down the filesystem.
 	 */
-	protected static function logout() {
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId('');
+	protected static function logout(): void {
+		Server::get(SetupManager::class)->tearDown();
+		$userSession = Server::get(\OC\User\Session::class);
+		$userSession->getSession()->set('user_id', '');
 		// needed for fully logout
-		Server::get(IUserSession::class)->setUser(null);
+		$userSession->setUser(null);
 	}
 
 	/**
 	 * Run all commands pushed to the bus
 	 */
-	protected function runCommands() {
-		// get the user for which the fs is setup
-		$view = Filesystem::getView();
-		if ($view) {
-			[, $user] = explode('/', $view->getRoot());
-		} else {
-			$user = null;
-		}
+	protected function runCommands(): void {
+		$setupManager = Server::get(SetupManager::class);
+		$session = Server::get(IUserSession::class);
+		$user = $session->getUser();
 
-		\OC_Util::tearDownFS(); // command can't reply on the fs being setup
+		$setupManager->tearDown(); // commands can't reply on the fs being setup
 		$this->commandBus->run();
-		\OC_Util::tearDownFS();
+		$setupManager->tearDown();
 
 		if ($user) {
-			\OC_Util::setupFS($user);
+			$setupManager->setupForUser($user);
 		}
 	}
 
@@ -518,7 +474,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 * @return boolean true if the file is locked with the
 	 *                 given type, false otherwise
 	 */
-	protected function isFileLocked($view, $path, $type, $onMountPoint = false) {
+	protected function isFileLocked(View $view, string $path, int $type, bool $onMountPoint = false) {
 		// Note: this seems convoluted but is necessary because
 		// the format of the lock key depends on the storage implementation
 		// (in our case mostly md5)
@@ -543,6 +499,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
+	/**
+	 * @return list<string>
+	 */
 	protected function getGroupAnnotations(): array {
 		if (method_exists($this, 'getAnnotations')) {
 			$annotations = $this->getAnnotations();
@@ -553,7 +512,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		$doc = $r->getDocComment();
 
 		if (class_exists(Group::class)) {
-			$attributes = array_map(function (\ReflectionAttribute $attribute) {
+			$attributes = array_map(function (\ReflectionAttribute $attribute): string {
 				/** @var Group $group */
 				$group = $attribute->newInstance();
 				return $group->name();
@@ -568,75 +527,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 	protected function IsDatabaseAccessAllowed(): bool {
 		$annotations = $this->getGroupAnnotations();
-		if (isset($annotations)) {
-			if (in_array('DB', $annotations) || in_array('SLOWDB', $annotations)) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * @param string $expectedHtml
-	 * @param string $template
-	 * @param array $vars
-	 */
-	protected function assertTemplate($expectedHtml, $template, $vars = []) {
-		$requestToken = 12345;
-		/** @var Defaults|\PHPUnit\Framework\MockObject\MockObject $l10n */
-		$theme = $this->getMockBuilder('\OCP\Defaults')
-			->disableOriginalConstructor()->getMock();
-		$theme->expects($this->any())
-			->method('getName')
-			->willReturn('Nextcloud');
-		/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject $l10n */
-		$l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
-		$l10n
-			->expects($this->any())
-			->method('t')
-			->willReturnCallback(function ($text, $parameters = []) {
-				return vsprintf($text, $parameters);
-			});
-
-		$t = new Base($template, $requestToken, $l10n, $theme);
-		$buf = $t->fetchPage($vars);
-		$this->assertHtmlStringEqualsHtmlString($expectedHtml, $buf);
-	}
-
-	/**
-	 * @param string $expectedHtml
-	 * @param string $actualHtml
-	 * @param string $message
-	 */
-	protected function assertHtmlStringEqualsHtmlString($expectedHtml, $actualHtml, $message = '') {
-		$expected = new DOMDocument();
-		$expected->preserveWhiteSpace = false;
-		$expected->formatOutput = true;
-		$expected->loadHTML($expectedHtml);
-
-		$actual = new DOMDocument();
-		$actual->preserveWhiteSpace = false;
-		$actual->formatOutput = true;
-		$actual->loadHTML($actualHtml);
-		$this->removeWhitespaces($actual);
-
-		$expectedHtml1 = $expected->saveHTML();
-		$actualHtml1 = $actual->saveHTML();
-		self::assertEquals($expectedHtml1, $actualHtml1, $message);
-	}
-
-
-	private function removeWhitespaces(DOMNode $domNode) {
-		foreach ($domNode->childNodes as $node) {
-			if ($node->hasChildNodes()) {
-				$this->removeWhitespaces($node);
-			} else {
-				if ($node instanceof \DOMText && $node->isWhitespaceInElementContent()) {
-					$domNode->removeChild($node);
-				}
-			}
-		}
+		return in_array('DB', $annotations) || in_array('SLOWDB', $annotations);
 	}
 }


### PR DESCRIPTION
## Summary

This is the first step to enable psalm for our test suite to find issues also there.

At the moment, this already found some completely broken and unused method in TestCase and prepare the way for making ICommentsManager work with snowflake ids by using string instead of int for the ids consistently.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
