### PR TITLE
feat(OCP): Expose setup manager to OCP

### DIFF
--- a/apps/encryption/lib/Command/CleanOrphanedKeys.php
+++ b/apps/encryption/lib/Command/CleanOrphanedKeys.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 namespace OCA\Encryption\Command;
 
 use OC\Encryption\Util;
-use OC\Files\SetupManager;
 use OCA\Encryption\Crypto\Encryption;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\IUser;
@@ -34,7 +34,7 @@ class CleanOrphanedKeys extends Command {
 		protected QuestionHelper $questionHelper,
 		private IUserManager $userManager,
 		private Util $encryptionUtil,
-		private SetupManager $setupManager,
+		private ISetupManager $setupManager,
 		private IRootFolder $rootFolder,
 		private LoggerInterface $logger,
 	) {

--- a/apps/encryption/lib/Command/DropLegacyFileKey.php
+++ b/apps/encryption/lib/Command/DropLegacyFileKey.php
@@ -11,10 +11,10 @@ namespace OCA\Encryption\Command;
 
 use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Files\FileInfo;
-use OC\Files\SetupManager;
 use OC\Files\View;
 use OCA\Encryption\KeyManager;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
+use OCP\Files\ISetupManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
@@ -27,7 +27,7 @@ class DropLegacyFileKey extends Command {
 	public function __construct(
 		private readonly IUserManager $userManager,
 		private readonly KeyManager $keyManager,
-		private readonly SetupManager $setupManager,
+		private readonly ISetupManager $setupManager,
 	) {
 		parent::__construct();
 

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -8,12 +8,12 @@
 
 namespace OCA\Encryption\Command;
 
-use OC\Files\SetupManager;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OC\ServerNotAvailableException;
 use OCA\Encryption\Util;
 use OCP\Encryption\Exceptions\InvalidHeaderException;
+use OCP\Files\ISetupManager;
 use OCP\HintException;
 use OCP\IConfig;
 use OCP\IUser;
@@ -34,7 +34,7 @@ class FixEncryptedVersion extends Command {
 		private readonly IUserManager $userManager,
 		private readonly Util $util,
 		private readonly View $view,
-		private readonly SetupManager $setupManager,
+		private readonly ISetupManager $setupManager,
 	) {
 		parent::__construct();
 	}

--- a/apps/encryption/lib/Command/FixKeyLocation.php
+++ b/apps/encryption/lib/Command/FixKeyLocation.php
@@ -10,7 +10,6 @@ namespace OCA\Encryption\Command;
 
 use OC\Encryption\Manager;
 use OC\Encryption\Util;
-use OC\Files\SetupManager;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OCP\Encryption\IManager;
@@ -19,6 +18,7 @@ use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\Node;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -38,7 +38,7 @@ class FixKeyLocation extends Command {
 		private readonly IUserMountCache $userMountCache,
 		private readonly Util $encryptionUtil,
 		private readonly IRootFolder $rootFolder,
-		private readonly SetupManager $setupManager,
+		private readonly ISetupManager $setupManager,
 		IManager $encryptionManager,
 	) {
 		$this->keyRootDirectory = rtrim($this->encryptionUtil->getKeyStorageRoot(), '/');

--- a/apps/encryption/lib/Command/ScanLegacyFormat.php
+++ b/apps/encryption/lib/Command/ScanLegacyFormat.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
  */
 namespace OCA\Encryption\Command;
 
-use OC\Files\SetupManager;
 use OC\Files\View;
 use OCA\Encryption\Util;
+use OCP\Files\ISetupManager;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -27,7 +27,7 @@ class ScanLegacyFormat extends Command {
 		protected readonly IConfig $config,
 		protected readonly QuestionHelper $questionHelper,
 		private readonly IUserManager $userManager,
-		private readonly SetupManager $setupManager,
+		private readonly ISetupManager $setupManager,
 	) {
 		parent::__construct();
 

--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 namespace OCA\Encryption\Crypto;
 
 use OC\Encryption\Exceptions\DecryptionFailedException;
-use OC\Files\SetupManager;
 use OC\Files\View;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
 use OCP\Files\FileInfo;
+use OCP\Files\ISetupManager;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
@@ -53,7 +53,7 @@ class EncryptAll {
 		protected readonly QuestionHelper $questionHelper,
 		protected readonly ISecureRandom $secureRandom,
 		protected readonly LoggerInterface $logger,
-		protected readonly SetupManager $setupManager,
+		protected readonly ISetupManager $setupManager,
 	) {
 	}
 

--- a/apps/encryption/lib/Listeners/UserEventsListener.php
+++ b/apps/encryption/lib/Listeners/UserEventsListener.php
@@ -10,7 +10,6 @@ namespace OCA\Encryption\Listeners;
 
 use OC\Core\Events\BeforePasswordResetEvent;
 use OC\Core\Events\PasswordResetEvent;
-use OC\Files\SetupManager;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Services\PassphraseService;
 use OCA\Encryption\Session;
@@ -18,9 +17,8 @@ use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Files\ISetupManager;
 use OCP\IUser;
-use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\Lockdown\ILockdownManager;
 use OCP\User\Events\BeforePasswordUpdatedEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
@@ -40,9 +38,7 @@ class UserEventsListener implements IEventListener {
 		private Setup $userSetup,
 		private Session $session,
 		private KeyManager $keyManager,
-		private IUserManager $userManager,
-		private IUserSession $userSession,
-		private SetupManager $setupManager,
+		private ISetupManager $setupManager,
 		private PassphraseService $passphraseService,
 		private ILockdownManager $lockdownManager,
 	) {

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
 
 namespace OCA\Encryption\Tests\Command;
 
-use OC\Files\SetupManager;
 use OC\Files\View;
 use OCA\Encryption\Command\FixEncryptedVersion;
 use OCA\Encryption\Util;
 use OCP\Encryption\IManager;
+use OCP\Files\ISetupManager;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\ITempManager;
@@ -69,7 +69,7 @@ class FixEncryptedVersionTest extends TestCase {
 			Server::get(IUserManager::class),
 			$this->util,
 			new View('/'),
-			Server::get(SetupManager::class),
+			Server::get(ISetupManager::class),
 		);
 		$this->commandTester = new CommandTester($this->fixEncryptedVersion);
 

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
  */
 namespace OCA\Encryption\Tests\Crypto;
 
-use OC\Files\SetupManager;
 use OC\Files\View;
 use OCA\Encryption\Crypto\EncryptAll;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
 use OCP\Files\FileInfo;
+use OCP\Files\ISetupManager;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
@@ -50,7 +50,7 @@ class EncryptAllTest extends TestCase {
 	protected UserInterface&MockObject $userInterface;
 	protected ISecureRandom&MockObject $secureRandom;
 	protected LoggerInterface&MockObject $logger;
-	protected SetupManager&MockObject $setupManager;
+	protected ISetupManager&MockObject $setupManager;
 	protected IUser&MockObject $user1;
 	protected IUser&MockObject $user2;
 
@@ -84,7 +84,7 @@ class EncryptAllTest extends TestCase {
 		$this->userInterface = $this->getMockBuilder(UserInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->setupManager = $this->createMock(SetupManager::class);
+		$this->setupManager = $this->createMock(ISetupManager::class);
 
 		/**
 		 * We need format method to return a string

--- a/apps/encryption/tests/Listeners/UserEventsListenersTest.php
+++ b/apps/encryption/tests/Listeners/UserEventsListenersTest.php
@@ -10,16 +10,14 @@ namespace OCA\Encryption\Tests\Listeners;
 
 use OC\Core\Events\BeforePasswordResetEvent;
 use OC\Core\Events\PasswordResetEvent;
-use OC\Files\SetupManager;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Listeners\UserEventsListener;
 use OCA\Encryption\Services\PassphraseService;
 use OCA\Encryption\Session;
 use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
+use OCP\Files\ISetupManager;
 use OCP\IUser;
-use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\Lockdown\ILockdownManager;
 use OCP\User\Events\BeforePasswordUpdatedEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
@@ -32,14 +30,11 @@ use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserEventsListenersTest extends TestCase {
-
 	protected Util&MockObject $util;
 	protected Setup&MockObject $userSetup;
 	protected Session&MockObject $session;
 	protected KeyManager&MockObject $keyManager;
-	protected IUserManager&MockObject $userManager;
-	protected IUserSession&MockObject $userSession;
-	protected SetupManager&MockObject $setupManager;
+	protected ISetupManager&MockObject $setupManager;
 	protected ILockdownManager&MockObject $lockdownManager;
 	protected PassphraseService&MockObject $passphraseService;
 
@@ -52,9 +47,7 @@ class UserEventsListenersTest extends TestCase {
 		$this->userSetup = $this->createMock(Setup::class);
 		$this->session = $this->createMock(Session::class);
 		$this->keyManager = $this->createMock(KeyManager::class);
-		$this->userManager = $this->createMock(IUserManager::class);
-		$this->userSession = $this->createMock(IUserSession::class);
-		$this->setupManager = $this->createMock(SetupManager::class);
+		$this->setupManager = $this->createMock(ISetupManager::class);
 		$this->lockdownManager = $this->createMock(ILockdownManager::class);
 		$this->passphraseService = $this->createMock(PassphraseService::class);
 
@@ -63,8 +56,6 @@ class UserEventsListenersTest extends TestCase {
 			$this->userSetup,
 			$this->session,
 			$this->keyManager,
-			$this->userManager,
-			$this->userSession,
 			$this->setupManager,
 			$this->passphraseService,
 			$this->lockdownManager,

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -8,7 +8,6 @@ namespace OCA\FederatedFileSharing\OCM;
 
 use OC\AppFramework\Http;
 use OC\Files\Filesystem;
-use OC\Files\SetupManager;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Federation\TrustedServers;
@@ -31,6 +30,7 @@ use OCP\Federation\ICloudFederationShare;
 use OCP\Federation\ICloudIdManager;
 use OCP\Federation\ISignedCloudFederationProvider;
 use OCP\Files\IFilenameValidator;
+use OCP\Files\ISetupManager;
 use OCP\Files\NotFoundException;
 use OCP\HintException;
 use OCP\IConfig;
@@ -68,7 +68,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 		private readonly LoggerInterface $logger,
 		private readonly IFilenameValidator $filenameValidator,
 		private readonly IProviderFactory $shareProviderFactory,
-		private readonly SetupManager $setupManager,
+		private readonly ISetupManager $setupManager,
 		private readonly ExternalShareMapper $externalShareMapper,
 	) {
 	}

--- a/apps/files/lib/BackgroundJob/SanitizeFilenames.php
+++ b/apps/files/lib/BackgroundJob/SanitizeFilenames.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
  */
 namespace OCA\Files\BackgroundJob;
 
-use OC\Files\SetupManager;
 use OCA\Files\AppInfo\Application;
 use OCA\Files\Service\SettingsService;
 use OCP\AppFramework\Services\IAppConfig;
@@ -16,10 +15,10 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\QueuedJob;
 use OCP\Config\IUserConfig;
-use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IUser;
@@ -43,7 +42,7 @@ class SanitizeFilenames extends QueuedJob {
 		private IAppConfig $appConfig,
 		private IUserConfig $userConfig,
 		private IRootFolder $rootFolder,
-		private SetupManager $setupManager,
+		private ISetupManager $setupManager,
 		private IFilenameValidator $filenameValidator,
 		private LoggerInterface $logger,
 	) {

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -9,7 +9,6 @@
 namespace OCA\Files_Sharing\External;
 
 use OC\Files\Filesystem;
-use OC\Files\SetupManager;
 use OC\User\NoUserException;
 use OCA\FederatedFileSharing\Events\FederatedShareAddedEvent;
 use OCA\Files_Sharing\Helper;
@@ -21,6 +20,7 @@ use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\IStorageFactory;
@@ -53,7 +53,7 @@ class Manager {
 		private IEventDispatcher $eventDispatcher,
 		private LoggerInterface $logger,
 		private IRootFolder $rootFolder,
-		private SetupManager $setupManager,
+		private ISetupManager $setupManager,
 		private ICertificateManager $certificateManager,
 		private ExternalShareMapper $externalShareMapper,
 	) {

--- a/apps/files_sharing/lib/ShareTargetValidator.php
+++ b/apps/files_sharing/lib/ShareTargetValidator.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 namespace OCA\Files_Sharing;
 
 use OC\Files\Filesystem;
-use OC\Files\SetupManager;
 use OC\Files\View;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\ICachedMountInfo;
+use OCP\Files\ISetupManager;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\IUser;
@@ -30,7 +30,7 @@ class ShareTargetValidator {
 	public function __construct(
 		private readonly IManager $shareManager,
 		private readonly IEventDispatcher $eventDispatcher,
-		private readonly SetupManager $setupManager,
+		private readonly ISetupManager $setupManager,
 		private readonly IMountManager $mountManager,
 	) {
 		$this->folderExistsCache = new CappedMemoryCache();

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -9,7 +9,6 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Cache\Cache;
 use OC\Files\Filesystem;
-use OC\Files\SetupManager;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\Jail;
@@ -18,6 +17,7 @@ use OCA\Files_Sharing\SharedStorage;
 use OCP\Constants;
 use OCP\Files\Cache\IWatcher;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\Node;
 use OCP\IUserManager;
 use OCP\Server;
@@ -412,7 +412,7 @@ class CacheTest extends TestCase {
 		$share = $this->shareManager->createShare($share);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
-		Server::get(SetupManager::class)->tearDown();
+		Server::get(ISetupManager::class)->tearDown();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		$this->assertTrue(Filesystem::file_exists('/test.txt'));
@@ -443,7 +443,7 @@ class CacheTest extends TestCase {
 		$share = $this->shareManager->createShare($share);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
-		Server::get(SetupManager::class)->tearDown();
+		Server::get(ISetupManager::class)->tearDown();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		$this->assertTrue(Filesystem::file_exists('/foo'));
@@ -471,7 +471,7 @@ class CacheTest extends TestCase {
 		$share = $this->shareManager->createShare($share);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
-		Server::get(SetupManager::class)->tearDown();
+		Server::get(ISetupManager::class)->tearDown();
 
 		[$sourceStorage] = Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER1 . '/files/foo');
 
@@ -508,7 +508,7 @@ class CacheTest extends TestCase {
 		$share = $this->shareManager->createShare($share);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
-		Server::get(SetupManager::class)->tearDown();
+		Server::get(ISetupManager::class)->tearDown();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		$this->assertEquals('foo', Filesystem::file_get_contents('/sub/foo.txt'));
@@ -547,7 +547,7 @@ class CacheTest extends TestCase {
 		$share = $this->shareManager->createShare($share);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
-		Server::get(SetupManager::class)->tearDown();
+		Server::get(ISetupManager::class)->tearDown();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
@@ -582,7 +582,7 @@ class CacheTest extends TestCase {
 		$share = $this->shareManager->createShare($share);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
-		Server::get(SetupManager::class)->tearDown();
+		Server::get(ISetupManager::class)->tearDown();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -9,7 +9,6 @@ namespace OCA\Files_Sharing\Tests\External;
 
 use OC\Federation\CloudIdManager;
 use OC\Files\Mount\MountPoint;
-use OC\Files\SetupManager;
 use OC\Files\SetupManagerFactory;
 use OC\Files\Storage\StorageFactory;
 use OC\Files\Storage\Temporary;
@@ -24,6 +23,7 @@ use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\NotFoundException;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
@@ -68,7 +68,7 @@ class ManagerTest extends TestCase {
 	protected ICloudFederationFactory&MockObject $cloudFederationFactory;
 	protected IGroupManager&MockObject $groupManager;
 	protected IUserManager&MockObject $userManager;
-	protected SetupManager&MockObject $setupManager;
+	protected ISetupManager&MockObject $setupManager;
 	protected ICertificateManager&MockObject $certificateManager;
 	private ExternalShareMapper $externalShareMapper;
 
@@ -84,7 +84,7 @@ class ManagerTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
-		$this->setupManager = $this->createMock(SetupManager::class);
+		$this->setupManager = $this->createMock(ISetupManager::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->rootFolder->method('getUserFolder')
 			->willReturnCallback(function (string $userId): Folder {

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -7,13 +7,13 @@
  */
 namespace OCA\Files_Trashbin\BackgroundJob;
 
-use OC\Files\SetupManager;
 use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\Files\ISetupManager;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -32,7 +32,7 @@ class ExpireTrash extends TimedJob {
 		private IUserManager $userManager,
 		private Expiration $expiration,
 		private LoggerInterface $logger,
-		private SetupManager $setupManager,
+		private ISetupManager $setupManager,
 		private ILockingProvider $lockingProvider,
 		ITimeFactory $time,
 	) {

--- a/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 
 namespace OCA\Files_Trashbin\Tests\BackgroundJob;
 
-use OC\Files\SetupManager;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\BackgroundJob\ExpireTrash;
 use OCA\Files_Trashbin\Expiration;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
+use OCP\Files\ISetupManager;
 use OCP\IAppConfig;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
@@ -29,7 +29,7 @@ class ExpireTrashTest extends TestCase {
 	private IJobList&MockObject $jobList;
 	private LoggerInterface&MockObject $logger;
 	private ITimeFactory&MockObject $time;
-	private SetupManager&MockObject $setupManager;
+	private ISetupManager&MockObject $setupManager;
 	private ILockingProvider&MockObject $lockingProvider;
 
 	protected function setUp(): void {
@@ -40,7 +40,7 @@ class ExpireTrashTest extends TestCase {
 		$this->expiration = $this->createMock(Expiration::class);
 		$this->jobList = $this->createMock(IJobList::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->setupManager = $this->createMock(SetupManager::class);
+		$this->setupManager = $this->createMock(ISetupManager::class);
 		$this->lockingProvider = $this->createMock(ILockingProvider::class);
 
 		$this->time = $this->createMock(ITimeFactory::class);

--- a/core/Command/Background/JobWorker.php
+++ b/core/Command/Background/JobWorker.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace OC\Core\Command\Background;
 
 use OC\Core\Command\InterruptedException;
-use OC\Files\SetupManager;
 use OCP\BackgroundJob\IJobList;
+use OCP\Files\ISetupManager;
 use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,7 +24,7 @@ class JobWorker extends JobBase {
 		protected IJobList $jobList,
 		protected LoggerInterface $logger,
 		private ITempManager $tempManager,
-		private SetupManager $setupManager,
+		private ISetupManager $setupManager,
 	) {
 		parent::__construct($jobList, $logger);
 	}

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -7,7 +7,7 @@
 namespace OC\Core\Command\User;
 
 use OC\Core\Command\Base;
-use OC\Files\SetupManager;
+use OCP\Files\ISetupManager;
 use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -22,12 +22,12 @@ class Info extends Base {
 	public function __construct(
 		protected IUserManager $userManager,
 		protected IGroupManager $groupManager,
-		protected SetupManager $setupManager,
+		protected ISetupManager $setupManager,
 	) {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('user:info')
 			->setDescription('show user info')

--- a/core/Service/CronService.php
+++ b/core/Service/CronService.php
@@ -13,13 +13,13 @@ namespace OC\Core\Service;
 
 use OC;
 use OC\Authentication\LoginCredentials\Store;
-use OC\Files\SetupManager;
 use OC\Security\CSRF\TokenStorage\SessionStorage;
 use OC\Session\CryptoWrapper;
 use OC\Session\Memory;
 use OC\User\Session;
 use OCP\App\IAppManager;
 use OCP\BackgroundJob\IJobList;
+use OCP\Files\ISetupManager;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -44,7 +44,7 @@ class CronService {
 		private readonly ITempManager $tempManager,
 		private readonly IAppConfig $appConfig,
 		private readonly IJobList $jobList,
-		private readonly SetupManager $setupManager,
+		private readonly ISetupManager $setupManager,
 		private readonly bool $isCLI,
 	) {
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -477,6 +477,7 @@ return array(
     'OCP\\Files\\IMimeTypeDetector' => $baseDir . '/lib/public/Files/IMimeTypeDetector.php',
     'OCP\\Files\\IMimeTypeLoader' => $baseDir . '/lib/public/Files/IMimeTypeLoader.php',
     'OCP\\Files\\IRootFolder' => $baseDir . '/lib/public/Files/IRootFolder.php',
+    'OCP\\Files\\ISetupManager' => $baseDir . '/lib/public/Files/ISetupManager.php',
     'OCP\\Files\\InvalidCharacterInPathException' => $baseDir . '/lib/public/Files/InvalidCharacterInPathException.php',
     'OCP\\Files\\InvalidContentException' => $baseDir . '/lib/public/Files/InvalidContentException.php',
     'OCP\\Files\\InvalidDirectoryException' => $baseDir . '/lib/public/Files/InvalidDirectoryException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -518,6 +518,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\IMimeTypeDetector' => __DIR__ . '/../../..' . '/lib/public/Files/IMimeTypeDetector.php',
         'OCP\\Files\\IMimeTypeLoader' => __DIR__ . '/../../..' . '/lib/public/Files/IMimeTypeLoader.php',
         'OCP\\Files\\IRootFolder' => __DIR__ . '/../../..' . '/lib/public/Files/IRootFolder.php',
+        'OCP\\Files\\ISetupManager' => __DIR__ . '/../../..' . '/lib/public/Files/ISetupManager.php',
         'OCP\\Files\\InvalidCharacterInPathException' => __DIR__ . '/../../..' . '/lib/public/Files/InvalidCharacterInPathException.php',
         'OCP\\Files\\InvalidContentException' => __DIR__ . '/../../..' . '/lib/public/Files/InvalidContentException.php',
         'OCP\\Files\\InvalidDirectoryException' => __DIR__ . '/../../..' . '/lib/public/Files/InvalidDirectoryException.php',

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-declare(strict_types=1);
 
 namespace OC\Files;
 
@@ -119,6 +119,7 @@ class SetupManager implements ISetupManager {
 		return in_array($user->getUID(), $this->setupUsers, true);
 	}
 
+	#[Override]
 	public function isSetupComplete(IUser $user): bool {
 		return in_array($user->getUID(), $this->setupUsersComplete, true);
 	}
@@ -451,10 +452,7 @@ class SetupManager implements ISetupManager {
 		return $this->userManager->get($userId);
 	}
 
-	/**
-	 * Set up the filesystem for the specified path, optionally including all
-	 * children mounts.
-	 */
+	#[Override]
 	public function setupForPath(string $path, bool $includeChildren = false): void {
 		$user = $this->getUserForPath($path);
 		if (!$user) {

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -1,10 +1,11 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+declare(strict_types=1);
 
 namespace OC\Files;
 
@@ -13,8 +14,6 @@ use OC\Files\Config\MountProviderCollection;
 use OC\Files\Mount\HomeMountPoint;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Common;
-use OC\Files\Storage\Home;
-use OC\Files\Storage\Storage;
 use OC\Files\Storage\Wrapper\Availability;
 use OC\Files\Storage\Wrapper\Encoding;
 use OC\Files\Storage\Wrapper\PermissionsMask;
@@ -43,6 +42,7 @@ use OCP\Files\Events\BeforeFileSystemSetupEvent;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\Files\Events\Node\FilesystemTornDownEvent;
+use OCP\Files\ISetupManager;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
@@ -57,13 +57,14 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Lockdown\ILockdownManager;
 use OCP\Share\Events\ShareCreatedEvent;
+use Override;
 use Psr\Log\LoggerInterface;
 use function array_key_exists;
 use function count;
 use function dirname;
 use function in_array;
 
-class SetupManager {
+class SetupManager implements ISetupManager {
 	private bool $rootSetup = false;
 	// List of users for which at least one mount is setup
 	private array $setupUsers = [];
@@ -143,7 +144,7 @@ class SetupManager {
 		return false;
 	}
 
-	private function setupBuiltinWrappers() {
+	private function setupBuiltinWrappers(): void {
 		if ($this->setupBuiltinWrappersDone) {
 			return;
 		}
@@ -256,9 +257,7 @@ class SetupManager {
 		$updatingProviders = false;
 	}
 
-	/**
-	 * Setup the full filesystem for the specified user
-	 */
+	#[Override]
 	public function setupForUser(IUser $user): void {
 		if ($this->isSetupComplete($user)) {
 			return;
@@ -711,7 +710,8 @@ class SetupManager {
 		$this->eventLogger->end('fs:setup:user:providers');
 	}
 
-	public function tearDown() {
+	#[Override]
+	public function tearDown(): void {
 		$this->setupUsers = [];
 		$this->setupUsersComplete = [];
 		$this->setupUserMountProviders = [];

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -287,6 +287,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias(\OCP\Contacts\IManager::class, \OC\ContactsManager::class);
 
 		$this->registerAlias(\OCP\ContextChat\IContentManager::class, \OC\ContextChat\ContentManager::class);
+		$this->registerAlias(\OCP\Files\ISetupManager::class, \OC\Files\SetupManager::class);
 
 		$this->registerAlias(\OCP\DirectEditing\IManager::class, \OC\DirectEditing\Manager::class);
 		$this->registerAlias(ITemplateManager::class, TemplateManager::class);

--- a/lib/public/Files/ISetupManager.php
+++ b/lib/public/Files/ISetupManager.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCP\Files;
+
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\IUser;
+
+/**
+ * The files setup manager allow to set up the file system for specific users and
+ * also to tear it down when no longer needed.
+ *
+ * @since 34.0.0
+ */
+#[Consumable(since: '34.0.0')]
+interface ISetupManager {
+
+	/**
+	 * Set up the full filesystem for a specified user.
+	 */
+	public function setupForUser(IUser $user): void;
+
+	/**
+	 * Tear down all file systems to free some memory.
+	 */
+	public function tearDown(): void;
+}

--- a/lib/public/Files/ISetupManager.php
+++ b/lib/public/Files/ISetupManager.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-declare(strict_types=1);
 
 namespace OCP\Files;
 
@@ -16,6 +16,10 @@ use OCP\IUser;
  * The files setup manager allow to set up the file system for specific users and
  * also to tear it down when no longer needed.
  *
+ * This is mostly useful in backgroun jobs, where an operation need to be done for
+ * multiple users and their file system need to be setup and teared down between
+ * each user.
+ *
  * @since 34.0.0
  */
 #[Consumable(since: '34.0.0')]
@@ -23,6 +27,9 @@ interface ISetupManager {
 
 	/**
 	 * Set up the full filesystem for a specified user.
+	 *
+	 * @throws \OCP\HintException
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function setupForUser(IUser $user): void;
 
@@ -30,4 +37,18 @@ interface ISetupManager {
 	 * Tear down all file systems to free some memory.
 	 */
 	public function tearDown(): void;
+
+	/**
+	 * Set up the filesystem for the specified path, optionally including all
+	 * children mounts.
+	 *
+	 * @throws \OCP\HintException
+	 * @throws \OC\ServerNotAvailableException
+	 */
+	public function setupForPath(string $path, bool $includeChildren = false): void;
+
+	/**
+	 * Get whether the file system is already setup for a specific user.
+	 */
+	public function isSetupComplete(IUser $user): bool;
 }


### PR DESCRIPTION
## Summary

It's used by a lot of apps so expose just the two methods that are most of the time used, to prevent the apps to relly on private APIs.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
