### PR TITLE
fix: clearify meaning of getMountsForPath arguments

### DIFF
--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -84,9 +84,12 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 	}
 
 	/**
-	 * @param MountProviderArgs[] $mountProviderArgs
-	 * @return array<string, IMountPoint> IMountPoint array indexed by mount
-	 *                                    point.
+	 * The caller is responsible to ensure that all provided MountProviderArgs
+	 * are for the same user.
+	 * And that the `$providerClass` implements IPartialMountProvider.
+	 *
+	 * @param list<MountProviderArgs> $mountProviderArgs
+	 * @return array<string, IMountPoint> IMountPoint array indexed by mount point.
 	 */
 	public function getUserMountsFromProviderByPath(
 		string $providerClass,
@@ -98,14 +101,16 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 		if ($provider === null) {
 			return [];
 		}
+		if (count($mountProviderArgs) === 0) {
+			return [];
+		}
 
-		if (!is_a($providerClass, IPartialMountProvider::class, true)) {
+		if (!$provider instanceof IPartialMountProvider) {
 			throw new \LogicException(
 				'Mount provider does not support partial mounts'
 			);
 		}
 
-		/** @var IPartialMountProvider $provider */
 		return $provider->getMountsForPath(
 			$path,
 			$forChildren,

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -600,7 +600,7 @@ class SetupManager {
 				}
 				$this->setupMountProviderPaths[$mountPoint] = self::SETUP_WITH_CHILDREN;
 				foreach ($authoritativeCachedMounts as $providerClass => $cachedMounts) {
-					$providerArgs = array_filter(array_map(
+					$providerArgs = array_values(array_filter(array_map(
 						static function (ICachedMountInfo $info) use ($rootsMetadata) {
 							$rootMetadata = $rootsMetadata[$info->getRootId()] ?? null;
 
@@ -609,7 +609,7 @@ class SetupManager {
 								: null;
 						},
 						$cachedMounts
-					));
+					)));
 					$authoritativeMounts[] = $this->mountProviderCollection->getUserMountsFromProviderByPath(
 						$providerClass,
 						$path,

--- a/lib/public/Files/Config/IPartialMountProvider.php
+++ b/lib/public/Files/Config/IPartialMountProvider.php
@@ -20,6 +20,8 @@ use OCP\Files\Storage\IStorageFactory;
 interface IPartialMountProvider extends IMountProvider {
 
 	/**
+	 * Get the mounts for a user by path.
+	 *
 	 * Called during the Filesystem setup of a specific path.
 	 *
 	 * The provided arguments give information about the path being set up,
@@ -29,15 +31,28 @@ interface IPartialMountProvider extends IMountProvider {
 	 * Implementations should verify the MountProviderArgs and return the
 	 * corresponding IMountPoint instances.
 	 *
-	 * @param string $path path for which the mounts are set up
-	 * @param bool $forChildren when true, only child mounts for path should be returned
-	 * @param MountProviderArgs[] $mountProviderArgs
+	 * If the mount for one of the MountProviderArgs no longer exists, implementations
+	 * should simply leave them out from the returned mounts.
+	 *
+	 * Implementations are allowed to, but not expected to, return more mounts than requested.
+	 *
+	 * The user for which the mounts are being setup can be found in the `mountInfo->getUser()`
+	 * of a MountProviderArgs.
+	 * All provided MountProviderArgs will always be for the same user.
+	 *
+	 * @param string $setupPathHint path for which the mounts are being set up.
+	 *                              This might not be the same as the path of the expected mount(s).
+	 * @param bool $forChildren when true, only child mounts for `$setupPathHint` were requested.
+	 *                          The $mountProviderArgs will hold a list of expected child mounts
+	 * @param non-empty-list<MountProviderArgs> $mountProviderArgs The data for the mount which should be provided.
+	 *                                                             Contains the mount information and root-cache-entry
+	 *                                                             for each mount the system knows about
+	 *                                                             in the scope of the setup request.
 	 * @param IStorageFactory $loader
-	 * @return array<string, IMountPoint> IMountPoint instances, indexed by
-	 *                                    mount-point
+	 * @return array<string, IMountPoint> IMountPoint instances, indexed by mount-point
 	 */
 	public function getMountsForPath(
-		string $path,
+		string $setupPathHint,
 		bool $forChildren,
 		array $mountProviderArgs,
 		IStorageFactory $loader,


### PR DESCRIPTION
The meaning of `$path` was repeatedly causing confusion.

Further improvements to variable naming and documentation is more than welcome.