### PR TITLE
docs: annotate valid renderAs values

### DIFF
--- a/apps/workflowengine/lib/Settings/ASettings.php
+++ b/apps/workflowengine/lib/Settings/ASettings.php
@@ -77,7 +77,7 @@ abstract class ASettings implements ISettings {
 			$this->urlGenerator->linkToDocs('admin-workflowengine')
 		);
 
-		return new TemplateResponse(Application::APP_ID, 'settings', [], 'blank');
+		return new TemplateResponse(Application::APP_ID, 'settings', [], TemplateResponse::RENDER_AS_BLANK);
 	}
 
 	/**

--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -74,12 +74,12 @@ class TemplateResponse extends Response {
 	protected $appName;
 
 	/**
-	 * constructor of TemplateResponse
 	 * @param string $appName the name of the app to load the template from
 	 * @param string $templateName the name of the template
 	 * @param array $params an array of parameters which should be passed to the
 	 *                      template
 	 * @param string $renderAs how the page should be rendered, defaults to user
+	 * @psalm-param TemplateResponse::RENDER_AS_* $renderAs
 	 * @param S $status
 	 * @param H $headers
 	 * @since 6.0.0 - parameters $params and $renderAs were added in 7.0.0


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Then Psalm can warn about using invalid values. 

There's also `'blank'`, which appears to be a legacy alias for `''`, but I didn't add it because there's no constant for it.

## Testing

The expected failure, as there's one instantiation with 'blank'. 
 
<img width="2888" height="318" alt="image" src="https://github.com/user-attachments/assets/d7831c38-ba29-4030-a2f2-fb49a80ccd52" />



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
