### PR TITLE
perf: Replace getById call with getFirstNodeById

### DIFF
--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -12,7 +12,6 @@ use OCP\App\IAppManager;
 use OCP\Comments\CommentsEvent;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\IRootFolder;
-use OCP\Files\Node;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IShareHelper;
@@ -47,10 +46,8 @@ class Listener {
 		foreach ($mounts as $mount) {
 			$owner = $mount->getUser()->getUID();
 			$ownerFolder = $this->rootFolder->getUserFolder($owner);
-			$nodes = $ownerFolder->getById((int)$event->getComment()->getObjectId());
-			if (!empty($nodes)) {
-				/** @var Node $node */
-				$node = array_shift($nodes);
+			$node = $ownerFolder->getFirstNodeById((int)$event->getComment()->getObjectId());
+			if ($node !== null) {
 				$al = $this->shareHelper->getPathsForAccessList($node);
 				$users += $al['users'];
 			}

--- a/apps/comments/lib/Controller/NotificationsController.php
+++ b/apps/comments/lib/Controller/NotificationsController.php
@@ -70,11 +70,11 @@ class NotificationsController extends Controller {
 				return new NotFoundResponse();
 			}
 			$userFolder = $this->rootFolder->getUserFolder($currentUser->getUID());
-			$files = $userFolder->getById((int)$comment->getObjectId());
+			$file = $userFolder->getFirstNodeById((int)$comment->getObjectId());
 
 			$this->markProcessed($comment, $currentUser);
 
-			if (empty($files)) {
+			if ($file === null) {
 				return new NotFoundResponse();
 			}
 

--- a/apps/comments/lib/Listener/CommentsEntityEventListener.php
+++ b/apps/comments/lib/Listener/CommentsEntityEventListener.php
@@ -32,8 +32,8 @@ class CommentsEntityEventListener implements IEventListener {
 		}
 
 		$event->addEntityCollection('files', function ($name): bool {
-			$nodes = $this->rootFolder->getUserFolder($this->userId)->getById((int)$name);
-			return !empty($nodes);
+			$node = $this->rootFolder->getUserFolder($this->userId)->getFirstNodeById((int)$name);
+			return $node !== null;
 		});
 	}
 }

--- a/apps/comments/lib/Notification/Notifier.php
+++ b/apps/comments/lib/Notification/Notifier.php
@@ -84,11 +84,10 @@ class Notifier implements INotifier {
 					throw new UnknownNotificationException('Unsupported comment object');
 				}
 				$userFolder = $this->rootFolder->getUserFolder($notification->getUser());
-				$nodes = $userFolder->getById((int)$parameters[1]);
-				if (empty($nodes)) {
+				$node = $userFolder->getFirstNodeById((int)$parameters[1]);
+				if ($node === null) {
 					throw new AlreadyProcessedException();
 				}
-				$node = $nodes[0];
 
 				$path = rtrim($node->getPath(), '/');
 				if (str_starts_with($path, '/' . $notification->getUser() . '/files/')) {

--- a/apps/comments/lib/Search/CommentsSearchProvider.php
+++ b/apps/comments/lib/Search/CommentsSearchProvider.php
@@ -116,11 +116,11 @@ class CommentsSearchProvider implements IProvider {
 	 * @throws NotFoundException
 	 */
 	protected function getFileForComment(Folder $userFolder, IComment $comment): Node {
-		$nodes = $userFolder->getById((int)$comment->getObjectId());
-		if (empty($nodes)) {
+		$node = $userFolder->getFirstNodeById((int)$comment->getObjectId());
+		if ($node === null) {
 			throw new NotFoundException('File not found');
 		}
 
-		return array_shift($nodes);
+		return $node;
 	}
 }

--- a/apps/comments/tests/Unit/Activity/ListenerTest.php
+++ b/apps/comments/tests/Unit/Activity/ListenerTest.php
@@ -92,12 +92,11 @@ class ListenerTest extends TestCase {
 			->willReturn($userMountCache);
 
 		$node = $this->createMock(Node::class);
-		$nodes = [ $node ];
 
 		$ownerFolder = $this->createMock(Folder::class);
 		$ownerFolder->expects($this->any())
-			->method('getById')
-			->willReturn($nodes);
+			->method('getFirstNodeById')
+			->willReturn($node);
 
 		$this->rootFolder->expects($this->any())
 			->method('getUserFolder')

--- a/apps/comments/tests/Unit/Controller/NotificationsTest.php
+++ b/apps/comments/tests/Unit/Controller/NotificationsTest.php
@@ -107,8 +107,8 @@ class NotificationsTest extends TestCase {
 			->willReturn($folder);
 
 		$folder->expects($this->once())
-			->method('getById')
-			->willReturn([$file]);
+			->method('getFirstNodeById')
+			->willReturn($file);
 
 		$this->session->expects($this->once())
 			->method('getUser')
@@ -183,8 +183,8 @@ class NotificationsTest extends TestCase {
 			->willReturn($folder);
 
 		$folder->expects($this->once())
-			->method('getById')
-			->willReturn([]);
+			->method('getFirstNodeById')
+			->willReturn(null);
 
 		$user = $this->createMock(IUser::class);
 

--- a/apps/comments/tests/Unit/Notification/NotifierTest.php
+++ b/apps/comments/tests/Unit/Notification/NotifierTest.php
@@ -86,9 +86,9 @@ class NotifierTest extends TestCase {
 			->with('you')
 			->willReturn($userFolder);
 		$userFolder->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with('678')
-			->willReturn([$node]);
+			->willReturn($node);
 
 		$this->notification->expects($this->exactly(2))
 			->method('getUser')
@@ -202,9 +202,9 @@ class NotifierTest extends TestCase {
 			->with('you')
 			->willReturn($userFolder);
 		$userFolder->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with('678')
-			->willReturn([$node]);
+			->willReturn($node);
 
 		$this->notification->expects($this->exactly(2))
 			->method('getUser')
@@ -301,7 +301,7 @@ class NotifierTest extends TestCase {
 
 		$this->folder
 			->expects($this->never())
-			->method('getById');
+			->method('getFirstNodeById');
 
 		$this->notification
 			->expects($this->once())
@@ -338,7 +338,7 @@ class NotifierTest extends TestCase {
 
 		$this->folder
 			->expects($this->never())
-			->method('getById');
+			->method('getFirstNodeById');
 
 		$this->notification
 			->expects($this->once())
@@ -378,7 +378,7 @@ class NotifierTest extends TestCase {
 
 		$this->folder
 			->expects($this->never())
-			->method('getById');
+			->method('getFirstNodeById');
 
 		$this->notification
 			->expects($this->once())
@@ -435,7 +435,7 @@ class NotifierTest extends TestCase {
 
 		$this->folder
 			->expects($this->never())
-			->method('getById');
+			->method('getFirstNodeById');
 
 		$this->notification
 			->expects($this->once())
@@ -497,9 +497,9 @@ class NotifierTest extends TestCase {
 			->with('you')
 			->willReturn($userFolder);
 		$userFolder->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with('678')
-			->willReturn([]);
+			->willReturn(null);
 
 		$this->notification->expects($this->once())
 			->method('getUser')

--- a/apps/dav/lib/DAV/ViewOnlyPlugin.php
+++ b/apps/dav/lib/DAV/ViewOnlyPlugin.php
@@ -69,9 +69,8 @@ class ViewOnlyPlugin extends ServerPlugin {
 				// The version source file is relative to the owner storage.
 				// But we need the node from the current user perspective.
 				if ($node->getOwner()->getUID() !== $currentUserId) {
-					$nodes = $this->userFolder->getById($node->getId());
-					$node = array_pop($nodes);
-					if (!$node) {
+					$node = $this->userFolder->getFirstNodeById($node->getId());
+					if ($node === null) {
 						throw new NotFoundException('Version file not accessible by current user');
 					}
 				}

--- a/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
@@ -97,6 +97,7 @@ class ViewOnlyPluginTest extends TestCase {
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'providesDataForCanGet')]
 	public function testCanGet(bool $isVersion, ?bool $attrEnabled, bool $expectCanDownloadFile, bool $allowViewWithoutDownload): void {
 		$nodeInfo = $this->createMock(File::class);
+		$nodeInfo->method('getId')->willReturn(42);
 		if ($isVersion) {
 			$davPath = 'versions/alice/versions/117/123456';
 			$version = $this->createMock(IVersion::class);
@@ -122,8 +123,9 @@ class ViewOnlyPluginTest extends TestCase {
 				->method('getUID')
 				->willReturn('bob');
 			$this->userFolder->expects($this->once())
-				->method('getById')
-				->willReturn([$nodeInfo]);
+				->method('getFirstNodeById')
+				->with(42)
+				->willReturn($nodeInfo);
 			$this->userFolder->expects($this->once())
 				->method('getOwner')
 				->willReturn($owner);

--- a/apps/files/lib/Collaboration/Resources/ResourceProvider.php
+++ b/apps/files/lib/Collaboration/Resources/ResourceProvider.php
@@ -20,6 +20,7 @@ use OCP\IUser;
 class ResourceProvider implements IProvider {
 	public const RESOURCE_TYPE = 'file';
 
+	/** @var array<int, Node> $nodes */
 	protected array $nodes = [];
 
 	public function __construct(
@@ -86,9 +87,9 @@ class ResourceProvider implements IProvider {
 		}
 
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
-		$node = $userFolder->getById((int)$resource->getId());
+		$node = $userFolder->getFirstNodeById((int)$resource->getId());
 
-		if ($node) {
+		if ($node !== null) {
 			$this->nodes[(int)$resource->getId()] = $node;
 			return true;
 		}

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -164,8 +164,11 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		if ($share->getShareOwner() !== $share->getSharedBy()) {
 			$ownerFolder = $this->rootFolder->getUserFolder($share->getShareOwner());
 			$fileId = $share->getNode()->getId();
-			$nodes = $ownerFolder->getById($fileId);
-			$ownerPath = $nodes[0]->getPath();
+			$node = $ownerFolder->getFirstNodeById($fileId);
+			if ($node === null) {
+				throw new \LogicException("Unable to find node $fileId asociated with the share");
+			}
+			$ownerPath = $node->getPath();
 			$this->publishActivity(
 				$type === 'share' ? Activity::SUBJECT_SHARED_EMAIL_BY : Activity::SUBJECT_UNSHARED_EMAIL_BY,
 				[$ownerFolder->getRelativePath($ownerPath), $share->getSharedWith(), $share->getSharedBy()],


### PR DESCRIPTION
Avoid looking at all the mounts

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
