### PR TITLE
refactor(CacheMountInfo): Use constructor paramater promotion

### DIFF
--- a/lib/private/Files/Config/CachedMountInfo.php
+++ b/lib/private/Files/Config/CachedMountInfo.php
@@ -13,45 +13,21 @@ use OCP\Files\Node;
 use OCP\IUser;
 
 class CachedMountInfo implements ICachedMountInfo {
-	protected IUser $user;
-	protected int $storageId;
-	protected int $rootId;
-	protected string $mountPoint;
-	protected ?int $mountId;
-	protected string $rootInternalPath;
-	protected string $mountProvider;
 	protected string $key;
 
-	/**
-	 * CachedMountInfo constructor.
-	 *
-	 * @param IUser $user
-	 * @param int $storageId
-	 * @param int $rootId
-	 * @param string $mountPoint
-	 * @param int|null $mountId
-	 * @param string $rootInternalPath
-	 */
 	public function __construct(
-		IUser $user,
-		int $storageId,
-		int $rootId,
-		string $mountPoint,
-		string $mountProvider,
-		?int $mountId = null,
-		string $rootInternalPath = '',
+		protected IUser $user,
+		protected int $storageId,
+		protected int $rootId,
+		protected string $mountPoint,
+		protected string $mountProvider,
+		protected ?int $mountId = null,
+		protected string $rootInternalPath = '',
 	) {
-		$this->user = $user;
-		$this->storageId = $storageId;
-		$this->rootId = $rootId;
-		$this->mountPoint = $mountPoint;
-		$this->mountId = $mountId;
-		$this->rootInternalPath = $rootInternalPath;
-		if (strlen($mountProvider) > 128) {
-			throw new \Exception("Mount provider $mountProvider name exceeds the limit of 128 characters");
+		if (strlen($this->mountProvider) > 128) {
+			throw new \Exception("Mount provider $this->mountProvider name exceeds the limit of 128 characters");
 		}
-		$this->mountProvider = $mountProvider;
-		$this->key = $rootId . '::' . $mountPoint;
+		$this->key = $this->rootId . '::' . $this->mountPoint;
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
