### PR TITLE
fix(external-storage): Rtrim trailing slash at the end

### DIFF
--- a/apps/files_external/lib/Service/DBConfigService.php
+++ b/apps/files_external/lib/Service/DBConfigService.php
@@ -120,6 +120,7 @@ class DBConfigService {
 	 */
 	public function getMountsForUserAndPath(string $userId, array $groupIds, string $path, bool $forChildren): array {
 		$path = str_replace('/' . $userId . '/files', '', $path);
+		$path = rtrim($path, '/');
 		$builder = $this->getSelectQueryBuilder();
 		$builder->where($builder->expr()->orX(
 			$builder->expr()->andX( // global mounts

--- a/apps/files_external/tests/Config/ConfigAdapterTest.php
+++ b/apps/files_external/tests/Config/ConfigAdapterTest.php
@@ -214,7 +214,7 @@ class ConfigAdapterTest extends TestCase {
 	public function testPartialMountpointExact(): void {
 		$mountFileInfo = $this->createMock(ICachedMountFileInfo::class);
 		$mountFileInfo->method('getUser')->willReturn($this->user);
-		$mountFileInfo->method('getMountPoint')->willReturn('/user1/files/subfolder/subfolder');
+		$mountFileInfo->method('getMountPoint')->willReturn('/user1/files/subfolder/subfolder/');
 		$cacheEntry = $this->createMock(ICacheEntry::class);
 
 		$result = $this->adapter->getMountsForPath('/user1/files/subfolder/subfolder', true, [


### PR DESCRIPTION
Otherwise we don't have any matches when $forChildren is false

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
