### PR TITLE
fix(files_sharing): Fix BeforeZipCreatedListener path handling

### DIFF
--- a/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
@@ -35,16 +35,20 @@ class BeforeZipCreatedListener implements IEventListener {
 		$dir = $event->getDirectory();
 		$files = $event->getFiles();
 
-		$pathsToCheck = [];
-		foreach ($files as $file) {
-			$pathsToCheck[] = $dir . '/' . $file;
+		if (empty($files)) {
+			$pathsToCheck = [$dir];
+		} else {
+			$pathsToCheck = [];
+			foreach ($files as $file) {
+				$pathsToCheck[] = $dir . '/' . $file;
+			}
 		}
 
 		// Check only for user/group shares. Don't restrict e.g. share links
 		$user = $this->userSession->getUser();
 		if ($user) {
 			$viewOnlyHandler = new ViewOnly(
-				$this->rootFolder->getUserFolder($user->getUID())
+				$this->rootFolder
 			);
 			if (!$viewOnlyHandler->check($pathsToCheck)) {
 				$event->setErrorMessage('Access to this resource or one of its sub-items has been denied.');

--- a/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
@@ -48,7 +48,7 @@ class BeforeZipCreatedListener implements IEventListener {
 		$user = $this->userSession->getUser();
 		if ($user) {
 			$viewOnlyHandler = new ViewOnly(
-				$this->rootFolder
+				$this->rootFolder->getUserFolder($user->getUID())
 			);
 			if (!$viewOnlyHandler->check($pathsToCheck)) {
 				$event->setErrorMessage('Access to this resource or one of its sub-items has been denied.');

--- a/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
@@ -32,6 +32,7 @@ class BeforeZipCreatedListener implements IEventListener {
 			return;
 		}
 
+		/** @psalm-suppress DeprecatedMethod should be migrated to getFolder but for now it would just duplicate code */
 		$dir = $event->getDirectory();
 		$files = $event->getFiles();
 

--- a/apps/files_sharing/lib/ViewOnly.php
+++ b/apps/files_sharing/lib/ViewOnly.php
@@ -24,7 +24,7 @@ class ViewOnly {
 	}
 
 	/**
-	 * @param string[] $pathsToCheck
+	 * @param string[] $pathsToCheck paths to check, relative to the user folder
 	 * @return bool
 	 */
 	public function check(array $pathsToCheck): bool {

--- a/lib/public/Files/Events/BeforeZipCreatedEvent.php
+++ b/lib/public/Files/Events/BeforeZipCreatedEvent.php
@@ -21,12 +21,13 @@ use OCP\Files\Folder;
  * @since 25.0.0
  */
 class BeforeZipCreatedEvent extends Event {
-	private string $directory;
+	private ?string $directory = null;
 	private bool $successful = true;
 	private ?string $errorMessage = null;
 	private ?Folder $folder = null;
 
 	/**
+	 * @param string|Folder $directory Folder instance, or (deprecated) string path relative to user folder
 	 * @param list<string> $files
 	 * @since 25.0.0
 	 * @since 31.0.0 support `OCP\Files\Folder` as `$directory` parameter - passing a string is deprecated now
@@ -37,7 +38,6 @@ class BeforeZipCreatedEvent extends Event {
 	) {
 		parent::__construct();
 		if ($directory instanceof Folder) {
-			$this->directory = $directory->getPath();
 			$this->folder = $directory;
 		} else {
 			$this->directory = $directory;
@@ -53,8 +53,13 @@ class BeforeZipCreatedEvent extends Event {
 
 	/**
 	 * @since 25.0.0
+	 * @deprecated 33.0.0 Use getFolder instead and use node API
+	 * @return string returns folder path relative to user folder
 	 */
 	public function getDirectory(): string {
+		if ($this->folder instanceof Folder) {
+			return preg_replace('|^/[^/]+/files/|', '/', $this->folder->getPath());
+		}
 		return $this->directory;
 	}
 

--- a/lib/public/Files/Events/BeforeZipCreatedEvent.php
+++ b/lib/public/Files/Events/BeforeZipCreatedEvent.php
@@ -21,7 +21,7 @@ use OCP\Files\Folder;
  * @since 25.0.0
  */
 class BeforeZipCreatedEvent extends Event {
-	private ?string $directory = null;
+	private string $directory = '';
 	private bool $successful = true;
 	private ?string $errorMessage = null;
 	private ?Folder $folder = null;


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Lighter alternative to https://github.com/nextcloud/server/pull/57335

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
