### PR TITLE
Share mount validation fixes

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -18,6 +18,7 @@ use OCA\Encryption\Util;
 use OCA\Files\Exception\TransferOwnershipException;
 use OCA\Files_External\Config\ConfigAdapter;
 use OCP\Encryption\IManager as IEncryptionManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IHomeMountProvider;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
@@ -30,6 +31,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Server;
+use OCP\Share\Events\ShareTransferredEvent;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -52,6 +54,7 @@ class OwnershipTransferService {
 		private IUserManager $userManager,
 		private IFactory $l10nFactory,
 		private IRootFolder $rootFolder,
+		private IEventDispatcher $eventDispatcher,
 	) {
 	}
 
@@ -544,6 +547,7 @@ class OwnershipTransferService {
 			} catch (\Throwable $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getMessage() . ' : ' . $e->getTraceAsString() . '</error>');
 			}
+			$this->eventDispatcher->dispatchTyped(new ShareTransferredEvent($share));
 			$progress->advance();
 		}
 		$progress->finish();

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -57,6 +57,7 @@ use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\Share\Events\BeforeShareDeletedEvent;
 use OCP\Share\Events\ShareCreatedEvent;
+use OCP\Share\Events\ShareTransferredEvent;
 use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
@@ -117,6 +118,7 @@ class Application extends App implements IBootstrap {
 		// Update mounts
 		$context->registerEventListener(ShareCreatedEvent::class, SharesUpdatedListener::class);
 		$context->registerEventListener(BeforeShareDeletedEvent::class, SharesUpdatedListener::class);
+		$context->registerEventListener(ShareTransferredEvent::class, SharesUpdatedListener::class);
 		$context->registerEventListener(UserAddedEvent::class, SharesUpdatedListener::class);
 		$context->registerEventListener(UserRemovedEvent::class, SharesUpdatedListener::class);
 		$context->registerEventListener(UserShareAccessUpdatedEvent::class, SharesUpdatedListener::class);

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -48,7 +48,6 @@ use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\Events\Node\BeforeNodeReadEvent;
-use OCP\Files\Events\Node\FilesystemTornDownEvent;
 use OCP\Group\Events\GroupChangedEvent;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
@@ -122,7 +121,6 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserAddedEvent::class, SharesUpdatedListener::class);
 		$context->registerEventListener(UserRemovedEvent::class, SharesUpdatedListener::class);
 		$context->registerEventListener(UserShareAccessUpdatedEvent::class, SharesUpdatedListener::class);
-		$context->registerEventListener(FilesystemTornDownEvent::class, SharesUpdatedListener::class);
 
 		$context->registerConfigLexicon(ConfigLexicon::class);
 	}

--- a/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
+++ b/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
@@ -22,12 +22,13 @@ use OCP\Group\Events\UserRemovedEvent;
 use OCP\IUser;
 use OCP\Share\Events\BeforeShareDeletedEvent;
 use OCP\Share\Events\ShareCreatedEvent;
+use OCP\Share\Events\ShareTransferredEvent;
 use OCP\Share\IManager;
 
 /**
  * Listen to various events that can change what shares a user has access to
  *
- * @template-implements IEventListener<UserAddedEvent|UserRemovedEvent|ShareCreatedEvent|BeforeShareDeletedEvent|UserShareAccessUpdatedEvent|FilesystemTornDownEvent>
+ * @template-implements IEventListener<UserAddedEvent|UserRemovedEvent|ShareCreatedEvent|ShareTransferredEvent|BeforeShareDeletedEvent|UserShareAccessUpdatedEvent|FilesystemTornDownEvent>
  */
 class SharesUpdatedListener implements IEventListener {
 	private CappedMemoryCache $updatedUsers;
@@ -52,7 +53,11 @@ class SharesUpdatedListener implements IEventListener {
 		if ($event instanceof UserAddedEvent || $event instanceof UserRemovedEvent) {
 			$this->updateForUser($event->getUser());
 		}
-		if ($event instanceof ShareCreatedEvent || $event instanceof BeforeShareDeletedEvent) {
+		if (
+			$event instanceof ShareCreatedEvent
+			|| $event instanceof BeforeShareDeletedEvent
+			|| $event instanceof ShareTransferredEvent
+		) {
 			foreach ($this->shareManager->getUsersForShare($event->getShare()) as $user) {
 				$this->updateForUser($user);
 			}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -848,6 +848,7 @@ return array(
     'OCP\\Share\\Events\\ShareCreatedEvent' => $baseDir . '/lib/public/Share/Events/ShareCreatedEvent.php',
     'OCP\\Share\\Events\\ShareDeletedEvent' => $baseDir . '/lib/public/Share/Events/ShareDeletedEvent.php',
     'OCP\\Share\\Events\\ShareDeletedFromSelfEvent' => $baseDir . '/lib/public/Share/Events/ShareDeletedFromSelfEvent.php',
+    'OCP\\Share\\Events\\ShareTransferredEvent' => $baseDir . '/lib/public/Share/Events/ShareTransferredEvent.php',
     'OCP\\Share\\Events\\VerifyMountPointEvent' => $baseDir . '/lib/public/Share/Events/VerifyMountPointEvent.php',
     'OCP\\Share\\Exceptions\\AlreadySharedException' => $baseDir . '/lib/public/Share/Exceptions/AlreadySharedException.php',
     'OCP\\Share\\Exceptions\\GenericShareException' => $baseDir . '/lib/public/Share/Exceptions/GenericShareException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -889,6 +889,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Share\\Events\\ShareCreatedEvent' => __DIR__ . '/../../..' . '/lib/public/Share/Events/ShareCreatedEvent.php',
         'OCP\\Share\\Events\\ShareDeletedEvent' => __DIR__ . '/../../..' . '/lib/public/Share/Events/ShareDeletedEvent.php',
         'OCP\\Share\\Events\\ShareDeletedFromSelfEvent' => __DIR__ . '/../../..' . '/lib/public/Share/Events/ShareDeletedFromSelfEvent.php',
+        'OCP\\Share\\Events\\ShareTransferredEvent' => __DIR__ . '/../../..' . '/lib/public/Share/Events/ShareTransferredEvent.php',
         'OCP\\Share\\Events\\VerifyMountPointEvent' => __DIR__ . '/../../..' . '/lib/public/Share/Events/VerifyMountPointEvent.php',
         'OCP\\Share\\Exceptions\\AlreadySharedException' => __DIR__ . '/../../..' . '/lib/public/Share/Exceptions/AlreadySharedException.php',
         'OCP\\Share\\Exceptions\\GenericShareException' => __DIR__ . '/../../..' . '/lib/public/Share/Exceptions/GenericShareException.php',

--- a/lib/public/Share/Events/ShareTransferredEvent.php
+++ b/lib/public/Share/Events/ShareTransferredEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Share\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\Share\IShare;
+
+/**
+ * @since 33.0.0
+ */
+class ShareTransferredEvent extends Event {
+	/**
+	 * @since 33.0.0
+	 */
+	public function __construct(
+		private readonly IShare $share,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @since 33.0.0
+	 */
+	public function getShare(): IShare {
+		return $this->share;
+	}
+}


### PR DESCRIPTION
- For transfered shares we might need to re-perform share target validation.
- The "only refresh shares once per user per request" optimization seems to be overeager, breaks some cases and needs to be reworked.