### PR TITLE
perf(files_external/S3): slightly optimize memory in opendir 

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -294,10 +294,11 @@ class AmazonS3 extends Common {
 
 	public function opendir(string $path) {
 		try {
-			$content = iterator_to_array($this->getDirectoryContent($path));
-			return IteratorDirectory::wrap(array_map(function (array $item) {
+			$content = $this->getDirectoryContent($path);
+			$names = array_map(function (array $item) {
 				return $item['name'];
-			}, $content));
+			}, iterator_to_array($content));
+			return IteratorDirectory::wrap($names);
 		} catch (S3Exception $e) {
 			return false;
 		}

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -302,6 +302,10 @@ class AmazonS3 extends Common {
 			}			
 			return IteratorDirectory::wrap($names);
 		} catch (S3Exception $e) {
+			$this->logger->error($e->getMessage(), [
+				'app' => 'files_external',
+				'exception' => $e,
+			]);
 			return false;
 		}
 	}

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -294,10 +294,12 @@ class AmazonS3 extends Common {
 
 	public function opendir(string $path) {
 		try {
-			$content = $this->getDirectoryContent($path);
-			$names = array_map(function (array $item) {
-				return $item['name'];
-			}, iterator_to_array($content));
+			$names = [];
+			foreach ($this->getDirectoryContent($path) as $item) {
+				if (isset($item['name'])) {
+					$names[] = $item['name'];
+				}
+			}			
 			return IteratorDirectory::wrap($names);
 		} catch (S3Exception $e) {
 			return false;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

* A small optimization from only carrying forward the key we care about into the final array.
* Also: slightly better variable naming and exception logging (rather than silently swallowing every `S3Exception`)

## TODO

- [ ] A much bigger win (in terms of memory/CPU usage for larger directories) would be a rewind-safe iterator. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
