### PR TITLE
[stable33] getById: don't setup for all users with access by default

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3781,17 +3781,12 @@
       <code><![CDATA[$this->mountManager->findByNumericId($numericId)]]></code>
       <code><![CDATA[$this->mountManager->findByStorageId($storageId)]]></code>
       <code><![CDATA[$this->mountManager->findIn($mountPoint)]]></code>
-      <code><![CDATA[$this->user]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[MountPoint[]]]></code>
       <code><![CDATA[\OC\Files\Mount\MountPoint[]]]></code>
       <code><![CDATA[\OC\Files\Mount\MountPoint[]]]></code>
-      <code><![CDATA[\OC\User\User]]></code>
     </MoreSpecificReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->user]]></code>
-    </NullableReturnStatement>
     <UndefinedMethod>
       <code><![CDATA[remove]]></code>
     </UndefinedMethod>

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -230,11 +230,11 @@ class Manager implements IMountManager {
 	}
 
 	/**
-	 * Return all mounts in a path from a specific mount provider
+	 * Return all mounts in a path from a specific mount provider, indexed by mount point
 	 *
 	 * @param string $path
 	 * @param string[] $mountProviders
-	 * @return IMountPoint[]
+	 * @return array<string, IMountPoint>
 	 */
 	public function getMountsByMountProvider(string $path, array $mountProviders) {
 		$this->getSetupManager()->setupForProvider($path, $mountProviders);

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -541,6 +541,8 @@ class FolderTest extends NodeTestCase {
 
 		$manager->method('getMountFromMountInfo')
 			->willReturn($mount);
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount]);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
@@ -586,6 +588,8 @@ class FolderTest extends NodeTestCase {
 
 		$manager->method('getMountFromMountInfo')
 			->willReturn($mount);
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount]);
 
 		$node = new Folder($root, $view, '/bar');
 		$result = $node->getById(1);
@@ -631,6 +635,8 @@ class FolderTest extends NodeTestCase {
 
 		$manager->method('getMountFromMountInfo')
 			->willReturn($mount);
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount]);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
@@ -694,6 +700,8 @@ class FolderTest extends NodeTestCase {
 				}
 				return null;
 			});
+		$manager->method('getMountsByMountProvider')
+			->willReturn([$mount1, $mount2]);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);


### PR DESCRIPTION
Partly reverts the behavior of https://github.com/nextcloud/server/pull/57913 to use the already-setup mounts.

Only when no already setup mounts are found, do we perform extra setups, and then only for the relevant user (if a user is available)

Extracted from https://github.com/nextcloud/server/pull/57910