### PR TITLE
fix(setup): prevent unnecessary mime migrations on new installs

### DIFF
--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -389,13 +389,11 @@ class RepairMimeTypes implements IRepairStep {
 	 * Get the current mimetype version
 	 */
 	private function getMimeTypeVersion(): string {
-		$serverVersion = $this->config->getSystemValueString('version', '0.0.0');
-		// 29.0.0.10 is the last version with a mimetype migration before it was moved to a separate version number
-		if (version_compare($serverVersion, '29.0.0.10', '>')) {
-			return $this->appConfig->getValueString('files', 'mimetype_version', '29.0.0.10');
-		}
-
-		return $serverVersion;
+		// 29.0.0.10 is the last version with a mimetype migration before tracking was moved to mimetype_version.
+		// However since it's possible that someone may have upgraded without running expensive repair steps prior 
+		// to 29.0.0.10, we assume none have been ran (once). This is acceptable since (a) only happens when expensive 
+		// repair steps are explicitly requested; (b) only happens once *ever* in a given environment.
+		return $this->appConfig->getValueString('files', 'mimetype_version', '0.0.0');
 	}
 
 	/**

--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -390,8 +390,8 @@ class RepairMimeTypes implements IRepairStep {
 	 */
 	private function getMimeTypeVersion(): string {
 		// 29.0.0.10 is the last version with a mimetype migration before tracking was moved to mimetype_version.
-		// However since it's possible that someone may have upgraded without running expensive repair steps prior 
-		// to 29.0.0.10, we assume none have been ran (once). This is acceptable since (a) only happens when expensive 
+		// However since it's possible that someone may have upgraded without running expensive repair steps prior
+		// to 29.0.0.10, we assume none have been ran (once). This is acceptable since (a) only happens when expensive
 		// repair steps are explicitly requested; (b) only happens once *ever* in a given environment.
 		return $this->appConfig->getValueString('files', 'mimetype_version', '0.0.0');
 	}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -508,6 +508,10 @@ class Setup {
 			}
 		}
 
+		// Seed the mimetype_version for future mimetype repair jobs with the install-time version
+		$serverVersion = $config->getSystemValueString('version', '0.0.0');
+		$appConfig->setValueString('files', 'mimetype_version', $serverVersion);
+
 		// Dispatch installation completed event
 		$adminUsername = !$disableAdminUser ? ($options['adminlogin'] ?? null) : null;
 		$adminEmail = !empty($options['adminemail']) ? $options['adminemail'] : null;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #58234 <!-- related github issue -->

## Summary

* Avoids running the repairs for prior versions on new installs
  - also avoids the misleading/confusing setup check warning on new installations: `One or more mimetype migrations are available [...] Use the command occ maintenance:repair --include-expensive to perform the migrations`.
* Also makes sure that <v29 mime type repairs aren't skipped inadvertently regardless of upgrade path.
  - Still only runs if necessary except in a single scenario: an environment that had pre-v29 mime repair steps that were never ran and is now running >v29. And even then only when explicitly triggered and only once *ever*.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
