### PR TITLE
feat: Add SetupCheck to warn about missing second factor provider

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -140,6 +140,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\TaskProcessingSuccessRate' => $baseDir . '/../lib/SetupChecks/TaskProcessingSuccessRate.php',
     'OCA\\Settings\\SetupChecks\\TempSpaceAvailable' => $baseDir . '/../lib/SetupChecks/TempSpaceAvailable.php',
     'OCA\\Settings\\SetupChecks\\TransactionIsolation' => $baseDir . '/../lib/SetupChecks/TransactionIsolation.php',
+    'OCA\\Settings\\SetupChecks\\TwoFactorConfiguration' => $baseDir . '/../lib/SetupChecks/TwoFactorConfiguration.php',
     'OCA\\Settings\\SetupChecks\\WellKnownUrls' => $baseDir . '/../lib/SetupChecks/WellKnownUrls.php',
     'OCA\\Settings\\SetupChecks\\Woff2Loading' => $baseDir . '/../lib/SetupChecks/Woff2Loading.php',
     'OCA\\Settings\\UserMigration\\AccountMigrator' => $baseDir . '/../lib/UserMigration/AccountMigrator.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -155,6 +155,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\TaskProcessingSuccessRate' => __DIR__ . '/..' . '/../lib/SetupChecks/TaskProcessingSuccessRate.php',
         'OCA\\Settings\\SetupChecks\\TempSpaceAvailable' => __DIR__ . '/..' . '/../lib/SetupChecks/TempSpaceAvailable.php',
         'OCA\\Settings\\SetupChecks\\TransactionIsolation' => __DIR__ . '/..' . '/../lib/SetupChecks/TransactionIsolation.php',
+        'OCA\\Settings\\SetupChecks\\TwoFactorConfiguration' => __DIR__ . '/..' . '/../lib/SetupChecks/TwoFactorConfiguration.php',
         'OCA\\Settings\\SetupChecks\\WellKnownUrls' => __DIR__ . '/..' . '/../lib/SetupChecks/WellKnownUrls.php',
         'OCA\\Settings\\SetupChecks\\Woff2Loading' => __DIR__ . '/..' . '/../lib/SetupChecks/Woff2Loading.php',
         'OCA\\Settings\\UserMigration\\AccountMigrator' => __DIR__ . '/..' . '/../lib/UserMigration/AccountMigrator.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -75,6 +75,7 @@ use OCA\Settings\SetupChecks\SystemIs64bit;
 use OCA\Settings\SetupChecks\TaskProcessingPickupSpeed;
 use OCA\Settings\SetupChecks\TempSpaceAvailable;
 use OCA\Settings\SetupChecks\TransactionIsolation;
+use OCA\Settings\SetupChecks\TwoFactorConfiguration;
 use OCA\Settings\SetupChecks\WellKnownUrls;
 use OCA\Settings\SetupChecks\Woff2Loading;
 use OCA\Settings\UserMigration\AccountMigrator;
@@ -218,6 +219,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(TaskProcessingPickupSpeed::class);
 		$context->registerSetupCheck(TempSpaceAvailable::class);
 		$context->registerSetupCheck(TransactionIsolation::class);
+		$context->registerSetupCheck(TwoFactorConfiguration::class);
 		$context->registerSetupCheck(PushService::class);
 		$context->registerSetupCheck(WellKnownUrls::class);
 		$context->registerSetupCheck(Woff2Loading::class);

--- a/apps/settings/lib/SetupChecks/TwoFactorConfiguration.php
+++ b/apps/settings/lib/SetupChecks/TwoFactorConfiguration.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Settings\SetupChecks;
+
+use OC\Authentication\TwoFactorAuth\ProviderLoader;
+use OCP\IL10N;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class TwoFactorConfiguration implements ISetupCheck {
+	public function __construct(
+		private IL10N $l10n,
+		private ProviderLoader $providerLoader,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Two factor configuration');
+	}
+
+	public function getCategory(): string {
+		return 'security';
+	}
+
+	public function run(): SetupResult {
+		$providers = $this->providerLoader->getProviders();
+		if (count($providers) === 0) {
+			return SetupResult::warning($this->l10n->t('This instance has no second factor provider available.'));
+		} else {
+			return SetupResult::success(
+				$this->l10n->t(
+					'Second factor providers are available: %s.',
+					[
+						implode(', ', array_map(
+							fn ($p) => '"' . $p->getDisplayName() . '"',
+							$providers)
+						)
+					]
+				)
+			);
+		}
+	}
+}

--- a/apps/settings/lib/SetupChecks/TwoFactorConfiguration.php
+++ b/apps/settings/lib/SetupChecks/TwoFactorConfiguration.php
@@ -3,12 +3,13 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 namespace OCA\Settings\SetupChecks;
 
 use OC\Authentication\TwoFactorAuth\ProviderLoader;
+use OC\Authentication\TwoFactorAuth\ProviderSet;
 use OCP\IL10N;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
@@ -21,7 +22,7 @@ class TwoFactorConfiguration implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Two factor configuration');
+		return $this->l10n->t('Second factor configuration');
 	}
 
 	public function getCategory(): string {
@@ -30,7 +31,9 @@ class TwoFactorConfiguration implements ISetupCheck {
 
 	public function run(): SetupResult {
 		$providers = $this->providerLoader->getProviders();
-		if (count($providers) === 0) {
+		$providerSet = new ProviderSet($providers, false);
+		$primaryProviders = $providerSet->getPrimaryProviders();
+		if (count($primaryProviders) === 0) {
 			return SetupResult::warning($this->l10n->t('This instance has no second factor provider available.'));
 		} else {
 			return SetupResult::success(
@@ -39,7 +42,7 @@ class TwoFactorConfiguration implements ISetupCheck {
 					[
 						implode(', ', array_map(
 							fn ($p) => '"' . $p->getDisplayName() . '"',
-							$providers)
+							$primaryProviders)
 						)
 					]
 				)

--- a/lib/private/Authentication/TwoFactorAuth/ProviderLoader.php
+++ b/lib/private/Authentication/TwoFactorAuth/ProviderLoader.php
@@ -30,8 +30,12 @@ class ProviderLoader {
 	 * @return IProvider[]
 	 * @throws Exception
 	 */
-	public function getProviders(IUser $user): array {
-		$allApps = $this->appManager->getEnabledAppsForUser($user);
+	public function getProviders(?IUser $user = null): array {
+		if ($user === null) {
+			$allApps = $this->appManager->getEnabledApps();
+		} else {
+			$allApps = $this->appManager->getEnabledAppsForUser($user);
+		}
 		$providers = [];
 
 		foreach ($allApps as $appId) {


### PR DESCRIPTION
* Resolves: #57408

## Summary

Add warning if no two factor auth provider is found.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
