### PR TITLE
fix(snowflake_ids): allow multiple instances with same temp directory

### DIFF
--- a/lib/private/Snowflake/FileSequence.php
+++ b/lib/private/Snowflake/FileSequence.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\Snowflake;
 
+use OC_Util;
 use OCP\ITempManager;
 use Override;
 
@@ -27,7 +28,7 @@ class FileSequence implements ISequence {
 	public function __construct(
 		ITempManager $tempManager,
 	) {
-		$this->workDir = $tempManager->getTempBaseDir() . '/' . self::LOCK_FILE_DIRECTORY;
+		$this->workDir = $tempManager->getTempBaseDir() . '/' . self::LOCK_FILE_DIRECTORY . '_' . OC_Util::getInstanceId();
 		$this->ensureWorkdirExists();
 	}
 


### PR DESCRIPTION
* Resolves: #58416

## Summary

Allows multiple instances to be setup on the same server, sharing the same `tempdirectory`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
