### PR TITLE
fix(occ): Do not attempt to send headers on CLI

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -766,9 +766,10 @@ class OC {
 		self::checkConfig();
 		self::checkInstalled($systemConfig);
 
-		self::addSecurityHeaders();
-
-		self::performSameSiteCookieProtection($config);
+		if (!self::$CLI) {
+			self::addSecurityHeaders();
+			self::performSameSiteCookieProtection($config);
+		}
 
 		if (!defined('OC_CONSOLE')) {
 			$eventLogger->start('check_server', 'Run a few configuration checks');


### PR DESCRIPTION
## Summary

This avoids errors like 'Cannot modify header information - headers already sent', when using --debug-log with occ.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
