### PR TITLE
fix(Cron): Log WebCron access at INFO LEVEL

### DIFF
--- a/core/Service/CronService.php
+++ b/core/Service/CronService.php
@@ -226,7 +226,7 @@ class CronService {
 	private function runWeb(string $appMode): void {
 		if ($appMode === 'cron') {
 			// Cron is cron :-P
-			throw new \RuntimeException('Backgroundjobs are using system cron!');
+			$this->logger->info('WebCron accessed even though backgroundjobs_mode is set to use system cron.', ['app' => 'cron']);
 		} else {
 			// Work and success :-)
 			$job = $this->jobList->getNext();


### PR DESCRIPTION
Fixes #58470

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #58470 <!-- related github issue -->

## Summary

During a refactor (#55517), this error message was changed from only being sent (as web output) to the external caller (e.g. whatever this external service is that is calling your `/cron.php` URL via HTTP) to throwing a runtime exception and, as a result, then being logged on the instance now (albeit indirectly by throwing an exception).

This PR adjusts is so that:

- it no longer throws an exception that gets logged at level 3
- logs at info level only then returns silently

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
