### PR TITLE
chore: bypass slow password validation in integration tests

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, ldap, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, ldap, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite, apcu
           coverage: none
           ini-file: development
         env:
@@ -154,6 +154,7 @@ jobs:
           ./occ maintenance:install --verbose ${{ contains(matrix.test-suite,'ldap') && '--data-dir=/dev/shm/nc_int' || '' }} --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ config:system:set hashing_default_password --value=true --type=boolean
           ./occ app:enable security_softening
+          ./occ config:system:set memcache.local --value='\OC\Memcache\APCu'
 
       - name: Configure caching
         if: ${{ contains(matrix.test-suite,'ldap') }}

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -120,6 +120,13 @@ jobs:
           path: apps/activity
           ref: ${{ matrix.activity-versions }}
 
+      - name: Checkout Security-Softening app
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: icewind1991/security_softening
+          path: apps/security_softening
+
       - name: Set up php ${{ matrix.php-versions }}
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 #v2.36.0
         timeout-minutes: 5
@@ -146,6 +153,7 @@ jobs:
           mkdir data
           ./occ maintenance:install --verbose ${{ contains(matrix.test-suite,'ldap') && '--data-dir=/dev/shm/nc_int' || '' }} --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ config:system:set hashing_default_password --value=true --type=boolean
+          ./occ app:enable security_softening
 
       - name: Configure caching
         if: ${{ contains(matrix.test-suite,'ldap') }}

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -130,6 +130,13 @@ jobs:
           path: apps/activity
           ref: ${{ matrix.activity-versions }}
 
+      - name: Checkout Security-Softening app
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: icewind1991/security_softening
+          path: apps/security_softening
+
       - name: Set up php ${{ matrix.php-versions }}
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
@@ -157,6 +164,7 @@ jobs:
           mkdir data
           ./occ maintenance:install --verbose ${{ contains(matrix.test-suite,'ldap') && '--data-dir=/dev/shm/nc_int' || '' }} --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ config:system:set hashing_default_password --value=true --type=boolean
+          ./occ app:enable security_softening
 
       - name: Configure caching
         if: ${{ contains(matrix.test-suite,'ldap') }}

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, ldap, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, ldap, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite, apcu
           coverage: none
           ini-file: development
           ini-values: disable_functions=""
@@ -165,6 +165,7 @@ jobs:
           ./occ maintenance:install --verbose ${{ contains(matrix.test-suite,'ldap') && '--data-dir=/dev/shm/nc_int' || '' }} --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ config:system:set hashing_default_password --value=true --type=boolean
           ./occ app:enable security_softening
+          ./occ config:system:set memcache.local --value='\OC\Memcache\APCu'
 
       - name: Configure caching
         if: ${{ contains(matrix.test-suite,'ldap') }}


### PR DESCRIPTION
From early testing it looks like we spend 50%-60% of the runtime of integration tests doing password validation :see_no_evil: 

This enables the [security_softening](https://github.com/icewind1991/security_softening), which bypasses this by caching the password validation.