### PR TITLE
refactor: use strict comparison operator

### DIFF
--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -121,10 +121,10 @@ class TAR extends Archive {
 			$this->cachedHeaders = $this->tar->listContent();
 		}
 		foreach ($this->cachedHeaders as $header) {
-			if ($file == $header['filename']
-				|| $file . '/' == $header['filename']
-				|| '/' . $file . '/' == $header['filename']
-				|| '/' . $file == $header['filename']
+			if ($file === $header['filename']
+				|| $file . '/' === $header['filename']
+				|| '/' . $file . '/' === $header['filename']
+				|| '/' . $file === $header['filename']
 			) {
 				return $header;
 			}
@@ -158,10 +158,10 @@ class TAR extends Archive {
 		$folderContent = [];
 		$pathLength = strlen($path);
 		foreach ($files as $file) {
-			if ($file[0] == '/') {
+			if ($file[0] === '/') {
 				$file = substr($file, 1);
 			}
-			if (substr($file, 0, $pathLength) == $path && $file != $path) {
+			if (substr($file, 0, $pathLength) === $path && $file !== $path) {
 				$result = substr($file, $pathLength);
 				if ($pos = strpos($result, '/')) {
 					$result = substr($result, 0, $pos + 1);
@@ -250,12 +250,12 @@ class TAR extends Archive {
 			$folderPath = rtrim($path, '/') . '/';
 			$pathLength = strlen($folderPath);
 			foreach ($files as $file) {
-				if (strlen($file) > $pathLength && substr($file, 0, $pathLength) == $folderPath) {
+				if (strlen($file) > $pathLength && substr($file, 0, $pathLength) === $folderPath) {
 					return true;
 				}
 			}
 		}
-		if ($path[0] != '/') { //not all programs agree on the use of a leading /
+		if ($path[0] !== '/') { //not all programs agree on the use of a leading /
 			return $this->fileExists('/' . $path);
 		} else {
 			return false;
@@ -296,10 +296,10 @@ class TAR extends Archive {
 		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 		if ($this->fileExists($path)) {
 			$this->extractFile($path, $tmpFile);
-		} elseif ($mode == 'r' || $mode == 'rb') {
+		} elseif ($mode === 'r' || $mode === 'rb') {
 			return false;
 		}
-		if ($mode == 'r' || $mode == 'rb') {
+		if ($mode === 'r' || $mode === 'rb') {
 			return fopen($tmpFile, $mode);
 		} else {
 			$handle = fopen($tmpFile, $mode);

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -92,7 +92,7 @@ class ZIP extends Archive {
 		$folderContent = [];
 		$pathLength = strlen($path);
 		foreach ($files as $file) {
-			if (substr($file, 0, $pathLength) == $path && $file != $path) {
+			if (substr($file, 0, $pathLength) === $path && $file !== $path) {
 				if (strrpos(substr($file, 0, -1), '/') <= $pathLength) {
 					$folderContent[] = substr($file, $pathLength);
 				}
@@ -220,7 +220,7 @@ class ZIP extends Archive {
 	}
 
 	private function stripPath(string $path): string {
-		if (!$path || $path[0] == '/') {
+		if (!$path || $path[0] === '/') {
 			return substr($path, 1);
 		} else {
 			return $path;

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -104,7 +104,7 @@ class CacheJail extends CacheWrapper {
 	 * @return ICacheEntry|false
 	 */
 	public function get($file) {
-		if (is_string($file) || $file == '') {
+		if (is_string($file) || $file === '') {
 			$file = $this->getSourcePath($file);
 		}
 		return parent::get($file);

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -258,7 +258,7 @@ class LazyFolder implements Folder {
 	 */
 	public function isReadable() {
 		if (isset($this->data['permissions'])) {
-			return ($this->data['permissions'] & Constants::PERMISSION_READ) == Constants::PERMISSION_READ;
+			return ($this->data['permissions'] & Constants::PERMISSION_READ) === Constants::PERMISSION_READ;
 		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
@@ -268,7 +268,7 @@ class LazyFolder implements Folder {
 	 */
 	public function isUpdateable() {
 		if (isset($this->data['permissions'])) {
-			return ($this->data['permissions'] & Constants::PERMISSION_UPDATE) == Constants::PERMISSION_UPDATE;
+			return ($this->data['permissions'] & Constants::PERMISSION_UPDATE) === Constants::PERMISSION_UPDATE;
 		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
@@ -278,7 +278,7 @@ class LazyFolder implements Folder {
 	 */
 	public function isDeletable() {
 		if (isset($this->data['permissions'])) {
-			return ($this->data['permissions'] & Constants::PERMISSION_DELETE) == Constants::PERMISSION_DELETE;
+			return ($this->data['permissions'] & Constants::PERMISSION_DELETE) === Constants::PERMISSION_DELETE;
 		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
@@ -288,7 +288,7 @@ class LazyFolder implements Folder {
 	 */
 	public function isShareable() {
 		if (isset($this->data['permissions'])) {
-			return ($this->data['permissions'] & Constants::PERMISSION_SHARE) == Constants::PERMISSION_SHARE;
+			return ($this->data['permissions'] & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE;
 		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}

--- a/lib/private/Files/Search/QueryOptimizer/PathPrefixOptimizer.php
+++ b/lib/private/Files/Search/QueryOptimizer/PathPrefixOptimizer.php
@@ -40,7 +40,7 @@ class PathPrefixOptimizer extends QueryOptimizerStep {
 	}
 
 	private function isPathPrefixOperator(ISearchOperator $operator): bool {
-		if ($operator instanceof ISearchBinaryOperator && $operator->getType() === ISearchBinaryOperator::OPERATOR_OR && count($operator->getArguments()) == 2) {
+		if ($operator instanceof ISearchBinaryOperator && $operator->getType() === ISearchBinaryOperator::OPERATOR_OR && count($operator->getArguments()) === 2) {
 			$a = $operator->getArguments()[0];
 			$b = $operator->getArguments()[1];
 			if ($this->operatorPairIsPathPrefix($a, $b) || $this->operatorPairIsPathPrefix($b, $a)) {

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -391,15 +391,15 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	 * @return string cleaned path
 	 */
 	public function cleanPath(string $path): string {
-		if (strlen($path) == 0 || $path[0] != '/') {
+		if (strlen($path) === 0 || $path[0] !== '/') {
 			$path = '/' . $path;
 		}
 
 		$output = [];
 		foreach (explode('/', $path) as $chunk) {
-			if ($chunk == '..') {
+			if ($chunk === '..') {
 				array_pop($output);
-			} elseif ($chunk == '.') {
+			} elseif ($chunk === '.') {
 			} else {
 				$output[] = $chunk;
 			}
@@ -611,7 +611,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		if ($data['mtime'] === false) {
 			$data['mtime'] = time();
 		}
-		if ($data['mimetype'] == 'httpd/unix-directory') {
+		if ($data['mimetype'] === 'httpd/unix-directory') {
 			$data['size'] = -1; //unknown
 		} else {
 			$data['size'] = $this->filesize($path);

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -284,7 +284,7 @@ class DAV extends Common {
 				/** @var ResourceType[] $response */
 				$responseType = $response['{DAV:}resourcetype']->getValue();
 			}
-			return (count($responseType) > 0 && $responseType[0] == '{DAV:}collection') ? 'dir' : 'file';
+			return (count($responseType) > 0 && $responseType[0] === '{DAV:}collection') ? 'dir' : 'file';
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);
 		}
@@ -572,7 +572,7 @@ class DAV extends Common {
 			/** @var ResourceType[] $response */
 			$responseType = $response['{DAV:}resourcetype']->getValue();
 		}
-		$type = (count($responseType) > 0 && $responseType[0] == '{DAV:}collection') ? 'dir' : 'file';
+		$type = (count($responseType) > 0 && $responseType[0] === '{DAV:}collection') ? 'dir' : 'file';
 		if ($type === 'dir') {
 			$mimeType = 'httpd/unix-directory';
 		} elseif (isset($response['{DAV:}getcontenttype'])) {
@@ -648,7 +648,7 @@ class DAV extends Common {
 		$path = $this->cleanPath($path);
 		try {
 			$response = $this->client->request($method, $this->encodePath($path), $body);
-			return $response['statusCode'] == $expected;
+			return $response['statusCode'] === $expected;
 		} catch (ClientHttpException $e) {
 			if ($e->getHttpStatus() === 404 && $method === 'DELETE') {
 				$this->statCache->clear($path . '/');

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -216,7 +216,7 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function filetype(string $path): string|false {
 		$filetype = filetype($this->getSourcePath($path));
-		if ($filetype == 'link') {
+		if ($filetype === 'link') {
 			$filetype = filetype(realpath($this->getSourcePath($path)));
 		}
 		return $filetype;

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -104,7 +104,7 @@ class View {
 	 * @param string $fakeRoot
 	 */
 	public function chroot($fakeRoot): void {
-		if (!$fakeRoot == '') {
+		if ($fakeRoot !== '') {
 			if ($fakeRoot[0] !== '/') {
 				$fakeRoot = '/' . $fakeRoot;
 			}
@@ -126,7 +126,7 @@ class View {
 	 */
 	public function getRelativePath($path): ?string {
 		$this->assertPathLength($path);
-		if ($this->fakeRoot == '') {
+		if ($this->fakeRoot === '') {
 			return $path;
 		}
 
@@ -319,7 +319,7 @@ class View {
 	 * @return bool|mixed
 	 */
 	public function is_dir($path) {
-		if ($path == '/') {
+		if ($path === '/') {
 			return true;
 		}
 		return $this->basicOperation('is_dir', $path);
@@ -330,7 +330,7 @@ class View {
 	 * @return bool|mixed
 	 */
 	public function is_file($path) {
-		if ($path == '/') {
+		if ($path === '/') {
 			return false;
 		}
 		return $this->basicOperation('is_file', $path);
@@ -496,7 +496,7 @@ class View {
 	 * @return bool|mixed
 	 */
 	public function file_exists($path) {
-		if ($path == '/') {
+		if ($path === '/') {
 			return true;
 		}
 		return $this->basicOperation('file_exists', $path);
@@ -728,7 +728,7 @@ class View {
 			$target = $this->getRelativePath($absolutePath2);
 			$exists = $this->file_exists($target);
 
-			if ($source == null || $target == null) {
+			if ($source === null || $target === null) {
 				return false;
 			}
 
@@ -925,7 +925,7 @@ class View {
 			$source = $this->getRelativePath($absolutePath1);
 			$target = $this->getRelativePath($absolutePath2);
 
-			if ($source == null || $target == null) {
+			if ($source === null || $target === null) {
 				return false;
 			}
 			$run = true;
@@ -960,7 +960,7 @@ class View {
 					$this->changeLock($target, ILockingProvider::LOCK_EXCLUSIVE);
 					$lockTypePath2 = ILockingProvider::LOCK_EXCLUSIVE;
 
-					if ($mount1->getMountPoint() == $mount2->getMountPoint()) {
+					if ($mount1->getMountPoint() === $mount2->getMountPoint()) {
 						if ($storage1) {
 							$result = $storage1->copy($internalPath1, $internalPath2);
 						} else {
@@ -1131,7 +1131,7 @@ class View {
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 		if (Filesystem::isValidPath($path)) {
 			$path = $this->getRelativePath($absolutePath);
-			if ($path == null) {
+			if ($path === null) {
 				return false;
 			}
 			if ($this->shouldEmitHooks($path)) {
@@ -1182,7 +1182,7 @@ class View {
 			&& !Filesystem::isFileBlacklisted($path)
 		) {
 			$path = $this->getRelativePath($absolutePath);
-			if ($path == null) {
+			if ($path === null) {
 				return false;
 			}
 
@@ -1250,7 +1250,7 @@ class View {
 				}
 
 				if ($this->shouldEmitHooks($path) && $result !== false) {
-					if ($operation != 'fopen') { //no post hooks for fopen, the file stream is still open
+					if ($operation !== 'fopen') { //no post hooks for fopen, the file stream is still open
 						$this->runHooks($hooks, $path, true);
 					}
 				}
@@ -1318,7 +1318,7 @@ class View {
 		$run = true;
 		if ($this->shouldEmitHooks($relativePath)) {
 			foreach ($hooks as $hook) {
-				if ($hook != 'read') {
+				if ($hook !== 'read') {
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
 						$prefix . $hook,
@@ -2252,7 +2252,7 @@ class View {
 			throw new NotFoundException($this->getAbsolutePath($filename) . ' not found');
 		}
 		$uid = $info->getOwner()->getUID();
-		if ($uid != \OC_User::getUser()) {
+		if ($uid !== \OC_User::getUser()) {
 			Filesystem::initMountPoints($uid);
 			$ownerView = new View('/' . $uid . '/files');
 			try {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Found no good reason for any of these to not be strict.
Not sure if this is a refactor or a fix 😆 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
