### PR TITLE
perf(UserMountCache): Optimize loop

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -491,11 +491,10 @@ class UserMountCache implements IUserMountCache {
 	}
 
 	public function getMountForPath(IUser $user, string $path): ICachedMountInfo {
-		$mounts = $this->getMountsForUser($user);
-		$mountPoints = array_map(function (ICachedMountInfo $mount) {
-			return $mount->getMountPoint();
-		}, $mounts);
-		$mounts = array_combine($mountPoints, $mounts);
+		$mounts = [];
+		foreach ($this->getMountsForUser($user) as $mount) {
+			$mounts[$mount->getMountPoint()] = $mount;
+		}
 
 		$current = rtrim($path, '/');
 		// walk up the directory tree until we find a path that has a mountpoint set
@@ -519,9 +518,13 @@ class UserMountCache implements IUserMountCache {
 
 	public function getMountsInPath(IUser $user, string $path): array {
 		$path = rtrim($path, '/') . '/';
-		$mounts = $this->getMountsForUser($user);
-		return array_filter($mounts, function (ICachedMountInfo $mount) use ($path) {
-			return $mount->getMountPoint() !== $path && str_starts_with($mount->getMountPoint(), $path);
-		});
+		$result = [];
+		foreach ($this->getMountsForUser($user) as $key => $mount) {
+			$mountPoint = $mount->getMountPoint();
+			if ($mountPoint !== $path && str_starts_with($mountPoint, $path)) {
+				$result[$key] = $mount;
+			}
+		}
+		return $result;
 	}
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

These loops since to be called around 60 000 times in one trace I saw. So it makes sense to use the faster foreach construct.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
