### PR TITLE
Keep config.php group-writable

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -283,7 +283,7 @@ class Config {
 		$filePointer = fopen($this->configFilePath, 'r+');
 
 		// Prevent others not to read the config
-		chmod($this->configFilePath, 0640);
+		chmod($this->configFilePath, 0660);
 
 		// File does not exist, this can happen when doing a fresh install
 		if (!is_resource($filePointer)) {


### PR DESCRIPTION
## Summary

This changes makes config.php group-writable.

This is useful when Nextcloud is installed in a directory with ownership shared between webserver (www-data) and a user with FTP or SSH access, so that the installation/update script may be run as user (CLI) without Nextcloud failing due to www-data not being able to write to the file, or as www-data (from web interface) without the user being unable to move/delete the file from their own cloud space (e.g. to delete Nextcloud).

One may use the setgid bit to ensure all files are owned by a common group, or ACL to ensure user and www-data can read/write all files, but the current chmod break that.

This change keeps the config not readable by others, as specified in the comment.

(See https://help.nextcloud.com/t/installing-nextcloud-in-user-home-directory-on-shared-server/238081/3.)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
