### PR TITLE
feat(config): Allow defining config.php permissions after write

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2614,6 +2614,13 @@ $CONFIG = [
 	'data-fingerprint' => '',
 
 	/**
+	 * config.php file mode in octal notation.
+	 *
+	 * Defaults to ``0640`` (writable by user, readable by group).
+	 */
+	'configfilemode' => 0640,
+
+	/**
 	 * This entry serves as a warning if the sample configuration was copied.
 	 * DO NOT ADD THIS TO YOUR CONFIGURATION!
 	 *

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -276,8 +276,9 @@ class Config {
 		touch($this->configFilePath);
 		$filePointer = fopen($this->configFilePath, 'r+');
 
-		// Prevent others not to read the config
-		chmod($this->configFilePath, 0640);
+		// Apply permissions for config.php, defaulting to user read-write and group read
+		$permissions = $this->cache['configfilemode'] ?? 0640;
+		chmod($this->configFilePath, $permissions);
 
 		// File does not exist, this can happen when doing a fresh install
 		if (!is_resource($filePointer)) {


### PR DESCRIPTION
- Replacement for https://github.com/nextcloud/server/pull/57874 from @lafrech
- Adding a config to specify the desired permissions

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
