### PR TITLE
fix: add since param for activity manager

### DIFF
--- a/lib/public/Activity/IManager.php
+++ b/lib/public/Activity/IManager.php
@@ -134,6 +134,7 @@ interface IManager {
 	 * @param string $type
 	 * @param int|numeric-string $id
 	 * @since 8.2.0
+	 * @since 33.0.0 $id can also be a string
 	 */
 	public function setFormattingObject(string $type, int|string $id): void;
 


### PR DESCRIPTION
As per Joas' feedback

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
