### PR TITLE
fix(dav): Strip DTSTAMP before etag comparison in webcal refresh

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
@@ -112,7 +112,13 @@ class RefreshWebcalService {
 
 				$sObject = $vObject->serialize();
 				$uid = $vBase->UID->getValue();
-				$etag = md5($sObject);
+				// Strip DTSTAMP lines for etag computation only.
+				// Many providers (Google Calendar, Outlook, itslearning) set DTSTAMP
+				// to the current time on every feed request per RFC 5545, causing
+				// every event to appear modified on every refresh.
+				// DTSTAMP is kept in the stored data as it is a required property.
+				$sObjectForEtag = preg_replace('/^DTSTAMP[;:].*\r?\n([ \t].*\r?\n)*/m', '', $sObject);
+				$etag = md5($sObjectForEtag);
 
 				// No existing object with this UID, create it
 				if (!isset($existingObjects[$uid])) {


### PR DESCRIPTION
## Summary

- Exclude `DTSTAMP` from etag computation in `RefreshWebcalService` to prevent false change detection
- DTSTAMP is preserved in stored calendar data (required property per RFC 5545)

## Problem

Many iCal providers (Google Calendar, Outlook 365, itslearning) set `DTSTAMP` to the current UTC time on every feed request per [RFC 5545](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.2). Since Nextcloud computes the etag as `md5(serialized_data)` and DTSTAMP changes every time, every event appears modified on every refresh — even if nothing actually changed.

For a Google Calendar subscription with 2,621 events refreshed every ~15 minutes, this generates **~189K false change rows per day** in `oc_calendarchanges`.

Reported at: https://github.com/nextcloud/server/issues/51120#issuecomment-3870028545

## Approach

Instead of stripping DTSTAMP from the VObject (which would remove a required property from stored data), the fix strips DTSTAMP lines from a copy of the serialized string used only for etag computation:

```php
$sObjectForEtag = preg_replace('/^DTSTAMP:.*\r?\n/m', '', $sObject);
$etag = md5($sObjectForEtag);
```

The stored calendar data (`$sObject`) is completely unchanged.

## Test plan

- [x] New test `testDtstampChangeDoesNotTriggerUpdate` verifies a DTSTAMP-only change does not trigger `updateCalendarObject`
- [x] Updated `identicalDataProvider` etag computation to match the new DTSTAMP-stripped hashing
- [ ] Run `RefreshWebcalServiceTest` unit tests

Fixes: https://github.com/nextcloud/server/issues/51120

🤖 Generated with [Claude Code](https://claude.com/claude-code)