### PR TITLE
fix(TaskProcessing): Expose userFacingErrorMessage on ResponseDefinitions#CoreTaskProcessingTask

### DIFF
--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -212,6 +212,7 @@ namespace OC\Core;
  *     endedAt: ?int,
  *     allowCleanup: bool,
  *     includeWatermark: bool,
+ *     userFacingErrorMessage: ?string,
  * }
  *
  * @psalm-type CoreProfileAction = array{

--- a/core/openapi-ex_app.json
+++ b/core/openapi-ex_app.json
@@ -203,7 +203,8 @@
                     "startedAt",
                     "endedAt",
                     "allowCleanup",
-                    "includeWatermark"
+                    "includeWatermark",
+                    "userFacingErrorMessage"
                 ],
                 "properties": {
                     "id": {
@@ -280,6 +281,10 @@
                     },
                     "includeWatermark": {
                         "type": "boolean"
+                    },
+                    "userFacingErrorMessage": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -663,7 +663,8 @@
                     "startedAt",
                     "endedAt",
                     "allowCleanup",
-                    "includeWatermark"
+                    "includeWatermark",
+                    "userFacingErrorMessage"
                 ],
                 "properties": {
                     "id": {
@@ -740,6 +741,10 @@
                     },
                     "includeWatermark": {
                         "type": "boolean"
+                    },
+                    "userFacingErrorMessage": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -663,7 +663,8 @@
                     "startedAt",
                     "endedAt",
                     "allowCleanup",
-                    "includeWatermark"
+                    "includeWatermark",
+                    "userFacingErrorMessage"
                 ],
                 "properties": {
                     "id": {
@@ -740,6 +741,10 @@
                     },
                     "includeWatermark": {
                         "type": "boolean"
+                    },
+                    "userFacingErrorMessage": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },

--- a/lib/public/TaskProcessing/Task.php
+++ b/lib/public/TaskProcessing/Task.php
@@ -295,7 +295,7 @@ final class Task implements \JsonSerializable {
 	}
 
 	/**
-	 * @psalm-return array{id: int, lastUpdated: int, type: string, status: 'STATUS_CANCELLED'|'STATUS_FAILED'|'STATUS_SUCCESSFUL'|'STATUS_RUNNING'|'STATUS_SCHEDULED'|'STATUS_UNKNOWN', userId: ?string, appId: string, input: array<string, list<numeric|string>|numeric|string>, output: ?array<string, list<numeric|string>|numeric|string>, customId: ?string, completionExpectedAt: ?int, progress: ?float, scheduledAt: ?int, startedAt: ?int, endedAt: ?int, allowCleanup: bool, includeWatermark: bool}
+	 * @psalm-return array{id: int, lastUpdated: int, type: string, status: 'STATUS_CANCELLED'|'STATUS_FAILED'|'STATUS_SUCCESSFUL'|'STATUS_RUNNING'|'STATUS_SCHEDULED'|'STATUS_UNKNOWN', userId: ?string, appId: string, input: array<string, list<numeric|string>|numeric|string>, output: ?array<string, list<numeric|string>|numeric|string>, customId: ?string, completionExpectedAt: ?int, progress: ?float, scheduledAt: ?int, startedAt: ?int, endedAt: ?int, allowCleanup: bool, includeWatermark: bool, userFacingErrorMessage: ?string}
 	 * @since 30.0.0
 	 */
 	final public function jsonSerialize(): array {
@@ -316,6 +316,7 @@ final class Task implements \JsonSerializable {
 			'endedAt' => $this->getEndedAt(),
 			'allowCleanup' => $this->getAllowCleanup(),
 			'includeWatermark' => $this->getIncludeWatermark(),
+			'userFacingErrorMessage' => $this->getUserFacingErrorMessage(),
 		];
 	}
 

--- a/openapi.json
+++ b/openapi.json
@@ -709,7 +709,8 @@
                     "startedAt",
                     "endedAt",
                     "allowCleanup",
-                    "includeWatermark"
+                    "includeWatermark",
+                    "userFacingErrorMessage"
                 ],
                 "properties": {
                     "id": {
@@ -786,6 +787,10 @@
                     },
                     "includeWatermark": {
                         "type": "boolean"
+                    },
+                    "userFacingErrorMessage": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
