### PR TITLE
chore(openmetrics): export only "real" files count

### DIFF
--- a/lib/private/OpenMetrics/Exporters/FilesByType.php
+++ b/lib/private/OpenMetrics/Exporters/FilesByType.php
@@ -61,6 +61,7 @@ class FilesByType extends Cached {
 		$qb = $this->connection->getQueryBuilder()->runAcrossAllShards();
 		$metrics = $qb->select('mimetype', $qb->func()->count('*', 'count'))
 			->from('filecache')
+			->where($qb->expr()->like('path', $qb->createNamedParameter('files/%')))
 			->groupBy('mimetype')
 			->executeQuery();
 


### PR DESCRIPTION
## Summary

Export only "real" files count in OpenMetrics exporter
Other files like files in trashbin or file versions should be exported by related apps

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
