### PR TITLE
perf(dav): Avoid getting DB Connection inside callback

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Server.php
+++ b/apps/dav/lib/Connector/Sabre/Server.php
@@ -150,12 +150,13 @@ class Server extends \Sabre\DAV\Server {
 		string $pluginName,
 		string $eventName,
 	): callable {
+		$connection = \OCP\Server::get(Connection::class);
 		return function (PropFind $propFind, INode $node) use (
 			$callBack,
 			$pluginName,
 			$eventName,
+			$connection,
 		): bool {
-			$connection = \OCP\Server::get(Connection::class);
 			$queriesBefore = $connection->getStats()['executed'];
 			$result = $callBack($propFind, $node);
 			$queriesAfter = $connection->getStats()['executed'];


### PR DESCRIPTION
## Summary

Fetch it once outside instead and pass it to the callback.

According to blackfire this is called a very large number of times:

<img width="692" height="859" alt="image" src="https://github.com/user-attachments/assets/0b22dccb-b100-4f09-a62a-d3677f56a0c4" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
