### PR TITLE
fix(files_reminders): reduce N+1 query issue for big folders

### DIFF
--- a/apps/files_reminders/lib/Service/ReminderService.php
+++ b/apps/files_reminders/lib/Service/ReminderService.php
@@ -44,7 +44,7 @@ class ReminderService {
 		protected LoggerInterface $logger,
 		protected ICacheFactory $cacheFactory,
 	) {
-		$this->cache = $this->cacheFactory->createInMemory();
+		$this->cache = $this->cacheFactory->createInMemory(30000);
 	}
 
 	public function cacheFolder(IUser $user, Folder $folder): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Increases the `CappedMemoryCache` size for `ReminderService` to 30k.

## Context

`OCA\FilesReminders\Dav\PropFindPlugin` preloads reminders information for an entire collection during PROPFIND. `ReminderService` has a `cacheFolder` method which uses a `CappedMemoryCache` as cache. The problem is that the default size for this cache is `512` meaning that if a directory has more than 512 files inside we start getting cache misses and start querying the DB.

What's worse is that once the condition hits, it always voids the pre-cached data and causes N+1 queries:
1. `preloadCollection` starts caching reminders for files in a directory
2. once the limit of the `CappedMemoryCache` is reached, the information that was cached earlier is discarded
3. when the PROPFIND is serialized into XML, the first file is no longer in the cache
4. The code queries the DB and caches the value, pushing another previously cached value out
5. This continues making the pre-caching useless :exploding_head:

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
