### PR TITLE
refactor: Prefer using IFunctionBuilder than createFunction

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -798,7 +798,7 @@ class Manager implements ICommentsManager {
 
 		$query = $this->dbConn->getQueryBuilder();
 		$query->select('actor_id')
-			->selectAlias($query->createFunction('MAX(' . $query->getColumnName('creation_timestamp') . ')'), 'last_comment')
+			->selectAlias($query->func()->max('creation_timestamp'), 'last_comment')
 			->from('comments')
 			->where($query->expr()->eq('object_type', $query->createNamedParameter($objectType)))
 			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -13,6 +13,7 @@ use OCP\DB\QueryBuilder\IFunctionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 use OCP\IDBConnection;
+use Override;
 
 class FunctionBuilder implements IFunctionBuilder {
 	/** @var IDBConnection|Connection */
@@ -104,5 +105,10 @@ class FunctionBuilder implements IFunctionBuilder {
 
 	public function least($x, $y): IQueryFunction {
 		return new QueryFunction('LEAST(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
+	}
+
+	#[Override]
+	public function now(): IQueryFunction {
+		return new QueryFunction('NOW()');
 	}
 }

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -990,7 +990,7 @@ class QueryBuilder implements IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $column The column into which the value should be inserted.
-	 * @param IParameter|string $value The value that should be inserted into the column.
+	 * @param IParameter|IQueryFunction|string $value The value that should be inserted into the column.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -29,8 +29,8 @@ class CacheQueryBuilder extends ExtendedQueryBuilder {
 	public function selectTagUsage(): self {
 		$this
 			->select('systemtag.name', 'systemtag.id', 'systemtag.visibility', 'systemtag.editable', 'systemtag.etag', 'systemtag.color')
-			->selectAlias($this->createFunction('COUNT(filecache.fileid)'), 'number_files')
-			->selectAlias($this->createFunction('MAX(filecache.fileid)'), 'ref_file_id')
+			->selectAlias($this->func()->count('filecache.fileid'), 'number_files')
+			->selectAlias($this->func()->max('filecache.fileid'), 'ref_file_id')
 			->from('filecache', 'filecache')
 			->leftJoin('filecache', 'systemtag_object_mapping', 'systemtagmap', $this->expr()->andX(
 				$this->expr()->eq('filecache.fileid', $this->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),

--- a/lib/private/FilesMetadata/Service/MetadataRequestService.php
+++ b/lib/private/FilesMetadata/Service/MetadataRequestService.php
@@ -63,7 +63,7 @@ class MetadataRequestService {
 			->setValue('file_id', $qb->createNamedParameter($filesMetadata->getFileId(), IQueryBuilder::PARAM_INT))
 			->setValue('json', $qb->createNamedParameter(json_encode($filesMetadata->jsonSerialize())))
 			->setValue('sync_token', $qb->createNamedParameter($this->generateSyncToken()))
-			->setValue('last_update', (string)$qb->createFunction('NOW()'));
+			->setValue('last_update', $qb->func()->now());
 		$qb->executeStatement();
 	}
 
@@ -159,7 +159,7 @@ class MetadataRequestService {
 			->hintShardKey('files_metadata', $this->getStorageId($filesMetadata))
 			->set('json', $qb->createNamedParameter(json_encode($filesMetadata->jsonSerialize())))
 			->set('sync_token', $qb->createNamedParameter($this->generateSyncToken()))
-			->set('last_update', $qb->createFunction('NOW()'))
+			->set('last_update', $qb->func()->now())
 			->where(
 				$expr->andX(
 					$expr->eq('file_id', $qb->createNamedParameter($filesMetadata->getFileId(), IQueryBuilder::PARAM_INT)),

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -170,4 +170,10 @@ interface IFunctionBuilder {
 	 * @since 18.0.0
 	 */
 	public function least($x, $y): IQueryFunction;
+
+	/**
+	 * Get the current date and time as a UNIX timestamp.
+	 * @since 34.0.0
+	 */
+	public function now(): IQueryFunction;
 }

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -770,7 +770,7 @@ interface IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $column The column into which the value should be inserted.
-	 * @param IParameter|string $value The value that should be inserted into the column.
+	 * @param IParameter|IQueryFunction|string $value The value that should be inserted into the column.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0
@@ -1001,9 +1001,10 @@ interface IQueryBuilder {
 	public function createParameter($name);
 
 	/**
-	 * Creates a new function
+	 * Creates a new function.
 	 *
-	 * Attention: Column names inside the call have to be quoted before hand
+	 * @warning Column names inside the call have to be quoted beforehand. In most
+	 * case you can use the IFunctionBuilder instead.
 	 *
 	 * Example:
 	 * <code>


### PR DESCRIPTION
## Summary

See for example where createFunction was wrongly used: https://github.com/nextcloud/suspicious_login/pull/1065

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
