### PR TITLE
fix(snowflake): cast lastId to string

### DIFF
--- a/lib/private/Preview/Db/PreviewMapper.php
+++ b/lib/private/Preview/Db/PreviewMapper.php
@@ -204,10 +204,10 @@ class PreviewMapper extends QBMapper {
 	/**
 	 * @return \Generator<Preview>
 	 */
-	public function getPreviews(int $lastId, int $limit = 1000): \Generator {
+	public function getPreviews(string $lastId, int $limit = 1000): \Generator {
 		$qb = $this->db->getQueryBuilder();
 		$this->joinLocation($qb)
-			->where($qb->expr()->gt('p.id', $qb->createNamedParameter($lastId, IQueryBuilder::PARAM_INT)))
+			->where($qb->expr()->gt('p.id', $qb->createNamedParameter($lastId)))
 			->setMaxResults($limit);
 		return $this->yieldEntities($qb);
 

--- a/lib/private/Preview/PreviewService.php
+++ b/lib/private/Preview/PreviewService.php
@@ -110,7 +110,7 @@ class PreviewService {
 	 * @throws Exception
 	 */
 	public function deleteAll(): void {
-		$lastId = 0;
+		$lastId = '0';
 		while (true) {
 			$previews = $this->previewMapper->getPreviews($lastId, 1000);
 			$i = 0;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Fixes https://github.com/nextcloud/previewgenerator/issues/637

## Summary

Snowflake IDs are strings, so the mapper method needs to change

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
