### PR TITLE
fix(config): update lazy status using lexicon on hasKey()

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -163,7 +163,7 @@ class AppConfig implements IAppConfig {
 	public function hasKey(string $app, string $key, ?bool $lazy = false): bool {
 		$this->assertParams($app, $key);
 		$this->loadConfig($app, $lazy ?? true);
-		$this->matchAndApplyLexiconDefinition($app, $key);
+		$this->matchAndApplyLexiconDefinition($app, $key, $lazy);
 
 		$hasLazy = isset($this->lazyCache[$app][$key]);
 		$hasFast = isset($this->fastCache[$app][$key]);


### PR DESCRIPTION
get lazy status from Config Lexicon when calling hasKey():

The method `matchAndApplyLexiconDefinition()` references`$lazy` and will update its value based on Lexicon, if available.
With this PR, the hasKey() can be called without specifying the lazyness of the config key