### PR TITLE
test(files): add tests to confirm reads don't impact quota in stream_read

### DIFF
--- a/lib/private/Files/Stream/Quota.php
+++ b/lib/private/Files/Stream/Quota.php
@@ -48,40 +48,59 @@ class Quota extends Wrapper {
 	}
 
 	public function stream_seek($offset, $whence = SEEK_SET) {
-		if ($whence === SEEK_END) {
-			// go to the end to find out last position's offset
-			$oldOffset = $this->stream_tell();
-			if (fseek($this->source, 0, $whence) !== 0) {
-				return false;
-			}
-			$whence = SEEK_SET;
-			$offset = $this->stream_tell() + $offset;
-			$this->limit += $oldOffset - $offset;
-		} elseif ($whence === SEEK_SET) {
-			$this->limit += $this->stream_tell() - $offset;
-		} else {
-			$this->limit -= $offset;
-		}
 		// this wrapper needs to return "true" for success.
 		// the fseek call itself returns 0 on succeess
 		return fseek($this->source, $offset, $whence) === 0;
 	}
 
 	public function stream_read($count) {
-		$this->limit -= $count;
+		// Do not decrement $this->limit for reads
 		return fread($this->source, $count);
 	}
 
 	public function stream_write($data) {
 		$size = strlen($data);
-		if ($size > $this->limit) {
-			$data = substr($data, 0, $this->limit);
-			$size = $this->limit;
+
+		// Get current pointer and file size
+		$curPos = ftell($this->source);
+		fseek($this->source, 0, SEEK_END);
+		$fileSize = ftell($this->source);
+		fseek($this->source, $curPos, SEEK_SET);
+
+		$writeEnd = $curPos + $size;
+
+		// Calculate how many bytes are "new" (beyond end of existing)
+		$newBytes = max(0, $writeEnd - $fileSize);
+
+		// Enforce quota for new bytes only
+		if ($newBytes > $this->limit) {
+			 // Only this many new bytes are permitted:
+			$allowedNewBytes = $this->limit;
+			// Adjust write size to fit quota
+			// Calculate max amount we can write, given cursor position and allowed new bytes
+			$allowedSize = $size - ($newBytes - $allowedNewBytes);
+
+			if ($allowedSize <= 0) {
+				return 0; // No new bytes allowed
+			}
+			$data = substr($data, 0, $allowedSize);
+			$size = $allowedSize;
+			// Recalculate position/write end after truncation (for safety)
+			$writeEnd = $curPos + $size;
+			$newBytes = max(0, $writeEnd - $fileSize);
 		}
+
 		$written = fwrite($this->source, $data);
+
+		// Decrement limit by actually written new bytes
+		// (Extra safety: recalculate actual new bytes in case fwrite was truncated)
+		$actualWriteEnd = ftell($this->source);
+		$actualFileSize = max($fileSize, $actualWriteEnd);
+		$actualNewBytes = max(0, $actualFileSize - $fileSize);
 		// Decrement quota by the actual number of bytes written ($written),
 		// not the intended size
-		$this->limit -= $written;
+		$this->limit -= $actualNewBytes;
+
 		return $written;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
