### PR TITLE
Fix inconsistency: Use themed manifest for PWA installations to avoid breaking user theming

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -386,6 +386,15 @@ class ThemingDefaults extends \OC_Defaults {
 			$route = $this->urlGenerator->linkToRoute('theming.Icon.getTouchIcon', ['app' => $app]);
 		}
 		if ($image === 'manifest.json') {
+			// Force instance branding for the installable shell manifest.
+			// `core` and `settings` ship a static manifest.json, but for PWAs we want
+			// the dynamic theming manifest so the app name/icon follow instance theming.
+			if ($app === 'core' || $app === 'settings') {
+				$route = $this->urlGenerator->linkToRoute('theming.Theming.getManifest', ['app' => 'core']);
+			}
+			if ($route !== false) {
+				return $route . '?v=' . $this->util->getCacheBuster();
+			}
 			try {
 				$appPath = $this->appManager->getAppPath($app);
 				if (file_exists($appPath . '/img/manifest.json')) {

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -386,14 +386,11 @@ class ThemingDefaults extends \OC_Defaults {
 			$route = $this->urlGenerator->linkToRoute('theming.Icon.getTouchIcon', ['app' => $app]);
 		}
 		if ($image === 'manifest.json') {
-			// Force instance branding for the installable shell manifest.
-			// `core` and `settings` ship a static manifest.json, but for PWAs we want
+			// Force instance branding for the installable web app manifest.
+			// `core` ships a static manifest.json, but for PWAs we want
 			// the dynamic theming manifest so the app name/icon follow instance theming.
 			if ($app === 'core' || $app === 'settings') {
-				$route = $this->urlGenerator->linkToRoute('theming.Theming.getManifest', ['app' => 'core']);
-			}
-			if ($route !== false) {
-				return $route . '?v=' . $this->util->getCacheBuster();
+				return $this->urlGenerator->linkToRoute('theming.Theming.getManifest', ['app' => 'core']) . '?v=' . $this->util->getCacheBuster();
 			}
 			try {
 				$appPath = $this->appManager->getAppPath($app);


### PR DESCRIPTION
…ll follow theme.

## Resolves - https://github.com/nextcloud/server/issues/56135

## Summary - Fix inconsistency: core/settings ship static manifests, which breaks instance branding in PWA installs. Force them to use the theming manifest so instance branding is consistent.

This PR also makes it possible to install an 'overall PWA' that stays with the instance branding applied in theme. (NOTE - the icon may still have an icon from the path if the path supplies a specific app icon, a plugin to setup an 'overall PWA' like those that were possible in older versions of NC will be made available in the near future. But this PR still fixes the naming issue being defaulted to Nextcloud and default icon.)


(Tested on NC33 installed server running installation from nextcloud/vm and updated to 33 via updater in the vm scripts. However, in theory any installation should work just fine. ) 
