### PR TITLE
test(Session): Fix CryptoWrappingTest to verify real session wrapping logic + expand tests

### DIFF
--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -33,7 +33,7 @@ class CryptoSessionDataTest extends Session {
 	private const TAMPERED_BLOB = 'garbage-data';
 	private const MALFORMED_JSON_BLOB = '{not:valid:json}';
 
-	protected ICrypto|MockObject $crypto;
+	protected ICrypto&MockObject $crypto;
 	protected ISession $session;
 
 	protected function setUp(): void {
@@ -171,7 +171,7 @@ class CryptoSessionDataTest extends Session {
 		});
 		$crypto->method('decrypt')->willReturnCallback(function ($input, $passphrase = null) {
 			// Only successfully decrypt if the embedded passphrase matches
-			if (strpos($input, $passphrase . '#') === 0 && strrpos($input, '#' . $passphrase) === strlen($input) - strlen('#' . $passphrase)) {
+			if (str_starts_with($input, $passphrase . '#') && str_ends_with($input, '#' . $passphrase)) {
 				// Strip off passphrase markers and return the "decrypted" string
 				return substr($input, strlen($passphrase . '#'), -strlen('#' . $passphrase));
 			}

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -13,6 +13,11 @@ use OC\Session\Memory;
 use OCP\ISession;
 use OCP\Security\ICrypto;
 
+/**
+ * Test case for OC\Session\CryptoSessionData using in-memory session storage.
+ * Reuses session contract tests but verifies they hold with encrypted storage 
+ * (i.e., session values are encrypted/decrypted transparently).
+ */
 class CryptoSessionDataTest extends Session {
 	/** @var \PHPUnit\Framework\MockObject\MockObject|ICrypto */
 	protected $crypto;

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -43,10 +43,10 @@ class CryptoSessionDataTest extends Session {
 		$this->crypto = $this->createMock(ICrypto::class);
 
 		$this->crypto->method('encrypt')->willReturnCallback(
-			fn($input) => '#' . $input . '#'
+			fn ($input) => '#' . $input . '#'
 		);
 		$this->crypto->method('decrypt')->willReturnCallback(
-			fn($input) => ($input === '' || strlen($input) < 2) ? '' : substr($input, 1, -1)
+			fn ($input) => ($input === '' || strlen($input) < 2) ? '' : substr($input, 1, -1)
 		);
 
 		$this->session = new Memory();
@@ -59,7 +59,7 @@ class CryptoSessionDataTest extends Session {
 	public function testSessionDataStoredEncrypted(): void {
 		$keyName = 'secret';
 		$unencryptedValue = 'superSecretValue123';
-		
+
 		$this->instance->set($keyName, $unencryptedValue);
 		$this->instance->close();
 
@@ -89,11 +89,11 @@ class CryptoSessionDataTest extends Session {
 
 	public static function roundTripValuesProvider(): array {
 		return [
-			'simple string'  => ['foo', 'bar'],
-			'unicode value'  => ['uni', "héllo 🌍"],
-			'large value'    => ['big', str_repeat('x', 4096)],
-			'large array'    => ['thousand', json_encode(self::makeLargeArray())],
-			'empty string'   => ['', ''],
+			'simple string' => ['foo', 'bar'],
+			'unicode value' => ['uni', "héllo 🌍"],
+			'large value' => ['big', str_repeat('x', 4096)],
+			'large array' => ['thousand', json_encode(self::makeLargeArray())],
+			'empty string' => ['', ''],
 		];
 	}
 
@@ -166,11 +166,11 @@ class CryptoSessionDataTest extends Session {
 	private function createPassphraseAwareCryptoMock(): ICrypto {
 		$crypto = $this->createMock(ICrypto::class);
 
-		$crypto->method('encrypt')->willReturnCallback(function($plain, $passphrase = null) {
+		$crypto->method('encrypt')->willReturnCallback(function ($plain, $passphrase = null) {
 			// Set up: store a value with the passphrase embedded (fake encryption)
 			return $passphrase . '#' . $plain . '#' . $passphrase;
 		});
-		$crypto->method('decrypt')->willReturnCallback(function($input, $passphrase = null) {
+		$crypto->method('decrypt')->willReturnCallback(function ($input, $passphrase = null) {
 			// Only successfully decrypt if the embedded passphrase matches
 			if (strpos($input, $passphrase . '#') === 0 && strrpos($input, '#' . $passphrase) === strlen($input) - strlen('#' . $passphrase)) {
 				// Strip off passphrase markers and return the "decrypted" string

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -90,7 +90,7 @@ class CryptoSessionDataTest extends Session {
 	public static function roundTripValuesProvider(): array {
 		return [
 			'simple string' => ['foo', 'bar'],
-			'unicode value' => ['uni', "héllo 🌍"],
+			'unicode value' => ['uni', 'héllo 🌍'],
 			'large value' => ['big', str_repeat('x', 4096)],
 			'large array' => ['thousand', json_encode(self::makeLargeArray())],
 			'empty string' => ['', ''],

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -45,7 +45,6 @@ class CryptoSessionDataTest extends Session {
 	public function testSessionDataStoredEncrypted(): void {
 		$keyName = 'secret';
 		$unencryptedValue = 'superSecretValue123';
-		$encryptedValue = $this->crypto->encrypt($unencryptedValue);
 		
 		$this->instance->set('secret', 'superSecretValue123');
 		$this->instance->close();

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -12,7 +12,6 @@ use OC\Session\CryptoSessionData;
 use OC\Session\Memory;
 use OCP\ISession;
 use OCP\Security\ICrypto;
-use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -12,6 +12,8 @@ use OC\Session\CryptoSessionData;
 use OC\Session\Memory;
 use OCP\ISession;
 use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test case for OC\Session\CryptoSessionData using in-memory session storage.
@@ -19,31 +21,134 @@ use OCP\Security\ICrypto;
  * (i.e., session values are encrypted/decrypted transparently).
  */
 class CryptoSessionDataTest extends Session {
-	/** @var \PHPUnit\Framework\MockObject\MockObject|ICrypto */
-	protected $crypto;
-
-	/** @var ISession */
-	protected $wrappedSession;
+	protected ICrypto|MockObject $crypto;
+	protected ISession $session;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->wrappedSession = new Memory();
-		$this->crypto = $this->createMock(ICrypto::class);
-		$this->crypto->expects($this->any())
-			->method('encrypt')
-			->willReturnCallback(function ($input) {
-				return '#' . $input . '#';
-			});
-		$this->crypto->expects($this->any())
-			->method('decrypt')
-			->willReturnCallback(function ($input) {
-				if ($input === '') {
-					return '';
-				}
-				return substr($input, 1, -1);
-			});
+		$this->session = new Memory();
 
-		$this->instance = new CryptoSessionData($this->wrappedSession, $this->crypto, 'PASS');
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->crypto->method('encrypt')
+			->willReturnCallback(fn($input) =>
+				'#' . $input . '#');
+		$this->crypto->method('decrypt')
+			->willReturnCallback(fn($input) =>
+				($input === '' || strlen($input) < 2) ? '' : substr($input, 1, -1));
+
+		$this->instance = new CryptoSessionData($this->session, $this->crypto, 'PASS');
+	}
+
+	/* Basic API conformity/contract tests are in parent class; these are crypto specific pre-wrapper additions */
+
+	public function testSessionDataStoredEncrypted(): void {
+		$keyName = 'secret';
+		$unencryptedValue = 'superSecretValue123';
+		$encryptedValue = $this->crypto->encrypt($unencryptedValue);
+		
+		$this->instance->set('secret', 'superSecretValue123');
+		$this->instance->close();
+
+		$unencryptedSessionDataJson = json_encode(["$keyName" => "$unencryptedValue"]);
+		$expectedEncryptedSessionDataBlob = $this->crypto->encrypt($unencryptedSessionDataJson, 'PASS');
+
+		// Retrieve the CryptoSessionData blob directly from lower level session layer to guarantee bypass of crypto layer
+		$encryptedSessionDataBlob = $this->session->get('encrypted_session_data'); // should contain raw encrypted blob not the decrypted data
+		// Definitely encrypted?
+		$this->assertStringStartsWith('#', $encryptedSessionDataBlob); // Must match mocked crypto->encrypt()
+		$this->assertStringEndsWith('#', $encryptedSessionDataBlob); // ditto
+		$this->assertFalse($expectedEncryptedSessionDataBlob === $unencryptedSessionDataJson);
+		// Expected before/after?
+		$this->assertSame($expectedEncryptedSessionDataBlob, $encryptedSessionDataBlob);
+	}
+
+	public function testLargeAndUnicodeValuesRoundTrip() {
+		$unicodeValue = "héllo 🌍";
+		$largeValue = str_repeat('x', 4096);
+		$this->instance->set('unicode', $unicodeValue);
+		$this->instance->set('big', $largeValue);
+		$this->instance->close();
+		// Simulate reload 
+		$instance2 = new CryptoSessionData($this->session, $this->crypto, 'PASS');
+		$this->assertSame($unicodeValue, $instance2->get('unicode'));
+		$this->assertSame($largeValue, $instance2->get('big'));
+	}
+
+	public function testLargeArrayRoundTrip() {
+		$bigArray = [];
+		for ($i = 0; $i < 1000; $i++) {
+			$bigArray["key$i"] = "val$i";
+		}
+		$this->instance->set('thousand', json_encode($bigArray));
+		$this->instance->close();
+
+		$instance2 = new CryptoSessionData($this->session, $this->crypto, 'PASS');
+		$this->assertSame(json_encode($bigArray), $instance2->get('thousand'));
+	}
+
+	public function testRemovedValueIsGoneAfterClose() {
+		$this->instance->set('temp', 'gone soon');
+		$this->instance->remove('temp');
+		$this->instance->close();
+
+		$instance2 = new CryptoSessionData($this->session, $this->crypto, 'PASS');
+		$this->assertNull($instance2->get('temp'));
+	}
+
+	public function testTamperedBlobReturnsNull() {
+		$this->instance->set('foo', 'bar');
+		$this->instance->close();
+		// Tamper the lower level blob
+		$this->session->set('encrypted_session_data', 'garbage-data');
+
+		$instance2 = new CryptoSessionData($this->session, $this->crypto, 'PASS');
+		$this->assertNull($instance2->get('foo'));
+		$this->assertNull($instance2->get('notfoo'));
+	}
+
+	public function testWrongPassphraseGivesNoAccess() {
+		// Override ICrypto mock/stubs for this test only
+		$crypto = $this->createMock(ICrypto::class);
+		$crypto->method('encrypt')->willReturnCallback(function($plain, $passphrase = null) {
+			// Set up: store a value with the passphrase embedded (fake encryption)
+			return $passphrase . '#' . $plain . '#' . $passphrase;
+		});
+		$crypto->method('decrypt')->willReturnCallback(function($input, $passphrase = null) {
+			// Only successfully decrypt if the embedded passphrase matches
+			if (strpos($input, $passphrase . '#') === 0 && strrpos($input, '#' . $passphrase) === strlen($input) - strlen('#' . $passphrase)) {
+				// Strip off passphrase markers and return the "decrypted" string
+				return substr($input, strlen($passphrase . '#'), -strlen('#' . $passphrase));
+			}
+			// Fail to decrypt
+			return '';
+		});
+
+		// Override main instance with local ISession and local ICrypto mock/stubs
+		$session = new Memory();
+		$instance = new CryptoSessionData($session, $crypto, 'PASS');
+
+		$instance->set('secure', 'yes');
+		$instance->close();
+
+		$instance2 = new CryptoSessionData($session, $crypto, 'DIFFERENT');
+		$this->assertNull($instance2->get('secure'));
+		$this->assertFalse($instance2->exists('secure'));
+	}
+
+	public function testEmptyKeyValue() {
+		$this->instance->set('', '');
+		$this->instance->close();
+		$instance2 = new CryptoSessionData($this->session, $this->crypto, 'PASS');
+		$this->assertSame('', $instance2->get(''));
+	}
+
+	public function testDoubleCloseDoesNotCorrupt() {
+		$this->instance->set('safe', 'value');
+		$this->instance->close();
+		$blobBefore = $this->session->get('encrypted_session_data');
+		$this->instance->close(); // Should do nothing harmful
+		$blobAfter = $this->session->get('encrypted_session_data');
+		$this->assertSame($blobBefore, $blobAfter);
 	}
 }

--- a/tests/lib/Session/CryptoWrappingTest.php
+++ b/tests/lib/Session/CryptoWrappingTest.php
@@ -39,9 +39,9 @@ class CryptoWrappingTest extends TestCase {
 	private const GENERATED_PASSPHRASE = 'generatedPassphrase';
 	private const SERVER_PROTOCOL = 'https';
 
-	protected ICrypto|MockObject $crypto;
-	protected ISecureRandom|MockObject $random;
-	protected IRequest|MockObject $request;
+	protected ICrypto&MockObject $crypto;
+	protected ISecureRandom&MockObject $random;
+	protected IRequest&MockObject $request;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Session/CryptoWrappingTest.php
+++ b/tests/lib/Session/CryptoWrappingTest.php
@@ -8,8 +8,8 @@
 
 namespace Test\Session;
 
-use OC\Session\CryptoWrapper;
 use OC\Session\CryptoSessionData;
+use OC\Session\CryptoWrapper;
 use OC\Session\Memory;
 use OCP\IRequest;
 use OCP\Security\ICrypto;
@@ -38,7 +38,7 @@ class CryptoWrappingTest extends TestCase {
 	private const COOKIE_PASSPHRASE = 'cookiePassphrase';
 	private const GENERATED_PASSPHRASE = 'generatedPassphrase';
 	private const SERVER_PROTOCOL = 'https';
-	
+
 	protected ICrypto|MockObject $crypto;
 	protected ISecureRandom|MockObject $random;
 	protected IRequest|MockObject $request;
@@ -134,10 +134,10 @@ class CryptoWrappingTest extends TestCase {
 		$expectedPassphrase = str_pad(self::GENERATED_PASSPHRASE, 128, '_' . __FUNCTION__, STR_PAD_RIGHT);
 
 		$this->crypto->method('encrypt')->willReturnCallback(
-			fn($input) => '#' . $input . '#'
+			fn ($input) => '#' . $input . '#'
 		);
 		$this->crypto->method('decrypt')->willReturnCallback(
-			fn($input) => ($input === '' || strlen($input) < 2) ? '' : substr($input, 1, -1)
+			fn ($input) => ($input === '' || strlen($input) < 2) ? '' : substr($input, 1, -1)
 		);
 
 		$this->random->method('generate')->with(128)->willReturn($expectedPassphrase);
@@ -145,9 +145,9 @@ class CryptoWrappingTest extends TestCase {
 		$this->request->method('getServerProtocol')->willReturn(self::SERVER_PROTOCOL);
 
 		$session = new Memory();
-		$cryptoWrapper = new CryptoWrapper($this->crypto, $this->random, $this->request);		
+		$cryptoWrapper = new CryptoWrapper($this->crypto, $this->random, $this->request);
 		$wrappedSession = $cryptoWrapper->wrapSession($session);
-	
+
 		$wrappedSession->set($keyName, $unencryptedValue);
 		$wrappedSession->close();
 

--- a/tests/lib/Session/CryptoWrappingTest.php
+++ b/tests/lib/Session/CryptoWrappingTest.php
@@ -56,5 +56,13 @@ class CryptoWrappingTest extends TestCase {
 
 		$this->assertTrue($this->instance->exists($keyName));
 		$this->assertSame($unencryptedValue, $this->instance->get($keyName));
+
+		// Trigger flush so encrypted_session_data blob gets written out
+		$this->instance->close(); // or unset($this->instance)
+
+		// Confirm data is truly encrypted
+		$encryptedSessionDataBlob = $this->session->get('encrypted_session_data'); // should contain raw encrypted blob not the decrypted data
+		$expectedEncryptedSessionDataBlob = $this->crypto->encrypt(json_encode(["$keyName" => "$unencryptedValue"]), $this->passphrase);
+		$this->assertSame($expectedEncryptedSessionDataBlob, $encryptedSessionDataBlob);
 	}
 }

--- a/tests/lib/Session/CryptoWrappingTest.php
+++ b/tests/lib/Session/CryptoWrappingTest.php
@@ -13,6 +13,12 @@ use OCP\ISession;
 use OCP\Security\ICrypto;
 use Test\TestCase;
 
+/**
+ * Test cases for the internal logic of OC\Session\CryptoSessionData.
+ * Focuses on correct encryption/decryption of session data and wrapping behavior.
+ *
+ * TODO: Should really be testing CryptoWrapper!
+ */
 class CryptoWrappingTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject|ICrypto */
 	protected $crypto;

--- a/tests/lib/Session/MemoryTest.php
+++ b/tests/lib/Session/MemoryTest.php
@@ -11,6 +11,10 @@ namespace Test\Session;
 use OC\Session\Memory;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 
+/**
+ * Concrete test case for OC\Session\Memory (in-memory session storage).
+ * Reuses session contract tests and adds in-memory specific assertions.
+ */
 class MemoryTest extends Session {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Session/Session.php
+++ b/tests/lib/Session/Session.php
@@ -8,6 +8,11 @@
 
 namespace Test\Session;
 
+/**
+ * Abstract base test class defining the contract for session storage backends.
+ * Contains generic tests for set/get/remove/clear/array session API compliance.
+ * Extend this class to provide $this->instance and validate custom session implementations.
+ */
 abstract class Session extends \Test\TestCase {
 	/**
 	 * @var \OC\Session\Session


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

* Fixes `CryptoWrappingTest` to exercise and verify real session wrapping logic and integration, replacing stub/mock-only testing with true functional coverage.
* Reorients `CryptoWrappingTest` to focus exclusively on testing `CryptoWrapper` itself rather than `CryptoSessionData`, which already has its own test class.
* Expands `CryptoWrappingTest` to cover more code paths within `CryptoWrapper` and `CryptoSessionData`.

Follow-ups:

- [ ] Rename CryptoWrappingTest -> CryptoWrapperTest
- [x] Add better coverage of CryptoWrapper logic
- [x] Assess coverage of CryptoSessionData logic
- [x] Asess coverage of Internal session class

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
