### PR TITLE
fix(workflowengine): Fix list of checks being a list instead of array…

### DIFF
--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -616,9 +616,8 @@ class Manager implements IManager {
 	public function formatOperation(array $operation): array {
 		$checkIds = json_decode($operation['checks'], true);
 
-		/** @var list<WorkflowEngineCheck> $checks */
 		$checks = $this->getChecks($checkIds);
-		$operation['checks'] = $checks;
+		$operation['checks'] = array_values($checks);
 
 		/** @var list<class-string<IEntityEvent>> $events */
 		$events = json_decode($operation['events'], true) ?? [];


### PR DESCRIPTION
…<int, …>

## Steps
1. Create a flow 
  > <img width="1330" height="926" alt="grafik" src="https://github.com/user-attachments/assets/679edca2-2426-4429-b7ad-96e002915665" />

2. Reload the page
3. Seems psalm was right and I was wrong :see_no_evil: 
4. Regression from https://github.com/nextcloud/server/pull/58278


### Expected
Workflow shows

### Actual
Error about `some()` in console
<img width="728" height="510" alt="grafik" src="https://github.com/user-attachments/assets/dc927d39-c33f-49c4-93f3-17c713f686c3" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
