### PR TITLE
fix(openmetrics): Multiple exporters per app

### DIFF
--- a/lib/private/OpenMetrics/ExporterManager.php
+++ b/lib/private/OpenMetrics/ExporterManager.php
@@ -63,13 +63,18 @@ class ExporterManager {
 			if (!isset($appInfo[self::XML_ENTRY]) || !is_array($appInfo[self::XML_ENTRY])) {
 				continue;
 			}
-			foreach ($appInfo[self::XML_ENTRY] as $classname) {
-				if (isset($this->skippedClasses[$classname])) {
-					continue;
-				}
-				$exporter = $this->loadExporter($classname, $appId);
-				if ($exporter !== null) {
-					yield $exporter;
+			foreach ($appInfo[self::XML_ENTRY] as $classEntries) {
+				// When multiple exporters are specified, $classEntries will be an array, instead of a string
+				$classnames = is_array($classEntries) ? $classEntries : [$classEntries];
+
+				foreach ($classnames as $classname) {
+					if (isset($this->skippedClasses[$classname])) {
+						continue;
+					}
+					$exporter = $this->loadExporter($classname, $appId);
+					if ($exporter !== null) {
+						yield $exporter;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When apps specify multiple exporters, the ExportManager crashes:

```
Nachricht: Illegal offset type in isset or empty
Datei: /var/www/html/lib/private/OpenMetrics/ExporterManager.php
Zeile: 67

#0 /var/www/html/core/Controller/OpenMetricsController.php(80): OC\OpenMetrics\ExporterManager->export()
#1 /var/www/html/lib/public/AppFramework/Http/StreamTraversableResponse.php(46): OC\Core\Controller\OpenMetricsController->generate()
#2 /var/www/html/lib/private/AppFramework/App.php(210): OCP\AppFramework\Http\StreamTraversableResponse->callback(Object(OC\AppFramework\Http\Output))
#3 /var/www/html/lib/private/Route/Router.php(321): OC\AppFramework\App::main('OC\\Core\\Control...', 'export', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#4 /var/www/html/lib/base.php(1125): OC\Route\Router->match('/metrics')
#5 /var/www/html/index.php(25): OC::handleRequest()
#6 {main}
```

Not really sure how to easily add a test for this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
