### PR TITLE
[stable31] fix(TaskProcessing): Fix occ commands to cast strings to integer

### DIFF
--- a/core/Command/TaskProcessing/Statistics.php
+++ b/core/Command/TaskProcessing/Statistics.php
@@ -78,9 +78,9 @@ class Statistics extends Base {
 		$type = $input->getOption('type');
 		$appId = $input->getOption('appId');
 		$customId = $input->getOption('customId');
-		$status = $input->getOption('status');
-		$scheduledAfter = $input->getOption('scheduledAfter');
-		$endedBefore = $input->getOption('endedBefore');
+		$status = $input->getOption('status') !== null ? (int)$input->getOption('status') : null;
+		$scheduledAfter = $input->getOption('scheduledAfter') !== null ? (int)$input->getOption('scheduledAfter') : null;
+		$endedBefore = $input->getOption('endedBefore') !== null ? (int)$input->getOption('endedBefore') : null;
 
 		$tasks = $this->taskProcessingManager->getTasks($userIdFilter, $type, $appId, $customId, $status, $scheduledAfter, $endedBefore);
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/pull/57111
* Manual backport of #57641

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
