### PR TITLE
chore(Files): explicitly cast mtime in View

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -148,7 +148,7 @@ class Node implements INode {
 				if (is_null($mtime)) {
 					$mtime = time();
 				}
-				$this->fileInfo['mtime'] = $mtime;
+				$this->fileInfo['mtime'] = $mtime; // XXX This isn't normalized like it is at the View::touch() level
 			}
 		} else {
 			throw new NotPermittedException();

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -518,6 +518,8 @@ class View {
 		if (!is_null($mtime) && !is_numeric($mtime)) {
 			$mtime = strtotime($mtime);
 		}
+		// Ensure mtime is always an integer to prevent implicit conversion warnings in PHP 8.1+
+		$mtime = (int) $mtime;
 
 		$hooks = ['touch'];
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -515,37 +515,60 @@ class View {
 	 * @param int|string $mtime
 	 */
 	public function touch($path, $mtime = null): bool {
-		if (!is_null($mtime) && !is_numeric($mtime)) {
-			$mtime = strtotime($mtime);
-		}
-		// Ensure mtime is always an integer to prevent implicit conversion warnings in PHP 8.1+
-		$mtime = (int) $mtime;
+		$mtime = $this->normalizeMTime($mtime);
 
 		$hooks = ['touch'];
-
 		if (!$this->file_exists($path)) {
 			$hooks[] = 'create';
 			$hooks[] = 'write';
 		}
+
 		try {
 			$result = $this->basicOperation('touch', $path, $hooks, $mtime);
 		} catch (\Exception $e) {
-			$this->logger->info('Error while setting modified time', ['app' => 'core', 'exception' => $e]);
+			$this->logger->info(
+				'Error while setting modified time',
+				[ 'app' => 'core', 'exception' => $e, 'path' => $path, 'mtime' => $mtime ]
+			);
 			$result = false;
 		}
+
 		if (!$result) {
 			// If create file fails because of permissions on external storage like SMB folders,
 			// check file exists and return false if not.
 			if (!$this->file_exists($path)) {
 				return false;
 			}
-			if (is_null($mtime)) {
+			if ($mtime === null) {
 				$mtime = time();
 			}
 			//if native touch fails, we emulate it by changing the mtime in the cache
 			$this->putFileInfo($path, ['mtime' => floor($mtime)]);
 		}
 		return true;
+	}
+
+	private function normalizeMTime($mtime): int|null {
+		if ($mtime === null) {
+			return null;
+		}
+
+		if (!is_numeric($mtime)) {
+			$timestamp = strtotime($mtime);
+			if ($timestamp === false || $timestamp < 0) {
+				// Treat unparseable or negative timestamps as "now"
+				return null;
+			}
+			return $timestamp;
+		}
+
+		// Prevent implicit conversion warnings if a float
+		$intMtime = (int)$mtime;
+		if ($intMtime < 0) {
+			// Treat negative mtime as "now"
+			return null;
+		}
+		return $intMtime;
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

To solve this for now:

```
--

1 test triggered 1 PHP deprecation:

1) /home/runner/work/server/server/lib/private/Files/Storage/Wrapper/Wrapper.php:159
Implicit conversion from float 500.5 to int loses precision

Triggered by:

* Test\Files\ViewTest::testTouchFloat
  /home/runner/work/server/server/tests/lib/Files/ViewTest.php:598
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
