### PR TITLE
fix(systemtags): Correct the return type of system tag object mapper

### DIFF
--- a/apps/systemtags/lib/Command/Files/DeleteAll.php
+++ b/apps/systemtags/lib/Command/Files/DeleteAll.php
@@ -35,13 +35,14 @@ class DeleteAll extends Command {
 		$targetInput = $input->getArgument('target');
 		$targetNode = $this->fileUtils->getNode($targetInput);
 
-		if (! $targetNode) {
+		if (!$targetNode) {
 			$output->writeln("<error>file $targetInput not found</error>");
 			return 1;
 		}
 
-		$tags = $this->systemTagObjectMapper->getTagIdsForObjects([$targetNode->getId()], 'files');
-		$this->systemTagObjectMapper->unassignTags((string)$targetNode->getId(), 'files', $tags[$targetNode->getId()]);
+		$targetNodeId = (string)$targetNode->getId();
+		$tags = $this->systemTagObjectMapper->getTagIdsForObjects([$targetNodeId], 'files');
+		$this->systemTagObjectMapper->unassignTags($targetNodeId, 'files', $tags[$targetNodeId]);
 		$output->writeln('<info>all tags removed.</info>');
 
 		return 0;

--- a/apps/systemtags/lib/Search/TagSearchProvider.php
+++ b/apps/systemtags/lib/Search/TagSearchProvider.php
@@ -130,7 +130,7 @@ class TagSearchProvider implements IProvider {
 					$searchResultEntry = new SearchResultEntry(
 						$thumbnailUrl,
 						$result->getName(),
-						$this->formatSubline($query, $matchedTags[$nodeId]),
+						$this->formatSubline($query, $matchedTags[(string)$nodeId]),
 						$this->urlGenerator->getAbsoluteURL($link),
 						$result->getMimetype() === FileInfo::MIMETYPE_FOLDER
 							? 'icon-folder'

--- a/lib/public/SystemTag/ISystemTagObjectMapper.php
+++ b/lib/public/SystemTag/ISystemTagObjectMapper.php
@@ -8,30 +8,36 @@ declare(strict_types=1);
  */
 namespace OCP\SystemTag;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * Public interface to access and manage system-wide tags.
  *
  * @since 9.0.0
  */
+#[Consumable(since: '9.0.0')]
 interface ISystemTagObjectMapper {
 	/**
 	 * Get a list of tag ids for the given object ids.
 	 *
 	 * This returns an array that maps object id to tag ids
+	 *
+	 * ```
 	 * [
-	 *   1 => array('id1', 'id2'),
-	 *   2 => array('id3', 'id2'),
-	 *   3 => array('id5'),
-	 *   4 => array()
+	 *   1 => ['id1', 'id2'],
+	 *   2 => ['id3', 'id2'],
+	 *   3 => ['id5'],
+	 *   4 => []
 	 * ]
+	 * ```
 	 *
 	 * Untagged objects will have an empty array associated.
 	 *
-	 * @param string|array $objIds object ids
+	 * @param string|list<string> $objIds object ids
 	 * @param string $objectType object type
 	 *
-	 * @return array with object id as key and an array
-	 *               of tag ids as value
+	 * @return array<string, list<string>> with object id as key and an array
+	 *                                     of tag ids as value
 	 *
 	 * @since 9.0.0
 	 */
@@ -40,12 +46,12 @@ interface ISystemTagObjectMapper {
 	/**
 	 * Get a list of objects tagged with $tagIds.
 	 *
-	 * @param string|array $tagIds Tag id or array of tag ids.
+	 * @param string|list<string> $tagIds Tag id or array of tag ids.
 	 * @param string $objectType object type
 	 * @param int $limit Count of object ids you want to get
 	 * @param string $offset The last object id you already received
 	 *
-	 * @return string[] array of object ids or empty array if none found
+	 * @return list<string> array of object ids or empty array if none found
 	 *
 	 * @throws TagNotFoundException if at least one of the
 	 *                              given tags does not exist
@@ -66,7 +72,7 @@ interface ISystemTagObjectMapper {
 	 *
 	 * @param string $objId object id
 	 * @param string $objectType object type
-	 * @param string|array $tagIds tag id or array of tag ids to assign
+	 * @param string|list<string> $tagIds tag id or array of tag ids to assign
 	 *
 	 * @throws TagNotFoundException if at least one of the
 	 *                              given tags does not exist
@@ -85,7 +91,7 @@ interface ISystemTagObjectMapper {
 	 *
 	 * @param string $objId object id
 	 * @param string $objectType object type
-	 * @param string|array $tagIds tag id or array of tag ids to unassign
+	 * @param string|list<string> $tagIds tag id or array of tag ids to unassign
 	 *
 	 * @throws TagNotFoundException if at least one of the
 	 *                              given tags does not exist
@@ -97,7 +103,7 @@ interface ISystemTagObjectMapper {
 	/**
 	 * Checks whether the given objects have the given tag.
 	 *
-	 * @param string|array $objIds object ids
+	 * @param string|list<string> $objIds object ids
 	 * @param string $objectType object type
 	 * @param string $tagId tag id to check
 	 * @param bool $all true to check that ALL objects have the tag assigned,
@@ -128,7 +134,7 @@ interface ISystemTagObjectMapper {
 	 *
 	 * @param string $tagId tag id
 	 * @param string $objectType object type
-	 * @param string[] $objectIds list of object ids
+	 * @param list<string> $objectIds list of object ids
 	 *
 	 * @throws TagNotFoundException if the tag does not exist
 	 * @since 31.0.0


### PR DESCRIPTION
## Summary

Currently, it is documented in some places as returning a string but returns a int or a string depending on the database used.

This then breaks then using strict comparaison in https://github.com/nextcloud/approval/pull/362

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
