### PR TITLE
refactor(QueryException): Remove most usage of QueryException

### DIFF
--- a/apps/dav/lib/AppInfo/PluginManager.php
+++ b/apps/dav/lib/AppInfo/PluginManager.php
@@ -14,7 +14,7 @@ use OCA\DAV\CalDAV\AppCalendar\AppCalendarPlugin;
 use OCA\DAV\CalDAV\Integration\ICalendarProvider;
 use OCA\DAV\CardDAV\Integration\IAddressBookProvider;
 use OCP\App\IAppManager;
-use OCP\AppFramework\QueryException;
+use Psr\Container\ContainerExceptionInterface;
 use Sabre\DAV\Collection;
 use Sabre\DAV\ServerPlugin;
 use function array_map;
@@ -229,7 +229,7 @@ class PluginManager {
 	private function createClass(string $className): object {
 		try {
 			return $this->container->get($className);
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface $e) {
 			if (class_exists($className)) {
 				return new $className();
 			}

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace OCA\DAV\CalDAV\Reminder;
 
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException;
-use OCP\AppFramework\QueryException;
 use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * Class NotificationProviderManager
@@ -55,7 +55,7 @@ class NotificationProviderManager {
 	 * Registers a new provider
 	 *
 	 * @param string $providerClassName
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	public function registerProvider(string $providerClassName):void {
 		$provider = Server::get($providerClassName);

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -15,7 +15,6 @@ use OCA\DAV\CardDAV\Integration\ExternalAddressBook;
 use OCA\DAV\CardDAV\Integration\IAddressBookProvider;
 use OCA\DAV\ConfigLexicon;
 use OCA\Federation\TrustedServers;
-use OCP\AppFramework\QueryException;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -83,7 +82,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 				try {
 					$trustedServers = Server::get(TrustedServers::class);
 					$request = Server::get(IRequest::class);
-				} catch (QueryException|NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+				} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 					// nothing to do, the request / trusted servers don't exist
 				}
 				if ($addressBook['principaluri'] === 'principals/system/system') {

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -17,7 +17,6 @@ use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
 use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\App\IAppManager;
-use OCP\AppFramework\QueryException;
 use OCP\Constants;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -27,6 +26,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Share\IManager as IShareManager;
+use Psr\Container\ContainerExceptionInterface;
 use Sabre\DAV\Exception;
 use Sabre\DAV\PropPatch;
 use Sabre\DAVACL\PrincipalBackend\BackendInterface;
@@ -539,7 +539,7 @@ class Principal implements BackendInterface {
 
 		try {
 			$circle = Circles::detailsCircle($circleUniqueId, true);
-		} catch (QueryException $ex) {
+		} catch (ContainerExceptionInterface $ex) {
 			return null;
 		} catch (CircleNotFoundException $ex) {
 			return null;
@@ -563,7 +563,7 @@ class Principal implements BackendInterface {
 	 * @param string $principal
 	 * @return array
 	 * @throws Exception
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 * @suppress PhanUndeclaredClassMethod
 	 */
 	public function getCircleMembership($principal):array {

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
@@ -14,7 +14,7 @@ use OCA\DAV\CalDAV\Reminder\NotificationProvider\PushProvider;
 use OCA\DAV\CalDAV\Reminder\NotificationProviderManager;
 use OCA\DAV\CalDAV\Reminder\NotificationTypeDoesNotExistException;
 use OCA\DAV\Capabilities;
-use OCP\AppFramework\QueryException;
+use Psr\Container\ContainerExceptionInterface;
 use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group('DB')]
@@ -22,7 +22,7 @@ class NotificationProviderManagerTest extends TestCase {
 	private NotificationProviderManager $providerManager;
 
 	/**
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -65,7 +65,7 @@ class NotificationProviderManagerTest extends TestCase {
 	}
 
 	/**
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	public function testRegisterBadProvider(): void {
 		$this->expectException(\InvalidArgumentException::class);

--- a/apps/files/lib/Collaboration/Resources/ResourceProvider.php
+++ b/apps/files/lib/Collaboration/Resources/ResourceProvider.php
@@ -20,8 +20,7 @@ use OCP\IUser;
 class ResourceProvider implements IProvider {
 	public const RESOURCE_TYPE = 'file';
 
-	/** @var array */
-	protected $nodes = [];
+	protected array $nodes = [];
 
 	public function __construct(
 		protected IRootFolder $rootFolder,

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -51,7 +51,6 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\QueryException;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Group\Events\BeforeGroupDeletedEvent;
 use OCP\Group\Events\GroupDeletedEvent;
@@ -60,6 +59,7 @@ use OCP\Group\Events\UserRemovedEvent;
 use OCP\User\Events\PostLoginEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserDeletedEvent;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * @package OCA\Files_External\AppInfo
@@ -70,7 +70,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 	/**
 	 * Application constructor.
 	 *
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);

--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -16,7 +16,6 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\MountConfig;
 use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;
-use OCP\AppFramework\QueryException;
 use OCP\Files\Config\IAuthoritativeMountProvider;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Mount\IMountPoint;
@@ -28,6 +27,7 @@ use OCP\Files\StorageNotAvailableException;
 use OCP\IUser;
 use OCP\Server;
 use Psr\Clock\ClockInterface;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -57,7 +57,7 @@ class ConfigAdapter implements IMountProvider, IAuthoritativeMountProvider {
 	/**
 	 * Process storage ready for mounting
 	 *
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	private function prepareStorageConfig(StorageConfig &$storage, IUser $user): void {
 		foreach ($storage->getBackendOptions() as $option => $value) {

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -15,12 +15,12 @@ use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;
-use OCP\AppFramework\QueryException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
 use phpseclib\Crypt\AES;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -48,7 +48,7 @@ class MountConfig {
 	 * @param mixed $input
 	 * @param string|null $userId
 	 * @return mixed
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 * @since 16.0.0
 	 */
 	public static function substitutePlaceholdersInConfig($input, ?string $userId = null) {

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -181,10 +181,10 @@ class DeletedShareAPIController extends OCSController {
 	 * Returns the helper of DeletedShareAPIController for room shares.
 	 *
 	 * If the Talk application is not enabled or the helper is not available
-	 * a QueryException is thrown instead.
+	 * a ContainerExceptionInterface is thrown instead.
 	 *
 	 * @psalm-suppress UndefinedClass
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	private function getRoomShareHelper(): \OCA\Talk\Share\Helper\DeletedShareAPIController {
 		if (!$this->appManager->isEnabledForUser('spreed')) {
@@ -199,10 +199,10 @@ class DeletedShareAPIController extends OCSController {
 	 * Returns the helper of DeletedShareAPIHelper for deck shares.
 	 *
 	 * If the Deck application is not enabled or the helper is not available
-	 * a QueryException is thrown instead.
+	 * a ContainerExceptionInterface is thrown instead.
 	 *
 	 * @psalm-suppress UndefinedClass
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	private function getDeckShareHelper(): \OCA\Deck\Sharing\ShareAPIHelper {
 		if (!$this->appManager->isEnabledForUser('deck')) {

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -13,6 +13,7 @@ use OC\AppFramework\Utility\SimpleContainer;
 use OC\ServerContainer;
 use OCP\IConfig;
 use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -90,7 +91,7 @@ class App {
 
 		try {
 			$this->container = \OC::$server->getRegisteredAppContainer($appName);
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface $e) {
 			$this->container = new \OC\AppFramework\DependencyInjection\DIContainer($appName, $urlParams);
 		}
 	}

--- a/lib/public/IContainer.php
+++ b/lib/public/IContainer.php
@@ -11,7 +11,6 @@
 namespace OCP;
 
 use Closure;
-use OCP\AppFramework\QueryException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -37,7 +36,6 @@ interface IContainer extends ContainerInterface {
 	 * @since 8.2.0
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 * @throws ContainerExceptionInterface if the class could not be found or instantiated
-	 * @throws QueryException if the class could not be found or instantiated
 	 */
 	public function resolve($name);
 
@@ -53,7 +51,6 @@ interface IContainer extends ContainerInterface {
 	 * @psalm-return ($name is class-string ? T : mixed)
 	 * @throws ContainerExceptionInterface if the query could not be resolved
 	 * @throws NotFoundExceptionInterface if the name could not be found within the container
-	 * @throws QueryException if the query could not be resolved
 	 * @since 6.0.0
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 */

--- a/lib/public/Log/functions.php
+++ b/lib/public/Log/functions.php
@@ -10,7 +10,8 @@ declare(strict_types=1);
 namespace OCP\Log;
 
 use OC;
-use OCP\AppFramework\QueryException;
+use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use function class_exists;
@@ -45,14 +46,14 @@ function logger(?string $appId = null): LoggerInterface {
 		try {
 			$appContainer = OC::$server->getRegisteredAppContainer($appId);
 			return $appContainer->get(LoggerInterface::class);
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface $e) {
 			// Ignore and return the server logger below
 		}
 	}
 
 	try {
-		return OC::$server->get(LoggerInterface::class);
-	} catch (QueryException $e) {
+		return Server::get(LoggerInterface::class);
+	} catch (ContainerExceptionInterface $e) {
 		return new NullLogger();
 	}
 }


### PR DESCRIPTION
## Summary

This is preparation to move QueryException from OCP to OC as part of Nextcloud 34.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
