### PR TITLE
feat: Allow user backends to manage property permissions

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -422,10 +422,8 @@ class UsersController extends Controller {
 			IAccountManager::PROPERTY_BIRTHDATE => ['value' => $birthdate, 'scope' => $birthdateScope],
 			IAccountManager::PROPERTY_PRONOUNS => ['value' => $pronouns, 'scope' => $pronounsScope],
 		];
-		$allowUserToChangeDisplayName = $this->config->getSystemValueBool('allow_user_to_change_display_name', true);
 		foreach ($updatable as $property => $data) {
-			if ($allowUserToChangeDisplayName === false
-				&& in_array($property, [IAccountManager::PROPERTY_DISPLAYNAME, IAccountManager::PROPERTY_EMAIL], true)) {
+			if (!$user->canEditProperty($property)) {
 				continue;
 			}
 			$property = $userAccount->getProperty($property);

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -337,6 +337,16 @@ class UsersControllerTest extends \Test\TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('johndoe');
 
+		$user->expects($this->atLeastOnce())
+			->method('canEditProperty')
+			->willReturnCallback(
+				fn (string $property): bool => match($property) {
+					IAccountManager::PROPERTY_EMAIL,
+					IAccountManager::PROPERTY_DISPLAYNAME => false,
+					default => true,
+				}
+			);
+
 		$this->userSession->method('getUser')->willReturn($user);
 
 		/** @var MockObject|IAccount $userAccount */
@@ -377,11 +387,6 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('setValue');
 		$emailProperty->expects($this->never())
 			->method('setScope');
-
-		$this->config->expects($this->once())
-			->method('getSystemValueBool')
-			->with('allow_user_to_change_display_name')
-			->willReturn(false);
 
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -15,6 +15,7 @@ use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\ICountMappedUsersBackend;
 use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\ILimitAwareCountUsersBackend;
+use OCP\User\Backend\IPropertyPermissionBackend;
 use OCP\User\Backend\IProvideEnabledStateBackend;
 use OCP\UserInterface;
 use Psr\Log\LoggerInterface;
@@ -22,7 +23,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @template-extends Proxy<User_LDAP>
  */
-class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP, ILimitAwareCountUsersBackend, ICountMappedUsersBackend, IProvideEnabledStateBackend, IGetDisplayNameBackend {
+class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP, ILimitAwareCountUsersBackend, ICountMappedUsersBackend, IProvideEnabledStateBackend, IGetDisplayNameBackend, IPropertyPermissionBackend {
 	public function __construct(
 		private Helper $helper,
 		ILDAPWrapper $ldap,
@@ -431,5 +432,9 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 				$limit
 			)
 		);
+	}
+
+	public function canEditProperty(string $uid, string $property): bool {
+		return $this->handleRequest($uid, 'canEditProperty', [$uid, $property]);
 	}
 }

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -267,6 +267,9 @@ trait Provisioning {
 
 		$expectedFields = $fields->getRows();
 		$expectedFields = $this->simplifyArray($expectedFields);
+		/* Sort both arrays as order is not important */
+		sort($fieldsArray);
+		sort($expectedFields);
 		Assert::assertEquals($expectedFields, $fieldsArray);
 	}
 

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -79,6 +79,7 @@ Feature: provisioning
       | role |
       | headline |
       | biography |
+      | birthdate |
       | profile_enabled |
       | pronouns |
     Given As an "brand-new-user"
@@ -96,6 +97,7 @@ Feature: provisioning
       | role |
       | headline |
       | biography |
+      | birthdate |
       | profile_enabled |
       | pronouns |
     Then user "self" has editable fields
@@ -112,6 +114,7 @@ Feature: provisioning
       | role |
       | headline |
       | biography |
+      | birthdate |
       | profile_enabled |
       | pronouns |
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2135,9 +2135,6 @@
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
-      <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
-      <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
-      <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
     </DeprecatedConstant>
     <DeprecatedMethod>
       <code><![CDATA[deleteUserValue]]></code>
@@ -2147,8 +2144,6 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[implementsActions]]></code>
-      <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[search]]></code>
       <code><![CDATA[search]]></code>
@@ -2497,8 +2492,6 @@
   </file>
   <file src="apps/theming/lib/Controller/ThemingController.php">
     <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1013,6 +1013,7 @@ return array(
     'OCP\\User\\Backend\\ILimitAwareCountUsersBackend' => $baseDir . '/lib/public/User/Backend/ILimitAwareCountUsersBackend.php',
     'OCP\\User\\Backend\\IPasswordConfirmationBackend' => $baseDir . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
     'OCP\\User\\Backend\\IPasswordHashBackend' => $baseDir . '/lib/public/User/Backend/IPasswordHashBackend.php',
+    'OCP\\User\\Backend\\IPropertyPermissionBackend' => $baseDir . '/lib/public/User/Backend/IPropertyPermissionBackend.php',
     'OCP\\User\\Backend\\IProvideAvatarBackend' => $baseDir . '/lib/public/User/Backend/IProvideAvatarBackend.php',
     'OCP\\User\\Backend\\IProvideEnabledStateBackend' => $baseDir . '/lib/public/User/Backend/IProvideEnabledStateBackend.php',
     'OCP\\User\\Backend\\ISearchKnownUsersBackend' => $baseDir . '/lib/public/User/Backend/ISearchKnownUsersBackend.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1054,6 +1054,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\User\\Backend\\ILimitAwareCountUsersBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ILimitAwareCountUsersBackend.php',
         'OCP\\User\\Backend\\IPasswordConfirmationBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
         'OCP\\User\\Backend\\IPasswordHashBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordHashBackend.php',
+        'OCP\\User\\Backend\\IPropertyPermissionBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPropertyPermissionBackend.php',
         'OCP\\User\\Backend\\IProvideAvatarBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IProvideAvatarBackend.php',
         'OCP\\User\\Backend\\IProvideEnabledStateBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IProvideEnabledStateBackend.php',
         'OCP\\User\\Backend\\ISearchKnownUsersBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ISearchKnownUsersBackend.php',

--- a/lib/private/User/LazyUser.php
+++ b/lib/private/User/LazyUser.php
@@ -100,20 +100,24 @@ class LazyUser implements IUser {
 		return $this->getUser()->getBackend();
 	}
 
-	public function canChangeAvatar() {
+	public function canChangeAvatar(): bool {
 		return $this->getUser()->canChangeAvatar();
 	}
 
-	public function canChangePassword() {
+	public function canChangePassword(): bool {
 		return $this->getUser()->canChangePassword();
 	}
 
-	public function canChangeDisplayName() {
+	public function canChangeDisplayName(): bool {
 		return $this->getUser()->canChangeDisplayName();
 	}
 
 	public function canChangeEmail(): bool {
 		return $this->getUser()->canChangeEmail();
+	}
+
+	public function canEditProperty(string $property): bool {
+		return $this->getUser()->canEditProperty($property);
 	}
 
 	public function isEnabled() {

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -8,12 +8,15 @@
 namespace OCP;
 
 use InvalidArgumentException;
+use OCP\Accounts\IAccountManager;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * Interface IUser
  *
  * @since 8.0.0
  */
+#[Consumable(since: '8.0.0')]
 interface IUser {
 	/**
 	 * @since 32.0.0
@@ -133,26 +136,23 @@ interface IUser {
 	/**
 	 * check if the backend allows the user to change their avatar on Personal page
 	 *
-	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function canChangeAvatar();
+	public function canChangeAvatar(): bool;
 
 	/**
 	 * check if the backend supports changing passwords
 	 *
-	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function canChangePassword();
+	public function canChangePassword(): bool;
 
 	/**
 	 * check if the backend supports changing display names
 	 *
-	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function canChangeDisplayName();
+	public function canChangeDisplayName(): bool;
 
 	/**
 	 * Check if the backend supports changing email
@@ -160,6 +160,12 @@ interface IUser {
 	 * @since 32.0.0
 	 */
 	public function canChangeEmail(): bool;
+
+	/**
+	 * @param IAccountManager::PROPERTY_*|IAccountManager::COLLECTION_* $property
+	 * @since 34.0.0
+	 */
+	public function canEditProperty(string $property): bool;
 
 	/**
 	 * check if the user is enabled

--- a/lib/public/User/Backend/IPropertyPermissionBackend.php
+++ b/lib/public/User/Backend/IPropertyPermissionBackend.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\User\Backend;
+
+use OCP\Accounts\IAccountManager;
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\AppFramework\Attribute\Implementable;
+
+/**
+ * @since 34.0.0
+ */
+#[Implementable(since: '34.0.0')]
+#[Consumable(since: '34.0.0')]
+interface IPropertyPermissionBackend {
+	/**
+	 * @since 34.0.0
+	 *
+	 * @param IAccountManager::PROPERTY_*|IAccountManager::COLLECTION_* $property
+	 * @return bool Whether the user is allowed to edit its own property
+	 */
+	public function canEditProperty(string $uid, string $property): bool;
+}


### PR DESCRIPTION
## Summary

This allows user backends to control which account property can be edited by the users.
The existing API for display name and API are falling back on the new clean API.

Not yet reflected in the UI apart from displayname/email/avatar.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
