### PR TITLE
fix: Add translator hints to avoid confusion between big and large

### DIFF
--- a/apps/settings/src/components/SettingsPresets/PresetsSelectionForm.vue
+++ b/apps/settings/src/components/SettingsPresets/PresetsSelectionForm.vue
@@ -31,7 +31,9 @@ const emit = defineEmits<{
 }>()
 
 const PresetNames = {
+// TRANSLATORS Large organization > Big organization > Small organization
 	LARGE: t('settings', 'Large organization'),
+// TRANSLATORS Large organization > Big organization > Small organization
 	MEDIUM: t('settings', 'Big organization'),
 	SMALL: t('settings', 'Small organization'),
 	SHARED: t('settings', 'Hosting company'),


### PR DESCRIPTION
## Summary

French translation was wrong and inversed the order between large and big, so making it clearer.
Should we even add more details like in https://nextcloud-server.netlify.app/classes/ocp-config-lexicon-preset#tags ? Or is that too much details and risk of getting out-of-sync?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
