### PR TITLE
fix(psalm): Fix static analysis issues in apps/*/tests

### DIFF
--- a/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
+++ b/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
@@ -26,7 +26,7 @@ use Test\TestCase;
  *
  * @package OCA\Comments\Tests\Unit\AppInfo
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ApplicationTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/comments/tests/Unit/Collaboration/CommentersSorterTest.php
+++ b/apps/comments/tests/Unit/Collaboration/CommentersSorterTest.php
@@ -27,7 +27,7 @@ class CommentersSorterTest extends TestCase {
 	/**
 	 * @param $data
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('sortDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sortDataProvider')]
 	public function testSort($data): void {
 		$commentMocks = [];
 		foreach ($data['actors'] as $actorType => $actors) {

--- a/apps/comments/tests/Unit/EventHandlerTest.php
+++ b/apps/comments/tests/Unit/EventHandlerTest.php
@@ -61,7 +61,7 @@ class EventHandlerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('handledProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'handledProvider')]
 	public function testHandled(string $eventType): void {
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);

--- a/apps/comments/tests/Unit/Notification/ListenerTest.php
+++ b/apps/comments/tests/Unit/Notification/ListenerTest.php
@@ -51,7 +51,7 @@ class ListenerTest extends TestCase {
 	 * @param string $eventType
 	 * @param string $notificationMethod
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('eventProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'eventProvider')]
 	public function testEvaluate(string $eventType, $notificationMethod): void {
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);
@@ -111,7 +111,7 @@ class ListenerTest extends TestCase {
 		$this->listener->evaluate($event);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('eventProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'eventProvider')]
 	public function testEvaluateNoMentions(string $eventType): void {
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);

--- a/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
+++ b/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
@@ -17,7 +17,7 @@ use Sabre\VObject\Component\VCard;
 use Sabre\VObject\UUIDUtil;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class RecentContactMapperTest extends TestCase {
 	private RecentContactMapper $recentContactMapper;
 	private ITimeFactory $time;

--- a/apps/dav/tests/integration/DAV/Sharing/CalDavSharingBackendTest.php
+++ b/apps/dav/tests/integration/DAV/Sharing/CalDavSharingBackendTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CalDavSharingBackendTest extends TestCase {
 
 	private IDBConnection $db;

--- a/apps/dav/tests/integration/DAV/Sharing/SharingMapperTest.php
+++ b/apps/dav/tests/integration/DAV/Sharing/SharingMapperTest.php
@@ -14,7 +14,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SharingMapperTest extends TestCase {
 
 	private SharingMapper $mapper;

--- a/apps/dav/tests/integration/Db/PropertyMapperTest.php
+++ b/apps/dav/tests/integration/Db/PropertyMapperTest.php
@@ -13,7 +13,7 @@ use OCA\DAV\Db\PropertyMapper;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PropertyMapperTest extends TestCase {
 
 	/** @var PropertyMapper */

--- a/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 use function scandir;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CalendarMigratorTest extends TestCase {
 
 	private IUserManager $userManager;
@@ -87,7 +87,7 @@ class CalendarMigratorTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAssets')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataAssets')]
 	public function testImportExportAsset(string $userId, string $filename, string $initialCalendarUri, VCalendar $importCalendar): void {
 		$user = $this->userManager->createUser($userId, 'topsecretpassword');
 

--- a/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 use function scandir;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ContactsMigratorTest extends TestCase {
 
 	private IUserManager $userManager;
@@ -93,7 +93,7 @@ class ContactsMigratorTest extends TestCase {
 	 * @param array{displayName: string, description?: string} $importMetadata
 	 * @param VCard[] $importCards
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAssets')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataAssets')]
 	public function testImportExportAsset(string $userId, string $filename, string $initialAddressBookUri, array $importMetadata, array $importCards): void {
 		$user = $this->userManager->createUser($userId, 'topsecretpassword');
 

--- a/apps/dav/tests/unit/AppInfo/ApplicationTest.php
+++ b/apps/dav/tests/unit/AppInfo/ApplicationTest.php
@@ -19,7 +19,7 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\Unit\AppInfo
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ApplicationTest extends TestCase {
 	public function test(): void {
 		$app = new Application();

--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -27,7 +27,7 @@ class AvatarHomeTest extends TestCase {
 		$this->home = new AvatarHome(['uri' => 'principals/users/admin'], $this->avatarManager);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesForbiddenMethods')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesForbiddenMethods')]
 	public function testForbiddenMethods($method): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -58,7 +58,7 @@ class AvatarHomeTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesTestGetChild')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesTestGetChild')]
 	public function testGetChild(?string $expectedException, bool $hasAvatar, string $path): void {
 		if ($expectedException !== null) {
 			$this->expectException($expectedException);
@@ -83,7 +83,7 @@ class AvatarHomeTest extends TestCase {
 		self::assertEquals(1, count($avatarNodes));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesTestGetChild')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesTestGetChild')]
 	public function testChildExists(?string $expectedException, bool $hasAvatar, string $path): void {
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->method('exists')->willReturn($hasAvatar);

--- a/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
@@ -50,7 +50,7 @@ class EventReminderJobTest extends TestCase {
 	 * @param bool $sendEventRemindersMode
 	 * @param bool $expectCall
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('data')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'data')]
 	public function testRun(bool $sendEventReminders, bool $sendEventRemindersMode, bool $expectCall): void {
 		$this->config->expects($this->exactly($sendEventReminders ? 2 : 1))
 			->method('getAppValue')

--- a/apps/dav/tests/unit/BackgroundJob/PruneOutdatedSyncTokensJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/PruneOutdatedSyncTokensJobTest.php
@@ -39,7 +39,7 @@ class PruneOutdatedSyncTokensJobTest extends TestCase {
 		$this->backgroundJob = new PruneOutdatedSyncTokensJob($this->timeFactory, $this->calDavBackend, $this->cardDavBackend, $this->config, $this->logger);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestRun')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataForTestRun')]
 	public function testRun(string $configToKeep, string $configRetentionDays, int $actualLimit, int $retentionDays, int $deletedCalendarSyncTokens, int $deletedAddressBookSyncTokens): void {
 		$this->config->expects($this->exactly(2))
 			->method('getAppValue')

--- a/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
@@ -42,7 +42,7 @@ class RefreshWebcalJobTest extends TestCase {
 	 * @param int $time
 	 * @param bool $process
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'runDataProvider')]
 	public function testRun(int $lastRun, int $time, bool $process): void {
 		$backgroundJob = new RefreshWebcalJob($this->refreshWebcalService, $this->config, $this->logger, $this->timeFactory);
 		$backgroundJob->setId('42');

--- a/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserStatusAutomationTest extends TestCase {
 	protected ITimeFactory&MockObject $time;
 	protected IJobList&MockObject $jobList;
@@ -86,7 +86,7 @@ class UserStatusAutomationTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataRun')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataRun')]
 	public function testRunNoOOO(string $ruleDay, string $currentTime, bool $isAvailable): void {
 		$user = $this->createConfiguredMock(IUser::class, [
 			'getUID' => 'user'

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -42,7 +42,7 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\unit\CalDAV
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 abstract class AbstractCalDavBackend extends TestCase {
 
 

--- a/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
@@ -71,7 +71,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCallTriggerCalendarActivity')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataCallTriggerCalendarActivity')]
 	public function testCallTriggerCalendarActivity(string $method, array $payload, string $expectedSubject, array $expectedPayload): void {
 		$backend = $this->getBackend(['triggerCalendarActivity']);
 		$backend->expects($this->once())
@@ -166,7 +166,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTriggerCalendarActivity')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTriggerCalendarActivity')]
 	public function testTriggerCalendarActivity(string $action, array $data, array $shares, array $changedProperties, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
@@ -295,7 +295,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsersForShares')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetUsersForShares')]
 	public function testGetUsersForShares(array $shares, array $groups, array $expected): void {
 		$backend = $this->getBackend();
 

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
@@ -60,7 +60,7 @@ class CalendarTest extends TestCase {
 	 * @param string[] $types
 	 * @param string[] $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilterTypes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilterTypes')]
 	public function testFilterTypes(array $types, array $expected): void {
 		$this->assertEquals($expected, $this->filter->filterTypes($types));
 	}

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
@@ -13,7 +13,7 @@ use OCP\Activity\IFilter;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GenericTest extends TestCase {
 	public static function dataFilters(): array {
 		return [
@@ -22,27 +22,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testImplementsInterface(string $filterClass): void {
 		$filter = Server::get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetIdentifier(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetName(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetPriority(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -52,7 +52,7 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetIcon(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -60,14 +60,14 @@ class GenericTest extends TestCase {
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testFilterTypes(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testAllowedApps(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
@@ -60,7 +60,7 @@ class TodoTest extends TestCase {
 	 * @param string[] $types
 	 * @param string[] $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilterTypes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilterTypes')]
 	public function testFilterTypes(array $types, array $expected): void {
 		$this->assertEquals($expected, $this->filter->filterTypes($types));
 	}

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
@@ -44,7 +44,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetSubjects')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSetSubjects')]
 	public function testSetSubjects(string $subject, array $parameters): void {
 		$event = $this->createMock(IEvent::class);
 		$event->expects($this->once())
@@ -66,7 +66,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateCalendarParameter')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGenerateCalendarParameter')]
 	public function testGenerateCalendarParameter(array $data, string $name): void {
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())
@@ -89,7 +89,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateLegacyCalendarParameter')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGenerateLegacyCalendarParameter')]
 	public function testGenerateLegacyCalendarParameter(int $id, string $name): void {
 		$this->assertEquals([
 			'type' => 'calendar',
@@ -105,7 +105,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateGroupParameter')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGenerateGroupParameter')]
 	public function testGenerateGroupParameter(string $gid): void {
 		$this->assertEquals([
 			'type' => 'user-group',

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -67,7 +67,7 @@ class EventTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateObjectParameter')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGenerateObjectParameter')]
 	public function testGenerateObjectParameter(int $id, string $name, ?array $link, bool $calendarAppEnabled = true): void {
 		$affectedUser = 'otheruser';
 		if ($link) {
@@ -148,7 +148,7 @@ class EventTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('generateObjectParameterLinkEncodingDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'generateObjectParameterLinkEncodingDataProvider')]
 	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId): void {
 		$generatedLink = [
 			'objectId' => $objectId,
@@ -181,7 +181,7 @@ class EventTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateObjectParameterThrows')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGenerateObjectParameterThrows')]
 	public function testGenerateObjectParameterThrows(string|array $eventData, string $exception = InvalidArgumentException::class): void {
 		$this->expectException($exception);
 

--- a/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
@@ -23,27 +23,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testImplementsInterface(string $settingClass): void {
 		$setting = Server::get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testGetIdentifier(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testGetName(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testGetPriority(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
@@ -53,28 +53,28 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testCanChangeStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testIsDefaultEnabledStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testCanChangeMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testIsDefaultEnabledMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -29,7 +29,7 @@ use function time;
 /**
  * Class CalDavBackendTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CalDavBackendTest extends AbstractCalDavBackend {
 	public function testCalendarOperations(): void {
 		$calendarId = $this->createTestCalendar();
@@ -111,7 +111,7 @@ class CalDavBackendTest extends AbstractCalDavBackend {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesSharingData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesSharingData')]
 	public function testCalendarSharing($userCanRead, $userCanWrite, $groupCanRead, $groupCanWrite, $add, $principals): void {
 		$logger = $this->createMock(\Psr\Log\LoggerInterface::class);
 		$config = $this->createMock(IConfig::class);
@@ -400,7 +400,7 @@ EOD;
 		$this->assertCount(0, $calendarObjects);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesCalendarQueryParameters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesCalendarQueryParameters')]
 	public function testCalendarQuery($expectedEventsInResult, $propFilters, $compFilter): void {
 		$calendarId = $this->createTestCalendar();
 		$events = [];
@@ -689,7 +689,7 @@ EOS;
 	/**
 	 * @param $objectData
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesSchedulingData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesSchedulingData')]
 	public function testScheduling($objectData): void {
 		$this->backend->createSchedulingObject(self::UNIT_TEST_USER, 'Sample Schedule', $objectData);
 
@@ -705,7 +705,7 @@ EOS;
 		$this->assertCount(0, $sos);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesCalDataForGetDenormalizedData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesCalDataForGetDenormalizedData')]
 	public function testGetDenormalizedData($expected, $key, $calData): void {
 		try {
 			$actual = $this->backend->getDenormalizedData($calData);
@@ -871,7 +871,7 @@ EOD;
 		$this->assertEquals(count($search5), 0);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('searchDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'searchDataProvider')]
 	public function testSearch(bool $isShared, array $searchOptions, int $count): void {
 		$calendarId = $this->createTestCalendar();
 

--- a/apps/dav/tests/unit/CalDAV/CalendarObjectTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarObjectTest.php
@@ -79,7 +79,7 @@ class CalendarObjectTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideConfidentialObjectData')]
+	#[DataProvider(methodName: 'provideConfidentialObjectData')]
 	public function testGetWithConfidentialObject(
 		bool $expectConfidential,
 		array $calendarInfo,

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -144,7 +144,7 @@ class CalendarTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataPropPatch')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataPropPatch')]
 	public function testPropPatch(string $ownerPrincipal, string $principalUri, array $mutations, bool $shared): void {
 		/** @var CalDavBackend&MockObject $backend */
 		$backend = $this->createMock(CalDavBackend::class);
@@ -166,7 +166,7 @@ class CalendarTest extends TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesReadOnlyInfo')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesReadOnlyInfo')]
 	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet, $uri = 'default'): void {
 		/** @var CalDavBackend&MockObject $backend */
 		$backend = $this->createMock(CalDavBackend::class);
@@ -266,7 +266,7 @@ class CalendarTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesConfidentialClassificationData')]
 	public function testPrivateClassification(int $expectedChildren, bool $isShared): void {
 		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
@@ -304,7 +304,7 @@ class CalendarTest extends TestCase {
 		$this->assertEquals(!$isShared, $c->childExists('event-2'));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesConfidentialClassificationData')]
 	public function testConfidentialClassification(int $expectedChildren, bool $isShared): void {
 		$start = '20160609';
 		$end = '20160610';

--- a/apps/dav/tests/unit/CalDAV/Federation/CalendarFederationConfigTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/CalendarFederationConfigTest.php
@@ -37,7 +37,7 @@ class CalendarFederationConfigTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideIsFederationEnabledData')]
+	#[DataProvider(methodName: 'provideIsFederationEnabledData')]
 	public function testIsFederationEnabled(bool $configValue): void {
 		$this->appConfig->expects(self::once())
 			->method('getAppValueBool')

--- a/apps/dav/tests/unit/CalDAV/Federation/CalendarFederationProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/CalendarFederationProviderTest.php
@@ -239,7 +239,7 @@ class CalendarFederationProviderTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideIncompleteProtocolData')]
+	#[DataProvider(methodName: 'provideIncompleteProtocolData')]
 	public function testShareReceivedWithIncompleteProtocolData(array $protocol): void {
 		$share = $this->createMock(ICloudFederationShare::class);
 		$share->method('getShareType')
@@ -400,7 +400,7 @@ class CalendarFederationProviderTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideIncompleteSyncCalendarNotificationData')]
+	#[DataProvider(methodName: 'provideIncompleteSyncCalendarNotificationData')]
 	public function testNotificationReceivedWithSyncCalendarNotificationAndIncompleteData(
 		array $notification,
 	): void {

--- a/apps/dav/tests/unit/CalDAV/Federation/FederatedCalendarAuthTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/FederatedCalendarAuthTest.php
@@ -109,7 +109,7 @@ class FederatedCalendarAuthTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideCheckData')]
+	#[DataProvider(methodName: 'provideCheckData')]
 	public function testCheck(
 		string $requestPath,
 		?string $authHeader,

--- a/apps/dav/tests/unit/CalDAV/Federation/FederatedCalendarSyncServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/FederatedCalendarSyncServiceTest.php
@@ -126,7 +126,7 @@ class FederatedCalendarSyncServiceTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideUnexpectedSyncTokenData')]
+	#[DataProvider(methodName: 'provideUnexpectedSyncTokenData')]
 	public function testSyncOneWithUnexpectedSyncTokenFormat(string $syncToken): void {
 		$calendar = new FederatedCalendarEntity();
 		$calendar->setId(1);

--- a/apps/dav/tests/unit/CalDAV/Federation/FederationSharingServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/FederationSharingServiceTest.php
@@ -390,7 +390,7 @@ class FederationSharingServiceTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideInvalidRemoteUserPrincipalData')]
+	#[DataProvider(methodName: 'provideInvalidRemoteUserPrincipalData')]
 	public function testShareWithWithInvalidRemoteUserPrincipal(string $remoteUserPrincipal): void {
 		$shareable = $this->createMock(Calendar::class);
 		$shareable->method('getOwner')

--- a/apps/dav/tests/unit/CalDAV/Integration/ExternalCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Integration/ExternalCalendarTest.php
@@ -68,7 +68,7 @@ class ExternalCalendarTest extends TestCase {
 		$this->assertTrue(ExternalCalendar::isAppGeneratedCalendar('app-generated--example--foo--2'));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('splitAppGeneratedCalendarUriDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'splitAppGeneratedCalendarUriDataProvider')]
 	public function testSplitAppGeneratedCalendarUriInvalid(string $name):void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Provided calendar uri was not app-generated');

--- a/apps/dav/tests/unit/CalDAV/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/PluginTest.php
@@ -36,7 +36,7 @@ class PluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('linkProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'linkProvider')]
 	public function testGetCalendarHomeForPrincipal(string $input, string $expected): void {
 		$this->assertSame($expected, $this->plugin->getCalendarHomeForPrincipal($input));
 	}

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarObjectTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarObjectTest.php
@@ -65,7 +65,7 @@ class PublicCalendarObjectTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideConfidentialObjectData')]
+	#[DataProvider(methodName: 'provideConfidentialObjectData')]
 	public function testGetWithConfidentialObject(array $calendarInfo): void {
 		$ics = <<<EOF
 BEGIN:VCALENDAR

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -32,7 +32,7 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\unit\CalDAV
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PublicCalendarRootTest extends TestCase {
 	public const UNIT_TEST_USER = '';
 	private CalDavBackend $backend;

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
@@ -16,7 +16,7 @@ use Sabre\VObject\Reader;
 
 class PublicCalendarTest extends CalendarTest {
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesConfidentialClassificationData')]
 	public function testPrivateClassification(int $expectedChildren, bool $isShared): void {
 		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
@@ -55,7 +55,7 @@ class PublicCalendarTest extends CalendarTest {
 		$this->assertFalse($c->childExists('event-2'));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesConfidentialClassificationData')]
 	public function testConfidentialClassification(int $expectedChildren, bool $isShared): void {
 		$start = '20160609';
 		$end = '20160610';

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
@@ -17,7 +17,7 @@ use OCA\DAV\Capabilities;
 use OCP\AppFramework\QueryException;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class NotificationProviderManagerTest extends TestCase {
 	private NotificationProviderManager $providerManager;
 

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
@@ -170,7 +170,7 @@ class NotifierTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataPrepare')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataPrepare')]
 	public function testPrepare(string $subjectType, array $subjectParams, string $subject, array $messageParams, string $message): void {
 		/** @var INotification&MockObject $notification */
 		$notification = $this->createMock(INotification::class);

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
@@ -246,7 +246,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 		$this->assertEquals(0, $actual);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchPrincipals')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSearchPrincipals')]
 	public function testSearchPrincipals($expected, $test): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())

--- a/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
@@ -251,7 +251,7 @@ class PluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('propFindDefaultCalendarUrlProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'propFindDefaultCalendarUrlProvider')]
 	public function testPropFindDefaultCalendarUrl(string $principalUri, ?string $calendarHome, bool $isResource, string $calendarUri, string $displayName, bool $exists, bool $deleted = false, bool $hasExistingCalendars = false, bool $propertiesForPath = true): void {
 		$propFind = new PropFind(
 			$principalUri,

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/ConnectionTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/ConnectionTest.php
@@ -32,7 +32,7 @@ class ConnectionTest extends TestCase {
 		$this->connection = new Connection($this->clientService, $this->config, $this->logger);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('runLocalURLDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'runLocalURLDataProvider')]
 	public function testLocalUrl($source): void {
 		$subscription = [
 			'id' => 42,
@@ -89,7 +89,7 @@ class ConnectionTest extends TestCase {
 
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('urlDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'urlDataProvider')]
 	public function testConnection(string $url, string $contentType, string $expectedFormat): void {
 		$client = $this->createMock(IClient::class);
 		$response = $this->createMock(IResponse::class);

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
@@ -50,7 +50,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		return $stream;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'runDataProvider')]
 	public function testRun(string $body, string $format, string $result): void {
 		$refreshWebcalService = new RefreshWebcalService(
 			$this->caldavBackend,
@@ -119,7 +119,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('identicalDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'identicalDataProvider')]
 	public function testRunIdentical(string $uid, array $calendarObject, string $body, string $format, string $result): void {
 		$refreshWebcalService = new RefreshWebcalService(
 			$this->caldavBackend,
@@ -354,7 +354,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'runDataProvider')]
 	public function testRunCreateCalendarNoException(string $body, string $format, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
 			->onlyMethods(['getSubscription'])
@@ -407,7 +407,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'runDataProvider')]
 	public function testRunCreateCalendarBadRequest(string $body, string $format, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
 			->onlyMethods(['getSubscription'])

--- a/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
@@ -37,10 +37,7 @@ class BackendTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 	}
 
-	/**
-	 * @return Backend|MockObject
-	 */
-	protected function getBackend(array $methods = []): Backend {
+	protected function getBackend(array $methods = []): Backend|MockObject {
 		if (empty($methods)) {
 			return new Backend(
 				$this->activityManager,
@@ -71,7 +68,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCallTriggerAddressBookActivity')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataCallTriggerAddressBookActivity')]
 	public function testCallTriggerAddressBookActivity(string $method, array $payload, string $expectedSubject, array $expectedPayload): void {
 		$backend = $this->getBackend(['triggerAddressbookActivity']);
 		$backend->expects($this->once())
@@ -152,7 +149,7 @@ class BackendTest extends TestCase {
 	 * @param string[]|null $shareUsers
 	 * @param string[] $users
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTriggerAddressBookActivity')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTriggerAddressBookActivity')]
 	public function testTriggerAddressBookActivity(string $action, array $data, array $shares, array $changedProperties, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
@@ -316,7 +313,7 @@ class BackendTest extends TestCase {
 	 * @param string[]|null $shareUsers
 	 * @param string[] $users
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTriggerCardActivity')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTriggerCardActivity')]
 	public function testTriggerCardActivity(string $action, array $addressBookData, array $shares, array $cardData, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
@@ -430,7 +427,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsersForShares')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetUsersForShares')]
 	public function testGetUsersForShares(array $shares, array $groups, array $expected): void {
 		$backend = $this->getBackend();
 
@@ -460,7 +457,7 @@ class BackendTest extends TestCase {
 
 	/**
 	 * @param string[] $users
-	 * @return IUser[]|MockObject[]
+	 * @return list<IUser&MockObject>
 	 */
 	protected function getUsers(array $users): array {
 		$list = [];
@@ -470,10 +467,7 @@ class BackendTest extends TestCase {
 		return $list;
 	}
 
-	/**
-	 * @return IUser|MockObject
-	 */
-	protected function getUserMock(string $uid): IUser {
+	protected function getUserMock(string $uid): IUser&MockObject {
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('getUID')

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -80,7 +80,7 @@ class AddressBookImplTest extends TestCase {
 			->getMock();
 
 		$pattern = 'pattern';
-		$searchProperties = 'properties';
+		$searchProperties = ['properties'];
 
 		$this->backend->expects($this->once())->method('search')
 			->with($this->addressBookInfo['id'], $pattern, $searchProperties)
@@ -104,7 +104,7 @@ class AddressBookImplTest extends TestCase {
 		$this->assertSame(2, count($result));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCreate')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCreate')]
 	public function testCreate(array $properties): void {
 		$uid = 'uid';
 
@@ -229,7 +229,7 @@ class AddressBookImplTest extends TestCase {
 		$addressBookImpl->createOrUpdate($properties);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetPermissions')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetPermissions')]
 	public function testGetPermissions(array $permissions, int $expected): void {
 		$this->addressBook->expects($this->once())->method('getACL')
 			->willReturn($permissions);

--- a/apps/dav/tests/unit/CardDAV/AddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookTest.php
@@ -117,7 +117,7 @@ class AddressBookTest extends TestCase {
 		$addressBook->propPatch(new PropPatch(['{DAV:}displayname' => 'Test address book']));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesReadOnlyInfo')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesReadOnlyInfo')]
 	public function testAcl(bool $expectsWrite, ?bool $readOnlyValue, bool $hasOwnerSet): void {
 		/** @var MockObject | CardDavBackend $backend */
 		$backend = $this->createMock(CardDavBackend::class);

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -50,7 +50,7 @@ class BirthdayServiceTest extends TestCase {
 			$this->dbConnection, $this->l10n);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesVCards')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesVCards')]
 	public function testBuildBirthdayFromContact(?string $expectedSummary, ?string $expectedDTStart, ?string $expectedRrule, ?string $expectedFieldType, ?string $expectedUnknownYear, ?string $expectedOriginalYear, ?string $expectedReminder, ?string $data, string $fieldType, string $prefix, bool $supports4Bytes, ?string $configuredReminder): void {
 		$this->dbConnection->method('supports4ByteText')->willReturn($supports4Bytes);
 		$cal = $this->service->buildDateFromContact($data, $fieldType, $prefix, $configuredReminder);
@@ -198,7 +198,7 @@ class BirthdayServiceTest extends TestCase {
 		$service->onCardChanged(666, 'gump.vcf', '');
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesCardChanges')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesCardChanges')]
 	public function testOnCardChanged(string $expectedOp): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
@@ -289,7 +289,7 @@ class BirthdayServiceTest extends TestCase {
 		$service->onCardChanged(666, 'gump.vcf', '');
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesBirthday')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesBirthday')]
 	public function testBirthdayEvenChanged(bool $expected, string $old, string $new): void {
 		$new = Reader::read($new);
 		$this->assertEquals($expected, $this->service->birthdayEvenChanged($old, $new));

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -46,7 +46,7 @@ use function time;
  *
  * @package OCA\DAV\Tests\unit\CardDAV
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CardDavBackendTest extends TestCase {
 	private Principal&MockObject $principal;
 	private IUserManager&MockObject $userManager;
@@ -656,7 +656,7 @@ class CardDavBackendTest extends TestCase {
 		$this->invokePrivate($this->backend, 'getCardId', [1, 'uri']);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSearch')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSearch')]
 	public function testSearch(string $pattern, array $properties, array $options, array $expected): void {
 		/** @var VCard $vCards */
 		$vCards = [];

--- a/apps/dav/tests/unit/CardDAV/ConverterTest.php
+++ b/apps/dav/tests/unit/CardDAV/ConverterTest.php
@@ -79,7 +79,7 @@ class ConverterTest extends TestCase {
 		return $accountManager;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesNewUsers')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesNewUsers')]
 	public function testCreation($expectedVCard, $displayName = null, $eMailAddress = null, $cloudId = null): void {
 		$user = $this->getUserMock((string)$displayName, $eMailAddress, $cloudId);
 		$accountManager = $this->getAccountManager($user);
@@ -187,7 +187,7 @@ class ConverterTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesNames')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesNames')]
 	public function testNameSplitter(string $expected, string $fullName): void {
 		$converter = new Converter($this->accountManager, $this->userManager, $this->urlGenerator, $this->logger);
 		$r = $converter->splitFullName($fullName);

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -45,7 +45,7 @@ class ImageExportPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesQueryParams')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesQueryParams')]
 	public function testQueryParams(array $param): void {
 		$this->request->expects($this->once())->method('getQueryParameters')->willReturn($param);
 		$result = $this->plugin->httpGet($this->request, $this->response);
@@ -86,7 +86,7 @@ class ImageExportPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCard')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCard')]
 	public function testCard(?int $size, bool $photo): void {
 		$query = ['photo' => null];
 		if ($size !== null) {

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -325,7 +325,7 @@ END:VCARD';
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataActivatedUsers')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataActivatedUsers')]
 	public function testUpdateAndDeleteUser(bool $activated, int $createCalls, int $updateCalls, int $deleteCalls): void {
 		/** @var CardDavBackend | MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
@@ -425,7 +425,7 @@ END:VCARD';
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providerUseAbsoluteUriReport')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providerUseAbsoluteUriReport')]
 	public function testUseAbsoluteUriReport(string $host, string $expected): void {
 		$body = '<?xml version="1.0"?>
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns">

--- a/apps/dav/tests/unit/CardDAV/SystemAddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/SystemAddressBookTest.php
@@ -34,7 +34,7 @@ class SystemAddressBookTest extends TestCase {
 	private array $addressBookInfo;
 	private IL10N&MockObject $l10n;
 	private IConfig&MockObject $config;
-	private IUserSession $userSession;
+	private IUserSession&MockObject $userSession;
 	private IRequest&MockObject $request;
 	private array $server;
 	private TrustedServers&MockObject $trustedServers;

--- a/apps/dav/tests/unit/Command/ListAddressbooksTest.php
+++ b/apps/dav/tests/unit/Command/ListAddressbooksTest.php
@@ -78,7 +78,7 @@ class ListAddressbooksTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecute')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecute')]
 	public function testWithCorrectUser(bool $readOnly, string $output): void {
 		$this->userManager->expects($this->once())
 			->method('userExists')

--- a/apps/dav/tests/unit/Command/ListCalendarsTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarsTest.php
@@ -79,7 +79,7 @@ class ListCalendarsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecute')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecute')]
 	public function testWithCorrectUser(bool $readOnly, string $output): void {
 		$this->userManager->expects($this->once())
 			->method('userExists')

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -64,7 +64,7 @@ class MoveCalendarTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecute')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecute')]
 	public function testWithBadUserOrigin(bool $userOriginExists, bool $userDestinationExists): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -176,7 +176,7 @@ class MoveCalendarTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestMoveWithDestinationNotPartOfGroup')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestMoveWithDestinationNotPartOfGroup')]
 	public function testMoveWithDestinationNotPartOfGroup(bool $shareWithGroupMembersOnly): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')
@@ -307,7 +307,7 @@ class MoveCalendarTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestMoveWithCalendarAlreadySharedToDestination')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestMoveWithCalendarAlreadySharedToDestination')]
 	public function testMoveWithCalendarAlreadySharedToDestination(bool $force): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')

--- a/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
@@ -24,7 +24,7 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\Unit\Repair
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class RemoveInvalidSharesTest extends TestCase {
 	private RemoveInvalidShares $command;
 

--- a/apps/dav/tests/unit/Comments/CommentsNodeTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsNodeTest.php
@@ -469,7 +469,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('readCommentProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'readCommentProvider')]
 	public function testGetPropertiesUnreadProperty(\DateTime $creationDT, ?\DateTime $readDT, string $expected): void {
 		$this->comment->expects($this->any())
 			->method('getCreationDateTime')

--- a/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\DAV\Tests\unit\Connector
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class LegacyPublicAuthTest extends \Test\TestCase {
 	private ISession&MockObject $session;
 	private IRequest&MockObject $request;

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -19,7 +19,9 @@ use OCP\IUser;
 use OCP\Security\Bruteforce\IThrottler;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Server;
+use Sabre\HTTP\Request;
 use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\Response;
 use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
@@ -28,7 +30,7 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AuthTest extends TestCase {
 	private ISession&MockObject $session;
 	private Session&MockObject $userSession;
@@ -454,8 +456,8 @@ class AuthTest extends TestCase {
 
 	public function testAuthenticateNoBasicAuthenticateHeadersProvided(): void {
 		$server = $this->createMock(Server::class);
-		$server->httpRequest = $this->createMock(RequestInterface::class);
-		$server->httpResponse = $this->createMock(ResponseInterface::class);
+		$server->httpRequest = $this->createMock(Request::class);
+		$server->httpResponse = $this->createMock(Response::class);
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);
 		$this->assertEquals([false, 'No \'Authorization: Basic\' header found. Either the client didn\'t send one, or the server is misconfigured'], $response);
 	}
@@ -525,9 +527,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjaxButUserIsStillLoggedIn(): void {
-		/** @var \Sabre\HTTP\RequestInterface $httpRequest */
 		$httpRequest = $this->createMock(RequestInterface::class);
-		/** @var \Sabre\HTTP\ResponseInterface $httpResponse */
 		$httpResponse = $this->createMock(ResponseInterface::class);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('MyTestUser');
@@ -561,14 +561,14 @@ class AuthTest extends TestCase {
 
 	public function testAuthenticateValidCredentials(): void {
 		$server = $this->createMock(Server::class);
-		$server->httpRequest = $this->createMock(RequestInterface::class);
+		$server->httpRequest = $this->createMock(Request::class);
 		$server->httpRequest
 			->expects($this->once())
 			->method('getHeader')
 			->with('Authorization')
 			->willReturn('basic dXNlcm5hbWU6cGFzc3dvcmQ=');
 
-		$server->httpResponse = $this->createMock(ResponseInterface::class);
+		$server->httpResponse = $this->createMock(Response::class);
 		$this->userSession
 			->expects($this->once())
 			->method('logClientIn')
@@ -588,7 +588,7 @@ class AuthTest extends TestCase {
 
 	public function testAuthenticateInvalidCredentials(): void {
 		$server = $this->createMock(Server::class);
-		$server->httpRequest = $this->createMock(RequestInterface::class);
+		$server->httpRequest = $this->createMock(Request::class);
 		$server->httpRequest
 			->expects($this->exactly(2))
 			->method('getHeader')
@@ -596,7 +596,7 @@ class AuthTest extends TestCase {
 				['Authorization', 'basic dXNlcm5hbWU6cGFzc3dvcmQ='],
 				['X-Requested-With', null],
 			]);
-		$server->httpResponse = $this->createMock(ResponseInterface::class);
+		$server->httpResponse = $this->createMock(Response::class);
 		$this->userSession
 			->expects($this->once())
 			->method('logClientIn')

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -19,7 +19,7 @@ use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class BearerAuthTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private ISession&MockObject $session;
@@ -74,7 +74,7 @@ class BearerAuthTest extends TestCase {
 		$request = $this->createMock(RequestInterface::class);
 		/** @var ResponseInterface&MockObject $response */
 		$response = $this->createMock(ResponseInterface::class);
-		$result = $this->bearerAuth->challenge($request, $response);
-		$this->assertEmpty($result);
+		$this->bearerAuth->challenge($request, $response);
+		$this->assertTrue(true);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -55,7 +55,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('oldDesktopClientProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'oldDesktopClientProvider')]
 	public function testBeforeHandlerException(string $userAgent, ERROR_TYPE $errorType): void {
 		$this->themingDefaults
 			->expects($this->atMost(1))
@@ -94,7 +94,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 	/**
 	 * Ensure that there is no room for XSS attack through configured URL / version
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('oldDesktopClientProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'oldDesktopClientProvider')]
 	public function testBeforeHandlerExceptionPreventXSSAttack(string $userAgent, ERROR_TYPE $errorType): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -140,7 +140,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('newAndAlternateDesktopClientProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'newAndAlternateDesktopClientProvider')]
 	public function testBeforeHandlerSuccess(string $userAgent): void {
 		/** @var RequestInterface|MockObject $request */
 		$request = $this->createMock(RequestInterface::class);

--- a/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
@@ -43,7 +43,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('nodeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'nodeProvider')]
 	public function testHandleGetProperties(string $class, bool $expectedSuccessful): void {
 		$propFind = $this->createMock(PropFind::class);
 
@@ -67,7 +67,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('baseUriProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'baseUriProvider')]
 	public function testGetCommentsLink(string $baseUri, string $fid, ?string $expectedHref): void {
 		$node = $this->createMock(File::class);
 		$node->expects($this->any())
@@ -89,7 +89,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('userProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'userProvider')]
 	public function testGetUnreadCount(?string $user): void {
 		$node = $this->createMock(File::class);
 		$node->expects($this->any())

--- a/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
@@ -13,6 +13,8 @@ use OCA\DAV\Connector\Sabre\File;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Server;
 use Sabre\DAV\Tree;
+use Sabre\HTTP\Request;
+use Sabre\HTTP\Response;
 use Test\TestCase;
 
 class CopyEtagHeaderPluginTest extends TestCase {
@@ -27,8 +29,8 @@ class CopyEtagHeaderPluginTest extends TestCase {
 	}
 
 	public function testCopyEtag(): void {
-		$request = new \Sabre\Http\Request('GET', 'dummy.file');
-		$response = new \Sabre\Http\Response();
+		$request = new Request('GET', 'dummy.file');
+		$response = new Response();
 		$response->setHeader('Etag', 'abcd');
 
 		$this->plugin->afterMethod($request, $response);
@@ -37,8 +39,8 @@ class CopyEtagHeaderPluginTest extends TestCase {
 	}
 
 	public function testNoopWhenEmpty(): void {
-		$request = new \Sabre\Http\Request('GET', 'dummy.file');
-		$response = new \Sabre\Http\Response();
+		$request = new Request('GET', 'dummy.file');
+		$response = new Response();
 
 		$this->plugin->afterMethod($request, $response);
 

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -25,7 +25,7 @@ use Sabre\DAV\Tree;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CustomPropertiesBackendTest extends \Test\TestCase {
 	private \Sabre\DAV\Server $server;
 	private \Sabre\DAV\Tree&MockObject $tree;

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -58,7 +58,7 @@ class TestViewDirectory extends View {
 }
 
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DirectoryTest extends \Test\TestCase {
 	use UserTrait;
 
@@ -514,20 +514,20 @@ class DirectoryTest extends \Test\TestCase {
 		$this->assertEquals([200, 800], $dir->getQuotaInfo()); //200 used, 800 free
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('moveFailedProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'moveFailedProvider')]
 	public function testMoveFailed(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->moveTest($source, $destination, $updatables, $deletables);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('moveSuccessProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'moveSuccessProvider')]
 	public function testMoveSuccess(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->moveTest($source, $destination, $updatables, $deletables);
 		$this->addToAssertionCount(1);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('moveFailedInvalidCharsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'moveFailedInvalidCharsProvider')]
 	public function testMoveFailedInvalidChars(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->expectException(InvalidPath::class);
 

--- a/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
@@ -40,9 +40,7 @@ class DummyGetResponsePluginTest extends TestCase {
 
 
 	public function testHttpGet(): void {
-		/** @var \Sabre\HTTP\RequestInterface $request */
 		$request = $this->createMock(RequestInterface::class);
-		/** @var \Sabre\HTTP\ResponseInterface $response */
 		$response = $this->createMock(ResponseInterface::class);
 		$response
 			->expects($this->once())

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -42,7 +42,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesExceptions')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesExceptions')]
 	public function testLogging(string $expectedLogLevel, \Throwable $e): void {
 		$this->init();
 

--- a/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
@@ -119,7 +119,7 @@ class FakeLockerPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('tokenDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tokenDataProvider')]
 	public function testValidateTokens(array $input, array $expected): void {
 		$request = $this->createMock(RequestInterface::class);
 		$this->fakeLockerPlugin->validateTokens($request, $input);

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -49,7 +49,7 @@ use Test\Traits\UserTrait;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FileTest extends TestCase {
 	use MountProviderTrait;
 	use UserTrait;
@@ -150,7 +150,7 @@ class FileTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('fopenFailuresProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'fopenFailuresProvider')]
 	public function testSimplePutFails(?\Throwable $thrownException, string $expectedException, bool $checkPreviousClass = true): void {
 		// setup
 		$storage = $this->getMockBuilder(Local::class)
@@ -315,7 +315,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test putting a file with string Mtime
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('legalMtimeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'legalMtimeProvider')]
 	public function testPutSingleFileLegalMtime(mixed $requestMtime, ?int $resultMtime): void {
 		$request = new Request([
 			'server' => [

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -26,16 +26,18 @@ use OCP\IPreview;
 use OCP\IRequest;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\PropPatch;
 use Sabre\DAV\Server;
 use Sabre\DAV\Tree;
 use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\Response;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\Xml\Service;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FilesPluginTest extends TestCase {
 
 	private Tree&MockObject $tree;
@@ -72,14 +74,17 @@ class FilesPluginTest extends TestCase {
 			$this->accountManager,
 		);
 
-		$response = $this->createMock(ResponseInterface::class);
+		$response = $this->createMock(Response::class);
 		$this->server->httpResponse = $response;
 		$this->server->xml = new Service();
 
 		$this->plugin->initialize($this->server);
 	}
 
-	private function createTestNode(string $class, string $path = '/dummypath'): MockObject {
+	/**
+	 * @param class-string<INode> $class
+	 */
+	private function createTestNode(string $class, string $path = '/dummypath'): INode&MockObject {
 		$node = $this->createMock($class);
 
 		$node->expects($this->any())
@@ -650,7 +655,7 @@ class FilesPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('downloadHeadersProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'downloadHeadersProvider')]
 	public function testDownloadHeaders(bool $isClumsyAgent, string $contentDispositionHeader): void {
 		$request = $this->createMock(RequestInterface::class);
 		$response = $this->createMock(ResponseInterface::class);

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -846,7 +846,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('filesBaseUriProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'filesBaseUriProvider')]
 	public function testFilesBaseUri(string $uri, string $reportPath, string $expectedUri): void {
 		$this->assertEquals($expectedUri, self::invokePrivate($this->plugin, 'getFilesBaseUri', [$uri, $reportPath]));
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class NodeTest extends \Test\TestCase {
 	public static function davPermissionsProvider(): array {
 		return [
@@ -51,7 +51,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('davPermissionsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'davPermissionsProvider')]
 	public function testDavPermissions(int $permissions, string $type, bool $shared, int $shareRootPermissions, bool $mounted, string $internalPath, string $expected): void {
 		$info = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()
@@ -139,7 +139,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('sharePermissionsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sharePermissionsProvider')]
 	public function testSharePermissions(string $type, ?string $user, int $permissions, int $expected): void {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('getPermissions')->willReturn($permissions);
@@ -238,7 +238,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('sanitizeMtimeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sanitizeMtimeProvider')]
 	public function testSanitizeMtime(string|int $mtime, int $expected): void {
 		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
@@ -258,7 +258,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('invalidSanitizeMtimeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'invalidSanitizeMtimeProvider')]
 	public function testInvalidSanitizeMtime(int|string $mtime): void {
 		$this->expectException(\InvalidArgumentException::class);
 

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -26,7 +26,7 @@ use OCP\Files\Mount\IMountManager;
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ObjectTreeTest extends \Test\TestCase {
 	public static function copyDataProvider(): array {
 		return [
@@ -39,7 +39,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('copyDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'copyDataProvider')]
 	public function testCopy(string $sourcePath, string $targetPath, string $targetParent): void {
 		$view = $this->createMock(View::class);
 		$view->expects($this->once())
@@ -81,7 +81,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$objectTree->copy($sourcePath, $targetPath);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('copyDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'copyDataProvider')]
 	public function testCopyFailNotCreatable($sourcePath, $targetPath, $targetParent): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -120,7 +120,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$objectTree->copy($sourcePath, $targetPath);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('nodeForPathProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'nodeForPathProvider')]
 	public function testGetNodeForPath(
 		string $inputFileName,
 		string $fileInfoQueryPath,

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -463,7 +463,7 @@ class PrincipalTest extends TestCase {
 			['{http://sabredav.org/ns}email-address' => 'foo']));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('searchPrincipalsDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'searchPrincipalsDataProvider')]
 	public function testSearchPrincipals(bool $sharingEnabled, bool $groupsOnly, string $test, array $result): void {
 		$this->shareManager->expects($this->once())
 			->method('shareAPIEnabled')
@@ -824,7 +824,7 @@ class PrincipalTest extends TestCase {
 		$this->assertEquals(null, $this->connector->findByUri('mailto:user@foo.com', 'principals/users'));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('findByUriWithGroupRestrictionDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'findByUriWithGroupRestrictionDataProvider')]
 	public function testFindByUriWithGroupRestriction(string $uri, string $email, ?string $expects): void {
 		$this->shareManager->expects($this->once())
 			->method('shareApiEnabled')
@@ -875,7 +875,7 @@ class PrincipalTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('findByUriWithoutGroupRestrictionDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'findByUriWithoutGroupRestrictionDataProvider')]
 	public function testFindByUriWithoutGroupRestriction(string $uri, string $email, string $expects): void {
 		$this->shareManager->expects($this->once())
 			->method('shareApiEnabled')

--- a/apps/dav/tests/unit/Connector/Sabre/PropFindMonitorPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PropFindMonitorPluginTest.php
@@ -105,7 +105,7 @@ class PropFindMonitorPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTest')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTest')]
 	public function test(array $queries, $expectedLogCalls): void {
 		$this->plugin->initialize($this->server);
 		$this->server->expects($this->once())->method('getPluginQueries')

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -25,7 +25,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\DAV\Tests\unit\Connector
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PublicAuthTest extends \Test\TestCase {
 
 	private ISession&MockObject $session;

--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -25,7 +25,7 @@ class QuotaPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('lengthProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'lengthProvider')]
 	public function testLength(?int $expected, array $headers): void {
 		$this->init(0);
 
@@ -34,7 +34,7 @@ class QuotaPluginTest extends TestCase {
 		$this->assertEquals($expected, $length);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('quotaOkayProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'quotaOkayProvider')]
 	public function testCheckQuota(int $quota, array $headers): void {
 		$this->init($quota);
 
@@ -43,7 +43,7 @@ class QuotaPluginTest extends TestCase {
 		$this->assertTrue($result);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('quotaExceededProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'quotaExceededProvider')]
 	public function testCheckExceededQuota(int $quota, array $headers): void {
 		$this->expectException(\Sabre\DAV\Exception\InsufficientStorage::class);
 
@@ -53,7 +53,7 @@ class QuotaPluginTest extends TestCase {
 		$this->plugin->checkQuota('');
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('quotaOkayProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'quotaOkayProvider')]
 	public function testCheckQuotaOnPath(int $quota, array $headers): void {
 		$this->init($quota, 'sub/test.txt');
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
@@ -17,7 +17,7 @@ use OCP\Files\FileInfo;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DeleteTest extends RequestTestCase {
 	public function testBasicUpload(): void {
 		$user = self::getUniqueID();

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
@@ -17,7 +17,7 @@ use OCP\Lock\ILockingProvider;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DownloadTest extends RequestTestCase {
 	public function testDownload(): void {
 		$user = self::getUniqueID();

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
@@ -20,7 +20,7 @@ use Test\Traits\EncryptionTrait;
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class EncryptionMasterKeyUploadTest extends UploadTest {
 	use EncryptionTrait;
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
@@ -20,7 +20,7 @@ use Test\Traits\EncryptionTrait;
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class EncryptionUploadTest extends UploadTest {
 	use EncryptionTrait;
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
@@ -17,7 +17,7 @@ use OCP\Server;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PartFileInRootUploadTest extends UploadTest {
 	protected function setUp(): void {
 		$config = Server::get(IConfig::class);

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
@@ -19,7 +19,7 @@ use OCP\Lock\ILockingProvider;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UploadTest extends RequestTestCase {
 	public function testBasicUpload(): void {
 		$user = self::getUniqueID();

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -51,7 +51,7 @@ class SharesPluginTest extends \Test\TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('sharesGetPropertiesDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sharesGetPropertiesDataProvider')]
 	public function testGetProperties(array $shareTypes): void {
 		$sabreNode = $this->createMock(Node::class);
 		$sabreNode->expects($this->any())
@@ -114,7 +114,7 @@ class SharesPluginTest extends \Test\TestCase {
 		$this->assertEquals($shareTypes, $result[200][self::SHARETYPES_PROPERTYNAME]->getShareTypes());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('sharesGetPropertiesDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sharesGetPropertiesDataProvider')]
 	public function testPreloadThenGetProperties(array $shareTypes): void {
 		$sabreNode1 = $this->createMock(File::class);
 		$sabreNode1->method('getId')

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -58,7 +58,7 @@ class TagsPluginTest extends \Test\TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('tagsGetPropertiesDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tagsGetPropertiesDataProvider')]
 	public function testGetProperties(array $tags, array $requestedProperties, array $expectedProperties): void {
 		$node = $this->createMock(Node::class);
 		$node->expects($this->any())
@@ -93,7 +93,7 @@ class TagsPluginTest extends \Test\TestCase {
 		$this->assertEquals($expectedProperties, $result);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('tagsGetPropertiesDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tagsGetPropertiesDataProvider')]
 	public function testPreloadThenGetProperties(array $tags, array $requestedProperties, array $expectedProperties): void {
 		$node1 = $this->createMock(File::class);
 		$node1->expects($this->any())

--- a/apps/dav/tests/unit/Connector/ServerTest.php
+++ b/apps/dav/tests/unit/Connector/ServerTest.php
@@ -45,7 +45,7 @@ class ServerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('removeAllListenersData')]
+	#[DataProvider(methodName: 'removeAllListenersData')]
 	public function testRemoveAllListeners(?string $removeEventName): void {
 		$listener = static function () {
 			return false;

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -53,7 +53,7 @@ class InvitationResponseControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'attendeeProvider')]
 	public function testAccept(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -115,7 +115,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'attendeeProvider')]
 	public function testAcceptSequence(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -177,7 +177,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'attendeeProvider')]
 	public function testAcceptRecurrenceId(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -267,7 +267,7 @@ EOF;
 		$this->assertEquals([], $response->getParams());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'attendeeProvider')]
 	public function testDecline(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -336,7 +336,7 @@ EOF;
 		$this->assertEquals(['token' => 'TOKEN123'], $response->getParams());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'attendeeProvider')]
 	public function testProcessMoreOptionsResult(bool $isExternalAttendee): void {
 		$this->request->expects($this->once())
 			->method('getParam')
@@ -430,7 +430,7 @@ EOF;
 		$expr->expects($this->once())
 			->method('eq')
 			->with('token', 'namedParameterToken')
-			->willReturn((string)$function);
+			->willReturn($function);
 
 		$this->dbConnection->expects($this->once())
 			->method('getQueryBuilder')

--- a/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
+++ b/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
@@ -15,7 +15,7 @@ use Sabre\HTTP\Response;
 
 class BrowserErrorPagePluginTest extends \Test\TestCase {
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesExceptions')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesExceptions')]
 	public function test(int $expectedCode, \Throwable $exception): void {
 		/** @var BrowserErrorPagePlugin&MockObject $plugin */
 		$plugin = $this->getMockBuilder(BrowserErrorPagePlugin::class)->onlyMethods(['sendResponse', 'generateBody'])->getMock();

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -25,7 +25,7 @@ use Sabre\DAVACL\IACL;
 use Sabre\DAVACL\IPrincipal;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CustomPropertiesBackendTest extends TestCase {
 	private const BASE_URI = '/remote.php/dav/';
 
@@ -274,7 +274,7 @@ class CustomPropertiesBackendTest extends TestCase {
 
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('propFindPrincipalScheduleDefaultCalendarProviderUrlProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'propFindPrincipalScheduleDefaultCalendarProviderUrlProvider')]
 	public function testPropFindPrincipalScheduleDefaultCalendarUrl(
 		string $user,
 		array $nodes,
@@ -336,7 +336,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals($returnedProps, $setProps);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('propPatchProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'propPatchProvider')]
 	public function testPropPatch(string $path, array $existing, array $props, array $result): void {
 		$this->server->method('calculateUri')
 			->willReturnCallback(function ($uri) {
@@ -417,7 +417,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals([], $storedProps);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('deleteProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'deleteProvider')]
 	public function testDelete(string $path): void {
 		$this->insertProps('dummy_user_42', $path, ['foo' => 'bar']);
 		$this->backend->delete($path);
@@ -431,7 +431,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('moveProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'moveProvider')]
 	public function testMove(string $source, string $target): void {
 		$this->insertProps('dummy_user_42', $source, ['foo' => 'bar']);
 		$this->backend->move($source, $target);

--- a/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
+++ b/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
@@ -192,7 +192,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 			['{DAV:}displayname' => 'Foo']));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('searchPrincipalsDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'searchPrincipalsDataProvider')]
 	public function testSearchPrincipals(bool $sharingEnabled, bool $groupSharingEnabled, bool $groupsOnly, string $test, array $result): void {
 		$this->shareManager->expects($this->once())
 			->method('shareAPIEnabled')
@@ -263,7 +263,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('findByUriDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'findByUriDataProvider')]
 	public function testFindByUri(bool $sharingEnabled, bool $groupSharingEnabled, bool $groupsOnly, string $findUri, ?string $result): void {
 		$this->shareManager->expects($this->once())
 			->method('shareAPIEnabled')

--- a/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
@@ -14,7 +14,7 @@ use Test\TestCase;
 
 class SystemPrincipalBackendTest extends TestCase {
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesPrefix')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesPrefix')]
 	public function testGetPrincipalsByPrefix(array $expected, string $prefix): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalsByPrefix($prefix);
@@ -36,7 +36,7 @@ class SystemPrincipalBackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesPath')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesPath')]
 	public function testGetPrincipalByPath(?array $expected, string $path): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalByPath($path);
@@ -55,7 +55,7 @@ class SystemPrincipalBackendTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesPrincipalForGetGroupMemberSet')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesPrincipalForGetGroupMemberSet')]
 	public function testGetGroupMemberSetExceptional(?string $principal): void {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Principal not found');
@@ -77,7 +77,7 @@ class SystemPrincipalBackendTest extends TestCase {
 		$this->assertEquals(['principals/system/system'], $result);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesPrincipalForGetGroupMembership')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesPrincipalForGetGroupMembership')]
 	public function testGetGroupMembershipExceptional(string $principal): void {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Principal not found');

--- a/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
@@ -94,7 +94,7 @@ class ViewOnlyPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesDataForCanGet')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesDataForCanGet')]
 	public function testCanGet(bool $isVersion, ?bool $attrEnabled, bool $expectCanDownloadFile, bool $allowViewWithoutDownload): void {
 		$nodeInfo = $this->createMock(File::class);
 		if ($isVersion) {

--- a/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
+++ b/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
@@ -36,7 +36,7 @@ class ActivityUpdaterListenerTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestHandleCalendarObjectDeletedEvent')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataForTestHandleCalendarObjectDeletedEvent')]
 	public function testHandleCalendarObjectDeletedEvent(int $calendarId, array $calendarData, array $shares, array $objectData, bool $createsActivity): void {
 		$event = new CalendarObjectDeletedEvent($calendarId, $calendarData, $shares, $objectData);
 		$this->logger->expects($this->once())->method('debug')->with(
@@ -58,7 +58,7 @@ class ActivityUpdaterListenerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestHandleCalendarDeletedEvent')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataForTestHandleCalendarDeletedEvent')]
 	public function testHandleCalendarDeletedEvent(int $calendarId, array $calendarData, array $shares, bool $createsActivity): void {
 		$event = new CalendarDeletedEvent($calendarId, $calendarData, $shares);
 		$this->logger->expects($this->once())->method('debug')->with(

--- a/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
+++ b/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
@@ -22,7 +22,7 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\Unit\DAV\Migration
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CalDAVRemoveEmptyValueTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 	private CalDavBackend&MockObject $backend;

--- a/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
+++ b/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
@@ -45,7 +45,7 @@ class RemoveDeletedUsersCalendarSubscriptionsTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRun')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestRun')]
 	public function testRun(array $subscriptions, array $userExists, int $deletions): void {
 		$qb = $this->createMock(IQueryBuilder::class);
 

--- a/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
@@ -408,7 +408,7 @@ class EventsSearchProviderTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('provideDeepLinkData')]
+	#[DataProvider(methodName: 'provideDeepLinkData')]
 	public function testGetDeepLinkToCalendarApp(
 		string $principalUri,
 		string $expectedBase64DavUrl,
@@ -435,7 +435,7 @@ class EventsSearchProviderTest extends TestCase {
 		$this->assertEquals('absolute-url-to-route', $actual);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('generateSublineDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'generateSublineDataProvider')]
 	public function testGenerateSubline(string $ics, string $expectedSubline): void {
 		$vCalendar = Reader::read($ics, Reader::OPTION_FORGIVING);
 		$eventComponent = $vCalendar->VEVENT;

--- a/apps/dav/tests/unit/Search/TasksSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/TasksSearchProviderTest.php
@@ -289,7 +289,7 @@ class TasksSearchProviderTest extends TestCase {
 		$this->assertEquals('absolute-url-link-to-route-tasks.indexcalendars/uri-john.doe/tasks/task-uri.ics', $actual);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('generateSublineDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'generateSublineDataProvider')]
 	public function testGenerateSubline(string $ics, string $expectedSubline): void {
 		$vCalendar = Reader::read($ics, Reader::OPTION_FORGIVING);
 		$taskComponent = $vCalendar->VTODO;

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -17,10 +17,10 @@ use OCP\IRequest;
  *
  * @package OCA\DAV\Tests\Unit
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ServerTest extends \Test\TestCase {
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesUris')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesUris')]
 	public function test(string $uri, array $plugins): void {
 		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $r */
 		$r = $this->createMock(IRequest::class);

--- a/apps/dav/tests/unit/Service/ExampleContactServiceTest.php
+++ b/apps/dav/tests/unit/Service/ExampleContactServiceTest.php
@@ -173,7 +173,7 @@ class ExampleContactServiceTest extends TestCase {
 		return [[true], [false]];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('provideDefaultContactEnableData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'provideDefaultContactEnableData')]
 	public function testIsDefaultContactEnabled(bool $enabled): void {
 		$this->appConfig->expects(self::once())
 			->method('getAppValueBool')
@@ -183,7 +183,7 @@ class ExampleContactServiceTest extends TestCase {
 		$this->assertEquals($enabled, $this->service->isDefaultContactEnabled());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('provideDefaultContactEnableData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'provideDefaultContactEnableData')]
 	public function testSetDefaultContactEnabled(bool $enabled): void {
 		$this->appConfig->expects(self::once())
 			->method('setAppValueBool')

--- a/apps/dav/tests/unit/Service/ExampleEventServiceTest.php
+++ b/apps/dav/tests/unit/Service/ExampleEventServiceTest.php
@@ -62,7 +62,7 @@ class ExampleEventServiceTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('provideCustomEventData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'provideCustomEventData')]
 	public function testCreateExampleEventWithCustomEvent($customEventIcs): void {
 		$this->appConfig->expects(self::once())
 			->method('getValueBool')
@@ -142,7 +142,7 @@ class ExampleEventServiceTest extends TestCase {
 		$this->service->createExampleEvent(1000);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('provideCustomEventData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'provideCustomEventData')]
 	public function testGetExampleEventWithCustomEvent($customEventIcs): void {
 		$exampleEventFolder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects(self::once())

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -107,7 +107,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeDeleteProviderPermissionException')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tagNodeDeleteProviderPermissionException')]
 	public function testDeleteTagExpectedException(ISystemTag $tag, $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -49,7 +49,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		return [[true], [false]];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('adminFlagProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'adminFlagProvider')]
 	public function testGetters(bool $isAdmin): void {
 		$tag = new SystemTag('1', 'Test', true, true);
 		$node = $this->getTagNode($isAdmin, $tag);
@@ -87,7 +87,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tagNodeProvider')]
 	public function testUpdateTag(bool $isAdmin, ISystemTag $originalTag, array $changedArgs): void {
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -145,7 +145,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeProviderPermissionException')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tagNodeProviderPermissionException')]
 	public function testUpdateTagPermissionException(ISystemTag $originalTag, array $changedArgs, string $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')
@@ -210,7 +210,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		$this->getTagNode(false, $tag)->update('Renamed', true, true, null);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('adminFlagProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'adminFlagProvider')]
 	public function testDeleteTag(bool $isAdmin): void {
 		$tag = new SystemTag('1', 'tag1', true, true);
 		$this->tagManager->expects($isAdmin ? $this->once() : $this->never())
@@ -241,7 +241,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeDeleteProviderPermissionException')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tagNodeDeleteProviderPermissionException')]
 	public function testDeleteTagPermissionException(ISystemTag $tag, string $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -142,7 +142,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('getPropertiesDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'getPropertiesDataProvider')]
 	public function testGetProperties(ISystemTag $systemTag, array $groups, array $requestedProperties, array $expectedProperties): void {
 		$this->user->expects($this->any())
 			->method('getUID')
@@ -339,7 +339,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 			[true, true, 'group1|group2'],
 		];
 	}
-	#[\PHPUnit\Framework\Attributes\DataProvider('createTagInsufficientPermissionsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'createTagInsufficientPermissionsProvider')]
 	public function testCreateNotAssignableTagAsRegularUser(bool $userVisible, bool $userAssignable, string $groups): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Not sufficient permissions');
@@ -448,7 +448,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('createTagProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'createTagProvider')]
 	public function testCreateTagInByIdCollection(bool $userVisible, bool $userAssignable, string $groups): void {
 		$this->user->expects($this->once())
 			->method('getUID')
@@ -613,7 +613,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$this->plugin->httpPost($request, $response);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('nodeClassProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'nodeClassProvider')]
 	public function testCreateTagConflict(string $nodeClass): void {
 		$this->expectException(\Sabre\DAV\Exception\Conflict::class);
 

--- a/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
@@ -185,7 +185,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('childExistsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'childExistsProvider')]
 	public function testChildExists(bool $userVisible, bool $expectedResult): void {
 		$tag = new SystemTag('123', 'One', $userVisible, false);
 		$this->tagManager->expects($this->once())

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -93,7 +93,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('permissionsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'permissionsProvider')]
 	public function testAssignTagNoPermission(bool $userVisible, bool $userAssignable, string $expectedException): void {
 		$tag = new SystemTag('1', 'Test', $userVisible, $userAssignable);
 		$this->tagManager->expects($this->once())

--- a/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
@@ -12,7 +12,7 @@ use Sabre\DAV\File;
 
 class AssemblyStreamTest extends \Test\TestCase {
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesNodes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesNodes')]
 	public function testGetContents(string $expected, array $nodeData): void {
 		$nodes = [];
 		foreach ($nodeData as $data) {
@@ -24,7 +24,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 		$this->assertEquals($expected, $content);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesNodes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesNodes')]
 	public function testGetContentsFread(string $expected, array $nodeData, int $chunkLength = 3): void {
 		$nodes = [];
 		foreach ($nodeData as $data) {
@@ -44,7 +44,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 		$this->assertEquals($expected, $content);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesNodes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesNodes')]
 	public function testSeek(string $expected, array $nodeData): void {
 		$nodes = [];
 		foreach ($nodeData as $data) {

--- a/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
+++ b/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
@@ -68,7 +68,7 @@ class UploadAutoMkcolPluginTest extends TestCase {
 		$this->assertTrue($return);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataMissingHeaderShouldReturnTrue')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataMissingHeaderShouldReturnTrue')]
 	public function testBeforeMethodWithMissingHeaderShouldReturnTrue(?string $header): void {
 		$this->request->expects(self::once())
 			->method('getHeader')

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -33,7 +33,7 @@ use Test\Traits\UserTrait;
  *
  * @package OCA\Encryption\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FixEncryptedVersionTest extends TestCase {
 	use MountProviderTrait;
 	use EncryptionTrait;

--- a/apps/encryption/tests/Command/TestEnableMasterKey.php
+++ b/apps/encryption/tests/Command/TestEnableMasterKey.php
@@ -46,7 +46,7 @@ class TestEnableMasterKey extends TestCase {
 		$this->enableMasterKey = new EnableMasterKey($this->util, $this->config, $this->questionHelper);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestExecute')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestExecute')]
 	public function testExecute(bool $isAlreadyEnabled, string $answer): void {
 		$this->util->expects($this->once())->method('isMasterKeyEnabled')
 			->willReturn($isAlreadyEnabled);

--- a/apps/encryption/tests/Controller/RecoveryControllerTest.php
+++ b/apps/encryption/tests/Controller/RecoveryControllerTest.php
@@ -44,7 +44,7 @@ class RecoveryControllerTest extends TestCase {
 	 * @param $expectedMessage
 	 * @param $expectedStatus
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('adminRecoveryProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'adminRecoveryProvider')]
 	public function testAdminRecovery($recoveryPassword, $passConfirm, $enableRecovery, $expectedMessage, $expectedStatus): void {
 		$this->recoveryMock->expects($this->any())
 			->method('enableAdminRecovery')
@@ -80,7 +80,7 @@ class RecoveryControllerTest extends TestCase {
 	 * @param $expectedMessage
 	 * @param $expectedStatus
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('changeRecoveryPasswordProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'changeRecoveryPasswordProvider')]
 	public function testChangeRecoveryPassword($password, $confirmPassword, $oldPassword, $expectedMessage, $expectedStatus): void {
 		$this->recoveryMock->expects($this->any())
 			->method('changeRecoveryKeyPassword')
@@ -110,7 +110,7 @@ class RecoveryControllerTest extends TestCase {
 	 * @param $expectedMessage
 	 * @param $expectedStatus
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('userSetRecoveryProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'userSetRecoveryProvider')]
 	public function testUserSetRecovery($enableRecovery, $expectedMessage, $expectedStatus): void {
 		$this->recoveryMock->expects($this->any())
 			->method('setRecoveryForUser')

--- a/apps/encryption/tests/Controller/StatusControllerTest.php
+++ b/apps/encryption/tests/Controller/StatusControllerTest.php
@@ -54,7 +54,7 @@ class StatusControllerTest extends TestCase {
 	 * @param string $status
 	 * @param string $expectedStatus
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetStatus')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetStatus')]
 	public function testGetStatus($status, $expectedStatus): void {
 		$this->sessionMock->expects($this->atLeastOnce())
 			->method('getStatus')->willReturn($status);

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -81,7 +81,7 @@ class CryptTest extends TestCase {
 	/**
 	 * test generateHeader with valid key formats
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGenerateHeader')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGenerateHeader')]
 	public function testGenerateHeader($keyFormat, $expected): void {
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
@@ -132,7 +132,7 @@ class CryptTest extends TestCase {
 	 * @param string $configValue
 	 * @param string $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderGetCipher')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataProviderGetCipher')]
 	public function testGetCipher($configValue, $expected): void {
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
@@ -172,7 +172,7 @@ class CryptTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitMetaData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSplitMetaData')]
 	public function testSplitMetaData($data, $expected): void {
 		$this->config->method('getSystemValueBool')
 			->with('encryption_skip_signature_check', false)
@@ -197,7 +197,7 @@ class CryptTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestHasSignature')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestHasSignature')]
 	public function testHasSignature($data, $expected): void {
 		$this->config->method('getSystemValueBool')
 			->with('encryption_skip_signature_check', false)
@@ -214,7 +214,7 @@ class CryptTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestHasSignatureFail')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestHasSignatureFail')]
 	public function testHasSignatureFail($cipher): void {
 		$this->expectException(GenericEncryptionException::class);
 
@@ -245,7 +245,7 @@ class CryptTest extends TestCase {
 	 * @param $data
 	 * @param $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderRemovePadding')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataProviderRemovePadding')]
 	public function testRemovePadding($data, $expected): void {
 		$result = self::invokePrivate($this->crypt, 'removePadding', [$data]);
 		$this->assertSame($expected, $result);
@@ -320,7 +320,7 @@ class CryptTest extends TestCase {
 	/**
 	 * test return values of valid ciphers
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetKeySize')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetKeySize')]
 	public function testGetKeySize($cipher, $expected): void {
 		$result = $this->invokePrivate($this->crypt, 'getKeySize', [$cipher]);
 		$this->assertSame($expected, $result);
@@ -345,7 +345,7 @@ class CryptTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDecryptPrivateKey')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestDecryptPrivateKey')]
 	public function testDecryptPrivateKey($header, $privateKey, $expectedCipher, $isValidKey, $expected): void {
 		$this->config->method('getSystemValueBool')
 			->willReturnMap([

--- a/apps/encryption/tests/Crypto/DecryptAllTest.php
+++ b/apps/encryption/tests/Crypto/DecryptAllTest.php
@@ -63,7 +63,7 @@ class DecryptAllTest extends TestCase {
 	 * @param string $user
 	 * @param string $recoveryKeyId
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetPrivateKey')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetPrivateKey')]
 	public function testGetPrivateKey($user, $recoveryKeyId, $masterKeyId): void {
 		$password = 'passwd';
 		$recoveryKey = 'recoveryKey';

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -383,7 +383,7 @@ class EncryptAllTest extends TestCase {
 	/**
 	 * @param $isEncrypted
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestEncryptFile')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestEncryptFile')]
 	public function testEncryptFile($isEncrypted): void {
 		$fileInfo = $this->createMock(FileInfo::class);
 		$fileInfo->expects($this->any())->method('isEncrypted')

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -152,7 +152,7 @@ class EncryptionTest extends TestCase {
 		return $publicKeys;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderForTestGetPathToRealFile')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataProviderForTestGetPathToRealFile')]
 	public function testGetPathToRealFile($path, $expected): void {
 		$this->assertSame($expected,
 			self::invokePrivate($this->instance, 'getPathToRealFile', [$path])
@@ -168,7 +168,7 @@ class EncryptionTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestBegin')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestBegin')]
 	public function testBegin($mode, $header, $legacyCipher, $defaultCipher, $fileKey, $expected): void {
 		$this->sessionMock->expects($this->once())
 			->method('decryptAllModeActivated')
@@ -265,7 +265,7 @@ class EncryptionTest extends TestCase {
 	 * @param string $fileKey
 	 * @param boolean $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUpdate')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestUpdate')]
 	public function testUpdate($fileKey, $expected): void {
 		$this->keyManagerMock->expects($this->once())
 			->method('getFileKey')->willReturn($fileKey);
@@ -351,7 +351,7 @@ class EncryptionTest extends TestCase {
 	 * by default the encryption module should encrypt regular files, files in
 	 * files_versions and files in files_trashbin
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShouldEncrypt')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestShouldEncrypt')]
 	public function testShouldEncrypt($path, $shouldEncryptHomeStorage, $isHomeStorage, $expected): void {
 		$this->utilMock->expects($this->once())->method('shouldEncryptHomeStorage')
 			->willReturn($shouldEncryptHomeStorage);

--- a/apps/encryption/tests/EncryptedStorageTest.php
+++ b/apps/encryption/tests/EncryptedStorageTest.php
@@ -23,7 +23,7 @@ class TemporaryNoEncrypted extends Temporary implements IDisableEncryptionStorag
 
 }
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class EncryptedStorageTest extends TestCase {
 	use MountProviderTrait;
 	use EncryptionTrait;

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -167,7 +167,7 @@ class KeyManagerTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUserHasKeys')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestUserHasKeys')]
 	public function testUserHasKeys($key, $expected): void {
 		$this->keyStorageMock->expects($this->exactly(2))
 			->method('getUserKey')
@@ -222,7 +222,7 @@ class KeyManagerTest extends TestCase {
 	/**
 	 * @param bool $useMasterKey
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestInit')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestInit')]
 	public function testInit($useMasterKey): void {
 		/** @var KeyManager&MockObject $instance */
 		$instance = $this->getMockBuilder(KeyManager::class)
@@ -353,7 +353,7 @@ class KeyManagerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetFileKey')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetFileKey')]
 	public function testGetFileKey(?string $uid, bool $isMasterKeyEnabled, string $privateKey, string $encryptedFileKey, string $expected): void {
 		$path = '/foo.txt';
 
@@ -459,7 +459,7 @@ class KeyManagerTest extends TestCase {
 	 * @param string $uid
 	 * @param array $expectedKeys
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestAddSystemKeys')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestAddSystemKeys')]
 	public function testAddSystemKeys($accessList, $publicKeys, $uid, $expectedKeys): void {
 		$publicShareKeyId = 'publicShareKey';
 		$recoveryKeyId = 'recoveryKey';
@@ -542,7 +542,7 @@ class KeyManagerTest extends TestCase {
 	/**
 	 * @param $masterKey
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestValidateMasterKey')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestValidateMasterKey')]
 	public function testValidateMasterKey($masterKey): void {
 		/** @var KeyManager&MockObject $instance */
 		$instance = $this->getMockBuilder(KeyManager::class)

--- a/apps/encryption/tests/Listeners/UserEventsListenersTest.php
+++ b/apps/encryption/tests/Listeners/UserEventsListenersTest.php
@@ -30,7 +30,7 @@ use OCP\User\Events\UserLoggedOutEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserEventsListenersTest extends TestCase {
 
 	protected Util&MockObject $util;

--- a/apps/encryption/tests/PassphraseServiceTest.php
+++ b/apps/encryption/tests/PassphraseServiceTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PassphraseServiceTest extends TestCase {
 
 	protected Util&MockObject $util;

--- a/apps/encryption/tests/SessionTest.php
+++ b/apps/encryption/tests/SessionTest.php
@@ -115,7 +115,7 @@ class SessionTest extends TestCase {
 	 * @param int $status
 	 * @param bool $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsReady')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsReady')]
 	public function testIsReady($status, $expected): void {
 		/** @var Session&MockObject $instance */
 		$instance = $this->getMockBuilder(Session::class)

--- a/apps/encryption/tests/Users/SetupTest.php
+++ b/apps/encryption/tests/Users/SetupTest.php
@@ -50,7 +50,7 @@ class SetupTest extends TestCase {
 	 * @param bool $hasKeys
 	 * @param bool $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetupUser')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSetupUser')]
 	public function testSetupUser($hasKeys, $expected): void {
 		$this->keyManagerMock->expects($this->once())->method('userHasKeys')
 			->with('uid')->willReturn($hasKeys);

--- a/apps/encryption/tests/UtilTest.php
+++ b/apps/encryption/tests/UtilTest.php
@@ -119,7 +119,7 @@ class UtilTest extends TestCase {
 	 * @param string $value
 	 * @param bool $expect
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsMasterKeyEnabled')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsMasterKeyEnabled')]
 	public function testIsMasterKeyEnabled($value, $expect): void {
 		$this->configMock->expects($this->once())->method('getAppValue')
 			->with('encryption', 'useMasterKey', '1')->willReturn($value);
@@ -139,7 +139,7 @@ class UtilTest extends TestCase {
 	 * @param string $returnValue return value from getAppValue()
 	 * @param bool $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShouldEncryptHomeStorage')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestShouldEncryptHomeStorage')]
 	public function testShouldEncryptHomeStorage($returnValue, $expected): void {
 		$this->configMock->expects($this->once())->method('getAppValue')
 			->with('encryption', 'encryptHomeStorage', '1')
@@ -160,7 +160,7 @@ class UtilTest extends TestCase {
 	 * @param $value
 	 * @param $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetEncryptHomeStorage')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSetEncryptHomeStorage')]
 	public function testSetEncryptHomeStorage($value, $expected): void {
 		$this->configMock->expects($this->once())->method('setAppValue')
 			->with('encryption', 'encryptHomeStorage', $expected);

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -80,7 +80,7 @@ class AddressHandlerTest extends \Test\TestCase {
 		return $testCases;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitUserRemote')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSplitUserRemote')]
 	public function testSplitUserRemote(string $remote, string $expectedUser, string $expectedUrl): void {
 		$this->contactsManager->expects($this->any())
 			->method('search')
@@ -109,14 +109,14 @@ class AddressHandlerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitUserRemoteError')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSplitUserRemoteError')]
 	public function testSplitUserRemoteError(string $id): void {
 		$this->expectException(HintException::class);
 
 		$this->addressHandler->splitUserRemote($id);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCompareAddresses')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCompareAddresses')]
 	public function testCompareAddresses(string $user1, string $server1, string $user2, string $server2, bool $expected): void {
 		$this->assertSame($expected,
 			$this->addressHandler->compareAddresses($user1, $server1, $user2, $server2)
@@ -143,7 +143,7 @@ class AddressHandlerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRemoveProtocolFromUrl')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestRemoveProtocolFromUrl')]
 	public function testRemoveProtocolFromUrl(string $url, string $expectedResult): void {
 		$result = $this->addressHandler->removeProtocolFromUrl($url);
 		$this->assertSame($expectedResult, $result);
@@ -157,7 +157,7 @@ class AddressHandlerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUrlContainProtocol')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestUrlContainProtocol')]
 	public function testUrlContainProtocol(string $url, bool $expectedResult): void {
 		$result = $this->addressHandler->urlContainProtocol($url);
 		$this->assertSame($expectedResult, $result);

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -85,7 +85,7 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCreateFederatedShare')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCreateFederatedShare')]
 	public function testCreateFederatedShare(
 		string $shareWith,
 		bool $outgoingSharesAllowed,

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -28,7 +28,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\FederatedFileSharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class RequestHandlerControllerTest extends \Test\TestCase {
 	private string $owner = 'owner';
 	private string $user1 = 'user1';

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -37,7 +37,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\FederatedFileSharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FederatedShareProviderTest extends \Test\TestCase {
 	protected IDBConnection $connection;
 	protected AddressHandler&MockObject $addressHandler;
@@ -117,7 +117,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCreate')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCreate')]
 	public function testCreate(?\DateTime $expirationDate, ?string $expectedDataDate): void {
 		$share = $this->shareManager->newShare();
 
@@ -417,7 +417,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		}
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUpdate')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestUpdate')]
 	public function testUpdate(string $owner, string $sharedBy, ?\DateTime $expirationDate): void {
 		$this->provider = $this->getMockBuilder(FederatedShareProvider::class)
 			->setConstructorArgs(
@@ -708,7 +708,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	 * @param string $deletedUser The user that is deleted
 	 * @param bool $rowDeleted Is the row deleted in this setup
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteUser')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataDeleteUser')]
 	public function testDeleteUser(string $owner, string $initiator, string $recipient, string $deletedUser, bool $rowDeleted): void {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
@@ -738,7 +738,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->assertCount($rowDeleted ? 0 : 1, $data);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsOutgoingServer2serverShareEnabled')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsOutgoingServer2serverShareEnabled')]
 	public function testIsOutgoingServer2serverShareEnabled(bool $internalOnly, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('onlyInternalFederation')
 			->willReturn($internalOnly);
@@ -760,7 +760,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsIncomingServer2serverShareEnabled')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsIncomingServer2serverShareEnabled')]
 	public function testIsIncomingServer2serverShareEnabled(bool $onlyInternal, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('onlyInternalFederation')
 			->willReturn($onlyInternal);
@@ -782,7 +782,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsLookupServerQueriesEnabled')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsLookupServerQueriesEnabled')]
 	public function testIsLookupServerQueriesEnabled(bool $gsEnabled, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('isGlobalScaleEnabled')
 			->willReturn($gsEnabled);
@@ -808,7 +808,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsLookupServerUploadEnabled')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsLookupServerUploadEnabled')]
 	public function testIsLookupServerUploadEnabled(bool $gsEnabled, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('isGlobalScaleEnabled')
 			->willReturn($gsEnabled);

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -78,7 +78,7 @@ class NotificationsTest extends \Test\TestCase {
 	}
 
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSendUpdateToRemote')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSendUpdateToRemote')]
 	public function testSendUpdateToRemote(int $try, array $httpRequestResult, bool $expected): void {
 		$remote = 'http://remote';
 		$id = 42;

--- a/apps/federatedfilesharing/tests/Settings/AdminTest.php
+++ b/apps/federatedfilesharing/tests/Settings/AdminTest.php
@@ -53,7 +53,7 @@ class AdminTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('sharingStateProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sharingStateProvider')]
 	public function testGetForm(bool $state): void {
 		$this->federatedShareProvider
 			->expects($this->once())

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -19,7 +19,7 @@ use OCP\Server;
 /**
  * Base class for sharing tests.
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 abstract class TestCase extends \Test\TestCase {
 	public const TEST_FILES_SHARING_API_USER1 = 'test-share-user1';
 	public const TEST_FILES_SHARING_API_USER2 = 'test-share-user2';

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -30,7 +30,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\Federation\Tests\BackgroundJob
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GetSharedSecretTest extends TestCase {
 
 	private MockObject&IClient $httpClient;
@@ -76,7 +76,7 @@ class GetSharedSecretTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestExecute')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestExecute')]
 	public function testExecute(bool $isTrustedServer, bool $retainBackgroundJob): void {
 		/** @var GetSharedSecret&MockObject $getSharedSecret */
 		$getSharedSecret = $this->getMockBuilder(GetSharedSecret::class)
@@ -134,7 +134,7 @@ class GetSharedSecretTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRun')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestRun')]
 	public function testRun(int $statusCode): void {
 		$target = 'targetURL';
 		$source = 'sourceURL';

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -66,7 +66,7 @@ class RequestSharedSecretTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestStart')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestStart')]
 	public function testStart(bool $isTrustedServer, bool $retainBackgroundJob): void {
 		/** @var RequestSharedSecret&MockObject $requestSharedSecret */
 		$requestSharedSecret = $this->getMockBuilder(RequestSharedSecret::class)
@@ -125,7 +125,7 @@ class RequestSharedSecretTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRun')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestRun')]
 	public function testRun(int $statusCode, int $attempt = 0): void {
 		$target = 'targetURL';
 		$source = 'sourceURL';

--- a/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
+++ b/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
@@ -64,7 +64,7 @@ class OCSAuthAPIControllerTest extends TestCase {
 			->willReturn($this->currentTime);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRequestSharedSecret')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestRequestSharedSecret')]
 	public function testRequestSharedSecret(string $token, string $localToken, bool $isTrustedServer, bool $ok): void {
 		$url = 'url';
 
@@ -104,7 +104,7 @@ class OCSAuthAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetSharedSecret')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetSharedSecret')]
 	public function testGetSharedSecret(bool $isTrustedServer, bool $isValidToken, bool $ok): void {
 		$url = 'url';
 		$token = 'token';

--- a/apps/federation/tests/Controller/SettingsControllerTest.php
+++ b/apps/federation/tests/Controller/SettingsControllerTest.php
@@ -65,7 +65,7 @@ class SettingsControllerTest extends TestCase {
 		$this->assertArrayHasKey('id', $data);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('checkServerFails')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'checkServerFails')]
 	public function testAddServerFail(bool $isTrustedServer, bool $isNextcloud): void {
 		$this->trustedServers
 			->expects($this->any())
@@ -113,7 +113,7 @@ class SettingsControllerTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('checkServerFails')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'checkServerFails')]
 	public function testCheckServerFail(bool $isTrustedServer, bool $isNextcloud): void {
 		$this->trustedServers
 			->expects($this->any())

--- a/apps/federation/tests/DAV/FedAuthTest.php
+++ b/apps/federation/tests/DAV/FedAuthTest.php
@@ -15,7 +15,7 @@ use Test\TestCase;
 
 class FedAuthTest extends TestCase {
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesUser')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesUser')]
 	public function testFedAuth(bool $expected, string $user, string $password): void {
 		/** @var DbHandler&MockObject $db */
 		$db = $this->createMock(DbHandler::class);

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -16,7 +16,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DbHandlerTest extends TestCase {
 	private DbHandler $dbHandler;
 	private IL10N&MockObject $il10n;
@@ -55,7 +55,7 @@ class DbHandlerTest extends TestCase {
 	 * @param string $expectedUrl the url we expect to be written to the db
 	 * @param string $expectedHash the hash value we expect to be written to the db
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestAddServer')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestAddServer')]
 	public function testAddServer(string $url, string $expectedUrl, string $expectedHash): void {
 		$id = $this->dbHandler->addServer($url);
 
@@ -126,7 +126,7 @@ class DbHandlerTest extends TestCase {
 		$this->assertSame($id2, (int)$result[1]['id']);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestServerExists')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestServerExists')]
 	public function testServerExists(string $serverInTable, string $checkForServer, bool $expected): void {
 		$this->dbHandler->addServer($serverInTable);
 		$this->assertSame($expected,
@@ -231,7 +231,7 @@ class DbHandlerTest extends TestCase {
 	/**
 	 * hash should always be computed with the normalized URL
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestHash')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestHash')]
 	public function testHash(string $url, string $expected): void {
 		$this->assertSame($expected,
 			$this->invokePrivate($this->dbHandler, 'hash', [$url])
@@ -247,7 +247,7 @@ class DbHandlerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestNormalizeUrl')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestNormalizeUrl')]
 	public function testNormalizeUrl(string $url, string $expected): void {
 		$this->assertSame($expected,
 			$this->invokePrivate($this->dbHandler, 'normalizeUrl', [$url])
@@ -264,7 +264,7 @@ class DbHandlerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesAuth')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesAuth')]
 	public function testAuth(bool $expectedResult, string $user, string $password): void {
 		if ($expectedResult) {
 			$this->dbHandler->addServer('url1');

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -174,7 +174,7 @@ class TrustedServersTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetServer')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetServer')]
 	public function testGetServer(int $id, ?array $expectedServer): void {
 		$servers = [
 			[
@@ -228,7 +228,7 @@ class TrustedServersTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsNextcloudServer')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsNextcloudServer')]
 	public function testIsNextcloudServer(int $statusCode, bool $isValidNextcloudVersion, bool $expected): void {
 		$server = 'server1';
 
@@ -295,7 +295,7 @@ class TrustedServersTest extends TestCase {
 		$this->assertFalse($this->trustedServers->isNextcloudServer($server));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCheckNextcloudVersion')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCheckNextcloudVersion')]
 	public function testCheckNextcloudVersion(string $status): void {
 		$this->assertTrue(self::invokePrivate($this->trustedServers, 'checkNextcloudVersion', [$status]));
 	}
@@ -307,7 +307,7 @@ class TrustedServersTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCheckNextcloudVersionTooLow')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCheckNextcloudVersionTooLow')]
 	public function testCheckNextcloudVersionTooLow(string $status): void {
 		$this->expectException(HintException::class);
 		$this->expectExceptionMessage('Remote server version is too low. 9.0 is required.');
@@ -321,7 +321,7 @@ class TrustedServersTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUpdateProtocol')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestUpdateProtocol')]
 	public function testUpdateProtocol(string $url, string $expected): void {
 		$this->assertSame($expected,
 			self::invokePrivate($this->trustedServers, 'updateProtocol', [$url])

--- a/apps/files/tests/Activity/Filter/GenericTest.php
+++ b/apps/files/tests/Activity/Filter/GenericTest.php
@@ -18,7 +18,7 @@ use Test\TestCase;
  *
  * @package OCA\Files\Tests\Activity\Filter
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GenericTest extends TestCase {
 	public static function dataFilters(): array {
 		return [
@@ -27,27 +27,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testImplementsInterface(string $filterClass): void {
 		$filter = Server::get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetIdentifier(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetName(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetPriority(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -57,7 +57,7 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testGetIcon(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -65,14 +65,14 @@ class GenericTest extends TestCase {
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testFilterTypes(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFilters')]
 	public function testAllowedApps(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);

--- a/apps/files/tests/Activity/ProviderTest.php
+++ b/apps/files/tests/Activity/ProviderTest.php
@@ -90,7 +90,7 @@ class ProviderTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetFile')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetFile')]
 	public function testGetFile(array|string $parameter, ?int $eventId, string $id, string $name, string $path): void {
 		$provider = $this->getProvider();
 
@@ -134,7 +134,7 @@ class ProviderTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUser')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetUser')]
 	public function testGetUser(string $uid, ?string $userDisplayName, ?array $cloudIdData, array $expected): void {
 		$provider = $this->getProvider();
 

--- a/apps/files/tests/Activity/Setting/GenericTest.php
+++ b/apps/files/tests/Activity/Setting/GenericTest.php
@@ -22,27 +22,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testImplementsInterface(string $settingClass): void {
 		$setting = Server::get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testGetIdentifier(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testGetName(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testGetPriority(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
@@ -52,28 +52,28 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testCanChangeStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testIsDefaultEnabledStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testCanChangeMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSettings')]
 	public function testIsDefaultEnabledMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);

--- a/apps/files/tests/AdvancedCapabilitiesTest.php
+++ b/apps/files/tests/AdvancedCapabilitiesTest.php
@@ -23,7 +23,7 @@ class AdvancedCapabilitiesTest extends TestCase {
 		$this->capabilities = new AdvancedCapabilities($this->service);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetCapabilities')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetCapabilities')]
 	public function testGetCapabilities(bool $wcf): void {
 		$this->service
 			->expects(self::once())

--- a/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
+++ b/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
@@ -21,7 +21,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package Test\BackgroundJob
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 	protected IDBConnection $connection;
 	protected LoggerInterface $logger;

--- a/apps/files/tests/BackgroundJob/ScanFilesTest.php
+++ b/apps/files/tests/BackgroundJob/ScanFilesTest.php
@@ -28,7 +28,7 @@ use Test\Traits\UserTrait;
  *
  * @package OCA\Files\Tests\BackgroundJob
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ScanFilesTest extends TestCase {
 	use UserTrait;
 	use MountProviderTrait;

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -25,7 +25,7 @@ use Test\TestCase;
  *
  * @package OCA\Files\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DeleteOrphanedFilesTest extends TestCase {
 
 	private DeleteOrphanedFiles $command;
@@ -93,7 +93,7 @@ class DeleteOrphanedFilesTest extends TestCase {
 		$fileInfo = $view->getFileInfo('files/test');
 
 		$storageId = $fileInfo->getStorage()->getId();
-		$numericStorageId = $fileInfo->getStorage()->getStorageCache()->getNumericId();
+		$numericStorageId = $fileInfo->getStorage()->getCache()->getNumericStorageId();
 
 		$this->assertCount(1, $this->getFile($fileInfo->getId()), 'Asserts that file is available');
 		$this->assertEquals(1, $this->getMountsCount($numericStorageId), 'Asserts that mount is available');

--- a/apps/files/tests/Controller/ApiControllerTest.php
+++ b/apps/files/tests/Controller/ApiControllerTest.php
@@ -44,11 +44,11 @@ class ApiControllerTest extends TestCase {
 	private string $appName = 'files';
 	private IUser $user;
 	private IRequest $request;
-	private TagService $tagService;
+	private TagService&MockObject $tagService;
 	private IPreview&MockObject $preview;
 	private ApiController $apiController;
 	private IManager $shareManager;
-	private IConfig $config;
+	private IConfig&MockObject $config;
 	private Folder&MockObject $userFolder;
 	private UserConfig&MockObject $userConfig;
 	private ViewConfig&MockObject $viewConfig;

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -214,7 +214,7 @@ class ViewControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShortRedirect')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestShortRedirect')]
 	public function testShortRedirect(?string $openfile, ?string $opendetails, string $result): void {
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')

--- a/apps/files/tests/HelperTest.php
+++ b/apps/files/tests/HelperTest.php
@@ -76,7 +76,7 @@ class HelperTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('sortDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sortDataProvider')]
 	public function testSortByName(string $sort, bool $sortDescending, array $expectedOrder): void {
 		if (($sort === 'mtime') && (PHP_INT_SIZE < 8)) {
 			$this->markTestSkipped('Skip mtime sorting on 32bit');

--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\Files
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class TagServiceTest extends \Test\TestCase {
 	private string $user;
 	private IUserSession&MockObject $userSession;
@@ -44,9 +44,6 @@ class TagServiceTest extends \Test\TestCase {
 		\OC_User::setUserId($this->user);
 		\OC_Util::setupFS($this->user);
 		$user = $this->createMock(IUser::class);
-		/**
-		 * @var IUserSession
-		 */
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userSession->expects($this->any())
 			->method('getUser')

--- a/apps/files_external/lib/Controller/GlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/GlobalStoragesController.php
@@ -25,18 +25,9 @@ use Psr\Log\LoggerInterface;
 class GlobalStoragesController extends StoragesController {
 	/**
 	 * Creates a new global storages controller.
-	 *
-	 * @param string $AppName application name
-	 * @param IRequest $request request object
-	 * @param IL10N $l10n l10n service
-	 * @param GlobalStoragesService $globalStoragesService storage service
-	 * @param LoggerInterface $logger
-	 * @param IUserSession $userSession
-	 * @param IGroupManager $groupManager
-	 * @param IConfig $config
 	 */
 	public function __construct(
-		$appName,
+		string $appName,
 		IRequest $request,
 		IL10N $l10n,
 		GlobalStoragesService $globalStoragesService,
@@ -64,24 +55,22 @@ class GlobalStoragesController extends StoragesController {
 	 * @param string $backend backend identifier
 	 * @param string $authMechanism authentication mechanism identifier
 	 * @param array $backendOptions backend-specific options
-	 * @param array $mountOptions mount-specific options
-	 * @param array $applicableUsers users for which to mount the storage
-	 * @param array $applicableGroups groups for which to mount the storage
-	 * @param int $priority priority
-	 *
-	 * @return DataResponse
+	 * @param ?array $mountOptions mount-specific options
+	 * @param ?array $applicableUsers users for which to mount the storage
+	 * @param ?array $applicableGroups groups for which to mount the storage
+	 * @param ?int $priority priority
 	 */
 	#[PasswordConfirmationRequired(strict: true)]
 	public function create(
 		string $mountPoint,
 		string $backend,
 		string $authMechanism,
-		$backendOptions,
-		$mountOptions,
-		$applicableUsers,
-		$applicableGroups,
-		$priority,
-	) {
+		array $backendOptions,
+		?array $mountOptions,
+		?array $applicableUsers,
+		?array $applicableGroups,
+		?int $priority,
+	): DataResponse {
 		$canCreateNewLocalStorage = $this->config->getSystemValue('files_external_allow_create_new_local', true);
 		if (!$canCreateNewLocalStorage && $backend === 'local') {
 			return new DataResponse(
@@ -129,12 +118,10 @@ class GlobalStoragesController extends StoragesController {
 	 * @param string $backend backend identifier
 	 * @param string $authMechanism authentication mechanism identifier
 	 * @param array $backendOptions backend-specific options
-	 * @param array $mountOptions mount-specific options
-	 * @param array $applicableUsers users for which to mount the storage
-	 * @param array $applicableGroups groups for which to mount the storage
-	 * @param int $priority priority
-	 *
-	 * @return DataResponse
+	 * @param ?array $mountOptions mount-specific options
+	 * @param ?array $applicableUsers users for which to mount the storage
+	 * @param ?array $applicableGroups groups for which to mount the storage
+	 * @param ?int $priority priority
 	 */
 	#[PasswordConfirmationRequired(strict: true)]
 	public function update(
@@ -142,12 +129,12 @@ class GlobalStoragesController extends StoragesController {
 		string $mountPoint,
 		string $backend,
 		string $authMechanism,
-		$backendOptions,
-		$mountOptions,
-		$applicableUsers,
-		$applicableGroups,
-		$priority,
-	) {
+		array $backendOptions,
+		?array $mountOptions,
+		?array $applicableUsers,
+		?array $applicableGroups,
+		?int $priority,
+	): DataResponse {
 		$storage = $this->createStorage(
 			$mountPoint,
 			$backend,

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -70,11 +70,11 @@ abstract class StoragesController extends Controller {
 		string $mountPoint,
 		string $backend,
 		string $authMechanism,
-		$backendOptions,
-		$mountOptions = null,
-		$applicableUsers = null,
-		$applicableGroups = null,
-		$priority = null,
+		array $backendOptions,
+		?array $mountOptions = null,
+		?array $applicableUsers = null,
+		?array $applicableGroups = null,
+		?int $priority = null,
 	) {
 		$canCreateNewLocalStorage = $this->config->getSystemValue('files_external_allow_create_new_local', true);
 		if (!$canCreateNewLocalStorage && $backend === 'local') {

--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -21,6 +21,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Override;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -29,17 +30,9 @@ use Psr\Log\LoggerInterface;
 class UserStoragesController extends StoragesController {
 	/**
 	 * Creates a new user storages controller.
-	 *
-	 * @param string $AppName application name
-	 * @param IRequest $request request object
-	 * @param IL10N $l10n l10n service
-	 * @param UserStoragesService $userStoragesService storage service
-	 * @param LoggerInterface $logger
-	 * @param IUserSession $userSession
-	 * @param IGroupManager $groupManager
 	 */
 	public function __construct(
-		$appName,
+		string $appName,
 		IRequest $request,
 		IL10N $l10n,
 		UserStoragesService $userStoragesService,
@@ -60,7 +53,7 @@ class UserStoragesController extends StoragesController {
 		);
 	}
 
-	protected function manipulateStorageConfig(StorageConfig $storage) {
+	protected function manipulateStorageConfig(StorageConfig $storage): void {
 		/** @var AuthMechanism */
 		$authMechanism = $storage->getAuthMechanism();
 		$authMechanism->manipulateStorageConfig($storage, $this->userSession->getUser());
@@ -71,21 +64,19 @@ class UserStoragesController extends StoragesController {
 
 	/**
 	 * Get all storage entries
-	 *
-	 * @return DataResponse
 	 */
+	#[Override]
 	#[NoAdminRequired]
-	public function index() {
+	public function index(): DataResponse {
 		return parent::index();
 	}
 
 	/**
 	 * Return storage
-	 *
-	 * {@inheritdoc}
 	 */
+	#[Override]
 	#[NoAdminRequired]
-	public function show(int $id) {
+	public function show(int $id): DataResponse {
 		return parent::show($id);
 	}
 
@@ -97,8 +88,6 @@ class UserStoragesController extends StoragesController {
 	 * @param string $authMechanism authentication mechanism identifier
 	 * @param array $backendOptions backend-specific options
 	 * @param array $mountOptions backend-specific mount options
-	 *
-	 * @return DataResponse
 	 */
 	#[NoAdminRequired]
 	#[PasswordConfirmationRequired(strict: true)]
@@ -106,9 +95,9 @@ class UserStoragesController extends StoragesController {
 		string $mountPoint,
 		string $backend,
 		string $authMechanism,
-		$backendOptions,
-		$mountOptions,
-	) {
+		array $backendOptions,
+		?array $mountOptions,
+	): DataResponse {
 		$canCreateNewLocalStorage = $this->config->getSystemValue('files_external_allow_create_new_local', true);
 		if (!$canCreateNewLocalStorage && $backend === 'local') {
 			return new DataResponse(
@@ -152,9 +141,7 @@ class UserStoragesController extends StoragesController {
 	 * @param string $backend backend identifier
 	 * @param string $authMechanism authentication mechanism identifier
 	 * @param array $backendOptions backend-specific options
-	 * @param array $mountOptions backend-specific mount options
-	 *
-	 * @return DataResponse
+	 * @param ?array $mountOptions backend-specific mount options
 	 */
 	#[NoAdminRequired]
 	#[PasswordConfirmationRequired(strict: true)]
@@ -163,9 +150,9 @@ class UserStoragesController extends StoragesController {
 		string $mountPoint,
 		string $backend,
 		string $authMechanism,
-		$backendOptions,
-		$mountOptions,
-	) {
+		array $backendOptions,
+		?array $mountOptions,
+	): DataResponse {
 		$storage = $this->createStorage(
 			$mountPoint,
 			$backend,
@@ -204,12 +191,11 @@ class UserStoragesController extends StoragesController {
 
 	/**
 	 * Delete storage
-	 *
-	 * {@inheritdoc}
 	 */
+	#[Override]
 	#[NoAdminRequired]
 	#[PasswordConfirmationRequired(strict: true)]
-	public function destroy(int $id) {
+	public function destroy(int $id): DataResponse {
 		return parent::destroy($id);
 	}
 }

--- a/apps/files_external/lib/Service/StoragesService.php
+++ b/apps/files_external/lib/Service/StoragesService.php
@@ -268,14 +268,14 @@ abstract class StoragesService {
 	 * @return StorageConfig
 	 */
 	public function createStorage(
-		$mountPoint,
-		$backendIdentifier,
-		$authMechanismIdentifier,
-		$backendOptions,
-		$mountOptions = null,
-		$applicableUsers = null,
-		$applicableGroups = null,
-		$priority = null,
+		string $mountPoint,
+		string $backendIdentifier,
+		string $authMechanismIdentifier,
+		array $backendOptions,
+		?array $mountOptions = null,
+		?array $applicableUsers = null,
+		?array $applicableGroups = null,
+		?int $priority = null,
 	) {
 		$backend = $this->backendService->getBackend($backendIdentifier);
 		if (!$backend) {

--- a/apps/files_external/tests/Auth/AuthMechanismTest.php
+++ b/apps/files_external/tests/Auth/AuthMechanismTest.php
@@ -37,7 +37,7 @@ class AuthMechanismTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'validateStorageProvider')]
 	public function testValidateStorage(bool $expectedSuccess, string $scheme, bool $definitionSuccess): void {
 		$mechanism = $this->getMockBuilder(AuthMechanism::class)
 			->onlyMethods(['validateStorageDefinition'])

--- a/apps/files_external/tests/Backend/BackendTest.php
+++ b/apps/files_external/tests/Backend/BackendTest.php
@@ -41,7 +41,7 @@ class BackendTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'validateStorageProvider')]
 	public function testValidateStorage(bool $expectedSuccess, bool $definitionSuccess): void {
 		$backend = $this->getMockBuilder(Backend::class)
 			->onlyMethods(['validateStorageDefinition'])

--- a/apps/files_external/tests/Config/UserPlaceholderHandlerTest.php
+++ b/apps/files_external/tests/Config/UserPlaceholderHandlerTest.php
@@ -58,13 +58,13 @@ class UserPlaceholderHandlerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('optionProvider')]
+	#[DataProvider(methodName: 'optionProvider')]
 	public function testHandle(string|array $option, string|array $expected): void {
 		$this->setUser();
 		$this->assertSame($expected, $this->handler->handle($option));
 	}
 
-	#[DataProvider('optionProvider')]
+	#[DataProvider(methodName: 'optionProvider')]
 	public function testHandleNoUser(string|array $option): void {
 		$this->shareManager->expects($this->once())
 			->method('getShareByToken')

--- a/apps/files_external/tests/Controller/StoragesControllerTestCase.php
+++ b/apps/files_external/tests/Controller/StoragesControllerTestCase.php
@@ -186,7 +186,7 @@ abstract class StoragesControllerTestCase extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('mountPointNamesProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'mountPointNamesProvider')]
 	public function testAddOrUpdateStorageInvalidMountPoint($mountPoint): void {
 		$storageConfig = new StorageConfig(1);
 		$storageConfig->setMountPoint($mountPoint);
@@ -355,7 +355,7 @@ abstract class StoragesControllerTestCase extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'validateStorageProvider')]
 	public function testValidateStorage(bool $backendValidate, bool $authMechValidate, bool $expectSuccess): void {
 		$backend = $this->getBackendMock();
 		$backend->method('validateStorage')

--- a/apps/files_external/tests/DefinitionParameterTest.php
+++ b/apps/files_external/tests/DefinitionParameterTest.php
@@ -68,7 +68,7 @@ class DefinitionParameterTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('validateValueProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'validateValueProvider')]
 	public function testValidateValue($type, $flags, $value, $success, $expectedValue = null): void {
 		$param = new Param('foo', 'bar');
 		$param->setType($type);

--- a/apps/files_external/tests/FrontendDefinitionTraitTest.php
+++ b/apps/files_external/tests/FrontendDefinitionTraitTest.php
@@ -45,7 +45,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'validateStorageProvider')]
 	public function testValidateStorage(bool $expectedSuccess, array $params): void {
 		$backendParams = [];
 		foreach ($params as $name => $valid) {

--- a/apps/files_external/tests/Listener/StorePasswordListenerTest.php
+++ b/apps/files_external/tests/Listener/StorePasswordListenerTest.php
@@ -18,7 +18,7 @@ use OCP\User\Events\UserLoggedInEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class StorePasswordListenerTest extends TestCase {
 	protected IUser&MockObject $mockedUser;
 

--- a/apps/files_external/tests/OwnCloudFunctionsTest.php
+++ b/apps/files_external/tests/OwnCloudFunctionsTest.php
@@ -16,7 +16,7 @@ use OCA\Files_External\Lib\Storage\OwnCloud;
  *
  * @package OCA\Files_External\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class OwnCloudFunctionsTest extends \Test\TestCase {
 	public static function configUrlProvider(): array {
 		return [
@@ -87,7 +87,7 @@ class OwnCloudFunctionsTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('configUrlProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'configUrlProvider')]
 	public function testConfig(array $config, string $expectedUri): void {
 		$config['user'] = 'someuser';
 		$config['password'] = 'somepassword';

--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -208,7 +208,7 @@ class BackendServiceTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('invalidConfigPlaceholderProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'invalidConfigPlaceholderProvider')]
 	public function testRegisterConfigHandlerInvalid(array $placeholders): void {
 		$this->expectException(\RuntimeException::class);
 

--- a/apps/files_external/tests/Service/DBConfigServiceTest.php
+++ b/apps/files_external/tests/Service/DBConfigServiceTest.php
@@ -14,7 +14,7 @@ use OCP\Security\ICrypto;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DBConfigServiceTest extends TestCase {
 	private IDBConnection $connection;
 	private DBConfigService $dbConfig;

--- a/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
@@ -13,7 +13,7 @@ use OCA\Files_External\MountConfig;
 
 use OCA\Files_External\Service\GlobalStoragesService;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 	protected function setUp(): void {
 		parent::setUp();
@@ -113,7 +113,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('storageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'storageDataProvider')]
 	public function testAddStorage($storageParams): void {
 		$storage = $this->makeStorageConfig($storageParams);
 		$newStorage = $this->service->addStorage($storage);
@@ -135,7 +135,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		$this->assertEquals($baseId + 1, $nextStorage->getId());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('storageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'storageDataProvider')]
 	public function testUpdateStorage($updatedStorageParams): void {
 		$updatedStorage = $this->makeStorageConfig($updatedStorageParams);
 		$storage = $this->makeStorageConfig([
@@ -275,7 +275,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('hooksAddStorageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'hooksAddStorageDataProvider')]
 	public function testHooksAddStorage($applicableUsers, $applicableGroups, $expectedCalls): void {
 		$storage = $this->makeTestStorageData();
 		$storage->setApplicableUsers($applicableUsers);
@@ -411,7 +411,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('hooksUpdateStorageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'hooksUpdateStorageDataProvider')]
 	public function testHooksUpdateStorage(
 		array $sourceApplicableUsers,
 		array $sourceApplicableGroups,
@@ -569,7 +569,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('hooksDeleteStorageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'hooksDeleteStorageDataProvider')]
 	public function testHooksDeleteStorage(
 		array $sourceApplicableUsers,
 		array $sourceApplicableGroups,

--- a/apps/files_external/tests/Service/StoragesServiceTestCase.php
+++ b/apps/files_external/tests/Service/StoragesServiceTestCase.php
@@ -53,7 +53,7 @@ class CleaningDBConfig extends DBConfigService {
 	}
 }
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 abstract class StoragesServiceTestCase extends \Test\TestCase {
 	protected StoragesService $service;
 	protected BackendService&MockObject $backendService;
@@ -249,7 +249,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('deleteStorageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'deleteStorageDataProvider')]
 	public function testDeleteStorage(array $backendOptions, string $rustyStorageId): void {
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\DAV');
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');
@@ -382,11 +382,13 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 	}
 
 	public function testGetStoragesBackendNotVisible(): void {
+		/** @var Backend&MockObject $backend */
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
 		$backend->expects($this->once())
 			->method('isVisibleFor')
 			->with($this->service->getVisibilityType())
 			->willReturn(false);
+		/** @var AuthMechanism&MockObject $authMechanism */
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');
 		$authMechanism->method('isVisibleFor')
 			->with($this->service->getVisibilityType())
@@ -405,10 +407,12 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 	}
 
 	public function testGetStoragesAuthMechanismNotVisible(): void {
+		/** @var Backend&MockObject $backend */
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
 		$backend->method('isVisibleFor')
 			->with($this->service->getVisibilityType())
 			->willReturn(true);
+		/** @var AuthMechanism&MockObject $authMechanism */
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');
 		$authMechanism->expects($this->once())
 			->method('isVisibleFor')

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -20,7 +20,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 	use UserTrait;
 
@@ -96,7 +96,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('applicableStorageProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'applicableStorageProvider')]
 	public function testGetStorageWithApplicable($applicableUsers, $applicableGroups, $isVisible): void {
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');
@@ -170,7 +170,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		$this->ActualNonExistingStorageTest();
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('deleteStorageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'deleteStorageDataProvider')]
 	public function testDeleteStorage($backendOptions, $rustyStorageId): void {
 		$this->expectException(\DomainException::class);
 
@@ -224,7 +224,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('getUniqueStoragesProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'getUniqueStoragesProvider')]
 	public function testGetUniqueStorages(
 		$priority1, $applicableUsers1, $applicableGroups1,
 		$priority2, $applicableUsers2, $applicableGroups2,

--- a/apps/files_external/tests/Service/UserStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserStoragesServiceTest.php
@@ -22,7 +22,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserStoragesServiceTest extends StoragesServiceTestCase {
 	use UserTrait;
 
@@ -126,7 +126,7 @@ class UserStoragesServiceTest extends StoragesServiceTestCase {
 		$this->assertEmpty(self::$hookCalls);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('deleteStorageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'deleteStorageDataProvider')]
 	public function testDeleteStorage($backendOptions, $rustyStorageId): void {
 		parent::testDeleteStorage($backendOptions, $rustyStorageId);
 

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -15,8 +15,8 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
-#[\PHPUnit\Framework\Attributes\Group('S3')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'S3')]
 class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/** @var AmazonS3 */

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -16,7 +16,7 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 #[\PHPUnit\Framework\Attributes\Group('S3')]
 class Amazons3Test extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;

--- a/apps/files_external/tests/Storage/FtpTest.php
+++ b/apps/files_external/tests/Storage/FtpTest.php
@@ -16,7 +16,7 @@ use OCA\Files_External\Lib\Storage\FTP;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FtpTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/OwncloudTest.php
+++ b/apps/files_external/tests/Storage/OwncloudTest.php
@@ -16,7 +16,7 @@ use OCA\Files_External\Lib\Storage\OwnCloud;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class OwncloudTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/SFTP_KeyTest.php
+++ b/apps/files_external/tests/Storage/SFTP_KeyTest.php
@@ -16,7 +16,7 @@ use OCA\Files_External\Lib\Storage\SFTP_Key;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SFTP_KeyTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -16,7 +16,7 @@ use OCA\Files_External\Lib\Storage\SFTP;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SftpTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/**
@@ -42,7 +42,7 @@ class SftpTest extends \Test\Files\Storage\Storage {
 		parent::tearDown();
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('configProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'configProvider')]
 	public function testStorageId($config, $expectedStorageId): void {
 		$instance = new SFTP($config);
 		$this->assertEquals($expectedStorageId, $instance->getId());

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\ExpectationFailedException;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SmbTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/**

--- a/apps/files_external/tests/Storage/SwiftTest.php
+++ b/apps/files_external/tests/Storage/SwiftTest.php
@@ -17,7 +17,7 @@ use OCA\Files_External\Lib\Storage\Swift;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SwiftTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
+++ b/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Files_External\Tests\Storage;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 #[\PHPUnit\Framework\Attributes\Group('S3')]
 class VersionedAmazonS3Test extends Amazons3Test {
 	protected function setUp(): void {

--- a/apps/files_external/tests/Storage/WebdavTest.php
+++ b/apps/files_external/tests/Storage/WebdavTest.php
@@ -19,7 +19,7 @@ use OCP\Server;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class WebdavTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -48,7 +48,7 @@ use Test\Traits\EmailValidatorTrait;
  * Class ApiTest
  */
 #[\PHPUnit\Framework\Attributes\Medium]
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ApiTest extends TestCase {
 	use EmailValidatorTrait;
 
@@ -216,7 +216,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
+	#[\PHPUnit\Framework\Attributes\Group(name: 'RoutingWeirdness')]
 	public function testCreateShareLink(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
@@ -239,8 +239,8 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAllowFederationOnPublicShares')]
-	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataAllowFederationOnPublicShares')]
+	#[\PHPUnit\Framework\Attributes\Group(name: 'RoutingWeirdness')]
 	public function testCreateShareLinkPublicUpload(array $appConfig, int $permissions): void {
 		$this->appConfig->method('getValueBool')
 			->willReturnMap([$appConfig]);
@@ -472,8 +472,8 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
-	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
+	#[\PHPUnit\Framework\Attributes\Depends(methodName: 'testCreateShareUserFile')]
+	#[\PHPUnit\Framework\Attributes\Depends(methodName: 'testCreateShareLink')]
 	public function testGetShareFromSource(): void {
 		$node = $this->userFolder->get($this->filename);
 		$share = $this->shareManager->newShare();
@@ -502,8 +502,8 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share2);
 	}
 
-	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
-	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
+	#[\PHPUnit\Framework\Attributes\Depends(methodName: 'testCreateShareUserFile')]
+	#[\PHPUnit\Framework\Attributes\Depends(methodName: 'testCreateShareLink')]
 	public function testGetShareFromSourceWithReshares(): void {
 		$node = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
@@ -541,7 +541,7 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share2);
 	}
 
-	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
+	#[\PHPUnit\Framework\Attributes\Depends(methodName: 'testCreateShareUserFile')]
 	public function testGetShareFromId(): void {
 		$node = $this->userFolder->get($this->filename);
 		$share1 = $this->shareManager->newShare();
@@ -920,8 +920,8 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareUserFile')]
-	#[\PHPUnit\Framework\Attributes\Depends('testCreateShareLink')]
+	#[\PHPUnit\Framework\Attributes\Depends(methodName: 'testCreateShareUserFile')]
+	#[\PHPUnit\Framework\Attributes\Depends(methodName: 'testCreateShareLink')]
 	public function testUpdateShare(): void {
 		$password = md5(time());
 
@@ -979,7 +979,7 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share2);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAllowFederationOnPublicShares')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataAllowFederationOnPublicShares')]
 	public function testUpdateShareUpload(array $appConfig, int $permissions): void {
 		$this->appConfig->method('getValueBool')->willReturnMap([
 			$appConfig,
@@ -1275,7 +1275,7 @@ class ApiTest extends TestCase {
 	/**
 	 * Make sure only ISO 8601 dates are accepted
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('datesProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'datesProvider')]
 	#[\PHPUnit\Framework\Attributes\Group('RoutingWeirdness')]
 	public function testPublicLinkExpireDate($date, $valid): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);

--- a/apps/files_sharing/tests/ApplicationTest.php
+++ b/apps/files_sharing/tests/ApplicationTest.php
@@ -56,7 +56,7 @@ class ApplicationTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('providesDataForCanGet')]
+	#[DataProvider(methodName: 'providesDataForCanGet')]
 	public function testCheckDirectCanBeDownloaded(
 		string $path,
 		string $storageClass,
@@ -115,7 +115,7 @@ class ApplicationTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('providesDataForCanZip')]
+	#[DataProvider(methodName: 'providesDataForCanZip')]
 	public function testCheckZipCanBeDownloaded(
 		string $dir,
 		array $files,

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -18,6 +18,7 @@ use OCA\Files_Sharing\SharedStorage;
 use OCP\Constants;
 use OCP\Files\Cache\IWatcher;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\IUserManager;
 use OCP\Server;
 use OCP\Share\IShare;
@@ -25,27 +26,14 @@ use OCP\Share\IShare;
 /**
  * Class CacheTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CacheTest extends TestCase {
-
-	/**
-	 * @var View
-	 */
-	public $user2View;
-
-	/** @var Cache */
-	protected $ownerCache;
-
-	/** @var Cache */
-	protected $sharedCache;
-
-	/** @var Storage */
-	protected $ownerStorage;
-
-	/** @var Storage */
-	protected $sharedStorage;
-
-	/** @var \OCP\Share\IManager */
+	public View $user2View;
+	protected Cache $ownerCache;
+	protected Cache $sharedCache;
+	protected Storage $ownerStorage;
+	protected Storage $sharedStorage;
+	/** @var \OCP\Share\IManager $shareManager */
 	protected $shareManager;
 
 	protected function setUp(): void {
@@ -321,9 +309,7 @@ class CacheTest extends TestCase {
 		self::assertEquals([
 			'welcome.txt',
 			'simplefile.txt'
-		], array_map(function ($node) {
-			return $node->getFileInfo()['name'];
-		}, $recents));
+		], array_map(static fn (Node $node): string => $node->getName(), $recents));
 	}
 
 	public function testGetFolderContentsWhenSubSubdirShared(): void {

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -30,17 +30,16 @@ use Psr\Log\LoggerInterface;
 /**
  * Class CapabilitiesTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CapabilitiesTest extends \Test\TestCase {
 
 	/**
 	 * Test for the general part in each return statement and assert.
 	 * Strip of the general part on the way.
 	 *
-	 * @param string[] $data Capabilities
-	 * @return string[]
+	 * @param array $data Capabilities
 	 */
-	private function getFilesSharingPart(array $data) {
+	private function getFilesSharingPart(array $data): array {
 		$this->assertArrayHasKey('files_sharing', $data);
 		return $data['files_sharing'];
 	}
@@ -51,9 +50,8 @@ class CapabilitiesTest extends \Test\TestCase {
 	 * levels in the array
 	 *
 	 * @param (string[])[] $map Map of arguments to return types for the getAppValue function in the mock
-	 * @return string[]
 	 */
-	private function getResults(array $map, array $typedMap = [], bool $federationEnabled = true) {
+	private function getResults(array $map, array $typedMap = [], bool $federationEnabled = true): array {
 		$config = $this->getMockBuilder(IConfig::class)->disableOriginalConstructor()->getMock();
 		$appManager = $this->getMockBuilder(IAppManager::class)->disableOriginalConstructor()->getMock();
 		$config->method('getAppValue')->willReturnMap($map);
@@ -97,8 +95,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		);
 
 		$cap = new Capabilities($config, $appConfig, $shareManager, $appManager);
-		$result = $this->getFilesSharingPart($cap->getCapabilities());
-		return $result;
+		return $this->getFilesSharingPart($cap->getCapabilities());
 	}
 
 	public function testEnabledSharingAPI(): void {

--- a/apps/files_sharing/tests/Collaboration/ShareRecipientSorterTest.php
+++ b/apps/files_sharing/tests/Collaboration/ShareRecipientSorterTest.php
@@ -38,7 +38,7 @@ class ShareRecipientSorterTest extends TestCase {
 	/**
 	 * @param $data
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('sortDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'sortDataProvider')]
 	public function testSort($data): void {
 		$node = $this->createMock(Node::class);
 

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
-#[Group('DB')]
+#[Group(name: 'DB')]
 class CleanupRemoteStoragesTest extends TestCase {
 
 	protected IDBConnection $connection;

--- a/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class ExternalShareControllerTest extends \Test\TestCase {
 	private IRequest&MockObject $request;
-	private Manager $externalManager;
+	private Manager&MockObject $externalManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -29,10 +29,7 @@ class ExternalShareControllerTest extends \Test\TestCase {
 		$this->externalManager = $this->createMock(Manager::class);
 	}
 
-	/**
-	 * @return ExternalSharesController
-	 */
-	public function getExternalShareController() {
+	public function getExternalShareController(): ExternalSharesController {
 		return new ExternalSharesController(
 			'files_sharing',
 			$this->request,

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -59,7 +59,7 @@ class PublicPreviewControllerTest extends TestCase {
 	}
 
 	public function testInvalidToken(): void {
-		$res = $this->controller->getPreview('', 'file', 10, 10, '');
+		$res = $this->controller->getPreview('', 'file', 10, 10);
 		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
 
 		$this->assertEquals($expected, $res);

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -64,7 +64,7 @@ use Test\Traits\EmailValidatorTrait;
  *
  * @package OCA\Files_Sharing\Tests\Controller
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ShareAPIControllerTest extends TestCase {
 	use EmailValidatorTrait;
 
@@ -838,7 +838,7 @@ class ShareAPIControllerTest extends TestCase {
 		return $data;
 	}
 
-	#[DataProvider('dataGetShare')]
+	#[DataProvider(methodName: 'dataGetShare')]
 	public function testGetShare(array $shareParams, array $result, bool $attributes): void {
 
 		$cache = $this->createMock(ICache::class);
@@ -1529,7 +1529,7 @@ class ShareAPIControllerTest extends TestCase {
 		return $node;
 	}
 
-	#[DataProvider('dataGetShares')]
+	#[DataProvider(methodName: 'dataGetShares')]
 	public function testGetShares(array $getSharesParameters, array $shares, array $extraShareTypes, array $expected): void {
 		$shares = array_map(
 			fn ($sharesByType) => array_map(
@@ -1706,7 +1706,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
 	}
 
-	#[DataProvider('dataCanAccessShareWithPermissions')]
+	#[DataProvider(methodName: 'dataCanAccessShareWithPermissions')]
 	public function testCanAccessShareWithPermissions(int $permissions, bool $expected): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
@@ -1744,7 +1744,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('dataCanAccessShareAsGroupMember')]
+	#[DataProvider(methodName: 'dataCanAccessShareAsGroupMember')]
 	public function testCanAccessShareAsGroupMember(string $group, bool $expected): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_GROUP);
@@ -1804,7 +1804,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('dataCanAccessRoomShare')]
+	#[DataProvider(methodName: 'dataCanAccessRoomShare')]
 	public function testCanAccessRoomShare(
 		bool $expected,
 		bool $helperAvailable,
@@ -3061,7 +3061,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
-	#[DataProvider('publicUploadParamsProvider')]
+	#[DataProvider(methodName: 'publicUploadParamsProvider')]
 	public function testUpdateLinkShareEnablePublicUpload($permissions, $publicUpload, $expireDate, $password): void {
 		$ocs = $this->mockFormatShare();
 
@@ -3120,7 +3120,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('publicLinkValidPermissionsProvider')]
+	#[DataProvider(methodName: 'publicLinkValidPermissionsProvider')]
 	public function testUpdateLinkShareSetCRUDPermissions($permissions): void {
 		$ocs = $this->mockFormatShare();
 
@@ -3173,7 +3173,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('publicLinkInvalidPermissionsProvider1')]
+	#[DataProvider(methodName: 'publicLinkInvalidPermissionsProvider1')]
 	public function testUpdateLinkShareSetInvalidCRUDPermissions1($permissions): void {
 		$this->expectException(OCSBadRequestException::class);
 		$this->expectExceptionMessage('Share must at least have READ or CREATE permissions');
@@ -3188,7 +3188,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('publicLinkInvalidPermissionsProvider2')]
+	#[DataProvider(methodName: 'publicLinkInvalidPermissionsProvider2')]
 	public function testUpdateLinkShareSetInvalidCRUDPermissions2($permissions): void {
 		$this->expectException(OCSBadRequestException::class);
 		$this->expectExceptionMessage('Share must have READ permission if UPDATE or DELETE permission is set');
@@ -3240,7 +3240,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('publicUploadParamsProvider')]
+	#[DataProvider(methodName: 'publicUploadParamsProvider')]
 	public function testUpdateLinkSharePublicUploadNotAllowed($permissions, $publicUpload, $expireDate, $password): void {
 		$this->expectException(OCSForbiddenException::class);
 		$this->expectExceptionMessage('Public upload disabled by the administrator');
@@ -4898,7 +4898,7 @@ class ShareAPIControllerTest extends TestCase {
 		return $result;
 	}
 
-	#[DataProvider('dataFormatShare')]
+	#[DataProvider(methodName: 'dataFormatShare')]
 	public function testFormatShare(
 		array $expects,
 		array $shareParams,
@@ -5155,7 +5155,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @param bool $helperAvailable
 	 * @param array $formatShareByHelper
 	 */
-	#[DataProvider('dataFormatRoomShare')]
+	#[DataProvider(methodName: 'dataFormatRoomShare')]
 	public function testFormatRoomShare(array $expects, bool $helperAvailable, array $formatShareByHelper): void {
 		$file = $this->createMock(File::class);
 
@@ -5309,7 +5309,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('trustedServerProvider')]
+	#[DataProvider(methodName: 'trustedServerProvider')]
 	public function testFormatShareWithFederatedShare(bool $isKnownServer, bool $isTrusted): void {
 		$nodeId = 12;
 		$nodePath = '/test.txt';

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -52,7 +52,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * @package OCA\Files_Sharing\Controllers
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ShareControllerTest extends \Test\TestCase {
 
 	private string $user;
@@ -245,7 +245,7 @@ class ShareControllerTest extends \Test\TestCase {
 		/** @var Manager */
 		$manager = Server::get(Manager::class);
 		$share = $manager->newShare();
-		$share->setId(42)
+		$share->setId('42')
 			->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE)
 			->setPassword('password')
 			->setShareOwner('ownerUID')
@@ -401,7 +401,7 @@ class ShareControllerTest extends \Test\TestCase {
 		/** @var Manager */
 		$manager = Server::get(Manager::class);
 		$share = $manager->newShare();
-		$share->setId(42)
+		$share->setId('42')
 			->setPermissions(Constants::PERMISSION_CREATE)
 			->setPassword('password')
 			->setShareOwner('ownerUID')
@@ -549,7 +549,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 		/** @var IShare */
 		$share = Server::get(Manager::class)->newShare();
-		$share->setId(42);
+		$share->setId('42');
 		$share->setPassword('password')
 			->setShareOwner('ownerUID')
 			->setSharedBy('initiatorUID')
@@ -656,7 +656,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$owner->method('getDisplayName')->willReturn('ownerDisplay');
 		$owner->method('getUID')->willReturn('ownerUID');
 
-		$file = $this->getMockBuilder('OCP\Files\File')->getMock();
+		$file = $this->getMockBuilder(File::class)->getMock();
 		$file->method('getName')->willReturn($filename);
 		$file->method('getMimetype')->willReturn('text/plain');
 		$file->method('getSize')->willReturn(33);
@@ -664,7 +664,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$file->method('isReadable')->willReturn(true);
 
 		$share = Server::get(\OCP\Share\IManager::class)->newShare();
-		$share->setId(42);
+		$share->setId('42');
 		$share->setPassword('password')
 			->setShareOwner('ownerUID')
 			->setNode($file)
@@ -757,7 +757,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$folder = $this->createMock(Folder::class);
 
 		$share = Server::get(\OCP\Share\IManager::class)->newShare();
-		$share->setId(42);
+		$share->setId('42');
 		$share->setPermissions(Constants::PERMISSION_CREATE)
 			->setShareOwner('ownerUID')
 			->setSharedBy('initiatorUID')
@@ -798,7 +798,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$folder = $this->createMock(Folder::class);
 
 		$share = Server::get(\OCP\Share\IManager::class)->newShare();
-		$share->setId(42);
+		$share->setId('42');
 		$share->setPermissions(Constants::PERMISSION_CREATE)
 			->setShareOwner('ownerUID')
 			->setSharedBy('initiatorUID')

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\Files_Sharing\Tests\API
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ShareesAPIControllerTest extends TestCase {
 	/** @var ShareesAPIController */
 	protected $sharees;
@@ -211,7 +211,7 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param bool $allowGroupSharing
 	 * @throws OCSBadRequestException
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearch')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSearch')]
 	public function testSearch(
 		array $getData,
 		string $apiSetting,
@@ -333,7 +333,7 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param array $getData
 	 * @param string $message
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchInvalid')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSearchInvalid')]
 	public function testSearchInvalid($getData, $message): void {
 		$page = $getData['page'] ?? 1;
 		$perPage = $getData['perPage'] ?? 200;
@@ -391,7 +391,7 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param string $itemType
 	 * @param bool $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsRemoteSharingAllowed')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataIsRemoteSharingAllowed')]
 	public function testIsRemoteSharingAllowed($itemType, $expected): void {
 		$this->assertSame($expected, $this->invokePrivate($this->sharees, 'isRemoteSharingAllowed', [$itemType]));
 	}
@@ -434,7 +434,7 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param array $params
 	 * @param array $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetPaginationLink')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetPaginationLink')]
 	public function testGetPaginationLink($page, $scriptName, $params, $expected): void {
 		$this->request->expects($this->once())
 			->method('getScriptName')
@@ -455,7 +455,7 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param string $scriptName
 	 * @param bool $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsV2')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataIsV2')]
 	public function testIsV2($scriptName, $expected): void {
 		$this->request->expects($this->once())
 			->method('getScriptName')

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -23,7 +23,7 @@ use OCP\Share\IShare;
  *
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 	/**
 	 * @var bool

--- a/apps/files_sharing/tests/EncryptedSizePropagationTest.php
+++ b/apps/files_sharing/tests/EncryptedSizePropagationTest.php
@@ -12,7 +12,7 @@ use OCP\ITempManager;
 use OCP\Server;
 use Test\Traits\EncryptionTrait;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class EncryptedSizePropagationTest extends SizePropagationTest {
 	use EncryptionTrait;
 

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -20,7 +20,7 @@ use OCP\Share\IShare;
  *
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('SLOWDB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'SLOWDB')]
 class EtagPropagationTest extends PropagationTestCase {
 
 	/**

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  *
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ExpireSharesJobTest extends \Test\TestCase {
 
 	private ExpireSharesJob $job;
@@ -107,7 +107,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 	 * @param bool $addInterval If true add to the current time if false subtract
 	 * @param bool $shouldExpire Should this share be expired
 	 */
-	#[DataProvider('dataExpireLinkShare')]
+	#[DataProvider(methodName: 'dataExpireLinkShare')]
 	public function testExpireLinkShare(bool $addExpiration, string $interval, bool $addInterval, bool $shouldExpire): void {
 		$this->loginAsUser($this->user1->getUID());
 

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\Files_Sharing\Tests\External
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CacheTest extends TestCase {
 	protected IManager&MockObject $contactsManager;
 	private Storage&MockObject $storage;

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -50,7 +50,7 @@ use Test\Traits\UserTrait;
  *
  * @package OCA\Files_Sharing\Tests\External
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ManagerTest extends TestCase {
 	use UserTrait;
 

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -12,7 +12,7 @@ use OCA\Files_Sharing\External\Scanner;
 use OCA\Files_Sharing\External\Storage;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ScannerTest extends TestCase {
 	protected Scanner $scanner;
 	/** @var Storage|\PHPUnit\Framework\MockObject\MockObject */

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -17,7 +17,7 @@ use OCP\Http\Client\IResponse;
 /**
  * Tests for the external Storage class for remote shares.
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ExternalStorageTest extends \Test\TestCase {
 	public static function optionsProvider() {
 		return [
@@ -87,7 +87,7 @@ class ExternalStorageTest extends \Test\TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('optionsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'optionsProvider')]
 	public function testStorageMountOptions($inputUri, $baseUri): void {
 		$storage = $this->getTestStorage($inputUri);
 		$this->assertEquals($baseUri, $storage->getBaseUri());

--- a/apps/files_sharing/tests/GroupEtagPropagationTest.php
+++ b/apps/files_sharing/tests/GroupEtagPropagationTest.php
@@ -15,7 +15,7 @@ use OCP\Share\IShare;
 /**
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('SLOWDB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'SLOWDB')]
 class GroupEtagPropagationTest extends PropagationTestCase {
 	/**
 	 * "user1" creates /test, /test/sub and shares with group1

--- a/apps/files_sharing/tests/HelperTest.php
+++ b/apps/files_sharing/tests/HelperTest.php
@@ -15,7 +15,7 @@ use OCP\Server;
 /**
  * Class HelperTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class HelperTest extends TestCase {
 
 	/**

--- a/apps/files_sharing/tests/LockingTest.php
+++ b/apps/files_sharing/tests/LockingTest.php
@@ -22,7 +22,7 @@ use OCP\Share\IShare;
  *
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class LockingTest extends TestCase {
 	/**
 	 * @var \Test\Util\User\Dummy

--- a/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
@@ -72,7 +72,7 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	#[DataProvider('dataBeforeController')]
+	#[DataProvider(methodName: 'dataBeforeController')]
 	public function testBeforeController(string $controllerClass, bool $enabled, bool $exception): void {
 		$controller = $this->createMock($controllerClass);
 		$this->shareManager->method('shareApiEnabled')->willReturn($enabled);
@@ -99,7 +99,7 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	#[DataProvider('dataAfterController')]
+	#[DataProvider(methodName: 'dataAfterController')]
 	public function testAfterController(string $controllerClass): void {
 		$controller = $this->createMock($controllerClass);
 		if ($controller instanceof ShareAPIController) {

--- a/apps/files_sharing/tests/Middleware/SharingCheckMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/SharingCheckMiddlewareTest.php
@@ -115,7 +115,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 		return $data;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('externalSharesChecksDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'externalSharesChecksDataProvider')]
 	public function testExternalSharesChecks($annotations, $config, $expectedResult): void {
 		$this->reflector
 			->expects($this->atLeastOnce())
@@ -129,7 +129,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 		$this->assertEquals($expectedResult, self::invokePrivate($this->sharingCheckMiddleware, 'externalSharesChecks'));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('externalSharesChecksDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'externalSharesChecksDataProvider')]
 	public function testBeforeControllerWithExternalShareControllerWithSharingEnabled($annotations, $config, $noException): void {
 		$this->appManager
 			->expects($this->once())

--- a/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
+++ b/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
@@ -18,7 +18,7 @@ use OCP\Share\IShare;
 /**
  * Class SetPasswordColumnTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SetPasswordColumnTest extends TestCase {
 
 	/** @var IDBConnection */

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -25,7 +25,7 @@ use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class MountProviderTest extends \Test\TestCase {
 
 	protected MountProvider $provider;
@@ -41,7 +41,7 @@ class MountProviderTest extends \Test\TestCase {
 
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->user = $this->getMockBuilder(IUser::class)->getMock();
-		$this->loader = $this->getMockBuilder('OCP\Files\Storage\IStorageFactory')->getMock();
+		$this->loader = $this->getMockBuilder(IStorageFactory::class)->getMock();
 		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -156,13 +156,13 @@ class MountProviderTest extends \Test\TestCase {
 				return new Share($rootFolder, $userManager);
 			});
 
+		/** @var SharedMount[] $mounts */
 		$mounts = $this->provider->getMountsForUser($this->user, $this->loader);
 		$this->assertCount(4, $mounts);
 		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[0]);
 		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[1]);
 		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[2]);
 		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[3]);
-		/** @var SharedMount[] $mounts */
 		$mountedShare1 = $mounts[0]->getShare();
 		$this->assertEquals('2', $mountedShare1->getId());
 		$this->assertEquals('user2', $mountedShare1->getShareOwner());
@@ -335,7 +335,7 @@ class MountProviderTest extends \Test\TestCase {
 	 * @param array $groupShares array of group share specs
 	 * @param array $expectedShares array of expected supershare specs
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('mergeSharesDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'mergeSharesDataProvider')]
 	public function testMergeShares(array $userShares, array $groupShares, array $expectedShares, bool $moveFails = false): void {
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userManager = $this->createMock(IUserManager::class);

--- a/apps/files_sharing/tests/ShareTest.php
+++ b/apps/files_sharing/tests/ShareTest.php
@@ -20,7 +20,7 @@ use OCP\Share\IShare;
 /**
  * Class ShareTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ShareTest extends TestCase {
 	public const TEST_FOLDER_NAME = '/folder_share_api_test';
 
@@ -189,7 +189,7 @@ class ShareTest extends TestCase {
 	/**
 	 * shared files should never have delete permissions
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderTestFileSharePermissions')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataProviderTestFileSharePermissions')]
 	public function testFileSharePermissions($permission, $expectedvalid): void {
 		$pass = true;
 		try {

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -23,7 +23,7 @@ use OCP\Share\IShare;
 /**
  * Class SharedMountTest
  */
-#[\PHPUnit\Framework\Attributes\Group('SLOWDB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'SLOWDB')]
 class SharedMountTest extends TestCase {
 
 	/** @var IGroupManager */
@@ -225,7 +225,7 @@ class SharedMountTest extends TestCase {
 	 * @param string $expectedResult
 	 * @param bool $exception if a exception is expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderTestStripUserFilesPath')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataProviderTestStripUserFilesPath')]
 	public function testStripUserFilesPath($path, $expectedResult, $exception): void {
 		$testClass = new DummyTestClassSharedMount(null, null);
 		try {

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -26,7 +26,7 @@ use OCP\Share\IShare;
 /**
  * Class SharedStorageTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SharedStorageTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SharesReminderJobTest extends \Test\TestCase {
 	private SharesReminderJob $job;
 	private IDBConnection $db;
@@ -151,7 +151,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 	 * @param int $permissions
 	 * @param bool $shouldBeReminded
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSharesReminder')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSharesReminder')]
 	public function testSharesReminder(
 		?\DateTime $expirationDate, string $email, bool $isEmpty, int $permissions, bool $shouldBeReminded,
 	): void {

--- a/apps/files_sharing/tests/SizePropagationTest.php
+++ b/apps/files_sharing/tests/SizePropagationTest.php
@@ -20,7 +20,7 @@ use Test\Traits\UserTrait;
  *
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SizePropagationTest extends TestCase {
 	use UserTrait;
 

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -29,7 +29,7 @@ use Test\Traits\MountProviderTrait;
 /**
  * Base class for sharing tests.
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 abstract class TestCase extends \Test\TestCase {
 	use MountProviderTrait;
 

--- a/apps/files_sharing/tests/UnshareChildrenTest.php
+++ b/apps/files_sharing/tests/UnshareChildrenTest.php
@@ -18,7 +18,7 @@ use OCP\Util;
  *
  * @package OCA\Files_Sharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UnshareChildrenTest extends TestCase {
 	protected $subsubfolder;
 

--- a/apps/files_sharing/tests/UpdaterTest.php
+++ b/apps/files_sharing/tests/UpdaterTest.php
@@ -22,7 +22,7 @@ use OCP\Share\IShare;
 /**
  * Class UpdaterTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UpdaterTest extends TestCase {
 	public const TEST_FOLDER_NAME = '/folder_share_updater_test';
 
@@ -136,7 +136,7 @@ class UpdaterTest extends TestCase {
 	 *
 	 * @param string $shareFolder share folder to use
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('shareFolderProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'shareFolderProvider')]
 	public function testShareFile($shareFolder): void {
 		$config = Server::get(IConfig::class);
 		$oldShareFolder = $config->getSystemValue('share_folder');

--- a/apps/files_sharing/tests/WatcherTest.php
+++ b/apps/files_sharing/tests/WatcherTest.php
@@ -16,7 +16,7 @@ use OCP\Share\IShare;
 /**
  * Class WatcherTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class WatcherTest extends TestCase {
 
 	/** @var Storage */

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -27,7 +27,7 @@ use Test\TestCase;
  *
  * @package OCA\Files_Trashbin\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CleanUpTest extends TestCase {
 	protected IUserManager&MockObject $userManager;
 	protected IRootFolder&MockObject $rootFolder;
@@ -69,7 +69,7 @@ class CleanUpTest extends TestCase {
 		$this->assertCount(10, $result);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRemoveDeletedFiles')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestRemoveDeletedFiles')]
 	public function testRemoveDeletedFiles(bool $nodeExists): void {
 		$this->initTable();
 		$this->rootFolder

--- a/apps/files_trashbin/tests/Command/ExpireTest.php
+++ b/apps/files_trashbin/tests/Command/ExpireTest.php
@@ -17,7 +17,7 @@ use Test\TestCase;
  *
  * @package OCA\Files_Trashbin\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ExpireTest extends TestCase {
 	public function testExpireNonExistingUser(): void {
 		$command = new Expire('test');

--- a/apps/files_trashbin/tests/Command/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/Command/ExpireTrashTest.php
@@ -10,12 +10,14 @@ use OCA\Files_Trashbin\Command\ExpireTrash;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Helper;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
-use OCP\Files\Node;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,14 +29,14 @@ use Test\TestCase;
  *
  * @package OCA\Files_Trashbin\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[Group(name: 'DB')]
 class ExpireTrashTest extends TestCase {
 	private Expiration $expiration;
-	private Node $userFolder;
+	private Folder $userFolder;
 	private IConfig $config;
 	private IUserManager $userManager;
 	private IUser $user;
-	private ITimeFactory $timeFactory;
+	private ITimeFactory&MockObject $timeFactory;
 
 
 	protected function setUp(): void {
@@ -64,7 +66,7 @@ class ExpireTrashTest extends TestCase {
 		parent::tearDown();
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('retentionObligationProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'retentionObligationProvider')]
 	public function testRetentionObligation(string $obligation, string $quota, int $elapsed, int $fileSize, bool $shouldExpire): void {
 		$this->config->setSystemValues(['trashbin_retention_obligation' => $obligation]);
 		$this->expiration->setRetentionObligation($obligation);

--- a/apps/files_trashbin/tests/ExpirationTest.php
+++ b/apps/files_trashbin/tests/ExpirationTest.php
@@ -82,7 +82,7 @@ class ExpirationTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('expirationData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'expirationData')]
 	public function testExpiration(string $retentionObligation, int $timeNow, int $timestamp, bool $quotaExceeded, bool $expectedResult): void {
 		$mockedConfig = $this->getMockedConfig($retentionObligation);
 		$mockedTimeFactory = $this->getMockedTimeFactory($timeNow);
@@ -108,7 +108,7 @@ class ExpirationTest extends \Test\TestCase {
 	}
 
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('timestampTestData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'timestampTestData')]
 	public function testGetMaxAgeAsTimestamp(string $configValue, bool|int $expectedMaxAgeTimestamp): void {
 		$mockedConfig = $this->getMockedConfig($configValue);
 		$mockedTimeFactory = $this->getMockedTimeFactory(

--- a/apps/files_trashbin/tests/Sabre/TrashbinPluginTest.php
+++ b/apps/files_trashbin/tests/Sabre/TrashbinPluginTest.php
@@ -29,7 +29,7 @@ class TrashbinPluginTest extends TestCase {
 		$this->server = new Server($tree);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('quotaProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'quotaProvider')]
 	public function testQuota(int $quota, int $fileSize, bool $expectedResult): void {
 		$fileInfo = $this->createMock(ITrashItem::class);
 		$fileInfo->method('getSize')

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -49,7 +49,7 @@ class TemporaryNoCross extends Temporary {
  *
  * @package OCA\Files_Trashbin\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class StorageTest extends \Test\TestCase {
 	use MountProviderTrait;
 
@@ -560,7 +560,7 @@ class StorageTest extends \Test\TestCase {
 		$this->assertCount(0, $results);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShouldMoveToTrash')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestShouldMoveToTrash')]
 	public function testShouldMoveToTrash(string $mountPoint, string $path, bool $userExists, bool $appDisablesTrash, bool $expected): void {
 		$fileID = 1;
 		$cache = $this->createMock(ICache::class);

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -23,6 +23,7 @@ use OCA\Files_Trashbin\Trashbin;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
+use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
@@ -34,7 +35,7 @@ use OCP\Share\IShare;
 /**
  * Class Test_Encryption
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class TrashbinTest extends \Test\TestCase {
 	public const TEST_TRASHBIN_USER1 = 'test-trashbin-user1';
 	public const TEST_TRASHBIN_USER2 = 'test-trashbin-user2';
@@ -377,6 +378,7 @@ class TrashbinTest extends \Test\TestCase {
 			)
 		);
 
+		/** @var File $file */
 		$file = $userFolder->get('file1.txt');
 		$this->assertEquals('foo', $file->getContent());
 	}
@@ -410,6 +412,7 @@ class TrashbinTest extends \Test\TestCase {
 			)
 		);
 
+		/** @var File $file */
 		$file = $userFolder->get('folder/file1.txt');
 		$this->assertEquals('foo', $file->getContent());
 	}
@@ -443,6 +446,7 @@ class TrashbinTest extends \Test\TestCase {
 			)
 		);
 
+		/** @var File $file */
 		$file = $userFolder->get('folder/file1.txt');
 		$this->assertEquals('foo', $file->getContent());
 	}
@@ -476,6 +480,7 @@ class TrashbinTest extends \Test\TestCase {
 			)
 		);
 
+		/** @var File $file */
 		$file = $userFolder->get('file1.txt');
 		$this->assertEquals('foo', $file->getContent());
 	}
@@ -513,6 +518,7 @@ class TrashbinTest extends \Test\TestCase {
 			)
 		);
 
+		/** @var File $file */
 		$file = $userFolder->get('file1.txt');
 		$this->assertEquals('foo', $file->getContent());
 	}
@@ -550,9 +556,11 @@ class TrashbinTest extends \Test\TestCase {
 			)
 		);
 
+		/** @var File $anotherFile */
 		$anotherFile = $userFolder->get('file1.txt');
 		$this->assertEquals('bar', $anotherFile->getContent());
 
+		/** @var File $restoredFile */
 		$restoredFile = $userFolder->get('file1 (restored).txt');
 		$this->assertEquals('foo', $restoredFile->getContent());
 	}
@@ -591,9 +599,11 @@ class TrashbinTest extends \Test\TestCase {
 			)
 		);
 
+		/** @var File $anotherFile */
 		$anotherFile = $userFolder->get('folder/file1.txt');
 		$this->assertEquals('bar', $anotherFile->getContent());
 
+		/** @var File $restoredFile */
 		$restoredFile = $userFolder->get('folder/file1 (restored).txt');
 		$this->assertEquals('foo', $restoredFile->getContent());
 	}
@@ -648,6 +658,7 @@ class TrashbinTest extends \Test\TestCase {
 				)
 			);
 
+			/** @var File $file */
 			$file = $userFolder->get('file1.txt');
 			$this->assertEquals('foo', $file->getContent());
 

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -25,7 +25,7 @@ use Test\TestCase;
  *
  * @package OCA\Files_Versions\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CleanupTest extends TestCase {
 	protected Manager&MockObject $userManager;
 	protected IRootFolder&MockObject $rootFolder;
@@ -45,7 +45,7 @@ class CleanupTest extends TestCase {
 	/**
 	 * @param boolean $nodeExists
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDeleteVersions')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestDeleteVersions')]
 	public function testDeleteVersions(bool $nodeExists): void {
 		$this->rootFolder->expects($this->once())
 			->method('nodeExists')

--- a/apps/files_versions/tests/Command/ExpireTest.php
+++ b/apps/files_versions/tests/Command/ExpireTest.php
@@ -17,7 +17,7 @@ use Test\TestCase;
  *
  * @package OCA\Files_Versions\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ExpireTest extends TestCase {
 	public function testExpireNonExistingUser(): void {
 		$command = new Expire($this->getUniqueID('test'), '');

--- a/apps/files_versions/tests/ExpirationTest.php
+++ b/apps/files_versions/tests/ExpirationTest.php
@@ -81,7 +81,7 @@ class ExpirationTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('expirationData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'expirationData')]
 	public function testExpiration(string $retentionObligation, int $timeNow, int $timestamp, bool $quotaExceeded, bool $expectedResult): void {
 		$mockedConfig = $this->getMockedConfig($retentionObligation);
 		$mockedTimeFactory = $this->getMockedTimeFactory($timeNow);

--- a/apps/files_versions/tests/StorageTest.php
+++ b/apps/files_versions/tests/StorageTest.php
@@ -16,7 +16,7 @@ use OCP\Server;
 use Test\TestCase;
 use Test\Traits\UserTrait;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class StorageTest extends TestCase {
 	use UserTrait;
 

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -35,7 +35,7 @@ use OCP\Util;
  * Class Test_Files_versions
  * this class provide basic files versions test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class VersioningTest extends \Test\TestCase {
 	public const TEST_VERSIONS_USER = 'test-versions-user';
 	public const TEST_VERSIONS_USER2 = 'test-versions-user2';
@@ -139,7 +139,7 @@ class VersioningTest extends \Test\TestCase {
 	/**
 	 * test expire logic
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('versionsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'versionsProvider')]
 	public function testGetExpireList($versions, $sizeOfAllDeletedFiles): void {
 
 		// last interval end at 2592000

--- a/apps/files_versions/tests/Versions/VersionManagerTest.php
+++ b/apps/files_versions/tests/Versions/VersionManagerTest.php
@@ -26,6 +26,9 @@ class VersionManagerTest extends TestCase {
 		return $backend;
 	}
 
+	/**
+	 * @param class-string<IStorage> $class
+	 */
 	private function getStorage(string $class): IStorage&MockObject {
 		return $this->getMockBuilder($class)
 			->disableOriginalConstructor()

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -23,7 +23,7 @@ use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class LoginRedirectorControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private IURLGenerator&MockObject $urlGenerator;

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -236,7 +236,7 @@ class OauthApiControllerTest extends TestCase {
 	 * @param string $clientId
 	 * @param string $clientSecret
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('invalidClientProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'invalidClientProvider')]
 	public function testRefreshTokenInvalidClient($clientId, $clientSecret): void {
 		$expected = new JSONResponse([
 			'error' => 'invalid_client',

--- a/apps/oauth2/tests/Controller/SettingsControllerTest.php
+++ b/apps/oauth2/tests/Controller/SettingsControllerTest.php
@@ -22,7 +22,7 @@ use OCP\Security\ISecureRandom;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SettingsControllerTest extends TestCase {
 	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	private $request;

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -14,7 +14,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AccessTokenMapperTest extends TestCase {
 	/** @var AccessTokenMapper */
 	private $accessTokenMapper;
@@ -28,7 +28,7 @@ class AccessTokenMapperTest extends TestCase {
 		$this->accessTokenMapper->deleteByClientId(1234);
 		$token = new AccessToken();
 		$token->setClientId(1234);
-		$token->setTokenId((string)time());
+		$token->setTokenId(time());
 		$token->setEncryptedToken('MyEncryptedToken');
 		$token->setHashedCode(hash('sha512', 'MyAwesomeToken'));
 		$this->accessTokenMapper->insert($token);
@@ -46,7 +46,7 @@ class AccessTokenMapperTest extends TestCase {
 		$this->accessTokenMapper->deleteByClientId(1234);
 		$token = new AccessToken();
 		$token->setClientId(1234);
-		$token->setTokenId((string)time());
+		$token->setTokenId(time());
 		$token->setEncryptedToken('MyEncryptedToken');
 		$token->setHashedCode(hash('sha512', 'MyAwesomeToken'));
 		$this->accessTokenMapper->insert($token);

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -13,7 +13,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ClientMapperTest extends TestCase {
 	/** @var ClientMapper */
 	private $clientMapper;

--- a/apps/profile/tests/Controller/ProfilePageControllerTest.php
+++ b/apps/profile/tests/Controller/ProfilePageControllerTest.php
@@ -20,11 +20,12 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\IManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ProfilePageControllerTest extends TestCase {
 
-	private IUserManager $userManager;
+	private IUserManager&MockObject $userManager;
 	private ProfilePageController $controller;
 
 	protected function setUp(): void {

--- a/apps/provisioning_api/tests/CapabilitiesTest.php
+++ b/apps/provisioning_api/tests/CapabilitiesTest.php
@@ -20,7 +20,7 @@ use Test\TestCase;
  *
  * @package OCA\Provisioning_API\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CapabilitiesTest extends TestCase {
 
 	protected IAppManager&MockObject $appManager;
@@ -48,7 +48,7 @@ class CapabilitiesTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('getCapabilitiesProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'getCapabilitiesProvider')]
 	public function testGetCapabilities(bool $federationAppEnabled, bool $federatedFileSharingAppEnabled, bool $lookupServerEnabled, bool $expectedFederatedScopeEnabled, bool $expectedPublishedScopeEnabled): void {
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')

--- a/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
@@ -108,7 +108,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetKeys')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetKeys')]
 	public function testGetKeys(string $app, ?array $keys, ?\Throwable $throws, int $status): void {
 		$api = $this->getInstance(['verifyAppId']);
 		if ($throws instanceof \Exception) {
@@ -147,7 +147,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetValue')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetValue')]
 	public function testGetValue(string $app, string $key, string $default, ?string $return, ?\Throwable $throws, int $status): void {
 		$api = $this->getInstance(['verifyAppId']);
 		if ($throws instanceof \Exception) {
@@ -191,7 +191,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetValue')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSetValue')]
 	public function testSetValue(string $app, string $key, string $value, ?\Throwable $appThrows, ?\Throwable $keyThrows, int $status, int|\Throwable $type = IAppConfig::VALUE_MIXED): void {
 		$adminUser = $this->createMock(IUser::class);
 		$adminUser->expects($this->once())
@@ -289,7 +289,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteValue')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataDeleteValue')]
 	public function testDeleteValue(string $app, string $key, ?\Throwable $appThrows, ?\Throwable $keyThrows, int $status): void {
 		$api = $this->getInstance(['verifyAppId', 'verifyConfigKey']);
 		if ($appThrows instanceof \Exception) {
@@ -353,7 +353,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataVerifyAppIdThrows')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataVerifyAppIdThrows')]
 	public function testVerifyAppIdThrows(string $app): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -370,7 +370,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataVerifyConfigKey')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataVerifyConfigKey')]
 	public function testVerifyConfigKey(string $app, string $key, string $value): void {
 		$api = $this->getInstance();
 		$this->invokePrivate($api, 'verifyConfigKey', [$app, $key, $value]);
@@ -391,7 +391,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataVerifyConfigKeyThrows')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataVerifyConfigKeyThrows')]
 	public function testVerifyConfigKeyThrows(string $app, string $key, string $value): void {
 		$this->expectException(\InvalidArgumentException::class);
 

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\Provisioning_API\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AppsControllerTest extends TestCase {
 	private IAppManager $appManager;
 	private IAppConfig&MockObject $appConfig;

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -161,7 +161,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetGroups')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetGroups')]
 	public function testGetGroups(?string $search, int $limit, int $offset): void {
 		$groups = [$this->createGroup('group1'), $this->createGroup('group2')];
 
@@ -183,7 +183,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	 * @param int|null $limit
 	 * @param int|null $offset
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetGroups')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetGroups')]
 	public function testGetGroupsDetails($search, $limit, $offset): void {
 		$groups = [$this->createGroup('group1'), $this->createGroup('group2')];
 

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -482,9 +482,6 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testAddUserSuccessfulWithDisplayName(): void {
-		/**
-		 * @var UserController
-		 */
 		$api = $this->getMockBuilder(UsersController::class)
 			->setConstructorArgs([
 				'provisioning_api',
@@ -1590,7 +1587,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchByPhoneNumbers')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSearchByPhoneNumbers')]
 	public function testSearchByPhoneNumbers(string $location, array $search, int $status, ?array $searchUsers, ?array $userMatches, array $expected): void {
 		$knownTo = 'knownTo';
 		$user = $this->createMock(IUser::class);
@@ -1917,7 +1914,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('selfEditChangePropertyProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'selfEditChangePropertyProvider')]
 	public function testEditUserRegularUserSelfEditChangeProperty($propertyName, $oldValue, $newValue): void {
 		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
@@ -1994,7 +1991,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('selfEditChangePropertyProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'selfEditChangePropertyProvider')]
 	public function testEditUserRegularUserSelfEditChangePropertyScope($propertyName, $oldScope, $newScope): void {
 		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
@@ -2329,7 +2326,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataEditUserSelfEditChangeLanguageButForced')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataEditUserSelfEditChangeLanguageButForced')]
 	public function testEditUserSelfEditChangeLanguageButForced($forced): void {
 		$this->expectException(OCSException::class);
 
@@ -2423,7 +2420,7 @@ class UsersControllerTest extends TestCase {
 		$this->assertEquals([], $this->api->editUser('UserToEdit', 'language', 'de')->getData());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataEditUserSelfEditChangeLanguageButForced')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataEditUserSelfEditChangeLanguageButForced')]
 	public function testEditUserAdminEditChangeLanguageInvalidLanguage(): void {
 		$this->expectException(OCSException::class);
 
@@ -4422,7 +4419,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetEditableFields')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetEditableFields')]
 	public function testGetEditableFields(bool $allowedToChangeDisplayName, bool $allowedToChangeEmail, string $userBackend, array $expected): void {
 		$this->config->method('getSystemValue')->willReturnCallback(fn (string $key, mixed $default) => match ($key) {
 			'allow_user_to_change_display_name' => $allowedToChangeDisplayName,

--- a/apps/provisioning_api/tests/Middleware/ProvisioningApiMiddlewareTest.php
+++ b/apps/provisioning_api/tests/Middleware/ProvisioningApiMiddlewareTest.php
@@ -44,7 +44,7 @@ class ProvisioningApiMiddlewareTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAnnotation')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataAnnotation')]
 	public function testBeforeController(bool $subadminRequired, bool $isAdmin, bool $isSubAdmin, bool $hasSettingAuthorizationAnnotation, bool $shouldThrowException): void {
 		$middleware = new ProvisioningApiMiddleware(
 			$this->reflector,
@@ -81,7 +81,7 @@ class ProvisioningApiMiddlewareTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterException')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataAfterException')]
 	public function testAfterException(\Exception $exception, bool $forwared): void {
 		$middleware = new ProvisioningApiMiddleware(
 			$this->reflector,

--- a/apps/provisioning_api/tests/TestCase.php
+++ b/apps/provisioning_api/tests/TestCase.php
@@ -15,13 +15,9 @@ use OCP\Server;
 abstract class TestCase extends \Test\TestCase {
 
 	/** @var IUser[] */
-	protected $users = [];
-
-	/** @var IUserManager */
-	protected $userManager;
-
-	/** @var IGroupManager */
-	protected $groupManager;
+	protected array $users = [];
+	protected IUserManager $userManager;
+	protected IGroupManager $groupManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,7 +39,9 @@ abstract class TestCase extends \Test\TestCase {
 			$this->users[] = $user;
 			$users[] = $user;
 		}
-		return count($users) == 1 ? reset($users) : $users;
+		$result = count($users) === 1 ? reset($users) : $users;
+		$this->assertNotEquals(false, $result);
+		return $result;
 	}
 
 	protected function tearDown(): void {

--- a/apps/settings/tests/Activity/SecurityProviderTest.php
+++ b/apps/settings/tests/Activity/SecurityProviderTest.php
@@ -50,7 +50,7 @@ class SecurityProviderTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('subjectData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'subjectData')]
 	public function testParse(string $subject): void {
 		$lang = 'ru';
 		$event = $this->createMock(IEvent::class);

--- a/apps/settings/tests/AppInfo/ApplicationTest.php
+++ b/apps/settings/tests/AppInfo/ApplicationTest.php
@@ -26,7 +26,7 @@ use Test\TestCase;
  *
  * @package Tests\Settings
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ApplicationTest extends TestCase {
 	protected Application $app;
 	protected IAppContainer $container;
@@ -56,7 +56,7 @@ class ApplicationTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataContainerQuery')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataContainerQuery')]
 	public function testContainerQuery(string $service, string $expected): void {
 		$this->assertTrue($this->container->query($service) instanceof $expected);
 	}

--- a/apps/settings/tests/Controller/AdminSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AdminSettingsControllerTest.php
@@ -29,7 +29,7 @@ use Test\TestCase;
  *
  * @package Tests\Settings\Controller
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AdminSettingsControllerTest extends TestCase {
 
 	private IRequest&MockObject $request;

--- a/apps/settings/tests/Controller/AppSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AppSettingsControllerTest.php
@@ -35,7 +35,7 @@ use Test\TestCase;
  *
  * @package Tests\Settings\Controller
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AppSettingsControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private IL10N&MockObject $l10n;

--- a/apps/settings/tests/Controller/AuthSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AuthSettingsControllerTest.php
@@ -255,7 +255,7 @@ class AuthSettingsControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenameToken')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataRenameToken')]
 	public function testUpdateRename(string $name, string $newName): void {
 		$tokenId = 42;
 		$token = $this->createMock(PublicKeyToken::class);
@@ -293,7 +293,7 @@ class AuthSettingsControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateFilesystemScope')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUpdateFilesystemScope')]
 	public function testUpdateFilesystemScope(bool $filesystem, bool $newFilesystem): void {
 		$tokenId = 42;
 		$token = $this->createMock(PublicKeyToken::class);

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * @package Tests\Settings\Controller
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UsersControllerTest extends \Test\TestCase {
 	private IGroupManager&MockObject $groupManager;
 	private UserManager&MockObject $userManager;
@@ -250,7 +250,7 @@ class UsersControllerTest extends \Test\TestCase {
 		return $account;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetUserSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSetUserSettings')]
 	public function testSetUserSettings(string $email, bool $validEmail, int $expectedStatus): void {
 		$controller = $this->getController(false, ['saveUserSettings']);
 		$user = $this->createMock(IUser::class);
@@ -516,7 +516,7 @@ class UsersControllerTest extends \Test\TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetUserSettingsSubset')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSetUserSettingsSubset')]
 	public function testSetUserSettingsSubset(string $property, string $propertyValue): void {
 		$controller = $this->getController(false, ['saveUserSettings']);
 		$user = $this->createMock(IUser::class);
@@ -668,7 +668,7 @@ class UsersControllerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSaveUserSettings')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSaveUserSettings')]
 	public function testSaveUserSettings(array $data, ?string $oldEmailAddress, ?string $oldDisplayName): void {
 		$controller = $this->getController();
 		$user = $this->createMock(IUser::class);
@@ -783,7 +783,7 @@ class UsersControllerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSaveUserSettingsException')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSaveUserSettingsException')]
 	public function testSaveUserSettingsException(
 		array $data,
 		string $oldEmailAddress,
@@ -866,7 +866,7 @@ class UsersControllerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetVerificationCode')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetVerificationCode')]
 	public function testGetVerificationCode(string $account, string $type, array $dataBefore, array $expectedData, bool $onlyVerificationCode): void {
 		$message = 'Use my Federated Cloud ID to share with me: user@nextcloud.com';
 		$signature = 'theSignature';
@@ -961,7 +961,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $result->getStatus());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCanAdminChangeUserPasswords')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCanAdminChangeUserPasswords')]
 	public function testCanAdminChangeUserPasswords(
 		bool $encryptionEnabled,
 		bool $encryptionModuleLoaded,
@@ -1003,7 +1003,7 @@ class UsersControllerTest extends \Test\TestCase {
 			[false, false, false, true],
 		];
 	}
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetPreference')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSetPreference')]
 	public function testSetPreference(string $key, string $value, bool $isUserValue, bool $isAppValue, int $expectedStatus): void {
 		$controller = $this->getController(false, []);
 		$user = $this->createMock(IUser::class);

--- a/apps/settings/tests/Integration/DuplicateAssignmentIntegrationTest.php
+++ b/apps/settings/tests/Integration/DuplicateAssignmentIntegrationTest.php
@@ -17,7 +17,7 @@ use Test\TestCase;
  * Integration test for duplicate prevention in AuthorizedGroupService
  * This test verifies the complete flow of duplicate detection and prevention
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DuplicateAssignmentIntegrationTest extends TestCase {
 
 	private AuthorizedGroupService $service;

--- a/apps/settings/tests/Settings/Admin/MailTest.php
+++ b/apps/settings/tests/Settings/Admin/MailTest.php
@@ -47,7 +47,7 @@ class MailTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetForm')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetForm')]
 	public function testGetForm(bool $sendmail) {
 		$finder = $this->createMock(IBinaryFinder::class);
 		$finder->expects(self::atLeastOnce())

--- a/apps/settings/tests/Settings/Admin/SecurityTest.php
+++ b/apps/settings/tests/Settings/Admin/SecurityTest.php
@@ -17,8 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SecurityTest extends TestCase {
-	private Manager $manager;
-	private IUserManager $userManager;
+	private Manager&MockObject $manager;
+	private IUserManager&MockObject $userManager;
 	private MandatoryTwoFactor&MockObject $mandatoryTwoFactor;
 	private IInitialState&MockObject $initialState;
 	private Security $admin;
@@ -46,7 +46,7 @@ class SecurityTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('encryptionSettingsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'encryptionSettingsProvider')]
 	public function testGetFormWithOnlyOneBackend(bool $enabled): void {
 		$this->manager
 			->expects($this->once())
@@ -76,7 +76,7 @@ class SecurityTest extends TestCase {
 	/**
 	 * @param bool $enabled
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('encryptionSettingsProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'encryptionSettingsProvider')]
 	public function testGetFormWithMultipleBackends($enabled): void {
 		$this->manager
 			->expects($this->once())

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -17,11 +17,11 @@ use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
-use OCP\IUrlGenerator;
+use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ServerTest extends TestCase {
 	private IDBConnection $connection;
 	private Server&MockObject $admin;
@@ -31,7 +31,7 @@ class ServerTest extends TestCase {
 	private IConfig&MockObject $config;
 	private IAppConfig&MockObject $appConfig;
 	private IL10N&MockObject $l10n;
-	private IUrlGenerator&MockObject $urlGenerator;
+	private IURLGenerator&MockObject $urlGenerator;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -42,7 +42,7 @@ class ServerTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
-		$this->urlGenerator = $this->createMock(IUrlGenerator::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 
 		$this->admin = $this->getMockBuilder(Server::class)
 			->onlyMethods(['cronMaxAge'])

--- a/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
+++ b/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
@@ -54,7 +54,7 @@ class DataDirectoryProtectedTest extends TestCase {
 			->getMock();
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestStatusCode')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestStatusCode')]
 	public function testStatusCode(array $status, string $expected, bool $hasBody): void {
 		$responses = array_map(function ($state) use ($hasBody) {
 			$response = $this->createMock(IResponse::class);

--- a/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
@@ -14,13 +14,15 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\SetupCheck\SetupResult;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ForwardedForHeadersTest extends TestCase {
-	private IL10N $l10n;
-	private IConfig $config;
-	private IURLGenerator $urlGenerator;
-	private IRequest $request;
+	private IL10N&MockObject $l10n;
+	private IConfig&MockObject $config;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IRequest&MockObject $request;
 	private ForwardedForHeaders $check;
 
 	protected function setUp(): void {
@@ -32,9 +34,9 @@ class ForwardedForHeadersTest extends TestCase {
 			->willReturnCallback(function ($message, array $replace) {
 				return vsprintf($message, $replace);
 			});
-		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
-		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->request = $this->createMock(IRequest::class);
 		$this->check = new ForwardedForHeaders(
 			$this->l10n,
 			$this->config,
@@ -43,7 +45,7 @@ class ForwardedForHeadersTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataForwardedForHeadersWorking')]
+	#[DataProvider(methodName: 'dataForwardedForHeadersWorking')]
 	public function testForwardedForHeadersWorking(array $trustedProxies, string $remoteAddrNotForwarded, string $remoteAddr, string $result): void {
 		$this->config->expects($this->once())
 			->method('getSystemValue')

--- a/apps/settings/tests/SetupChecks/LoggingLevelTest.php
+++ b/apps/settings/tests/SetupChecks/LoggingLevelTest.php
@@ -59,7 +59,7 @@ class LoggingLevelTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataRun')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataRun')]
 	public function testRun(string|int $value, string $expected): void {
 		$this->urlGenerator->method('linkToDocs')->willReturn('admin-logging');
 

--- a/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
@@ -106,7 +106,7 @@ class SecurityHeadersTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSuccess')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSuccess')]
 	public function testSuccess(array $headers): void {
 		$headers = array_merge(
 			[
@@ -145,7 +145,7 @@ class SecurityHeadersTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFailure')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataFailure')]
 	public function testFailure(array $headers, string $msg): void {
 		$headers = array_merge(
 			[

--- a/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
+++ b/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
@@ -16,7 +16,7 @@ use OCP\Server;
 use OCP\SetupCheck\SetupResult;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SupportedDatabaseTest extends TestCase {
 	private IL10N $l10n;
 	private IUrlGenerator $urlGenerator;

--- a/apps/settings/tests/SetupChecks/TaskProcessingPickupSpeedTest.php
+++ b/apps/settings/tests/SetupChecks/TaskProcessingPickupSpeedTest.php
@@ -14,21 +14,22 @@ use OCP\IL10N;
 use OCP\SetupCheck\SetupResult;
 use OCP\TaskProcessing\IManager;
 use OCP\TaskProcessing\Task;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class TaskProcessingPickupSpeedTest extends TestCase {
-	private IL10N $l10n;
-	private ITimeFactory $timeFactory;
-	private IManager $taskProcessingManager;
+	private IL10N&MockObject $l10n;
+	private ITimeFactory&MockObject $timeFactory;
+	private IManager&MockObject $taskProcessingManager;
 
 	private TaskProcessingPickupSpeed $check;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
-		$this->timeFactory = $this->getMockBuilder(ITimeFactory::class)->getMock();
-		$this->taskProcessingManager = $this->getMockBuilder(IManager::class)->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->taskProcessingManager = $this->createMock(IManager::class);
 
 		$this->check = new TaskProcessingPickupSpeed(
 			$this->l10n,

--- a/apps/settings/tests/SetupChecks/TaskProcessingSuccessRateTest.php
+++ b/apps/settings/tests/SetupChecks/TaskProcessingSuccessRateTest.php
@@ -14,12 +14,13 @@ use OCP\IL10N;
 use OCP\SetupCheck\SetupResult;
 use OCP\TaskProcessing\IManager;
 use OCP\TaskProcessing\Task;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class TaskProcessingSuccessRateTest extends TestCase {
-	private IL10N $l10n;
-	private ITimeFactory $timeFactory;
-	private IManager $taskProcessingManager;
+	private IL10N&MockObject $l10n;
+	private ITimeFactory&MockObject $timeFactory;
+	private IManager&MockObject $taskProcessingManager;
 
 	private TaskProcessingSuccessRate $check;
 

--- a/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
+++ b/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
@@ -97,7 +97,7 @@ class WellKnownUrlsTest extends TestCase {
 	/**
 	 * Test responses
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestResponses')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestResponses')]
 	public function testResponses($responses, string $expectedSeverity): void {
 		$createResponse = function (int $statuscode, array $header = []): IResponse&MockObject {
 			$response = $this->createMock(IResponse::class);

--- a/apps/settings/tests/UserMigration/AccountMigratorTest.php
+++ b/apps/settings/tests/UserMigration/AccountMigratorTest.php
@@ -23,7 +23,7 @@ use Sabre\VObject\UUIDUtil;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AccountMigratorTest extends TestCase {
 	private IUserManager $userManager;
 	private IAvatarManager $avatarManager;
@@ -83,7 +83,7 @@ class AccountMigratorTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataImportExportAccount')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataImportExportAccount')]
 	public function testImportExportAccount(string $userId, array $importData, string $avatarPath, array $importConfig): void {
 		$user = $this->userManager->createUser($userId, 'topsecretpassword');
 		$avatarExt = pathinfo($avatarPath, PATHINFO_EXTENSION);

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -48,7 +48,7 @@ use Test\Traits\EmailValidatorTrait;
  *
  * @package OCA\ShareByMail\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ShareByMailProviderTest extends TestCase {
 	use EmailValidatorTrait;
 
@@ -827,7 +827,7 @@ class ShareByMailProviderTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateSendPassword')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUpdateSendPassword')]
 	public function testUpdateSendPassword(?string $plainTextPassword, string $originalPassword, string $newPassword, bool $originalSendPasswordByTalk, bool $newSendPasswordByTalk, bool $sendMail): void {
 		$node = $this->createMock(File::class);
 		$node->expects($this->any())->method('getName')->willReturn('filename');

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -130,7 +130,7 @@ class CapabilitiesTest extends TestCase {
 	/**
 	 * @param non-empty-array<string, string> $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetCapabilities')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetCapabilities')]
 	public function testGetCapabilities(string $name, string $url, string $slogan, string $color, string $textColor, string $logo, string $background, string $backgroundColor, string $backgroundTextColor, string $baseUrl, bool $backgroundThemed, array $expected): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -18,6 +18,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\File;
 use OCP\Files\NotFoundException;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -61,8 +62,8 @@ class IconControllerTest extends TestCase {
 		parent::setUp();
 	}
 
-	private function iconFileMock($filename, $data) {
-		$icon = $this->getMockBuilder('OCP\Files\File')->getMock();
+	private function iconFileMock($filename, $data): SimpleFile {
+		$icon = $this->createMock(File::class);
 		$icon->expects($this->any())->method('getContent')->willReturn($data);
 		$icon->expects($this->any())->method('getMimeType')->willReturn('image type');
 		$icon->expects($this->any())->method('getEtag')->willReturn('my etag');

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -98,7 +98,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateStylesheetSuccess')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUpdateStylesheetSuccess')]
 	public function testUpdateStylesheetSuccess(string $setting, string $value, string $message, ?string $realSetting = null): void {
 		$this->themingDefaults
 			->expects($this->once())
@@ -156,7 +156,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateStylesheetError')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUpdateStylesheetError')]
 	public function testUpdateStylesheetError(string $setting, string $value, string $message): void {
 		$this->themingDefaults
 			->expects($this->never())
@@ -345,7 +345,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateImages')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUpdateImages')]
 	public function testUpdateLogoNormalLogoUpload(string $mimeType, bool $folderExists = true): void {
 		$tmpLogo = Server::get(ITempManager::class)->getTemporaryFolder() . '/logo.svg';
 		$destination = Server::get(ITempManager::class)->getTemporaryFolder();
@@ -501,7 +501,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataPhpUploadErrors')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataPhpUploadErrors')]
 	public function testUpdateLogoLoginScreenUploadWithInvalidImageUpload(int $error, string $expectedErrorMessage): void {
 		$this->request
 			->expects($this->once())
@@ -538,7 +538,7 @@ class ThemingControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->themingController->uploadImage());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataPhpUploadErrors')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataPhpUploadErrors')]
 	public function testUpdateLogoUploadWithInvalidImageUpload($error, $expectedErrorMessage): void {
 		$this->request
 			->expects($this->once())
@@ -607,7 +607,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUndoDelete')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUndoDelete')]
 	public function testUndoDelete(string $value, string $filename): void {
 		$this->l10n
 			->expects($this->once())
@@ -707,7 +707,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetManifest')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetManifest')]
 	public function testGetManifest(bool $standalone): void {
 		$this->config
 			->expects($this->once())

--- a/apps/theming/tests/Controller/UserThemeControllerTest.php
+++ b/apps/theming/tests/Controller/UserThemeControllerTest.php
@@ -92,7 +92,7 @@ class UserThemeControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestThemes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestThemes')]
 	public function testEnableTheme(string $themeId, ?string $exception = null): void {
 		$this->themesService
 			->expects($this->any())
@@ -107,7 +107,7 @@ class UserThemeControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->userThemeController->enableTheme($themeId));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestThemes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestThemes')]
 	public function testDisableTheme(string $themeId, ?string $exception = null): void {
 		$this->themesService
 			->expects($this->any())

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -63,7 +63,7 @@ class IconBuilderTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenderAppIcon')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataRenderAppIcon')]
 	public function testRenderAppIcon(string $app, string $color, string $file): void {
 		$this->checkImagick();
 		$this->themingDefaults->expects($this->once())
@@ -87,7 +87,7 @@ class IconBuilderTest extends TestCase {
 		// cloud be something like $expectedIcon->compareImages($icon, Imagick::METRIC_MEANABSOLUTEERROR)[1])
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenderAppIcon')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataRenderAppIcon')]
 	public function testGetTouchIcon(string $app, string $color, string $file): void {
 		$this->checkImagick();
 		$this->themingDefaults->expects($this->once())
@@ -112,7 +112,7 @@ class IconBuilderTest extends TestCase {
 		// cloud be something like $expectedIcon->compareImages($icon, Imagick::METRIC_MEANABSOLUTEERROR)[1])
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenderAppIcon')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataRenderAppIcon')]
 	public function testGetFavicon(string $app, string $color, string $file): void {
 		$this->checkImagick();
 		$this->imageManager->expects($this->once())

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -313,7 +313,7 @@ class ImageManagerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateImage')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUpdateImage')]
 	public function testUpdateImage(string $key, string $tmpFile, bool $folderExists, bool $shouldConvert): void {
 		$file = $this->createMock(ISimpleFile::class);
 		$folder = $this->createMock(ISimpleFolder::class);

--- a/apps/theming/tests/Migration/Version2006Date20240905111627Test.php
+++ b/apps/theming/tests/Migration/Version2006Date20240905111627Test.php
@@ -12,6 +12,7 @@ namespace OCA\Theming\Tests\Migration;
 use OCA\Theming\Migration\Version2006Date20240905111627;
 use OCP\BackgroundJob\IJobList;
 use OCP\Config\IUserConfig;
+use OCP\DB\ISchemaWrapper;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
@@ -20,7 +21,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class Version2006Date20240905111627Test extends TestCase {
 
 	private IAppConfig&MockObject $appConfig;
@@ -65,7 +66,7 @@ class Version2006Date20240905111627Test extends TestCase {
 			});
 
 		$output = $this->createMock(IOutput::class);
-		$this->migration->changeSchema($output, fn () => null, []);
+		$this->migration->changeSchema($output, fn () => $this->createMock(ISchemaWrapper::class), []);
 
 		$this->assertEquals([
 			['theming', 'background_color', 'ffab00', false, false],
@@ -73,7 +74,7 @@ class Version2006Date20240905111627Test extends TestCase {
 		], $setValueCalls);
 	}
 
-	#[\PHPUnit\Framework\Attributes\Group('DB')]
+	#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 	public function testRestoreUserColors(): void {
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
@@ -109,7 +110,7 @@ class Version2006Date20240905111627Test extends TestCase {
 			Server::get(IDBConnection::class),
 		);
 		// Run the migration
-		$migration->changeSchema($output, fn () => null, []);
+		$migration->changeSchema($output, fn () => $this->createMock(ISchemaWrapper::class), []);
 
 		// See new value
 		$config->clearCache('theming_legacy');
@@ -123,7 +124,7 @@ class Version2006Date20240905111627Test extends TestCase {
 	/**
 	 * Ensure only users with background color but no primary color are migrated
 	 */
-	#[\PHPUnit\Framework\Attributes\Group('DB')]
+	#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 	public function testRestoreUserColorsWithConflicts(): void {
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
@@ -163,7 +164,7 @@ class Version2006Date20240905111627Test extends TestCase {
 			Server::get(IDBConnection::class),
 		);
 		// Run the migration
-		$migration->changeSchema($output, fn () => null, []);
+		$migration->changeSchema($output, fn () => $this->createMock(ISchemaWrapper::class), []);
 
 		// See new value of only the legacy user
 		$config->clearCacheAll();

--- a/apps/theming/tests/Service/ThemesServiceTest.php
+++ b/apps/theming/tests/Service/ThemesServiceTest.php
@@ -130,7 +130,7 @@ class ThemesServiceTest extends TestCase {
 	 * @param string[] $enabledThemes
 	 * @param string[] $expectedEnabled
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestEnableTheme')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestEnableTheme')]
 	public function testEnableTheme(string $toEnable, array $enabledThemes, array $expectedEnabled): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -163,7 +163,7 @@ class ThemesServiceTest extends TestCase {
 	 * @param string[] $enabledThemes
 	 * @param string[] $expectedEnabled
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDisableTheme')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestDisableTheme')]
 	public function testDisableTheme(string $toDisable, array $enabledThemes, array $expectedEnabled): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -195,7 +195,7 @@ class ThemesServiceTest extends TestCase {
 	/**
 	 * @param string[] $enabledThemes
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsEnabled')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestIsEnabled')]
 	public function testIsEnabled(string $themeId, array $enabledThemes, bool $expected): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -273,7 +273,7 @@ class ThemesServiceTest extends TestCase {
 	 * @param string[] $enabledThemes
 	 * @param string[] $expected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetEnabledThemes')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSetEnabledThemes')]
 	public function testSetEnabledThemes(array $enabledThemes, array $expected): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())

--- a/apps/theming/tests/ServicesTest.php
+++ b/apps/theming/tests/ServicesTest.php
@@ -26,7 +26,7 @@ use Test\TestCase;
  *
  * @package OCA\Theming\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ServicesTest extends TestCase {
 	protected App $app;
 
@@ -60,7 +60,7 @@ class ServicesTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('queryData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'queryData')]
 	public function testContainerQuery(string $service, ?string $expected = null): void {
 		if ($expected === null) {
 			$expected = $service;

--- a/apps/theming/tests/Settings/PersonalTest.php
+++ b/apps/theming/tests/Settings/PersonalTest.php
@@ -85,7 +85,7 @@ class PersonalTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('dataTestGetForm')]
+	#[DataProvider(methodName: 'dataTestGetForm')]
 	public function testGetForm(string $enforcedTheme, array $themesState): void {
 		$themesState = array_map(
 			$this->formatThemeForm(...),

--- a/apps/theming/tests/Themes/AccessibleThemeTestCase.php
+++ b/apps/theming/tests/Themes/AccessibleThemeTestCase.php
@@ -201,7 +201,7 @@ class AccessibleThemeTestCase extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAccessibilityPairs')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataAccessibilityPairs')]
 	public function testAccessibilityOfVariables(array $mainColors, array $backgroundColors, float $minContrast): void {
 		if (!isset($this->theme)) {
 			$this->markTestSkipped('You need to setup $this->theme in your setUp function');

--- a/apps/theming/tests/Themes/DyslexiaFontTest.php
+++ b/apps/theming/tests/Themes/DyslexiaFontTest.php
@@ -149,7 +149,7 @@ class DyslexiaFontTest extends TestCase {
 	 * Ensure the fonts are always loaded from the web root
 	 * despite having url rewriting enabled or not
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetCustomCss')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestGetCustomCss')]
 	public function testGetCustomCss(string $webRoot, bool $prettyUrlsEnabled): void {
 		\OC::$WEBROOT = $webRoot;
 		$this->config->expects($this->any())

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -185,7 +185,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('legalUrlProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'legalUrlProvider')]
 	public function testGetImprintURL(string $imprintUrl): void {
 		$this->appConfig
 			->expects($this->once())
@@ -196,7 +196,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->assertEquals($imprintUrl, $this->template->getImprintUrl());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('legalUrlProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'legalUrlProvider')]
 	public function testGetPrivacyURL(string $privacyUrl): void {
 		$this->appConfig
 			->expects($this->once())
@@ -344,7 +344,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('invalidLegalUrlProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'invalidLegalUrlProvider')]
 	public function testGetShortFooterInvalidImprint(string $invalidImprintUrl): void {
 		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->appConfig
@@ -361,7 +361,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->assertEquals('<a href="url" target="_blank" rel="noreferrer noopener" class="entity-name">Name</a> – Slogan', $this->template->getShortFooter());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('invalidLegalUrlProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'invalidLegalUrlProvider')]
 	public function testGetShortFooterInvalidPrivacy(string $invalidPrivacyUrl): void {
 		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->appConfig
@@ -449,7 +449,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetColorPrimary')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetColorPrimary')]
 	public function testGetColorPrimary(bool $disableTheming, string $primaryColor, string $userPrimaryColor, string $expected): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -803,7 +803,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataReplaceImagePath')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataReplaceImagePath')]
 	public function testReplaceImagePath(string $app, string $image, string|bool $result = 'themingRoute?v=1234abcd'): void {
 		$this->cache->expects($this->any())
 			->method('get')
@@ -835,7 +835,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('setTypesProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'setTypesProvider')]
 	public function testSetTypes(string $setting, string $value, mixed $expected): void {
 		$setValue = null;
 		$cb = function ($setting, $value) use (&$setValue) {

--- a/apps/theming/tests/UtilTest.php
+++ b/apps/theming/tests/UtilTest.php
@@ -48,7 +48,7 @@ class UtilTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataColorContrast')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataColorContrast')]
 	public function testColorContrast(string $color1, string $color2, int|float $contrast): void {
 		$this->assertEqualsWithDelta($contrast, $this->util->colorContrast($color1, $color2), .001);
 	}
@@ -61,7 +61,7 @@ class UtilTest extends TestCase {
 			['#ffff00', true],
 		];
 	}
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataInvertTextColor')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataInvertTextColor')]
 	public function testInvertTextColor(string $color, bool $expected): void {
 		$invert = $this->util->invertTextColor($color);
 		$this->assertEquals($expected, $invert);
@@ -139,7 +139,7 @@ class UtilTest extends TestCase {
 		$this->assertEquals($expected, $button);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppIcon')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetAppIcon')]
 	public function testGetAppIcon(string $app, string $expected): void {
 		$this->appData->expects($this->any())
 			->method('getFolder')
@@ -172,7 +172,7 @@ class UtilTest extends TestCase {
 		$this->assertEquals($file, $icon);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppImage')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetAppImage')]
 	public function testGetAppImage(string $app, string $image, string|bool $expected): void {
 		$this->assertEquals($expected, $this->util->getAppImage($app, $image));
 	}
@@ -218,7 +218,7 @@ class UtilTest extends TestCase {
 			['backgroundColor', false],
 		];
 	}
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsBackgroundThemed')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataIsBackgroundThemed')]
 	public function testIsBackgroundThemed(string $backgroundMime, bool $expected): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')

--- a/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
@@ -15,7 +15,7 @@ use OCP\IUser;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class BackupCodeMapperTest extends TestCase {
 	private IDBConnection $db;
 	private BackupCodeMapper $mapper;

--- a/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
@@ -16,7 +16,7 @@ use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class BackupCodeStorageTest extends TestCase {
 	private IManager&MockObject $notificationManager;
 	private string $testUID = 'test123456789';

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
@@ -51,7 +51,7 @@ class ProviderTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('subjectData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'subjectData')]
 	public function testParse(string $subject): void {
 		$lang = 'ru';
 		$event = $this->createMock(IEvent::class);

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
@@ -10,7 +10,6 @@ namespace OCA\TwoFactorBackupCodes\Tests\Unit\Listener;
 
 use OCA\TwoFactorBackupCodes\Event\CodesGenerated;
 use OCA\TwoFactorBackupCodes\Listener\ClearNotifications;
-use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
@@ -30,14 +29,6 @@ class ClearNotificationsTest extends TestCase {
 			->willReturn(Server::get(IManager::class)->createNotification());
 
 		$this->listener = new ClearNotifications($this->notificationManager);
-	}
-
-	public function testHandleGenericEvent(): void {
-		$event = $this->createMock(Event::class);
-		$this->notificationManager->expects($this->never())
-			->method($this->anything());
-
-		$this->listener->handle($event);
 	}
 
 	public function testHandleCodesGeneratedEvent(): void {

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderDisabledTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderDisabledTest.php
@@ -13,7 +13,6 @@ use OCA\TwoFactorBackupCodes\Listener\ProviderDisabled;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserUnregistered;
 use OCP\BackgroundJob\IJobList;
-use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -30,14 +29,6 @@ class ProviderDisabledTest extends TestCase {
 		$this->jobList = $this->createMock(IJobList::class);
 
 		$this->listener = new ProviderDisabled($this->registy, $this->jobList);
-	}
-
-	public function testHandleGenericEvent(): void {
-		$event = $this->createMock(Event::class);
-		$this->jobList->expects($this->never())
-			->method($this->anything());
-
-		$this->listener->handle($event);
 	}
 
 	public function testHandleStillActiveProvider(): void {

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderEnabledTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderEnabledTest.php
@@ -13,7 +13,6 @@ use OCA\TwoFactorBackupCodes\Listener\ProviderEnabled;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserRegistered;
 use OCP\BackgroundJob\IJobList;
-use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -30,14 +29,6 @@ class ProviderEnabledTest extends TestCase {
 		$this->jobList = $this->createMock(IJobList::class);
 
 		$this->listener = new ProviderEnabled($this->registy, $this->jobList);
-	}
-
-	public function testHandleGenericEvent(): void {
-		$event = $this->createMock(Event::class);
-		$this->jobList->expects($this->never())
-			->method($this->anything());
-
-		$this->listener->handle($event);
 	}
 
 	public function testHandleCodesGeneratedEventAlraedyBackupcodes(): void {

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/RegistryUpdaterTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/RegistryUpdaterTest.php
@@ -12,7 +12,6 @@ use OCA\TwoFactorBackupCodes\Event\CodesGenerated;
 use OCA\TwoFactorBackupCodes\Listener\RegistryUpdater;
 use OCA\TwoFactorBackupCodes\Provider\BackupCodesProvider;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
-use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -29,14 +28,6 @@ class RegistryUpdaterTest extends TestCase {
 		$this->provider = $this->createMock(BackupCodesProvider::class);
 
 		$this->listener = new RegistryUpdater($this->registry, $this->provider);
-	}
-
-	public function testHandleGenericEvent(): void {
-		$event = $this->createMock(Event::class);
-		$this->registry->expects($this->never())
-			->method('enableProviderFor');
-
-		$this->listener->handle($event);
 	}
 
 	public function testHandleCodesGeneratedEvent(): void {

--- a/apps/twofactor_backupcodes/tests/Unit/Migration/CheckBackupCodeTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Migration/CheckBackupCodeTest.php
@@ -11,7 +11,7 @@ namespace OCA\TwoFactorBackupCodes\Tests\Unit\Migration;
 use OCA\TwoFactorBackupCodes\Migration\CheckBackupCodes;
 use OCP\BackgroundJob\IJobList;
 use OCP\Migration\IOutput;
-use PHPunit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class CheckBackupCodeTest extends TestCase {

--- a/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
@@ -102,7 +102,7 @@ class BackupCodeStorageTest extends TestCase {
 		$code1 = new BackupCode();
 		$code1->setUsed(1);
 		$code2 = new BackupCode();
-		$code2->setUsed('0');
+		$code2->setUsed(0);
 		$codes = [
 			$code1,
 			$code2,
@@ -168,7 +168,7 @@ class BackupCodeStorageTest extends TestCase {
 	public function testValidateUsedCode(): void {
 		$user = $this->createMock(IUser::class);
 		$code = new BackupCode();
-		$code->setUsed('1');
+		$code->setUsed(1);
 		$code->setCode('HASHEDVALUE');
 		$codes = [
 			$code,

--- a/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
@@ -49,10 +49,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		$this->versionCheck = $this->createMock(VersionCheck::class);
 	}
 
-	/**
-	 * @return UpdateAvailableNotifications|MockObject
-	 */
-	protected function getJob(array $methods = []): UpdateAvailableNotifications {
+	protected function getJob(array $methods = []): UpdateAvailableNotifications|MockObject {
 		if (empty($methods)) {
 			return new UpdateAvailableNotifications(
 				$this->timeFactory,
@@ -152,7 +149,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckCoreUpdate')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataCheckCoreUpdate')]
 	public function testCheckCoreUpdate(string $channel, mixed $versionCheck, mixed $version, ?string $readableVersion, ?int $errorDays): void {
 		$job = $this->getJob([
 			'createNotifications',
@@ -229,7 +226,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckAppUpdates')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataCheckAppUpdates')]
 	public function testCheckAppUpdates(array $apps, array $isUpdateAvailable, array $notifications): void {
 		$job = $this->getJob([
 			'isUpdateAvailable',
@@ -264,7 +261,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateNotifications')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataCreateNotifications')]
 	public function testCreateNotifications(string $app, string $version, string|false $lastNotification, string|false $callDelete, bool $createNotification, ?array $users, ?array $userNotifications): void {
 		$job = $this->getJob([
 			'deleteOutdatedNotifications',
@@ -345,7 +342,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsersToNotify')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetUsersToNotify')]
 	public function testGetUsersToNotify(array $groups, array $groupUsers, array $expected): void {
 		$job = $this->getJob();
 
@@ -389,7 +386,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 	 * @param string $app
 	 * @param string $version
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteOutdatedNotifications')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataDeleteOutdatedNotifications')]
 	public function testDeleteOutdatedNotifications(string $app, string $version): void {
 		$notification = $this->createMock(INotification::class);
 		$notification->expects($this->once())

--- a/apps/updatenotification/tests/Controller/APIControllerTest.php
+++ b/apps/updatenotification/tests/Controller/APIControllerTest.php
@@ -55,7 +55,7 @@ class APIControllerTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppChangelog')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataGetAppChangelog')]
 	public function testGetAppChangelogEntry(
 		array $params,
 		bool $hasChanges,

--- a/apps/updatenotification/tests/Notification/NotifierTest.php
+++ b/apps/updatenotification/tests/Notification/NotifierTest.php
@@ -49,9 +49,8 @@ class NotifierTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return Notifier|MockObject
 	 */
-	protected function getNotifier(array $methods = []): Notifier {
+	protected function getNotifier(array $methods = []): Notifier|MockObject {
 		if (empty($methods)) {
 			return new Notifier(
 				$this->urlGenerator,
@@ -89,7 +88,7 @@ class NotifierTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateAlreadyInstalledCheck')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataUpdateAlreadyInstalledCheck')]
 	public function testUpdateAlreadyInstalledCheck(string $versionNotification, string $versionInstalled, bool $exception): void {
 		$notifier = $this->getNotifier();
 

--- a/apps/updatenotification/tests/Settings/AdminTest.php
+++ b/apps/updatenotification/tests/Settings/AdminTest.php
@@ -448,7 +448,7 @@ class AdminTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('changesProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'changesProvider')]
 	public function testFilterChanges($changes, $userLang, $expectation): void {
 		$iterator = $this->createMock(ILanguageIterator::class);
 		$iterator->expects($this->any())

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -41,7 +41,7 @@ use Test\TestCase;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AccessTest extends TestCase {
 	protected UserMapping&MockObject $userMapper;
 	protected IManager&MockObject $shareManager;
@@ -86,7 +86,10 @@ class AccessTest extends TestCase {
 		$this->access->setGroupMapper($this->groupMapper);
 	}
 
-	private function getConnectorAndLdapMock() {
+	/**
+	 * @return array{0: ILDAPWrapper&MockObject, 1: Connection&MockObject, 2: Manager&MockObject, 3: Helper}
+	 */
+	private function getConnectorAndLdapMock(): array {
 		/** @var ILDAPWrapper&MockObject */
 		$lw = $this->createMock(ILDAPWrapper::class);
 		/** @var Connection&MockObject */
@@ -135,7 +138,7 @@ class AccessTest extends TestCase {
 	 * @param array $sidArray
 	 * @param $sidExpected
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('convertSID2StrSuccessData')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'convertSID2StrSuccessData')]
 	public function testConvertSID2StrSuccess(array $sidArray, $sidExpected): void {
 		$sidBinary = implode('', $sidArray);
 		$this->assertSame($sidExpected, $this->access->convertSID2Str($sidBinary));
@@ -219,7 +222,7 @@ class AccessTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dnInputDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dnInputDataProvider')]
 	public function testStringResemblesDN(string $input, array|bool $interResult, bool $expectedResult): void {
 		[$lw, $con, $um, $helper] = $this->getConnectorAndLdapMock();
 		$access = new Access($lw, $con, $um, $helper, $this->ncUserManager, $this->logger, $this->appConfig, $this->dispatcher);
@@ -236,7 +239,7 @@ class AccessTest extends TestCase {
 		$this->assertSame($expectedResult, $access->stringResemblesDN($input));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dnInputDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dnInputDataProvider')]
 	public function testStringResemblesDNLDAPmod(string $input, array|bool $interResult, bool $expectedResult): void {
 		[, $con, $um, $helper] = $this->getConnectorAndLdapMock();
 		$lw = new LDAP();
@@ -406,7 +409,7 @@ class AccessTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dNAttributeProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dNAttributeProvider')]
 	public function testSanitizeDN(string $attribute): void {
 		[$lw, $con, $um, $helper] = $this->getConnectorAndLdapMock();
 		$dnFromServer = 'cn=Mixed Cases,ou=Are Sufficient To,ou=Test,dc=example,dc=org';
@@ -685,7 +688,7 @@ class AccessTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('intUsernameProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'intUsernameProvider')]
 	public function testSanitizeUsername(string $name, ?string $expected): void {
 		if ($expected === null) {
 			$this->expectException(\InvalidArgumentException::class);
@@ -694,7 +697,7 @@ class AccessTest extends TestCase {
 		$this->assertSame($expected, $sanitizedName);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('groupIDCandidateProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'groupIDCandidateProvider')]
 	public function testSanitizeGroupIDCandidate(string $name, string $expected): void {
 		$sanitizedName = $this->access->sanitizeGroupIDCandidate($name);
 		$this->assertSame($expected, $sanitizedName);

--- a/apps/user_ldap/tests/ConfigurationTest.php
+++ b/apps/user_ldap/tests/ConfigurationTest.php
@@ -86,7 +86,7 @@ class ConfigurationTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('configurationDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'configurationDataProvider')]
 	public function testSetValue(string $key, string|array $input, string|array $expected): void {
 		$this->configuration->setConfiguration([$key => $input]);
 		$this->assertSame($this->configuration->$key, $expected);
@@ -103,13 +103,13 @@ class ConfigurationTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('avatarRuleValueProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'avatarRuleValueProvider')]
 	public function testGetAvatarAttributes(string $setting, array $expected): void {
 		$this->configuration->setConfiguration(['ldapUserAvatarRule' => $setting]);
 		$this->assertSame($expected, $this->configuration->getAvatarAttributes());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('avatarRuleValueProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'avatarRuleValueProvider')]
 	public function testResolveRule(string $setting, array $expected): void {
 		$this->configuration->setConfiguration(['ldapUserAvatarRule' => $setting]);
 		// so far the only thing that can get resolved :)

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ConnectionTest extends \Test\TestCase {
 	protected ILDAPWrapper&MockObject $ldap;
 	protected Connection $connection;

--- a/apps/user_ldap/tests/HelperTest.php
+++ b/apps/user_ldap/tests/HelperTest.php
@@ -13,7 +13,7 @@ use OCP\IDBConnection;
 use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class HelperTest extends \Test\TestCase {
 	private IAppConfig&MockObject $appConfig;
 

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SyncTest extends TestCase {
 	protected Helper&MockObject $helper;
 	protected LDAP&MockObject $ldapWrapper;
@@ -100,7 +100,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('intervalDataProvider')]
+	#[DataProvider(methodName: 'intervalDataProvider')]
 	public function testUpdateInterval(int $userCount, int $pagingSize1, int $pagingSize2): void {
 		$this->appConfig->expects($this->once())
 			->method('setAppValueInt')
@@ -141,7 +141,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('moreResultsProvider')]
+	#[DataProvider(methodName: 'moreResultsProvider')]
 	public function testMoreResults($pagingSize, $results, $expected): void {
 		$connection = $this->getMockBuilder(Connection::class)
 			->setConstructorArgs([
@@ -198,7 +198,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('cycleDataProvider')]
+	#[DataProvider(methodName: 'cycleDataProvider')]
 	public function testDetermineNextCycle(?array $cycleData, array $prefixes, ?array $expectedCycle): void {
 		$this->helper->expects($this->any())
 			->method('getServerConfigurationPrefixes')
@@ -275,7 +275,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	#[DataProvider('runDataProvider')]
+	#[DataProvider(methodName: 'runDataProvider')]
 	public function testRun(array $runData): void {
 		$this->globalAppConfig->expects($this->any())
 			->method('getValueString')

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -31,7 +31,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class LDAPProviderTest extends \Test\TestCase {
 	private function getServerMock(IUserLDAP $userBackend, IGroupLDAP $groupBackend) {
 		$server = $this->getMockBuilder('OC\Server')

--- a/apps/user_ldap/tests/LDAPTest.php
+++ b/apps/user_ldap/tests/LDAPTest.php
@@ -33,7 +33,7 @@ class LDAPTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('errorProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'errorProvider')]
 	public function testSearchWithErrorHandler(string $errorMessage, bool $passThrough): void {
 		$wasErrorHandlerCalled = false;
 		$errorHandler = function ($number, $message, $file, $line) use (&$wasErrorHandlerCalled): void {

--- a/apps/user_ldap/tests/Mapping/GroupMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/GroupMappingTest.php
@@ -19,7 +19,7 @@ use OCP\IDBConnection;
  *
  * @package OCA\User_LDAP\Tests\Mapping
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GroupMappingTest extends AbstractMappingTestCase {
 	public function getMapper(IDBConnection $dbMock, ICacheFactory $cacheFactory, IAppConfig $appConfig): GroupMapping {
 		return new GroupMapping($dbMock, $cacheFactory, $appConfig, true);

--- a/apps/user_ldap/tests/Mapping/UserMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/UserMappingTest.php
@@ -20,7 +20,7 @@ use OCP\Support\Subscription\IAssertion;
  *
  * @package OCA\User_LDAP\Tests\Mapping
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserMappingTest extends AbstractMappingTestCase {
 	public function getMapper(IDBConnection $dbMock, ICacheFactory $cacheFactory, IAppConfig $appConfig): UserMapping {
 		return new UserMapping($dbMock, $cacheFactory, $appConfig, true, $this->createMock(IAssertion::class));

--- a/apps/user_ldap/tests/Migration/AbstractUUIDFixTestCase.php
+++ b/apps/user_ldap/tests/Migration/AbstractUUIDFixTestCase.php
@@ -24,7 +24,7 @@ abstract class AbstractUUIDFixTestCase extends TestCase {
 	protected LDAP&MockObject $ldap;
 	protected AbstractMapping $mapper;
 	protected UUIDFix $job;
-	protected Proxy $proxy;
+	protected Proxy&MockObject $proxy;
 	protected Access&MockObject $access;
 	protected ITimeFactory&MockObject $time;
 	protected bool $isUser = true;

--- a/apps/user_ldap/tests/Migration/UUIDFixGroupTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixGroupTest.php
@@ -16,7 +16,7 @@ use OCA\User_LDAP\Migration\UUIDFixGroup;
  *
  * @package OCA\Group_LDAP\Tests\Migration
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UUIDFixGroupTest extends AbstractUUIDFixTestCase {
 	protected function setUp(): void {
 		$this->isUser = false;

--- a/apps/user_ldap/tests/Migration/UUIDFixInsertTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixInsertTest.php
@@ -86,7 +86,7 @@ class UUIDFixInsertTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('recordProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'recordProvider')]
 	public function testRun(array $userBatches, array $groupBatches): void {
 		$this->appConfig->expects($this->once())
 			->method('getAppValueString')
@@ -114,7 +114,7 @@ class UUIDFixInsertTest extends TestCase {
 		$this->job->run($out);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('recordProviderTooLongAndNone')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'recordProviderTooLongAndNone')]
 	public function testRunWithManyAndNone(array $userBatches, array $groupBatches): void {
 		$this->appConfig->expects($this->once())
 			->method('getAppValueString')

--- a/apps/user_ldap/tests/Migration/UUIDFixUserTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixUserTest.php
@@ -16,7 +16,7 @@ use OCA\User_LDAP\User_Proxy;
  *
  * @package OCA\User_LDAP\Tests\Migration
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UUIDFixUserTest extends AbstractUUIDFixTestCase {
 	protected function setUp(): void {
 		$this->isUser = true;

--- a/apps/user_ldap/tests/Service/BirthdateParserServiceTest.php
+++ b/apps/user_ldap/tests/Service/BirthdateParserServiceTest.php
@@ -35,7 +35,7 @@ class BirthdateParserServiceTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('parseBirthdateDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'parseBirthdateDataProvider')]
 	public function testParseBirthdate(
 		string $value,
 		?DateTimeImmutable $expected,

--- a/apps/user_ldap/tests/Settings/AdminTest.php
+++ b/apps/user_ldap/tests/Settings/AdminTest.php
@@ -20,7 +20,7 @@ use Test\TestCase;
 /**
  * @package OCA\User_LDAP\Tests\Settings
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AdminTest extends TestCase {
 	private IL10N&MockObject $l10n;
 	private ITemplateManager $templateManager;

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\User_LDAP\Tests\User
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DeletedUsersIndexTest extends \Test\TestCase {
 	protected DeletedUsersIndex $dui;
 	protected IUserConfig $userConfig;

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -31,7 +31,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\User_LDAP\Tests\User
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ManagerTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected IConfig&MockObject $config;
@@ -93,7 +93,7 @@ class ManagerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dnProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dnProvider')]
 	public function testGetByDNExisting(string $inputDN): void {
 		$uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
 
@@ -190,7 +190,7 @@ class ManagerTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('attributeRequestProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'attributeRequestProvider')]
 	public function testGetAttributes($minimal): void {
 		$this->connection->setConfiguration([
 			'ldapEmailAttribute' => 'MAIL',

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -47,7 +47,7 @@ class OfflineUserTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('shareOwnerProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'shareOwnerProvider')]
 	public function testHasActiveShares(array $existingShareTypes, bool $expected): void {
 		$shareMock = $this->createMock(IShare::class);
 

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\User_LDAP\Tests\User
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected Connection&MockObject $connection;
@@ -788,7 +788,7 @@ class UserTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('extStorageHomeDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'extStorageHomeDataProvider')]
 	public function testUpdateExtStorageHome(string $expected, ?string $valueFromLDAP = null, bool $isSet = true): void {
 		if ($valueFromLDAP === null) {
 			$this->connection->expects($this->once())
@@ -944,7 +944,7 @@ class UserTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('emptyHomeFolderAttributeValueProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'emptyHomeFolderAttributeValueProvider')]
 	public function testGetHomePathNotConfigured(string $attributeValue): void {
 		$this->connection->expects($this->any())
 			->method('__get')
@@ -1018,7 +1018,7 @@ class UserTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('displayNameProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'displayNameProvider')]
 	public function testComposeAndStoreDisplayName(string $part1, string $part2, string $expected, bool $expectTriggerChange): void {
 		$this->userConfig->expects($this->once())
 			->method('setValueString');

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -37,7 +37,7 @@ use Test\TestCase;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class User_LDAPTest extends TestCase {
 	protected Access&MockObject $access;
 	protected OfflineUser&MockObject $offlineUser;
@@ -1324,7 +1324,7 @@ class User_LDAPTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('avatarDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'avatarDataProvider')]
 	public function testCanChangeAvatar(string|bool $imageData, bool $expected): void {
 		$isValidImage = str_starts_with((string)$imageData, 'valid');
 
@@ -1449,7 +1449,7 @@ class User_LDAPTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('actionProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'actionProvider')]
 	public function testImplementsAction(string $configurable, string|int $value, int $actionCode, bool $expected): void {
 		$this->pluginManager->expects($this->once())
 			->method('getImplementedActions')

--- a/apps/user_ldap/tests/WizardTest.php
+++ b/apps/user_ldap/tests/WizardTest.php
@@ -21,7 +21,7 @@ use Test\TestCase;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class WizardTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/user_status/tests/Integration/Service/StatusServiceIntegrationTest.php
+++ b/apps/user_status/tests/Integration/Service/StatusServiceIntegrationTest.php
@@ -18,7 +18,7 @@ use Test\TestCase;
 use function sleep;
 use function time;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class StatusServiceIntegrationTest extends TestCase {
 
 	private StatusService $service;

--- a/apps/user_status/tests/Unit/CapabilitiesTest.php
+++ b/apps/user_status/tests/Unit/CapabilitiesTest.php
@@ -24,7 +24,7 @@ class CapabilitiesTest extends TestCase {
 		$this->capabilities = new Capabilities($this->emojiHelper);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('getCapabilitiesDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'getCapabilitiesDataProvider')]
 	public function testGetCapabilities(bool $supportsEmojis): void {
 		$this->emojiHelper->expects($this->once())
 			->method('doesPlatformSupportEmoji')

--- a/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
+++ b/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
@@ -87,7 +87,7 @@ class UserStatusControllerTest extends TestCase {
 		$this->controller->getStatus();
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('setStatusDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'setStatusDataProvider')]
 	public function testSetStatus(
 		string $statusType,
 		?string $statusIcon,
@@ -147,7 +147,7 @@ class UserStatusControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('setPredefinedMessageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'setPredefinedMessageDataProvider')]
 	public function testSetPredefinedMessage(
 		string $messageId,
 		?int $clearAt,
@@ -207,7 +207,7 @@ class UserStatusControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('setCustomMessageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'setCustomMessageDataProvider')]
 	public function testSetCustomMessage(
 		?string $statusIcon,
 		string $message,

--- a/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
+++ b/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
@@ -134,7 +134,7 @@ class UserStatusMapperTest extends TestCase {
 		$this->mapper->insert($userStatus2);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('clearStatusesOlderThanDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'clearStatusesOlderThanDataProvider')]
 	public function testClearStatusesOlderThan(string $status, bool $isUserDefined, int $timestamp, bool $expectsClean): void {
 		$oldStatus = UserStatus::fromParams([
 			'userId' => 'john.doe',
@@ -231,7 +231,7 @@ class UserStatusMapperTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateBackupStatus')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataCreateBackupStatus')]
 	public function testCreateBackupStatus(bool $hasStatus, bool $hasBackup, bool $backupCreated): void {
 		if ($hasStatus) {
 			$userStatus1 = new UserStatus();

--- a/apps/user_status/tests/Unit/Listener/UserDeletedListenerTest.php
+++ b/apps/user_status/tests/Unit/Listener/UserDeletedListenerTest.php
@@ -10,7 +10,6 @@ namespace OCA\UserStatus\Tests\Listener;
 
 use OCA\UserStatus\Listener\UserDeletedListener;
 use OCA\UserStatus\Service\StatusService;
-use OCP\EventDispatcher\GenericEvent;
 use OCP\IUser;
 use OCP\User\Events\UserDeletedEvent;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -38,14 +37,6 @@ class UserDeletedListenerTest extends TestCase {
 			->with('john.doe');
 
 		$event = new UserDeletedEvent($user);
-		$this->listener->handle($event);
-	}
-
-	public function testHandleWithWrongEvent(): void {
-		$this->service->expects($this->never())
-			->method('removeUserStatus');
-
-		$event = new GenericEvent();
 		$this->listener->handle($event);
 	}
 }

--- a/apps/user_status/tests/Unit/Listener/UserLiveStatusListenerTest.php
+++ b/apps/user_status/tests/Unit/Listener/UserLiveStatusListenerTest.php
@@ -15,7 +15,6 @@ use OCA\UserStatus\Listener\UserLiveStatusListener;
 use OCA\UserStatus\Service\StatusService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\EventDispatcher\GenericEvent;
 use OCP\IUser;
 use OCP\User\Events\UserLiveStatusEvent;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -49,7 +48,7 @@ class UserLiveStatusListenerTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('handleEventWithCorrectEventDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'handleEventWithCorrectEventDataProvider')]
 	public function testHandleWithCorrectEvent(
 		string $userId,
 		string $previousStatus,
@@ -137,13 +136,5 @@ class UserLiveStatusListenerTest extends TestCase {
 			['john.doe', 'away', 5000, true, 'online', 5000, true, false],
 			['john.doe', 'online', 5000, true, 'away', 5000, true, false],
 		];
-	}
-
-	public function testHandleWithWrongEvent(): void {
-		$this->mapper->expects($this->never())
-			->method('insertOrUpdate');
-
-		$event = new GenericEvent();
-		$this->listener->handle($event);
 	}
 }

--- a/apps/user_status/tests/Unit/Service/PredefinedStatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/PredefinedStatusServiceTest.php
@@ -102,7 +102,7 @@ class PredefinedStatusServiceTest extends TestCase {
 		], $actual);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('getIconForIdDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'getIconForIdDataProvider')]
 	public function testGetIconForId(string $id, ?string $expectedIcon): void {
 		$actual = $this->service->getIconForId($id);
 		$this->assertEquals($expectedIcon, $actual);
@@ -121,7 +121,7 @@ class PredefinedStatusServiceTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('getTranslatedStatusForIdDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'getTranslatedStatusForIdDataProvider')]
 	public function testGetTranslatedStatusForId(string $id, ?string $expected): void {
 		$this->l10n->method('t')
 			->willReturnArgument(0);
@@ -143,7 +143,7 @@ class PredefinedStatusServiceTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('isValidIdDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'isValidIdDataProvider')]
 	public function testIsValidId(string $id, bool $expected): void {
 		$actual = $this->service->isValidId($id);
 		$this->assertEquals($expected, $actual);

--- a/apps/user_status/tests/Unit/Service/StatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/StatusServiceTest.php
@@ -219,7 +219,7 @@ class StatusServiceTest extends TestCase {
 		$this->assertNull($status->getMessageId());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('setStatusDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'setStatusDataProvider')]
 	public function testSetStatus(
 		string $userId,
 		string $status,
@@ -340,7 +340,7 @@ class StatusServiceTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('setPredefinedMessageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'setPredefinedMessageDataProvider')]
 	public function testSetPredefinedMessage(
 		string $userId,
 		string $messageId,
@@ -427,7 +427,7 @@ class StatusServiceTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('setCustomMessageDataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'setCustomMessageDataProvider')]
 	public function testSetCustomMessage(
 		string $userId,
 		?string $statusIcon,
@@ -791,7 +791,7 @@ class StatusServiceTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetUserStatus')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataSetUserStatus')]
 	public function testSetUserStatus(string $messageId, string $oldMessageId, bool $expectedUpdateShortcut): void {
 		$previous = new UserStatus();
 		$previous->setId(1);

--- a/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
+++ b/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
@@ -18,7 +18,7 @@ use OCP\Server;
 use OCP\User\Events\UserCreatedEvent;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class WebhookListenerMapperTest extends TestCase {
 	private IDBConnection $connection;
 	private WebhookListenerMapper $mapper;

--- a/apps/webhook_listeners/tests/Service/PHPMongoQueryTest.php
+++ b/apps/webhook_listeners/tests/Service/PHPMongoQueryTest.php
@@ -38,7 +38,7 @@ class PHPMongoQueryTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteQuery')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteQuery')]
 	public function testExecuteQuery(array $query, array $document, bool $matches): void {
 		$this->assertEquals($matches, PHPMongoQuery::executeQuery($query, $document));
 	}

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -264,7 +264,7 @@ class Manager implements IManager {
 	/**
 	 * @param string $class
 	 * @param string $name
-	 * @param array<int, Check> $checks
+	 * @param list<Check> $checks
 	 * @param string $operation
 	 * @return array The added operation
 	 * @throws \UnexpectedValueException
@@ -455,7 +455,7 @@ class Manager implements IManager {
 
 	/**
 	 * @param class-string<IOperation> $class
-	 * @param array<int, Check> $checks
+	 * @param list<Check> $checks
 	 * @param array $events
 	 * @throws \UnexpectedValueException
 	 */

--- a/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
+++ b/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
@@ -50,7 +50,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteStringCheck')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteStringCheck')]
 	public function testExecuteStringCheck(string $operation, string $checkValue, string $actualValue, bool $expected): void {
 		$check = $this->getCheckMock();
 
@@ -67,7 +67,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheck')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataValidateCheck')]
 	public function testValidateCheck(string $operator, string $value): void {
 		$check = $this->getCheckMock();
 
@@ -86,7 +86,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheckInvalid')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataValidateCheckInvalid')]
 	public function testValidateCheckInvalid(string $operator, string $value, int $exceptionCode, string $exceptionMessage): void {
 		$check = $this->getCheckMock();
 
@@ -106,7 +106,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataMatch')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataMatch')]
 	public function testMatch(string $pattern, string $subject, array $matches, bool $expected): void {
 		$check = $this->getCheckMock();
 

--- a/apps/workflowengine/tests/Check/FileMimeTypeTest.php
+++ b/apps/workflowengine/tests/Check/FileMimeTypeTest.php
@@ -25,7 +25,7 @@ class TemporaryNoLocal extends Temporary {
 	}
 }
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FileMimeTypeTest extends TestCase {
 	/** @var IL10N */
 	private $l10n;

--- a/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
+++ b/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
@@ -44,7 +44,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv4')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteCheckIPv4')]
 	public function testExecuteCheckMatchesIPv4(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
@@ -55,7 +55,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		$this->assertEquals($expected, $check->executeCheck('matchesIPv4', $value));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv4')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteCheckIPv4')]
 	public function testExecuteCheckNotMatchesIPv4(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
@@ -78,7 +78,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv6')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteCheckIPv6')]
 	public function testExecuteCheckMatchesIPv6(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
@@ -89,7 +89,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		$this->assertEquals($expected, $check->executeCheck('matchesIPv6', $value));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv6')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteCheckIPv6')]
 	public function testExecuteCheckNotMatchesIPv6(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 

--- a/apps/workflowengine/tests/Check/RequestTimeTest.php
+++ b/apps/workflowengine/tests/Check/RequestTimeTest.php
@@ -63,7 +63,7 @@ class RequestTimeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheck')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteCheck')]
 	public function testExecuteCheckIn(string $value, int $timestamp, bool $expected): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 
@@ -74,7 +74,7 @@ class RequestTimeTest extends \Test\TestCase {
 		$this->assertEquals($expected, $check->executeCheck('in', $value));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheck')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteCheck')]
 	public function testExecuteCheckNotIn(string $value, int $timestamp, bool $expected): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 
@@ -93,7 +93,7 @@ class RequestTimeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheck')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataValidateCheck')]
 	public function testValidateCheck(string $operator, string $value): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 		$check->validateCheck($operator, $value);
@@ -112,7 +112,7 @@ class RequestTimeTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheckInvalid')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataValidateCheckInvalid')]
 	public function testValidateCheckInvalid(string $operator, string $value, int $exceptionCode, string $exceptionMessage): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 

--- a/apps/workflowengine/tests/Check/RequestUserAgentTest.php
+++ b/apps/workflowengine/tests/Check/RequestUserAgentTest.php
@@ -82,7 +82,7 @@ class RequestUserAgentTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheck')]
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataExecuteCheck')]
 	public function testExecuteCheck(string $operation, string $checkValue, string $actualValue, bool $expected): void {
 		$this->request->expects($this->once())
 			->method('getHeader')

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -73,7 +73,7 @@ class TestUserOp extends TestAdminOp {
  *
  * @package OCA\WorkflowEngine\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ManagerTest extends TestCase {
 	protected Manager $manager;
 	protected IDBConnection $db;
@@ -394,6 +394,7 @@ class ManagerTest extends TestCase {
 		$operationMock->expects($this->any())
 			->method('isAvailableForScope')
 			->willReturnCallback(function () use (&$expectedCalls, &$i): bool {
+				$this->assertLessThanOrEqual(1, $i);
 				$this->assertEquals($expectedCalls[$i], func_get_args());
 				$i++;
 				return true;
@@ -559,9 +560,11 @@ class ManagerTest extends TestCase {
 
 	public function testValidateOperationOK(): void {
 		$check = [
+			'id' => 1,
 			'class' => ICheck::class,
 			'operator' => 'is',
 			'value' => 'barfoo',
+			'hash' => 'abc',
 		];
 
 		$operationMock = $this->createMock(IOperation::class);
@@ -619,9 +622,11 @@ class ManagerTest extends TestCase {
 
 	public function testValidateOperationCheckInputLengthError(): void {
 		$check = [
+			'id' => 1,
 			'class' => ICheck::class,
 			'operator' => 'is',
 			'value' => str_pad('', IManager::MAX_CHECK_VALUE_BYTES + 1, 'FooBar'),
+			'hash' => 'abc',
 		];
 
 		$operationMock = $this->createMock(IOperation::class);
@@ -660,18 +665,13 @@ class ManagerTest extends TestCase {
 		$this->container->expects($this->any())
 			->method('get')
 			->willReturnCallback(function ($className) use ($operationMock, $entityMock, $eventEntityMock, $checkMock) {
-				switch ($className) {
-					case IOperation::class:
-						return $operationMock;
-					case IEntity::class:
-						return $entityMock;
-					case IEntityEvent::class:
-						return $eventEntityMock;
-					case ICheck::class:
-						return $checkMock;
-					default:
-						return $this->createMock($className);
-				}
+				return match ($className) {
+					IOperation::class => $operationMock,
+					IEntity::class => $entityMock,
+					IEntityEvent::class => $eventEntityMock,
+					ICheck::class => $checkMock,
+					default => $this->createMock($className),
+				};
 			});
 
 		try {
@@ -683,9 +683,11 @@ class ManagerTest extends TestCase {
 
 	public function testValidateOperationDataLengthError(): void {
 		$check = [
+			'id' => 1,
 			'class' => ICheck::class,
 			'operator' => 'is',
 			'value' => 'barfoo',
+			'hash' => 'abc',
 		];
 		$operationData = str_pad('', IManager::MAX_OPERATION_VALUE_BYTES + 1, 'FooBar');
 
@@ -719,18 +721,13 @@ class ManagerTest extends TestCase {
 		$this->container->expects($this->any())
 			->method('get')
 			->willReturnCallback(function ($className) use ($operationMock, $entityMock, $eventEntityMock, $checkMock) {
-				switch ($className) {
-					case IOperation::class:
-						return $operationMock;
-					case IEntity::class:
-						return $entityMock;
-					case IEntityEvent::class:
-						return $eventEntityMock;
-					case ICheck::class:
-						return $checkMock;
-					default:
-						return $this->createMock($className);
-				}
+				return match ($className) {
+					IOperation::class => $operationMock,
+					IEntity::class => $entityMock,
+					IEntityEvent::class => $eventEntityMock,
+					ICheck::class => $checkMock,
+					default => $this->createMock($className),
+				};
 			});
 
 		try {
@@ -742,6 +739,7 @@ class ManagerTest extends TestCase {
 
 	public function testValidateOperationScopeNotAvailable(): void {
 		$check = [
+			'id' => 1,
 			'class' => ICheck::class,
 			'operator' => 'is',
 			'value' => 'barfoo',
@@ -783,18 +781,13 @@ class ManagerTest extends TestCase {
 		$this->container->expects($this->any())
 			->method('get')
 			->willReturnCallback(function ($className) use ($operationMock, $entityMock, $eventEntityMock, $checkMock) {
-				switch ($className) {
-					case IOperation::class:
-						return $operationMock;
-					case IEntity::class:
-						return $entityMock;
-					case IEntityEvent::class:
-						return $eventEntityMock;
-					case ICheck::class:
-						return $checkMock;
-					default:
-						return $this->createMock($className);
-				}
+				return match ($className) {
+					IOperation::class => $operationMock,
+					IEntity::class => $entityMock,
+					IEntityEvent::class => $eventEntityMock,
+					ICheck::class => $checkMock,
+					default => $this->createMock($className),
+				};
 			});
 
 		try {

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
 		"psalm:ocp": "psalm --no-cache --threads=$(nproc) -c psalm-ocp.xml",
 		"psalm:ncu": "psalm --no-cache --threads=$(nproc) -c psalm-ncu.xml",
 		"psalm:security": "psalm --no-cache --threads=$(nproc) --taint-analysis --use-baseline=build/psalm-baseline-security.xml",
+		"psalm:fix": "psalm --alter --issues=InvalidReturnType,InvalidNullableReturnType,MissingParamType,InvalidFalsableReturnType",
 		"psalm:update-baseline": "psalm --no-cache --threads=$(nproc) --update-baseline",
 		"serve": [
 			"Composer\\Config::disableProcessTimeout",

--- a/psalm.xml
+++ b/psalm.xml
@@ -64,8 +64,8 @@
 		<file name="version.php"/>
 		<file name="tests/lib/TestCase.php"/>
 		<ignoreFiles>
-			<directory name="apps/**/composer"/>
 			<directory name="apps/**/tests"/>
+			<directory name="apps/**/composer"/>
 			<directory name="lib/composer"/>
 			<directory name="lib/l10n"/>
 			<directory name="3rdparty"/>
@@ -170,37 +170,54 @@
 		<DeprecatedClass>
 			<errorLevel type="suppress">
 				<directory name="lib" />
+				<directory name="apps/*/tests" />
 			</errorLevel>
 		</DeprecatedClass>
 		<DeprecatedConstant>
 			<errorLevel type="suppress">
 				<directory name="lib" />
+				<directory name="apps/*/tests" />
 			</errorLevel>
 		</DeprecatedConstant>
 		<DeprecatedFunction>
 			<errorLevel type="suppress">
 				<directory name="lib" />
+				<directory name="apps/*/tests" />
 			</errorLevel>
 		</DeprecatedFunction>
 		<DeprecatedInterface>
 			<errorLevel type="suppress">
 				<directory name="lib" />
+				<directory name="apps/*/tests" />
 			</errorLevel>
 		</DeprecatedInterface>
 		<DeprecatedMethod>
 			<errorLevel type="suppress">
 				<directory name="lib" />
+				<directory name="apps/*/tests" />
 			</errorLevel>
 		</DeprecatedMethod>
 		<DeprecatedProperty>
 			<errorLevel type="suppress">
 				<directory name="lib" />
+				<directory name="apps/*/tests" />
 			</errorLevel>
 		</DeprecatedProperty>
 		<DeprecatedTrait>
 			<errorLevel type="suppress">
 				<directory name="lib" />
+				<directory name="apps/*/tests" />
 			</errorLevel>
 		</DeprecatedTrait>
+		<InternalMethod>
+			<errorLevel type="suppress">
+				<directory name="apps/*/tests" />
+			</errorLevel>
+		</InternalMethod>
+		<InternalClass>
+			<errorLevel type="suppress">
+				<directory name="apps/*/tests" />
+			</errorLevel>
+		</InternalClass>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
## Summary

There are still 1200 more to fix before we can enable static analysis for the tests, but at least this prepare the ground for doing that by fixing some repetitive issues.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
