### PR TITLE
fix(theming): Fix favicon and touchicon ratios

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -144,9 +144,8 @@ class IconBuilder {
 				$y = $tmp->getImageHeight();
 				$tmp->destroy();
 				// set resolution for proper scaling
-				$resX = (int)(72 * $size / $x);
-				$resY = (int)(72 * $size / $y);
-				$appIconFile->setResolution($resX, $resY);
+				$res = (int)(72 * $size / max($x, $y));
+				$appIconFile->setResolution($res, $res);
 				$appIconFile->readImageBlob($svg);
 			} else {
 				// handle non-SVG images

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -297,11 +297,9 @@ class IconBuilderTest extends TestCase {
 			$x = $tmp->getImageWidth();
 			$y = $tmp->getImageHeight();
 			$tmp->destroy();
-			// set resolution for proper scaling
-			$resX = (int)(72 * $size / $x);
-			$resY = (int)(72 * $size / $y);
+			$res = (int)(72 * $size / max($x, $y));
 			$appIconFile->setBackgroundColor(new \ImagickPixel('transparent'));
-			$appIconFile->setResolution($resX, $resY);
+			$appIconFile->setResolution($res, $res);
 			$appIconFile->readImageBlob($svgContent);
 		} else {
 			$appIconFile->readImage($filePath);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/pull/58225#discussion_r2841091631

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
