### PR TITLE
feat: calendar read and write federation

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -77,6 +77,7 @@ return array(
     'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarFactory' => $baseDir . '/../lib/CalDAV/Federation/FederatedCalendarFactory.php',
     'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarImpl' => $baseDir . '/../lib/CalDAV/Federation/FederatedCalendarImpl.php',
     'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarMapper' => $baseDir . '/../lib/CalDAV/Federation/FederatedCalendarMapper.php',
+    'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarObject' => $baseDir . '/../lib/CalDAV/Federation/FederatedCalendarObject.php',
     'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarSyncService' => $baseDir . '/../lib/CalDAV/Federation/FederatedCalendarSyncService.php',
     'OCA\\DAV\\CalDAV\\Federation\\FederationSharingService' => $baseDir . '/../lib/CalDAV/Federation/FederationSharingService.php',
     'OCA\\DAV\\CalDAV\\Federation\\Protocol\\CalendarFederationProtocolV1' => $baseDir . '/../lib/CalDAV/Federation/Protocol/CalendarFederationProtocolV1.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -92,6 +92,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarFactory' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/FederatedCalendarFactory.php',
         'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarImpl' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/FederatedCalendarImpl.php',
         'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarMapper' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/FederatedCalendarMapper.php',
+        'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarObject' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/FederatedCalendarObject.php',
         'OCA\\DAV\\CalDAV\\Federation\\FederatedCalendarSyncService' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/FederatedCalendarSyncService.php',
         'OCA\\DAV\\CalDAV\\Federation\\FederationSharingService' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/FederationSharingService.php',
         'OCA\\DAV\\CalDAV\\Federation\\Protocol\\CalendarFederationProtocolV1' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/Protocol/CalendarFederationProtocolV1.php',

--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -43,9 +43,9 @@ class CalendarProvider implements ICalendarProvider {
 			});
 		}
 
-		$additionalProperties = $this->getAdditionalPropertiesForCalendars($calendarInfos);
 		$iCalendars = [];
 
+		$additionalProperties = $this->getAdditionalPropertiesForCalendars($calendarInfos);
 		foreach ($calendarInfos as $calendarInfo) {
 			$user = str_replace('principals/users/', '', $calendarInfo['principaluri']);
 			$path = 'calendars/' . $user . '/' . $calendarInfo['uri'];
@@ -60,9 +60,7 @@ class CalendarProvider implements ICalendarProvider {
 			);
 		}
 
-		$additionalFederatedProps = $this->getAdditionalPropertiesForCalendars(
-			$federatedCalendarInfos,
-		);
+		$additionalFederatedProps = $this->getAdditionalPropertiesForCalendars($federatedCalendarInfos);
 		foreach ($federatedCalendarInfos as $calendarInfo) {
 			$user = str_replace('principals/users/', '', $calendarInfo['principaluri']);
 			$path = 'calendars/' . $user . '/' . $calendarInfo['uri'];

--- a/apps/dav/lib/CalDAV/Federation/FederatedCalendar.php
+++ b/apps/dav/lib/CalDAV/Federation/FederatedCalendar.php
@@ -10,29 +10,289 @@ declare(strict_types=1);
 namespace OCA\DAV\CalDAV\Federation;
 
 use OCA\DAV\CalDAV\CalDavBackend;
-use OCA\DAV\CalDAV\Calendar;
-use OCP\IConfig;
-use OCP\IL10N;
-use Psr\Log\LoggerInterface;
-use Sabre\CalDAV\Backend;
+use OCP\Constants;
+use Sabre\CalDAV\ICalendar;
+use Sabre\CalDAV\Plugin;
+use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\IMultiGet;
+use Sabre\DAV\INode;
+use Sabre\DAV\IProperties;
+use Sabre\DAV\PropPatch;
 
-class FederatedCalendar extends Calendar {
+class FederatedCalendar implements ICalendar, IProperties, IMultiGet {
+
+	private const CALENDAR_TYPE = CalDavBackend::CALENDAR_TYPE_FEDERATED;
+	private const DAV_PROPERTY_CALENDAR_LABEL = '{DAV:}displayname';
+	private const DAV_PROPERTY_CALENDAR_COLOR = '{http://apple.com/ns/ical/}calendar-color';
+
+	private string $principalUri;
+	private string $calendarUri;
+	private ?array $calendarACL = null;
+	private FederatedCalendarEntity $federationInfo;
+
 	public function __construct(
-		Backend\BackendInterface $caldavBackend,
-		$calendarInfo,
-		IL10N $l10n,
-		IConfig $config,
-		LoggerInterface $logger,
 		private readonly FederatedCalendarMapper $federatedCalendarMapper,
+		private readonly FederatedCalendarSyncService $federatedCalendarService,
+		private readonly CalDavBackend $caldavBackend,
+		$calendarInfo,
 	) {
-		parent::__construct($caldavBackend, $calendarInfo, $l10n, $config, $logger);
+		$this->principalUri = $calendarInfo['principaluri'];
+		$this->calendarUri = $calendarInfo['uri'];
+		$this->federationInfo = $federatedCalendarMapper->findByUri($this->principalUri, $this->calendarUri);
 	}
 
-	public function delete() {
-		$this->federatedCalendarMapper->deleteById($this->getResourceId());
+	public function getResourceId(): int {
+		return $this->federationInfo->getId();
+	}
+
+	public function getName(): string {
+		return $this->federationInfo->getUri();
+	}
+
+	/**
+	 * @param string $name Name of the file
+	 */
+	public function setName($name): void {
+		throw new MethodNotAllowed('Renaming federated calendars is not allowed');
 	}
 
 	protected function getCalendarType(): int {
-		return CalDavBackend::CALENDAR_TYPE_FEDERATED;
+		return self::CALENDAR_TYPE;
 	}
+
+	public function getPrincipalURI(): string {
+		return $this->federationInfo->getPrincipaluri();
+	}
+
+	public function getOwner(): ?string {
+		return $this->federationInfo->getSharedByPrincipal();
+	}
+
+	public function getGroup(): ?string {
+		return null;
+	}
+
+	/**
+	 * @return array<array-key, mixed>
+	 */
+	public function getACL(): array {
+		if ($this->calendarACL !== null) {
+			return $this->calendarACL;
+		}
+
+		$permissions = $this->federationInfo->getPermissions();
+		// default permission
+		$acl = [
+			// read object permission
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->principalUri,
+				'protected' => true,
+			],
+			// read acl permission
+			[
+				'privilege' => '{DAV:}read-acl',
+				'principal' => $this->principalUri,
+				'protected' => true,
+			],
+			// write properties permission (calendar name, color)
+			[
+				'privilege' => '{DAV:}write-properties',
+				'principal' => $this->principalUri,
+				'protected' => true,
+			],
+		];
+		// create permission
+		if ($permissions & Constants::PERMISSION_CREATE) {
+			$acl[] = [
+				'privilege' => '{DAV:}bind',
+				'principal' => $this->principalUri,
+				'protected' => true,
+			];
+		}
+		// update permission
+		if ($permissions & Constants::PERMISSION_UPDATE) {
+			$acl[] = [
+				'privilege' => '{DAV:}write-content',
+				'principal' => $this->principalUri,
+				'protected' => true,
+			];
+		}
+		// delete permission
+		if ($permissions & Constants::PERMISSION_DELETE) {
+			$acl[] = [
+				'privilege' => '{DAV:}unbind',
+				'principal' => $this->principalUri,
+				'protected' => true,
+			];
+		}
+
+		// cache the calculated ACL for later use
+		$this->calendarACL = $acl;
+
+		return $acl;
+	}
+
+	public function setACL(array $acl): void {
+		throw new MethodNotAllowed('Changing ACLs on federated calendars is not allowed');
+	}
+
+	public function getSupportedPrivilegeSet(): ?array {
+		return null;
+	}
+
+	/**
+	 * @return array<string, mixed> properties array, with property name as key
+	 */
+	public function getProperties($properties): array {
+		return [
+			self::DAV_PROPERTY_CALENDAR_LABEL => $this->federationInfo->getDisplayName(),
+			self::DAV_PROPERTY_CALENDAR_COLOR => $this->federationInfo->getColor(),
+			'{' . Plugin::NS_CALDAV . '}supported-calendar-component-set' => new SupportedCalendarComponentSet(explode(',', $this->federationInfo->getComponents())),
+		];
+	}
+
+	public function propPatch(PropPatch $propPatch): void {
+		$mutations = $propPatch->getMutations();
+		if (count($mutations) > 0) {
+			// evaluate if name was changed
+			if (isset($mutations[self::DAV_PROPERTY_CALENDAR_LABEL])) {
+				$this->federationInfo->setDisplayName($mutations[self::DAV_PROPERTY_CALENDAR_LABEL]);
+				$propPatch->setResultCode(self::DAV_PROPERTY_CALENDAR_LABEL, 200);
+			}
+			// evaluate if color was changed
+			if (isset($mutations[self::DAV_PROPERTY_CALENDAR_COLOR])) {
+				$this->federationInfo->setColor($mutations[self::DAV_PROPERTY_CALENDAR_COLOR]);
+				$propPatch->setResultCode(self::DAV_PROPERTY_CALENDAR_COLOR, 200);
+			}
+			$this->federatedCalendarMapper->update($this->federationInfo);
+		}
+	}
+
+
+	public function getChildACL(): array {
+		return $this->getACL();
+	}
+
+	public function getLastModified(): ?int {
+		return $this->federationInfo->getLastSync();
+	}
+
+	public function delete(): void {
+		$this->federatedCalendarMapper->deleteById($this->getResourceId());
+	}
+
+	/**
+	 * @param string $name Name of the file
+	 */
+	public function createDirectory($name): void {
+		throw new MethodNotAllowed('Creating nested collection is not allowed');
+	}
+
+	public function calendarQuery(array $filters): array {
+		$uris = $this->caldavBackend->calendarQuery($this->federationInfo->getId(), $filters, $this->getCalendarType());
+		return $uris;
+	}
+
+	/**
+	 * @param string $name Name of the file
+	 */
+	public function getChild($name): INode {
+		$obj = $this->caldavBackend->getCalendarObject($this->federationInfo->getId(), $name, $this->getCalendarType());
+
+		if ($obj === null) {
+			throw new NotFound('Calendar object not found');
+		}
+
+		return new FederatedCalendarObject($this, $obj);
+	}
+
+	/**
+	 * @return array<INode>
+	 */
+	public function getChildren(): array {
+		$objs = $this->caldavBackend->getCalendarObjects($this->federationInfo->getId(), $this->getCalendarType());
+
+		$children = [];
+		foreach ($objs as $obj) {
+			$children[] = new FederatedCalendarObject($this, $obj);
+		}
+
+		return $children;
+	}
+
+	/**
+	 * @param array<string> $paths Names of the files
+	 *
+	 * @return array<INode>
+	 */
+	public function getMultipleChildren(array $paths): array {
+		$objs = $this->caldavBackend->getMultipleCalendarObjects($this->federationInfo->getId(), $paths, $this->getCalendarType());
+
+		$children = [];
+		foreach ($objs as $obj) {
+			$children[] = new FederatedCalendarObject($this, $obj);
+		}
+
+		return $children;
+	}
+
+	/**
+	 * @param string $name Name of the file
+	 */
+	public function childExists($name): bool {
+		$obj = $this->caldavBackend->getCalendarObject($this->federationInfo->getId(), $name, $this->getCalendarType());
+		return $obj !== null;
+	}
+
+	/**
+	 * @param string $name Name of the file
+	 * @param resource|string $data Initial payload
+	 */
+	public function createFile($name, $data = null): string {
+		if (is_resource($data)) {
+			$data = stream_get_contents($data);
+		}
+
+		// Create on remote server first
+		$etag = $this->federatedCalendarService->createCalendarObject($this->federationInfo, $name, $data);
+
+		if (empty($etag)) {
+			throw new \Exception('Failed to create calendar object on remote server');
+		}
+
+		// Then store locally
+		return $this->caldavBackend->createCalendarObject($this->federationInfo->getId(), $name, $data, $this->getCalendarType());
+	}
+
+	/**
+	 * @param string $name Name of the file
+	 * @param resource|string $data Initial payload
+	 */
+	public function updateFile($name, $data): string {
+		if (is_resource($data)) {
+			$data = stream_get_contents($data);
+		}
+
+		// Update remote calendar first
+		$etag = $this->federatedCalendarService->updateCalendarObject($this->federationInfo, $name, $data);
+
+		if (empty($etag)) {
+			throw new \Exception('Failed to update calendar object on remote server');
+		}
+
+		// Then update locally
+		return $this->caldavBackend->updateCalendarObject($this->federationInfo->getId(), $name, $data, $this->getCalendarType());
+	}
+
+	public function deleteFile(string $name): void {
+		// Delete from remote server first
+		$this->federatedCalendarService->deleteCalendarObject($this->federationInfo, $name);
+
+		// Then delete locally
+		$this->caldavBackend->deleteCalendarObject($this->federationInfo->getId(), $name, $this->getCalendarType());
+	}
+
 }

--- a/apps/dav/lib/CalDAV/Federation/FederatedCalendarEntity.php
+++ b/apps/dav/lib/CalDAV/Federation/FederatedCalendarEntity.php
@@ -94,8 +94,8 @@ class FederatedCalendarEntity extends Entity {
 			'{' . \Sabre\CalDAV\Plugin::NS_CALENDARSERVER . '}getctag' => $this->getSyncTokenForSabre(),
 			'{' . \Sabre\CalDAV\Plugin::NS_CALDAV . '}supported-calendar-component-set' => $this->getSupportedCalendarComponentSet(),
 			'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => $this->getSharedByPrincipal(),
-			// TODO: implement read-write sharing
-			'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only' => 1
+			'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only' => ($this->getPermissions() & \OCP\Constants::PERMISSION_UPDATE) === 0 ? 1 : 0,
+			'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}permissions' => $this->getPermissions(),
 		];
 	}
 }

--- a/apps/dav/lib/CalDAV/Federation/FederatedCalendarFactory.php
+++ b/apps/dav/lib/CalDAV/Federation/FederatedCalendarFactory.php
@@ -9,34 +9,23 @@ declare(strict_types=1);
 
 namespace OCA\DAV\CalDAV\Federation;
 
-use OCA\DAV\AppInfo\Application;
 use OCA\DAV\CalDAV\CalDavBackend;
-use OCP\IConfig;
-use OCP\IL10N;
-use OCP\L10N\IFactory as IL10NFactory;
-use Psr\Log\LoggerInterface;
 
 class FederatedCalendarFactory {
-	private readonly IL10N $l10n;
 
 	public function __construct(
-		private readonly CalDavBackend $caldavBackend,
-		private readonly IConfig $config,
-		private readonly LoggerInterface $logger,
 		private readonly FederatedCalendarMapper $federatedCalendarMapper,
-		IL10NFactory $l10nFactory,
+		private readonly FederatedCalendarSyncService $federatedCalendarService,
+		private readonly CalDavBackend $caldavBackend,
 	) {
-		$this->l10n = $l10nFactory->get(Application::APP_ID);
 	}
 
 	public function createFederatedCalendar(array $calendarInfo): FederatedCalendar {
 		return new FederatedCalendar(
+			$this->federatedCalendarMapper,
+			$this->federatedCalendarService,
 			$this->caldavBackend,
 			$calendarInfo,
-			$this->l10n,
-			$this->config,
-			$this->logger,
-			$this->federatedCalendarMapper,
 		);
 	}
 }

--- a/apps/dav/lib/CalDAV/Federation/FederatedCalendarImpl.php
+++ b/apps/dav/lib/CalDAV/Federation/FederatedCalendarImpl.php
@@ -51,8 +51,7 @@ class FederatedCalendarImpl implements ICalendar, ICalendarIsShared, ICalendarIs
 	}
 
 	public function getPermissions(): int {
-		// TODO: implement read-write sharing
-		return Constants::PERMISSION_READ;
+		return $this->calendarInfo['{http://owncloud.org/ns}permissions'] ?? Constants::PERMISSION_READ;
 	}
 
 	public function isDeleted(): bool {
@@ -64,7 +63,8 @@ class FederatedCalendarImpl implements ICalendar, ICalendarIsShared, ICalendarIs
 	}
 
 	public function isWritable(): bool {
-		return false;
+		$permissions = $this->getPermissions();
+		return ($permissions & Constants::PERMISSION_UPDATE) !== 0;
 	}
 
 	public function isEnabled(): bool {

--- a/apps/dav/lib/CalDAV/Federation/FederatedCalendarObject.php
+++ b/apps/dav/lib/CalDAV/Federation/FederatedCalendarObject.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\CalDAV\Federation;
+
+use Sabre\CalDAV\ICalendarObject;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAVACL\IACL;
+
+class FederatedCalendarObject implements ICalendarObject, IACL {
+
+	public function __construct(
+		protected FederatedCalendar $calendarObject,
+		protected $objectData,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->objectData['uri'];
+	}
+
+	/**
+	 * @param string $name Name of the file
+	 */
+	public function setName($name) {
+		throw new \Exception('Not implemented');
+	}
+
+	public function get(): string {
+		return $this->objectData['calendardata'];
+	}
+
+	/**
+	 * @param resource|string $data contents of the file
+	 */
+	public function put($data): string {
+
+		$etag = $this->calendarObject->updateFile($this->objectData['uri'], $data);
+		$this->objectData['calendardata'] = $data;
+		$this->objectData['etag'] = $etag;
+
+		return $etag;
+	}
+
+	public function delete(): void {
+		$this->calendarObject->deleteFile($this->objectData['uri']);
+	}
+
+	public function getContentType(): ?string {
+		$mime = 'text/calendar; charset=utf-8';
+		if (isset($this->objectData['component']) && $this->objectData['component']) {
+			$mime .= '; component=' . $this->objectData['component'];
+		}
+
+		return $mime;
+	}
+
+	public function getETag(): string {
+		if (isset($this->objectData['etag'])) {
+			return $this->objectData['etag'];
+		} else {
+			return '"' . md5($this->get()) . '"';
+		}
+	}
+
+	public function getLastModified(): int {
+		return $this->objectData['lastmodified'];
+	}
+
+	public function getSize(): int {
+		if (isset($this->objectData['size'])) {
+			return $this->objectData['size'];
+		} else {
+			return strlen($this->get());
+		}
+	}
+
+	public function getOwner(): ?string {
+		return $this->calendarObject->getPrincipalURI();
+	}
+
+	public function getGroup(): ?string {
+		return null;
+	}
+
+	/**
+	 * @return array<array-key, mixed>
+	 */
+	public function getACL(): array {
+		return $this->calendarObject->getACL();
+	}
+
+	public function setACL(array $acl): void {
+		throw new MethodNotAllowed('Changing ACLs on federated events is not allowed');
+	}
+
+	public function getSupportedPrivilegeSet(): ?array {
+		return null;
+	}
+
+}

--- a/apps/dav/lib/CalDAV/Federation/FederatedCalendarSyncService.php
+++ b/apps/dav/lib/CalDAV/Federation/FederatedCalendarSyncService.php
@@ -9,20 +9,52 @@ declare(strict_types=1);
 
 namespace OCA\DAV\CalDAV\Federation;
 
-use OCA\DAV\CalDAV\SyncService as CalDavSyncService;
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\Service\ASyncService;
+use OCP\AppFramework\Db\TTransactional;
+use OCP\AppFramework\Http;
 use OCP\Federation\ICloudIdManager;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCP\IDBConnection;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
 
-class FederatedCalendarSyncService {
+class FederatedCalendarSyncService extends ASyncService {
+	use TTransactional;
+
 	private const SYNC_TOKEN_PREFIX = 'http://sabre.io/ns/sync/';
 
 	public function __construct(
+		IClientService $clientService,
+		IConfig $config,
 		private readonly FederatedCalendarMapper $federatedCalendarMapper,
 		private readonly LoggerInterface $logger,
-		private readonly CalDavSyncService $syncService,
+		private readonly CalDavBackend $backend,
+		private readonly IDBConnection $dbConnection,
 		private readonly ICloudIdManager $cloudIdManager,
 	) {
+		parent::__construct($clientService, $config);
+	}
+
+	/**
+	 * Extract and encode credentials from a federated calendar entity.
+	 *
+	 * @return array{username: string, remoteUrl: string, token: string}
+	 */
+	private function getCredentials(FederatedCalendarEntity $calendar): array {
+		[,, $sharedWith] = explode('/', $calendar->getPrincipaluri());
+		$calDavUser = $this->cloudIdManager->getCloudId($sharedWith, null)->getId();
+
+		// Need to encode the cloud id as it might contain a colon which is not allowed in basic
+		// auth according to RFC 7617
+		$calDavUser = base64_encode($calDavUser);
+
+		return [
+			'username' => $calDavUser,
+			'remoteUrl' => $calendar->getRemoteUrl(),
+			'token' => $calendar->getToken(),
+		];
 	}
 
 	/**
@@ -31,29 +63,77 @@ class FederatedCalendarSyncService {
 	 * @throws ClientExceptionInterface If syncing the calendar fails.
 	 */
 	public function syncOne(FederatedCalendarEntity $calendar): int {
-		[,, $sharedWith] = explode('/', $calendar->getPrincipaluri());
-		$calDavUser = $this->cloudIdManager->getCloudId($sharedWith, null)->getId();
-		$remoteUrl = $calendar->getRemoteUrl();
+		$credentials = $this->getCredentials($calendar);
 		$syncToken = $calendar->getSyncTokenForSabre();
 
-		// Need to encode the cloud id as it might contain a colon which is not allowed in basic
-		// auth according to RFC 7617
-		$calDavUser = base64_encode($calDavUser);
+		try {
+			$response = $this->requestSyncReport(
+				$credentials['remoteUrl'],
+				$credentials['username'],
+				$credentials['token'],
+				$syncToken,
+			);
+		} catch (ClientExceptionInterface $ex) {
+			if ($ex->getCode() === Http::STATUS_UNAUTHORIZED) {
+				// Remote server revoked access to the calendar => remove it
+				$this->federatedCalendarMapper->delete($calendar);
+				$this->logger->warning("Authorization failed, remove federated calendar: {$credentials['remoteUrl']}", [
+					'app' => 'dav',
+				]);
+				return 0;
+			}
+			$this->logger->error('Client exception:', ['app' => 'dav', 'exception' => $ex]);
+			throw $ex;
+		}
 
-		$syncResponse = $this->syncService->syncRemoteCalendar(
-			$remoteUrl,
-			$calDavUser,
-			$calendar->getToken(),
-			$syncToken,
-			$calendar,
-		);
+		// Process changes from remote
+		$downloadedEvents = 0;
+		foreach ($response['response'] as $resource => $status) {
+			$objectUri = basename($resource);
+			if (isset($status[200])) {
+				// Object created or updated
+				$absoluteUrl = $this->prepareUri($credentials['remoteUrl'], $resource);
+				$calendarData = $this->download($absoluteUrl, $credentials['username'], $credentials['token']);
+				$this->atomic(function () use ($calendar, $objectUri, $calendarData): void {
+					$existingObject = $this->backend->getCalendarObject(
+						$calendar->getId(),
+						$objectUri,
+						CalDavBackend::CALENDAR_TYPE_FEDERATED
+					);
+					if (!$existingObject) {
+						$this->backend->createCalendarObject(
+							$calendar->getId(),
+							$objectUri,
+							$calendarData,
+							CalDavBackend::CALENDAR_TYPE_FEDERATED
+						);
+					} else {
+						$this->backend->updateCalendarObject(
+							$calendar->getId(),
+							$objectUri,
+							$calendarData,
+							CalDavBackend::CALENDAR_TYPE_FEDERATED
+						);
+					}
+				}, $this->dbConnection);
+				$downloadedEvents++;
+			} else {
+				// Object deleted
+				$this->backend->deleteCalendarObject(
+					$calendar->getId(),
+					$objectUri,
+					CalDavBackend::CALENDAR_TYPE_FEDERATED,
+					true
+				);
+			}
+		}
 
-		$newSyncToken = $syncResponse->getSyncToken();
+		$newSyncToken = $response['token'];
 
 		// Check sync token format and extract the actual sync token integer
 		$matches = [];
 		if (!preg_match('/^http:\/\/sabre\.io\/ns\/sync\/([0-9]+)$/', $newSyncToken, $matches)) {
-			$this->logger->error("Failed to sync federated calendar at $remoteUrl: New sync token has unexpected format: $newSyncToken", [
+			$this->logger->error("Failed to sync federated calendar at {$credentials['remoteUrl']}: New sync token has unexpected format: $newSyncToken", [
 				'calendar' => $calendar->toCalendarInfo(),
 				'newSyncToken' => $newSyncToken,
 			]);
@@ -67,10 +147,58 @@ class FederatedCalendarSyncService {
 				$newSyncToken,
 			);
 		} else {
-			$this->logger->debug("Sync Token for $remoteUrl unchanged from previous sync");
+			$this->logger->debug("Sync Token for {$credentials['remoteUrl']} unchanged from previous sync");
 			$this->federatedCalendarMapper->updateSyncTime($calendar->getId());
 		}
 
-		return $syncResponse->getDownloadedEvents();
+		return $downloadedEvents;
+	}
+
+	/**
+	 * Create a calendar object on the remote server.
+	 *
+	 * @throws ClientExceptionInterface If the remote request fails.
+	 */
+	public function createCalendarObject(FederatedCalendarEntity $calendar, string $name, string $data): string {
+		$credentials = $this->getCredentials($calendar);
+		$objectUrl = $this->prepareUri($credentials['remoteUrl'], $name);
+
+		return $this->requestPut(
+			$objectUrl,
+			$credentials['username'],
+			$credentials['token'],
+			$data,
+			'text/calendar; charset=utf-8'
+		);
+	}
+
+	/**
+	 * Update a calendar object on the remote server.
+	 *
+	 * @throws ClientExceptionInterface If the remote request fails.
+	 */
+	public function updateCalendarObject(FederatedCalendarEntity $calendar, string $name, string $data): string {
+		$credentials = $this->getCredentials($calendar);
+		$objectUrl = $this->prepareUri($credentials['remoteUrl'], $name);
+
+		return $this->requestPut(
+			$objectUrl,
+			$credentials['username'],
+			$credentials['token'],
+			$data,
+			'text/calendar; charset=utf-8'
+		);
+	}
+
+	/**
+	 * Delete a calendar object on the remote server.
+	 *
+	 * @throws ClientExceptionInterface If the remote request fails.
+	 */
+	public function deleteCalendarObject(FederatedCalendarEntity $calendar, string $name): void {
+		$credentials = $this->getCredentials($calendar);
+		$objectUrl = $this->prepareUri($credentials['remoteUrl'], $name);
+
+		$this->requestDelete($objectUrl, $credentials['username'], $credentials['token']);
 	}
 }

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -12,6 +12,7 @@ use OCA\DAV\CalDAV\Calendar;
 use OCA\DAV\CalDAV\CalendarHome;
 use OCA\DAV\CalDAV\CalendarObject;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
+use OCA\DAV\CalDAV\Federation\FederatedCalendar;
 use OCA\DAV\CalDAV\TipBroker;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
@@ -173,8 +174,15 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 				return;
 			}
 
-			/** @var Calendar $calendarNode */
+			/** @var Calendar&ICalendar $calendarNode */
 			$calendarNode = $this->server->tree->getNodeForPath($calendarPath);
+
+			// abort if calendar is federated
+			if ($calendarNode instanceof FederatedCalendar) {
+				$this->logger->debug('Not processing scheduling for federated calendar at path: ' . $calendarPath);
+				return;
+			}
+
 			// extract addresses for owner
 			$addresses = $this->getAddressesForPrincipal($calendarNode->getOwner());
 			// determine if request is from a sharee

--- a/apps/dav/lib/Service/ASyncService.php
+++ b/apps/dav/lib/Service/ASyncService.php
@@ -191,4 +191,70 @@ abstract class ASyncService {
 			rtrim($responseUri, '/'),
 		);
 	}
+
+	/**
+	 * Push data to the remote server via HTTP PUT.
+	 * Used for creating or updating CalDAV/CardDAV objects.
+	 *
+	 * @param string $url The absolute URL to PUT to
+	 * @param string $username The username for authentication
+	 * @param string $token The authentication token/password
+	 * @param string $data The data to upload
+	 * @param string $contentType The Content-Type header (e.g., 'text/calendar' or 'text/vcard')
+	 *
+	 * @return string The ETag returned by the server
+	 */
+	protected function requestPut(
+		string $url,
+		string $username,
+		string $token,
+		string $data,
+		string $contentType = 'text/calendar; charset=utf-8',
+	): string {
+		$client = $this->getClient();
+
+		$options = [
+			'auth' => [$username, $token],
+			'body' => $data,
+			'headers' => [
+				'Content-Type' => $contentType,
+			],
+			'verify' => !$this->config->getSystemValue(
+				'sharing.federation.allowSelfSignedCertificates',
+				false,
+			),
+		];
+
+		$response = $client->put($url, $options);
+
+		// Extract and return the ETag from the response
+		$etag = $response->getHeader('ETag');
+		return $etag;
+	}
+
+	/**
+	 * Delete a resource from the remote server via HTTP DELETE.
+	 * Used for deleting CalDAV/CardDAV objects.
+	 *
+	 * @param string $url The absolute URL to DELETE
+	 * @param string $username The username for authentication
+	 * @param string $token The authentication token/password
+	 */
+	protected function requestDelete(
+		string $url,
+		string $username,
+		string $token,
+	): void {
+		$client = $this->getClient();
+
+		$options = [
+			'auth' => [$username, $token],
+			'verify' => !$this->config->getSystemValue(
+				'sharing.federation.allowSelfSignedCertificates',
+				false,
+			),
+		];
+
+		$client->delete($url, $options);
+	}
 }

--- a/apps/dav/tests/unit/CalDAV/Federation/FederatedCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/FederatedCalendarTest.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\CalDAV\Federation;
+
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\Federation\FederatedCalendar;
+use OCA\DAV\CalDAV\Federation\FederatedCalendarEntity;
+use OCA\DAV\CalDAV\Federation\FederatedCalendarMapper;
+use OCA\DAV\CalDAV\Federation\FederatedCalendarObject;
+use OCA\DAV\CalDAV\Federation\FederatedCalendarSyncService;
+use OCP\Constants;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\PropPatch;
+use Test\TestCase;
+
+class FederatedCalendarTest extends TestCase {
+	private FederatedCalendar $federatedCalendar;
+
+	private FederatedCalendarMapper&MockObject $federatedCalendarMapper;
+	private FederatedCalendarSyncService&MockObject $federatedCalendarService;
+	private CalDavBackend&MockObject $caldavBackend;
+	private FederatedCalendarEntity $federationInfo;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->federatedCalendarMapper = $this->createMock(FederatedCalendarMapper::class);
+		$this->federatedCalendarService = $this->createMock(FederatedCalendarSyncService::class);
+		$this->caldavBackend = $this->createMock(CalDavBackend::class);
+
+		$this->federationInfo = new FederatedCalendarEntity();
+		$this->federationInfo->setId(10);
+		$this->federationInfo->setPrincipaluri('principals/users/user1');
+		$this->federationInfo->setUri('calendar-uri');
+		$this->federationInfo->setDisplayName('Federated Calendar');
+		$this->federationInfo->setColor('#ff0000');
+		$this->federationInfo->setSharedBy('user2@nextcloud.remote');
+		$this->federationInfo->setSharedByDisplayName('User 2');
+		$this->federationInfo->setPermissions(Constants::PERMISSION_READ);
+		$this->federationInfo->setLastSync(1234567890);
+
+		$this->federatedCalendarMapper->method('findByUri')
+			->with('principals/users/user1', 'calendar-uri')
+			->willReturn($this->federationInfo);
+
+		$calendarInfo = [
+			'principaluri' => 'principals/users/user1',
+			'id' => 10,
+			'uri' => 'calendar-uri',
+		];
+
+		$this->federatedCalendar = new FederatedCalendar(
+			$this->federatedCalendarMapper,
+			$this->federatedCalendarService,
+			$this->caldavBackend,
+			$calendarInfo,
+		);
+	}
+
+	public function testGetResourceId(): void {
+		$this->assertEquals(10, $this->federatedCalendar->getResourceId());
+	}
+
+	public function testGetName(): void {
+		$this->assertEquals('calendar-uri', $this->federatedCalendar->getName());
+	}
+
+	public function testSetName(): void {
+		$this->expectException(MethodNotAllowed::class);
+		$this->expectExceptionMessage('Renaming federated calendars is not allowed');
+		$this->federatedCalendar->setName('new-name');
+	}
+
+	public function testGetPrincipalURI(): void {
+		$this->assertEquals('principals/users/user1', $this->federatedCalendar->getPrincipalURI());
+	}
+
+	public function testGetOwner(): void {
+		$expected = 'principals/remote-users/' . base64_encode('user2@nextcloud.remote');
+		$this->assertEquals($expected, $this->federatedCalendar->getOwner());
+	}
+
+	public function testGetGroup(): void {
+		$this->assertNull($this->federatedCalendar->getGroup());
+	}
+
+	public function testGetACLWithReadOnlyPermissions(): void {
+		$this->federationInfo->setPermissions(Constants::PERMISSION_READ);
+
+		$acl = $this->federatedCalendar->getACL();
+
+		$this->assertCount(3, $acl);
+		// Check basic read permissions
+		$this->assertEquals('{DAV:}read', $acl[0]['privilege']);
+		$this->assertTrue($acl[0]['protected']);
+		$this->assertEquals('{DAV:}read-acl', $acl[1]['privilege']);
+		$this->assertTrue($acl[1]['protected']);
+		$this->assertEquals('{DAV:}write-properties', $acl[2]['privilege']);
+		$this->assertTrue($acl[2]['protected']);
+	}
+
+	public function testGetACLWithCreatePermission(): void {
+		$this->federationInfo->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_CREATE);
+
+		$acl = $this->federatedCalendar->getACL();
+
+		$this->assertCount(4, $acl);
+		// Check that create permission is added
+		$privileges = array_column($acl, 'privilege');
+		$this->assertContains('{DAV:}bind', $privileges);
+	}
+
+	public function testGetACLWithUpdatePermission(): void {
+		$this->federationInfo->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE);
+
+		$acl = $this->federatedCalendar->getACL();
+
+		$this->assertCount(4, $acl);
+		// Check that update permission is added (write-content, not write-properties which is already in base ACL)
+		$privileges = array_column($acl, 'privilege');
+		$this->assertContains('{DAV:}write-content', $privileges);
+	}
+
+	public function testGetACLWithDeletePermission(): void {
+		$this->federationInfo->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_DELETE);
+
+		$acl = $this->federatedCalendar->getACL();
+
+		$this->assertCount(4, $acl);
+		// Check that delete permission is added
+		$privileges = array_column($acl, 'privilege');
+		$this->assertContains('{DAV:}unbind', $privileges);
+	}
+
+	public function testGetACLWithAllPermissions(): void {
+		$this->federationInfo->setPermissions(
+			Constants::PERMISSION_READ
+			| Constants::PERMISSION_CREATE
+			| Constants::PERMISSION_UPDATE
+			| Constants::PERMISSION_DELETE
+		);
+
+		$acl = $this->federatedCalendar->getACL();
+
+		$this->assertCount(6, $acl);
+		$privileges = array_column($acl, 'privilege');
+		$this->assertContains('{DAV:}read', $privileges);
+		$this->assertContains('{DAV:}bind', $privileges);
+		$this->assertContains('{DAV:}write-content', $privileges);
+		$this->assertContains('{DAV:}write-properties', $privileges);
+		$this->assertContains('{DAV:}unbind', $privileges);
+	}
+
+	public function testSetACL(): void {
+		$this->expectException(MethodNotAllowed::class);
+		$this->expectExceptionMessage('Changing ACLs on federated calendars is not allowed');
+		$this->federatedCalendar->setACL([]);
+	}
+
+	public function testGetSupportedPrivilegeSet(): void {
+		$this->assertNull($this->federatedCalendar->getSupportedPrivilegeSet());
+	}
+
+	public function testGetProperties(): void {
+		$properties = $this->federatedCalendar->getProperties([
+			'{DAV:}displayname',
+			'{http://apple.com/ns/ical/}calendar-color',
+		]);
+
+		$this->assertEquals('Federated Calendar', $properties['{DAV:}displayname']);
+		$this->assertEquals('#ff0000', $properties['{http://apple.com/ns/ical/}calendar-color']);
+	}
+
+	public function testPropPatchWithDisplayName(): void {
+		$propPatch = $this->createMock(PropPatch::class);
+		$propPatch->method('getMutations')
+			->willReturn([
+				'{DAV:}displayname' => 'New Calendar Name',
+			]);
+
+		$this->federatedCalendarMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(function (FederatedCalendarEntity $entity) {
+				$this->assertEquals('New Calendar Name', $entity->getDisplayName());
+				return $entity;
+			});
+
+		$propPatch->expects(self::once())
+			->method('setResultCode')
+			->with('{DAV:}displayname', 200);
+
+		$this->federatedCalendar->propPatch($propPatch);
+	}
+
+	public function testPropPatchWithColor(): void {
+		$propPatch = $this->createMock(PropPatch::class);
+		$propPatch->method('getMutations')
+			->willReturn([
+				'{http://apple.com/ns/ical/}calendar-color' => '#00ff00',
+			]);
+
+		$this->federatedCalendarMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(function (FederatedCalendarEntity $entity) {
+				$this->assertEquals('#00ff00', $entity->getColor());
+				return $entity;
+			});
+
+		$propPatch->expects(self::once())
+			->method('setResultCode')
+			->with('{http://apple.com/ns/ical/}calendar-color', 200);
+
+		$this->federatedCalendar->propPatch($propPatch);
+	}
+
+	public function testPropPatchWithNoMutations(): void {
+		$propPatch = $this->createMock(PropPatch::class);
+		$propPatch->method('getMutations')
+			->willReturn([]);
+
+		$this->federatedCalendarMapper->expects(self::never())
+			->method('update');
+
+		$propPatch->expects(self::never())
+			->method('handle');
+
+		$this->federatedCalendar->propPatch($propPatch);
+	}
+
+	public function testGetChildACL(): void {
+		$this->assertEquals($this->federatedCalendar->getACL(), $this->federatedCalendar->getChildACL());
+	}
+
+	public function testGetLastModified(): void {
+		$this->assertEquals(1234567890, $this->federatedCalendar->getLastModified());
+	}
+
+	public function testDelete(): void {
+		$this->federatedCalendarMapper->expects(self::once())
+			->method('deleteById')
+			->with(10);
+
+		$this->federatedCalendar->delete();
+	}
+
+	public function testCreateDirectory(): void {
+		$this->expectException(MethodNotAllowed::class);
+		$this->expectExceptionMessage('Creating nested collection is not allowed');
+		$this->federatedCalendar->createDirectory('test');
+	}
+
+	public function testCalendarQuery(): void {
+		$filters = ['comp-filter' => ['name' => 'VEVENT']];
+		$expectedUris = ['event1.ics', 'event2.ics'];
+
+		$this->caldavBackend->expects(self::once())
+			->method('calendarQuery')
+			->with(10, $filters, 2) // 2 is CALENDAR_TYPE_FEDERATED
+			->willReturn($expectedUris);
+
+		$result = $this->federatedCalendar->calendarQuery($filters);
+		$this->assertEquals($expectedUris, $result);
+	}
+
+	public function testGetChild(): void {
+		$objectData = [
+			'id' => 1,
+			'uri' => 'event1.ics',
+			'calendardata' => 'BEGIN:VCALENDAR...',
+		];
+
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarObject')
+			->with(10, 'event1.ics', 2) // 2 is CALENDAR_TYPE_FEDERATED
+			->willReturn($objectData);
+
+		$child = $this->federatedCalendar->getChild('event1.ics');
+		$this->assertInstanceOf(FederatedCalendarObject::class, $child);
+	}
+
+	public function testGetChildNotFound(): void {
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarObject')
+			->with(10, 'nonexistent.ics', 2)
+			->willReturn(null);
+
+		$this->expectException(NotFound::class);
+		$this->federatedCalendar->getChild('nonexistent.ics');
+	}
+
+	public function testGetChildren(): void {
+		$objects = [
+			['id' => 1, 'uri' => 'event1.ics', 'calendardata' => 'BEGIN:VCALENDAR...'],
+			['id' => 2, 'uri' => 'event2.ics', 'calendardata' => 'BEGIN:VCALENDAR...'],
+		];
+
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarObjects')
+			->with(10, 2) // 2 is CALENDAR_TYPE_FEDERATED
+			->willReturn($objects);
+
+		$children = $this->federatedCalendar->getChildren();
+		$this->assertCount(2, $children);
+		$this->assertInstanceOf(FederatedCalendarObject::class, $children[0]);
+		$this->assertInstanceOf(FederatedCalendarObject::class, $children[1]);
+	}
+
+	public function testGetMultipleChildren(): void {
+		$paths = ['event1.ics', 'event2.ics'];
+		$objects = [
+			['id' => 1, 'uri' => 'event1.ics', 'calendardata' => 'BEGIN:VCALENDAR...'],
+			['id' => 2, 'uri' => 'event2.ics', 'calendardata' => 'BEGIN:VCALENDAR...'],
+		];
+
+		$this->caldavBackend->expects(self::once())
+			->method('getMultipleCalendarObjects')
+			->with(10, $paths, 2) // 2 is CALENDAR_TYPE_FEDERATED
+			->willReturn($objects);
+
+		$children = $this->federatedCalendar->getMultipleChildren($paths);
+		$this->assertCount(2, $children);
+		$this->assertInstanceOf(FederatedCalendarObject::class, $children[0]);
+		$this->assertInstanceOf(FederatedCalendarObject::class, $children[1]);
+	}
+
+	public function testChildExists(): void {
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarObject')
+			->with(10, 'event1.ics', 2)
+			->willReturn(['id' => 1, 'uri' => 'event1.ics']);
+
+		$result = $this->federatedCalendar->childExists('event1.ics');
+		$this->assertTrue($result);
+	}
+
+	public function testChildNotExists(): void {
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarObject')
+			->with(10, 'nonexistent.ics', 2)
+			->willReturn(null);
+
+		$result = $this->federatedCalendar->childExists('nonexistent.ics');
+		$this->assertFalse($result);
+	}
+
+	public function testCreateFile(): void {
+		$calendarData = 'BEGIN:VCALENDAR...END:VCALENDAR';
+		$remoteEtag = '"remote-etag-123"';
+		$localEtag = '"local-etag-456"';
+
+		$this->federatedCalendarService->expects(self::once())
+			->method('createCalendarObject')
+			->with($this->federationInfo, 'event1.ics', $calendarData)
+			->willReturn($remoteEtag);
+
+		$this->caldavBackend->expects(self::once())
+			->method('createCalendarObject')
+			->with(10, 'event1.ics', $calendarData, 2)
+			->willReturn($localEtag);
+
+		$result = $this->federatedCalendar->createFile('event1.ics', $calendarData);
+		$this->assertEquals($localEtag, $result);
+	}
+
+	public function testUpdateFile(): void {
+		$calendarData = 'BEGIN:VCALENDAR...UPDATED...END:VCALENDAR';
+		$remoteEtag = '"remote-etag-updated"';
+		$localEtag = '"local-etag-updated"';
+
+		$this->federatedCalendarService->expects(self::once())
+			->method('updateCalendarObject')
+			->with($this->federationInfo, 'event1.ics', $calendarData)
+			->willReturn($remoteEtag);
+
+		$this->caldavBackend->expects(self::once())
+			->method('updateCalendarObject')
+			->with(10, 'event1.ics', $calendarData, 2)
+			->willReturn($localEtag);
+
+		$result = $this->federatedCalendar->updateFile('event1.ics', $calendarData);
+		$this->assertEquals($localEtag, $result);
+	}
+
+	public function testDeleteFile(): void {
+		$this->federatedCalendarService->expects(self::once())
+			->method('deleteCalendarObject')
+			->with($this->federationInfo, 'event1.ics');
+
+		$this->caldavBackend->expects(self::once())
+			->method('deleteCalendarObject')
+			->with(10, 'event1.ics', 2);
+
+		$this->federatedCalendar->deleteFile('event1.ics');
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # feature request

## Summary
- Requires https://github.com/nextcloud/calendar/pull/7951
- modified federated calendar logic to add write ability
- close https://github.com/nextcloud/server/issues/1440
- documentation https://github.com/nextcloud/documentation/pull/14091

## Testing
- Federate two instances of NC
- Share a calendar with user from instance A to another user on instance B
- Update a event on instance B in calendar from instance A

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
