### PR TITLE
ci(performance): fix Unexpected input warning for profiler-branch

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -63,7 +63,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Run before measurements
-        uses: nextcloud/profiler@6801ee10fc80f10b444388fb6ca9b36ad8a2ea83
+        uses: nextcloud/profiler@6a74c915048285b35b8e1cd96c0835a635945044
         with:
           run: |
             curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run after measurements
         id: compare
-        uses: nextcloud/profiler@6801ee10fc80f10b444388fb6ca9b36ad8a2ea83
+        uses: nextcloud/profiler@6a74c915048285b35b8e1cd96c0835a635945044
         with:
           run: |
             curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Existing commit targets a version that supported profiler-branch parameter in the code, but not in the action.yml. Updates to a more recent commit.

Should fix this output in CI runs that trigger performance check:

```
Warning: Unexpected input(s) 'profiler-branch', valid inputs are ['run', 'output', 'compare-with']
```

Related context: nextcloud/profiler#334

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
