### PR TITLE
Make share mount provider authoritative

### DIFF
--- a/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
+++ b/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
@@ -15,6 +15,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IUserMountCache;
+use OCP\Files\Storage\IStorageFactory;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\IUser;
@@ -36,48 +37,62 @@ class SharesUpdatedListener implements IEventListener {
 		private readonly IUserMountCache $userMountCache,
 		private readonly MountProvider $shareMountProvider,
 		private readonly ShareTargetValidator $shareTargetValidator,
+		private readonly IStorageFactory $storageFactory,
 	) {
 	}
 	public function handle(Event $event): void {
 		if ($event instanceof UserShareAccessUpdatedEvent) {
 			foreach ($event->getUsers() as $user) {
-				$this->updateForUser($user);
+				$this->updateForUser($user, true);
 			}
 		}
 		if ($event instanceof UserAddedEvent || $event instanceof UserRemovedEvent) {
-			$this->updateForUser($event->getUser());
+			$this->updateForUser($event->getUser(), true);
 		}
 		if (
 			$event instanceof ShareCreatedEvent
-			|| $event instanceof BeforeShareDeletedEvent
 			|| $event instanceof ShareTransferredEvent
 		) {
 			foreach ($this->shareManager->getUsersForShare($event->getShare()) as $user) {
-				$this->updateForUser($user);
+				$this->updateForUser($user, true);
+			}
+		}
+		if ($event instanceof BeforeShareDeletedEvent) {
+			foreach ($this->shareManager->getUsersForShare($event->getShare()) as $user) {
+				$this->updateForUser($user, false, [$event->getShare()]);
 			}
 		}
 	}
 
-	private function updateForUser(IUser $user): void {
+	private function updateForUser(IUser $user, bool $verifyMountPoints, array $ignoreShares = []): void {
 		// prevent recursion
 		if (isset($this->inUpdate[$user->getUID()])) {
 			return;
 		}
 		$this->inUpdate[$user->getUID()] = true;
-
 		$cachedMounts = $this->userMountCache->getMountsForUser($user);
+		$shareMounts = array_filter($cachedMounts, fn (ICachedMountInfo $mount) => $mount->getMountProvider() === MountProvider::class);
 		$mountPoints = array_map(fn (ICachedMountInfo $mount) => $mount->getMountPoint(), $cachedMounts);
 		$mountsByPath = array_combine($mountPoints, $cachedMounts);
 
-		$shares = $this->shareMountProvider->getSuperSharesForUser($user);
+		$shares = $this->shareMountProvider->getSuperSharesForUser($user, $ignoreShares);
 
+		$mountsChanged = count($shares) !== count($shareMounts);
 		foreach ($shares as &$share) {
 			[$parentShare, $groupedShares] = $share;
 			$mountPoint = '/' . $user->getUID() . '/files/' . trim($parentShare->getTarget(), '/') . '/';
 			$mountKey = $parentShare->getNodeId() . '::' . $mountPoint;
 			if (!isset($cachedMounts[$mountKey])) {
-				$this->shareTargetValidator->verifyMountPoint($user, $parentShare, $mountsByPath, $groupedShares);
+				$mountsChanged = true;
+				if ($verifyMountPoints) {
+					$this->shareTargetValidator->verifyMountPoint($user, $parentShare, $mountsByPath, $groupedShares);
+				}
 			}
+		}
+
+		if ($mountsChanged) {
+			$newMounts = $this->shareMountProvider->getMountsFromSuperShares($user, $shares, $this->storageFactory);
+			$this->userMountCache->registerMounts($user, $newMounts, [MountProvider::class]);
 		}
 
 		unset($this->inUpdate[$user->getUID()]);


### PR DESCRIPTION
Makes the registered share mounts for users update on share create/update.

Requires

- [x] https://github.com/nextcloud/server/pull/56499
- [x] https://github.com/nextcloud/server/pull/57295
- [x] Share providers to implement https://github.com/nextcloud/server/pull/57392 and https://github.com/nextcloud/server/pull/57158
- [x] https://github.com/nextcloud/server/pull/57745