### PR TITLE
[stable33] fix: don't do full setup in setupForProvider if all requested providers are authoritative

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -673,7 +673,18 @@ class SetupManager {
 			return;
 		}
 
-		if ($this->fullSetupRequired($user)) {
+		$providersAreAuthoritative = true;
+		foreach ($providers as $provider) {
+			if (!(
+				is_a($provider, IAuthoritativeMountProvider::class, true)
+				|| is_a($provider, IRootMountProvider::class, true)
+				|| is_a($provider, IHomeMountProvider::class, true)
+			)) {
+				$providersAreAuthoritative = false;
+			}
+		}
+
+		if (!$providersAreAuthoritative && $this->fullSetupRequired($user)) {
 			$this->setupForUser($user);
 			return;
 		}


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/57767 to stable33