### PR TITLE
fix(FileDisplayResponse): return 404 if not found

### DIFF
--- a/lib/public/Files/SimpleFS/InMemoryFile.php
+++ b/lib/public/Files/SimpleFS/InMemoryFile.php
@@ -105,7 +105,7 @@ class InMemoryFile implements ISimpleFile {
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * @inheritDoc
 	 * @since 24.0.0
 	 */
 	public function getExtension(): string {
@@ -113,15 +113,15 @@ class InMemoryFile implements ISimpleFile {
 	}
 
 	/**
-	 * Stream reading is unsupported for in memory files.
-	 *
-	 * @throws NotPermittedException
+	 * @inheritDoc
 	 * @since 16.0.0
+	 * @since 34.0.0 - return in-memory stream of contents
 	 */
 	public function read() {
-		throw new NotPermittedException(
-			'Stream reading is unsupported for in memory files'
-		);
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, $this->contents);
+		rewind($stream);
+		return $stream;
 	}
 
 	/**

--- a/tests/lib/Files/SimpleFS/InMemoryFileTest.php
+++ b/tests/lib/Files/SimpleFS/InMemoryFileTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-only
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace Test\File\SimpleFS;
@@ -14,7 +14,7 @@ use OCP\Files\SimpleFS\InMemoryFile;
 use Test\TestCase;
 
 /**
- * This class provide test casesf or the InMemoryFile.
+ * This class provide test cases for the InMemoryFile.
  *
  * @package Test\File\SimpleFS
  */
@@ -106,13 +106,13 @@ class InMemoryFileTest extends TestCase {
 
 
 	/**
-	 * Asserts that read() raises an NotPermittedException.
-	 *
-	 * @return void
+	 * Ensure that read() returns a stream with the same contents than the original file.
 	 */
 	public function testRead(): void {
-		self::expectException(NotPermittedException::class);
-		$this->testPdf->read();
+		self::assertEquals(
+			file_get_contents(__DIR__ . '/../../../data/test.pdf'),
+			stream_get_contents($this->testPdf->read()),
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
If the linked file is not found (anymore) return proper 404 status code.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
