### PR TITLE
perf(normalization): Optimize path normalization

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -7,10 +7,8 @@
  */
 namespace OC\Files;
 
-use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\StorageFactory;
 use OC\User\NoUserException;
-use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\FilesystemTornDownEvent;
 use OCP\Files\Mount\IMountManager;
@@ -27,8 +25,6 @@ class Filesystem {
 	public static bool $loaded = false;
 
 	private static ?View $defaultInstance = null;
-
-	private static ?CappedMemoryCache $normalizedPathCache = null;
 
 	private static ?FilenameValidator $validator = null;
 
@@ -607,16 +603,6 @@ class Filesystem {
 			return '/';
 		}
 
-		if (is_null(self::$normalizedPathCache)) {
-			self::$normalizedPathCache = new CappedMemoryCache(2048);
-		}
-
-		$cacheKey = json_encode([$path, $stripTrailingSlash, $isAbsolutePath, $keepUnicode]);
-
-		if ($cacheKey && isset(self::$normalizedPathCache[$cacheKey])) {
-			return self::$normalizedPathCache[$cacheKey];
-		}
-
 		//normalize unicode if possible
 		if (!$keepUnicode) {
 			$path = \OC_Util::normalizeUnicode($path);
@@ -641,8 +627,6 @@ class Filesystem {
 		if ($stripTrailingSlash && strlen($path) > 1) {
 			$path = rtrim($path, '/');
 		}
-
-		self::$normalizedPathCache[$cacheKey] = $path;
 
 		return $path;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Remove caching since when we request path normalization for more entries than the cache size, it's useless and is quite expensive

<img width="1342" height="665" alt="image" src="https://github.com/user-attachments/assets/400d6b82-eb04-4a4e-8689-a534ad228018" />

When doing a PROPFIND on the root, decrease memory usage from normalizedPath but increase it a bit on normalizedUnicode

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
