### PR TITLE
ci(lint): Lint multiple files at once when possible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,12 @@
 		],
 		"cs:fix": "php-cs-fixer fix",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
-		"lint": "find . -name \\*.php -not -path './lib/composer/*' -not -path './build/stubs/*' -print0 | xargs -0 -n1 php -l",
+		"lint": [
+			"@lint-8.2-or-earlier",
+			"@lint-8.3-or-later"
+		],
+		"lint-8.2-or-earlier": "[ $(php -r \"echo PHP_VERSION_ID;\") -ge 80300 ] || find . -type f -name '*.php' -not -path './3rdparty/*' -not -path '*/composer/*' -not -path '*/stubs/*' -not -path '*/vendor-bin/*' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P$(nproc) php -l",
+		"lint-8.3-or-later": "[ $(php -r \"echo PHP_VERSION_ID;\") -lt 80300 ] || find . -type f -name '*.php' -not -path './3rdparty/*' -not -path '*/composer/*' -not -path '*/stubs/*' -not -path '*/vendor-bin/*' -not -path '*/vendor/*' -print0 | xargs -0 -n200 -P$(nproc) php -l",
 		"psalm": "psalm --no-cache --threads=$(nproc)",
 		"psalm:ocp": "psalm --no-cache --threads=$(nproc) -c psalm-ocp.xml",
 		"psalm:ncu": "psalm --no-cache --threads=$(nproc) -c psalm-ncu.xml",


### PR DESCRIPTION
- [x] Merge: https://github.com/nextcloud/3rdparty/pull/2259

Since PHP 8.3 the linting command "php -l" can consume multiple files at once.
This drastically speeds up the time necessary for the linting from ~3 minutes
to few seconds.
By also running the linting on multiple cores, the time can be dropped to < 1s