### PR TITLE
fix(migrations): Restore type definitions for API class used in apps

### DIFF
--- a/lib/public/Migration/SimpleMigrationStep.php
+++ b/lib/public/Migration/SimpleMigrationStep.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  */
 namespace OCP\Migration;
 
+use OCP\DB\ISchemaWrapper;
 use Override;
 
 /**
@@ -15,25 +16,51 @@ use Override;
  * @since 13.0.0
  */
 abstract class SimpleMigrationStep implements IMigrationStep {
+	/**
+	 * Human-readable name of the migration step
+	 *
+	 * @since 14.0.0
+	 */
 	#[Override]
 	public function name(): string {
 		return '';
 	}
 
+	/**
+	 * Human-readable description of the migration step
+	 *
+	 * @since 14.0.0
+	 */
 	#[Override]
 	public function description(): string {
 		return '';
 	}
 
+	/**
+	 * @param Closure():ISchemaWrapper $schemaClosure
+	 * @param array{tablePrefix?: string} $options
+	 * @since 13.0.0
+	 */
 	#[Override]
 	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 	}
 
+	/**
+	 * @param Closure():ISchemaWrapper $schemaClosure
+	 * @param array{tablePrefix?: string} $options
+	 * @return null|ISchemaWrapper
+	 * @since 13.0.0
+	 */
 	#[Override]
 	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
 		return null;
 	}
 
+	/**
+	 * @param Closure():ISchemaWrapper $schemaClosure
+	 * @param array{tablePrefix?: string} $options
+	 * @since 13.0.0
+	 */
 	#[Override]
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 	}


### PR DESCRIPTION
- https://github.com/nextcloud/server/pull/58282 broke typing in apps, because the subclass SimpleMigrationStep that is used in all apps now has no Closure typing anymore.

### Before
```
ERROR: MoreSpecificImplementedParamType - lib/Migration/Version23000Date20260107162758.php:30:56 - Argument 2 of OCA\Talk\Migration\Version23000Date20260107162758::changeSchema has the more specific type 'Closure():OCP\DB\ISchemaWrapper', expecting 'Closure' as defined by OCP\Migration\SimpleMigrationStep::changeSchema (see https://psalm.dev/140)
	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
```

### Option1 (bad) - Remove docs in Talk
Before removing Talk docs | After
---|---
<img width="930" height="527" alt="Bildschirmfoto vom 2026-02-18 08-49-53" src="https://github.com/user-attachments/assets/2359e22e-3cb5-45d3-a14e-a2094d2061ce" /> | <img width="832" height="321" alt="Bildschirmfoto vom 2026-02-18 08-50-06" src="https://github.com/user-attachments/assets/3b8d1aff-aa1d-4c52-8273-c71817c34f78" />
Types are hinted and parameter name of createTable is known | Types are lost, no hinting

### Option2 (better) - Restore the docs on SimpleMigrationStep
```
------------------------------
                              
       No errors found!       
                              
------------------------------
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
