### PR TITLE
Authoritative mount setup

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -31,6 +31,7 @@ use OCP\App\IAppManager;
 use OCP\Constants;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Config\IAuthoritativeMountProvider;
 use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IHomeMountProvider;
 use OCP\Files\Config\IMountProvider;
@@ -227,6 +228,24 @@ class SetupManager {
 	}
 
 	/**
+	 * Update the cached mounts for all non-authoritative mount providers for a user.
+	 */
+	private function updateNonAuthoritativeProviders(IUser $user): void {
+		$providers = $this->mountProviderCollection->getProviders();
+		$nonAuthoritativeProviders = array_filter(
+			$providers,
+			fn (IMountProvider $provider) => !(
+				$provider instanceof IAuthoritativeMountProvider
+				|| $provider instanceof IRootMountProvider
+				|| $provider instanceof IHomeMountProvider
+			)
+		);
+		$providerNames = array_map(fn (IMountProvider $provider) => get_class($provider), $nonAuthoritativeProviders);
+		$mount = $this->mountProviderCollection->getUserMountsForProviderClasses($user, $providerNames);
+		$this->userMountCache->registerMounts($user, $mount, $providerNames);
+	}
+
+	/**
 	 * Setup the full filesystem for the specified user
 	 */
 	public function setupForUser(IUser $user): void {
@@ -335,12 +354,16 @@ class SetupManager {
 		});
 		$this->registerMounts($user, $mounts, $newProviders);
 
+		$this->markUserMountsCached($user);
+		$this->eventLogger->end('fs:setup:user:full:post');
+	}
+
+	private function markUserMountsCached(IUser $user): void {
 		$cacheDuration = $this->config->getSystemValueInt('fs_mount_cache_duration', 5 * 60);
 		if ($cacheDuration > 0) {
 			$this->cache->set($user->getUID(), true, $cacheDuration);
 			$this->fullSetupRequired[$user->getUID()] = false;
 		}
-		$this->eventLogger->end('fs:setup:user:full:post');
 	}
 
 	/**
@@ -434,8 +457,8 @@ class SetupManager {
 		}
 
 		if ($this->fullSetupRequired($user)) {
-			$this->setupForUser($user);
-			return;
+			$this->updateNonAuthoritativeProviders($user);
+			$this->markUserMountsCached($user);
 		}
 
 		// for the user's home folder, and includes children we need everything always
@@ -505,11 +528,10 @@ class SetupManager {
 			$subCachedMounts = $this->userMountCache->getMountsInPath($user, $path);
 			$this->eventLogger->end('fs:setup:user:path:find');
 
-			$needsFullSetup
-				= array_any(
-					$subCachedMounts,
-					fn (ICachedMountInfo $info) => $info->getMountProvider() === ''
-				);
+			$needsFullSetup = array_any(
+				$subCachedMounts,
+				fn (ICachedMountInfo $info) => $info->getMountProvider() === ''
+			);
 
 			if ($needsFullSetup) {
 				$this->logger->debug('mount has no provider set, performing full setup');
@@ -542,11 +564,10 @@ class SetupManager {
 
 				$currentProviders[] = $mountProvider;
 				$setupProviders[] = $mountProvider;
-				$fullProviderMounts[]
-					= $this->mountProviderCollection->getUserMountsForProviderClasses(
-						$user,
-						[$mountProvider]
-					);
+				$fullProviderMounts[] = $this->mountProviderCollection->getUserMountsForProviderClasses(
+					$user,
+					[$mountProvider]
+				);
 			}
 
 			if (!empty($authoritativeCachedMounts)) {
@@ -573,13 +594,12 @@ class SetupManager {
 						},
 						$cachedMounts
 					));
-					$authoritativeMounts[]
-						= $this->mountProviderCollection->getUserMountsFromProviderByPath(
-							$providerClass,
-							$path,
-							true,
-							$providerArgs,
-						);
+					$authoritativeMounts[] = $this->mountProviderCollection->getUserMountsFromProviderByPath(
+						$providerClass,
+						$path,
+						true,
+						$providerArgs,
+					);
 				}
 			}
 		} else {
@@ -758,6 +778,7 @@ class SetupManager {
 
 	/**
 	 * Drops partially set-up mounts for the given user
+	 *
 	 * @param class-string<IMountProvider>[] $providers
 	 */
 	public function dropPartialMountsForUser(IUser $user, array $providers = []): void {


### PR DESCRIPTION
When the "requires non-cached filesystem setup" logic is hit when setting up for a path, just reload the non-authoritative mount providers instead of doing the full setup.

- [x] requires https://github.com/nextcloud/server/pull/56499