### PR TITLE
feat(util): add binary unit label support to humanFileSize()

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -940,7 +940,7 @@ class OC {
 				};
 
 				$memoryLimitIni = @ini_get('memory_limit');
-				$message = 'Request used ' . Util::humanFileSize($memoryPeak) . ' of memory. Memory limit: ' . ($memoryLimitIni ?: 'unknown');
+				$message = 'Request used ' . Util::humanFileSize($memoryPeak, true) . ' of memory. Memory limit: ' . ($memoryLimitIni ?: 'unknown');
 			} else {
 				// Fall back to hardcoded thresholds if memory_limit cannot be determined or if debug mode is enabled
 				$logLevel = match (true) {
@@ -950,7 +950,7 @@ class OC {
 					default => null,
 				};
 
-				$message = 'Request used more than 300 MB of RAM: ' . Util::humanFileSize($memoryPeak);
+				$message = 'Request used more than 300 MB of RAM: ' . Util::humanFileSize($memoryPeak, true);
 			}
 
 			// Log the message

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -27,7 +27,7 @@ use Psr\Container\ContainerExceptionInterface;
 class Util {
 	private const DECIMAL_LABELS = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
 	private const BINARY_LABELS = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
-	private const MAX_LANE:_INDEX = 5;
+	private const MAX_LABEL_INDEX = 5;
 
 	private static ?IManager $shareManager = null;
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -371,6 +371,7 @@ class Util {
 		for ($unitIndex = 1; $unitIndex <= self::MAX_LABEL_INDEX; $unitIndex++) {
 			$value = round($value / 1024, 1);
 			if ($value < 1024 || $unitIndex === self::MAX_LABEL_INDEX) {
+				/** @var int<0, 5> $unitIndex */
 				return "$value {$units[$unitIndex]}";
 			}
 		}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -25,6 +25,10 @@ use Psr\Container\ContainerExceptionInterface;
  * @since 4.0.0
  */
 class Util {
+	private const DECIMAL_LABELS = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+	private const BINARY_LABELS = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
+	private const MAX_LANE:_INDEX = 5;
+
 	private static ?IManager $shareManager = null;
 
 	private static array $scriptsInit = [];
@@ -326,41 +330,57 @@ class Util {
 	}
 
 	/**
-	 * Make a human file size (2048 to 2 kB)
-	 * @param int|float $bytes file size in bytes
-	 * @return string a human readable file size
+	 * Converts byte values into human-friendly strings using base-1024 logic.
+	 *
+	 * Always divides by 1024, but uses decimal (SI) unit labels (KB, MB) by default (which is
+	 * common in many OSes). Can optionally use more technically accurate IEC binary unit labels
+	 * (KiB, MiB).
+	 *
+	 * - **Rounding:** KB/KiB uses 0 decimals; MB+ uses 1 decimal place.
+	 * - **Transition:** Prevents "1024 KB" by rounding up to "1.0 MB" early.
+	 *
+	 * @example humanFileSize(2048)				// "2 KB" (whole)
+	 * @example humanFileSize(1500000)			// "1.4 MB" (decimal)
+	 * @example humanFileSize(1500000, true)	// "1.4 MiB" (more accurate IEC label)
+	 * @example humanFileSize(1048575)			// "1.0 MB" (edge case: rounds up from 1023.999... KB)
+	 *
+	 * @param int|float $bytes File size in bytes
+	 * @param bool $useBinaryLabel If true, use IEC binary labels (KiB, MiB). If false (default),
+	 *                             use SI decimal labels (KB, MB). Note: Calculation is always
+	 *                             binary (÷1024) regardless of this setting.
+	 * @return string Human-readable file size string, or "?" for negative values
 	 * @since 4.0.0
 	 */
-	public static function humanFileSize(int|float $bytes): string {
+	public static function humanFileSize(int|float $bytes, bool $useBinaryLabel = false): string {
 		if ($bytes < 0) {
 			return '?';
 		}
 		if ($bytes < 1024) {
 			return "$bytes B";
 		}
-		$bytes = round($bytes / 1024, 0);
-		if ($bytes < 1024) {
-			return "$bytes KB";
-		}
-		$bytes = round($bytes / 1024, 1);
-		if ($bytes < 1024) {
-			return "$bytes MB";
-		}
-		$bytes = round($bytes / 1024, 1);
-		if ($bytes < 1024) {
-			return "$bytes GB";
-		}
-		$bytes = round($bytes / 1024, 1);
-		if ($bytes < 1024) {
-			return "$bytes TB";
+
+		$units = $useBinaryLabel ? self::BINARY_LABELS : self::DECIMAL_LABELS;
+
+		// First step: KB/KiB (0 decimals, round immediately)
+		$value = round($bytes / 1024, 0);
+		if ($value < 1024) {
+			return "$value {$units[0]}";
 		}
 
-		$bytes = round($bytes / 1024, 1);
-		return "$bytes PB";
+		// Subsequent steps: larger units (1 decimal, round at each step)
+		for ($unitIndex = 1; $unitIndex <= self::MAX_LABEL_INDEX; $unitIndex++) {
+			$value = round($value / 1024, 1);
+			if ($value < 1024 || $unitIndex === self::MAX_LABEL_INDEX) {
+				return "$value {$units[$unitIndex]}";
+			}
+		}
+
+		// Unreachable, but keeps static analyzer happy
+		return "$value {$units[self::MAX_LABEL_INDEX]}";
 	}
 
 	/**
-	 * Make a computer file size (2 kB to 2048)
+	 * Converts human-readable file size strings into bytes using base-1024 logic.
 	 * Inspired by: https://www.php.net/manual/en/function.filesize.php#92418
 	 *
 	 * @param string $str file size in a fancy format


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #58019 <!-- related github issue -->

## Summary

Refactors `humanFileSize()` to support IEC binary unit labels (KiB, MiB, GiB) while maintaining backward compatibility with existing decimal labels (KB, MB, GB). Math stays the same, but permits us to make the string be technically accurate where we'd prefer that (i.e. in logs - e.g. see #58019) versus where the conventional (albeit inaccurate) end-user friendly facing convention of using KB/MB/GB is preferred even when doing base-1024 math.

### Changes
- **New parameter**: Added optional `$useBinaryLabel` parameter (defaults to `false`)
- **Refactored logic**: Replaced cascading if-statements with maintainable loop-based structure
- **Class constants**: Introduced `DECIMAL_LABELS`, `BINARY_LABELS`, and `MAX_LABEL_INDEX` for better maintainability
- **Improved documentation**: Enhanced docblock with examples and clear explanation of binary vs decimal labels
- **Preserved behavior**: Maintains existing rounding strategy (0 decimals for KB/KiB, 1 decimal for larger units) to prevent "1024 KB" displays
- **EB / EiB support**: !

### Motivation
- Provides technically accurate option for displaying file sizes using IEC binary prefixes
- Improves code maintainability by eliminating repetitive if-statement cascade
- Makes it trivial to add support for additional units (ZB/ZiB!) in the future
- Addresses the common confusion between binary calculation (÷1024) and decimal unit labels (KB, MB)


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
