### PR TITLE
refactor(Setup/PostgreSQL): more robust credential handling and code organization

### DIFF
--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -23,7 +23,7 @@ class PostgreSQL extends AbstractDatabase {
 	 * This method handles two scenarios:
 	 * 1. Automatic setup: Creates user, database, and schema when connecting as superuser
 	 * 2. Manual setup: Uses pre-configured credentials when automatic setup fails
-	 * 
+	 *
 	 * @throws DatabaseSetupException If database connection or setup fails
 	 */
 	public function setupDatabase(): void {
@@ -91,8 +91,8 @@ class PostgreSQL extends AbstractDatabase {
 		} catch (\Exception $e) { // @todo: catch more specific DatabaseException | DatabaseSetupException | \PDOException $e instead?
 			// Automatic setup failed - log and continue with verification (upstream.. which will give up if necessary)
 			$this->logger->warning('Automatic database setup failed, will attempt to verify manual configuration', [
-					'exception' => $e,
-					'app' => 'pgsql.setup',
+				'exception' => $e,
+				'app' => 'pgsql.setup',
 			]);
 
 			// Ensure credentials are saved even if automatic setup failed
@@ -253,7 +253,7 @@ class PostgreSQL extends AbstractDatabase {
 
 	/**
 	 * Verifies connection to the Nextcloud database with configured credentials.
-	 * 
+	 *
 	 * @throws DatabaseSetupException If connection fails
 	 */
 	private function verifyDatabaseConnection(): void {

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -12,7 +12,6 @@ use OC\DatabaseSetupException;
 use OC\DB\Connection;
 use OC\DB\QueryBuilder\Literal;
 use OCP\Security\ISecureRandom;
-use OCP\Server;
 
 class PostgreSQL extends AbstractDatabase {
 	public $dbprettyname = 'PostgreSQL';
@@ -213,7 +212,7 @@ class PostgreSQL extends AbstractDatabase {
 		// Generate Nextcloud-specific credentials so we don't need to store / use the db admin credentials
 		$baseUser = 'oc_admin';
 		$newUser = $baseUser;
-		$newPassword = Server::get(ISecureRandom::class)->generate(30, ISecureRandom::CHAR_ALPHANUMERIC);
+		$newPassword = $this->random->generate(30, ISecureRandom::CHAR_ALPHANUMERIC);
 
 		// Find/generate an available username
 		try {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary

Before:
- Key properties were overused (e.g. `$this->dbUser` / `$this->dbPassword`) that made logic harder to follow, troubleshoot, or change
- Different scenarios all followed the same code path unnecessarily (i.e. automatic credential creation versus manually pre-provisioned by admin)
- Didn't use any helpers making it harder to read/troubleshoot

After:
- Code is easier to follow.
- Clearer separation of concerns
- Elimination of hidden state dependencies. 

**Easiest to review probably by commit-by-commit**

Specific improvements:

1. Credential Management
   - Admin credentials now saved in local variables before mutation
   - Credentials generated entirely inside `createDBUser()` and only assigned to `$this->` after success
   - `userExists()` now accepts explicit "dbUser" parameter
2. Code Organization
   - Separates automatic vs. manual setup paths (new `performAutomaticSetup()` introduced + less conditional logic depth)
   - Extracted key bits of existing logic into new helpers: `checkCanCreateRoles()`, `verifyDatabaseConnection()`, `grantCreateOnPublicSchema()`
   - Single `$connection` object/variable; less confusion between connection scenarios and more explicit lifecycle management
3. Observability
   - Better error context (user, database, exception details)
   - Some additional logging scenarios and clarity (e.g. when alternate username chosen)
   - Added `'app' => 'pgsql.setup'` to all log contexts

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
