### PR TITLE
fix(federation): Don't ask the database for an empty url

### DIFF
--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -163,7 +163,10 @@ class OCSAuthAPIController extends OCSController {
 	}
 
 	protected function isValidToken(string $url, string $token): bool {
+		if ($url === '' || $token === '') {
+			return false;
+		}
 		$storedToken = $this->dbHandler->getToken($url);
-		return hash_equals($storedToken, $token);
+		return $storedToken !== '' && hash_equals($storedToken, $token);
 	}
 }

--- a/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
+++ b/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
@@ -110,28 +110,24 @@ class OCSAuthAPIControllerTest extends TestCase {
 		$token = 'token';
 
 		/** @var OCSAuthAPIController&MockObject $ocsAuthApi */
-		$ocsAuthApi = $this->getMockBuilder(OCSAuthAPIController::class)
-			->setConstructorArgs(
-				[
-					'federation',
-					$this->request,
-					$this->secureRandom,
-					$this->jobList,
-					$this->trustedServers,
-					$this->dbHandler,
-					$this->logger,
-					$this->timeFactory,
-					$this->throttler
-				]
-			)
-			->onlyMethods(['isValidToken'])
-			->getMock();
+		$ocsAuthApi = new OCSAuthAPIController(
+			'federation',
+			$this->request,
+			$this->secureRandom,
+			$this->jobList,
+			$this->trustedServers,
+			$this->dbHandler,
+			$this->logger,
+			$this->timeFactory,
+			$this->throttler,
+		);
 
 		$this->trustedServers
 			->expects($this->any())
 			->method('isTrustedServer')->with($url)->willReturn($isTrustedServer);
-		$ocsAuthApi->expects($this->any())
-			->method('isValidToken')->with($url, $token)->willReturn($isValidToken);
+		$this->dbHandler->method('getToken')
+			->with($url)
+			->willReturn($isValidToken ? $token : 'not $token');
 
 		if ($ok) {
 			$this->secureRandom->expects($this->once())->method('generate')->with(32)


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
