### PR TITLE
fix(user_ldap): Fix crash in some code path when a DN is longer that 64

### DIFF
--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -166,8 +166,13 @@ class Manager {
 	 * @param string $id the Nextcloud username
 	 */
 	public function isDeletedUser(string $id): bool {
-		return $this->userConfig->getValueBool(
-			$id, 'user_ldap', 'isDeleted');
+		try {
+			return $this->userConfig->getValueBool($id, 'user_ldap', 'isDeleted');
+		} catch (\InvalidArgumentException $e) {
+			// Most likely the string is too long to be a valid user id
+			$this->logger->debug('Invalid id given to isDeletedUser', ['exception' => $e]);
+			return false;
+		}
 	}
 
 	/**

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -1715,6 +1715,7 @@ class UserConfig implements IUserConfig {
 	 * @param bool $allowEmptyUser
 	 * @param bool $allowEmptyApp $app can be empty string
 	 * @param ValueType|null $valueType assert value type is only one type
+	 * @throws InvalidArgumentException if userId, app, or prefKey is invalid (too long, or empty string)
 	 */
 	private function assertParams(
 		string $userId = '',

--- a/lib/public/Config/IUserConfig.php
+++ b/lib/public/Config/IUserConfig.php
@@ -52,6 +52,7 @@ interface IUserConfig {
 	 * @param string $appId optional id of app
 	 *
 	 * @return list<string> list of userIds
+	 * @throws \InvalidArgumentException if $appId is invalid (too long)
 	 *
 	 * @since 32.0.0
 	 */
@@ -66,6 +67,7 @@ interface IUserConfig {
 	 * @param string $userId id of the user
 	 *
 	 * @return list<string> list of app ids
+	 * @throws \InvalidArgumentException if $userId is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -81,6 +83,7 @@ interface IUserConfig {
 	 * @param string $app id of the app
 	 *
 	 * @return list<string> list of stored config keys
+	 * @throws \InvalidArgumentException if $userId or $app is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -95,6 +98,7 @@ interface IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 *
 	 * @return bool TRUE if key exists
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -110,6 +114,7 @@ interface IUserConfig {
 	 *
 	 * @return bool TRUE if value is sensitive
 	 * @throws UnknownKeyException if config key is not known
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -130,6 +135,7 @@ interface IUserConfig {
 	 *
 	 * @return bool TRUE if value is sensitive
 	 * @throws UnknownKeyException if config key is not known
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -146,6 +152,7 @@ interface IUserConfig {
 	 *
 	 * @return bool TRUE if config is lazy loaded
 	 * @throws UnknownKeyException if config key is not known
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 * @see IUserConfig for details about lazy loading
 	 *
 	 * @since 32.0.0
@@ -164,6 +171,7 @@ interface IUserConfig {
 	 * @param bool $filtered filter sensitive config values
 	 *
 	 * @return array<string, string|int|float|bool|array> [key => value]
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -179,6 +187,7 @@ interface IUserConfig {
 	 * @param bool $filtered filter sensitive config values
 	 *
 	 * @return array<string, string|int|float|bool|array> [key => value]
+	 * @throws \InvalidArgumentException if $userId is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -194,6 +203,7 @@ interface IUserConfig {
 	 * @param ValueType|null $typedAs enforce type for the returned values
 	 *
 	 * @return array<string, string|int|float|bool|array> [appId => value]
+	 * @throws \InvalidArgumentException if $userId or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -211,6 +221,7 @@ interface IUserConfig {
 	 * @param array|null $userIds limit the search to a list of user ids
 	 *
 	 * @return array<string, string|int|float|bool|array> [userId => value]
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -228,6 +239,7 @@ interface IUserConfig {
 	 * @param bool $caseInsensitive non-case-sensitive search, only works if $value is a string
 	 *
 	 * @return Generator<string>
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -244,6 +256,7 @@ interface IUserConfig {
 	 * @param int $value config value
 	 *
 	 * @return Generator<string>
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -260,6 +273,7 @@ interface IUserConfig {
 	 * @param array $values list of possible config values
 	 *
 	 * @return Generator<string>
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -276,6 +290,7 @@ interface IUserConfig {
 	 * @param bool $value config value
 	 *
 	 * @return Generator<string>
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -293,6 +308,7 @@ interface IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 *
 	 * @return string stored config value or $default if not set in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -316,6 +332,7 @@ interface IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 *
 	 * @return int stored config value or $default if not set in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -339,6 +356,7 @@ interface IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 *
 	 * @return float stored config value or $default if not set in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -362,6 +380,7 @@ interface IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 *
 	 * @return bool stored config value or $default if not set in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -385,6 +404,7 @@ interface IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 *
 	 * @return array stored config value or $default if not set in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -410,6 +430,7 @@ interface IUserConfig {
 	 * @return ValueType type of the value
 	 * @throws UnknownKeyException if config key is not known
 	 * @throws IncorrectTypeException if config value type is not known
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -429,6 +450,7 @@ interface IUserConfig {
 	 * @return int a bitflag in relation to the config value
 	 * @throws UnknownKeyException if config key is not known
 	 * @throws IncorrectTypeException if config value type is not known
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -450,6 +472,7 @@ interface IUserConfig {
 	 * @param bool $lazy set config as lazy loaded
 	 *
 	 * @return bool TRUE if value was different, therefor updated in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -482,6 +505,7 @@ interface IUserConfig {
 	 * @param bool $lazy set config as lazy loaded
 	 *
 	 * @return bool TRUE if value was different, therefor updated in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -509,6 +533,7 @@ interface IUserConfig {
 	 * @param bool $lazy set config as lazy loaded
 	 *
 	 * @return bool TRUE if value was different, therefor updated in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -535,6 +560,7 @@ interface IUserConfig {
 	 * @param bool $lazy set config as lazy loaded
 	 *
 	 * @return bool TRUE if value was different, therefor updated in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -562,6 +588,7 @@ interface IUserConfig {
 	 * @param bool $lazy set config as lazy loaded
 	 *
 	 * @return bool TRUE if value was different, therefor updated in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 *
@@ -584,6 +611,7 @@ interface IUserConfig {
 	 * @param bool $sensitive TRUE to set as sensitive, FALSE to unset
 	 *
 	 * @return bool TRUE if database update were necessary
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -597,6 +625,7 @@ interface IUserConfig {
 	 * @param string $app id of the app
 	 * @param string $key config key
 	 * @param bool $sensitive TRUE to set as sensitive, FALSE to unset
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -614,6 +643,7 @@ interface IUserConfig {
 	 * @param bool $indexed TRUE to set as indexed, FALSE to unset
 	 *
 	 * @return bool TRUE if database update were necessary
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -627,6 +657,7 @@ interface IUserConfig {
 	 * @param string $app id of the app
 	 * @param string $key config key
 	 * @param bool $indexed TRUE to set as indexed, FALSE to unset
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -641,6 +672,7 @@ interface IUserConfig {
 	 * @param bool $lazy TRUE to set as lazy loaded, FALSE to unset
 	 *
 	 * @return bool TRUE if database update was necessary
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -654,6 +686,7 @@ interface IUserConfig {
 	 * @param string $app id of the app
 	 * @param string $key config key
 	 * @param bool $lazy TRUE to set as lazy loaded, FALSE to unset
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -680,6 +713,7 @@ interface IUserConfig {
 	 *
 	 * @return array
 	 * @throws UnknownKeyException if config key is not known in database
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -691,6 +725,7 @@ interface IUserConfig {
 	 * @param string $userId id of the user
 	 * @param string $app id of the app
 	 * @param string $key config key
+	 * @throws \InvalidArgumentException if $userId, $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -701,6 +736,7 @@ interface IUserConfig {
 	 *
 	 * @param string $app id of the app
 	 * @param string $key config key
+	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -710,6 +746,7 @@ interface IUserConfig {
 	 * delete all config keys linked to an app
 	 *
 	 * @param string $app id of the app
+	 * @throws \InvalidArgumentException if $app is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -719,6 +756,7 @@ interface IUserConfig {
 	 * delete all config keys linked to a user
 	 *
 	 * @param string $userId id of the user
+	 * @throws \InvalidArgumentException if $userId is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */
@@ -731,6 +769,7 @@ interface IUserConfig {
 	 *
 	 * @param string $userId id of the user
 	 * @param bool $reload set to TRUE to refill cache instantly after clearing it
+	 * @throws \InvalidArgumentException if $userId is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
 	 */


### PR DESCRIPTION
## Summary

UserConfig throws when given an invalid user id, which is new.
So catch the exception and ignore it. (in user_ldap we sometimes do not know if we are manipulating a user id or a DN)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
