### PR TITLE
fix: quote tablenames for truncating in oracle

### DIFF
--- a/lib/private/DB/OracleConnection.php
+++ b/lib/private/DB/OracleConnection.php
@@ -26,6 +26,13 @@ class OracleConnection extends Connection {
 		return $return;
 	}
 
+	public function truncateTable(string $table, bool $cascade) {
+		if ($table[0] !== $this->getDatabasePlatform()->getIdentifierQuoteCharacter()) {
+			$table = $this->quoteIdentifier($table);
+		}
+		return parent::truncateTable($table, $cascade);
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */


### PR DESCRIPTION
Resolves: #58022 
Oracle updates to 32.0.4 and 32.0.5 are broken because the truncateTable command is not setting quoteIdentifiers causing the table to be converted to uppercase by the library.