### PR TITLE
fix: delete CalDav and CardDav shares upon group deletion

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -89,6 +89,7 @@ use OCP\Contacts\IManager as IContactsManager;
 use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
 use OCP\Federation\ICloudFederationProviderManager;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Server;
@@ -205,6 +206,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserCreatedEvent::class, UserEventsListener::class);
 		$context->registerEventListener(UserChangedEvent::class, UserEventsListener::class);
 		$context->registerEventListener(UserUpdatedEvent::class, UserEventsListener::class);
+		$context->registerEventListener(GroupDeletedEvent::class, UserEventsListener::class);
 
 		$context->registerEventListener(SabrePluginAuthInitEvent::class, SabrePluginAuthInitListener::class);
 

--- a/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
+++ b/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
@@ -182,4 +182,15 @@ class UserEventsListenerTest extends TestCase {
 		$this->userEventsListener->preDeleteUser($user);
 		$this->userEventsListener->postDeleteUser('newUser');
 	}
+
+	public function testDeleteGroup(): void {
+		$this->calDavBackend->expects($this->once())
+			->method('deleteAllSharesByUser')
+			->with('principals/groups/testGroup');
+		$this->cardDavBackend->expects($this->once())
+			->method('deleteAllSharesByUser')
+			->with('principals/groups/testGroup');
+
+		$this->userEventsListener->postDeleteGroup('testGroup');
+	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
* Resolves: https://github.com/nextcloud/calendar/issues/7775
* Community PR: https://github.com/nextcloud/server/pull/57075 

## Summary
Unlike user shares, group shares were not deleted when the group was deleted. This lead to dangling group shares (calenders shared with groups that didn't exist anymore). This PR removes all group shares upon deletion.

## Testing
- Create a couple NC groups
- Share a calendar with those groups
- Delete a group
- Check "dav_shares" table

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
