### PR TITLE
fix: don't try to create preview folder if it already exists

### DIFF
--- a/lib/private/Preview/Storage/LocalPreviewStorage.php
+++ b/lib/private/Preview/Storage/LocalPreviewStorage.php
@@ -80,7 +80,9 @@ class LocalPreviewStorage implements IPreviewStorage {
 
 	private function createParentFiles(string $path): void {
 		$dirname = dirname($path);
-		@mkdir($dirname, recursive: true);
+		if (!is_dir($dirname)) {
+			mkdir($dirname, recursive: true);
+		}
 		if (!is_dir($dirname)) {
 			throw new NotPermittedException("Unable to create directory '$dirname'");
 		}


### PR DESCRIPTION
The `@` doesn't seem to be enough to reliably silence a warning being logged