### PR TITLE
refactor(SetupManager): user ID retrieval once

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -267,7 +267,7 @@ class SetupManager implements ISetupManager {
 		}
 
 		$userId = $user->getUID();
-		
+
 		$this->setupUsersComplete[] = $userId;
 
 		$this->eventLogger->start('fs:setup:user:full', 'Setup full filesystem for user');
@@ -824,11 +824,12 @@ class SetupManager implements ISetupManager {
 	 *
 	 * @param class-string<IMountProvider>[] $providers
 	 */
-	public function dropPartialMountsForUser(IUser $user, array $providers = []): void
+	public function dropPartialMountsForUser(IUser $user, array $providers = []): void {
 		// mounts are cached by mount-point
 		$mounts = $this->mountManager->getAll();
+
 		$userDir = '/' . $user->getUID() . '/files';
-	
+
 		$partialMounts = array_filter($this->setupMountProviderPaths,
 			static function (string $mountPoint) use (
 				$providers,

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -266,7 +266,9 @@ class SetupManager implements ISetupManager {
 			return;
 		}
 
-		$this->setupUsersComplete[] = $user->getUID();
+		$userId = $user->getUID();
+
+		$this->setupUsersComplete[] = $userId;
 
 		$this->eventLogger->start('fs:setup:user:full', 'Setup full filesystem for user');
 

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -266,9 +266,7 @@ class SetupManager implements ISetupManager {
 			return;
 		}
 
-		$userId = $user->getUID();
-
-		$this->setupUsersComplete[] = $userId;
+		$this->setupUsersComplete[] = $user->getUID();
 
 		$this->eventLogger->start('fs:setup:user:full', 'Setup full filesystem for user');
 
@@ -281,7 +279,7 @@ class SetupManager implements ISetupManager {
 			$this->mountProviderCollection->addMountForUser($user, $this->mountManager, function (
 				string $providerClass,
 			) use ($user) {
-				return !in_array($providerClass, $this->setupUserMountProviders[$userId]);
+				return !in_array($providerClass, $this->setupUserMountProviders[$user->getUID()]);
 			});
 		});
 		$this->afterUserFullySetup($user, $previouslySetupProviders);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Pre-calculate the user ID once.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
