### PR TITLE
fix(View): Handle ICacheEntry returned by FileInfo->getData()

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -8,6 +8,7 @@
 namespace OC\Files;
 
 use Icewind\Streams\CallbackWrapper;
+use OC\Files\Cache\CacheEntry;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\Wrapper\Quota;
@@ -1657,6 +1658,9 @@ class View {
 	public function putFileInfo($path, $data) {
 		$this->assertPathLength($path);
 		if ($data instanceof FileInfo) {
+			$data = $data->getData();
+		}
+		if ($data instanceof CacheEntry) {
 			$data = $data->getData();
 		}
 		$path = Filesystem::normalizePath($this->fakeRoot . '/' . $path);


### PR DESCRIPTION
https://github.com/nextcloud/server/blob/7005bd2a258deae1f43e7eab380c5c230fb178a5/lib/private/Files/FileInfo.php#L21-L21 can be an array or ICacheEntry, so we need to handle it and turn it into an array. Otherwise https://github.com/nextcloud/server/blob/7005bd2a258deae1f43e7eab380c5c230fb178a5/lib/private/Files/View.php#L1679-L1679 fails, because it expects an array.