### PR TITLE
refactor(Setup/AbstractDatabase): enable easier child class customization and improve code readability, robustness

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3874,12 +3874,6 @@
     <TypeDoesNotContainType>
       <code><![CDATA[ctype_digit($this->dbPort)]]></code>
     </TypeDoesNotContainType>
-    <UndefinedThisPropertyFetch>
-      <code><![CDATA[$this->dbprettyname]]></code>
-      <code><![CDATA[$this->dbprettyname]]></code>
-      <code><![CDATA[$this->dbprettyname]]></code>
-      <code><![CDATA[$this->dbprettyname]]></code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/private/Share20/ProviderFactory.php">
     <InvalidReturnStatement>

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -154,9 +154,18 @@ abstract class AbstractDatabase {
 		$connectionParams['primary'] = $connectionParams;
 		$connectionParams['replica'] = [$connectionParams];
 
+		$dbType = $this->config->getValue('dbtype', 'sqlite');
+
+		$this->logger->debug('Creating database connection', [
+			'dbtype' => $dbType,
+			'host' => $connectionParams['host'] ?? 'unknown',
+			'port' => $connectionParams['port'] ?? $connectionParams['unix_socket'] ?? 'default',
+			'dbname' => $connectionParams['dbname'] ?? 'none',
+		]);
+
 		// Create and return the connection
 		$cf = new ConnectionFactory($this->config);
-		$connection = $cf->getConnection($this->config->getValue('dbtype', 'sqlite'), $connectionParams);
+		$connection = $cf->getConnection($dbType, $connectionParams);
 		$connection->ensureConnectedToPrimary();
 		return $connection;
 	}

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -69,10 +69,18 @@ abstract class AbstractDatabase {
 
 		$dbName = $config['dbname'] ?? '';
 
+		if (empty($dbName)) {
+			return $errors;
+		}
+
 		// Avoid downsides of supporting database names with dots (`.`)
-		if (!empty($dbName) && str_contains($dbName, '.')) {
+		if (str_contains($dbName, '.')) {
 			$errors[] = $this->trans->t('You cannot use dots in the database name %s', [$this->getDisplayName]);
 		}
+
+		// Note: Child classes should implement db specific name validations
+		// (optionally still calling this parent for default validations)
+		// (e.g. length, characters, casing, starting character, reserved words)
 
 		return $errors;
 	}

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -36,16 +36,24 @@ abstract class AbstractDatabase {
 
 	public function validate(array $config): array {
 		$errors = [];
-		if (empty($config['dbuser']) && empty($config['dbname'])) {
+
+		$dbUser = $config['dbuser'] ?? '';
+		$dbName = $config['dbname'] ?? '';
+
+		// Check for missing required parameters
+		if (empty($dbUser) && empty($dbName)) {
 			$errors[] = $this->trans->t('Enter the database Login and name for %s', [$this->dbprettyname]);
-		} elseif (empty($config['dbuser'])) {
+		} elseif (empty($dbUser)) {
 			$errors[] = $this->trans->t('Enter the database Login for %s', [$this->dbprettyname]);
-		} elseif (empty($config['dbname'])) {
+		} elseif (empty($dbName)) {
 			$errors[] = $this->trans->t('Enter the database name for %s', [$this->dbprettyname]);
 		}
-		if (substr_count($config['dbname'], '.') >= 1) {
+
+		// Avoid downsides of supporting database names with dots (`.`)
+		if (!empty($dbName) && str_contains($dbName, '.')) {
 			$errors[] = $this->trans->t('You cannot use dots in the database name %s', [$this->dbprettyname]);
 		}
+
 		return $errors;
 	}
 

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -39,10 +39,9 @@ abstract class AbstractDatabase {
 	 */
 	abstract protected function getDisplayName(): string;
 
-	
 	/**
 	 * Validates the database configuration
-	 * 
+	 *
 	 * @param array $config Configuration array containing database credentials and settings
 	 * @return array Array of validation error messages (empty if valid)
 	 */
@@ -52,7 +51,7 @@ abstract class AbstractDatabase {
 		$errors = array_merge($errors, $this->validateRequiredFields($config));
 		$errors = array_merge($errors, $this->validateDatabaseName($config));
 
-		 return $errors;
+		return $errors;
 	}
 
 	protected function validateRequiredFields(array $config): array {
@@ -138,7 +137,7 @@ abstract class AbstractDatabase {
 		$this->dbHost = $dbParams['host'];
 		$this->dbPort = $dbParams['port'];
 		$this->tablePrefix = $dbParams['tablePrefix'];
-	}		
+	}
 
 	/**
 	 * @param array $configOverwrite Optional parameters to override (e.g., ['dbname' => null])
@@ -194,20 +193,19 @@ abstract class AbstractDatabase {
 		if (str_contains($this->dbHost, ':')) {
 			[$host, $portOrSocket] = explode(':', $this->dbHost, 2);
 			$params['host'] = $host;
-			// Host variable may carry a port or socket.			
+			// Host variable may carry a port or socket.
 			if (ctype_digit($portOrSocket)) {
 				$params['port'] = $portOrSocket;
 			} else {
 				$params['unix_socket'] = $portOrSocket;
 			}
-			return $params;
 		}
-		// Shouldn't reach here...
+		return $params;
 	}
 
 	/**
 	 * Sets up the database (creates database, users, etc.)
-	 * 
+	 *
 	 * Must be implemented by database-specific child classes
 	 */
 	abstract public function setupDatabase(): void;
@@ -228,7 +226,7 @@ abstract class AbstractDatabase {
 		$this->logger->info('Starting core database migrations');
 
 		$migrationService = new MigrationService('core', Server::get(Connection::class), $output);
-		
+
 		// Migrate to latest version, applying schema changes only
 		// (no data migrations needed for fresh install)
 		$migrationService->migrate('latest', true);

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -37,6 +37,15 @@ abstract class AbstractDatabase {
 	public function validate(array $config): array {
 		$errors = [];
 
+		$errors = array_merge($errors, $this->validateRequiredFields($config));
+		$errors = array_merge($errors, $this->validateDatabaseName($config));
+
+		 return $errors;
+	}
+
+	protected function validateRequiredFields(array $config): array {
+		$errors = [];
+
 		$dbUser = $config['dbuser'] ?? '';
 		$dbName = $config['dbname'] ?? '';
 
@@ -48,6 +57,14 @@ abstract class AbstractDatabase {
 		} elseif (empty($dbName)) {
 			$errors[] = $this->trans->t('Enter the database name for %s', [$this->dbprettyname]);
 		}
+
+		return $errors;
+	}
+
+	protected function validateDatabaseName(array $config): array {
+		$errors = [];
+
+		$dbName = $config['dbname'] ?? '';
 
 		// Avoid downsides of supporting database names with dots (`.`)
 		if (!empty($dbName) && str_contains($dbName, '.')) {

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -34,6 +34,8 @@ abstract class AbstractDatabase {
 	) {
 	}
 
+	abstract protected function getDisplayName(): string;
+
 	public function validate(array $config): array {
 		$errors = [];
 
@@ -48,14 +50,15 @@ abstract class AbstractDatabase {
 
 		$dbUser = $config['dbuser'] ?? '';
 		$dbName = $config['dbname'] ?? '';
+		$displayName = $this->getDisplayName();
 
 		// Check for missing required parameters
 		if (empty($dbUser) && empty($dbName)) {
-			$errors[] = $this->trans->t('Enter the database Login and name for %s', [$this->dbprettyname]);
+			$errors[] = $this->trans->t('Enter the database Login and name for %s', [$displayName]);
 		} elseif (empty($dbUser)) {
-			$errors[] = $this->trans->t('Enter the database Login for %s', [$this->dbprettyname]);
+			$errors[] = $this->trans->t('Enter the database Login for %s', [$displayName]);
 		} elseif (empty($dbName)) {
-			$errors[] = $this->trans->t('Enter the database name for %s', [$this->dbprettyname]);
+			$errors[] = $this->trans->t('Enter the database name for %s', [$displayName]);
 		}
 
 		return $errors;
@@ -68,7 +71,7 @@ abstract class AbstractDatabase {
 
 		// Avoid downsides of supporting database names with dots (`.`)
 		if (!empty($dbName) && str_contains($dbName, '.')) {
-			$errors[] = $this->trans->t('You cannot use dots in the database name %s', [$this->dbprettyname]);
+			$errors[] = $this->trans->t('You cannot use dots in the database name %s', [$this->getDisplayName]);
 		}
 
 		return $errors;

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -16,7 +16,10 @@ use OCP\IDBConnection;
 use OCP\Security\ISecureRandom;
 
 class MySQL extends AbstractDatabase {
-	public string $dbprettyname = 'MySQL/MariaDB';
+
+	protected function getDisplayName(): string {
+		return 'MySQL/MariaDB';
+	}
 
 	public function setupDatabase(): void {
 		//check if the database user has admin right

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -30,16 +30,9 @@ class OCI extends AbstractDatabase {
 		]);
 	}
 
-	public function validate(array $config): array {
-		$errors = [];
-		if (empty($config['dbuser']) && empty($config['dbname'])) {
-			$errors[] = $this->trans->t('Enter the database Login and name for %s', [$this->dbprettyname]);
-		} elseif (empty($config['dbuser'])) {
-			$errors[] = $this->trans->t('Enter the database Login for %s', [$this->dbprettyname]);
-		} elseif (empty($config['dbname'])) {
-			$errors[] = $this->trans->t('Enter the database name for %s', [$this->dbprettyname]);
-		}
-		return $errors;
+	protected function validateDatabaseName(array $config): array {
+		// Override default checks; allow dots in service name for oracle autosetup
+		return [];
 	}
 
 	public function setupDatabase(): void {

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -10,9 +10,11 @@ namespace OC\Setup;
 use OC\DatabaseSetupException;
 
 class OCI extends AbstractDatabase {
-	public $dbprettyname = 'Oracle';
-
 	protected $dbtablespace;
+
+	protected function getDisplayName(): string {
+		return 'Oracle';
+	}
 
 	public function initialize(array $config): void {
 		parent::initialize($config);

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -15,7 +15,10 @@ use OCP\Security\ISecureRandom;
 use OCP\Server;
 
 class PostgreSQL extends AbstractDatabase {
-	public $dbprettyname = 'PostgreSQL';
+
+	protected function getDisplayName(): string {
+		return 'PostgreSQL';
+	}
 
 	/**
 	 * @throws DatabaseSetupException

--- a/lib/private/Setup/Sqlite.php
+++ b/lib/private/Setup/Sqlite.php
@@ -10,7 +10,10 @@ namespace OC\Setup;
 use OC\DB\ConnectionFactory;
 
 class Sqlite extends AbstractDatabase {
-	public string $dbprettyname = 'Sqlite';
+
+	protected function getDisplayName(): string {
+		return 'SQLite';
+	}
 
 	public function validate(array $config): array {
 		return [];


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

**Easiest to review commit-by-commit**

* Split up `validate()` logic
  - Improved readability
  - Easier child class customization
    - e.g. `Setup/OCI` override (to avoid the dot check) is streamlined
* Eliminate magic property `$this->dbprettyname`
  - Makes the undefined property explicit and required (less psalm baseline noise)
  - Updated in all child classes
* Split up `initialize()` logic
  - Improved readability
  - Easier child class customization
* Split up `connect()` logic / extracted port and socket parsing to a helper function
  - Improved readability
  - Added helpful inline comments
  - Simplified primary/replica param merging (same outcome)
* Improved readability and logging in `runMigrations()`

Some misc minor robustness / modernization throughout.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
