### PR TITLE
fix(IRegistrationContext): Use SimpleContainer in registerService factory

### DIFF
--- a/lib/private/AppFramework/Bootstrap/ServiceFactoryRegistration.php
+++ b/lib/private/AppFramework/Bootstrap/ServiceFactoryRegistration.php
@@ -8,13 +8,15 @@ declare(strict_types=1);
  */
 namespace OC\AppFramework\Bootstrap;
 
+use OC\AppFramework\Utility\SimpleContainer;
+
 /**
  * @psalm-immutable
  */
 class ServiceFactoryRegistration extends ARegistration {
 	/**
 	 * @var callable
-	 * @psalm-var callable(\Psr\Container\ContainerInterface): mixed
+	 * @psalm-var callable(SimpleContainer): mixed
 	 */
 	private $factory;
 
@@ -36,7 +38,7 @@ class ServiceFactoryRegistration extends ARegistration {
 	}
 
 	/**
-	 * @psalm-return callable(\Psr\Container\ContainerInterface): mixed
+	 * @psalm-return callable(SimpleContainer): mixed
 	 */
 	public function getFactory(): callable {
 		return $this->factory;

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -37,10 +37,7 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 	/**
 	 * @template T
 	 * @param class-string<T>|string $id
-	 * @return T|mixed
-	 * @psalm-template S as class-string<T>|string
-	 * @psalm-param S $id
-	 * @psalm-return (S is class-string<T> ? T : mixed)
+	 * @return ($id is class-string<T> ? T : mixed)
 	 */
 	public function get(string $id): mixed {
 		return $this->query($id);

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -172,15 +172,6 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 		$this[$name] = $value;
 	}
 
-	/**
-	 * The given closure is call the first time the given service is queried.
-	 * The closure has to return the instance for the given service.
-	 * Created instance will be cached in case $shared is true.
-	 *
-	 * @param string $name name of the service to register another backend for
-	 * @param Closure $closure the closure to be called on service creation
-	 * @param bool $shared
-	 */
 	public function registerService($name, Closure $closure, $shared = true) {
 		$wrapped = function () use ($closure) {
 			return $closure($this);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -958,7 +958,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(ILockingProvider::class, function (ContainerInterface $c) {
 			$ini = $c->get(IniGetWrapper::class);
 			$config = $c->get(IConfig::class);
-			$ttl = $config->getSystemValueInt('filelocking.ttl', max(3600, $ini->getNumeric('max_execution_time')));
+			$ttl = $config->getSystemValueInt('filelocking.ttl', max(3600, (int)($ini->getNumeric('max_execution_time') ?? 0)));
 			if ($config->getSystemValueBool('filelocking.enabled', true) || (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				/** @var Factory $memcacheFactory */
 				$memcacheFactory = $c->get(ICacheFactory::class);
@@ -1212,7 +1212,9 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerService(ISession::class, function (ContainerInterface $c) {
-			return $c->get(IUserSession::class)->getSession();
+			/** @var Session $session */
+			$session = $c->get(IUserSession::class);
+			return $session->getSession();
 		}, false);
 
 		$this->registerService(IShareHelper::class, function (ContainerInterface $c) {

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework\Bootstrap;
 
+use OC\AppFramework\Utility\SimpleContainer;
 use OCP\AppFramework\IAppContainer;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Calendar\ICalendarProvider;
@@ -68,7 +69,7 @@ interface IRegistrationContext {
 	 *
 	 * @param string $name
 	 * @param callable $factory
-	 * @psalm-param callable(\Psr\Container\ContainerInterface): mixed $factory
+	 * @psalm-param callable(SimpleContainer): mixed $factory
 	 * @param bool $shared If set to true the factory result will be cached otherwise every query will call the factory again
 	 *
 	 * @return void

--- a/lib/public/IContainer.php
+++ b/lib/public/IContainer.php
@@ -11,6 +11,7 @@
 namespace OCP;
 
 use Closure;
+use OC\AppFramework\Utility\SimpleContainer;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -75,7 +76,7 @@ interface IContainer extends ContainerInterface {
 	 * In case the parameter is false the service will be recreated on every call.
 	 *
 	 * @param string $name
-	 * @param \Closure $closure
+	 * @param \Closure(SimpleContainer): mixed $closure
 	 * @param bool $shared
 	 * @return void
 	 * @since 6.0.0


### PR DESCRIPTION
Using SimpleContainer as the type is important so that psalm and PHPstan will get our correct type annotation for the get method, as the ContainerInterface just returns mixed.