### PR TITLE
fix(Propagator): Also skip groupfolders versions and trash entries

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -52,9 +52,14 @@ class Propagator implements IPropagator {
 		$storageId = $this->storage->getCache()->getNumericStorageId();
 
 		$parents = $this->getParents($internalPath);
-		if ($this->storage->instanceOfStorage(LocalRootStorage::class) && str_starts_with($internalPath, '__groupfolders')) {
-			// Remove '' and '__groupfolders'
-			$parents = array_slice($parents, 2);
+		if ($this->storage->instanceOfStorage(LocalRootStorage::class)) {
+			if (str_starts_with($internalPath, '__groupfolders/versions') || str_starts_with($internalPath, '__groupfolders/trash')) {
+				// Remove '', '__groupfolders' and '__groupfolders/versions' or '__groupfolders/trash'
+				$parents = array_slice($parents, 3);
+			} elseif (str_starts_with($internalPath, '__groupfolders')) {
+				// Remove '' and '__groupfolders'
+				$parents = array_slice($parents, 2);
+			}
 		}
 
 		if ($this->inBatch) {


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/58402.
The same locking issues also happen on `__groupfolders/versions` and while it is much less likely, I also extended it to cover `__groupfolders/trash` as well.