### PR TITLE
chore(previews): delete empty previews directory during migration

### DIFF
--- a/lib/private/Preview/PreviewMigrationService.php
+++ b/lib/private/Preview/PreviewMigrationService.php
@@ -83,6 +83,8 @@ class PreviewMigrationService {
 		}
 
 		if (empty($previewFiles)) {
+			$this->deleteFolder($internalPath);
+
 			return $previews;
 		}
 


### PR DESCRIPTION
## Summary

Empty preview directories are not deleted during migration