### PR TITLE
feat(lexicon): validate value on set

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -795,10 +795,18 @@ class AppConfig implements IAppConfig {
 		int $type,
 	): bool {
 		$this->assertParams($app, $key);
-		if (!$this->matchAndApplyLexiconDefinition($app, $key, $lazy, $type)) {
+		/** @var ?Entry $lexiconEntry */
+		$lexiconEntry = null;
+		if (!$this->matchAndApplyLexiconDefinition($app, $key, $lazy, $type, lexiconEntry: $lexiconEntry)) {
 			return false; // returns false as database is not updated
 		}
 		$this->loadConfig(null, $lazy ?? true);
+
+		// lexicon entry might have requested a check on the value
+		$confirmationClosure = $lexiconEntry?->onSetConfirmation();
+		if ($confirmationClosure !== null && !$confirmationClosure($value)) {
+			return false;
+		}
 
 		$sensitive = $this->isTyped(self::VALUE_SENSITIVE, $type);
 		$inserted = $refreshCache = false;

--- a/lib/public/Config/Lexicon/Entry.php
+++ b/lib/public/Config/Lexicon/Entry.php
@@ -35,7 +35,7 @@ class Entry {
 	 * @param string|null $rename source in case of a rename of a config key.
 	 * @param int $options additional bitflag options {@see self::RENAME_INVERT_BOOLEAN}
 	 * @param string $note additional note and warning related to the use of the config key.
-	 * @param Closure|null $onSetConfirm callback to be called when a config value is set. {@see onSetConfirmation()} for more details.
+	 * @param (Closure(string $value): bool)|null $onSetConfirm callback to be called when a config value is set. {@see onSetConfirmation()} for more details.
 	 *
 	 * @since 32.0.0
 	 * @since 34.0.0 added $onSetConfirm

--- a/lib/public/Config/Lexicon/Entry.php
+++ b/lib/public/Config/Lexicon/Entry.php
@@ -35,8 +35,10 @@ class Entry {
 	 * @param string|null $rename source in case of a rename of a config key.
 	 * @param int $options additional bitflag options {@see self::RENAME_INVERT_BOOLEAN}
 	 * @param string $note additional note and warning related to the use of the config key.
+	 * @param Closure|null $onSetConfirm callback to be called when a config value is set. {@see onSetConfirmation()} for more details.
 	 *
 	 * @since 32.0.0
+	 * @since 34.0.0 added $onSetConfirm
 	 * @psalm-suppress PossiblyInvalidCast
 	 * @psalm-suppress RiskyCast
 	 */
@@ -51,6 +53,7 @@ class Entry {
 		private readonly ?string $rename = null,
 		private readonly int $options = 0,
 		private readonly string $note = '',
+		private readonly ?Closure $onSetConfirm = null,
 	) {
 		// key can only contain alphanumeric chars and underscore "_"
 		if (preg_match('/[^[:alnum:]_]/', $key)) {
@@ -193,6 +196,20 @@ class Entry {
 	 */
 	public function getNote(): string {
 		return $this->note;
+	}
+
+	/**
+	 * Returns an optional callback to be called when a config value is set.
+	 * If not null, the callback will be called before the config value is set.
+	 * Callable must accept a string-typed parameter containing the new value.
+	 * String-typed parameter can be referenced and modified to a new value from the Callable.
+	 * Callback must return a boolean indicating if the set operation should be allowed.
+	 *
+	 * @return (Closure(string $value): bool)|null
+	 * @since 34.0.0
+	 */
+	public function onSetConfirmation(): ?Closure {
+		return $this->onSetConfirm;
 	}
 
 	/**


### PR DESCRIPTION
Adding a new parameter to Lexicon `Entry` so that a `Closure` can be set to validate the config value before storing it to database.

This would allow to use `provision_api` endpoints to set app/user configs while keeping an eye on its value without having a specific controller.

_would be nice to have this added to next RC of 33, as it could be used to confirm the format of a string when configuring Federated Teams_