### PR TITLE
refactor(memoryinfo): use ini_parse_quantity for memory limit parsing

### DIFF
--- a/lib/private/MemoryInfo.php
+++ b/lib/private/MemoryInfo.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace OC;
 
-use OCP\Util;
-
 /**
  * Helper class that covers memory info.
  */

--- a/tests/lib/MemoryInfoTest.php
+++ b/tests/lib/MemoryInfoTest.php
@@ -32,12 +32,14 @@ class MemoryInfoTest extends TestCase {
 	}
 
 	public static function getMemoryLimitTestData(): array {
+		// On 32-bit, '2G' should overflows to 0; on 64-bit, it is 2147483648
+		$twoG = PHP_INT_SIZE === 4 ? 0 : 2147483648;
 		return [
 			'unlimited' => ['-1', -1,],
 			'524288000 bytes' => ['524288000', 524288000,],
 			'500M' => ['500M', 524288000,],
 			'512000K' => ['512000K', 524288000,],
-			'2G' => ['2G', 2147483648,],
+			'2G' => ['2G', $twoG,],
 		];
 	}
 

--- a/tests/lib/MemoryInfoTest.php
+++ b/tests/lib/MemoryInfoTest.php
@@ -32,8 +32,8 @@ class MemoryInfoTest extends TestCase {
 	}
 
 	public static function getMemoryLimitTestData(): array {
-		// On 32-bit, '2G' should overflows to 0; on 64-bit, it is 2147483648
-		$twoG = PHP_INT_SIZE === 4 ? 0 : 2147483648;
+		// On 32-bit, '2G' should overflow; on 64-bit, it'll be 2147483648
+		$twoG = PHP_INT_SIZE === 4 ? -2147483648 : 2147483648;
 		return [
 			'unlimited' => ['-1', -1,],
 			'524288000 bytes' => ['524288000', 524288000,],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

*Refactor `MemoryInfo` to leverage PHP's (8.2+) native `ini_parse_quantity()` for parsing and converting `memory_limit` values.*

- Eliminates custom logic and unnecessary checks.
- Fully aligns parsing with PHP's internal parsing behavior.
- Fixes a bug where our support for `float` in this particular context was too generous, because on 32-bit systems PHP's own parsing of this value wraps. By switching to this new function we are literally checking from PHP's perspective rather than checking the user's intent. Checking actual effective config value is more appropriate in this context.

*Refactor Util::uploadLimit(), maxUploadFilesize(), and related helpers to improve reliability, correctness, and standards alignment.*

- Use PHP's native ini_parse_quantity() for accurate parsing of upload_max_filesize and post_max_size, replacing custom logic and computerFileSize().
- Normalize both 0 and -1 as unlimited for INI settings, consistently returning -1 instead of INF or 0 for unlimited upload settings.
- Throw InvalidArgumentException for invalid or unparsable INI values, making misconfigs fail fast instead of silently.
- Always return the stricter of upload_max_filesize or post_max_size, with clear logic and optional warning on misconfiguration.
- Update maxUploadFilesize() logic to clearly and robustly combine quota/free space and system limits, supporting unlimited semantics correctly.
- Improve docblocks for clarity and standards compliance.
- Remove ambiguous or legacy code paths, reducing edge cases and future bugs.

Refs:

- https://www.php.net/manual/en/function.ini-parse-quantity.php
- https://php.watch/versions/8.2/ini_parse_quantity#:~:text=Version8.2,string%20$shorthand):%20int%20%7B%20%7D

## TODO

- [x] Make similar changes to Util::uploadLimit()
  - https://github.com/nextcloud/server/blob/3f9849d9217a006853ef86951386eb94ba62b7cc/lib/public/Util.php#L564
- [ ] Make similar changes in ServerInfo
  - https://github.com/nextcloud/serverinfo/blob/dd28d4025f2facb672695cb90e99cfeea3f12adf/lib/PhpStatistics.php#L27
- [ ] Look for other similar spots 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
