### PR TITLE
feat(dav): allow extending propfind properties via event

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -440,6 +440,7 @@ return array(
     'OCP\\Files\\Events\\BeforeFileScannedEvent' => $baseDir . '/lib/public/Files/Events/BeforeFileScannedEvent.php',
     'OCP\\Files\\Events\\BeforeFileSystemSetupEvent' => $baseDir . '/lib/public/Files/Events/BeforeFileSystemSetupEvent.php',
     'OCP\\Files\\Events\\BeforeFolderScannedEvent' => $baseDir . '/lib/public/Files/Events/BeforeFolderScannedEvent.php',
+    'OCP\\Files\\Events\\BeforeRemotePropfindEvent' => $baseDir . '/lib/public/Files/Events/BeforeRemotePropfindEvent.php',
     'OCP\\Files\\Events\\BeforeZipCreatedEvent' => $baseDir . '/lib/public/Files/Events/BeforeZipCreatedEvent.php',
     'OCP\\Files\\Events\\FileCacheUpdated' => $baseDir . '/lib/public/Files/Events/FileCacheUpdated.php',
     'OCP\\Files\\Events\\FileScannedEvent' => $baseDir . '/lib/public/Files/Events/FileScannedEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -481,6 +481,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\Events\\BeforeFileScannedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/BeforeFileScannedEvent.php',
         'OCP\\Files\\Events\\BeforeFileSystemSetupEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/BeforeFileSystemSetupEvent.php',
         'OCP\\Files\\Events\\BeforeFolderScannedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/BeforeFolderScannedEvent.php',
+        'OCP\\Files\\Events\\BeforeRemotePropfindEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/BeforeRemotePropfindEvent.php',
         'OCP\\Files\\Events\\BeforeZipCreatedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/BeforeZipCreatedEvent.php',
         'OCP\\Files\\Events\\FileCacheUpdated' => __DIR__ . '/../../..' . '/lib/public/Files/Events/FileCacheUpdated.php',
         'OCP\\Files\\Events\\FileScannedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/FileScannedEvent.php',

--- a/lib/public/Files/Events/BeforeRemotePropfindEvent.php
+++ b/lib/public/Files/Events/BeforeRemotePropfindEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Files\Events;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is fired before a PROPFIND request is sent to remote WebDAV storage
+ * Used to extend the list of properties to request additional data from the remote server
+ *
+ * @since 33.0.0
+ */
+class BeforeRemotePropfindEvent extends Event {
+	public function __construct(
+		private array $properties,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @return array<string>
+	 * @since 33.0.0
+	 */
+	public function getProperties(): array {
+		return $this->properties;
+	}
+
+	/**
+	 * @param array<string> $properties
+	 * @since 33.0.0
+	 */
+	public function addProperties(array $properties): void {
+		array_push($this->properties, ...$properties);
+	}
+}


### PR DESCRIPTION
## Summary
Makes the list of WebDAV properties requested in PROPFIND calls extendable via `BeforePropfindEvent`.
This was implemented to enable the files_lock app to add lock properties for federation.

## Changes
- Dispatch `BeforePropfindEvent` in `DAV::getPropfindProperties()`
- Add `getPropfindPropertyValue()` method to access requested properties

Required for https://github.com/nextcloud/files_lock/pull/954