### PR TITLE
feat: optimize user mount cache

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -382,7 +382,8 @@ class UserMountCache implements IUserMountCache {
 		$query = $builder->select('storage_id', 'root_id', 'user_id', 'mount_point', 'mount_id', 'f.path', 'mount_provider_class')
 			->from('mounts', 'm')
 			->innerJoin('m', 'filecache', 'f', $builder->expr()->eq('m.root_id', 'f.fileid'))
-			->where($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
+			->where($builder->expr()->eq('m.storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
+			->andWhere($builder->expr()->eq('m.storage_id', 'f.storage')) # Hint for DBs
 			->andWhere(
 				$builder->expr()->orX(
 					$builder->expr()->eq('f.fileid', $builder->createNamedParameter($fileId)),


### PR DESCRIPTION
Optimize requests like: 
```sql
SELECT
  `storage_id`,
  `root_id`,
  `user_id`,
  `mount_point`,
  `mount_id`,
  `f`.`path`,
  `mount_provider_class`
FROM
  `oc_mounts` `m`
  INNER JOIN `oc_filecache` `f` ON `m`.`root_id` = `f`.`fileid`
WHERE
  (`storage_id` = ?)
  AND (
    (`f`.`fileid` = ?)
    OR (`f`.`path` = ?)
    OR (
      `CONCAT` (`f`.`path`, ?) = SUBSTRING (?, ..., `CHAR_LENGTH` (`f`.`path`) + ?)
    )
  )
```

### TODO
- [x] Is it better to add both fields so DB can choose the best path? ⇒ Changed

### Explain
**Before**
```
+------+-------------+-------+--------+-----------------------------------------------------------+--------------------+---------+--------------+-------+-------------+
| id   | select_type | table | type   | possible_keys                                             | key                | key_len | ref          | rows  | Extra       |
+------+-------------+-------+--------+-----------------------------------------------------------+--------------------+---------+--------------+-------+-------------+
|    1 | SIMPLE      | m     | ref    | mounts_storage_index,mounts_root_index,mount_user_storage | mount_user_storage | 8       | const        | 64048 |             |
|    1 | SIMPLE      | f     | eq_ref | PRIMARY                                                   | PRIMARY            | 8       | oc.m.root_id | 1     | Using where |
+------+-------------+-------+--------+-----------------------------------------------------------+--------------------+---------+--------------+-------+-------------+
```
**After**
```
+------+-------------+-------+------+-------------------------------------------------------------------------------------------------------------+---------------------+---------+-------------+-------+-------------+
| id   | select_type | table | type | possible_keys                                                                                               | key                 | key_len | ref         | rows  | Extra       |
+------+-------------+-------+------+-------------------------------------------------------------------------------------------------------------+---------------------+---------+-------------+-------+-------------+
|    1 | SIMPLE      | f     | ref  | PRIMARY,fs_storage_path_hash,fs_storage_mimetype,fs_storage_mimepart,fs_storage_size,fs_storage_path_prefix | fs_storage_mimetype | 8       | const       | 20918 | Using where |
|    1 | SIMPLE      | m     | ref  | mounts_root_index                                                                                           | mounts_root_index   | 8       | oc.f.fileid | 7     |             |
+------+-------------+-------+------+-------------------------------------------------------------------------------------------------------------+---------------------+---------+-------------+-------+-------------+
```
The change allows to filter on filecache first

### (Rough) Benchmark
- Before: ≈ 400 ms
- After : ≈ 70 ms