### PR TITLE
feat(build): add .nextcloudignore file to match Krankerl behaviour

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# Files removed at build time
+
+# Global exclude
+.editorconfig
+.git
+.git-blame-ignore-revs
+.gitattributes
+.github
+.gitignore
+.gitmodules
+.idea
+.l10nignore
+.nextcloudignore
+.noopenapi
+.tx
+cypress
+tests
+
+# Server specific
+/.devcontainer
+/__mocks__
+/__tests__
+/autotest*.sh
+/build
+/config/config.php
+/contribute
+/data

--- a/build/files-checker.php
+++ b/build/files-checker.php
@@ -22,6 +22,7 @@ $expectedFiles = [
 	'.idea',
 	'.jshintrc',
 	'.mailmap',
+	'.nextcloudignore',
 	'.npmignore',
 	'.php-cs-fixer.dist.php',
 	'.pre-commit-config.yaml',


### PR DESCRIPTION
## Summary
Help to build release with a `.nextcloudignore` file (as the one used by Krankerl to build applications).
The syntax is identical to `.gitignore` files


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
