### PR TITLE
fix(2fa): allow null redirect URL on 2FA challenge page

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -72,7 +72,7 @@ class TwoFactorChallengeController extends Controller {
 	#[NoCSRFRequired]
 	#[FrontpageRoute(verb: 'GET', url: '/login/selectchallenge')]
 	#[TwoFactorSetUpDoneRequired]
-	public function selectChallenge(string $redirect_url): StandaloneTemplateResponse {
+	public function selectChallenge(?string $redirect_url = null): StandaloneTemplateResponse {
 		$user = $this->userSession->getUser();
 		$providerSet = $this->twoFactorManager->getProviderSet($user);
 		$allProviders = $providerSet->getProviders();
@@ -96,7 +96,7 @@ class TwoFactorChallengeController extends Controller {
 	#[UseSession]
 	#[TwoFactorSetUpDoneRequired]
 	#[FrontpageRoute(verb: 'GET', url: '/login/challenge/{challengeProviderId}')]
-	public function showChallenge(string $challengeProviderId, string $redirect_url): StandaloneTemplateResponse|RedirectResponse {
+	public function showChallenge(string $challengeProviderId, ?string $redirect_url = null): StandaloneTemplateResponse|RedirectResponse {
 		$user = $this->userSession->getUser();
 		$providerSet = $this->twoFactorManager->getProviderSet($user);
 		$provider = $providerSet->getProvider($challengeProviderId);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Makes it possible to use 2FA during login without a redirect URL.

| Before | After |
|--------|--------|
| <img width="1433" height="683" alt="Bildschirmfoto vom 2026-01-29 14-36-53" src="https://github.com/user-attachments/assets/e63eab89-937b-46cb-a7d0-022dc5412698" /> | <img width="1433" height="683" alt="Bildschirmfoto vom 2026-01-29 14-37-00" src="https://github.com/user-attachments/assets/420a6519-b760-4ebf-9c3c-3f45a4370667" /> |  

Regression of https://github.com/nextcloud/server/pull/55474.
Discovered in https://github.com/nextcloud/twofactor_totp/pull/1716

## TODO

- [x] Fix

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
