### PR TITLE
test(user-picker): fix PHPUnit 12 dataprovider deprecations

### DIFF
--- a/apps/user_picker/tests/unit/Reference/ProfilePickerReferenceProviderTest.php
+++ b/apps/user_picker/tests/unit/Reference/ProfilePickerReferenceProviderTest.php
@@ -17,6 +17,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Profile\IProfileManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ProfilePickerReferenceProviderTest extends \Test\TestCase {

--- a/apps/user_picker/tests/unit/Reference/ProfilePickerReferenceProviderTest.php
+++ b/apps/user_picker/tests/unit/Reference/ProfilePickerReferenceProviderTest.php
@@ -273,9 +273,8 @@ class ProfilePickerReferenceProviderTest extends \Test\TestCase {
 
 	/**
 	 * Resolved reference should contain the expected reference fields according to account property scope
-	 *
-	 * @dataProvider resolveReferenceDataProvider
 	 */
+	#[DataProvider('resolveReferenceDataProvider')]
 	public function testResolveReference($expected, $reference, $userId) {
 		if (isset($userId)) {
 			$expectedReference = $this->setupUserAccountReferenceExpectation($userId);
@@ -291,15 +290,15 @@ class ProfilePickerReferenceProviderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider referenceDataProvider
 	 */
+	#[DataProvider('referenceDataProvider')]
 	public function testMatchReference($expected, $reference) {
 		$this->assertEquals($expected, $this->referenceProvider->matchReference($reference));
 	}
 
 	/**
-	 * @dataProvider cacheKeyDataProvider
 	 */
+	#[DataProvider('cacheKeyDataProvider')]
 	public function testGetCacheKey($expected, $reference) {
 		$this->assertEquals($expected, $this->referenceProvider->getCacheKey($reference));
 	}
@@ -319,16 +318,15 @@ class ProfilePickerReferenceProviderTest extends \Test\TestCase {
 	/**
 	 * Test getObjectId method.
 	 * It should return the userid extracted from the link (http(s)://domain.com/(index.php)/u/{userid}).
-	 *
-	 * @dataProvider objectIdDataProvider
 	 */
+	#[DataProvider('objectIdDataProvider')]
 	public function testGetObjectId($expected, $reference) {
 		$this->assertEquals($expected, $this->referenceProvider->getObjectId($reference));
 	}
 
 	/**
-	 * @dataProvider locationDataProvider
 	 */
+	#[DataProvider('locationDataProvider')]
 	public function testGetOpenStreetLocationUrl($expected, $location) {
 		$this->assertEquals($expected, $this->referenceProvider->getOpenStreetLocationUrl($location));
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Eliminates PHPUnit deprecation notices (due to @dataProvider use) that were introduced via #57539:

```
There were 5 PHPUnit test runner deprecations:

1) Metadata found in doc-comment for method OCA\UserPicker\Reference\ProfilePickerReferenceProviderTest::testResolveReference(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

2) Metadata found in doc-comment for method OCA\UserPicker\Reference\ProfilePickerReferenceProviderTest::testMatchReference(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

3) Metadata found in doc-comment for method OCA\UserPicker\Reference\ProfilePickerReferenceProviderTest::testGetCacheKey(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

4) Metadata found in doc-comment for method OCA\UserPicker\Reference\ProfilePickerReferenceProviderTest::testGetObjectId(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

5) Metadata found in doc-comment for method OCA\UserPicker\Reference\ProfilePickerReferenceProviderTest::testGetOpenStreetLocationUrl(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
