### PR TITLE
fix(docs): Fix dead documentation link for Windows file names

### DIFF
--- a/apps/files/lib/Settings/AdminSettings.php
+++ b/apps/files/lib/Settings/AdminSettings.php
@@ -37,7 +37,7 @@ class AdminSettings implements ISettings {
 	public function getForm(): TemplateResponse {
 		$windowSupport = $this->service->hasFilesWindowsSupport();
 		$this->initialState->provideInitialState('filesCompatibilitySettings', [
-			'docUrl' => $this->urlGenerator->linkToDocs(''),
+			'docUrl' => $this->urlGenerator->linkToDocs('admin-windows-compatible-filenames'),
 			'status' => $this->service->getSanitizationStatus(),
 			'windowsSupport' => $windowSupport,
 		]);


### PR DESCRIPTION
Before: https://docs.nextcloud.com/server/33/go.php?to=
After: https://docs.nextcloud.com/server/33/go.php?to=admin-windows-compatible-filenames

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
