### PR TITLE
Fix/more missing userid cases

### DIFF
--- a/apps/dav/lib/Connector/Sabre/UserIdHeaderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/UserIdHeaderPlugin.php
@@ -19,7 +19,7 @@ class UserIdHeaderPlugin extends \Sabre\DAV\ServerPlugin {
 	}
 
 	public function initialize(\Sabre\DAV\Server $server): void {
-		$server->on('afterMethod:*', [$this, 'afterMethod']);
+		$server->on('beforeMethod:*', [$this, 'beforeMethod']);
 	}
 
 	/**
@@ -28,7 +28,7 @@ class UserIdHeaderPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @param RequestInterface $request request
 	 * @param ResponseInterface $response response
 	 */
-	public function afterMethod(RequestInterface $request, ResponseInterface $response): void {
+	public function beforeMethod(RequestInterface $request, ResponseInterface $response): void {
 		if ($user = $this->userSession->getUser()) {
 			$response->setHeader('X-User-Id', $user->getUID());
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -1190,7 +1190,9 @@ class OC {
 		// Redirect to the default app or login only as an entry point
 		if ($requestPath === '') {
 			// Someone is logged in
-			if (Server::get(IUserSession::class)->isLoggedIn()) {
+			$userSession = Server::get(IUserSession::class);
+			if ($userSession->isLoggedIn()) {
+				header('X-User-Id: ' . $userSession->getUser()?->getUID());
 				header('Location: ' . Server::get(IURLGenerator::class)->linkToDefaultPageUrl());
 			} else {
 				// Not handled and not logged in


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Sets the user id header in DAV responses in `beforeMethod` instead of `afterMethod`, this ensures that if some plugins stop the event propagation, the user id header will still be set.

Adds the same header in the redirect response when calling `GET /index.php` which redirects to the default app.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
