### PR TITLE
fix(db): add time_sensitive to oc_jobs index for maintenance window performance

### DIFF
--- a/core/Listener/AddMissingIndicesListener.php
+++ b/core/Listener/AddMissingIndicesListener.php
@@ -152,8 +152,8 @@ class AddMissingIndicesListener implements IEventListener {
 
 		$event->addMissingIndex(
 			'jobs',
-			'job_lastcheck_reserved',
-			['last_checked', 'reserved_at']
+			'job_lastcheck_timesens',
+			['last_checked', 'reserved_at', 'time_sensitive'],
 		);
 
 		$event->addMissingIndex(

--- a/core/Migrations/Version33000Date20260224000000.php
+++ b/core/Migrations/Version33000Date20260224000000.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Migrations;
+
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add time_sensitive column to the job_lastcheck_reserved index on oc_jobs.
+ *
+ * The cron background job scheduler query filters on three columns:
+ *   reserved_at <= ?, last_checked <= ?, AND time_sensitive = ?
+ *
+ * The old index only covered last_checked and reserved_at, forcing the
+ * database to do a full table scan to evaluate the time_sensitive predicate.
+ * Adding time_sensitive to the index allows the database to evaluate all
+ * three conditions using the index alone (covering index scan), significantly
+ * improving performance when a maintenance window is configured.
+ *
+ * @see https://github.com/nextcloud/server/issues/46126
+ */
+class Version33000Date20260224000000 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('jobs')) {
+			return null;
+		}
+
+		$table = $schema->getTable('jobs');
+
+		// Drop the old index that only covers last_checked and reserved_at
+		if ($table->hasIndex('job_lastcheck_reserved')) {
+			$table->dropIndex('job_lastcheck_reserved');
+		}
+
+		// Recreate the index with time_sensitive included.
+		// This allows the background job scheduler query to use a full index scan
+		// instead of a partial index + row lookup, improving performance when
+		// a maintenance window restricts which jobs are eligible to run.
+		if (!$table->hasIndex('job_lastcheck_timesens')) {
+			$table->addIndex(
+				['last_checked', 'reserved_at', 'time_sensitive'],
+				'job_lastcheck_timesens',
+			);
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
Fixes #46126

## Problem

The background job scheduler uses this query to pick the next job:

```sql
SELECT * FROM oc_jobs
WHERE reserved_at <= ?
  AND last_checked <= ?
  AND time_sensitive = ?
ORDER BY last_checked ASC
LIMIT ?
```

The old index `job_lastcheck_reserved` only covered `(last_checked, reserved_at)`. The database had to do a partial index scan and then fetch each row individually to evaluate `time_sensitive = ?`. Under load with a maintenance window this causes many unnecessary I/O operations since most rows are excluded by the `time_sensitive` condition.

## Solution

Drop `job_lastcheck_reserved` and replace it with `job_lastcheck_timesens` on `(last_checked, reserved_at, time_sensitive)`. Because the query's WHERE columns are now all in the index the database can use a covering index scan, evaluating the `time_sensitive` predicate without reading any data rows.

## Changes

### 1. New DB migration
`core/Migrations/Version33000Date20260224000000.php`

- Drops old index `job_lastcheck_reserved`
- Creates new index `job_lastcheck_timesens` with all three columns

### 2. AddMissingIndicesListener update
`core/Listener/AddMissingIndicesListener.php`

- Updated to reference the new index name and columns
- Ensures `occ db:add-missing-indices` repairs existing installations

## Impact

- Faster cron execution, especially when a maintenance window is active
- Reduces database I/O during background job scheduling
- No functional change — index covers the same query that already existed

Made with [Cursor](https://cursor.com)