### PR TITLE
feat: declarative password salt, secret config

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -48,7 +48,9 @@ class Install extends Command {
 			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'Login of the admin account', 'admin')
 			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account')
 			->addOption('admin-email', null, InputOption::VALUE_OPTIONAL, 'E-Mail of the admin account')
-			->addOption('data-dir', null, InputOption::VALUE_REQUIRED, 'Path to data directory', \OC::$SERVERROOT . '/data');
+			->addOption('data-dir', null, InputOption::VALUE_REQUIRED, 'Path to data directory', \OC::$SERVERROOT . '/data')
+			->addOption('password-salt', null, InputOption::VALUE_OPTIONAL, 'Password salt, at least ' . Setup::MIN_PASSWORD_SALT_LENGTH . ' characters (will be randomly generated if not provided)')
+			->addOption('server-secret', null, InputOption::VALUE_OPTIONAL, 'Server secret, at least ' . Setup::MIN_SECRET_LENGTH . ' characters (will be randomly generated if not provided)');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
@@ -152,6 +154,16 @@ class Install extends Command {
 			throw new InvalidArgumentException('Invalid e-mail-address <' . $adminEmail . '> for <' . $adminLogin . '>.');
 		}
 
+		$passwordSalt = $input->getOption('password-salt');
+		$secret = $input->getOption('server-secret');
+
+		if ($passwordSalt !== null && strlen($passwordSalt) < Setup::MIN_PASSWORD_SALT_LENGTH) {
+			throw new InvalidArgumentException('Password salt must be at least ' . Setup::MIN_PASSWORD_SALT_LENGTH . ' characters long.');
+		}
+		if ($secret !== null && strlen($secret) < Setup::MIN_SECRET_LENGTH) {
+			throw new InvalidArgumentException('Server secret must be at least ' . Setup::MIN_SECRET_LENGTH . ' characters long.');
+		}
+
 		$options = [
 			'dbtype' => $db,
 			'dbuser' => $dbUser,
@@ -162,7 +174,9 @@ class Install extends Command {
 			'adminlogin' => $adminLogin,
 			'adminpass' => $adminPassword,
 			'adminemail' => $adminEmail,
-			'directory' => $dataDir
+			'directory' => $dataDir,
+			'passwordsalt' => $passwordSalt,
+			'secret' => $secret,
 		];
 		if ($db === 'oci') {
 			$options['dbtablespace'] = $input->getParameterOption('--database-table-space', '');

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -43,6 +43,9 @@ use OCP\ServerVersion;
 use Psr\Log\LoggerInterface;
 
 class Setup {
+	public const MIN_PASSWORD_SALT_LENGTH = 30;
+	public const MIN_SECRET_LENGTH = 48;
+
 	protected IL10N $l10n;
 
 	public function __construct(
@@ -357,10 +360,8 @@ class Setup {
 			$dbType = 'sqlite3';
 		}
 
-		//generate a random salt that is used to salt the local  passwords
-		$salt = $this->random->generate(30);
-		// generate a secret
-		$secret = $this->random->generate(48);
+		$salt = $options['passwordsalt'] ?: $this->random->generate(self::MIN_PASSWORD_SALT_LENGTH);
+		$secret = $options['secret'] ?: $this->random->generate(self::MIN_SECRET_LENGTH);
 
 		//write the config file
 		$newConfigValues = [


### PR DESCRIPTION
## Summary

Adds `--password-salt` and `--secret` options to `maintenance:install` for fully declarative deployments (e.g., sops-nix, Ansible Vault). Values are validated for minimum length and fall back to random generation if not provided.

Running this in my homelab for months without issues.

## TODO

I have not added unit tests to this commit as the main change is in the install function that has a lot of side effects. Looking for comments in regards to how to implement this, if at all.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)