### PR TITLE
fix: handle circle shares in share target repair

### DIFF
--- a/apps/files_sharing/lib/Repair/CleanupShareTarget.php
+++ b/apps/files_sharing/lib/Repair/CleanupShareTarget.php
@@ -15,7 +15,9 @@ use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\ICacheFactory;
 use OCP\IDBConnection;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -44,6 +46,7 @@ class CleanupShareTarget implements IRepairStep {
 		private readonly IUserMountCache $userMountCache,
 		private readonly IRootFolder $rootFolder,
 		private readonly LoggerInterface $logger,
+		private readonly ICacheFactory $cacheFactory,
 	) {
 	}
 
@@ -65,7 +68,14 @@ class CleanupShareTarget implements IRepairStep {
 		$userFolder = null;
 
 		foreach ($this->getProblemShares() as $shareInfo) {
-			$recipient = $this->userManager->getExistingUser($shareInfo['share_with']);
+			if ($shareInfo['share_type'] === IShare::TYPE_CIRCLE) {
+				$recipient = $this->getCircleShareOwner($shareInfo['share_with']);
+				if ($recipient === null) {
+					continue;
+				}
+			} else {
+				$recipient = $this->userManager->getExistingUser($shareInfo['share_with']);
+			}
 			if (!$recipient->isEnabled()) {
 				continue;
 			}
@@ -115,6 +125,7 @@ class CleanupShareTarget implements IRepairStep {
 
 			$output->advance();
 		}
+		$this->cacheFactory->createDistributed('circles/')->clear();
 		$output->finishProgress();
 		$output->info("Fixed $count shares");
 	}
@@ -146,7 +157,14 @@ class CleanupShareTarget implements IRepairStep {
 		$query->select('id', 'share_type', 'share_with', 'file_source', 'file_target')
 			->from('share')
 			->where($query->expr()->like('file_target', $query->createNamedParameter('% (_) (_)%')))
-			->andWhere($query->expr()->in('share_type', $query->createNamedParameter(self::USER_SHARE_TYPES, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY))
+			->andWhere($query->expr()->orX(
+				$query->expr()->in('share_type', $query->createNamedParameter(self::USER_SHARE_TYPES, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY),
+				$query->expr()->andX(
+					$query->expr()->eq('share_type', $query->createNamedParameter(
+						IShare::TYPE_CIRCLE, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
+					$query->expr()->isNotNull('parent'),
+				),
+			))
 			->orderBy('share_with')
 			->addOrderBy('id');
 		$result = $query->executeQuery();
@@ -157,5 +175,26 @@ class CleanupShareTarget implements IRepairStep {
 
 	private function cleanTarget(string $target): string {
 		return preg_replace('/( \([2-9]\)){2,}/', '', $target);
+	}
+
+	/**
+	 * Get the user of a federated user from circles, if the circle id belong to a user
+	 */
+	private function getCircleShareOwner(string $circleId): ?IUser {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('name')
+			->from('circles_circle')
+			->where($query->expr()->eq('unique_id', $query->createNamedParameter($circleId)))
+			->andWhere($query->expr()->eq('source', $query->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
+		$name = $query->executeQuery()->fetchOne();
+		if ($name === false) {
+			return null;
+		}
+		[$type, $userId,] = explode(':', $name, 3);
+		if ($type === 'user') {
+			return $this->userManager->getExistingUser($userId);
+		} else {
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
Circle shares have the be handled a bit differently since their shared_with is a circle id