### PR TITLE
feat(http-client): add option to add instance URL to HTTP client user-agent

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -828,6 +828,17 @@ $CONFIG = [
 	'allow_local_remote_servers' => true,
 
 	/**
+	 * Add the URL of the Nextcloud server in User-Agent headers HTTP calls.
+	 *
+	 * This helps service providers identifying calls from your server,
+	 * which can be helpful for them, but can be a privacy issue on small
+	 * Nextcloud servers.
+	 *
+	 * Defaults to ``false``
+	 */
+	'http_client_add_user_agent_url' => false,
+
+	/**
 	 * Deleted Items (trash bin)
 	 *
 	 * These parameters control the Deleted files app.

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -75,6 +75,10 @@ class Client implements IClient {
 
 		if (!isset($options[RequestOptions::HEADERS]['User-Agent'])) {
 			$userAgent = 'Nextcloud-Server-Crawler/' . $this->serverVersion->getVersionString();
+			$overwriteCliUrl = $this->config->getSystemValueString('overwrite.cli.url');
+			if ($this->config->getSystemValueBool('http_client_add_user_agent_url') && !empty($overwriteCliUrl)) {
+				$userAgent .= '; +' . rtrim($overwriteCliUrl, '/');
+			}
 			$options[RequestOptions::HEADERS]['User-Agent'] = $userAgent;
 		}
 


### PR DESCRIPTION
## Summary


## TODO

- [x] Check tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
