### PR TITLE
[stable32] fix: correctly quote tablenames for truncating with oracle

### DIFF
--- a/lib/private/DB/OracleConnection.php
+++ b/lib/private/DB/OracleConnection.php
@@ -26,6 +26,13 @@ class OracleConnection extends Connection {
 		return $return;
 	}
 
+	public function truncateTable(string $table, bool $cascade) {
+		if ($table[0] !== $this->getDatabasePlatform()->getIdentifierQuoteCharacter()) {
+			$table = $this->quoteIdentifier($table);
+		}
+		return parent::truncateTable($table, $cascade);
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */


### PR DESCRIPTION
manual backport of #58223 as the bot didn't do it.