### PR TITLE
Fix Dutch pronouns example placeholder in user settings

### DIFF
--- a/apps/settings/l10n/nl.js
+++ b/apps/settings/l10n/nl.js
@@ -438,7 +438,7 @@ OC.L10N.register(
     "she/her" : "zij/haar",
     "he/him" : "hij/hem",
     "they/them" : "zij/hun",
-    "Your pronouns. E.g. {pronounsExample}" : "Je voornamen. Bijvoorbeeld ${pronounsExample}",
+    "Your pronouns. E.g. {pronounsExample}" : "Je voornamen. Bijvoorbeeld {pronounsExample}",
     "Your role" : "Jouw rol",
     "Timezone" : "Tijdzone",
     "Your X (formerly Twitter) handle" : "Je X (voorheen Twitter) handle",

--- a/apps/settings/l10n/nl.json
+++ b/apps/settings/l10n/nl.json
@@ -436,7 +436,7 @@
     "she/her" : "zij/haar",
     "he/him" : "hij/hem",
     "they/them" : "zij/hun",
-    "Your pronouns. E.g. {pronounsExample}" : "Je voornamen. Bijvoorbeeld ${pronounsExample}",
+    "Your pronouns. E.g. {pronounsExample}" : "Je voornamen. Bijvoorbeeld {pronounsExample}",
     "Your role" : "Jouw rol",
     "Timezone" : "Tijdzone",
     "Your X (formerly Twitter) handle" : "Je X (voorheen Twitter) handle",


### PR DESCRIPTION

<img width="305" height="116" alt="Screenshot 2026-02-13 165139" src="https://github.com/user-attachments/assets/2b99184c-8532-4f46-bd0f-c012af0a4b28" />



- This PR fixes a Dutch localization issue in Personal settings where the pronouns example was rendered with an unexpected $ prefix.
- Updated the translation string from ${pronounsExample} to {pronounsExample} so the UI correctly shows examples like zij/hun.
- Scope is limited to Dutch l10n entries used by the settings app, with no functional logic changes.

Prevents incorrect text rendering on index.php/settings/user for Dutch users and keeps placeholder formatting consistent with other locales.