### PR TITLE
fix(openmetrics): remove superfluous empty lines

### DIFF
--- a/core/Controller/OpenMetricsController.php
+++ b/core/Controller/OpenMetricsController.php
@@ -87,7 +87,6 @@ class OpenMetricsController extends Controller {
 			# UNIT nextcloud_exporter_duration seconds
 			# HELP nextcloud_exporter_duration Exporter run time
 			nextcloud_exporter_duration $elapsed
-
 			# EOF
 
 			SUMMARY;
@@ -112,7 +111,6 @@ class OpenMetricsController extends Controller {
 			}
 			$output .= "\n";
 		}
-		$output .= "\n";
 
 		return $output;
 	}

--- a/core/Controller/OpenMetricsController.php
+++ b/core/Controller/OpenMetricsController.php
@@ -83,10 +83,10 @@ class OpenMetricsController extends Controller {
 
 		$elapsed = (string)(microtime(true) - $_SERVER['REQUEST_TIME_FLOAT']);
 		yield <<<SUMMARY
-			# TYPE nextcloud_exporter_duration gauge
-			# UNIT nextcloud_exporter_duration seconds
-			# HELP nextcloud_exporter_duration Exporter run time
-			nextcloud_exporter_duration $elapsed
+			# TYPE nextcloud_exporter_run_seconds gauge
+			# UNIT nextcloud_exporter_run_seconds seconds
+			# HELP nextcloud_exporter_run_seconds Exporter run time
+			nextcloud_exporter_run_seconds $elapsed
 			# EOF
 
 			SUMMARY;

--- a/lib/private/OpenMetrics/Exporters/AppsCount.php
+++ b/lib/private/OpenMetrics/Exporters/AppsCount.php
@@ -27,7 +27,7 @@ class AppsCount implements IMetricFamily {
 
 	#[Override]
 	public function name(): string {
-		return 'apps_count';
+		return 'installed_applications';
 	}
 
 	#[Override]
@@ -42,7 +42,7 @@ class AppsCount implements IMetricFamily {
 
 	#[Override]
 	public function help(): string {
-		return 'Number of apps in Nextcloud';
+		return 'Number of applications installed in Nextcloud';
 	}
 
 	#[Override]

--- a/lib/private/OpenMetrics/Exporters/RunningJobs.php
+++ b/lib/private/OpenMetrics/Exporters/RunningJobs.php
@@ -27,7 +27,7 @@ class RunningJobs implements IMetricFamily {
 
 	#[Override]
 	public function name(): string {
-		return 'jobs_running';
+		return 'running_jobs';
 	}
 
 	#[Override]

--- a/tests/Core/Controller/OpenMetricsControllerTest.php
+++ b/tests/Core/Controller/OpenMetricsControllerTest.php
@@ -54,10 +54,10 @@ class OpenMetricsControllerTest extends TestCase {
 		$this->assertEquals('200', $response->getStatus());
 		$this->assertEquals('application/openmetrics-text; version=1.0.0; charset=utf-8', $response->getHeaders()['Content-Type']);
 		$expected = <<<EXPECTED
-			# TYPE nextcloud_exporter_duration gauge
-			# UNIT nextcloud_exporter_duration seconds
-			# HELP nextcloud_exporter_duration Exporter run time
-			nextcloud_exporter_duration %f
+			# TYPE nextcloud_exporter_run_seconds gauge
+			# UNIT nextcloud_exporter_run_seconds seconds
+			# HELP nextcloud_exporter_run_seconds Exporter run time
+			nextcloud_exporter_run_seconds %f
 			# EOF
 
 			EXPECTED;

--- a/tests/Core/Controller/OpenMetricsControllerTest.php
+++ b/tests/Core/Controller/OpenMetricsControllerTest.php
@@ -58,7 +58,6 @@ class OpenMetricsControllerTest extends TestCase {
 			# UNIT nextcloud_exporter_duration seconds
 			# HELP nextcloud_exporter_duration Exporter run time
 			nextcloud_exporter_duration %f
-
 			# EOF
 
 			EXPECTED;

--- a/tests/Core/Controller/OpenMetricsControllerTest.php
+++ b/tests/Core/Controller/OpenMetricsControllerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\Controller;
 
+use Generator;
 use OC\Core\Controller\OpenMetricsController;
 use OC\OpenMetrics\ExporterManager;
 use OCP\AppFramework\Http\IOutput;
@@ -16,6 +17,9 @@ use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StreamTraversableResponse;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\OpenMetrics\IMetricFamily;
+use OCP\OpenMetrics\Metric;
+use OCP\OpenMetrics\MetricType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -34,10 +38,23 @@ class OpenMetricsControllerTest extends TestCase {
 			->willReturn('192.168.1.1');
 		$this->config = $this->createMock(IConfig::class);
 		$this->exporterManager = $this->createMock(ExporterManager::class);
+		$this->exporterManager->method('export')->willReturnCallback([$this, 'getFakeMetrics']);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->controller = new OpenMetricsController('core', $this->request, $this->config, $this->exporterManager, $this->logger);
 	}
 
+	public function getFakeMetrics(): Generator {
+		$metric = $this->createMock(IMetricFamily::class);
+		$metric->method('type')->willReturn(MetricType::gauge);
+		$metric->method('unit')->willReturn('fake');
+		$metric->method('name')->willReturn('fake_count');
+		$metric->method('help')->willReturn('A fake count used for tests');
+		$metric->method('metrics')->willReturnCallback(function () {
+			yield new Metric(42, ['type' => 'used']);
+			yield new Metric(24, ['type' => 'unused']);
+		});
+		yield $metric;
+	}
 	public function testGetMetrics(): void {
 		$output = $this->createMock(IOutput::class);
 		$fullOutput = '';
@@ -54,6 +71,11 @@ class OpenMetricsControllerTest extends TestCase {
 		$this->assertEquals('200', $response->getStatus());
 		$this->assertEquals('application/openmetrics-text; version=1.0.0; charset=utf-8', $response->getHeaders()['Content-Type']);
 		$expected = <<<EXPECTED
+			# TYPE nextcloud_fake_count gauge
+			# UNIT nextcloud_fake_count fake
+			# HELP nextcloud_fake_count A fake count used for tests
+			nextcloud_fake_count{type="used"} 42
+			nextcloud_fake_count{type="unused"} 24
 			# TYPE nextcloud_exporter_run_seconds gauge
 			# UNIT nextcloud_exporter_run_seconds seconds
 			# HELP nextcloud_exporter_run_seconds Exporter run time

--- a/tests/lib/OpenMetrics/Exporters/ExporterTestCase.php
+++ b/tests/lib/OpenMetrics/Exporters/ExporterTestCase.php
@@ -26,11 +26,28 @@ abstract class ExporterTestCase extends TestCase {
 	}
 
 	public function testNotEmptyData(): void {
-		$this->assertNotEmpty($this->exporter->name());
 		$this->assertNotEmpty($this->metrics);
 	}
 
-	public function testValidNames(): void {
+	public function testValidExporterName(): void {
+		$exporterName = $this->exporter->name();
+		$this->assertMatchesRegularExpression('/^[a-z_:][a-z0-9_:]*$/i', $exporterName, );
+
+		$unit = $this->exporter->unit();
+		if ($unit === '') {
+			return;
+		}
+		// Unit name must follow metric name format
+		$this->assertMatchesRegularExpression('/^[a-z_:][a-z0-9_:]*$/i', $unit);
+		// Unit name must be a suffix in exporter name
+		$this->assertMatchesRegularExpression(
+			'/(^|_)' . $unit . '$/',
+			$exporterName,
+			'Metric name "' . $exporterName . '" must contains unit "' . $unit . '" as a suffix',
+		);
+	}
+
+	public function testValidLabelKey(): void {
 		$labelNames = [];
 		foreach ($this->metrics as $metric) {
 			foreach ($metric->labels as $label => $value) {


### PR DESCRIPTION
## Summary
Fix issues on OpenMetrics exporter:
 - remove empty lines
 - ensure unit is part of metric name

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
