### PR TITLE
feat(Config.php): change `array_merge` to `array_replace_recursive` when merging configs

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -242,7 +242,7 @@ class Config {
 				throw new \Exception($errorMessage);
 			}
 			if (isset($CONFIG) && is_array($CONFIG)) {
-				$this->cache = array_merge($this->cache, $CONFIG);
+				$this->cache = array_replace_recursive($this->cache, $CONFIG);
 			}
 		}
 


### PR DESCRIPTION
Consider an s3.config.php file for initial installation like this:

<details>
<summary>Expand</summary>

```
<?php
  $use_ssl = getenv('OBJECTSTORE_S3_SSL');
  $use_path = getenv('OBJECTSTORE_S3_USEPATH_STYLE');
  $use_legacyauth = getenv('OBJECTSTORE_S3_LEGACYAUTH');
  $autocreate = getenv('OBJECTSTORE_S3_AUTOCREATE');
  $multibucket = getenv('OBJECTSTORE_S3_MULTIBUCKET');
  $CONFIG = array(
    'objectstore' => array(
      'class' => '\OC\Files\ObjectStore\S3',
      'arguments' => array(
        'multibucket' => $multibucket === 'true',
        'bucket' => getenv('OBJECTSTORE_S3_BUCKET'),
        'key' => getenv('OBJECTSTORE_S3_KEY') ?: '',
        'secret' => getenv('OBJECTSTORE_S3_SECRET') ?: '',
        'region' => getenv('OBJECTSTORE_S3_REGION') ?: '',
        'hostname' => getenv('OBJECTSTORE_S3_HOST') ?: '',
        'port' => getenv('OBJECTSTORE_S3_PORT') ?: '',
        'storageClass' => getenv('OBJECTSTORE_S3_STORAGE_CLASS') ?: '',
        'objectPrefix' => getenv("OBJECTSTORE_S3_OBJECT_PREFIX") ? getenv("OBJECTSTORE_S3_OBJECT_PREFIX") : "urn:oid:",
        'autocreate' => strtolower($autocreate) !== 'false',
        'use_ssl' => strtolower($use_ssl) !== 'false',
        // required for some non Amazon S3 implementations
        'use_path_style' => strtolower($use_path) === 'true',
        // required for older protocol versions
        'legacy_auth' => strtolower($use_legacyauth) === 'true',
        'use_nextcloud_bundle' => 1,
      )
    )
  );

  $sse_c_key = getenv('OBJECTSTORE_S3_SSE_C_KEY');
  if ($sse_c_key) {
    $CONFIG['objectstore']['arguments']['sse_c_key'] = $sse_c_key;
  }


```

</details>

Now, you want to add additional perBucket settings using the occ command
```
php occ config:system:set --value=test objectstore arguments perBucket test1 secret
php occ config:system:set --value=test objectstore arguments perBucket test2 secret
```

It will not work without this PR.