### PR TITLE
perf(files): Optimize CacheEntry creation

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -148,41 +148,36 @@ class Cache implements ICache {
 
 	/**
 	 * Create a CacheEntry from database row
-	 *
-	 * @param array $data
-	 * @param IMimeTypeLoader $mimetypeLoader
-	 * @return CacheEntry
 	 */
-	public static function cacheEntryFromData($data, IMimeTypeLoader $mimetypeLoader) {
-		//fix types
-		$data['name'] = (string)$data['name'];
-		$data['path'] = (string)$data['path'];
-		$data['fileid'] = (int)$data['fileid'];
-		$data['parent'] = (int)$data['parent'];
-		$data['size'] = Util::numericToNumber($data['size']);
-		$data['unencrypted_size'] = Util::numericToNumber($data['unencrypted_size'] ?? 0);
-		$data['mtime'] = (int)$data['mtime'];
-		$data['storage_mtime'] = (int)$data['storage_mtime'];
-		$data['encryptedVersion'] = (int)$data['encrypted'];
-		$data['encrypted'] = (bool)$data['encrypted'];
-		$data['storage_id'] = $data['storage'];
-		$data['storage'] = (int)$data['storage'];
-		$data['mimetype'] = $mimetypeLoader->getMimetypeById($data['mimetype']);
-		$data['mimepart'] = $mimetypeLoader->getMimetypeById($data['mimepart']);
-		if ($data['storage_mtime'] == 0) {
-			$data['storage_mtime'] = $data['mtime'];
-		}
-		if (isset($data['f_permissions'])) {
-			$data['scan_permissions'] ??= $data['f_permissions'];
-		}
-		$data['permissions'] = (int)$data['permissions'];
-		if (isset($data['creation_time'])) {
-			$data['creation_time'] = (int)$data['creation_time'];
-		}
-		if (isset($data['upload_time'])) {
-			$data['upload_time'] = (int)$data['upload_time'];
-		}
-		return new CacheEntry($data);
+	public static function cacheEntryFromData(array $data, IMimeTypeLoader $mimetypeLoader): CacheEntry {
+		return new CacheEntry([
+			'name' => (string)$data['name'],
+			'etag' => (string)$data['etag'],
+			'path' => (string)$data['path'],
+			'path_hash' => (string)$data['path_hash'],
+			'checksum' => (string)$data['checksum'],
+			'fileid' => (int)$data['fileid'],
+			'parent' => (int)$data['parent'],
+			'size' => Util::numericToNumber($data['size']),
+			'unencrypted_size' => Util::numericToNumber($data['unencrypted_size'] ?? 0),
+			'mtime' => (int)$data['mtime'],
+			'storage_mtime' => (int)($data['storage_mtime'] ?: $data['mtime']),
+			'encryptedVersion' => (int)$data['encrypted'],
+			'encrypted' => (bool)$data['encrypted'],
+			'storage_id' => $data['storage'],
+			'storage_string_id' => isset($data['storage_string_id']) ? (string)$data['storage_string_id'] : null,
+			'storage' => (int)$data['storage'],
+			'mimetype' => $mimetypeLoader->getMimetypeById($data['mimetype']),
+			'mimepart' => $mimetypeLoader->getMimetypeById($data['mimepart']),
+			'permissions' => (int)$data['permissions'],
+			'creation_time' => isset($data['creation_time']) ? (int)$data['creation_time'] : null,
+			'upload_time' => isset($data['upload_time']) ? (int)$data['upload_time'] : null,
+			'metadata_etag' => isset($data['metadata_etag']) ? (string)$data['metadata_etag'] : null,
+			'scan_permissions' => $data['scan_permissions'] ?? ($data['f_permissions'] ?? null),
+			'metadata' => $data['metadata'] ?? null,
+			'meta_json' => $data['meta_json'] ?? null,
+			'meta_sync_token' => $data['meta_sync_token'] ?? null,
+		]);
 	}
 
 	/**

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -150,7 +150,7 @@ class Cache implements ICache {
 	 * Create a CacheEntry from database row
 	 */
 	public static function cacheEntryFromData(array $data, IMimeTypeLoader $mimetypeLoader): CacheEntry {
-		return new CacheEntry([
+		$normalized = [
 			'name' => (string)$data['name'],
 			'etag' => (string)$data['etag'],
 			'path' => (string)$data['path'],
@@ -177,7 +177,21 @@ class Cache implements ICache {
 			'metadata' => $data['metadata'] ?? null,
 			'meta_json' => $data['meta_json'] ?? null,
 			'meta_sync_token' => $data['meta_sync_token'] ?? null,
-		]);
+		];
+
+		if (isset($data['folder_id'])) {
+			// groupfolders specific fields
+			$normalized['folder_id'] = (int)$data['folder_id'];
+			$normalized['mount_point'] = (string)$data['mount_point'];
+			$normalized['quota'] = $data['quota'];
+			$normalized['acl'] = (int)$data['acl'];
+			$normalized['acl_default_no_permission'] = (int)$data['acl_default_no_permission'];
+			$normalized['storage_id'] = (int)$data['storage_id'];
+			$normalized['root_id'] = (int)$data['root_id'];
+			$normalized['options'] = (string)$data['options'];
+		}
+
+		return new CacheEntry($normalized);
 	}
 
 	/**

--- a/lib/private/Files/Cache/CacheEntry.php
+++ b/lib/private/Files/Cache/CacheEntry.php
@@ -13,13 +13,9 @@ use OCP\Files\Cache\ICacheEntry;
  * meta data for a file or folder
  */
 class CacheEntry implements ICacheEntry {
-	/**
-	 * @var array
-	 */
-	private $data;
-
-	public function __construct(array $data) {
-		$this->data = $data;
+	public function __construct(
+		private array $data,
+	) {
 	}
 
 	public function offsetSet($offset, $value): void {

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -587,9 +587,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 				$sourceEntry = $sourceStorage->getCache()->get($sourceInternalPath);
 				$sourceEntryData = $sourceEntry->getData();
 				// $sourceEntry['permissions'] here is the permissions from the jailed storage for the current
-				// user. Instead we use $sourceEntryData['scan_permissions'] that are the permissions from the
+				// user. Instead, we use $sourceEntryData['scan_permissions'] that are the permissions from the
 				// unjailed storage.
-				if (is_array($sourceEntryData) && array_key_exists('scan_permissions', $sourceEntryData)) {
+				if (is_array($sourceEntryData) && $sourceEntryData['scan_permissions'] !== null) {
 					$sourceEntry['permissions'] = $sourceEntryData['scan_permissions'];
 				}
 				$this->copyInner($sourceStorage->getCache(), $sourceEntry, $targetInternalPath);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

<img width="1094" height="943" alt="image" src="https://github.com/user-attachments/assets/8f6c2a31-1a2c-477a-a83c-4ab1bac19790" />


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
