### PR TITLE
fix(openmetrics): fix label names and add test for them

### DIFF
--- a/lib/private/OpenMetrics/Exporters/InstanceInfo.php
+++ b/lib/private/OpenMetrics/Exporters/InstanceInfo.php
@@ -52,8 +52,8 @@ class InstanceInfo implements IMetricFamily {
 		yield new Metric(
 			1,
 			[
-				'full version' => $this->serverVersion->getHumanVersion(),
-				'major version' => (string)$this->serverVersion->getVersion()[0],
+				'full_version' => $this->serverVersion->getHumanVersion(),
+				'major_version' => (string)$this->serverVersion->getVersion()[0],
 				'build' => $this->serverVersion->getBuild(),
 				'installed' => $this->systemConfig->getValue('installed', false) ? '1' : '0',
 			],

--- a/tests/lib/OpenMetrics/Exporters/ExporterTestCase.php
+++ b/tests/lib/OpenMetrics/Exporters/ExporterTestCase.php
@@ -25,12 +25,30 @@ abstract class ExporterTestCase extends TestCase {
 		$this->metrics = iterator_to_array($this->exporter->metrics());
 	}
 
-	public function testNotEmptyData() {
+	public function testNotEmptyData(): void {
 		$this->assertNotEmpty($this->exporter->name());
 		$this->assertNotEmpty($this->metrics);
 	}
 
-	protected function assertLabelsAre(array $expectedLabels) {
+	public function testValidNames(): void {
+		$labelNames = [];
+		foreach ($this->metrics as $metric) {
+			foreach ($metric->labels as $label => $value) {
+				$labelNames[$label] = $label;
+			}
+		}
+
+		if (empty($labelNames)) {
+			$this->expectNotToPerformAssertions();
+			return;
+		}
+		foreach ($labelNames as $label) {
+			$this->assertMatchesRegularExpression('/^[a-z_][a-z0-9_]*$/i', $label);
+		}
+
+	}
+
+	protected function assertLabelsAre(array $expectedLabels): void {
 		$foundLabels = [];
 		foreach ($this->metrics as $metric) {
 			$foundLabels[] = $metric->labels;

--- a/tests/lib/OpenMetrics/Exporters/InstanceInfoTest.php
+++ b/tests/lib/OpenMetrics/Exporters/InstanceInfoTest.php
@@ -33,8 +33,8 @@ class InstanceInfoTest extends ExporterTestCase {
 		$this->assertCount(1, $this->metrics);
 		$metric = array_pop($this->metrics);
 		$this->assertSame([
-			'full version' => '33.13.17 Gold',
-			'major version' => '33',
+			'full_version' => '33.13.17 Gold',
+			'major_version' => '33',
 			'build' => 'dev',
 			'installed' => '0',
 		], $metric->labels);


### PR DESCRIPTION
## Summary
Enforce correct formatting for labels

```
label-name = label-name-initial-char *label-name-char
label-name-char = label-name-initial-char / DIGIT
label-name-initial-char = ALPHA / "_"
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
