### PR TITLE
chore: remove X from social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Enterprise? Public Sector or Education user? You may want to have a look into [*
 ## Get in touch 💬
 
 * [📋 Forum](https://help.nextcloud.com)
+* [🦋 Bluesky](https://bsky.app/profile/nextcloud.bsky.social)
 * [👥 Facebook](https://www.facebook.com/nextclouders)
-* [🐣 Twitter](https://twitter.com/Nextclouders)
 * [🐘 Mastodon](https://mastodon.xyz/@nextcloud)
 
 You can also [get support for Nextcloud](https://nextcloud.com/support)!

--- a/apps/settings/templates/settings/personal/development.notice.php
+++ b/apps/settings/templates/settings/personal/development.notice.php
@@ -33,20 +33,17 @@
 		<?php print_unescaped(str_replace(
 			[
 				'{facebookimage}',
-				'{ximage}',
 				'{blueskyimage}',
 				'{mastodonimage}',
 				'{rssimage}',
 				'{mailimage}',
 				'{facebookopen}',
-				'{xopen}',
 				'{blueskyopen}',
 				'{mastodonopen}',
 				'{rssopen}',
 				'{newsletteropen}',
 				'{linkclose}',
 				'{facebooktext}',
-				'{xtext}',
 				'{blueskytext}',
 				'{mastodontext}',
 				'{rsstext}',
@@ -54,20 +51,17 @@
 			],
 			[
 				image_path('core', 'facebook-light.svg'),
-				image_path('core', 'x-dark.svg'),
 				image_path('core', 'bluesky-light.svg'),
 				image_path('core', 'mastodon-light.svg'),
 				image_path('core', 'rss.svg'),
 				image_path('core', 'mail.svg'),
 				'<a target="_blank" rel="noreferrer noopener" href="https://www.facebook.com/Nextclouders/">',
-				'<a target="_blank" rel="noreferrer noopener" href="https://x.com/nextclouders">',
 				'<a target="_blank" rel="noreferrer noopener" href="https://bsky.app/profile/nextcloud.bsky.social">',
 				'<a target="_blank" rel="noreferrer noopener" href="https://mastodon.xyz/@nextcloud">',
 				'<a target="_blank" rel="noreferrer noopener" href="https://nextcloud.com/blog/">',
 				'<a target="_blank" rel="noreferrer noopener" href="https://newsletter.nextcloud.com/?p=subscribe&amp;id=1">',
 				'</a>',
 				$l->t('Like our Facebook page'),
-				$l->t('Follow us on X'),
 				$l->t('Follow us on Bluesky'),
 				$l->t('Follow us on Mastodon'),
 				$l->t('Check out our blog'),
@@ -75,7 +69,6 @@
 
 			],
 			'{facebookopen}<img width="50" height="50" src="{facebookimage}" title="{facebooktext}" alt="{facebooktext}">{linkclose}
-			{xopen}<img width="50" height="50" src="{ximage}" style="filter: var(--background-invert-if-dark);" title="{xtext}" alt="{xtext}">{linkclose}
 			{blueskyopen}<img width="50" height="50" src="{blueskyimage}" title="{blueskytext}" alt="{blueskytext}">{linkclose}
 			{mastodonopen}<img width="50" height="50" src="{mastodonimage}" title="{mastodontext}" alt="{mastodontext}">{linkclose}
 			{rssopen}<img width="50" height="50" src="{rssimage}" title="{rsstext}" alt="{rsstext}">{linkclose}


### PR DESCRIPTION
* resolves: https://github.com/nextcloud/server/issues/57753

## Summary
Nextcloud does not use X anymore.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
