### PR TITLE
fix: show file size on remote shares

### DIFF
--- a/apps/files_sharing/lib/Controller/RemoteController.php
+++ b/apps/files_sharing/lib/Controller/RemoteController.php
@@ -124,6 +124,7 @@ class RemoteController extends OCSController {
 		$shareData['permissions'] = $mountPointNode->getPermissions();
 		$shareData['type'] = $mountPointNode->getType();
 		$shareData['file_id'] = $mountPointNode->getId();
+		$shareData['item_size'] = $mountPointNode->getSize();
 
 		return $shareData;
 	}

--- a/apps/files_sharing/lib/External/ExternalShare.php
+++ b/apps/files_sharing/lib/External/ExternalShare.php
@@ -112,6 +112,7 @@ class ExternalShare extends SnowflakeAwareEntity implements \JsonSerializable {
 			'permissions' => null,
 			'mtime' => null,
 			'type' => null,
+			'item_size' => null,
 		];
 	}
 

--- a/apps/files_sharing/lib/ResponseDefinitions.php
+++ b/apps/files_sharing/lib/ResponseDefinitions.php
@@ -97,6 +97,7 @@ namespace OCA\Files_Sharing;
  *     share_type: int,
  *     type: string|null,
  *     user: string,
+ *     item_size: int|float|null,
  * }
  *
  * @psalm-type Files_SharingSharee = array{

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -407,7 +407,8 @@
                     "share_token",
                     "share_type",
                     "type",
-                    "user"
+                    "user",
+                    "item_size"
                 ],
                 "properties": {
                     "accepted": {
@@ -468,6 +469,19 @@
                     },
                     "user": {
                         "type": "string"
+                    },
+                    "item_size": {
+                        "nullable": true,
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        ]
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -2526,7 +2526,8 @@
                     "share_token",
                     "share_type",
                     "type",
-                    "user"
+                    "user",
+                    "item_size"
                 ],
                 "properties": {
                     "accepted": {
@@ -2587,6 +2588,19 @@
                     },
                     "user": {
                         "type": "string"
+                    },
+                    "item_size": {
+                        "nullable": true,
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        ]
                     }
                 }
             },


### PR DESCRIPTION
the shared-with-you section uses the remote_shares endpoint, which does not set the item_size field for the returned share objects.