### PR TITLE
[stable31] fix: pass only object key to deleteObjects call

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -267,8 +267,8 @@ class AmazonS3 extends Common {
 					$connection->deleteObjects([
 						'Bucket' => $this->bucket,
 						'Delete' => [
+							'Quiet' => true,
 							'Objects' => array_map(fn (array $object) => [
-								'ETag' => $object['ETag'],
 								'Key' => $object['Key'],
 							], $objects['Contents'])
 						]


### PR DESCRIPTION
Manual backport of #58582 