### PR TITLE
fix: don't rely on share providers being avaiable in CleanupShareTarget

### DIFF
--- a/apps/files_sharing/lib/Repair/CleanupShareTarget.php
+++ b/apps/files_sharing/lib/Repair/CleanupShareTarget.php
@@ -14,6 +14,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Migration\IOutput;
@@ -84,7 +85,12 @@ class CleanupShareTarget implements IRepairStep {
 			$oldTarget = $shareInfo['file_target'];
 			$newTarget = $this->cleanTarget($oldTarget);
 			$absoluteNewTarget = $userFolder->getFullPath($newTarget);
-			$targetParentNode = $this->rootFolder->get(dirname($absoluteNewTarget));
+			try {
+				$targetParentNode = $this->rootFolder->get(dirname($absoluteNewTarget));
+			} catch (NotFoundException) {
+				$absoluteNewTarget = $userFolder->getFullPath(basename($newTarget));
+				$targetParentNode = $userFolder;
+			}
 
 			try {
 				$absoluteNewTarget = $this->shareTargetValidator->generateUniqueTarget(

--- a/apps/files_sharing/lib/ShareTargetValidator.php
+++ b/apps/files_sharing/lib/ShareTargetValidator.php
@@ -85,7 +85,7 @@ class ShareTargetValidator {
 		}
 
 		$newAbsoluteMountPoint = $this->generateUniqueTarget(
-			$share,
+			$share->getNodeId(),
 			Filesystem::normalizePath($absoluteParent . '/' . $mountPoint),
 			$parentMount,
 			$allCachedMounts,
@@ -108,8 +108,8 @@ class ShareTargetValidator {
 	/**
 	 * @param ICachedMountInfo[] $allCachedMounts
 	 */
-	private function generateUniqueTarget(
-		IShare $share,
+	public function generateUniqueTarget(
+		int $shareNodeId,
 		string $absolutePath,
 		IMountPoint $parentMount,
 		array $allCachedMounts,
@@ -122,7 +122,7 @@ class ShareTargetValidator {
 		$i = 2;
 		$parentCache = $parentMount->getStorage()->getCache();
 		$internalPath = $parentMount->getInternalPath($absolutePath);
-		while ($parentCache->inCache($internalPath) || $this->hasConflictingMount($share, $allCachedMounts, $absolutePath)) {
+		while ($parentCache->inCache($internalPath) || $this->hasConflictingMount($shareNodeId, $allCachedMounts, $absolutePath)) {
 			$absolutePath = Filesystem::normalizePath($dir . '/' . $name . ' (' . $i . ')' . $ext);
 			$internalPath = $parentMount->getInternalPath($absolutePath);
 			$i++;
@@ -134,13 +134,13 @@ class ShareTargetValidator {
 	/**
 	 * @param ICachedMountInfo[] $allCachedMounts
 	 */
-	private function hasConflictingMount(IShare $share, array $allCachedMounts, string $absolutePath): bool {
+	private function hasConflictingMount(int $shareNodeId, array $allCachedMounts, string $absolutePath): bool {
 		if (!isset($allCachedMounts[$absolutePath . '/'])) {
 			return false;
 		}
 
 		$mount = $allCachedMounts[$absolutePath . '/'];
-		if ($mount->getMountProvider() === MountProvider::class && $mount->getRootId() === $share->getNodeId()) {
+		if ($mount->getMountProvider() === MountProvider::class && $mount->getRootId() === $shareNodeId) {
 			// "conflicting" mount is a mount for the current share
 			return false;
 		}


### PR DESCRIPTION
During maintenance, apps are not enabled, so the share providers from them aren't there.

This manually edits the DB instead and removes the need to construct `IShare` instances.