### PR TITLE
fix(dav): [GET] set explicit Cache-Control to avoid relying on browser heuristics

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -278,6 +278,7 @@ class FilesPlugin extends ServerPlugin {
 			}
 		}
 		$response->addHeader('X-Accel-Buffering', 'no');
+		$response->addHeader('Cache-Control', 'private, no-cache, must-revalidate');
 	}
 
 	/**

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -641,6 +641,7 @@ class FilesPluginTest extends TestCase {
 		$calls = [
 			['Content-Disposition', $contentDispositionHeader],
 			['X-Accel-Buffering', 'no'],
+			['Cache-Control', 'private, no-cache, must-revalidate'],
 		];
 		$response
 			->expects($this->exactly(count($calls)))


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

On our DAV endpoints, we don't explicitly set Cache-Control. This means browser's use heuristics to decide the caching policy.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#default_settings

Among other things, this may help with matters like nextcloud/files_pdfviewer#1216 (without resorting to cache busting filenames).

Separately, but related, there's probably an opportunity audit across the board (public.php + others) - e.g. #45399

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
