### PR TITLE
Refactor share backend to be more efficient

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -87,12 +87,11 @@ class SharesPluginTest extends \Test\TestCase {
 			});
 
 		$this->shareManager->expects($this->any())
-			->method('getSharedWith')
+			->method('getAllSharedWith')
 			->with(
 				$this->equalTo('user1'),
 				$this->anything(),
 				$this->equalTo($node),
-				$this->equalTo(-1)
 			)
 			->willReturn([]);
 
@@ -183,12 +182,11 @@ class SharesPluginTest extends \Test\TestCase {
 			});
 
 		$this->shareManager->expects($this->any())
-			->method('getSharedWith')
+			->method('getAllSharedWith')
 			->with(
 				$this->equalTo('user1'),
 				$this->anything(),
 				$this->equalTo($node),
-				$this->equalTo(-1)
 			)
 			->willReturn([]);
 

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -155,7 +155,7 @@ class Application extends App implements IBootstrap {
 		// notifications api to accept incoming user shares
 		$dispatcher->addListener(ShareCreatedEvent::class, function (ShareCreatedEvent $event): void {
 			/** @var Listener $listener */
-			$listener = $this->getContainer()->query(Listener::class);
+			$listener = $this->getContainer()->get(Listener::class);
 			$listener->shareNotification($event);
 		});
 		$dispatcher->addListener(IGroup::class . '::postAddUser', function ($event): void {
@@ -163,7 +163,7 @@ class Application extends App implements IBootstrap {
 				return;
 			}
 			/** @var Listener $listener */
-			$listener = $this->getContainer()->query(Listener::class);
+			$listener = $this->getContainer()->get(Listener::class);
 			$listener->userAddedToGroup($event);
 		});
 	}

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -23,6 +23,7 @@ use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserManager;
+use OCP\PaginationParameters;
 use OCP\Server;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -135,13 +136,9 @@ class DeletedShareAPIController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function index(): DataResponse {
-		$groupShares = $this->shareManager->getDeletedSharedWith($this->userId, IShare::TYPE_GROUP, null, -1, 0);
-		$teamShares = $this->shareManager->getDeletedSharedWith($this->userId, IShare::TYPE_CIRCLE, null, -1, 0);
-		$roomShares = $this->shareManager->getDeletedSharedWith($this->userId, IShare::TYPE_ROOM, null, -1, 0);
-		$deckShares = $this->shareManager->getDeletedSharedWith($this->userId, IShare::TYPE_DECK, null, -1, 0);
+		$shares = $this->shareManager->getAllDeletedSharedWith($this->userId, [IShare::TYPE_GROUP, IShare::TYPE_CIRCLE, IShare::TYPE_ROOM, IShare::TYPE_DECK], null, new PaginationParameters(limit: null));
 
-		$shares = array_merge($groupShares, $teamShares, $roomShares, $deckShares);
-		$shares = array_values(array_map(fn (IShare $share): array => $this->formatShare($share), $shares));
+		$shares = array_map(fn (IShare $share): array => $this->formatShare($share), $shares);
 
 		return new DataResponse($shares);
 	}

--- a/apps/files_sharing/lib/Listener/UserAddedToGroupListener.php
+++ b/apps/files_sharing/lib/Listener/UserAddedToGroupListener.php
@@ -13,6 +13,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\IConfig;
+use OCP\PaginationParameters;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 
@@ -39,7 +40,7 @@ class UserAddedToGroupListener implements IEventListener {
 		}
 
 		// Get all group shares this user has access to now to filter later
-		$shares = $this->shareManager->getSharedWith($user->getUID(), IShare::TYPE_GROUP, null, -1);
+		$shares = $this->shareManager->getAllSharedWith($user->getUID(), [IShare::TYPE_GROUP], null, new PaginationParameters());
 
 		foreach ($shares as $share) {
 			// If this is not the new group we can skip it

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -21,6 +21,7 @@ use OCP\Files\Storage\IStorageFactory;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IUser;
+use OCP\PaginationParameters;
 use OCP\Share\IAttributes;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -52,15 +53,10 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 	 */
 	public function getSuperSharesForUser(IUser $user, array $excludeShares = []): array {
 		$userId = $user->getUID();
-		$shares = $this->mergeIterables(
-			$this->shareManager->getSharedWith($userId, IShare::TYPE_USER, null, -1),
-			$this->shareManager->getSharedWith($userId, IShare::TYPE_GROUP, null, -1),
-			$this->shareManager->getSharedWith($userId, IShare::TYPE_CIRCLE, null, -1),
-			$this->shareManager->getSharedWith($userId, IShare::TYPE_ROOM, null, -1),
-			$this->shareManager->getSharedWith($userId, IShare::TYPE_DECK, null, -1),
-		);
+		$shareTypes = [IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_CIRCLE, IShare::TYPE_ROOM, IShare::TYPE_DECK];
 
 		$excludeShareIds = array_map(fn (IShare $share) => $share->getFullId(), $excludeShares);
+		$shares = $this->shareManager->getAllSharedWith($userId, $shareTypes, null, new PaginationParameters(limit: null), ignoreWithSelf: true);
 		$shares = $this->filterShares($shares, $userId, $excludeShareIds);
 		return $this->buildSuperShares($shares, $user);
 	}

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -18,6 +18,7 @@ use OCP\Files\Mount\IMountManager;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeZone;
+use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -92,6 +93,7 @@ class CapabilitiesTest extends \Test\TestCase {
 			$this->createMock(ShareDisableChecker::class),
 			$this->createMock(IDateTimeZone::class),
 			$appConfig,
+			$this->createMock(IDBConnection::class),
 		);
 
 		$cap = new Capabilities($config, $appConfig, $shareManager, $appManager);

--- a/apps/settings/tests/Settings/Admin/SharingTest.php
+++ b/apps/settings/tests/Settings/Admin/SharingTest.php
@@ -16,9 +16,11 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Share\IManager;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
+#[Group(name: 'DB')]
 class SharingTest extends TestCase {
 	private Sharing $admin;
 

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1079,11 +1079,10 @@ class DefaultShareProvider implements
 	/**
 	 * Create a share object from a database row
 	 *
-	 * @param mixed[] $data
-	 * @return IShare
+	 * @param array<string, mixed> $data
 	 * @throws InvalidShare
 	 */
-	private function createShare($data) {
+	private function createShare($data): IShare {
 		$share = new Share($this->rootFolder, $this->userManager);
 		$share->setId($data['id'])
 			->setShareType((int)$data['share_type'])

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -19,6 +19,7 @@ use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Sharing\SharedStorage;
 use OCA\ShareByMail\ShareByMailProvider;
 use OCP\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
@@ -32,6 +33,7 @@ use OCP\HintException;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeZone;
+use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUser;
@@ -90,6 +92,7 @@ class Manager implements IManager {
 		private ShareDisableChecker $shareDisableChecker,
 		private IDateTimeZone $dateTimeZone,
 		private IAppConfig $appConfig,
+		private IDBConnection $connection,
 	) {
 		$this->l = $this->l10nFactory->get('lib');
 		// The constructor of LegacyHooks registers the listeners of share events
@@ -1039,13 +1042,49 @@ class Manager implements IManager {
 			IShare::TYPE_EMAIL,
 		];
 
-		foreach ($userIds as $userId) {
+		// Figure out which users has some shares with which providers
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('uid_initiator', 'share_type')
+			->from('share')
+			->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
+			->andWhere($qb->expr()->in('share_type', $qb->createNamedParameter($shareTypes, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->in('uid_initiator', $qb->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)),
+					// Special case for old shares created via the web UI
+					$qb->expr()->andX(
+						$qb->expr()->in('uid_owner', $qb->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)),
+						$qb->expr()->isNull('uid_initiator')
+					)
+				)
+			);
+
+		if (!$node instanceof Folder) {
+			$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId(), IQueryBuilder::PARAM_INT)));
+		}
+
+		$qb->orderBy('id');
+
+		$cursor = $qb->executeQuery();
+		$rawShares = [];
+		while ($data = $cursor->fetch()) {
+			if (!isset($rawShares[$data['uid_initiator']])) {
+				$rawShares[$data['uid_initiator']] = [];
+			}
+			if (!in_array($data['share_type'], $rawShares[$data['uid_initiator']], true)) {
+				$rawShares[$data['uid_initiator']][] = $data['share_type'];
+			}
+		}
+		$cursor->closeCursor();
+
+		foreach ($rawShares as $userId => $shareTypes) {
 			foreach ($shareTypes as $shareType) {
 				try {
 					$provider = $this->factory->getProviderForType($shareType);
-				} catch (ProviderException $e) {
+				} catch (ProviderException) {
 					continue;
 				}
+
 
 				if ($node instanceof Folder) {
 					/* We need to get all shares by this user to get subshares */

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -40,6 +40,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\PaginationParameters;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
@@ -55,6 +56,7 @@ use OCP\Share\Exceptions\AlreadySharedException;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\ShareTokenException;
+use OCP\Share\ICreateShareProvider;
 use OCP\Share\IManager;
 use OCP\Share\IPartialShareProvider;
 use OCP\Share\IProviderFactory;
@@ -1229,10 +1231,94 @@ class Manager implements IManager {
 	}
 
 	#[Override]
+	public function getAllSharesBy(string $userId, ?Node $node = null, PaginationParameters $paginationParameters, bool $reshares = false, bool $onlyValid = true): array {
+		if ($node !== null && !$node instanceof File && !$node instanceof Folder) {
+			throw new \InvalidArgumentException($this->l->t('Invalid path'));
+		}
+
+		// Get all shares from the providers supporting createShare
+		$providers = $this->factory->getAllProviders();
+		$createShareProviders = array_filter($providers, fn (IShareProvider $provider) => $provider instanceof ICreateShareProvider);
+		$shareTypes = array_unique(array_merge(...array_map(fn (ICreateShareProvider $provider): array => $provider->getTokenShareTypes(), $createShareProviders)));
+
+		if ($node?->getMountPoint() instanceof IShareOwnerlessMount) {
+			return $this->getSharesByPath($node, $shareTypes, $paginationParameters);
+		}
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('share')
+			->andWhere($qb->expr()->in('share_type', $qb->createNamedParameter($shareTypes, IQueryBuilder::PARAM_INT_ARRAY)));
+
+		/**
+		 * Reshares for this user are shares where they are the owner.
+		 */
+		if ($reshares === false) {
+			//Special case for old shares created via the web UI
+			$or1 = $qb->expr()->andX(
+				$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+				$qb->expr()->isNull('uid_initiator')
+			);
+
+			$qb->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)),
+					$or1
+				)
+			);
+		} elseif ($node === null) {
+			$qb->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
+				)
+			);
+		}
+
+		if ($node !== null) {
+			$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
+		}
+
+		$paginationParameters->fillQuery($qb, 'id');
+
+		$cursor = $qb->executeQuery();
+		while ($data = $cursor->fetchAssociative()) {
+			$provider = $this->factory->getProviderForType((int)$data['share_type']);
+			if ($provider instanceof ICreateShareProvider) {
+				throw new \LogicException('Share type ' . $data['share_type'] . " doesn't have a corresponding ICreateShareProvider.");
+			}
+			$share = $provider->createShare($data);
+			try {
+				$this->checkShare($share, $added);
+			} catch (ShareNotFound $e) {
+				// Ignore since this basically means the share is deleted
+				continue;
+			}
+		}
+		$cursor->closeCursor();
+
+		// Get all the other shares from the providers not supporting createShare
+		$shares = [];
+		foreach ([IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_EMAIL, IShare::TYPE_CIRCLE, IShare::TYPE_ROOM, IShare::TYPE_DECK] as $shareType) {
+			if (!in_array($shareType, $shareTypes)) {
+				$shares = array_merge($shares, $this->getSharesBy($userId, $shareType, $node, $reshares, -1, 0));
+			}
+		}
+
+		// FEDERATION
+		if ($this->outgoingServer2ServerSharesAllowed() && !in_array(IShare::TYPE_REMOTE, $shareTypes)) {
+			$shares = array_merge($shares, $this->getSharesBy($userId, IShare::TYPE_REMOTE, $node, $reshares, -1, 0));
+		}
+		if ($this->outgoingServer2ServerGroupSharesAllowed() && !in_array(IShare::TYPE_REMOTE_GROUP, $shareTypes)) {
+			$shares = array_merge($shares, $this->getSharesBy($userId, IShare::TYPE_REMOTE_GROUP, $node, $reshares, -1, 0));
+		}
+
+		return $shares;
+	}
+
+	#[Override]
 	public function getSharesBy(string $userId, int $shareType, ?Node $path = null, bool $reshares = false, int $limit = 50, int $offset = 0, bool $onlyValid = true): array {
-		if ($path !== null
-			&& !($path instanceof File)
-			&& !($path instanceof Folder)) {
+		if ($path !== null && !($path instanceof File) && !($path instanceof Folder)) {
 			throw new \InvalidArgumentException($this->l->t('Invalid path'));
 		}
 
@@ -1305,8 +1391,70 @@ class Manager implements IManager {
 			}
 		}
 
-		$shares = $shares2;
+		return $shares2;
+	}
 
+	#[Override]
+	public function getAllSharedWith(string $userId, array $shareTypes, ?Node $node, PaginationParameters $paginationParameters, bool $ignoreWithSelf = false): array {
+		$shareTypes = [];
+		$noCreateShareProvider = [];
+		foreach ($this->factory->getAllProviders() as $provider) {
+			if ($provider instanceof ICreateShareProvider) {
+				$shareTypes = array_merge($provider->getShareTypes(), $shareTypes);
+			} else {
+				$noCreateShareProvider[] = $provider;
+			}
+		}
+		$shareTypes = array_unique($shareTypes);
+
+		// Get shares directly with this user
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('share');
+
+		$qb->where($qb->expr()->in('share_type', $qb->createNamedParameter($shareTypes, IQueryBuilder::PARAM_INT_ARRAY)));
+		$qb->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)));
+
+		if ($node !== null) {
+			$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
+		}
+
+		if ($ignoreWithSelf) {
+			$qb->andWhere($qb->expr()->neq('uid_owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+			$qb->andWhere($qb->expr()->neq('uid_initiator', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		}
+
+		$paginationParameters->fillQuery($qb, 'id');
+
+		$result = $qb->executeQuery();
+		$shares = [];
+		foreach ($result->fetchAssociative() as $data) {
+			try {
+				$provider = $this->factory->getProviderForType($data['share_type']);
+			} catch (ProviderException $e) {
+				continue;
+			}
+			if (!$provider instanceof ICreateShareProvider) {
+				throw new \LogicException($this->l->t('Invalid provider'));
+			}
+			$shares[] = $provider->createShare($data);
+		}
+
+		// Legacy for providers what don't support ICreateShareProvider
+		foreach ($noCreateShareProvider as $shareType) {
+			// TODO fix pagination
+			$unverifiedShares = $provider->getSharedWith($userId, $shareType, $node, 0, 0);
+
+			// remove all shares which are already expired
+			foreach ($unverifiedShares as $key => $share) {
+				try {
+					$this->checkShare($share);
+				} catch (ShareNotFound $e) {
+					unset($shares[$key]);
+				}
+				$shares[] = $share;
+			}
+		}
 		return $shares;
 	}
 
@@ -1332,9 +1480,7 @@ class Manager implements IManager {
 		return $shares;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
+	#[Override]
 	public function getSharedWithByPath(string $userId, int $shareType, string $path, bool $forChildren, int $limit = 50, int $offset = 0): iterable {
 		try {
 			$provider = $this->factory->getProviderForType($shareType);
@@ -1374,6 +1520,7 @@ class Manager implements IManager {
 
 	#[Override]
 	public function getDeletedSharedWith(string $userId, int $shareType, ?Node $node = null, int $limit = 50, int $offset = 0): array {
+		// TODO: Remove, it is no longer used.
 		$shares = $this->getSharedWith($userId, $shareType, $node, $limit, $offset);
 
 		// Only get shares deleted shares and where the owner still exists
@@ -1382,17 +1529,47 @@ class Manager implements IManager {
 	}
 
 	#[Override]
-	public function getShareById($id, $recipient = null, bool $onlyValid = true): IShare {
-		if ($id === null) {
-			throw new ShareNotFound();
-		}
+	public function getAllDeletedSharedWith(string $userId, array $shareTypes, ?Node $node = null, PaginationParameters $paginationParameters): array {
+		$shares = $this->getAllSharedWith($userId, $shareTypes, $node, $paginationParameters);
 
+		// Only get shares deleted shares and where the owner still exists
+		return array_filter($shares, fn (IShare $share): bool => $share->getPermissions() === 0
+			&& $this->userManager->userExists($share->getShareOwner()));
+	}
+
+	#[Override]
+	public function getShareById(string $id, ?string $recipient = null, bool $onlyValid = true): IShare {
 		[$providerId, $id] = $this->splitFullId($id);
 
 		try {
 			$provider = $this->factory->getProvider($providerId);
 		} catch (ProviderException $e) {
 			throw new ShareNotFound();
+		}
+
+		if ($provider instanceof ICreateShareProvider) {
+			$qb = $this->connection->getQueryBuilder();
+
+			$qb->select('*')
+				->from('share')
+				->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
+				->andWhere($qb->expr()->in('share_type', $qb->createNamedParameter($provider->getShareTypes(), IQueryBuilder::PARAM_INT_ARRAY)));
+
+			$cursor = $qb->executeQuery();
+			$data = $cursor->fetchAssociative();
+			$cursor->closeCursor();
+
+			if ($data === false) {
+				throw new ShareNotFound('Can not find share with ID: ' . $id);
+			}
+
+			$share = $provider->createShare($data);
+
+			if ($onlyValid) {
+				$this->checkShare($share);
+			}
+
+			return $share;
 		}
 
 		$share = $provider->getShareById($id, $recipient);
@@ -1404,24 +1581,87 @@ class Manager implements IManager {
 		return $share;
 	}
 
+	/**
+	 * @param list<IShare::TYPE_*> $shareTypes
+	 * @return list<IShare>
+	 */
+	private function getSharesByPath(Node $path, array $shareTypes, PaginationParameters $paginationParameters): array {
+		$qb = $this->connection->getQueryBuilder();
+
+		$qb = $qb->select('*')
+			->from('share')
+			->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($path->getId())))
+			->andWhere($qb->expr()->in('share_type', $qb->createNamedParameter($shareTypes, IQueryBuilder::PARAM_INT_ARRAY)));
+		$paginationParameters->fillQuery($qb, 'id');
+		$cursor = $qb->executeQuery();
+
+		$shares = [];
+		while ($data = $cursor->fetchAssociative()) {
+			$provider = $this->factory->getProvider((int)$data['share_type']);
+			if ($provider instanceof ICreateShareProvider) {
+				$shares[] = $provider->createShare($data);
+			} else {
+				$shares[] = $provider->getShareById((int)$data['id']);
+			}
+		}
+		$cursor->closeCursor();
+		return $shares;
+	}
+
+	/**
+	 * @return array{?IShare, list<IShare::TYPE_*>}
+	 */
+	private function getShareByTokenOptimized(string $token): array {
+		$providers = $this->factory->getAllProviders();
+		// Get all shares from the providers supporting createShare
+		$createShareProviders = array_filter($providers, fn (IShareProvider $provider) => $provider instanceof ICreateShareProvider);
+		$shareTypes = array_unique(array_merge(...array_map(fn (ICreateShareProvider $provider): array => $provider->getTokenShareTypes(), $createShareProviders)));
+		if (!$this->appConfig->getValueBool('core', 'shareapi_allow_links', true)) {
+			$shareTypes = array_filter($shareTypes, fn (int $shareType): bool => $shareType !== IShare::TYPE_LINK);
+		}
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select('*')
+			->from('share')
+			->where($qb->expr()->in('share_type', $qb->createNamedParameter($shareTypes)))
+			->andWhere($qb->expr()->eq('token', $qb->createNamedParameter($token)))
+			->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
+			->executeQuery();
+
+		$data = $result->fetch();
+		if ($data === false) {
+			return [null, $shareTypes];
+		}
+		$provider = $this->factory->getProviderForType((int)$data['share_type']);
+		if (!$provider instanceof ICreateShareProvider) {
+			throw new \LogicException('Share type ' . $data['share_type'] . " doesn't have a corresponding ICreateShareProvider.");
+		}
+		$data['id'] = (string)$data['id'];
+		$share = $provider->createShare($data);
+		return [$share, $shareTypes];
+	}
+
 	#[Override]
 	public function getShareByToken(string $token): IShare {
 		// tokens cannot be valid local usernames
 		if ($this->userManager->userExists($token)) {
 			throw new ShareNotFound();
 		}
-		$share = null;
-		try {
-			if ($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes') {
-				$provider = $this->factory->getProviderForType(IShare::TYPE_LINK);
-				$share = $provider->getShareByToken($token);
-			}
-		} catch (ProviderException|ShareNotFound) {
+
+		[$share, $testedShareTypes] = $this->getShareByTokenOptimized($token);
+		if ($share !== null) {
+			return $share;
 		}
 
+		if (!in_array(IShare::TYPE_LINK, $testedShareTypes) && $this->appConfig->getValueBool('core', 'shareapi_allow_links', true)) {
+			try {
+				$provider = $this->factory->getProviderForType(IShare::TYPE_LINK);
+				$share = $provider->getShareByToken($token);
+			} catch (ProviderException|ShareNotFound) {
+			}
+		}
 
 		// If it is not a link share try to fetch a federated share by token
-		if ($share === null) {
+		if ($share === null && !in_array(IShare::TYPE_REMOTE, $testedShareTypes)) {
 			try {
 				$provider = $this->factory->getProviderForType(IShare::TYPE_REMOTE);
 				$share = $provider->getShareByToken($token);
@@ -1430,7 +1670,7 @@ class Manager implements IManager {
 		}
 
 		// If it is not a link share try to fetch a mail share by token
-		if ($share === null && $this->shareProviderExists(IShare::TYPE_EMAIL)) {
+		if ($share === null && !in_array(IShare::TYPE_REMOTE, $testedShareTypes) && $this->shareProviderExists(IShare::TYPE_EMAIL)) {
 			try {
 				$provider = $this->factory->getProviderForType(IShare::TYPE_EMAIL);
 				$share = $provider->getShareByToken($token);
@@ -1438,7 +1678,7 @@ class Manager implements IManager {
 			}
 		}
 
-		if ($share === null && $this->shareProviderExists(IShare::TYPE_CIRCLE)) {
+		if ($share === null && !in_array(IShare::TYPE_REMOTE, $testedShareTypes) && $this->shareProviderExists(IShare::TYPE_CIRCLE)) {
 			try {
 				$provider = $this->factory->getProviderForType(IShare::TYPE_CIRCLE);
 				$share = $provider->getShareByToken($token);
@@ -1446,7 +1686,7 @@ class Manager implements IManager {
 			}
 		}
 
-		if ($share === null && $this->shareProviderExists(IShare::TYPE_ROOM)) {
+		if ($share === null && !in_array(IShare::TYPE_REMOTE, $testedShareTypes) && $this->shareProviderExists(IShare::TYPE_ROOM)) {
 			try {
 				$provider = $this->factory->getProviderForType(IShare::TYPE_ROOM);
 				$share = $provider->getShareByToken($token);
@@ -1677,21 +1917,21 @@ class Manager implements IManager {
 
 	#[Override]
 	public function shareApiEnabled(): bool {
-		return $this->config->getAppValue('core', 'shareapi_enabled', 'yes') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_enabled', true);
 	}
 
 	#[Override]
 	public function shareApiAllowLinks(?IUser $user = null): bool {
-		if ($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
+		if (!$this->appConfig->getValueBool('core', 'shareapi_allow_links', true)) {
 			return false;
 		}
 
 		$user = $user ?? $this->userSession->getUser();
 		if ($user) {
-			$excludedGroups = json_decode($this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '[]'));
+			$excludedGroups = $this->appConfig->getValueArray('core', 'shareapi_allow_links_exclude_groups');
 			if ($excludedGroups) {
 				$userGroups = $this->groupManager->getUserGroupIds($user);
-				return !(bool)array_intersect($excludedGroups, $userGroups);
+				return !array_intersect($excludedGroups, $userGroups);
 			}
 		}
 
@@ -1710,13 +1950,12 @@ class Manager implements IManager {
 
 	#[Override]
 	public function shareApiLinkEnforcePassword(bool $checkGroupMembership = true): bool {
-		$excludedGroups = $this->config->getAppValue('core', 'shareapi_enforce_links_password_excluded_groups', '');
-		if ($excludedGroups !== '' && $checkGroupMembership) {
-			$excludedGroups = json_decode($excludedGroups);
+		$excludedGroups = $this->appConfig->getValueArray('core', 'shareapi_enforce_links_password_excluded_groups');
+		if ($excludedGroups !== [] && $checkGroupMembership) {
 			$user = $this->userSession->getUser();
 			if ($user) {
 				$userGroups = $this->groupManager->getUserGroupIds($user);
-				if ((bool)array_intersect($excludedGroups, $userGroups)) {
+				if (array_intersect($excludedGroups, $userGroups)) {
 					return false;
 				}
 			}
@@ -1737,49 +1976,49 @@ class Manager implements IManager {
 
 	#[Override]
 	public function shareApiLinkDefaultExpireDays(): int {
-		return (int)$this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
+		return $this->appConfig->getValueInt('core', 'shareapi_expire_after_n_days', 7);
 	}
 
 	#[Override]
 	public function shareApiInternalDefaultExpireDate(): bool {
-		return $this->config->getAppValue('core', 'shareapi_default_internal_expire_date', 'no') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_default_internal_expire_date');
 	}
 
 	#[Override]
 	public function shareApiRemoteDefaultExpireDate(): bool {
-		return $this->config->getAppValue('core', 'shareapi_default_remote_expire_date', 'no') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_default_remote_expire_date');
 	}
 
 	#[Override]
 	public function shareApiInternalDefaultExpireDateEnforced(): bool {
 		return $this->shareApiInternalDefaultExpireDate()
-			&& $this->config->getAppValue('core', 'shareapi_enforce_internal_expire_date', 'no') === 'yes';
+			&& $this->appConfig->getValueBool('core', 'shareapi_enforce_internal_expire_date');
 	}
 
 	#[Override]
 	public function shareApiRemoteDefaultExpireDateEnforced(): bool {
 		return $this->shareApiRemoteDefaultExpireDate()
-			&& $this->config->getAppValue('core', 'shareapi_enforce_remote_expire_date', 'no') === 'yes';
+			&& $this->appConfig->getValueBool('core', 'shareapi_enforce_remote_expire_date');
 	}
 
 	#[Override]
 	public function shareApiInternalDefaultExpireDays(): int {
-		return (int)$this->config->getAppValue('core', 'shareapi_internal_expire_after_n_days', '7');
+		return $this->appConfig->getValueInt('core', 'shareapi_internal_expire_after_n_days', 7);
 	}
 
 	#[Override]
 	public function shareApiRemoteDefaultExpireDays(): int {
-		return (int)$this->config->getAppValue('core', 'shareapi_remote_expire_after_n_days', '7');
+		return $this->appConfig->getValueInt('core', 'shareapi_remote_expire_after_n_days', 7);
 	}
 
 	#[Override]
 	public function shareApiLinkAllowPublicUpload(): bool {
-		return $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_allow_public_upload', true);
 	}
 
 	#[Override]
 	public function shareWithGroupMembersOnly(): bool {
-		return $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_only_share_with_group_members');
 	}
 
 	#[Override]
@@ -1793,29 +2032,29 @@ class Manager implements IManager {
 
 	#[Override]
 	public function allowGroupSharing(): bool {
-		return $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_allow_group_sharing', true);
 	}
 
 	#[Override]
 	public function allowEnumeration(): bool {
-		return $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_allow_share_dialog_user_enumeration', true);
 	}
 
 	#[Override]
 	public function limitEnumerationToGroups(): bool {
 		return $this->allowEnumeration()
-			&& $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
+			&& $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_group');
 	}
 
 	#[Override]
 	public function limitEnumerationToPhone(): bool {
 		return $this->allowEnumeration()
-			&& $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';
+			&& $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_phone');
 	}
 
 	#[Override]
 	public function allowEnumerationFullMatch(): bool {
-		return $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match', 'yes') === 'yes';
+		return $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_full_match', true);
 	}
 
 	#[Override]
@@ -1918,7 +2157,32 @@ class Manager implements IManager {
 	public function getAllShares(): iterable {
 		$providers = $this->factory->getAllProviders();
 
-		foreach ($providers as $provider) {
+		// Get all shares from the providers supporting createShare
+		$createShareProviders = array_filter($providers, fn (IShareProvider $provider) => $provider instanceof ICreateShareProvider);
+		$shareTypes = array_unique(array_merge(...array_map(fn (ICreateShareProvider $provider): array => $provider->getShareTypes(), $createShareProviders)));
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select('*')
+			->from('share')
+			->where($qb->expr()->in('share_type', $qb->createNamedParameter($shareTypes, IQueryBuilder::PARAM_INT_ARRAY)))
+			->executeQuery();
+		/** @var array<IShare::TYPE*, IShareProvider> $providers */
+		$providers = [];
+		foreach ($result->iterateAssociative() as $row) {
+			if (!isset($providers[$row['share_type']])) {
+				$providers[$row['share_type']] = $this->factory->getProviderForType($row['share_type']);
+			}
+
+			$provider = $providers[$row['share_type']];
+			if (!$provider instanceof ICreateShareProvider) {
+				throw new \LogicException('Share type ' . $row['share_type'] . " doesn't have a corresponding ICreateShareProvider.");
+			}
+
+			yield $provider->createShare($row);
+		}
+
+		// Get all shares from the other providers
+		$noCreateShareProviders = array_filter($providers, fn (IShareProvider $provider) => !$provider instanceof ICreateShareProvider);
+		foreach ($noCreateShareProviders as $provider) {
 			yield from $provider->getAllShares();
 		}
 	}

--- a/lib/public/PaginationParameters.php
+++ b/lib/public/PaginationParameters.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH
+ * SPDX-FileContributor: Carl Schwan
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP;
+
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+/**
+ * Since 34.0.0
+ * @see https://docs.joinmastodon.org/api/guidelines/#pagination
+ */
+#[Consumable(since: '34.0.0')]
+class PaginationParameters {
+	/**
+	 * Pagination parameters.
+	 *
+	 * You can use $minId with $maxId and $maxId with $sinceId.
+	 *
+	 * @param ?int $limit The maximum number of results to return. Set to null to
+	 *                    return all results.
+	 * @param ?non-empty-string $maxId All results returned will be lesser than this ID. In effect, sets an upper bound on results.
+	 * @param ?non-empty-string $minId Returns results immediately greater than this ID. In effect, sets a cursor at this ID and paginates forward.
+	 * @param ?non-empty-string $sinceId All results returned will be greater than this ID. In effect, sets a lower bound on results.
+	 */
+	public function __construct(
+		public ?int $limit = 100,
+		public ?string $maxId = null,
+		public ?string $minId = null,
+		public ?string $sinceId = null,
+	) {
+		if ($minId !== null && $sinceId !== null) {
+			throw new \InvalidArgumentException("minId and sinceId can't be defined togeter");
+		}
+	}
+
+	/**
+	 * Add pagination condition to the query builder based on the configured pagination settings.
+	 */
+	public function fillQuery(IQueryBuilder $qb, string $idColumn): IQueryBuilder {
+		// This logic is inspired by
+		// https://github.com/mastodon/mastodon/blob/main/app/models/concerns/paginable.rb#L7
+
+		if ($this->minId !== null) {
+			// paginate by min id (last entries added in the table last)
+			$qb->andWhere($qb->expr()->gt($idColumn, $this->minId));
+			if ($this->maxId !== null) {
+				$qb->andWhere($qb->expr()->lt($idColumn, $this->maxId));
+			}
+			$qb->orderBy($idColumn, 'ASC');
+			$qb->setMaxResults($this->limit);
+			return $qb;
+		} else {
+			// paginate by max id (last entries added in the table first)
+			if ($this->maxId !== null) {
+				$qb->andWhere($qb->expr()->lt($idColumn, $this->maxId));
+			}
+			if ($this->sinceId !== null) {
+				$qb->andWhere($qb->expr()->gt($idColumn, $this->sinceId));
+			}
+			$qb->orderBy($idColumn, 'DESC');
+			$qb->setMaxResults($this->limit);
+			return $qb;
+		}
+	}
+}

--- a/lib/public/Share/ICreateShareProvider.php
+++ b/lib/public/Share/ICreateShareProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH
+ * SPDX-FileContributor: Carl Schwan
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Share;
+
+/**
+ * Interface IShareProviderSupportsAccept
+ *
+ * This interface allows to define IShareProvider that can list users for share with the getUsersForShare method,
+ * which is available since Nextcloud 17.
+ *
+ * @since 33.0.0
+ */
+interface ICreateShareProvider extends IShareProvider {
+	/**
+	 * Fill a share with additional information from the raw row of the database.
+	 *
+	 * @param array<string, mixed> $data
+	 * @return IShare $share
+	 * @since 34.0.0
+	 */
+	public function createShare(array $data): IShare;
+
+	/**
+	 * @return list<IShare::TYPE_*>
+	 * @since 34.0.0
+	 */
+	public function getShareTypes(): array;
+
+	/**
+	 * @return list<IShare::TYPE_*>
+	 * @since 34.0.0
+	 */
+	public function getTokenShareTypes(): array;
+}

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -12,6 +12,7 @@ use OCP\Files\Folder;
 use OCP\Files\Node;
 
 use OCP\IUser;
+use OCP\PaginationParameters;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\ShareTokenException;
@@ -115,10 +116,22 @@ interface IManager {
 	 * @param int $limit The maximum number of returned results, -1 for all results
 	 * @param int $offset
 	 * @param bool $onlyValid Only returns valid shares, invalid shares will be deleted automatically and are not returned
-	 * @return IShare[]
+	 * @return list<IShare>
 	 * @since 9.0.0
 	 */
 	public function getSharesBy(string $userId, int $shareType, ?Node $path = null, bool $reshares = false, int $limit = 50, int $offset = 0, bool $onlyValid = true): array;
+
+	/**
+	 * Get all shares shared by (initiated) by the provided user.
+	 *
+	 * @param string $userId
+	 * @param Node|null $path
+	 * @param bool $reshares
+	 * @param bool $onlyValid Only returns valid shares, invalid shares will be deleted automatically and are not returned
+	 * @return list<IShare>
+	 * @since 34.0.0
+	 */
+	public function getAllSharesBy(string $userId, ?Node $node, PaginationParameters $paginationParameters, bool $reshares = false, bool $onlyValid = true): array;
 
 	/**
 	 * Get shares shared with $user.
@@ -131,8 +144,18 @@ interface IManager {
 	 * @param int $offset
 	 * @return IShare[]
 	 * @since 9.0.0
+	 * @deprecated 34.0.0 Use getAllSharedWith instead, it's more efficient
 	 */
 	public function getSharedWith(string $userId, int $shareType, ?Node $node = null, int $limit = 50, int $offset = 0): array;
+
+	/**
+	 * @param string $userId
+	 * @param list<IShare::TYPE_*> $shareTypes
+	 * @param Node|null $node
+	 * @return list<IShare>
+	 * @since 34.0.0
+	 */
+	public function getAllSharedWith(string $userId, array $shareTypes, ?Node $node, PaginationParameters $paginationParameters, bool $ignoreWithSelf = false): array;
 
 	/**
 	 * Get shares shared with a $user filtering by $path.
@@ -152,10 +175,22 @@ interface IManager {
 	 *
 	 * @param IShare::TYPE_* $shareType
 	 * @param int $limit The maximum number of shares returned, -1 for all
-	 * @return IShare[]
+	 * @return list<IShare>
 	 * @since 14.0.0
+	 * @deprecated 34.0.0 Use getAllDeletedSharedWith instead
 	 */
 	public function getDeletedSharedWith(string $userId, int $shareType, ?Node $node = null, int $limit = 50, int $offset = 0): array;
+
+	/**
+	 * Get all the deleted shares shared with $user.
+	 *
+	 * Additionally filter by $node if provided
+	 *
+	 * @param list<IShare::TYPE_*> $shareTypes
+	 * @return list<IShare>
+	 * @since 34.0.0
+	 */
+	public function getAllDeletedSharedWith(string $userId, array $shareTypes, ?Node $node = null, PaginationParameters $paginationParameters): array;
 
 	/**
 	 * Retrieve a share by the share id.

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -129,7 +129,7 @@ interface IShareProvider {
 	 * Get shares for a given path
 	 *
 	 * @param Node $path
-	 * @return \OCP\Share\IShare[]
+	 * @return list<\OCP\Share\IShare>
 	 * @since 9.0.0
 	 */
 	public function getSharesByPath(Node $path);
@@ -138,14 +138,14 @@ interface IShareProvider {
 	 * Get shared with the given user
 	 *
 	 * @param string $userId get shares where this user is the recipient
-	 * @param int $shareType
+	 * @param IShare::TYPE_* $shareType
 	 * @param Node|null $node
 	 * @param int $limit The max number of entries returned, -1 for all
 	 * @param int $offset
 	 * @return \OCP\Share\IShare[]
 	 * @since 9.0.0
 	 */
-	public function getSharedWith($userId, $shareType, $node, $limit, $offset);
+	public function getSharedWith(string $userId, int $shareType, ?Node $node, int $limit, int $offset);
 
 	/**
 	 * Get a share by token
@@ -206,6 +206,7 @@ interface IShareProvider {
 	 *
 	 * @return iterable<IShare>
 	 * @since 18.0.0
+	 * @deprecated 34.0.0 This is no longer needed when implementing ICreateShareProvider
 	 */
 	public function getAllShares(): iterable;
 

--- a/tests/lib/Share/Backend.php
+++ b/tests/lib/Share/Backend.php
@@ -9,6 +9,7 @@
 namespace Test\Share;
 
 use OC\Share20\Manager;
+use OCP\PaginationParameters;
 use OCP\Server;
 use OCP\Share\IShare;
 use OCP\Share_Backend;
@@ -39,10 +40,7 @@ class Backend implements Share_Backend {
 
 
 		$shareManager = Server::get(Manager::class);
-		$shares = array_merge(
-			$shareManager->getSharedWith($shareWith, IShare::TYPE_USER),
-			$shareManager->getSharedWith($shareWith, IShare::TYPE_GROUP),
-		);
+		$shares = $shareManager->getAllSharedWith($shareWith, [IShare::TYPE_USER, IShare::TYPE_GROUP], null, new PaginationParameters(limit: null));
 
 		$knownTargets = [];
 		foreach ($shares as $share) {

--- a/tests/lib/Share20/LegacyHooksTest.php
+++ b/tests/lib/Share20/LegacyHooksTest.php
@@ -9,7 +9,6 @@ namespace Test\Share20;
 
 use OC\EventDispatcher\EventDispatcher;
 use OC\Share20\LegacyHooks;
-use OC\Share20\Manager;
 use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICacheEntry;
@@ -24,6 +23,7 @@ use OCP\Share\Events\ShareDeletedFromSelfEvent;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use OCP\Util;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
@@ -40,15 +40,11 @@ class Dummy {
 	}
 }
 
+#[Group(name: 'DB')]
 class LegacyHooksTest extends TestCase {
-	/** @var LegacyHooks */
-	private $hooks;
-
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
-
-	/** @var Manager */
-	private $manager;
+	private LegacyHooks $hooks;
+	private IEventDispatcher $eventDispatcher;
+	private IShareManager $manager;
 
 	protected function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
## Summary

Instead of making queries in each providers, do it once in the manager depending on the providers enabled and then only create the share objects in the share providers.

Additionally introduce a new API for iterating not based on offset but on max_id, min_id

## TODO

- [ ] Make it work xD

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
