### PR TITLE
test(DbHandler): make sure auto-increment is reset in between tests

### DIFF
--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -43,7 +43,7 @@ class DbHandlerTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->connection->truncateTable($this->dbTable);
+		$this->connection->truncateTable($this->dbTable, false);
 		parent::tearDown();
 	}
 

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -43,9 +43,7 @@ class DbHandlerTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$query = $this->connection->getQueryBuilder()->delete($this->dbTable);
-		$query->executeStatement()
-		;
+		$this->connection->truncateTable($this->dbTable);
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
DELETE doesn't reset auto-increment; TRUNCATE does. Also probably faster.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

We're doing DELETE rather than TRUNCATE in tearDown(). The former does not reset auto-increment/identity columns on MySQL. Random failures like below with MySQL may be because of this. 

Would not be caught in setUp() by the assert on select() because that's based on count not id.

```
There was 1 failure:

1) OCA\Federation\Tests\DbHandlerTest::testRemove
Failed asserting that 5 is identical to 0.

/home/runner/actions-runner/_work/server/server/apps/federation/tests/DbHandlerTest.php:95
```

P.S. Though I'm discovering from looking at DBAL's code that even though DBAL implements getTruncateTableSQL() for all supported databases, it merely does a DELETE in SQLite... so we may need a wrapper function or something to truly take care of this universally across our tests (since I suspect we have other tests want to do real TRUNCATE/equivalents in).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
