### PR TITLE
fix: fallback to full user setup if we cant find the expected mount root

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -521,6 +521,10 @@ class SetupManager {
 			if (is_a($mountProvider, IPartialMountProvider::class, true)) {
 				$rootId = $cachedMount->getRootId();
 				$rootMetadata = $this->fileAccess->getByFileId($rootId);
+				if (!$rootMetadata) {
+					$this->setupForUser($user);
+					return;
+				}
 				$providerArgs = new MountProviderArgs($cachedMount, $rootMetadata);
 				// mark the path as cached (without children for now...)
 				$this->setupMountProviderPaths[$mountPoint] = self::SETUP_WITHOUT_CHILDREN;


### PR DESCRIPTION
If things are out of sync somehow, a full setup is the best we can do probably.