### PR TITLE
fix: Make User_Proxy IGetDisplayNameBackend complient

### DIFF
--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -13,6 +13,7 @@ use OCA\User_LDAP\User\User;
 use OCP\IUserBackend;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\ICountMappedUsersBackend;
+use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\ILimitAwareCountUsersBackend;
 use OCP\User\Backend\IProvideEnabledStateBackend;
 use OCP\UserInterface;
@@ -21,7 +22,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @template-extends Proxy<User_LDAP>
  */
-class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP, ILimitAwareCountUsersBackend, ICountMappedUsersBackend, IProvideEnabledStateBackend {
+class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP, ILimitAwareCountUsersBackend, ICountMappedUsersBackend, IProvideEnabledStateBackend, IGetDisplayNameBackend {
 	public function __construct(
 		private Helper $helper,
 		ILDAPWrapper $ldap,
@@ -253,7 +254,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 	 * @param string $uid user ID of the user
 	 * @return string display name
 	 */
-	public function getDisplayName($uid) {
+	public function getDisplayName($uid): string {
 		return $this->handleRequest($uid, 'getDisplayName', [$uid]);
 	}
 


### PR DESCRIPTION
## Summary

I noticed that the system address book did not update the displayname after it was changed in LDAP. I tried `occ dav:sync-system-address` first, but no changes. Then I tried `occ user:sync-account-data`, but all accounts reported nothing to update. While digging through the code I noticed that `User_Proxy` did not implement `IGetDisplayNameBackend` (in contrast, `Group_Proxy` does for groups). Afterwards, the system address book was correctly updated.

(`occ user:sync-account-data` did still report nothing to update, as the displayname is already handled before the sync, because of https://github.com/nextcloud/server/pull/39770).

I did not find an issue about that, which makes me wonder if there's something I missed here and it should've worked without the interface ...?


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
