### PR TITLE
fix: Use configured loglevel even when log.condition matches is set

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -269,20 +269,9 @@ class Log implements ILogger, IDataLogger {
 			}
 		}
 
-		if (!isset($logCondition['matches'])) {
-			$configLogLevel = $this->config->getValue('loglevel', ILogger::WARN);
-			if (is_numeric($configLogLevel)) {
-				$this->nestingLevel--;
-				return min((int)$configLogLevel, ILogger::FATAL);
-			}
+		$logConditionMatches = $logCondition['matches'] ?? [];
 
-			// Invalid configuration, warn the user and fall back to default level of WARN
-			error_log('Nextcloud configuration: "loglevel" is not a valid integer');
-			$this->nestingLevel--;
-			return ILogger::WARN;
-		}
-
-		foreach ($logCondition['matches'] as $option) {
+		foreach ($logConditionMatches as $option) {
 			if (
 				(!isset($option['shared_secret']) || $this->checkLogSecret($option['shared_secret']))
 				&& (!isset($option['users']) || in_array($userId, $option['users'], true))
@@ -300,6 +289,14 @@ class Log implements ILogger, IDataLogger {
 			}
 		}
 
+		$configLogLevel = $this->config->getValue('loglevel', ILogger::WARN);
+		if (is_numeric($configLogLevel)) {
+			$this->nestingLevel--;
+			return min((int)$configLogLevel, ILogger::FATAL);
+		}
+
+		// Invalid configuration, warn the user and fall back to default level of WARN
+		error_log('Nextcloud configuration: "loglevel" is not a valid integer');
 		$this->nestingLevel--;
 		return ILogger::WARN;
 	}

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -159,6 +159,34 @@ class LoggerTest extends TestCase implements IWriter {
 		$this->assertEquals($expectedLogs, $this->getLogs());
 	}
 
+	public function testMatchesConditionIncreaseLoglevel(): void {
+		$this->config->expects($this->any())
+			->method('getValue')
+			->willReturnMap([
+				['loglevel', ILogger::WARN, ILogger::INFO],
+				['log.condition', [], ['matches' => [
+					[
+						'message' => 'catched',
+						'loglevel' => 3,
+					]
+				]]],
+			]);
+		$logger = $this->logger;
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')
+			->willReturn('test-userid');
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')
+			->willReturn($user);
+		$this->overwriteService(IUserSession::class, $userSession);
+
+		$logger->info('catched message');
+		$logger->info('info level message');
+
+		$this->assertEquals(['1 info level message'], $this->getLogs());
+	}
+
 	public function testLoggingWithDataArray(): void {
 		$this->mockDefaultLogLevel();
 		/** @var IWriter&MockObject */


### PR DESCRIPTION
Right now as soon as we have a `matches` setting for `log.condition`, we skip the default loglevel at:

https://github.com/nextcloud/server/blob/4d00f49757dad40195b6e533a5d20e8c2e1d0bed/lib/private/Log.php#L272-L283

and if the current logline does _not_ match, we always use `WARN`:
https://github.com/nextcloud/server/blob/4d00f49757dad40195b6e533a5d20e8c2e1d0bed/lib/private/Log.php#L303-L304

* Set the `loglevel` in `config.php` to `< WARN` (e.g. 1 for `INFO`)
* Define a `log.condition => matches` that does not match
* Observe that only warnings and above are logged

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
