### PR TITLE
feat(db/postgreSQL): Use user-named schema instead of `public`

### DIFF
--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -75,6 +75,7 @@ class PostgreSQL extends AbstractDatabase {
 				// See: https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PATTERNS
 				$connectionMainDatabase->executeQuery('CREATE SCHEMA IF NOT EXISTS "' . addslashes($this->dbUser) . '" AUTHORIZATION "' . addslashes($this->dbUser) . '"');
 				$connectionMainDatabase->close();
+				}
 			}
 		} catch (\Exception $e) {
 			$this->logger->warning('Error trying to connect as "postgres", assuming database is setup and tables need to be created', [

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -67,16 +67,14 @@ class PostgreSQL extends AbstractDatabase {
 
 			if ($this->tryCreateDbUser) {
 				if ($canCreateRoles) {
-					// Go to the main database and grant create on the public schema
-					// The code below is implemented to make installing possible with PostgreSQL version 15:
-					// https://www.postgresql.org/docs/release/15.0/
-					// From the release notes: For new databases having no need to defend against insider threats, granting CREATE permission will yield the behavior of prior releases
-					// Therefore we assume that the database is only used by one user/service which is Nextcloud
-					// Additional services should get installed in a separate database in order to stay secure
-					// Also see https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PATTERNS
-					$connectionMainDatabase->executeQuery('GRANT CREATE ON SCHEMA public TO "' . addslashes($this->dbUser) . '"');
-					$connectionMainDatabase->close();
-				}
+				// Create user-named schema for PostgreSQL 15+ compatibility.
+				// PostgreSQL 15 removed default CREATE privileges on `public` schema.
+				// User-named schemas are automatically in `search_path` and owned by the user.
+				// This only affects new installations; existing installations continue using 'public' schema.
+				// See: https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH
+				// See: https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PATTERNS
+				$connectionMainDatabase->executeQuery('CREATE SCHEMA IF NOT EXISTS "' . addslashes($this->dbUser) . '" AUTHORIZATION "' . addslashes($this->dbUser) . '"');
+				$connectionMainDatabase->close();
 			}
 		} catch (\Exception $e) {
 			$this->logger->warning('Error trying to connect as "postgres", assuming database is setup and tables need to be created', [


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

We've long assumed usage of the `public` schema in PostgreSQL, but this is a more of a legacy approach these days. Since pgsql 15 it's no longer the default behavior. Rather than using workarounds to toggle on and use the older approach, we can migrate to the modern approach.

This is a backwards-compatible fix because it only affects the installation code path, which never runs again after initial setup. Existing installations continue working unchanged in public, while new installations benefit from better schema isolation and avoid the PostgreSQL 15+ permission issue entirely.

Separate follow-ups:

- Update database configuration docs (i.e. drop `public` / add what's needed if/when relying on manual user creation)
- Add instructions to help existing installations confirm which approach they have (e.g. `SELECT schemaname FROM pg_tables WHERE tablename LIKE 'oc_%' LIMIT 1;`)
- Possibly add instructions on switching 

## TODO

- [ ] Tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)