### PR TITLE
feat(openmetrics): add log level

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1939,6 +1939,7 @@ return array(
     'OC\\OpenMetrics\\Exporters\\Cached' => $baseDir . '/lib/private/OpenMetrics/Exporters/Cached.php',
     'OC\\OpenMetrics\\Exporters\\FilesByType' => $baseDir . '/lib/private/OpenMetrics/Exporters/FilesByType.php',
     'OC\\OpenMetrics\\Exporters\\InstanceInfo' => $baseDir . '/lib/private/OpenMetrics/Exporters/InstanceInfo.php',
+    'OC\\OpenMetrics\\Exporters\\LogLevel' => $baseDir . '/lib/private/OpenMetrics/Exporters/LogLevel.php',
     'OC\\OpenMetrics\\Exporters\\Maintenance' => $baseDir . '/lib/private/OpenMetrics/Exporters/Maintenance.php',
     'OC\\OpenMetrics\\Exporters\\RunningJobs' => $baseDir . '/lib/private/OpenMetrics/Exporters/RunningJobs.php',
     'OC\\OpenMetrics\\Exporters\\UsersByBackend' => $baseDir . '/lib/private/OpenMetrics/Exporters/UsersByBackend.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1980,6 +1980,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\OpenMetrics\\Exporters\\Cached' => __DIR__ . '/../../..' . '/lib/private/OpenMetrics/Exporters/Cached.php',
         'OC\\OpenMetrics\\Exporters\\FilesByType' => __DIR__ . '/../../..' . '/lib/private/OpenMetrics/Exporters/FilesByType.php',
         'OC\\OpenMetrics\\Exporters\\InstanceInfo' => __DIR__ . '/../../..' . '/lib/private/OpenMetrics/Exporters/InstanceInfo.php',
+        'OC\\OpenMetrics\\Exporters\\LogLevel' => __DIR__ . '/../../..' . '/lib/private/OpenMetrics/Exporters/LogLevel.php',
         'OC\\OpenMetrics\\Exporters\\Maintenance' => __DIR__ . '/../../..' . '/lib/private/OpenMetrics/Exporters/Maintenance.php',
         'OC\\OpenMetrics\\Exporters\\RunningJobs' => __DIR__ . '/../../..' . '/lib/private/OpenMetrics/Exporters/RunningJobs.php',
         'OC\\OpenMetrics\\Exporters\\UsersByBackend' => __DIR__ . '/../../..' . '/lib/private/OpenMetrics/Exporters/UsersByBackend.php',

--- a/lib/private/OpenMetrics/ExporterManager.php
+++ b/lib/private/OpenMetrics/ExporterManager.php
@@ -37,6 +37,7 @@ class ExporterManager {
 			Exporters\AppsInfo::class,
 			Exporters\AppsCount::class,
 			Exporters\Maintenance::class,
+			Exporters\LogLevel::class,
 
 			// File exporters
 			Exporters\FilesByType::class,

--- a/lib/private/OpenMetrics/Exporters/LogLevel.php
+++ b/lib/private/OpenMetrics/Exporters/LogLevel.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\OpenMetrics\Exporters;
+
+use Generator;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\OpenMetrics\IMetricFamily;
+use OCP\OpenMetrics\Metric;
+use OCP\OpenMetrics\MetricType;
+
+class LogLevel implements IMetricFamily {
+	public function __construct(
+		private IConfig $config,
+	) {
+	}
+
+	public function name(): string {
+		return 'log_level';
+	}
+
+	public function type(): MetricType {
+		return MetricType::gauge;
+	}
+
+	public function unit(): string {
+		return '';
+	}
+
+	public function help(): string {
+		return 'Current log level (lower level means more logs)';
+	}
+
+	public function metrics(): Generator {
+		yield new Metric((int)$this->config->getSystemValue('loglevel', ILogger::WARN));
+	}
+}

--- a/tests/lib/OpenMetrics/Exporters/LogLevelTest.php
+++ b/tests/lib/OpenMetrics/Exporters/LogLevelTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\OpenMetrics\Exporters;
+
+use OC\OpenMetrics\Exporters\LogLevel;
+use OCP\IConfig;
+use OCP\OpenMetrics\IMetricFamily;
+use OCP\Server;
+
+class LogLevelTest extends ExporterTestCase {
+	protected function getExporter():IMetricFamily {
+		return new LogLevel(Server::get(IConfig::class));
+	}
+}


### PR DESCRIPTION
## Summary

Add log level to OpenMetrics endpoint.
It may be useful to know when debug log was enabled (usually results in more disk IOs)

Example: 
```
# TYPE nextcloud_log_level gauge
# HELP nextcloud_log_level Current log level (lower level means more logs)
nextcloud_log_level 2
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
