### PR TITLE
fix(apps): Enable TwoFactor TOTP by default

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -92,6 +92,7 @@
     "systemtags",
     "text",
     "theming",
+    "twofactor_totp",
     "updatenotification",
     "user_status",
     "viewer",


### PR DESCRIPTION
- To help people to stay more secure in a default setup
- For 2FA nextcloud notifications I first want to solve https://github.com/nextcloud/twofactor_nextcloud_notification/issues/22 and check if they really have a desktop/mobile client enabled or at least exported the backup tokens or have any other 2fa provider

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
