### PR TITLE
feat(cache): Add ability for optional custom prefix for Redis/Memcached cache keys

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1748,6 +1748,16 @@ $CONFIG = [
 	'memcache.distributed' => '\\OC\\Memcache\\Memcached',
 
 	/**
+	 * Cache Key Prefix for Redis or Memcached
+	 *
+	 * * Used for avoiding collisions in the cache system
+	 * * May be used for ACL restrictions in Redis
+	 *
+	 * Defaults to ``''`` (empty string), which means only an auto-generated, semi-unique ID is being used
+	 */
+	'memcache_customprefix' => 'mycustomprefix',
+
+	/**
 	 * Connection details for Redis to use for memory caching in a single server configuration.
 	 *
 	 * For enhanced security, it is recommended to configure Redis

--- a/lib/private/Memcache/Cache.php
+++ b/lib/private/Memcache/Cache.php
@@ -22,7 +22,7 @@ abstract class Cache implements \ArrayAccess, ICache {
 	 * @return string Prefix used for caching purposes
 	 */
 	public function getPrefix() {
-		return \OC::$server->getConfig()->getSystemValueString('memcache.customprefix') . $this->prefix;
+		return $this->prefix;
 	}
 
 	/**

--- a/lib/private/Memcache/Cache.php
+++ b/lib/private/Memcache/Cache.php
@@ -22,7 +22,7 @@ abstract class Cache implements \ArrayAccess, ICache {
 	 * @return string Prefix used for caching purposes
 	 */
 	public function getPrefix() {
-		return $this->prefix;
+		return \OC::$server->getConfig()->getSystemValueString('memcache.customprefix') . $this->prefix;
 	}
 
 	/**

--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -115,23 +115,29 @@ class Factory implements ICacheFactory {
 	protected function getGlobalPrefix(): string {
 		if ($this->globalPrefix === null) {
 			$config = Server::get(SystemConfig::class);
-			$maintenanceMode = $config->getValue('maintenance', false);
-			$versions = [];
-			if ($config->getValue('installed', false) && !$maintenanceMode) {
-				$appConfig = Server::get(IAppConfig::class);
-				// only get the enabled apps to clear the cache in case an app is enabled or disabled (e.g. clear routes)
-				$versions = $appConfig->getAppInstalledVersions(true);
-				ksort($versions);
-			} else {
-				// if not installed or in maintenance mode, we should distinguish between both states.
-				$versions['core:maintenance'] = $maintenanceMode ? '1' : '0';
+			$customprefix = $config->getValue('memcache.customprefix', '');
+			// use the value of memcache.customprefix setting as prefix if set
+			if ($customprefix != '') {
+				$this->globalPrefix = $customprefix;
+            } else {
+				$maintenanceMode = $config->getValue('maintenance', false);
+				$versions = [];
+				if ($config->getValue('installed', false) && !$maintenanceMode) {
+					$appConfig = Server::get(IAppConfig::class);
+					// only get the enabled apps to clear the cache in case an app is enabled or disabled (e.g. clear routes)
+					$versions = $appConfig->getAppInstalledVersions(true);
+					ksort($versions);
+				} else {
+					// if not installed or in maintenance mode, we should distinguish between both states.
+					$versions['core:maintenance'] = $maintenanceMode ? '1' : '0';
+				}
+				$versions['core'] = implode('.', $this->serverVersion->getVersion());
+	
+				// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
+				$instanceid = $config->getValue('instanceid');
+				$installedApps = implode(',', array_keys($versions)) . implode(',', array_values($versions));
+				$this->globalPrefix = hash('xxh128', $instanceid . $installedApps);
 			}
-			$versions['core'] = implode('.', $this->serverVersion->getVersion());
-
-			// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
-			$instanceid = $config->getValue('instanceid');
-			$installedApps = implode(',', array_keys($versions)) . implode(',', array_values($versions));
-			$this->globalPrefix = hash('xxh128', $instanceid . $installedApps);
 		}
 		return $this->globalPrefix;
 	}
@@ -145,9 +151,16 @@ class Factory implements ICacheFactory {
 	public function withServerVersionPrefix(\Closure $closure): void {
 		$backupPrefix = $this->globalPrefix;
 
-		// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
-		$instanceid = Server::get(SystemConfig::class)->getValue('instanceid');
-		$this->globalPrefix = hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
+		$config = Server::get(SystemConfig::class);
+		$customprefix = $config->getValue('memcache.customprefix', '');
+		// use the value of memcache.customprefix setting as prefix if set
+		if ($customprefix != '') {
+			$this->globalPrefix = $customprefix . '_v' . implode('.', $this->serverVersion->getVersion());
+        } else {
+			// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
+			$instanceid = Server::get(SystemConfig::class)->getValue('instanceid');
+			$this->globalPrefix = hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
+		}
 		$closure($this);
 		$this->globalPrefix = $backupPrefix;
 	}

--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -132,7 +132,7 @@ class Factory implements ICacheFactory {
 			// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
 			$instanceid = $config->getValue('instanceid');
 			$installedApps = implode(',', array_keys($versions)) . implode(',', array_values($versions));
-			$this->globalPrefix = $customprefix . ($customprefix != '' ? '/' : '') . hash('xxh128', $instanceid . $installedApps);
+			$this->globalPrefix = $customprefix . hash('xxh128', $instanceid . $installedApps);
 		}
 		return $this->globalPrefix;
 	}
@@ -150,7 +150,7 @@ class Factory implements ICacheFactory {
 		$customprefix = $config->getValue('memcache_customprefix', '');	
 		// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
 		$instanceid = $config->getValue('instanceid');
-		$this->globalPrefix = $customprefix . ($customprefix != '' ? '/' : '') . hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
+		$this->globalPrefix = $customprefix . hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
 		$closure($this);
 		$this->globalPrefix = $backupPrefix;
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/52034

## Summary

This adds the ability to use a custom prefix for Redis and Memcached keys. This is an optional variable.

One can use the variable setting `memcache_customprefix` for this.

Documentation PR: https://github.com/nextcloud/documentation/pull/14080

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
