### PR TITLE
fix: still setup for user when setting up root path with children

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3719,17 +3719,12 @@
       <code><![CDATA[$this->mountManager->findByNumericId($numericId)]]></code>
       <code><![CDATA[$this->mountManager->findByStorageId($storageId)]]></code>
       <code><![CDATA[$this->mountManager->findIn($mountPoint)]]></code>
-      <code><![CDATA[$this->user]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[MountPoint[]]]></code>
       <code><![CDATA[\OC\Files\Mount\MountPoint[]]]></code>
       <code><![CDATA[\OC\Files\Mount\MountPoint[]]]></code>
-      <code><![CDATA[\OC\User\User]]></code>
     </MoreSpecificReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->user]]></code>
-    </NullableReturnStatement>
     <UndefinedMethod>
       <code><![CDATA[remove]]></code>
     </UndefinedMethod>

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -230,11 +230,11 @@ class Manager implements IMountManager {
 	}
 
 	/**
-	 * Return all mounts in a path from a specific mount provider
+	 * Return all mounts in a path from a specific mount provider, indexed by mount point
 	 *
 	 * @param string $path
 	 * @param string[] $mountProviders
-	 * @return IMountPoint[]
+	 * @return array<string, IMountPoint>
 	 */
 	public function getMountsByMountProvider(string $path, array $mountProviders) {
 		$this->getSetupManager()->setupForProvider($path, $mountProviders);

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Node;
 
 use OC\Files\FileInfo;
@@ -19,6 +20,8 @@ use OCA\Files\ConfigLexicon;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Config\ICachedMountFileInfo;
+use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Events\Node\FilesystemTornDownEvent;
 use OCP\Files\IRootFolder;
@@ -82,10 +85,8 @@ class Root extends Folder implements IRootFolder {
 
 	/**
 	 * Get the user for which the filesystem is setup
-	 *
-	 * @return \OC\User\User
 	 */
-	public function getUser() {
+	public function getUser(): ?IUser {
 		return $this->user;
 	}
 
@@ -411,12 +412,12 @@ class Root extends Folder implements IRootFolder {
 		} else {
 			$user = null;
 		}
-		$mountsContainingFile = $mountCache->getMountsForFileId($id, $user);
+		$mountInfosContainingFiles = $mountCache->getMountsForFileId($id, $user);
 
 		// if the mount isn't in the cache yet, perform a setup first, then try again
-		if (count($mountsContainingFile) === 0) {
+		if (count($mountInfosContainingFiles) === 0) {
 			$setupManager->setupForPath($path, true);
-			$mountsContainingFile = $mountCache->getMountsForFileId($id, $user);
+			$mountInfosContainingFiles = $mountCache->getMountsForFileId($id, $user);
 		}
 
 		// when a user has access through the same storage through multiple paths
@@ -428,16 +429,37 @@ class Root extends Folder implements IRootFolder {
 
 		$mountRootIds = array_map(function ($mount) {
 			return $mount->getRootId();
-		}, $mountsContainingFile);
+		}, $mountInfosContainingFiles);
 		$mountRootPaths = array_map(function ($mount) {
 			return $mount->getRootInternalPath();
-		}, $mountsContainingFile);
+		}, $mountInfosContainingFiles);
 		$mountProviders = array_unique(array_map(function ($mount) {
 			return $mount->getMountProvider();
-		}, $mountsContainingFile));
+		}, $mountInfosContainingFiles));
+		$mountPoints = array_map(fn (ICachedMountInfo $mountInfo) => $mountInfo->getMountPoint(), $mountInfosContainingFiles);
 		$mountRoots = array_combine($mountRootIds, $mountRootPaths);
 
-		$mountsContainingFile = array_filter(array_map($this->mountManager->getMountFromMountInfo(...), $mountsContainingFile));
+		$mounts = $this->mountManager->getMountsByMountProvider($path, $mountProviders);
+		$mountsContainingFile = array_filter($mounts, fn (IMountPoint $mount) => in_array($mount->getMountPoint(), $mountPoints));
+
+		// if we haven't found a relevant mount that is setup, but we do have relevant mount infos
+		// we try to load them from the mount info.
+		if (count($mountsContainingFile) === 0 && count($mountInfosContainingFiles) > 0) {
+			// in order to minimize the cost of this, we only use the mount infos from one user.
+			if (!$user) {
+				// if we don't have a user from the path, use the user from the current filesystem setup
+				$user = $this->getUser()?->getUID();
+			}
+			if (!$user) {
+				// if there also isn't a current filesystem user, just use the user from the first mount info
+				/** @var ICachedMountFileInfo $firstMount */
+				$firstMount = current($mountInfosContainingFiles);
+				$user = $firstMount->getUser()->getUID();
+			}
+			// get the mount infos for the user we picked, and get the mounts for it
+			$mountInfosContainingFiles = array_filter($mountInfosContainingFiles, fn (ICachedMountInfo $mountInfo) => $mountInfo->getUser()->getUID() === $user);
+			$mountsContainingFile = array_filter(array_map($this->mountManager->getMountFromMountInfo(...), $mountInfosContainingFiles));
+		}
 
 		if (count($mountsContainingFile) === 0) {
 			if ($user === $this->getAppDataDirectoryName()) {

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -434,8 +434,8 @@ class SetupManager implements ISetupManager {
 	 * @param string $path
 	 * @return IUser|null
 	 */
-	private function getUserForPath(string $path): ?IUser {
-		if ($path === '' || $path === '/') {
+	private function getUserForPath(string $path, bool $includeChildren = false): ?IUser {
+		if (($path === '' || $path === '/') && !$includeChildren) {
 			return null;
 		} elseif (str_starts_with($path, '/__groupfolders')) {
 			return null;
@@ -456,7 +456,7 @@ class SetupManager implements ISetupManager {
 
 	#[Override]
 	public function setupForPath(string $path, bool $includeChildren = false): void {
-		$user = $this->getUserForPath($path);
+		$user = $this->getUserForPath($path, $includeChildren);
 		if (!$user) {
 			$this->setupRoot();
 			return;

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -541,6 +541,8 @@ class FolderTest extends NodeTestCase {
 
 		$manager->method('getMountFromMountInfo')
 			->willReturn($mount);
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount]);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
@@ -586,6 +588,8 @@ class FolderTest extends NodeTestCase {
 
 		$manager->method('getMountFromMountInfo')
 			->willReturn($mount);
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount]);
 
 		$node = new Folder($root, $view, '/bar');
 		$result = $node->getById(1);
@@ -631,6 +635,8 @@ class FolderTest extends NodeTestCase {
 
 		$manager->method('getMountFromMountInfo')
 			->willReturn($mount);
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount]);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
@@ -694,6 +700,8 @@ class FolderTest extends NodeTestCase {
 				}
 				return null;
 			});
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount1, $mount2]);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -29,6 +29,7 @@ use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
@@ -538,8 +539,8 @@ class FolderTest extends NodeTestCase {
 			->with('/bar/foo')
 			->willReturn([]);
 
-		$manager->method('getMountsByMountProvider')
-			->willReturn([$mount]);
+		$manager->method('getMountFromMountInfo')
+			->willReturn($mount);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
@@ -583,8 +584,8 @@ class FolderTest extends NodeTestCase {
 			->with(1)
 			->willReturn($fileInfo);
 
-		$manager->method('getMountsByMountProvider')
-			->willReturn([$mount]);
+		$manager->method('getMountFromMountInfo')
+			->willReturn($mount);
 
 		$node = new Folder($root, $view, '/bar');
 		$result = $node->getById(1);
@@ -628,8 +629,8 @@ class FolderTest extends NodeTestCase {
 			->with(1)
 			->willReturn($fileInfo);
 
-		$manager->method('getMountsByMountProvider')
-			->willReturn([$mount]);
+		$manager->method('getMountFromMountInfo')
+			->willReturn($mount);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
@@ -668,14 +669,31 @@ class FolderTest extends NodeTestCase {
 					1,
 					''
 				),
+				new CachedMountInfo(
+					$this->user,
+					1,
+					0,
+					'/bar/foo/asd/',
+					'test',
+					1,
+					''
+				),
 			]);
 
 		$cache->method('get')
 			->with(1)
 			->willReturn($fileInfo);
 
-		$manager->method('getMountsByMountProvider')
-			->willReturn([$mount1, $mount2]);
+		$manager->method('getMountFromMountInfo')
+			->willReturnCallback(function (ICachedMountInfo $mountInfo) use ($mount1, $mount2) {
+				if ($mountInfo->getMountPoint() === $mount1->getMountPoint()) {
+					return $mount1;
+				}
+				if ($mountInfo->getMountPoint() === $mount2->getMountPoint()) {
+					return $mount2;
+				}
+				return null;
+			});
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);


### PR DESCRIPTION
Follow up from #57829, when setting up with children, we still setup the full user, not just the root.
