### PR TITLE
perf(MountManager): use binary search to find mount in path

### DIFF
--- a/tests/lib/Files/Mount/ManagerTest.php
+++ b/tests/lib/Files/Mount/ManagerTest.php
@@ -54,6 +54,24 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals([$mount1, $mount3], $this->manager->findByStorageId($id));
 	}
 
+	public function testBinarySearch(): void {
+		$sortedArray = [
+			'a' => false,
+			'aa' => false,
+			'b' => false,
+			'bb' => false,
+			'bba' => true,
+			'bbb' => true,
+			'bdc' => false,
+		];
+		$sortedKey = array_keys($sortedArray);
+		$result = $this->invokePrivate($this->manager, 'binarySearch', [$sortedArray, $sortedKey, 'bb']);
+		$this->assertEquals(2, count($result));
+		foreach ($result as $entry) {
+			$this->assertTrue($entry);
+		}
+	}
+
 	public function testLong(): void {
 		$storage = new LongId([]);
 		$mount = new MountPoint($storage, '/foo');


### PR DESCRIPTION
## Summary

Should help when doing a `ocs/v2.php/apps/files/api/v1/folder-tree` request (which took 30s on prod) but also for other requests as this is a hot path 

<img width="675" height="943" alt="image" src="https://github.com/user-attachments/assets/7b4e23a1-fe0d-442c-9313-e0bfe820a208" />

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
