### PR TITLE
(feat) setup appdata folder based on config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2292,6 +2292,15 @@ $CONFIG = [
 	'updatedirectory' => '',
 
 	/**
+ 	* Override where Nextcloud stores the ``appdata_INSTANCEID`` directory. Useful
+ 	* when using remote object storage where local system disks provide faster data
+ 	* access. Defaults to `datadirectory` if unset.
+ 	*
+ 	* The Web server user must have write access to this directory.
+ 	*/
+	'appdatadirectory' => '',
+
+	/**
 	 * Block specific files or filenames, disallowing uploads or access (read and write).
 	 * ``.htaccess`` is blocked by default.
 	 *

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -429,8 +429,24 @@ class SetupManager implements ISetupManager {
 		foreach ($rootMounts as $rootMountProvider) {
 			$this->mountManager->addMount($rootMountProvider);
 		}
-
+		$this->setupAppData();
 		$this->eventLogger->end('fs:setup:root');
+	}
+
+	private function setupAppData(): void {
+		if ($appdatadirectory = $this->config->getSystemValue('appdatadirectory', null)) {
+			$instanceId = $this->config->getSystemValue('instanceid', null);
+			if ($instanceId === null) {
+				throw new \RuntimeException('no instance id!');
+			}
+			$folderName = 'appdata_' . $instanceId;
+			$arguments = [
+				'datadir' => $appdatadirectory,
+			];
+			$storage = new \OC\Files\Storage\Local($arguments);
+			$mount = new \OC\Files\Mount\MountPoint($storage, $folderName, $arguments);
+			$this->mountManager->addMount($mount);
+		}
 	}
 
 	/**

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -20,6 +20,7 @@ class SystemConfig {
 	protected const DEFAULT_SENSITIVE_VALUES = [
 		'instanceid' => true,
 		'datadirectory' => true,
+		'appdatadirectory' => true,
 		'dbname' => true,
 		'dbhost' => true,
 		'dbpassword' => true,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/12873

## Summary

- Inspired by https://github.com/nextcloud/server/pull/36337


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
