### PR TITLE
fix(search): All elements are included regardless of their keys

### DIFF
--- a/apps/systemtags/lib/Search/TagSearchProvider.php
+++ b/apps/systemtags/lib/Search/TagSearchProvider.php
@@ -112,30 +112,35 @@ class TagSearchProvider implements IProvider {
 		// prepare files results
 		return SearchResult::paginated(
 			$this->l10n->t('Tags'),
-			array_map(function (Node $result) use ($userFolder, $matchedTags, $query) {
-				// Generate thumbnail url
-				$thumbnailUrl = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', ['x' => 32, 'y' => 32, 'fileId' => $result->getId()]);
-				$path = $userFolder->getRelativePath($result->getPath());
+			[
+				...$tagResults,
+				...array_map(function (Node $result) use ($userFolder, $matchedTags, $query) {
+					$nodeId = $result->getId();
+					// Generate thumbnail url
+					$thumbnailUrl = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', ['x' => 32, 'y' => 32, 'fileId' => $nodeId]);
+					$path = $userFolder->getRelativePath($result->getPath());
 
-				// Use shortened link to centralize the various
-				// files/folder url redirection in files.View.showFile
-				$link = $this->urlGenerator->linkToRoute(
-					'files.View.showFile',
-					['fileid' => $result->getId()]
-				);
+					// Use shortened link to centralize the various
+					// files/folder url redirection in files.View.showFile
+					$link = $this->urlGenerator->linkToRoute(
+						'files.View.showFile',
+						['fileid' => $nodeId]
+					);
 
-				$searchResultEntry = new SearchResultEntry(
-					$thumbnailUrl,
-					$result->getName(),
-					$this->formatSubline($query, $matchedTags[$result->getId()]),
-					$this->urlGenerator->getAbsoluteURL($link),
-					$result->getMimetype() === FileInfo::MIMETYPE_FOLDER ? 'icon-folder' : $this->mimeTypeDetector->mimeTypeIcon($result->getMimetype())
-				);
-				$searchResultEntry->addAttribute('fileId', (string)$result->getId());
-				$searchResultEntry->addAttribute('path', $path);
-				return $searchResultEntry;
-			}, $searchResults)
-			+ $tagResults,
+					$searchResultEntry = new SearchResultEntry(
+						$thumbnailUrl,
+						$result->getName(),
+						$this->formatSubline($query, $matchedTags[$nodeId]),
+						$this->urlGenerator->getAbsoluteURL($link),
+						$result->getMimetype() === FileInfo::MIMETYPE_FOLDER
+							? 'icon-folder'
+							: $this->mimeTypeDetector->mimeTypeIcon($result->getMimetype())
+					);
+					$searchResultEntry->addAttribute('fileId', (string)$nodeId);
+					$searchResultEntry->addAttribute('path', $path);
+					return $searchResultEntry;
+				}, $searchResults)
+			],
 			$query->getCursor() + $query->getLimit()
 		);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/57730

## Summary

This ensures all elements are included regardless of their original keys.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
