### PR TITLE
fix(files): use destination path for MKCOL during drag & drop folder upload

### DIFF
--- a/apps/files/src/services/DropService.ts
+++ b/apps/files/src/services/DropService.ts
@@ -124,7 +124,7 @@ export async function onDropExternalFiles(root: RootDirectory, destination: IFol
 			if (file instanceof Directory) {
 				try {
 					logger.debug('Processing directory', { relativePath })
-					await createDirectoryIfNotExists(relativePath)
+					await createDirectoryIfNotExists(join(destination.path, relativePath))
 					await uploadDirectoryContents(file, relativePath)
 				} catch (error) {
 					showError(t('files', 'Unable to create the directory {directory}', { directory: file.name }))


### PR DESCRIPTION
## Summary

- **Fix drag & drop folder upload**: `createDirectoryIfNotExists()` was called with a path relative to the user's DAV root instead of the destination folder, causing the MKCOL to be skipped entirely and the subsequent PUT to fail with a 404.

## Root cause

When dragging `folder_to_copy` into `cmdb/`:

1. `createDirectoryIfNotExists('/folder_to_copy')` checked if `/files/user/folder_to_copy` existed (the **source** folder)
2. It returned `true` → MKCOL was **skipped**
3. `uploader.upload()` correctly targeted `/files/user/cmdb/folder_to_copy/file.txt` via `destination.source`
4. → **404 Not Found** because `/cmdb/folder_to_copy/` was never created

The fix prepends `destination.path` so the existence check and MKCOL target the correct path: `/cmdb/folder_to_copy`.

## Related issues

- #17064 — MKCOL 405 on drag & drop folder upload (NC 16)
- #42136 — Drag & drop broken on NC 28
- #43954 — Can't drag & drop multiple folders (NC 28)
- #50584 — File drop folder fails (NC 31)
- #51806 — Drag & drop folder to public link fails (NC 31)
- #57035 — Drag & drop folder uploads fail (NC 32)

## Test plan

- [ ] Drag & drop a single folder with files into another folder → structure preserved
- [ ] Drag & drop nested folders (folder with subfolders) → all levels created
- [ ] Drag & drop a folder that already exists at destination → conflict handling works
- [ ] Drag & drop multiple folders simultaneously → all created
- [ ] Drag & drop to root level → works
- [ ] Drag & drop to a deeply nested destination → works
- [ ] Import button (file input) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)