### PR TITLE
fix: don't include the mountpoints when getting fileinfo for getOwner

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1791,7 +1791,7 @@ class View {
 	 * @throws NotFoundException
 	 */
 	public function getOwner(string $path): string {
-		$info = $this->getFileInfo($path);
+		$info = $this->getFileInfo($path, false);
 		if (!$info) {
 			throw new NotFoundException($path . ' not found while trying to get owner');
 		}


### PR DESCRIPTION
No need to fetch all child mounts