### PR TITLE
fix(storage/local): stop deleting prior to forbidden items check

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -383,7 +383,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $copySuccess && $unlinkSuccess;
 	}
 
-	private function logRenameError(string $reason, string $path, string $level = "error"): void {
+	private function logRenameError(string $reason, string $path, string $level = 'error'): void {
 		Server::get(LoggerInterface::class)->$level(
 			"unable to rename, {$reason}: {$path}", ['app' => 'core']
 		);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

During rename operations, if something already exists in the destination path, it gets deleted prior to the forbidden items check. If the check doesn't pass, the operation is aborted but deletion has already occurred.

This PR moves the forbidden items check up so it takes place before any destructive activities occur (see `checkTreeForForbiddenItems`).

The 2nd commit also addresses an edge case where the copy+unlink fallback could still be triggered for case-only renames on case-insensitive filesystems.

Also included throughout:

- checks success/failure of removals
- logs removal fails
- eliminates duplicate code by using `remove()`
- adds a logging helper to tidy up readability
- moves source existence check to the top

## TODO

- [ ] Delete earlier no longer needed branch: https://github.com/nextcloud/server/tree/jtr/refactor-Storage-Local-rename-copy

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
