### PR TITLE
fix(encryption): improve setKey robustness (better checks/throws)

### DIFF
--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -316,13 +316,13 @@ class Storage implements IStorage {
 	private function setKey(string $path, array $key): bool {
 		$this->keySetPreparation(dirname($path));
 
-		if (!is_array($key) || !isset($key['key'])) {
-			throw new \UnexpectedValueException('Provided $key is not a valid array with required "key" entry');
+		if (!isset($key['key'])) {
+			throw new \UnexpectedValueException('Provided $key missing required "key" entry');
 		}
 
 		try {
 			$json = json_encode($key, JSON_THROW_ON_ERROR);
-			$data = $this->crypto->encrypt($json));
+			$data = $this->crypto->encrypt($json);
 		} catch (\JsonException $e) {
 			throw new \RuntimeException('Failed to JSON encode key for storage: ' . $e->getMessage(), 0, $e);
 		} catch (\Throwable $e) {

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -89,32 +89,6 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testSetFileOld(): void {
-		$this->config->method('getSystemValueString')
-			->with('version')
-			->willReturn('20.0.0.0');
-		$this->util->expects($this->any())
-			->method('getUidAndFilename')
-			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
-			->method('stripPartialFileExtension')
-			->willReturnArgument(0);
-		$this->util->expects($this->any())
-			->method('isSystemWideMountPoint')
-			->willReturn(false);
-		$this->crypto->expects($this->never())
-			->method('encrypt');
-		$this->view->expects($this->once())
-			->method('file_put_contents')
-			->with($this->equalTo('/user1/files_encryption/keys/files/foo.txt/encModule/fileKey'),
-				$this->equalTo('key'))
-			->willReturn(strlen('key'));
-
-		$this->assertTrue(
-			$this->storage->setFileKey('user1/files/foo.txt', 'fileKey', 'key', 'encModule')
-		);
-	}
-
 	public static function dataTestGetFileKey() {
 		return [
 			['/files/foo.txt', '/files/foo.txt', true, 'key'],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Ensures setKey throws on encoding, encryption, or write failure
- Adds explicit check for partial file writes by comparing bytes written to expected length
- Refines error handling for maximum cryptographic key safety
- Drops dead code (<= v21)
- Also refactors `getKey()` for clarity (dropping dead code, flattening conditionals, simplified migration logic, type hinting)

Context:

The `setKey()` function is the underlying basis for all the `set*Key()` functions. It's extremely important for data integrity. While it can in theory return false for failures, in reality almost no callers (direct or indirect) actually check the return value (nor would they necessarily know what to do with a false/failure since it's inherently catastrophic). 

This change maintains the API contract (boolean -- though only `true` is realistically returned) while utilizing exceptions for all catastrophic errors (and they're all catastrophic).

In additional to generally being wise, this may surface the causes of weird issues that sometimes get reported with keys.

## TODO

- [ ] Consider using `ServerNotAvailableException` like `getKey()` though that seems just as generic

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
