### PR TITLE
test(preview): properly test postscript preview provider

### DIFF
--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -86,14 +86,17 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           ini-file: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up dependencies
-        run: composer i
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ghostscript
+          composer i
 
       - name: Set up Nextcloud
         run: |
@@ -107,7 +110,7 @@ jobs:
         run: ./occ app:list && echo "======= System config =======" && ./occ config:list system
 
       - name: PHPUnit database tests
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
+        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }} tests/lib/Preview/PostscriptTest.php
 
       - name: Upload db code coverage
         if: ${{ !cancelled() && matrix.coverage }}
@@ -125,6 +128,8 @@ jobs:
       - name: Print logs
         if: always()
         run: |
+          gs --version
+          cat /etc/ImageMagick-6/policy.xml
           cat data/nextcloud.log
 
   summary:

--- a/lib/private/Preview/Postscript.php
+++ b/lib/private/Preview/Postscript.php
@@ -20,6 +20,6 @@ class Postscript extends Bitmap {
 	 * {@inheritDoc}
 	 */
 	protected function getAllowedMimeTypes(): string {
-		return '/application\/postscript/';
+		return '/(application\/postscript|image\/x-eps)/';
 	}
 }

--- a/tests/lib/Preview/PostscriptTest.php
+++ b/tests/lib/Preview/PostscriptTest.php
@@ -8,17 +8,22 @@
 
 namespace Test\Preview;
 
+use OC\BinaryFinder;
 use OC\Preview\Postscript;
 
-/**
- * Class BitmapTest
- *
- *
- * @package Test\Preview
- */
 #[\PHPUnit\Framework\Attributes\Group('DB')]
-class BitmapTest extends Provider {
+#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('imagick')]
+class PostscriptTest extends Provider {
+
 	protected function setUp(): void {
+		if (\Imagick::queryFormats('EPS') === false || \Imagick::queryFormats('PS') === false) {
+			$this->markTestSkipped('Imagick does not support postscript.');
+		}
+		if (\OCP\Server::get(BinaryFinder::class)->findBinaryPath('gs') === false) {
+			// Imagick forwards postscript rendering to Ghostscript but does not report this in queryFormats
+			$this->markTestSkipped('Ghostscript is not installed.');
+		}
+
 		parent::setUp();
 
 		$fileName = 'testimage.eps';

--- a/tests/lib/Preview/Provider.php
+++ b/tests/lib/Preview/Provider.php
@@ -13,18 +13,19 @@ use OC\Files\Node\File;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
+use OC\Preview\ProviderV2;
 use OC\Preview\TXT;
 use OCP\Files\IRootFolder;
 use OCP\IImage;
 use OCP\IUserManager;
+use OCP\Preview\IProviderV2;
 use OCP\Server;
 
 abstract class Provider extends \Test\TestCase {
 	protected string $imgPath;
 	protected int $width;
 	protected int $height;
-	/** @var \OC\Preview\Provider|mixed $provider */
-	protected $provider;
+	protected IProviderV2 $provider;
 	protected int $maxWidth = 1024;
 	protected int $maxHeight = 1024;
 	protected bool $scalingUp = false;
@@ -119,17 +120,11 @@ abstract class Provider extends \Test\TestCase {
 	/**
 	 * Retrieves a max size thumbnail can be created
 	 *
-	 * @param \OC\Preview\Provider $provider
-	 *
 	 * @return bool|IImage
 	 */
-	private function getPreview($provider) {
+	private function getPreview(ProviderV2 $provider) {
 		$file = new File(Server::get(IRootFolder::class), $this->rootView, $this->imgPath);
 		$preview = $provider->getThumbnail($file, $this->maxWidth, $this->maxHeight, $this->scalingUp);
-
-		if (get_class($this) === BitmapTest::class && $preview === null) {
-			$this->markTestSkipped('An error occured while operating with Imagick.');
-		}
 
 		$this->assertNotEquals(false, $preview);
 		$this->assertEquals(true, $preview->valid());


### PR DESCRIPTION
## Summary

The test was always skipped but the real reason it was failing was that the mime type for EPS files was missing (encapsulated postscript).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
