### PR TITLE
fix(image): Remove NOP imagedestroy call

### DIFF
--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -1137,9 +1137,6 @@ class Image implements IImage {
 	 * Destroys the current image and resets the object
 	 */
 	public function destroy(): void {
-		if ($this->valid()) {
-			imagedestroy($this->resource);
-		}
 		$this->resource = false;
 	}
 

--- a/tests/lib/Files/Mount/RootMountProviderTest.php
+++ b/tests/lib/Files/Mount/RootMountProviderTest.php
@@ -117,7 +117,6 @@ class RootMountProviderTest extends TestCase {
 
 		$class = new \ReflectionClass($storage);
 		$prop = $class->getProperty('objectStore');
-		$prop->setAccessible(true);
 		/** @var S3 $objectStore */
 		$objectStore = $prop->getValue($storage);
 		$this->assertEquals('nextcloud0', $objectStore->getBucket());

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1539,7 +1539,6 @@ class ViewTest extends \Test\TestCase {
 	public function testHookPaths($root, $path, $shouldEmit): void {
 		$filesystemReflection = new \ReflectionClass(Filesystem::class);
 		$defaultRootValue = $filesystemReflection->getProperty('defaultInstance');
-		$defaultRootValue->setAccessible(true);
 		$oldRoot = $defaultRootValue->getValue();
 		$defaultView = new View('/foo/files');
 		$defaultRootValue->setValue(null, $defaultView);


### PR DESCRIPTION
## Summary

This is NOP since 8.0 and deprecated since 8.5

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
