### PR TITLE
feat(UserPlugin): Include teams in group search

### DIFF
--- a/core/Controller/ContactsMenuController.php
+++ b/core/Controller/ContactsMenuController.php
@@ -4,11 +4,11 @@
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\Core\Controller;
 
 use Exception;
 use OC\Contacts\ContactsMenu\Manager;
-use OC\Teams\TeamManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
@@ -38,12 +38,10 @@ class ContactsMenuController extends Controller {
 	public function index(?string $filter = null, ?string $teamId = null): array {
 		$entries = $this->manager->getEntries($this->userSession->getUser(), $filter);
 		if ($teamId !== null) {
-			/** @var TeamManager */
-			$teamManager = $this->teamManager;
-			$memberIds = $teamManager->getMembersOfTeam($teamId, $this->userSession->getUser()->getUID());
+			$memberIds = $this->teamManager->getMembersOfTeam($teamId, $this->userSession->getUser()->getUID());
 			$entries['contacts'] = array_filter(
 				$entries['contacts'],
-				fn (IEntry $entry) => in_array($entry->getProperty('UID'), $memberIds, true)
+				fn (IEntry $entry) => array_key_exists($entry->getProperty('UID'), $memberIds)
 			);
 		}
 		return $entries;

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -18,6 +18,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\IShare;
+use OCP\Teams\ITeamManager;
 use OCP\UserStatus\IManager as IUserStatusManager;
 use OCP\UserStatus\IUserStatus;
 
@@ -26,6 +27,7 @@ readonly class UserPlugin implements ISearchPlugin {
 		private IAppConfig $appConfig,
 		private IUserManager $userManager,
 		private IGroupManager $groupManager,
+		private ITeamManager $teamManager,
 		private IUserSession $userSession,
 		private IUserStatusManager $userStatusManager,
 		private IDBConnection $connection,
@@ -41,6 +43,7 @@ readonly class UserPlugin implements ISearchPlugin {
 
 		/** @var array<string, array{0: 'wide'|'exact', 1: IUser}> $users */
 		$users = [];
+		$lowerSearch = mb_strtolower($search);
 
 		$shareeEnumeration = $this->appConfig->getValueString('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		if ($shareeEnumeration) {
@@ -67,6 +70,23 @@ readonly class UserPlugin implements ISearchPlugin {
 							}
 						}
 					}
+
+					// If teams are enabled, also search in them
+					if ($this->teamManager->hasTeamSupport()) {
+						$teams = $this->teamManager->getTeamsForUser($currentUser->getUID());
+						foreach ($teams as $team) {
+							$usersInTeam = $this->teamManager->getMembersOfTeam($team->getId(), $currentUser->getUID());
+							foreach ($usersInTeam as $userId => $displayName) {
+								if (!str_contains(mb_strtolower($userId), $lowerSearch) && !str_contains(mb_strtolower($displayName), $lowerSearch)) {
+									continue;
+								}
+								$user = $this->userManager->get($userId);
+								if ($user !== null && $user->isEnabled()) {
+									$users[$userId] = ['wide', $user];
+								}
+							}
+						}
+					}
 				}
 
 				if ($shareeEnumerationRestrictToPhone) {
@@ -86,8 +106,6 @@ readonly class UserPlugin implements ISearchPlugin {
 			$shareeEnumerationFullMatchUserId = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_userid', 'yes') === 'yes';
 			$shareeEnumerationFullMatchEmail = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_email', 'yes') === 'yes';
 			$shareeEnumerationFullMatchIgnoreSecondDisplayName = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_dn', 'no') === 'yes';
-
-			$lowerSearch = mb_strtolower($search);
 
 			// Re-use the results from earlier if possible
 			$usersByDisplayName ??= $this->userManager->searchDisplayName($search, $limit, $offset);

--- a/lib/private/Teams/TeamManager.php
+++ b/lib/private/Teams/TeamManager.php
@@ -133,7 +133,9 @@ class TeamManager implements ITeamManager {
 	}
 
 	/**
-	 * @return string[]
+	 * Returns a mapping of user id to display name for all members of a given team.
+	 *
+	 * @return array<string, string> userId => displayName
 	 */
 	public function getMembersOfTeam(string $teamId, string $userId): array {
 		$team = $this->getTeam($teamId, $userId);
@@ -141,7 +143,11 @@ class TeamManager implements ITeamManager {
 			return [];
 		}
 		$members = $team->getInheritedMembers();
-		return array_map(fn ($member) => $member->getUserId(), $members);
+		$result = [];
+		foreach ($members as $member) {
+			$result[$member->getUserId()] = $member->getDisplayName();
+		}
+		return $result;
 	}
 
 	/**

--- a/lib/public/Teams/ITeamManager.php
+++ b/lib/public/Teams/ITeamManager.php
@@ -56,4 +56,23 @@ interface ITeamManager {
 	 * @since 33.0.0
 	 */
 	public function getTeamsForUser(string $userId): array;
+
+	/**
+	 * Returns a mapping of user ID to display name for all members of a given team.
+	 *
+	 * @param string $teamId ID of the team whose members are being queried
+	 * @param string $userId ID of the user from whose point of view the members are being queried
+	 *
+	 * @return array<string, string> userId => displayName
+	 * @since 34.0.0
+	 */
+	public function getMembersOfTeam(string $teamId, string $userId): array;
+
+	/**
+	 * Returns whether the Teams backend is available
+	 *
+	 * @return bool
+	 * @since 34.0.0
+	 */
+	public function hasTeamSupport(): bool;
 }

--- a/tests/Core/Controller/ContactsMenuControllerTest.php
+++ b/tests/Core/Controller/ContactsMenuControllerTest.php
@@ -9,18 +9,18 @@ namespace Tests\Controller;
 
 use OC\Contacts\ContactsMenu\Manager;
 use OC\Core\Controller\ContactsMenuController;
-use OC\Teams\TeamManager;
 use OCP\Contacts\ContactsMenu\IEntry;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Teams\ITeamManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ContactsMenuControllerTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private Manager&MockObject $contactsManager;
-	private TeamManager&MockObject $teamManager;
+	private ITeamManager&MockObject $teamManager;
 
 	private ContactsMenuController $controller;
 
@@ -30,7 +30,7 @@ class ContactsMenuControllerTest extends TestCase {
 		$request = $this->createMock(IRequest::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->contactsManager = $this->createMock(Manager::class);
-		$this->teamManager = $this->createMock(TeamManager::class);
+		$this->teamManager = $this->createMock(ITeamManager::class);
 
 		$this->controller = new ContactsMenuController(
 			$request,
@@ -86,7 +86,7 @@ class ContactsMenuControllerTest extends TestCase {
 		$this->teamManager->expects($this->once())
 			->method('getMembersOfTeam')
 			->with('team-id', 'current-user')
-			->willReturn(['member1', 'member3']);
+			->willReturn(['member1' => 'Member 1', 'member3' => 'Member 3']);
 
 		$response = $this->controller->index(teamId: 'team-id');
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* (Partly) Resolves: #58465 

## Summary

- Extend UserPlugin: If autocompletion is enabled for groups and the teams interface is available, also search in teams.

## Changes:

- Update the private getTeamsForUser() function to return a dict (user id => display name) instead of only user id
- Add the updated getTeamsForUser() and the preexisting hasTeamSupport() to the public ITeamManager class
- Previously there was only one usage of the private getTeamsForUser() -> Adjust it to the new return value (dict instead of array), use the public ITeamInterface instead of TeamInterface and adjust the mocks for testing.

## TODO

- There does not  seem to be unit tests for UserPlugin. I am not sure if I should add one to test the behaviour, if so I would need a bit of guidance

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [-] Screenshots before/after for front-end changes
- [-] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [-] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [-] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI

I used AI to adjust the test mocks and comments 🙂