### PR TITLE
feat(occ): allow admins to clear account passwords

### DIFF
--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -43,6 +43,12 @@ class ResetPassword extends Base {
 				InputOption::VALUE_NONE,
 				'read password from environment variable NC_PASS/OC_PASS'
 			)
+			->addOption(
+				'no-password',
+				null,
+				InputOption::VALUE_NONE,
+				'Sets the password to blank'
+			)
 		;
 	}
 
@@ -76,22 +82,32 @@ class ResetPassword extends Base {
 				}
 			}
 
-			$question = new Question('Enter a new password: ');
-			$question->setHidden(true);
-			$password = $helper->ask($input, $output, $question);
+			if ($input->getOption('no-password')) {
+				$question = new ConfirmationQuestion('Are you sure you want to clear the password for ' . $username . '?');
 
-			if ($password === null) {
-				$output->writeln('<error>Password cannot be empty!</error>');
-				return 1;
-			}
+				if (!$helper->ask($input, $output, $question)) {
+					return 1;
+				}
 
-			$question = new Question('Confirm the new password: ');
-			$question->setHidden(true);
-			$confirm = $helper->ask($input, $output, $question);
+				$password = '';
+			} else {
+				$question = new Question('Enter a new password: ');
+				$question->setHidden(true);
+				$password = $helper->ask($input, $output, $question);
 
-			if ($password !== $confirm) {
-				$output->writeln('<error>Passwords did not match!</error>');
-				return 1;
+				if ($password === null) {
+					$output->writeln('<error>Password cannot be empty!</error>');
+					return 1;
+				}
+
+				$question = new Question('Confirm the new password: ');
+				$question->setHidden(true);
+				$confirm = $helper->ask($input, $output, $question);
+
+				if ($password !== $confirm) {
+					$output->writeln('<error>Passwords did not match!</error>');
+					return 1;
+				}
 			}
 		} else {
 			$output->writeln('<error>Interactive input or --password-from-env is needed for entering a new password!</error>');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
This adds the `--no-password` option to `occ user:resetpassword` to allow admins to clear users' passwords through the command line.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
