### PR TITLE
fix(TemplateLayout): Refactor user ID handling

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -119,17 +119,18 @@ class TemplateLayout {
 				}
 
 				$user = Server::get(IUserSession::class)->getUser();
+				$userId = $user?->getUID();
 
-				if ($user === null) {
+				if (empty($userId)) {
 					$page->assign('user_uid', false);
 					$page->assign('user_displayname', false);
 					$page->assign('userAvatarSet', false);
 					$page->assign('userStatus', false);
 				} else {
-					$page->assign('user_uid', $user->getUID());
+					$page->assign('user_uid', $userId);
 					$page->assign('user_displayname', $user->getDisplayName());
 					$page->assign('userAvatarSet', true);
-					$page->assign('userAvatarVersion', $this->config->getUserValue($user->getUID(), 'avatar', 'version', 0));
+					$page->assign('userAvatarVersion', $this->config->getUserValue($userId, 'avatar', 'version', 0));
 				}
 				break;
 			case TemplateResponse::RENDER_AS_ERROR:
@@ -143,14 +144,16 @@ class TemplateLayout {
 				Util::addStyle('guest');
 				$page->assign('bodyid', 'body-login');
 
-				$userDisplayName = false;
 				$user = Server::get(IUserSession::class)->getUser();
-				if ($user) {
-					$userDisplayName = $user->getDisplayName();
-				}
+				$userId = $user?->getUID();
 
-				$page->assign('user_displayname', $userDisplayName);
-				$page->assign('user_uid', \OC_User::getUser());
+				if (empty($userId)) {
+					$page->assign('user_displayname', false);
+					$page->assign('user_uid', false);
+				} else {
+					$page->assign('user_displayname', $user->getDisplayName());
+					$page->assign('user_uid', $userId);
+				}
 				break;
 			case TemplateResponse::RENDER_AS_PUBLIC:
 				$page = $this->templateManager->getTemplate('core', 'layout.public');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Resolves: https://github.com/nextcloud/server/issues/54166

<details>
  <summary>Stack trace</summary>

```
{
  "reqId": "82V7qlVkqgH0JmCmzvEl",
  "level": 3,
  "time": "2026-02-03T18:18:05+01:00",
  "remoteAddr": "185.204.254.31",
  "user": "--",
  "app": "index",
  "method": "GET",
  "url": "/apps/files/?dir=/&fileid=60365521",
  "scriptName": "/index.php",
  "message": "userId cannot be an empty string",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
  "version": "31.0.13.1",
  "exception": {
    "Exception": "InvalidArgumentException",
    "Message": "userId cannot be an empty string",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/Config/UserConfig.php",
        "line": 152,
        "function": "assertParams",
        "class": "OC\\Config\\UserConfig",
        "type": "->",
        "args": [
          "",
          "avatar",
          "version"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/AllConfig.php",
        "line": 282,
        "function": "hasKey",
        "class": "OC\\Config\\UserConfig",
        "type": "->",
        "args": [
          "",
          "avatar",
          "version"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/TemplateLayout.php",
        "line": 135,
        "function": "getUserValue",
        "class": "OC\\AllConfig",
        "type": "->",
        "args": [
          false,
          "avatar",
          "version",
          0
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/legacy/OC_Template.php",
        "line": 120,
        "function": "__construct",
        "class": "OC\\TemplateLayout",
        "type": "->",
        "args": [
          "user",
          "files"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/public/AppFramework/Http/TemplateResponse.php",
        "line": 189,
        "function": "fetchPage",
        "class": "OC_Template",
        "type": "->",
        "args": [
          []
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 159,
        "function": "render",
        "class": "OCP\\AppFramework\\Http\\TemplateResponse",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files\\Controller\\ViewController"
          },
          "index"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 315,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Files\\Controller\\ViewController",
          "index",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "_route": "files.view.index"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/base.php",
        "line": 1063,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/files/"
        ]
      },
      {
        "file": "/var/www/nextcloud/index.php",
        "line": 24,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/var/www/nextcloud/lib/private/Config/UserConfig.php",
    "Line": 1668,
    "message": "userId cannot be an empty string",
    "exception": [],
    "CustomMessage": "userId cannot be an empty string"
  },
  "id": "6982e36d39264"
}
```

</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
