### PR TITLE
feat(files_external/s3): Harden S3 cache invalidation prefix matching

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -31,10 +31,6 @@ class AmazonS3 extends Common {
 	use S3ObjectTrait;
 
 	private LoggerInterface $logger;
-
-	public function needsPartFile(): bool {
-		return false;
-	}
 
 	/** @var CappedMemoryCache<array|false> */
 	private CappedMemoryCache $objectCache;
@@ -75,6 +71,10 @@ class AmazonS3 extends Common {
 
 	private function isRoot(string $path): bool {
 		return $path === '.';
+	}
+
+	public function needsPartFile(): bool {
+		return false;
 	}
 
 	private function cleanKey(string $path): string {

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -108,9 +108,11 @@ class AmazonS3 extends Common {
 
 	private function invalidateByPrefix($cache, string $prefix): void {
 		$keys = array_keys($cache->getData);
-		// drops any exact or prefix matched keys found
+		$descendantPrefix = rtrim($prefix, '/') . '/';
+
 		foreach ($keys as $existingKey) {
-			if (str_starts_with($existingKey, $prefix)) {
+			// drop any exact + prefix matched keys
+			if ($existingKey === $prefix || str_starts_with($existingKey, $descendantPrefix)) {
 				unset($cache[$existingKey]);
 			}
 		}

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -91,10 +91,13 @@ class AmazonS3 extends Common {
 	}
 
 	private function invalidateCache(string $prefix): void {
-		// OBJECTS: exact + prefix matched keys
+		if ($prefix === '') {
+			return; // or throw InvalidArgumentException?
+		}
+
 		$this->invalidateByPrefix($this->objectCache, $prefix);
-		// DIRECTORIES: exact + prefix matched keys
 		$this->invalidateByPrefix($this->directoryCache, $prefix);
+
 		// FILES: exact match keys only (not hierarchically)
 		unset($this->filesCache[$prefix]);
 

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -98,20 +98,16 @@ class AmazonS3 extends Common {
 		$this->invalidateByPrefix($this->objectCache, $prefix);
 		$this->invalidateByPrefix($this->directoryCache, $prefix);
 
-		// FILES: exact match keys only (not hierarchically)
+		// FILES: exact match keys only (not hierarchical)
 		unset($this->filesCache[$prefix]);
-
-		// Concerns:
-		//		- lack of prefix / keying convention normalization
-		//		- add guard if empty ('')
 	}
 
-	private function invalidateByPrefix($cache, string $prefix): void {
-		$keys = array_keys($cache->getData);
+	private function invalidateByPrefix(CappedMemoryCache $cache, string $prefix): void {
+		$keys = array_keys($cache->getData());
 		$descendantPrefix = rtrim($prefix, '/') . '/';
 
 		foreach ($keys as $existingKey) {
-			// drop any exact + prefix matched keys
+			// exact + normalized prefix matched keys
 			if ($existingKey === $prefix || str_starts_with($existingKey, $descendantPrefix)) {
 				unset($cache[$existingKey]);
 			}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Refactor `invalidateCache()` in `AmazonS3` (`files_external`) to improve safety and clarity by:

- guarding empty prefixes to prevent inadvertent cache wipeouts
- centralizing prefix invalidation in a helper to remove duplication
- applying consistent hierarchical key normalization to avoid over-broad prefix matches
- using exact-or-descendant key matching for hierarchical caches while keeping `filesCache` exact-key only (non-hierarchical) 
- removing redundant exact-key unsets already covered by invalidation logic

This reduces accidental over-invalidation and makes cache invalidation semantics explicit.

May improve performance by keeping cache hit rates healthier, but unlikely to be dramatic.

## TODO

- [ ] Double-check state/coverage of current tests in this area

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
