### PR TITLE
refactor(entity): Don't type id

### DIFF
--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -19,7 +19,8 @@ use function substr;
  * @psalm-consistent-constructor
  */
 abstract class Entity {
-	public int|string|null $id = null;
+	/** @var int $id */
+	public $id;
 	private array $_updatedFields = [];
 	/** @psalm-param $_fieldTypes array<string, Types::*> */
 	protected array $_fieldTypes = ['id' => 'integer'];

--- a/lib/public/AppFramework/Db/SnowflakeAwareEntity.php
+++ b/lib/public/AppFramework/Db/SnowflakeAwareEntity.php
@@ -35,6 +35,7 @@ abstract class SnowflakeAwareEntity extends Entity {
 	 */
 	public function generateId(): void {
 		if ($this->id === null) {
+			/** @psalm-suppress InvalidPropertyAssignmentValue */
 			$this->id = Server::get(ISnowflakeGenerator::class)->nextId();
 			$this->markFieldUpdated('id');
 		}
@@ -50,7 +51,7 @@ abstract class SnowflakeAwareEntity extends Entity {
 		}
 
 		if ($this->snowflake === null) {
-			$this->snowflake = Server::get(ISnowflakeDecoder::class)->decode($this->id);
+			$this->snowflake = Server::get(ISnowflakeDecoder::class)->decode($this->getId());
 		}
 
 		return $this->snowflake;


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Some apps overwrite this and this breaks them.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
