### PR TITLE
feat(files_sharing): Support multiples users in UserShareAccessUpdatedEvent

### DIFF
--- a/apps/files_sharing/lib/Event/UserShareAccessUpdatedEvent.php
+++ b/apps/files_sharing/lib/Event/UserShareAccessUpdatedEvent.php
@@ -9,24 +9,36 @@ declare(strict_types=1);
 
 namespace OCA\Files_Sharing\Event;
 
+use OCP\AppFramework\Attribute\Dispatchable;
 use OCP\EventDispatcher\Event;
 use OCP\IUser;
 
 /**
- * Emitted when a user *might* have gained or lost access to an existing share.
+ * Emitted when one or multiple users *might* have gained or lost access to an existing share.
  *
  * For example, when a user is added to a group, they gain access to all shares for the group.
  *
  * @since 33.0.0
  */
+#[Dispatchable(since: '33.0.0')]
 class UserShareAccessUpdatedEvent extends Event {
+	/** @var list<IUser> $users */
+	private readonly array $users;
+
+	/**
+	 * @param IUser|list<IUser> $users
+	 */
 	public function __construct(
-		private readonly IUser $user,
+		IUser|array $users,
 	) {
 		parent::__construct();
+		$this->users = is_array($users) ? $users : [$users];
 	}
 
-	public function getUser(): IUser {
-		return $this->user;
+	/**
+	 * @return list<IUser>
+	 */
+	public function getUsers(): array {
+		return $this->users;
 	}
 }


### PR DESCRIPTION
Allows the listener handle cases where multiple users are affected more efficiently (e.g. Talk and Teams).