### PR TITLE
fix: improve logging around failed chunked object store uploads

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -801,7 +801,7 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 			}
 		} catch (S3MultipartUploadException|S3Exception $e) {
 			$this->logger->error(
-				'Could not complete multipart upload ' . $urn . ' with uploadId ' . $writeToken,
+				'Unable to complete multipart upload for "' . $urn . '" (uploadId: "' . $writeToken . '")',
 				[
 					'app' => 'objectstore',
 					'exception' => $e,
@@ -811,7 +811,7 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 				$this->objectStore->abortMultipartUpload($urn, $writeToken);
 			} catch (S3Exception $e) {
 				$this->logger->error(
-					'Failed to abort multi-part upload for ' . $urn . ' with uploadId ' . $writeToken,
+					'Unable to abort multipart upload for "' . $urn . '" (uploadId: "' . $writeToken . '") after completion error',
 					[
 						'app' => 'objectstore',
 						'exception' => $e,

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -818,7 +818,6 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 				$this->getCache()->update($stat['fileid'], $stat);
 			}
 		} catch (S3MultipartUploadException|S3Exception $e) {
-			$this->objectStore->abortMultipartUpload($urn, $writeToken);
 			$this->logger->error(
 				'Could not complete multipart upload ' . $urn . ' with uploadId ' . $writeToken,
 				[
@@ -826,6 +825,17 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 					'exception' => $e,
 				]
 			);
+			try {
+				$this->objectStore->abortMultipartUpload($urn, $writeToken);
+			} catch (S3Exception $e) {
+				$this->logger->error(
+					'Failed to abort multi-part upload for ' . $urn . ' with uploadId ' . $writeToken,
+					[
+						'app' => 'objectstore',
+						'exception' => $e,
+					]
+				);
+			}
 			throw new GenericFileException('Could not write chunked file');
 		}
 		return $size;

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -819,7 +819,7 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 			}
 		} catch (S3MultipartUploadException|S3Exception $e) {
 			$this->logger->error(
-				'Could not complete multipart upload ' . $urn . ' with uploadId ' . $writeToken,
+				'Unable to complete multipart upload for "' . $urn . '" (uploadId: "' . $writeToken . '")',
 				[
 					'app' => 'objectstore',
 					'exception' => $e,
@@ -829,7 +829,7 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 				$this->objectStore->abortMultipartUpload($urn, $writeToken);
 			} catch (S3Exception $e) {
 				$this->logger->error(
-					'Failed to abort multi-part upload for ' . $urn . ' with uploadId ' . $writeToken,
+					'Unable to abort multipart upload for "' . $urn . '" (uploadId: "' . $writeToken . '") after completion error',
 					[
 						'app' => 'objectstore',
 						'exception' => $e,


### PR DESCRIPTION
- Log the `completeMultipartUpload` error before trying to abort.
- Catch and log errors from the abort