### PR TITLE
fix: add X-User-Id header to logout response

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -79,8 +79,9 @@ class LoginController extends Controller {
 	#[FrontpageRoute(verb: 'GET', url: '/logout')]
 	public function logout() {
 		$loginToken = $this->request->getCookie('nc_token');
-		if (!is_null($loginToken)) {
-			$this->config->deleteUserValue($this->userSession->getUser()->getUID(), 'login_token', $loginToken);
+		$uid = $this->userSession->getUser()?->getUID();
+		if ($loginToken !== null && $uid !== null) {
+			$this->config->deleteUserValue($uid, 'login_token', $loginToken);
 		}
 		$this->userSession->logout();
 
@@ -97,6 +98,10 @@ class LoginController extends Controller {
 			&& !$this->request->isUserAgent([Request::USER_AGENT_CHROME, Request::USER_AGENT_ANDROID_MOBILE_CHROME])
 		) {
 			$response->addHeader('Clear-Site-Data', '"cache", "storage"');
+		}
+
+		if ($uid !== null) {
+			$response->addHeader('X-User-Id', $uid);
 		}
 
 		return $response;

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -218,6 +218,7 @@ class LoginControllerTest extends TestCase {
 
 		$expected = new RedirectResponse('/login');
 		$expected->addHeader('Clear-Site-Data', '"cache", "storage"');
+		$expected->addHeader('X-User-Id', 'JohnDoe');
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Follow up of https://github.com/nextcloud/server/pull/55176 and https://github.com/nextcloud/server/pull/57191

Makes sure that the `X-User-Id` header is added to the response before the user session is cleared.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
