### PR TITLE
fix(theming): Fix favicon and touchicon ratios

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -136,9 +136,8 @@ class IconBuilder {
 
 			// convert svg to resized image
 			$appIconFile = new Imagick();
-			$resX = (int)(72 * $size / $x);
-			$resY = (int)(72 * $size / $y);
-			$appIconFile->setResolution($resX, $resY);
+			$res = (int)(72 * $size / max($x, $y));
+			$appIconFile->setResolution($res, $res);
 			$appIconFile->setBackgroundColor(new ImagickPixel('transparent'));
 			$appIconFile->readImageBlob($svg);
 


### PR DESCRIPTION
* Resolves: #51228

## Summary

On some systems (depending on imagick version I think) the ratio would
 be messed up on the touchicon, favicon and link preview images.
This fixes it without breaking other systems.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
