### PR TITLE
perf: Allow filtering the directory content by mimetype

### DIFF
--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -331,7 +331,7 @@ class EncryptAllTest extends TestCase {
 			->willReturnMap([
 				[
 					'/user1/files',
-					'',
+					null,
 					null,
 					[
 						$this->createFileInfoMock(FileInfo::TYPE_FOLDER, 'foo'),
@@ -340,7 +340,7 @@ class EncryptAllTest extends TestCase {
 				],
 				[
 					'/user1/files/foo',
-					'',
+					null,
 					null,
 					[
 						$this->createFileInfoMock(FileInfo::TYPE_FILE, 'subfile'),

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -247,9 +247,11 @@ class ApiController extends Controller {
 
 	/**
 	 * @param \OCP\Files\Node[] $nodes
+	 * @param ?non-empty-string $mimeTypeFilter limit returned content to this mimetype or mimepart
 	 * @param int $depth The depth to traverse into the contents of each node
+	 * @return FilesFolderTree
 	 */
-	private function getChildren(array $nodes, int $depth = 1, int $currentDepth = 0, string $mimeTypeFilter = ''): array {
+	private function getChildren(array $nodes, int $depth = 1, int $currentDepth = 0, ?string $mimeTypeFilter = null): array {
 		if ($currentDepth >= $depth) {
 			return [];
 		}
@@ -272,6 +274,7 @@ class ApiController extends Controller {
 			}
 			$children[] = $entry;
 		}
+		/** @var FilesFolderTree $children */
 		return $children;
 	}
 

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -249,7 +249,7 @@ class ApiController extends Controller {
 	 * @param \OCP\Files\Node[] $nodes
 	 * @param int $depth The depth to traverse into the contents of each node
 	 */
-	private function getChildren(array $nodes, int $depth = 1, int $currentDepth = 0): array {
+	private function getChildren(array $nodes, int $depth = 1, int $currentDepth = 0, string $mimeTypeFilter = ''): array {
 		if ($currentDepth >= $depth) {
 			return [];
 		}
@@ -264,7 +264,7 @@ class ApiController extends Controller {
 			$entry = [
 				'id' => $node->getId(),
 				'basename' => $basename,
-				'children' => $this->getChildren($node->getDirectoryListing(), $depth, $currentDepth + 1),
+				'children' => $this->getChildren($node->getDirectoryListing($mimeTypeFilter), $depth, $currentDepth + 1),
 			];
 			$displayName = $node->getName();
 			if ($basename !== $displayName) {
@@ -308,8 +308,8 @@ class ApiController extends Controller {
 					'message' => $this->l10n->t('Invalid folder path'),
 				], Http::STATUS_BAD_REQUEST);
 			}
-			$nodes = $node->getDirectoryListing();
-			$tree = $this->getChildren($nodes, $depth);
+			$nodes = $node->getDirectoryListing('httpd/unix-directory');
+			$tree = $this->getChildren($nodes, $depth, 0, 'httpd/unix-directory');
 		} catch (NotFoundException $e) {
 			return new JSONResponse([
 				'message' => $this->l10n->t('Folder not found'),

--- a/apps/files_sharing/lib/External/Cache.php
+++ b/apps/files_sharing/lib/External/Cache.php
@@ -41,8 +41,8 @@ class Cache extends \OC\Files\Cache\Cache {
 		return $result;
 	}
 
-	public function getFolderContentsById($fileId) {
-		$results = parent::getFolderContentsById($fileId);
+	public function getFolderContentsById($fileId, ?string $mimeTypeFilter = null): array {
+		$results = parent::getFolderContentsById($fileId, $mimeTypeFilter);
 		foreach ($results as &$file) {
 			$file['displayname_owner'] = $this->cloudId->getDisplayId();
 		}

--- a/autotest.sh
+++ b/autotest.sh
@@ -309,7 +309,7 @@ function execute_tests {
 		if [ ! -z "$USEDOCKER" ] ; then
 			echo "Fire up the postgres docker"
 			DOCKER_CONTAINER_ID=$(docker run -e POSTGRES_DB="$DATABASENAME" -e POSTGRES_USER="$DATABASEUSER" -e POSTGRES_PASSWORD=owncloud -d postgres)
-			DATABASEHOST=$(docker inspect --format="{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}" "$DOCKER_CONTAINER_ID")
+			DATABASEHOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "$DOCKER_CONTAINER_ID")
 
 			echo "Waiting for Postgres initialisation ..."
 

--- a/autotest.sh
+++ b/autotest.sh
@@ -309,7 +309,7 @@ function execute_tests {
 		if [ ! -z "$USEDOCKER" ] ; then
 			echo "Fire up the postgres docker"
 			DOCKER_CONTAINER_ID=$(docker run -e POSTGRES_DB="$DATABASENAME" -e POSTGRES_USER="$DATABASEUSER" -e POSTGRES_PASSWORD=owncloud -d postgres)
-			DATABASEHOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "$DOCKER_CONTAINER_ID")
+			DATABASEHOST=$(docker inspect --format="{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}" "$DOCKER_CONTAINER_ID")
 
 			echo "Waiting for Postgres initialisation ..."
 

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -37,6 +37,7 @@ use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IDBConnection;
 use OCP\Server;
 use OCP\Util;
+use Override;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -201,23 +202,13 @@ class Cache implements ICache {
 		return new CacheEntry($normalized);
 	}
 
-	/**
-	 * get the metadata of all files stored in $folder
-	 *
-	 * @param string $folder
-	 * @return ICacheEntry[]
-	 */
-	public function getFolderContents($folder) {
+	#[Override]
+	public function getFolderContents(string $folder, ?string $mimeTypeFilter = null) {
 		$fileId = $this->getId($folder);
-		return $this->getFolderContentsById($fileId);
+		return $this->getFolderContentsById($fileId, $mimeTypeFilter);
 	}
 
-	/**
-	 * get the metadata of all files stored in $folder
-	 *
-	 * @param int $fileId the file id of the folder
-	 * @return ICacheEntry[]
-	 */
+	#[Override]
 	public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null) {
 		if ($fileId > -1) {
 			$query = $this->getQueryBuilder();

--- a/lib/private/Files/Cache/FailedCache.php
+++ b/lib/private/Files/Cache/FailedCache.php
@@ -45,7 +45,7 @@ class FailedCache implements ICache {
 		}
 	}
 
-	public function getFolderContents($folder): array {
+	public function getFolderContents(string $folder, ?string $mimeTypeFilter = null): array {
 		return [];
 	}
 

--- a/lib/private/Files/Cache/FailedCache.php
+++ b/lib/private/Files/Cache/FailedCache.php
@@ -26,12 +26,11 @@ class FailedCache implements ICache {
 	) {
 	}
 
-
-	public function getNumericStorageId() {
+	public function getNumericStorageId(): int {
 		return -1;
 	}
 
-	public function get($file) {
+	public function get($file): false|ICacheEntry {
 		if ($file === '') {
 			return new CacheEntry([
 				'fileid' => -1,
@@ -46,11 +45,11 @@ class FailedCache implements ICache {
 		}
 	}
 
-	public function getFolderContents($folder) {
+	public function getFolderContents($folder): array {
 		return [];
 	}
 
-	public function getFolderContentsById($fileId) {
+	public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null): array {
 		return [];
 	}
 
@@ -63,15 +62,15 @@ class FailedCache implements ICache {
 	public function update($id, array $data) {
 	}
 
-	public function getId($file) {
+	public function getId($file): int {
 		return -1;
 	}
 
-	public function getParentId($file) {
+	public function getParentId($file): int {
 		return -1;
 	}
 
-	public function inCache($file) {
+	public function inCache($file): bool {
 		return false;
 	}
 

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -89,11 +89,11 @@ class CacheWrapper extends Cache {
 	 * @param string $folder
 	 * @return ICacheEntry[]
 	 */
-	public function getFolderContents($folder) {
+	public function getFolderContents(string $folder, ?string $mimeTypeFilter = null): array {
 		// can't do a simple $this->getCache()->.... call here since getFolderContentsById needs to be called on this
 		// and not the wrapped cache
 		$fileId = $this->getId($folder);
-		return $this->getFolderContentsById($fileId);
+		return $this->getFolderContentsById($fileId, $mimeTypeFilter);
 	}
 
 	/**

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -102,9 +102,9 @@ class CacheWrapper extends Cache {
 	 * @param int $fileId the file id of the folder
 	 * @return array
 	 */
-	public function getFolderContentsById($fileId) {
-		$results = $this->getCache()->getFolderContentsById($fileId);
-		return array_map([$this, 'formatCacheEntry'], $results);
+	public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null) {
+		$results = $this->getCache()->getFolderContentsById($fileId, $mimeTypeFilter);
+		return array_map($this->formatCacheEntry(...), $results);
 	}
 
 	/**

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -666,10 +666,10 @@ class Filesystem {
 	 * Get the content of a directory.
 	 *
 	 * @param string $directory path under datadirectory
-	 * @param string $mimeTypeFilter limit returned content to this mimetype or mimepart
+	 * @param ?non-empty-string $mimeTypeFilter limit returned content to this mimetype or mimepart
 	 * @return FileInfo[]
 	 */
-	public static function getDirectoryContent($directory, string $mimeTypeFilter = '') {
+	public static function getDirectoryContent($directory, ?string $mimeTypeFilter = null): array {
 		return self::$defaultInstance->getDirectoryContent($directory, $mimeTypeFilter);
 	}
 

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -663,14 +663,14 @@ class Filesystem {
 	}
 
 	/**
-	 * get the content of a directory
+	 * Get the content of a directory.
 	 *
 	 * @param string $directory path under datadirectory
-	 * @param string $mimetype_filter limit returned content to this mimetype or mimepart
+	 * @param string $mimeTypeFilter limit returned content to this mimetype or mimepart
 	 * @return FileInfo[]
 	 */
-	public static function getDirectoryContent($directory, $mimetype_filter = '') {
-		return self::$defaultInstance->getDirectoryContent($directory, $mimetype_filter);
+	public static function getDirectoryContent($directory, string $mimeTypeFilter = '') {
+		return self::$defaultInstance->getDirectoryContent($directory, $mimeTypeFilter);
 	}
 
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -76,16 +76,11 @@ class Folder extends Node implements IFolder {
 		return str_starts_with($node->getPath(), $this->path . '/');
 	}
 
-	/**
-	 * get the content of this directory
-	 *
-	 * @return Node[]
-	 * @throws \OCP\Files\NotFoundException
-	 */
-	public function getDirectoryListing() {
-		$folderContent = $this->view->getDirectoryContent($this->path, '', $this->getFileInfo(false));
+	#[Override]
+	public function getDirectoryListing(?string $mimetypeFilter = null): array {
+		$folderContent = $this->view->getDirectoryContent($this->path, $mimetypeFilter, $this->getFileInfo(false));
 
-		return array_map(function (FileInfo $info) {
+		return array_map(function (FileInfo $info): Node {
 			if ($info->getMimetype() === FileInfo::MIMETYPE_FOLDER) {
 				return new Folder($this->root, $this->view, $info->getPath(), $info, $this);
 			} else {

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -415,10 +415,8 @@ class LazyFolder implements Folder {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	public function getDirectoryListing() {
+	#[Override]
+	public function getDirectoryListing(?string $mimetypeFilter = null): array {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 

--- a/lib/private/Files/Node/NonExistingFolder.php
+++ b/lib/private/Files/Node/NonExistingFolder.php
@@ -8,6 +8,7 @@
 namespace OC\Files\Node;
 
 use OCP\Files\NotFoundException;
+use Override;
 
 class NonExistingFolder extends Folder {
 	/**
@@ -118,7 +119,8 @@ class NonExistingFolder extends Folder {
 		throw new NotFoundException();
 	}
 
-	public function getDirectoryListing() {
+	#[Override]
+	public function getDirectoryListing(?string $mimetypeFilter = null): never {
 		throw new NotFoundException();
 	}
 

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -44,7 +44,7 @@ class NullCache implements ICache {
 		]);
 	}
 
-	public function getFolderContents($folder): array {
+	public function getFolderContents(string $folder, ?string $mimeTypeFilter = null): array {
 		return [];
 	}
 

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -20,11 +20,11 @@ use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 
 class NullCache implements ICache {
-	public function getNumericStorageId() {
+	public function getNumericStorageId(): int {
 		return -1;
 	}
 
-	public function get($file) {
+	public function get($file): false|ICacheEntry {
 		if ($file !== '') {
 			return false;
 		}
@@ -44,23 +44,23 @@ class NullCache implements ICache {
 		]);
 	}
 
-	public function getFolderContents($folder) {
+	public function getFolderContents($folder): array {
 		return [];
 	}
 
-	public function getFolderContentsById($fileId) {
+	public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null): array {
 		return [];
 	}
 
-	public function put($file, array $data) {
+	public function put($file, array $data): never {
 		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function insert($file, array $data) {
+	public function insert($file, array $data): never {
 		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function update($id, array $data) {
+	public function update($id, array $data): never {
 		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -52,7 +52,7 @@ interface ICache {
 	public function getNumericStorageId();
 
 	/**
-	 * get the stored metadata of a file or folder
+	 * Get the stored metadata of a file or folder.
 	 *
 	 * @param string | int $file either the path of a file or folder or the file id for a file or folder
 	 * @return ICacheEntry|false the cache entry or false if the file is not found in the cache
@@ -61,20 +61,21 @@ interface ICache {
 	public function get($file);
 
 	/**
-	 * get the metadata of all files stored in $folder
+	 * Get the metadata of all files stored in $folder.
 	 *
-	 * Only returns files one level deep, no recursion
+	 * @note This only returns files one level deep with no recursion.
 	 *
 	 * @param string $folder
+	 * @param ?non-empty-string $mimeTypeFilter The mimetype or mimepart for which the content should be filtered
 	 * @return ICacheEntry[]
 	 * @since 9.0.0
 	 */
-	public function getFolderContents($folder);
+	public function getFolderContents(string $folder, ?string $mimeTypeFilter = null);
 
 	/**
-	 * get the metadata of all files stored in $folder
+	 * Get the metadata of all files stored in $folder.
 	 *
-	 * Only returns files one level deep, no recursion
+	 * @note This only returns files one level deep with no recursion.
 	 *
 	 * @param int $fileId the file id of the folder
 	 * @param ?non-empty-string $mimeTypeFilter The mimetype or mimepart for which the content should be filtered
@@ -85,8 +86,9 @@ interface ICache {
 	public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null);
 
 	/**
-	 * store meta data for a file or folder
-	 * This will automatically call either insert or update depending on if the file exists
+	 * Store meta data for a file or folder.
+	 *
+	 * This will automatically call either insert or update depending on if the file exists.
 	 *
 	 * @param string $file
 	 * @param array $data

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -77,10 +77,12 @@ interface ICache {
 	 * Only returns files one level deep, no recursion
 	 *
 	 * @param int $fileId the file id of the folder
+	 * @param ?non-empty-string $mimeTypeFilter The mimetype or mimepart for which the content should be filtered
 	 * @return ICacheEntry[]
 	 * @since 9.0.0
+	 * @since 34.0.0 The $mimetypeFilter was added.
 	 */
-	public function getFolderContentsById($fileId);
+	public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null);
 
 	/**
 	 * store meta data for a file or folder

--- a/lib/public/Files/Folder.php
+++ b/lib/public/Files/Folder.php
@@ -46,13 +46,14 @@ interface Folder extends Node {
 	public function isSubNode($node);
 
 	/**
-	 * get the content of this directory
+	 * Get the content of this directory.
 	 *
+	 * @param ?non-empty-string $mimetypeFilter Limit the returned content to this mimetype or mimepart
 	 * @throws \OCP\Files\NotFoundException
 	 * @return \OCP\Files\Node[]
 	 * @since 6.0.0
 	 */
-	public function getDirectoryListing();
+	public function getDirectoryListing(?string $mimetypeFilter = null): array;
 
 	/**
 	 * Get the node at $path

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -248,7 +248,7 @@ class DecryptAllTest extends TestCase {
 			->method('getDirectoryContent')
 			->willReturnMap([
 				[
-					'/user1/files', '', null,
+					'/user1/files', null, null,
 					[
 						new FileInfo('path', $storage, 'intPath', ['name' => 'foo', 'type' => 'dir'], null),
 						new FileInfo('path', $storage, 'intPath', ['name' => 'bar', 'type' => 'file', 'encrypted' => true], null),
@@ -256,7 +256,7 @@ class DecryptAllTest extends TestCase {
 					],
 				],
 				[
-					'/user1/files/foo', '', null,
+					'/user1/files/foo', null, null,
 					[
 						new FileInfo('path', $storage, 'intPath', ['name' => 'subfile', 'type' => 'file', 'encrypted' => true], null)
 					],


### PR DESCRIPTION
## Summary

Likely too late for 33

Optimize a bit the /ocs/v2.php/apps/files/api/v1/folder-tree as it means we have less entry to fetch which takes around 30s to execute on prod 
 
<img width="613" height="921" alt="image" src="https://github.com/user-attachments/assets/b636db0f-8927-4f55-b423-efcaed31f1f3" />

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
