### PR TITLE
fix: correctly return false for filesize on non-existing file

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -97,11 +97,15 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	}
 
 	public function filesize(string $path): int|float|false {
-		if ($this->is_dir($path)) {
-			return 0; //by definition
+		$type = $this->filetype($path);
+		if ($type === false) {
+			return false;
+		}
+		if ($type !== 'file') {
+			return 0;
 		} else {
 			$stat = $this->stat($path);
-			return isset($stat['size']) ? $stat['size'] : 0;
+			return $stat['size'] ?? 0;
 		}
 	}
 

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -218,7 +218,7 @@ class Local extends Common {
 	}
 
 	public function filetype(string $path): string|false {
-		$filetype = filetype($this->getSourcePath($path));
+		$filetype = @filetype($this->getSourcePath($path));
 		if ($filetype === 'link') {
 			$filetype = filetype(realpath($this->getSourcePath($path)));
 		}
@@ -226,7 +226,11 @@ class Local extends Common {
 	}
 
 	public function filesize(string $path): int|float|false {
-		if (!$this->is_file($path)) {
+		$type = $this->filetype($path);
+		if ($type === false) {
+			return false;
+		}
+		if ($type !== 'file') {
 			return 0;
 		}
 		$fullPath = $this->getSourcePath($path);

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -311,6 +311,8 @@ abstract class Storage extends \Test\TestCase {
 
 		$this->instance->unlink('/lorem.txt');
 		$this->assertTrue($this->instance->hasUpdated('/', $mtimeStart - 5));
+
+		$this->assertFalse($this->instance->filesize('/non-existing-file.txt'));
 	}
 
 	/**


### PR DESCRIPTION
The old `!$this->is_file($path)` was meant to handle the case of the `$path` being a folder, but also triggers for the case where `$path` doesn't exist by accident.

Added test for all storages to ensure that this behavior is consistent.