### PR TITLE
[stable33] perf(mounts): Tear down file system after getting each root

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3777,7 +3777,6 @@
   </file>
   <file src="lib/private/Files/Node/Root.php">
     <LessSpecificReturnStatement>
-      <code><![CDATA[$folders]]></code>
       <code><![CDATA[$this->mountManager->findByNumericId($numericId)]]></code>
       <code><![CDATA[$this->mountManager->findByStorageId($storageId)]]></code>
       <code><![CDATA[$this->mountManager->findIn($mountPoint)]]></code>

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -338,7 +338,7 @@ class Folder extends Node implements IFolder {
 	 * in.
 	 *
 	 * @param int $id
-	 * @return array
+	 * @return list<Node>
 	 */
 	protected function getByIdInRootMount(int $id): array {
 		if (!method_exists($this->root, 'createNode')) {

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -36,7 +36,7 @@ interface IRootFolder extends Folder, Emitter {
 	 *
 	 * @param int $id
 	 * @param string $path
-	 * @return Node[]
+	 * @return list<Node>
 	 *
 	 * @since 24.0.0
 	 */


### PR DESCRIPTION
Avoid getting OOM issue because we are getting all the mounts at once. This likely also increase the SQL count.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
