### PR TITLE
Fix/setup for path optimizations

### DIFF
--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -20,6 +20,7 @@ use OCP\Files\NotFoundException;
 class Manager implements IMountManager {
 	/** @var array<string, IMountPoint> */
 	private array $mounts = [];
+	private array $mountsByProvider = [];
 	private bool $areMountsSorted = false;
 	/** @var list<string>|null $mountKeys */
 	private ?array $mountKeys = null;
@@ -36,7 +37,11 @@ class Manager implements IMountManager {
 	}
 
 	public function addMount(IMountPoint $mount): void {
-		$this->mounts[$mount->getMountPoint()] = $mount;
+		$mountPoint = $mount->getMountPoint();
+		$mountProvider = $mount->getMountProvider();
+		$this->mounts[$mountPoint] = $mount;
+		$this->mountsByProvider[$mountProvider] ??= [];
+		$this->mountsByProvider[$mountProvider][$mountPoint] = $mount;
 		$this->pathCache->clear();
 		$this->inPathCache->clear();
 		$this->areMountsSorted = false;
@@ -167,6 +172,7 @@ class Manager implements IMountManager {
 
 	public function clear(): void {
 		$this->mounts = [];
+		$this->mountsByProvider = [];
 		$this->pathCache->clear();
 		$this->inPathCache->clear();
 	}
@@ -236,15 +242,18 @@ class Manager implements IMountManager {
 	 * @param string[] $mountProviders
 	 * @return array<string, IMountPoint>
 	 */
-	public function getMountsByMountProvider(string $path, array $mountProviders) {
+	public function getMountsByMountProvider(string $path, array $mountProviders): array {
 		$this->getSetupManager()->setupForProvider($path, $mountProviders);
-		if (in_array('', $mountProviders)) {
+		if (\in_array('', $mountProviders)) {
 			return $this->mounts;
-		} else {
-			return array_filter($this->mounts, function ($mount) use ($mountProviders) {
-				return in_array($mount->getMountProvider(), $mountProviders);
-			});
 		}
+
+		$mounts = [];
+		foreach ($mountProviders as $mountProvider) {
+			$mounts[] = $this->mountsByProvider[$mountProvider];
+		}
+
+		return array_merge(...$mounts);
 	}
 
 	/**

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -493,7 +493,10 @@ class SetupManager implements ISetupManager {
 		$currentProviders = [];
 
 		try {
-			$cachedMount = $this->userMountCache->getMountForPath($user, $path);
+			// if the mount is already set up, get it from memory
+			$cachedMount = $this->isPathSetup($mountPointLikePath) ?
+				$this->mountManager->find($mountPointLikePath) :
+				$this->userMountCache->getMountForPath($user, $path);
 		} catch (NotFoundException $e) {
 			$this->setupForUser($user);
 			return;

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -523,6 +523,8 @@ class SetupManager implements ISetupManager {
 				return;
 			}
 
+			// mark the path as cached (without children for now...)
+			$this->setupMountProviderPaths[$mountPoint] = self::SETUP_WITHOUT_CHILDREN;
 			if (is_a($mountProvider, IPartialMountProvider::class, true)) {
 				$rootId = $cachedMount->getRootId();
 				$rootMetadata = $this->fileAccess->getByFileId($rootId);
@@ -531,8 +533,6 @@ class SetupManager implements ISetupManager {
 					return;
 				}
 				$providerArgs = new MountProviderArgs($cachedMount, $rootMetadata);
-				// mark the path as cached (without children for now...)
-				$this->setupMountProviderPaths[$mountPoint] = self::SETUP_WITHOUT_CHILDREN;
 				$authoritativeMounts[] = array_values(
 					$this->mountProviderCollection->getUserMountsFromProviderByPath(
 						$mountProvider,
@@ -594,6 +594,7 @@ class SetupManager implements ISetupManager {
 				);
 			}
 
+			$this->setupMountProviderPaths[$mountPoint] = self::SETUP_WITH_CHILDREN;
 			if (!empty($authoritativeCachedMounts)) {
 				$rootIds = array_map(
 					fn (ICachedMountInfo $mount) => $mount->getRootId(),
@@ -606,7 +607,6 @@ class SetupManager implements ISetupManager {
 						$rootsMetadata[$id] = $fileMetadata;
 					}
 				}
-				$this->setupMountProviderPaths[$mountPoint] = self::SETUP_WITH_CHILDREN;
 				foreach ($authoritativeCachedMounts as $providerClass => $cachedMounts) {
 					$providerArgs = array_values(array_filter(array_map(
 						static function (ICachedMountInfo $info) use ($rootsMetadata) {

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -130,10 +130,10 @@ class SetupManager implements ISetupManager {
 	 * Checks if a path has been cached either directly or through a full setup
 	 * of one of its parents.
 	 */
-	private function isPathSetup(string $path): bool {
+	private function isPathSetup(string $path, bool $withChildren = false): bool {
 		// if the exact path was already setup with or without children
 		if (array_key_exists($path, $this->setupMountProviderPaths)) {
-			return true;
+			return !$withChildren || $this->setupMountProviderPaths[$path] === self::SETUP_WITH_CHILDREN;
 		}
 
 		// or if any of the ancestors was fully setup
@@ -477,6 +477,12 @@ class SetupManager implements ISetupManager {
 		// for the user's home folder, and includes children we need everything always
 		if (rtrim($path) === '/' . $user->getUID() . '/files' && $includeChildren) {
 			$this->setupForUser($user);
+			return;
+		}
+
+		$mountPointLikePath = rtrim($path, '/') . '/';
+		// if we're lucky, $path is already a mount point, if so exit early
+		if ($this->isPathSetup($mountPointLikePath, $includeChildren)) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`setupForPath` has a few issues slowing things down:

1. it is currently hammering the `oc_mounts` table because of the call to `getMountForPath` which is always executed unless the user or the provider have been fully set up
2. keeps being re-executed if called with `$forChildren = false` for paths whose parents have not been set up with children and the path is not an MP itself (because we mark the MP as setup, not the path)
3. suffers from the issue that if any code calls `setupForPath('/Talk/01')`, `setupForPath('/Talk/02')`, ...  `setupForPath('/Talk/100')` then it would cause N+1 setups

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
