### PR TITLE
[stable28] chore: Improve SVG handling in link previews

### DIFF
--- a/lib/private/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/private/Collaboration/Reference/LinkReferenceProvider.php
@@ -170,8 +170,14 @@ class LinkReferenceProvider implements IReferenceProvider {
 					if (in_array($contentType, self::ALLOWED_CONTENT_TYPES, true) && $contentLength < self::MAX_PREVIEW_SIZE) {
 						$stream = Utils::streamFor($response->getBody());
 						$bodyStream = new LimitStream($stream, self::MAX_PREVIEW_SIZE, 0);
+						$content = $bodyStream->getContents();
+
+						if ($contentType === 'image/svg+xml' && stripos(html_entity_decode($content, ENT_XML1), 'XSL/Transform') !== false) {
+							return;
+						}
+
 						$reference->setImageContentType($contentType);
-						$folder->newFile(md5($reference->getId()), $bodyStream->getContents());
+						$folder->newFile(md5($reference->getId()), $content);
 						$reference->setImageUrl($this->urlGenerator->linkToRouteAbsolute('core.Reference.preview', ['referenceId' => md5($reference->getId())]));
 					}
 				}


### PR DESCRIPTION
Manual Backport of PR https://github.com/nextcloud/server/pull/58100
File got moved from `lib/private/Collaboration/` to `lib/public/Collaboration/` in 29.0.0