### PR TITLE
fix(cache): Fix parsing cache entry from groupfolder

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -180,15 +180,19 @@ class Cache implements ICache {
 		];
 
 		if (isset($data['folder_id'])) {
-			// groupfolders specific fields
+			// groupfolders and collectives specific fields
 			$normalized['folder_id'] = (int)$data['folder_id'];
-			$normalized['mount_point'] = (string)$data['mount_point'];
-			$normalized['quota'] = $data['quota'];
-			$normalized['acl'] = (int)$data['acl'];
-			$normalized['acl_default_no_permission'] = (int)$data['acl_default_no_permission'];
-			$normalized['storage_id'] = (int)$data['storage_id'];
-			$normalized['root_id'] = (int)$data['root_id'];
-			$normalized['options'] = (string)$data['options'];
+
+			if (isset($data['storage_id'])) {
+				// groupfolders specific fields
+				$normalized['mount_point'] = (string)$data['mount_point'];
+				$normalized['quota'] = $data['quota'];
+				$normalized['acl'] = (int)$data['acl'];
+				$normalized['acl_default_no_permission'] = (int)$data['acl_default_no_permission'];
+				$normalized['storage_id'] = (int)$data['storage_id'];
+				$normalized['root_id'] = (int)$data['root_id'];
+				$normalized['options'] = (string)$data['options'];
+			}
 		}
 
 		return new CacheEntry($normalized);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
