### PR TITLE
fix(openmetrics): Allow openmetrics in info.xml

### DIFF
--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -196,6 +196,9 @@ class InfoParser {
 		if (isset($array['dependencies']['backend']) && !is_array($array['dependencies']['backend'])) {
 			$array['dependencies']['backend'] = [$array['dependencies']['backend']];
 		}
+		if (isset($array['openmetrics']['exporter']) && !is_array($array['openmetrics']['exporter'])) {
+			$array['openmetrics']['exporter'] = [$array['openmetrics']['exporter']];
+		}
 
 		// Ensure some fields are always arrays
 		if (isset($array['screenshot']) && !is_array($array['screenshot'])) {

--- a/lib/private/OpenMetrics/ExporterManager.php
+++ b/lib/private/OpenMetrics/ExporterManager.php
@@ -63,10 +63,7 @@ class ExporterManager {
 			if (!isset($appInfo[self::XML_ENTRY]) || !is_array($appInfo[self::XML_ENTRY])) {
 				continue;
 			}
-			foreach ($appInfo[self::XML_ENTRY] as $classEntries) {
-				// When multiple exporters are specified, $classEntries will be an array, instead of a string
-				$classnames = is_array($classEntries) ? $classEntries : [$classEntries];
-
+			foreach ($appInfo[self::XML_ENTRY] as $classnames) {
 				foreach ($classnames as $classname) {
 					if (isset($this->skippedClasses[$classname])) {
 						continue;

--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -67,6 +67,8 @@
                             maxOccurs="1"/>
                 <xs:element name="collaboration" type="collaboration" minOccurs="0"
                             maxOccurs="1" />
+                <xs:element name="openmetrics" type="openmetrics" minOccurs="0"
+                            maxOccurs="1" />
                 <xs:element name="sabre" type="sabre" minOccurs="0"
                             maxOccurs="1" />
                 <xs:element name="public" type="public" minOccurs="0"
@@ -408,16 +410,16 @@
 
     <xs:complexType name="settings">
         <xs:sequence>
-			<xs:element name="admin" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="admin" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="admin-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element name="personal" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element name="personal-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
-			<xs:element name="admin-delegation" type="php-class" minOccurs="0"
-						maxOccurs="unbounded"/>
-			<xs:element name="admin-delegation-section" type="php-class" minOccurs="0"
+            <xs:element name="admin-delegation" type="php-class" minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element name="admin-delegation-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -528,6 +530,18 @@
             <xs:enumeration value="autocomplete-sort"/>
         </xs:restriction>
     </xs:simpleType>
+
+        <xs:complexType name="openmetrics">
+                <xs:sequence>
+                        <xs:element name="exporter" type="openmetrics-exporter" maxOccurs="unbounded"/>
+                </xs:sequence>
+        </xs:complexType>
+
+        <xs:complexType name="openmetrics-exporter">
+                <xs:simpleContent>
+                        <xs:extension base="php-class"/>
+                </xs:simpleContent>
+        </xs:complexType>
 
     <xs:complexType name="sabre">
         <xs:sequence>

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -65,6 +65,8 @@
                             maxOccurs="1"/>
                 <xs:element name="collaboration" type="collaboration" minOccurs="0"
                             maxOccurs="1" />
+                <xs:element name="openmetrics" type="openmetrics" minOccurs="0"
+                            maxOccurs="1" />
                 <xs:element name="sabre" type="sabre" minOccurs="0"
                             maxOccurs="1" />
                 <xs:element name="trash" type="trash" minOccurs="0"
@@ -404,16 +406,16 @@
 
     <xs:complexType name="settings">
         <xs:sequence>
-			<xs:element name="admin" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="admin-section" type="php-class" minOccurs="0"
+            <xs:element name="admin" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="admin-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element name="personal" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element name="personal-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
-			<xs:element name="admin-delegation" type="php-class" minOccurs="0"
-						maxOccurs="unbounded"/>
-			<xs:element name="admin-delegation-section" type="php-class" minOccurs="0"
+            <xs:element name="admin-delegation" type="php-class" minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element name="admin-delegation-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -524,6 +526,18 @@
             <xs:enumeration value="autocomplete-sort"/>
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:complexType name="openmetrics">
+        <xs:sequence>
+            <xs:element name="exporter" type="openmetrics-exporter" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="openmetrics-exporter">
+        <xs:simpleContent>
+            <xs:extension base="php-class"/>
+        </xs:simpleContent>
+    </xs:complexType>
 
     <xs:complexType name="sabre">
         <xs:sequence>

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -91,5 +91,11 @@
 		"admin-section": [],
 		"personal": [],
 		"personal-section": []
+	},
+	"openmetrics": {
+		"exporter": [
+			"OC\\OpenMetrics\\Exporters\\ActiveSessions",
+			"OC\\OpenMetrics\\Exporters\\ActiveUsers"
+		]
 	}
 }

--- a/tests/data/app/valid-info.xml
+++ b/tests/data/app/valid-info.xml
@@ -35,4 +35,9 @@
 		<owncloud min-version="7.0.1" max-version="8" />
 		<backend>caldav</backend>
 	</dependencies>
+
+	<openmetrics>
+		<exporter>OC\OpenMetrics\Exporters\ActiveSessions</exporter>
+		<exporter>OC\OpenMetrics\Exporters\ActiveUsers</exporter>
+	</openmetrics>
 </info>

--- a/tests/data/app/various-single-item.json
+++ b/tests/data/app/various-single-item.json
@@ -46,5 +46,10 @@
 		"personal-section": []
 	},
 	"two-factor-providers": [],
-	"types": []
+	"types": [],
+	"openmetrics": {
+		"exporter": [
+			"OC\\OpenMetrics\\Exporters\\ActiveUsers"
+		]
+	}
 }

--- a/tests/data/app/various-single-item.xml
+++ b/tests/data/app/various-single-item.xml
@@ -19,4 +19,8 @@
 	<dependencies>
 		<nextcloud min-version="16" max-version="16"/>
 	</dependencies>
+
+	<openmetrics>
+		<exporter>OC\OpenMetrics\Exporters\ActiveUsers</exporter>
+	</openmetrics>
 </info>

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -47,8 +47,6 @@ class InfoParserTest extends TestCase {
 		return [
 			['expected-info.json', 'valid-info.xml'],
 			[null, 'invalid-info.xml'],
-			['expected-info.json', 'valid-info.xml'],
-			[null, 'invalid-info.xml'],
 			['navigation-one-item.json', 'navigation-one-item.xml'],
 			['navigation-two-items.json', 'navigation-two-items.xml'],
 			['various-single-item.json', 'various-single-item.xml'],

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -132,8 +132,8 @@ class InfoXmlTest extends TestCase {
 			}
 		}
 
-		if (isset($appInfo['openmetrics'])) {
-			foreach ($appInfo['openmetrics'] as $class) {
+		if (isset($appInfo['openmetrics']['exporter'])) {
+			foreach ($appInfo['openmetrics']['exporter'] as $class) {
 				$this->assertTrue(class_exists($class), 'Asserting exporter "' . $class . '"exists');
 				$exporter = Server::get($class);
 				$this->assertInstanceOf($class, $exporter);


### PR DESCRIPTION
* Resolves: #57766 

## Summary
- Validate info.xml
- Make sure a single metrics is also parsed as an array

---

- [ ] After merge upstream the info.xsd to the appstore and make sure it gets deployed

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
