### PR TITLE
Use strict array search

### DIFF
--- a/apps/dav/lib/Connector/Sabre/TagsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/TagsPlugin.php
@@ -123,7 +123,7 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 		$isFav = false;
 		$tags = $this->getTags($fileId);
 		if ($tags) {
-			$favPos = array_search(self::TAG_FAVORITE, $tags);
+			$favPos = array_search(self::TAG_FAVORITE, $tags, true);
 			if ($favPos !== false) {
 				$isFav = true;
 				unset($tags[$favPos]);

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -242,11 +242,11 @@ class PersonalInfo implements ISettings {
 		$languages = $this->l10nFactory->getLanguages();
 
 		// associate the user language with the proper array
-		$userLangIndex = array_search($userConfLang, array_column($languages['commonLanguages'], 'code'));
+		$userLangIndex = array_search($userConfLang, array_column($languages['commonLanguages'], 'code'), true);
 		$userLang = $languages['commonLanguages'][$userLangIndex];
 		// search in the other languages
 		if ($userLangIndex === false) {
-			$userLangIndex = array_search($userConfLang, array_column($languages['otherLanguages'], 'code'));
+			$userLangIndex = array_search($userConfLang, array_column($languages['otherLanguages'], 'code'), true);
 			$userLang = $languages['otherLanguages'][$userLangIndex];
 		}
 		// if user language is not available but set somehow: show the actual code as name

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -141,7 +141,7 @@ class Helper {
 	 */
 	public function deleteServerConfiguration($prefix) {
 		$prefixes = $this->getServerConfigurationPrefixes();
-		$index = array_search($prefix, $prefixes);
+		$index = array_search($prefix, $prefixes, true);
 		if ($index === false) {
 			return false;
 		}

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -447,7 +447,7 @@ abstract class AbstractMapping {
 			DELETE FROM `' . $this->getTableName() . '`
 			WHERE `owncloud_name` = ?');
 
-		$dn = array_search($name, $this->cache);
+		$dn = array_search($name, $this->cache, true);
 		if ($dn !== false) {
 			unset($this->cache[$dn]);
 		}

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -71,7 +71,7 @@ class DeletedUsersIndexTest extends \Test\TestCase {
 		// ensure the different uids were used
 		foreach ($deletedUsers as $deletedUser) {
 			$this->assertTrue(in_array($deletedUser->getOCName(), $uids));
-			$i = array_search($deletedUser->getOCName(), $uids);
+			$i = array_search($deletedUser->getOCName(), $uids, true);
 			$this->assertNotFalse($i);
 			unset($uids[$i]);
 		}

--- a/apps/user_status/lib/Listener/UserLiveStatusListener.php
+++ b/apps/user_status/lib/Listener/UserLiveStatusListener.php
@@ -82,7 +82,7 @@ class UserLiveStatusListener implements IEventListener {
 
 		// If the emitted status is more important than the current status
 		// treat it as outdated and update
-		if (array_search($event->getStatus(), StatusService::PRIORITY_ORDERED_STATUSES) < array_search($userStatus->getStatus(), StatusService::PRIORITY_ORDERED_STATUSES)) {
+		if (array_search($event->getStatus(), StatusService::PRIORITY_ORDERED_STATUSES, true) < array_search($userStatus->getStatus(), StatusService::PRIORITY_ORDERED_STATUSES, true)) {
 			$needsUpdate = true;
 		}
 

--- a/build/integration/features/bootstrap/Trashbin.php
+++ b/build/integration/features/bootstrap/Trashbin.php
@@ -97,7 +97,7 @@ trait Trashbin {
 			$elementsSimplified = $this->simplifyArray($elementRows);
 			foreach ($elementsSimplified as $expectedElement) {
 				$expectedElement = ltrim($expectedElement, '/');
-				if (array_search($expectedElement, $trashContent) === false) {
+				if (array_search($expectedElement, $trashContent, true) === false) {
 					Assert::fail("$expectedElement" . ' is not in trash listing');
 				}
 			}
@@ -121,7 +121,7 @@ trait Trashbin {
 			return $item['{http://nextcloud.org/ns}trashbin-filename'];
 		}, $elementList));
 
-		if (array_search($name, array_values($trashContent)) === false) {
+		if (array_search($name, array_values($trashContent), true) === false) {
 			Assert::fail("$name" . ' is not in trash listing');
 		}
 	}

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -438,7 +438,7 @@ trait WebDav {
 		}
 
 		foreach ($table->getRows() as $row) {
-			$key = array_search($row[0], $foundTypes);
+			$key = array_search($row[0], $foundTypes, true);
 			if ($key === false) {
 				throw new \Exception('Expected type ' . $row[0] . ' not found');
 			}

--- a/lib/base.php
+++ b/lib/base.php
@@ -970,7 +970,7 @@ class OC {
 				if (empty($restrictions)) {
 					continue;
 				}
-				$key = array_search($group->getGID(), $restrictions);
+				$key = array_search($group->getGID(), $restrictions, true);
 				unset($restrictions[$key]);
 				$restrictions = array_values($restrictions);
 				if (empty($restrictions)) {

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -354,7 +354,7 @@ class AccountManager implements IAccountManager {
 	protected function addMissingDefaultValues(array $userData, array $defaultUserData): array {
 		foreach ($defaultUserData as $defaultDataItem) {
 			// If property does not exist, initialize it
-			$userDataIndex = array_search($defaultDataItem['name'], array_column($userData, 'name'));
+			$userDataIndex = array_search($defaultDataItem['name'], array_column($userData, 'name'), true);
 			if ($userDataIndex === false) {
 				$userData[] = $defaultDataItem;
 				continue;

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -250,7 +250,7 @@ class Local extends \OC\Files\Storage\Common {
 				return false;
 			}
 			$content = scandir($parentPath, SCANDIR_SORT_NONE);
-			return is_array($content) && array_search(basename($fullPath), $content) !== false;
+			return is_array($content) && array_search(basename($fullPath), $content, true) !== false;
 		} else {
 			return file_exists($this->getSourcePath($path));
 		}

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -654,7 +654,7 @@ class Factory implements IFactory {
 			// put appropriate languages into appropriate arrays, to print them sorted
 			// common languages -> divider -> other languages
 			if (in_array($lang, self::COMMON_LANGUAGE_CODES)) {
-				$commonLanguages[array_search($lang, self::COMMON_LANGUAGE_CODES)] = $ln;
+				$commonLanguages[array_search($lang, self::COMMON_LANGUAGE_CODES, true)] = $ln;
 			} else {
 				$otherLanguages[] = $ln;
 			}

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -645,7 +645,8 @@ class Tags implements ITags {
 		return array_search(strtolower($needle), array_map(
 			function ($tag) use ($mem) {
 				return strtolower(call_user_func([$tag, $mem]));
-			}, $haystack)
+			}, $haystack),
+			true
 		);
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Without `strict:true`, array_search has an unexpected behavior with string looking like numbers.

Example:
```php
<?php

$cache = [
	'user1' => '000E01',
	'user2' => '000F02',
];

// All of these calls return 'user1'
var_dump(
	array_search('000E02',    $cache),
	array_search('00E02',     $cache),
	array_search('0E02',      $cache),
	array_search('0E0',       $cache),
	array_search('0E01',      $cache),
);
```

I splitted in several commits to ease backporting a bit.

The issue was spotted with user_ldap user cache, but all instances of array_search could be impacted with such a corner case so I added `strict:true` to all array_search calls, apart from object arrays.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
