### PR TITLE
fix: Set files app lexicon strictness to IGNORE

### DIFF
--- a/apps/files/lib/ConfigLexicon.php
+++ b/apps/files/lib/ConfigLexicon.php
@@ -24,7 +24,7 @@ class ConfigLexicon implements ILexicon {
 	public const OVERWRITES_HOME_FOLDERS = 'overwrites_home_folders';
 
 	public function getStrictness(): Strictness {
-		return Strictness::NOTICE;
+		return Strictness::IGNORE;
 	}
 
 	public function getAppConfigs(): array {


### PR DESCRIPTION
Set strictness to IGNORE for now, until there's a chance to add more (and make the log output useful)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
