### PR TITLE
feat: delay fetching the display name of a share recipient untill we need it

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1096,16 +1096,10 @@ class DefaultShareProvider implements
 
 		if ($share->getShareType() === IShare::TYPE_USER) {
 			$share->setSharedWith($data['share_with']);
-			$displayName = $this->userManager->getDisplayName($data['share_with']);
-			if ($displayName !== null) {
-				$share->setSharedWithDisplayName($displayName);
-			}
+			$share->setSharedWithDisplayNameCallback(fn (IShare $share) => $this->userManager->getDisplayName($share->getSharedWith()));
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			$share->setSharedWith($data['share_with']);
-			$group = $this->groupManager->get($data['share_with']);
-			if ($group !== null) {
-				$share->setSharedWithDisplayName($group->getDisplayName());
-			}
+			$share->setSharedWithDisplayNameCallback(fn (IShare $share) => $this->groupManager->getDisplayName($share->getSharedWith()));
 		} elseif ($share->getShareType() === IShare::TYPE_LINK) {
 			$share->setPassword($data['password']);
 			$share->setSendPasswordByTalk((bool)$data['password_by_talk']);
@@ -1462,6 +1456,7 @@ class DefaultShareProvider implements
 
 	/**
 	 * For each user the path with the fewest slashes is returned
+	 *
 	 * @param array $shares
 	 * @return array
 	 */

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1118,16 +1118,10 @@ class DefaultShareProvider implements
 
 		if ($share->getShareType() === IShare::TYPE_USER) {
 			$share->setSharedWith($data['share_with']);
-			$displayName = $this->userManager->getDisplayName($data['share_with']);
-			if ($displayName !== null) {
-				$share->setSharedWithDisplayName($displayName);
-			}
+			$share->setSharedWithDisplayNameCallback(fn (IShare $share) => $this->userManager->getDisplayName($share->getSharedWith()));
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			$share->setSharedWith($data['share_with']);
-			$group = $this->groupManager->get($data['share_with']);
-			if ($group !== null) {
-				$share->setSharedWithDisplayName($group->getDisplayName());
-			}
+			$share->setSharedWithDisplayNameCallback(fn (IShare $share) => $this->groupManager->getDisplayName($share->getSharedWith()));
 		} elseif ($share->getShareType() === IShare::TYPE_LINK) {
 			$share->setPassword($data['password']);
 			$share->setSendPasswordByTalk((bool)$data['password_by_talk']);
@@ -1488,6 +1482,7 @@ class DefaultShareProvider implements
 
 	/**
 	 * For each user the path with the fewest slashes is returned
+	 *
 	 * @param array $shares
 	 * @return array
 	 */

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -33,8 +33,9 @@ class Share implements IShare {
 	private $shareType;
 	/** @var string */
 	private $sharedWith;
-	/** @var string */
-	private $sharedWithDisplayName;
+	private ?string $sharedWithDisplayName = null;
+	/** @var ?callable */
+	private $sharedWithDisplayNameCallback = null;
 	/** @var string */
 	private $sharedWithAvatar;
 	/** @var string */
@@ -247,10 +248,20 @@ class Share implements IShare {
 	}
 
 	/**
-	 * @inheritdoc
+	 * @param callable(IShare):?string $callback
+	 * @return $this
 	 */
+	public function setSharedWithDisplayNameCallback(callable $callback) {
+		$this->sharedWithDisplayNameCallback = $callback;
+		return $this;
+	}
+
 	public function getSharedWithDisplayName() {
-		return $this->sharedWithDisplayName;
+		if ($this->sharedWithDisplayNameCallback !== null) {
+			$this->sharedWithDisplayName = ($this->sharedWithDisplayNameCallback)($this);
+			$this->sharedWithDisplayNameCallback = null;
+		}
+		return $this->sharedWithDisplayName ?? $this->sharedWith;
 	}
 
 	/**

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -35,8 +35,9 @@ class Share implements IShare {
 	private $shareType;
 	/** @var string */
 	private $sharedWith;
-	/** @var string */
-	private $sharedWithDisplayName;
+	private ?string $sharedWithDisplayName = null;
+	/** @var ?callable */
+	private $sharedWithDisplayNameCallback = null;
 	/** @var string */
 	private $sharedWithAvatar;
 	/** @var string */
@@ -260,11 +261,24 @@ class Share implements IShare {
 	}
 
 	/**
-	 * @inheritdoc
+	 * @param callable(IShare):?string $callback
+	 * @return $this
 	 */
+	public function setSharedWithDisplayNameCallback(callable $callback) {
+		$this->sharedWithDisplayNameCallback = $callback;
+		return $this;
+	}
+
 	#[\Override]
 	public function getSharedWithDisplayName() {
-		return $this->sharedWithDisplayName;
+		if ($this->sharedWithDisplayNameCallback !== null) {
+			$displayName = ($this->sharedWithDisplayNameCallback)($this);
+			if ($displayName !== null) {
+				$this->sharedWithDisplayName = $displayName;
+			}
+			$this->sharedWithDisplayNameCallback = null;
+		}
+		return $this->sharedWithDisplayName ?? '';
 	}
 
 	/**


### PR DESCRIPTION
Instead of always setting the display name in the share object, set a way to fetch the display name on demand.