### PR TITLE
fix(L10N): stop stripping _ from language codes

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -145,7 +145,7 @@ class Factory implements IFactory {
 		if ($lang === null) {
 			return null;
 		}
-		$lang = preg_replace('/[^a-zA-Z0-9.;,=-]/', '', $lang);
+		$lang = preg_replace('/[^a-zA-Z0-9.;,=_-]/', '', $lang);
 		return str_replace('..', '', $lang);
 	}
 

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -95,6 +95,7 @@ class FactoryTest extends TestCase {
 		return [
 			'null shortcut' => [null, null],
 			'default language' => ['de', 'de'],
+			'regional language' => ['de_DE', 'de_DE'],
 			'malicious language' => ['de/../fr', 'defr'],
 			'request language' => ['kab;q=0.8,ka;q=0.7,de;q=0.6', 'kab;q=0.8,ka;q=0.7,de;q=0.6'],
 		];


### PR DESCRIPTION
## Summary

Stops stripping `_` from language codes which breaks translations for all languages like `de_DE` and similar.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
