### PR TITLE
fix(sftp): Handle empty port parameter to allow host-defined ports

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -68,9 +68,12 @@ class SFTP extends Common {
 		Stream::register();
 
 		$parsedHost = $this->splitHost($parameters['host']);
-
 		$this->host = $parsedHost[0];
-		$this->port = $parameters['port'] ?? $parsedHost[1];
+
+		// Handle empty port parameter to allow host-defined ports
+		// and ensure strictly numeric ports
+		$parsedPort = $parameters['port'] ?? null;
+		$this->port = (int)(is_numeric($parsedPort) ? $parsedPort : $parsedHost[1]);
 
 		if (!isset($parameters['user'])) {
 			throw new \UnexpectedValueException('no authentication parameters specified');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Fix https://github.com/nextcloud/server/issues/58324
Fix https://github.com/nextcloud/server/issues/58293

## Summary

Regression from https://github.com/nextcloud/server/pull/57793

When a host string includes a port (e.g., `1.2.3.4:22`), it was being ignored if `$parameters['port']` was present but empty (e.g., `''`). The previous logic `$parameters['port'] ?? $parsedHost[1]` treated an empty string as a valid value, overriding the port correctly parsed from the host.

This fix ensures `$parameters['port']` is only prioritized if it contains a valid numeric value. Empty strings, nulls, or non-numeric values now correctly fall back to the port defined in the host string.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
