### PR TITLE
feat: add upload_time support to file search and recent files

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -86,6 +86,7 @@ class FileSearchBackend implements ISearchBackend {
 			new SearchPropertyDefinition('{DAV:}displayname', true, true, true),
 			new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true),
 			new SearchPropertyDefinition('{DAV:}getlastmodified', true, true, true, SearchPropertyDefinition::DATATYPE_DATETIME),
+			new SearchPropertyDefinition('{http://nextcloud.org/ns}upload_time', true, true, true, SearchPropertyDefinition::DATATYPE_DATETIME),
 			new SearchPropertyDefinition(FilesPlugin::SIZE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
 			new SearchPropertyDefinition(TagsPlugin::FAVORITE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_BOOLEAN),
 			new SearchPropertyDefinition(FilesPlugin::INTERNAL_FILEID_PROPERTYNAME, true, true, false, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
@@ -298,6 +299,8 @@ class FileSearchBackend implements ISearchBackend {
 				return $node->getName();
 			case '{DAV:}getlastmodified':
 				return $node->getLastModified();
+			case '{http://nextcloud.org/ns}upload_time':
+				return $node->getNode()->getUploadTime();
 			case FilesPlugin::SIZE_PROPERTYNAME:
 				return $node->getSize();
 			case FilesPlugin::INTERNAL_FILEID_PROPERTYNAME:
@@ -458,6 +461,8 @@ class FileSearchBackend implements ISearchBackend {
 				return 'mimetype';
 			case '{DAV:}getlastmodified':
 				return 'mtime';
+			case '{http://nextcloud.org/ns}upload_time':
+				return 'upload_time';
 			case FilesPlugin::SIZE_PROPERTYNAME:
 				return 'size';
 			case TagsPlugin::FAVORITE_PROPERTYNAME:

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -151,9 +151,11 @@ class QuerySearchHelper {
 
 		$builder = $this->getQueryBuilder();
 
-		$query = $builder->selectFileCache('file', false);
-
 		$requestedFields = $this->searchBuilder->extractRequestedFields($searchQuery->getSearchOperation());
+
+		$joinExtendedCache = in_array('upload_time', $requestedFields);
+
+		$query = $builder->selectFileCache('file', $joinExtendedCache);
 
 		if (in_array('systemtag', $requestedFields)) {
 			$this->equipQueryForSystemTags($query, $this->requireUser($searchQuery));

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -64,6 +64,7 @@ class SearchBuilder {
 		'share_with' => 'string',
 		'share_type' => 'integer',
 		'owner' => 'string',
+		'upload_time' => 'integer',
 	];
 
 	/** @var array<string, int|string> */
@@ -257,6 +258,7 @@ class SearchBuilder {
 			'share_with' => ['eq'],
 			'share_type' => ['eq'],
 			'owner' => ['eq'],
+			'upload_time' => ['eq', 'gt', 'lt', 'gte', 'lte'],
 		];
 
 		if (!isset(self::$fieldTypes[$operator->getField()])) {


### PR DESCRIPTION
* Resolves: #

## Summary
This PR adds support for the `upload_time` property in file search queries, enabling filtering and ordering by when files were uploaded to the server.

An additional frontend PR was opened on `nextcloud-libraries/nextcloud-files` to utilize this new capability:
* nextcloud-libraries/nextcloud-files#1498

This backend PR is independent and can be merged first, as it only adds new functionality and should not break existing behavior.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
