### PR TITLE
feat: add event for apps that a users share access might have changed

### DIFF
--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -45,6 +45,7 @@ return array(
     'OCA\\Files_Sharing\\Event\\BeforeTemplateRenderedEvent' => $baseDir . '/../lib/Event/BeforeTemplateRenderedEvent.php',
     'OCA\\Files_Sharing\\Event\\ShareLinkAccessedEvent' => $baseDir . '/../lib/Event/ShareLinkAccessedEvent.php',
     'OCA\\Files_Sharing\\Event\\ShareMountedEvent' => $baseDir . '/../lib/Event/ShareMountedEvent.php',
+    'OCA\\Files_Sharing\\Event\\UserShareAccessUpdatedEvent' => $baseDir . '/../lib/Event/UserShareAccessUpdatedEvent.php',
     'OCA\\Files_Sharing\\Exceptions\\BrokenPath' => $baseDir . '/../lib/Exceptions/BrokenPath.php',
     'OCA\\Files_Sharing\\Exceptions\\S2SException' => $baseDir . '/../lib/Exceptions/S2SException.php',
     'OCA\\Files_Sharing\\Exceptions\\SharingRightsException' => $baseDir . '/../lib/Exceptions/SharingRightsException.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -60,6 +60,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Event\\BeforeTemplateRenderedEvent' => __DIR__ . '/..' . '/../lib/Event/BeforeTemplateRenderedEvent.php',
         'OCA\\Files_Sharing\\Event\\ShareLinkAccessedEvent' => __DIR__ . '/..' . '/../lib/Event/ShareLinkAccessedEvent.php',
         'OCA\\Files_Sharing\\Event\\ShareMountedEvent' => __DIR__ . '/..' . '/../lib/Event/ShareMountedEvent.php',
+        'OCA\\Files_Sharing\\Event\\UserShareAccessUpdatedEvent' => __DIR__ . '/..' . '/../lib/Event/UserShareAccessUpdatedEvent.php',
         'OCA\\Files_Sharing\\Exceptions\\BrokenPath' => __DIR__ . '/..' . '/../lib/Exceptions/BrokenPath.php',
         'OCA\\Files_Sharing\\Exceptions\\S2SException' => __DIR__ . '/..' . '/../lib/Exceptions/S2SException.php',
         'OCA\\Files_Sharing\\Exceptions\\SharingRightsException' => __DIR__ . '/..' . '/../lib/Exceptions/SharingRightsException.php',

--- a/apps/files_sharing/lib/Event/UserShareAccessUpdatedEvent.php
+++ b/apps/files_sharing/lib/Event/UserShareAccessUpdatedEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Sharing\Event;
+
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+
+/**
+ * Emitted when a user *might* have gained or lost access to an existing share.
+ *
+ * For example, when a user is added to a group, they gain access to all shares for the group.
+ *
+ * @since 33.0.0
+ */
+class UserShareAccessUpdatedEvent extends Event {
+	public function __construct(
+		private readonly IUser $user,
+	) {
+		parent::__construct();
+	}
+
+	public function getUser(): IUser {
+		return $this->user;
+	}
+}


### PR DESCRIPTION
This is needed for places like https://github.com/nextcloud/server/pull/57295 where files_sharing needs to be able to react to users gaining/losing access to shares.

This would need to be implemented in at least talk and circles, not sure about deck.

Since determining this reliably will be expensive, apps are expected to emit the event optimistically, so, for example, talk should probably just emit the event whenever a user is added to a room, regardless of whether or not the room has any associated shares.

cc @nickvergessen @juliusknorr @ArtificialOwl for the relevant apps.