### PR TITLE
Normalize object store paths for writeStream

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -123,7 +123,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	private function normalizePath(string $path): string {
 		$path = trim($path, '/');
 		//FIXME why do we sometimes get a path like 'files//username'?
-		$path = str_replace('//', '/', $path);
+		$path = preg_replace('#/{2,}#', '/', $path);
 
 		// dirname('/folder') returns '.' but internally (in the cache) we store the root as ''
 		if (!$path || $path === '.') {
@@ -456,6 +456,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	}
 
 	public function writeStream(string $path, $stream, ?int $size = null): int {
+		$path = $this->normalizePath($path);
 		if ($size === null) {
 			$stats = fstat($stream);
 			if (is_array($stats) && isset($stats['size'])) {

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -67,6 +67,18 @@ class ObjectStoreStorageTest extends Storage {
 		}
 	}
 
+	public function testWriteStreamNormalizesPath(): void {
+		$this->instance->mkdir('files');
+		$this->instance->mkdir('files/user');
+
+		$this->instance->file_put_contents('files//user/test.txt', 'foo');
+
+		$cache = $this->instance->getCache();
+		$this->assertTrue($cache->inCache('files/user/test.txt'));
+		$this->assertFalse($cache->inCache('files//user/test.txt'));
+		$this->assertEquals('foo', $this->instance->file_get_contents('files/user/test.txt'));
+	}
+
 	public function testCheckUpdate(): void {
 		$this->markTestSkipped('Detecting external changes is not supported on object storages');
 	}


### PR DESCRIPTION
## Summary
- Normalize paths in ObjectStoreStorage::writeStream to prevent double-slash cache keys
- Add regression test for path normalization

## Impact
Prevents object-store cache mismatches and missing file lookups when paths contain double slashes.