### PR TITLE
feat(cache): add iterate method to list files from cache

### DIFF
--- a/apps/files_sharing/lib/External/Cache.php
+++ b/apps/files_sharing/lib/External/Cache.php
@@ -48,4 +48,13 @@ class Cache extends \OC\Files\Cache\Cache {
 		}
 		return $results;
 	}
+
+	#[Override]
+	public function iterateFolderContentsById(int $fileId, bool $includeMetadata = false, bool $sortByName = false): iterable {
+		$displayId = $this->cloudId->getDisplayId();
+		foreach (parent::iterateFolderContentsById($fileI, $includeMetadata, $sortByName) as $entry) {
+			$entry['displayname_owner'] = $displayId;
+			yield $entry;
+		}
+	}
 }

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -41,7 +41,8 @@ class Helper {
 		$internalPath = $mount->getInternalPath($absoluteDir);
 
 		$extraData = Trashbin::getExtraData($user);
-		$dirContent = $storage->getCache()->getFolderContents($mount->getInternalPath($view->getAbsolutePath($dir)));
+		$dirId = $storage->getCache()->getId($mount->getInternalPath($view->getAbsolutePath($dir)));
+		$dirContent = $storage->getCache()->iterateFolderContentsById($dirId);
 		foreach ($dirContent as $entry) {
 			$entryName = $entry->getName();
 			$name = $entryName;

--- a/lib/private/Files/Cache/FailedCache.php
+++ b/lib/private/Files/Cache/FailedCache.php
@@ -59,6 +59,11 @@ class FailedCache implements ICache {
 		return [];
 	}
 
+	#[Override]
+	public function iterateFolderContentsById(int $fileId, bool $includeMetadata = false, bool $sortByName = false): iterable {
+		return [];
+	}
+
 	public function put($file, array $data) {
 	}
 

--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -141,7 +141,7 @@ class Watcher implements IWatcher {
 	 * @param string $path
 	 */
 	public function cleanFolder($path) {
-		$cachedContent = $this->cache->getFolderContents($path);
+		$cachedContent = $this->cache->iterateFolderContentsById($this->cache->getId($path));
 		foreach ($cachedContent as $entry) {
 			if (!$this->storage->file_exists($entry['path'])) {
 				$this->cache->remove($entry['path']);

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -110,6 +110,13 @@ class CacheWrapper extends Cache {
 		return array_map([$this, 'formatCacheEntry'], $results);
 	}
 
+	#[Override]
+	public function iterateFolderContentsById(int $fileId, bool $includeMetadata = false, bool $sortByName = false): iterable {
+		foreach ($this->getCache()->iterateFolderContentsById($fileId, $includeMetadata, $sortByName) as $entry) {
+			yield $this->formatCacheEntry($entry);
+		}
+	}
+
 	/**
 	 * insert or update meta data for a file or folder
 	 *

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -164,7 +164,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	}
 
 	private function rmObjects(ICacheEntry $entry): bool {
-		$children = $this->getCache()->getFolderContentsById($entry->getId());
+		$children = $this->getCache()->iterateFolderContentsById($entry->getId());
 		foreach ($children as $child) {
 			if ($child->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE) {
 				if (!$this->rmObjects($child)) {
@@ -263,7 +263,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 
 		try {
 			$files = [];
-			$folderContents = $this->getCache()->getFolderContents($path);
+			$folderContents = $this->getCache()->iterateFolderContentsById($this->getCache()->getId($path), false, true);
 			foreach ($folderContents as $file) {
 				$files[] = $file['name'];
 			}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1507,7 +1507,7 @@ class View {
 		}
 
 		$folderId = $data->getId();
-		$contents = $cache->getFolderContentsById($folderId); //TODO: mimetype_filter
+		$contents = $cache->iterateFolderContentsById($folderId, false, true); // TODO Mimetype filter
 
 		$sharingDisabled = \OCP\Util::isSharingDisabledForUser();
 		$permissionsMask = ~\OCP\Constants::PERMISSION_SHARE;

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -49,6 +49,11 @@ class NullCache implements ICache {
 		return [];
 	}
 
+	#[Override]
+	public function iterateFolderContentsById(int $fileId, bool $includeMetadata = false, bool $sortByName = false): iterable {
+		return [];
+	}
+
 	public function put($file, array $data) {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -83,6 +83,16 @@ interface ICache {
 	public function getFolderContentsById($fileId);
 
 	/**
+	 * Get an iterator on files stored in folder
+	 *
+	 * Only returns files one level deep, no recursion
+	 *
+	 * @return iterable<ICacheEntry>
+	 * @since 34.0.0
+	 */
+	public function iterateFolderContentsById(int $fileId, bool $includeMetadata = false, bool $sortByName = false): iterable;
+
+	/**
 	 * store meta data for a file or folder
 	 * This will automatically call either insert or update depending on if the file exists
 	 *


### PR DESCRIPTION
## Summary
Add an iterator to list files from a directory

Reduce memory usage on large directory listing (≈ 800 files here):
<img width="802" height="697" alt="image" src="https://github.com/user-attachments/assets/875cbb15-5244-4380-b282-1eb6d6d3b2c9" />

Also helps to remove large number of files with Primary object store

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
