### PR TITLE
fix: don't try to setup for a user when setting up /

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -434,8 +434,10 @@ class SetupManager {
 	 * @param string $path
 	 * @return IUser|null
 	 */
-	private function getUserForPath(string $path) {
-		if (str_starts_with($path, '/__groupfolders')) {
+	private function getUserForPath(string $path): ?IUser {
+		if ($path === '' || $path === '/') {
+			return null;
+		} elseif (str_starts_with($path, '/__groupfolders')) {
 			return null;
 		} elseif (substr_count($path, '/') < 2) {
 			if ($user = $this->userSession->getUser()) {


### PR DESCRIPTION
Since `IUserMountCache::getMountForPath('/')` always fails, we always trigger the full user setup for no reason.