### PR TITLE
[stable33] fix: target-repair: handle cases where the parent folder doesn't exist

### DIFF
--- a/apps/files_sharing/lib/Repair/CleanupShareTarget.php
+++ b/apps/files_sharing/lib/Repair/CleanupShareTarget.php
@@ -13,6 +13,7 @@ use OCA\Files_Sharing\ShareTargetValidator;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Migration\IOutput;
@@ -81,7 +82,12 @@ class CleanupShareTarget implements IRepairStep {
 			$oldTarget = $shareInfo['file_target'];
 			$newTarget = $this->cleanTarget($oldTarget);
 			$absoluteNewTarget = $userFolder->getFullPath($newTarget);
-			$targetParentNode = $this->rootFolder->get(dirname($absoluteNewTarget));
+			try {
+				$targetParentNode = $this->rootFolder->get(dirname($absoluteNewTarget));
+			} catch (NotFoundException) {
+				$absoluteNewTarget = $userFolder->getFullPath(basename($newTarget));
+				$targetParentNode = $userFolder;
+			}
 
 			try {
 				$absoluteNewTarget = $this->shareTargetValidator->generateUniqueTarget(


### PR DESCRIPTION
If the parent folder for the share target doesn't exist, move it to the users home, same as we do during the normal mount validation.