### PR TITLE
fix(snowflakes): create file lock files into lock directory

### DIFF
--- a/lib/private/Snowflake/FileSequence.php
+++ b/lib/private/Snowflake/FileSequence.php
@@ -33,6 +33,9 @@ class FileSequence implements ISequence {
 
 	private function ensureWorkdirExists(): void {
 		if (is_dir($this->workDir)) {
+			if (!is_writable($this->workDir)) {
+				throw new \Exception('File sequence directory exists but is not writable');
+			}
 			return;
 		}
 
@@ -104,6 +107,6 @@ class FileSequence implements ISequence {
 	}
 
 	private function getFilePath(int $fileId): string {
-		return $this->workDir . sprintf(self::LOCK_FILE_FORMAT, $fileId);
+		return $this->workDir . '/' . sprintf(self::LOCK_FILE_FORMAT, $fileId);
 	}
 }

--- a/tests/lib/Snowflake/FileSequenceTest.php
+++ b/tests/lib/Snowflake/FileSequenceTest.php
@@ -30,6 +30,5 @@ class FileSequenceTest extends ISequenceBase {
 		foreach (glob($lockDirectory . '/*') as $file) {
 			unlink($file);
 		}
-		rmdir($lockDirectory);
 	}
 }


### PR DESCRIPTION
## Summary
File locks are created outside of locks directory because of a missing `/`

Example: `sfi_file_sequenceseq-009.lock` instead of `sfi_file_sequences/eq-009.lock`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
