### PR TITLE
feat: Add twofactor applications to most of the presets

### DIFF
--- a/lib/private/Config/PresetManager.php
+++ b/lib/private/Config/PresetManager.php
@@ -233,8 +233,22 @@ class PresetManager {
 	 */
 	private function getPresetApps(Preset $preset): array {
 		return match ($preset) {
-			Preset::CLUB, Preset::FAMILY, Preset::SCHOOL, Preset::UNIVERSITY, Preset::SMALL, Preset::MEDIUM, Preset::LARGE => ['enabled' => ['user_status', 'guests'], 'disabled' => []],
-			Preset::SHARED => ['enabled' => ['external'], 'disabled' => ['user_status']],
+			Preset::CLUB, Preset::FAMILY, Preset::SCHOOL, Preset::SMALL, Preset::MEDIUM
+				=> [
+					'enabled' => ['user_status','guests','twofactor_backupcodes','twofactor_totp','twofactor_webauthn'],
+					'disabled' => []],
+			Preset::UNIVERSITY, Preset::LARGE
+				=> [
+					'enabled' => ['user_status','guests'],
+					'disabled' => []],
+			Preset::SHARED
+				=> [
+					'enabled' => ['external','twofactor_backupcodes','twofactor_totp','twofactor_webauthn'],
+					'disabled' => ['user_status']],
+			Preset::PRIVATE
+				=> [
+					'enabled' => ['twofactor_backupcodes','twofactor_totp','twofactor_webauthn'],
+					'disabled' => []],
 			default => ['enabled' => [], 'disabled' => []],
 		};
 	}

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -51,7 +51,7 @@ class AppConfigTest extends TestCase {
 
 	protected function getAppConfig($cached = false): AppConfig {
 		$this->config->method('getSystemValueBool')
-			->with('cache_app_config', $cached)
+			->with('cache_app_config', true)
 			->willReturn(true);
 		$this->cacheFactory->method('isLocalCacheAvailable')->willReturn($cached);
 		if ($cached) {

--- a/tests/lib/Config/LexiconTest.php
+++ b/tests/lib/Config/LexiconTest.php
@@ -10,12 +10,10 @@ namespace Tests\lib\Config;
 use OC\AppConfig;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Config\ConfigManager;
-use OC\Config\PresetManager;
 use OCP\App\IAppManager;
 use OCP\Config\Exceptions\TypeConflictException;
 use OCP\Config\Exceptions\UnknownKeyException;
 use OCP\Config\IUserConfig;
-use OCP\Config\Lexicon\Preset;
 use OCP\Exceptions\AppConfigTypeConflictException;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 use OCP\IAppConfig;
@@ -34,7 +32,6 @@ class LexiconTest extends TestCase {
 	private IAppConfig $appConfig;
 	private IUserConfig $userConfig;
 	private ConfigManager $configManager;
-	private PresetManager $presetManager;
 	private IAppManager $appManager;
 
 	protected function setUp(): void {
@@ -49,7 +46,6 @@ class LexiconTest extends TestCase {
 		$this->appConfig = Server::get(IAppConfig::class);
 		$this->userConfig = Server::get(IUserConfig::class);
 		$this->configManager = Server::get(ConfigManager::class);
-		$this->presetManager = Server::get(PresetManager::class);
 		$this->appManager = Server::get(IAppManager::class);
 	}
 
@@ -213,30 +209,6 @@ class LexiconTest extends TestCase {
 		$this->assertSame(true, $this->appConfig->getValueBool(TestConfigLexicon_I::APPID, 'key4'));
 		$this->configManager->migrateConfigLexiconKeys(TestConfigLexicon_I::APPID);
 		$this->assertSame(false, $this->appConfig->getValueBool(TestConfigLexicon_I::APPID, 'key4'));
-	}
-
-	public function testAppConfigLexiconPreset() {
-		$this->presetManager->setLexiconPreset(Preset::FAMILY);
-		$this->assertSame('family', $this->appConfig->getValueString(TestLexicon_E::APPID, 'key3'));
-	}
-
-	public function testAppConfigLexiconPresets() {
-		$this->presetManager->setLexiconPreset(Preset::MEDIUM);
-		$this->assertSame('club+medium', $this->appConfig->getValueString(TestLexicon_E::APPID, 'key3'));
-		$this->presetManager->setLexiconPreset(Preset::FAMILY);
-		$this->assertSame('family', $this->appConfig->getValueString(TestLexicon_E::APPID, 'key3'));
-	}
-
-	public function testUserConfigLexiconPreset() {
-		$this->presetManager->setLexiconPreset(Preset::FAMILY);
-		$this->assertSame('family', $this->userConfig->getValueString('user1', TestLexicon_E::APPID, 'key3'));
-	}
-
-	public function testUserConfigLexiconPresets() {
-		$this->presetManager->setLexiconPreset(Preset::MEDIUM);
-		$this->assertSame('club+medium', $this->userConfig->getValueString('user1', TestLexicon_E::APPID, 'key3'));
-		$this->presetManager->setLexiconPreset(Preset::FAMILY);
-		$this->assertSame('family', $this->userConfig->getValueString('user1', TestLexicon_E::APPID, 'key3'));
 	}
 
 	public function testLexiconIndexedUpdate() {


### PR DESCRIPTION
* Related: #57406

## Summary

All presets which are unlikely to have SSO in place should enable
 twofactor applications.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
