### PR TITLE
feat(contacts): support federated users/groups search when adding team members

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -11,6 +11,7 @@ namespace OCA\Files_Sharing\Controller;
 use Generator;
 use OC\Collaboration\Collaborators\SearchResult;
 use OC\Share\Share;
+use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\ResponseDefinitions;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
@@ -72,6 +73,7 @@ class ShareesAPIController extends OCSController {
 		protected IURLGenerator $urlGenerator,
 		protected IManager $shareManager,
 		protected ISearch $collaboratorSearch,
+		protected FederatedShareProvider $federatedShareProvider,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -141,6 +143,20 @@ class ShareesAPIController extends OCSController {
 			if ($this->shareManager->shareProviderExists(IShare::TYPE_ROOM)) {
 				$shareTypes[] = IShare::TYPE_ROOM;
 			}
+		} elseif ($itemType === 'contacts') {
+			if ($this->shareManager->allowGroupSharing()) {
+				$shareTypes[] = IShare::TYPE_GROUP;
+			}
+
+			if ($this->federatedShareProvider->isOutgoingServer2serverShareEnabled()) {
+				$shareTypes[] = IShare::TYPE_REMOTE;
+			}
+
+			if ($this->federatedShareProvider->isOutgoingServer2serverGroupShareEnabled()) {
+				$shareTypes[] = IShare::TYPE_REMOTE_GROUP;
+			}
+
+			$shareTypes[] = IShare::TYPE_EMAIL;
 		} else {
 			if ($this->shareManager->allowGroupSharing()) {
 				$shareTypes[] = IShare::TYPE_GROUP;

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -143,17 +143,13 @@ class ShareesAPIController extends OCSController {
 			if ($this->shareManager->shareProviderExists(IShare::TYPE_ROOM)) {
 				$shareTypes[] = IShare::TYPE_ROOM;
 			}
-		} elseif ($itemType === 'contacts') {
+		} elseif ($itemType === 'teams') {
 			if ($this->shareManager->allowGroupSharing()) {
 				$shareTypes[] = IShare::TYPE_GROUP;
 			}
 
 			if ($this->federatedShareProvider->isOutgoingServer2serverShareEnabled()) {
 				$shareTypes[] = IShare::TYPE_REMOTE;
-			}
-
-			if ($this->federatedShareProvider->isOutgoingServer2serverGroupShareEnabled()) {
-				$shareTypes[] = IShare::TYPE_REMOTE_GROUP;
 			}
 
 			$shareTypes[] = IShare::TYPE_EMAIL;

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\Files_Sharing\Tests\Controller;
 
+use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\Controller\ShareesAPIController;
 use OCA\Files_Sharing\Tests\TestCase;
 use OCP\AppFramework\Http\DataResponse;
@@ -46,6 +47,9 @@ class ShareesAPIControllerTest extends TestCase {
 	/** @var IConfig|MockObject */
 	protected $config;
 
+	/** @var FederatedShareProvider|MockObject */
+	protected $federatedShareProvider;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -58,6 +62,7 @@ class ShareesAPIControllerTest extends TestCase {
 		$urlGeneratorMock = $this->createMock(IURLGenerator::class);
 
 		$this->collaboratorSearch = $this->createMock(ISearch::class);
+		$this->federatedShareProvider = $this->createMock(FederatedShareProvider::class);
 
 		$this->sharees = new ShareesAPIController(
 			'files_sharing',
@@ -66,7 +71,8 @@ class ShareesAPIControllerTest extends TestCase {
 			$this->config,
 			$urlGeneratorMock,
 			$this->shareManager,
-			$this->collaboratorSearch
+			$this->collaboratorSearch,
+			$this->federatedShareProvider
 		);
 	}
 
@@ -260,7 +266,8 @@ class ShareesAPIControllerTest extends TestCase {
 				$config,
 				$urlGenerator,
 				$this->shareManager,
-				$this->collaboratorSearch
+				$this->collaboratorSearch,
+				$this->federatedShareProvider
 			])
 			->onlyMethods(['isRemoteSharingAllowed', 'isRemoteGroupSharingAllowed'])
 			->getMock();
@@ -359,7 +366,8 @@ class ShareesAPIControllerTest extends TestCase {
 				$config,
 				$urlGenerator,
 				$this->shareManager,
-				$this->collaboratorSearch
+				$this->collaboratorSearch,
+				$this->federatedShareProvider
 			])
 			->onlyMethods(['isRemoteSharingAllowed'])
 			->getMock();


### PR DESCRIPTION
* Related to: nextcloud/circles#2303

## Summary
Adds possibility to search for federated users (accounts from other instances) and federated groups when adding members to a team in the Contacts app.

## Context
* This PR implements the backend portion. Frontend implementation: nextcloud/contacts#5037.

When searching for members to add to a team in the Contacts app, a GET request is made to `ocs/v2.php/apps/files_sharing/api/v1/sharees` which in turn calls `files_sharing/lib/Controller/ShareesAPIController::search()`.

This is the same endpoint used by the Files app when searching to add an external share (used as a reference here, as pointed out in the issue).

## Changes
- Modified `files_sharing/lib/Controller/ShareesAPIController::search()` to handle `contacts` itemType, allowing `TYPE_REMOTE` and `TYPE_REMOTE_GROUP` searches
- Injected `FederatedShareProvider` into the controller constructor to check federation settings
- Called federation check methods directly via `FederatedShareProvider`
  - The wrapper methods `isRemoteSharingAllowed()` and `isRemoteGroupSharingAllowed()` require a share backend implementation
  - They call [`isShareTypeAllowed()`](https://github.com/nextcloud/server/blob/master/apps/files_sharing/lib/ShareBackend/File.php#L166), which ultimately invokes the same `FederatedShareProvider` methods used in this implementation (`isOutgoingServer2serverShareEnabled()` and `isOutgoingServer2serverGroupShareEnabled()`)
  - Since contacts doesn't have a registered share backend (similar to calendar), this direct approach was taken to achieve same functionality

## Note
When testing locally, the federated search functionality works correctly (remote users appear in search results). However, when attempting to actually add the remote member to a team, an error occurs indicating the remote instance is unreachable. I believe this is expected behavior when running locally, as a similar error occurs when trying to add an external share in the Files app using the same remote account, which is the reference implementation mentioned in the issue and was not modified in this PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
