### PR TITLE
fix(Propagator): Skip groupfolders root entries

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OC\Files\Cache;
 
 use OC\DB\Exceptions\DbalException;
+use OC\Files\Storage\LocalRootStorage;
 use OC\Files\Storage\Wrapper\Encryption;
 use OCP\DB\QueryBuilder\ILiteral;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -51,6 +52,10 @@ class Propagator implements IPropagator {
 		$storageId = $this->storage->getCache()->getNumericStorageId();
 
 		$parents = $this->getParents($internalPath);
+		if ($this->storage->instanceOfStorage(LocalRootStorage::class) && str_starts_with($internalPath, '__groupfolders')) {
+			// Remove '' and '__groupfolders'
+			$parents = array_slice($parents, 2);
+		}
 
 		if ($this->inBatch) {
 			foreach ($parents as $parent) {


### PR DESCRIPTION
This is for the "old" storage layout where all groupfolders were on a single storage.
Any change to any groupfolder caused the `__groupfolders` entry to be updated, causing locking issues on instances with lots of concurrent users.
This entry is actually not used at all by the clients, because only its subfolders are mounted, therefore the etag and mtime of it don't matter.