### PR TITLE
fix(db): add time_sensitive to jobs index for better query performance

### DIFF
--- a/core/Listener/AddMissingIndicesListener.php
+++ b/core/Listener/AddMissingIndicesListener.php
@@ -150,10 +150,12 @@ class AddMissingIndicesListener implements IEventListener {
 		);
 
 
-		$event->addMissingIndex(
+		$event->replaceIndex(
 			'jobs',
-			'job_lastcheck_reserved',
-			['last_checked', 'reserved_at']
+			['job_lastcheck_reserved'],
+			'job_sensitive_lastcheck_reserved',
+			['time_sensitive', 'last_checked', 'reserved_at'],
+			false,
 		);
 
 		$event->addMissingIndex(

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -504,7 +504,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['class'], 'job_class_index');
-			$table->addIndex(['last_checked', 'reserved_at'], 'job_lastcheck_reserved');
+			$table->addIndex(['time_sensitive', 'last_checked', 'reserved_at'], 'job_sensitive_lastcheck_reserved');
 		}
 
 		if (!$schema->hasTable('users')) {


### PR DESCRIPTION
## Summary

Replaces the `job_lastcheck_reserved` index on the `jobs` table with a new `job_sensitive_lastcheck_reserved` index that includes the `time_sensitive` column.

## Problem

The query for fetching background jobs filters on `reserved_at`, `last_checked`, and `time_sensitive`, but the existing index only covers `last_checked` and `reserved_at`. This forces the database to scan unnecessary rows when a maintenance window is configured.

## Solution

Replace the index with `(time_sensitive, last_checked, reserved_at)` — putting the equality column first for optimal index usage, as recommended in the issue discussion.

As shown in the issue's ANALYZE output, this reduces scanned rows significantly (from 15 to 1 on the reporter's dev instance).

Fixes #46126

Signed-off-by: QDenka <a@bigf.at>