### PR TITLE
doc(Entity): Add type for getUpdatedField in doc

### DIFF
--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -21,8 +21,9 @@ use function substr;
 abstract class Entity {
 	/** @var int $id */
 	public $id;
+	/** @var array<string, true> $_updatedFields */
 	private array $_updatedFields = [];
-	/** @psalm-param $_fieldTypes array<string, Types::*> */
+	/** @var array<string, Types::*> $_fieldTypes */
 	protected array $_fieldTypes = ['id' => 'integer'];
 
 	/**
@@ -251,7 +252,7 @@ abstract class Entity {
 
 
 	/**
-	 * @return array array of updated fields for update query
+	 * @return array<string, true> array of updated fields for update query
 	 * @since 7.0.0
 	 */
 	public function getUpdatedFields(): array {


### PR DESCRIPTION
The method is very confusing as the updated fields are the keys of the returned array.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
