### PR TITLE
fix(app-settings): limit app to group initial state

### DIFF
--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -69,6 +69,7 @@ class AppSettingsController extends Controller {
 		private CategoryFetcher $categoryFetcher,
 		private AppFetcher $appFetcher,
 		private IFactory $l10nFactory,
+		private IGroupManager $groupManager,
 		private BundleFetcher $bundleFetcher,
 		private Installer $installer,
 		private IURLGenerator $urlGenerator,
@@ -93,6 +94,13 @@ class AppSettingsController extends Controller {
 		$this->initialState->provideInitialState('appstoreEnabled', $this->config->getSystemValueBool('appstoreenabled', true));
 		$this->initialState->provideInitialState('appstoreBundles', $this->getBundles());
 		$this->initialState->provideInitialState('appstoreUpdateCount', count($this->getAppsWithUpdates()));
+
+		$groups = array_map(static fn (IGroup $group): array => [
+			'id' => $group->getGID(),
+			'name' => $group->getDisplayName(),
+		], $this->groupManager->search('', 5));
+
+		$this->initialState->provideInitialState('usersSettings', [ 'systemGroups' => $groups]);
 
 		if ($this->appManager->isEnabledForAnyone('app_api')) {
 			try {

--- a/apps/settings/tests/Controller/AppSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AppSettingsControllerTest.php
@@ -21,6 +21,8 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
@@ -45,6 +47,7 @@ class AppSettingsControllerTest extends TestCase {
 	private CategoryFetcher&MockObject $categoryFetcher;
 	private AppFetcher&MockObject $appFetcher;
 	private IFactory&MockObject $l10nFactory;
+	private IGroupManager&MockObject $groupManager;
 	private BundleFetcher&MockObject $bundleFetcher;
 	private Installer&MockObject $installer;
 	private IURLGenerator&MockObject $urlGenerator;
@@ -70,6 +73,7 @@ class AppSettingsControllerTest extends TestCase {
 		$this->categoryFetcher = $this->createMock(CategoryFetcher::class);
 		$this->appFetcher = $this->createMock(AppFetcher::class);
 		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->bundleFetcher = $this->createMock(BundleFetcher::class);
 		$this->installer = $this->createMock(Installer::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
@@ -89,6 +93,7 @@ class AppSettingsControllerTest extends TestCase {
 			$this->categoryFetcher,
 			$this->appFetcher,
 			$this->l10nFactory,
+			$this->groupManager,
 			$this->bundleFetcher,
 			$this->installer,
 			$this->urlGenerator,
@@ -168,9 +173,16 @@ class AppSettingsControllerTest extends TestCase {
 			->expects($this->once())
 			->method('setActiveEntry')
 			->with('core_apps');
+		$this->groupManager->expects($this->once())
+			->method('search')
+			->with($this->equalTo(''), $this->equalTo(5))
+			->willReturn([
+				$this->createMock(IGroup::class),
+				$this->createMock(IGroup::class),
+			]);
 
 		$this->initialState
-			->expects($this->exactly(3))
+			->expects($this->exactly(4))
 			->method('provideInitialState');
 
 		$policy = new ContentSecurityPolicy();
@@ -201,9 +213,16 @@ class AppSettingsControllerTest extends TestCase {
 			->expects($this->once())
 			->method('setActiveEntry')
 			->with('core_apps');
+		$this->groupManager->expects($this->once())
+			->method('search')
+			->with($this->equalTo(''), $this->equalTo(5))
+			->willReturn([
+				$this->createMock(IGroup::class),
+				$this->createMock(IGroup::class),
+			]);
 
 		$this->initialState
-			->expects($this->exactly(3))
+			->expects($this->exactly(4))
 			->method('provideInitialState');
 
 		$policy = new ContentSecurityPolicy();

--- a/cypress/e2e/settings/apps.cy.ts
+++ b/cypress/e2e/settings/apps.cy.ts
@@ -142,6 +142,32 @@ describe('Settings: App management', { testIsolation: true }, () => {
 		cy.get('#app-sidebar-vue').contains(/Version \d+\.\d+\.\d+/).should('be.visible')
 	})
 
+	it('Limit app usage to group', () => {
+		// When I open the "Active apps" section
+		cy.get('#app-category-enabled a')
+			.should('contain', 'Active apps')
+			.click({ force: true })
+		// Then I see that the current section is "Active apps"
+		cy.url().should('match', /settings\/apps\/enabled$/)
+		cy.get('#app-category-enabled').find('.active').should('exist')
+		// Then I select the app
+		cy.get('#apps-list')
+			.should('exist')
+			.contains('tr', 'Dashboard', { timeout: 10000 })
+			.click()
+		// Then I enable "limit app to group"
+		cy.get('[for="groups_enable_dashboard"]').click()
+		// Then I select a group
+		cy.get('#limitToGroups').click()
+		cy.get('ul[role="listbox"]')
+			.find('span')
+			.contains('admin')
+			.click()
+		cy.get('span.name-parts__first')
+			.contains('admin')
+			.should('be.visible')
+	})
+
 	/*
 	 * TODO: Improve testing with app store as external API
 	 * The following scenarios require the files_antivirus and calendar app

--- a/cypress/e2e/settings/apps.cy.ts
+++ b/cypress/e2e/settings/apps.cy.ts
@@ -166,6 +166,8 @@ describe('Settings: App management', { testIsolation: true }, () => {
 		cy.get('span.name-parts__first')
 			.contains('admin')
 			.should('be.visible')
+		// Then I disable the group limitation
+		cy.get('button[title="Deselect admin"]').click()
 	})
 
 	/*


### PR DESCRIPTION
## Summary
When you try to limit an app by a group, the dropdown is initially not filled with any groups. They only populate once you start typing the name of a group, which triggers a network request. This pull request provides the necessary initial state to the app list so that the groups are populated by default and you can quickly select one without searching.

## TODO

- [x] Write a proper test to make sure the dropdown is filled with some groups

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
