### PR TITLE
refactor(encryption): add typing and modernize IEncryptionModule

### DIFF
--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -266,7 +266,7 @@ class Encryption implements IEncryptionModule {
 		);
 	}
 
-	public function update(string $path, string $uid, array $accessList): bool {
+	public function update(string $path, ?string $uid, array $accessList): bool {
 		if (empty($accessList)) {
 			if (isset(self::$rememberVersion[$path])) {
 				$this->keyManager->setVersion($path, self::$rememberVersion[$path], new View());
@@ -357,7 +357,7 @@ class Encryption implements IEncryptionModule {
 		}
 	}
 
-	public function isReadable(string $path, string $uid): bool {
+	public function isReadable(string $path, ?string $uid): bool {
 		$fileKey = $this->keyManager->getFileKey($path, null);
 		if (empty($fileKey)) {
 			$owner = $this->util->getOwner($path);

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -394,13 +394,16 @@ class Encryption implements IEncryptionModule {
 	}
 
 	/**
-	 * @param string $path
-	 * @return string
+	 * Converts a versions file path to its canonical user file path.
+	 *
+	 * @param string $path File path (may be a versions path)
+	 * @return string Canonical file path
 	 */
 	protected function getPathToRealFile(string $path): string {
 		$realPath = $path;
 		$parts = explode('/', $path);
 		if ($parts[2] === 'files_versions') {
+			// e.g., "/user/files_versions/document.txt.v1234567890" --> "/user/files/document.txt"
 			$realPath = '/' . $parts[1] . '/files/' . implode('/', array_slice($parts, 3));
 			$length = strrpos($realPath, '.');
 			$realPath = substr($realPath, 0, $length);
@@ -410,11 +413,11 @@ class Encryption implements IEncryptionModule {
 	}
 
 	/**
-	 * remove .part file extension and the ocTransferId from the file to get the
-	 * original file name
+	 * Removes the .part extension and ocTransferId from a part file path,
+	 * returning the original file name.
 	 *
-	 * @param string $path
-	 * @return string
+	 * @param string $path File path, possibly with .part extension and ocTransferId
+	 * @return string Original file path without temporary upload markers
 	 */
 	protected function stripPartFileExtension(string $path): string {
 		if (pathinfo($path, PATHINFO_EXTENSION) === 'part') {
@@ -426,10 +429,10 @@ class Encryption implements IEncryptionModule {
 	}
 
 	/**
-	 * get owner of a file
+	 * Returns and caches the storage owner for a given file path.
 	 *
-	 * @param string $path
-	 * @return string
+	 * @param string $path File path
+	 * @return string User id of file owner
 	 */
 	protected function getOwner(string $path): string {
 		if (!isset($this->owner[$path])) {

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -145,6 +145,10 @@ class Encryption implements IEncryptionModule {
 		return $result;
 	}
 
+	/**
+	 * @throws PublicKeyMissingException
+	 * @throws MultiKeyEncryptException
+	 */
 	public function end(string $path, string $position = '0'): string {
 		$result = '';
 		if ($this->isWriteOperation) {

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -306,10 +306,18 @@ class EncryptionTest extends TestCase {
 			->method('decryptAllModeActivated')
 			->willReturn(false);
 
-		$this->sessionMock->expects($this->once())->method('isReady')->willReturn(false);
-		$this->utilMock->expects($this->once())->method('isMasterKeyEnabled')
+		$this->sessionMock->expects($this->once())
+			->method('isReady')
+			->willReturn(false);
+		$this->utilMock->expects($this->once())
+			->method('isMasterKeyEnabled')
 			->willReturn(true);
-		$this->keyManagerMock->expects($this->once())->method('init')->with('', '');
+		$this->keyManagerMock->expects($this->once())
+			->method('init')
+			->with('', '');
+		$this->cryptMock->expects($this->any())
+			->method('getLegacyCipher')
+			->willReturn('anyWillDo');
 
 		$this->instance->begin('/user/files/welcome.txt', 'user', 'r', [], []);
 	}

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -126,6 +126,10 @@ class EncryptionTest extends TestCase {
 				'user3' => 'encForUser3',
 			]);
 
+		$this->utilMock->expects($this->any())
+			->method('getOwner')
+			->willReturn('user1');
+
 		// Begin the encryption process as user1, with user2 missing their public key
 		$this->instance->begin('/foo/bar', 'user1', 'r', [], ['users' => ['user1', 'user2', 'user3']]);
 
@@ -277,6 +281,13 @@ class EncryptionTest extends TestCase {
 			->method('getFileKey')
 			->with($path, null, true)
 			->willReturn($fileKey);
+
+		$this->cryptMock->expects($this->any())
+			->method('getCipher')
+			->willReturn('AES-256-CTR');
+		$this->cryptMock->expects($this->any())
+			->method('getLegacyCipher')
+			->willReturn('AES-128-CFB');
 
 		$this->instance->begin($path, 'user', 'r', [], []);
 

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -325,6 +325,10 @@ class EncryptionTest extends TestCase {
 		$this->keyManagerMock->expects($this->never())->method('getVersion');
 		$this->keyManagerMock->expects($this->never())->method('setVersion');
 
+		$this->utilMock->expects($this->any())
+			->method('getOwner')
+			->willReturn('user1');
+
 		$this->assertSame($expected,
 			$this->instance->update('path', 'user1', ['users' => ['user1']])
 		);
@@ -384,6 +388,10 @@ class EncryptionTest extends TestCase {
 
 		$this->keyManagerMock->expects($this->never())->method('getVersion');
 		$this->keyManagerMock->expects($this->never())->method('setVersion');
+
+		$this->utilMock->expects($this->any())
+			->method('getOwner')
+			->willReturn('user1');
 
 		$this->assertTrue(
 			$this->instance->update('path', 'user1', ['users' => ['user1']])

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1083,9 +1083,6 @@
     </InternalMethod>
   </file>
   <file src="apps/encryption/lib/Crypto/Encryption.php">
-    <ImplementedParamTypeMismatch>
-      <code><![CDATA[$position]]></code>
-    </ImplementedParamTypeMismatch>
     <InternalClass>
       <code><![CDATA[new View()]]></code>
       <code><![CDATA[new View()]]></code>

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -461,9 +461,9 @@ class Encryption extends Wrapper {
 			$blockIndex = (int)floor($this->position / $this->unencryptedBlockSize);
 			$numberOfChunks = (int)($this->unencryptedSize / $this->unencryptedBlockSize);
 			if ($numberOfChunks === $blockIndex) {
-				$blockId = $blockIndex . 'end';
+				$blockId = (string)$blockIndex . 'end';
 			} else {
-				$blockId = $blockIndex;
+				$blockId = (string)$blockIndex;
 			}
 			$this->cache = $this->encryptionModule->decrypt($data, $blockId);
 		}

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -430,7 +430,7 @@ class Encryption extends Wrapper {
 			// we are handling that separately here and we don't want to
 			// get into an infinite loop
 			$blockIndex = (int)floor($this->position / $this->unencryptedBlockSize);
-			$blockId = (string)$blockIndex . $positionPrefix);
+			$blockId = (string)$blockIndex . $positionPrefix;
 			$encrypted = $this->encryptionModule->encrypt($this->cache, $blockId);
 			$bytesWritten = parent::stream_write($encrypted);
 			$this->writeFlag = false;

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -64,33 +64,33 @@ interface IEncryptionModule {
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function end(string $path, string $position): ?string;
+	public function end(string $path, string $position = '0'): ?string;
 
 	/**
 	 * encrypt data
 	 *
 	 * @param string $data you want to encrypt
-	 * @param string|int $position position of the block we want to encrypt (starts with '0')
+	 * @param string $position position of the block we want to encrypt (starts with '0')
 	 *
 	 * @return string encrypted data
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function encrypt(string $data, string|int $position): string;
+	public function encrypt(string $data, string $position = '0'): string;
 
 	/**
 	 * decrypt data
 	 *
 	 * @param string $data you want to decrypt
-	 * @param string|int $position position of the block we want to decrypt
+	 * @param string $position position of the block we want to decrypt
 	 *
 	 * @return string decrypted data
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function decrypt(string $data, string|int $position): string;
+	public function decrypt(string $data, string $position = '0'): string;
 
 	/**
 	 * update encrypted file, e.g. give additional users access to the file

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -78,8 +78,8 @@ interface IEncryptionModule {
 	 *
 	 * @param string $data you want to encrypt
 	 * @param string $blockId Block identifier representing the block index we want to encrypt
-	 *						  (starts with '0'). Usually a numeric string (e.g. "0", "5"), but
-	 *						  may have a special marker, such as "5end" to denote the final block.
+	 *                        (starts with '0'). Usually a numeric string (e.g. "0", "5"), but
+	 *                        may have a special marker, such as "5end" to denote the final block.
 	 *
 	 * @return string encrypted data
 	 *

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 namespace OCP\Encryption;
 
+use OC\Encryption\Exceptions\DecryptionFailedException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -65,9 +66,7 @@ interface IEncryptionModule {
 	 * @return string remained data which should be written to the file in case
 	 *                of a write operation
 	 *
-	 * @throws PublicKeyMissingException
 	 * @throws \Exception
-	 * @throws MultiKeyEncryptException
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -13,7 +13,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Interface IEncryptionModule
+ * Defines the contract for a pluggable storage encryption module.
+ *
+ * Implementations provide algorithms and key management to transparently
+ * encrypt and decrypt user file content, supporting block operations,
+ * file sharing, and migration.
  *
  * @since 8.1.0
  */

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -20,7 +22,7 @@ interface IEncryptionModule {
 	 * @return string defining the technical unique id
 	 * @since 8.1.0
 	 */
-	public function getId();
+	public function getId(): string;
 
 	/**
 	 * In comparison to getKey() this function returns a human readable (maybe translated) name
@@ -28,7 +30,7 @@ interface IEncryptionModule {
 	 * @return string
 	 * @since 8.1.0
 	 */
-	public function getDisplayName();
+	public function getDisplayName(): string;
 
 	/**
 	 * start receiving chunks from a file. This is the place where you can
@@ -36,17 +38,17 @@ interface IEncryptionModule {
 	 * chunks
 	 *
 	 * @param string $path to the file
-	 * @param string $user who read/write the file (null for public access)
+	 * @param string|null $user who read/write the file (null for public access)
 	 * @param string $mode php stream open mode
 	 * @param array $header contains the header data read from the file
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
 	 *
 	 * @return array $header contain data as key-value pairs which should be
 	 *               written to the header, in case of a write operation
-	 *               or if no additional data is needed return a empty array
+	 *               or if no additional data is needed return an empty array
 	 * @since 8.1.0
 	 */
-	public function begin($path, $user, $mode, array $header, array $accessList);
+	public function begin(string $path, ?string $user, string $mode, array $header, array $accessList): array;
 
 	/**
 	 * last chunk received. This is the place where you can perform some final
@@ -56,39 +58,39 @@ interface IEncryptionModule {
 	 * @param string $path to the file
 	 * @param string $position id of the last block (looks like "<Number>end")
 	 *
-	 * @return string remained data which should be written to the file in case
-	 *                of a write operation
+	 * @return string|null remained data which should be written to the file in case
+	 *                of a write operation, or null
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function end($path, $position);
+	public function end(string $path, string $position): ?string;
 
 	/**
 	 * encrypt data
 	 *
 	 * @param string $data you want to encrypt
-	 * @param string $position position of the block we want to encrypt (starts with '0')
+	 * @param string|int $position position of the block we want to encrypt (starts with '0')
 	 *
-	 * @return mixed encrypted data
+	 * @return string encrypted data
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function encrypt($data, $position);
+	public function encrypt(string $data, string|int $position): string;
 
 	/**
 	 * decrypt data
 	 *
 	 * @param string $data you want to decrypt
-	 * @param int|string $position position of the block we want to decrypt
+	 * @param string|int $position position of the block we want to decrypt
 	 *
-	 * @return mixed decrypted data
+	 * @return string decrypted data
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function decrypt($data, $position);
+	public function decrypt(string $data, string|int $position): string;
 
 	/**
 	 * update encrypted file, e.g. give additional users access to the file
@@ -96,19 +98,19 @@ interface IEncryptionModule {
 	 * @param string $path path to the file which should be updated
 	 * @param string $uid of the user who performs the operation
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
-	 * @return boolean
+	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function update($path, $uid, array $accessList);
+	public function update(string $path, string $uid, array $accessList): bool;
 
 	/**
 	 * should the file be encrypted or not
 	 *
 	 * @param string $path
-	 * @return boolean
+	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function shouldEncrypt($path);
+	public function shouldEncrypt(string $path): bool;
 
 	/**
 	 * get size of the unencrypted payload per block.
@@ -118,7 +120,7 @@ interface IEncryptionModule {
 	 * @return int
 	 * @since 8.1.0 optional parameter $signed was added in 9.0.0
 	 */
-	public function getUnencryptedBlockSize($signed = false);
+	public function getUnencryptedBlockSize(bool $signed = false): int;
 
 	/**
 	 * check if the encryption module is able to read the file,
@@ -126,10 +128,10 @@ interface IEncryptionModule {
 	 *
 	 * @param string $path
 	 * @param string $uid user for whom we want to check if they can read the file
-	 * @return boolean
+	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function isReadable($path, $uid);
+	public function isReadable(string $path, string $uid): bool;
 
 	/**
 	 * Initial encryption of all files
@@ -138,18 +140,18 @@ interface IEncryptionModule {
 	 * @param OutputInterface $output write some status information to the terminal during encryption
 	 * @since 8.2.0
 	 */
-	public function encryptAll(InputInterface $input, OutputInterface $output);
+	public function encryptAll(InputInterface $input, OutputInterface $output): void;
 
 	/**
 	 * prepare encryption module to decrypt all files
 	 *
 	 * @param InputInterface $input
 	 * @param OutputInterface $output write some status information to the terminal during encryption
-	 * @param $user (optional) for which the files should be decrypted, default = all users
+	 * @param string $user (optional) for which the files should be decrypted, default = all users
 	 * @return bool return false on failure or if it isn't supported by the module
 	 * @since 8.2.0
 	 */
-	public function prepareDecryptAll(InputInterface $input, OutputInterface $output, $user = '');
+	public function prepareDecryptAll(InputInterface $input, OutputInterface $output, string $user = ''): bool;
 
 	/**
 	 * Check if the module is ready to be used by that specific user.
@@ -158,10 +160,10 @@ interface IEncryptionModule {
 	 * cause issues during operations.
 	 *
 	 * @param string $user
-	 * @return boolean
+	 * @return bool
 	 * @since 9.1.0
 	 */
-	public function isReadyForUser($user);
+	public function isReadyForUser(string $user): bool;
 
 	/**
 	 * Does the encryption module needs a detailed list of users with access to the file?
@@ -171,5 +173,5 @@ interface IEncryptionModule {
 	 * @since 13.0.0
 	 * @return bool
 	 */
-	public function needDetailedAccessList();
+	public function needDetailedAccessList(): bool;
 }

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -78,8 +78,8 @@ interface IEncryptionModule {
 	 *
 	 * @param string $data you want to encrypt
 	 * @param string $blockId Block identifier representing the block index we want to encrypt
-	 *							(starts with '0'). Usually a numeric string (e.g. "0", "5"), but
-	 *							may have a special marker, such as "5end" to denote the final block.
+	 *						  (starts with '0'). Usually a numeric string (e.g. "0", "5"), but
+	 *						  may have a special marker, such as "5end" to denote the final block.
 	 *
 	 * @return string encrypted data
 	 *

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -105,12 +105,12 @@ interface IEncryptionModule {
 	 * update encrypted file, e.g. give additional users access to the file
 	 *
 	 * @param string $path path to the file which should be updated
-	 * @param string $uid of the user who performs the operation
+	 * @param null|string $uid of the user who performs the operation
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function update(string $path, string $uid, array $accessList): bool;
+	public function update(string $path, ?string $uid, array $accessList): bool;
 
 	/**
 	 * should the file be encrypted or not
@@ -136,11 +136,11 @@ interface IEncryptionModule {
 	 * e.g. if all encryption keys exists
 	 *
 	 * @param string $path
-	 * @param string $uid user for whom we want to check if they can read the file
+	 * @param null|string $uid user for whom we want to check if they can read the file
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function isReadable(string $path, string $uid): bool;
+	public function isReadable(string $path, ?string $uid): bool;
 
 	/**
 	 * Initial encryption of all files

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -61,7 +61,7 @@ interface IEncryptionModule {
 	 * buffer.
 	 *
 	 * @param string $path to the file
-	 * @param string $position id of the last block (looks like "<Number>end")
+	 * @param string $blockId Block identifier of the last block (looks like "<Number>end")
 	 *
 	 * @return string remained data which should be written to the file in case
 	 *                of a write operation
@@ -71,26 +71,28 @@ interface IEncryptionModule {
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function end(string $path, string $position = '0'): string;
+	public function end(string $path, string $blockId = '0'): string;
 
 	/**
 	 * encrypt data
 	 *
 	 * @param string $data you want to encrypt
-	 * @param string $position position of the block we want to encrypt (starts with '0')
+	 * @param string $blockId Block identifier representing the block index we want to encrypt
+	 *							(starts with '0'). Usually a numeric string (e.g. "0", "5"), but
+	 *							may have a special marker, such as "5end" to denote the final block.
 	 *
 	 * @return string encrypted data
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function encrypt(string $data, string $position = '0'): string;
+	public function encrypt(string $data, string $blockId = '0'): string;
 
 	/**
 	 * decrypt data
 	 *
 	 * @param string $data you want to decrypt
-	 * @param string $position position of the block we want to decrypt
+	 * @param string $blockId Block identifier representing the block index we want to decrypt
 	 *
 	 * @return string decrypted data
 	 *
@@ -99,13 +101,13 @@ interface IEncryptionModule {
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function decrypt(string $data, string $position = '0'): string;
+	public function decrypt(string $data, string $blockId = '0'): string;
 
 	/**
 	 * update encrypted file, e.g. give additional users access to the file
 	 *
 	 * @param string $path path to the file which should be updated
-	 * @param null|string $uid of the user who performs the operation
+	 * @param null|string $uid of the user who performs the operation (null for public access).
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
 	 * @return bool
 	 * @since 8.1.0

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -58,13 +58,17 @@ interface IEncryptionModule {
 	 * @param string $path to the file
 	 * @param string $position id of the last block (looks like "<Number>end")
 	 *
-	 * @return string|null remained data which should be written to the file in case
-	 *                of a write operation, or null
+	 * @return string remained data which should be written to the file in case
+	 *                of a write operation
+	 *
+	 * @throws PublicKeyMissingException
+	 * @throws \Exception
+	 * @throws MultiKeyEncryptException
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function end(string $path, string $position = '0'): ?string;
+	public function end(string $path, string $position = '0'): string;
 
 	/**
 	 * encrypt data
@@ -86,6 +90,8 @@ interface IEncryptionModule {
 	 * @param string $position position of the block we want to decrypt
 	 *
 	 * @return string decrypted data
+	 *
+	 * @throws DecryptionFailedException
 	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added

--- a/tests/lib/Encryption/UpdateTest.php
+++ b/tests/lib/Encryption/UpdateTest.php
@@ -92,6 +92,7 @@ class UpdateTest extends TestCase {
 		$this->encryptionManager->expects($this->once())
 			->method('getEncryptionModule')
 			->willReturn($this->encryptionModule);
+		$this->encryptionModule->method('needDetailedAccessList')->willReturn(true);
 
 		if ($isDir) {
 			$this->util->expects($this->once())


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

* Fully aligns IEncryptionModule interface and implementation function signatures
* Modernizes the interface (and its implementation) by introducing strict typing
* Drops redundant implementation docblocks (100% of essential API documentation now centralized in the interface)
* Helpful docblocks are added to non-interface helper functions for clarity and maintainability

Should be fully backwards compatible.

P.S. `$position` was already a de facto string. Any type related changes indicated in this PR for that parameter merely make it match implementation (and drop some casting). And despite it's name, it's used for string concatenation (at least in the context relevant to this PR).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
