### PR TITLE
Fix incorrect user count

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -224,7 +224,7 @@ class UsersController extends Controller {
 		$forceSortGroupByName = $sortGroupsBy === MetaData::SORT_GROUPNAME;
 
 		
-		// display user count with a plus appended, if limit is exceede
+		// display user count with a plus appended, if limit is exceeded
 		$userCount = ($userCount < self::COUNT_LIMIT_FOR_SUBADMINS) ? $userCount : self::COUNT_LIMIT_FOR_SUBADMINS . '+';
 
 

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -223,6 +223,11 @@ class UsersController extends Controller {
 		/** Using LDAP or admins (system config) can enfore sorting by group name, in this case the frontend setting is overwritten */
 		$forceSortGroupByName = $sortGroupsBy === MetaData::SORT_GROUPNAME;
 
+		
+		// display user count with a plus appended, if limit is exceede
+		$userCount = ($userCount < self::COUNT_LIMIT_FOR_SUBADMINS) ? $userCount : self::COUNT_LIMIT_FOR_SUBADMINS . '+';
+
+
 		/* FINAL DATA */
 		$serverData = [];
 		// groups


### PR DESCRIPTION

## Summary

Just a simple check if the limit is exceeded it adds a plus. Tested with a system with that many users in a subgroup and it showed up correctly.

Resolves #54878 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
