### PR TITLE
fix: Remove deprecated RFC7231 constant to avoid warnings on PHP 8.5

### DIFF
--- a/apps/dav/lib/Provisioning/Apple/AppleProvisioningNode.php
+++ b/apps/dav/lib/Provisioning/Apple/AppleProvisioningNode.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Provisioning\Apple;
 
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Constants;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\INode;
 use Sabre\DAV\IProperties;
@@ -60,7 +61,7 @@ class AppleProvisioningNode implements INode, IProperties {
 
 		return [
 			'{DAV:}getcontentlength' => 42,
-			'{DAV:}getlastmodified' => $datetime->format(\DateTimeInterface::RFC7231),
+			'{DAV:}getlastmodified' => $datetime->format(Constants::DATE_RFC7231),
 		];
 	}
 

--- a/lib/private/AppFramework/Middleware/NotModifiedMiddleware.php
+++ b/lib/private/AppFramework/Middleware/NotModifiedMiddleware.php
@@ -11,6 +11,7 @@ namespace OC\AppFramework\Middleware;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
+use OCP\Constants;
 use OCP\IRequest;
 
 class NotModifiedMiddleware extends Middleware {
@@ -27,7 +28,7 @@ class NotModifiedMiddleware extends Middleware {
 		}
 
 		$modifiedSinceHeader = $this->request->getHeader('IF_MODIFIED_SINCE');
-		if ($modifiedSinceHeader !== '' && $response->getLastModified() !== null && trim($modifiedSinceHeader) === $response->getLastModified()->format(\DateTimeInterface::RFC7231)) {
+		if ($modifiedSinceHeader !== '' && $response->getLastModified() !== null && trim($modifiedSinceHeader) === $response->getLastModified()->format(Constants::DATE_RFC7231)) {
 			$response->setStatus(Http::STATUS_NOT_MODIFIED);
 			return $response;
 		}

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -9,6 +9,7 @@ namespace OCP\AppFramework\Http;
 
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Constants;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -98,7 +99,7 @@ class Response {
 			$time = \OCP\Server::get(ITimeFactory::class);
 			$expires->setTimestamp($time->getTime());
 			$expires->add(new \DateInterval('PT' . $cacheSeconds . 'S'));
-			$this->addHeader('Expires', $expires->format(\DateTimeInterface::RFC7231));
+			$this->addHeader('Expires', $expires->format(Constants::DATE_RFC7231));
 		} else {
 			$this->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
 			unset($this->headers['Expires']);
@@ -240,7 +241,7 @@ class Response {
 		];
 
 		if ($this->lastModified) {
-			$mergeWith['Last-Modified'] = $this->lastModified->format(\DateTimeInterface::RFC7231);
+			$mergeWith['Last-Modified'] = $this->lastModified->format(Constants::DATE_RFC7231);
 		}
 
 		if ($this->ETag) {

--- a/lib/public/Constants.php
+++ b/lib/public/Constants.php
@@ -59,4 +59,12 @@ class Constants {
 	 * cf. sharing.maxAutocompleteResults in config.sample.php.
 	 */
 	public const SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT = 25;
+
+	/**
+	 * Replacement for the built-in `DATE_RFC7231` constant
+	 * deprecated since PHP 8.5.
+	 *
+	 * @since 34.0.0
+	 */
+	public const DATE_RFC7231 = 'D, d M Y H:i:s \G\M\T';
 }

--- a/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
@@ -12,6 +12,7 @@ use OC\AppFramework\Middleware\NotModifiedMiddleware;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Response;
+use OCP\Constants;
 use OCP\IRequest;
 
 class NotModifiedMiddlewareTest extends \Test\TestCase {
@@ -44,13 +45,13 @@ class NotModifiedMiddlewareTest extends \Test\TestCase {
 			[null, '"etag"', null, '', false],
 			['etag', '"etag"', null, '', true],
 
-			[null, '', $now, $now->format(\DateTimeInterface::RFC7231), true],
+			[null, '', $now, $now->format(Constants::DATE_RFC7231), true],
 			[null, '', $now, $now->format(\DateTimeInterface::ATOM), false],
-			[null, '', null, $now->format(\DateTimeInterface::RFC7231), false],
+			[null, '', null, $now->format(Constants::DATE_RFC7231), false],
 			[null, '', $now, '', false],
 
 			['etag', '"etag"', $now, $now->format(\DateTimeInterface::ATOM), true],
-			['etag', '"etag"', $now, $now->format(\DateTimeInterface::RFC7231), true],
+			['etag', '"etag"', $now, $now->format(Constants::DATE_RFC7231), true],
 		];
 	}
 


### PR DESCRIPTION
* Relates to: https://github.com/nextcloud/mail/issues/12384

## Summary
Since PHP 8.5, the RFC7231 constant is being deprecated ([see PHP wiki](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_date_rfc7231_and_datetimeinterfacerfc7231)). This produces deprecation warnings in several cases (in my case: when running the Mail app unit tests).

`PHP Deprecated:  Constant DateTimeInterface::RFC7231 is deprecated since 8.5, as this format ignores the associated timezone and always uses GMT in /var/www/html/lib/public/AppFramework/Http/Response.php on line 101`

To fix that, I replaced the constant with the value that's being used instead. This should be fine as we rely on GMT anyway here. If not, please let me know!

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
