### PR TITLE
style(buttons): remove conflicting !important style from Dashboard App

### DIFF
--- a/apps/dashboard/src/DashboardApp.vue
+++ b/apps/dashboard/src/DashboardApp.vue
@@ -672,7 +672,7 @@ export default {
 	&:hover,
 	&:focus,
 	&:active {
-		background-color: var(--color-background-hover)!important;
+		background-color: var(--color-background-hover);
 	}
 	&:focus-visible {
 		box-shadow: 0 0 0 4px var(--color-main-background) !important;


### PR DESCRIPTION
## Summary
This pull request makes a minor update to the styling in `DashboardApp.vue`, specifically by removing the `!important` flag from the `background-color` property for hover, focus, and active states as it conflicts with the dashboard buttons (specifically weather) active state.

Before:

<img width="240" height="150" alt="image" src="https://github.com/user-attachments/assets/25c4f336-0c1f-489a-9ef8-e368df7eebf3" />
<img width="240" height="150" alt="image" src="https://github.com/user-attachments/assets/5405f09a-6970-457f-9180-4f4c2f7a83f7" />
<img width="240" height="150" alt="image" src="https://github.com/user-attachments/assets/77589426-d540-4f7d-834b-80b71c582190" />


After:

<img width="240" height="150" alt="image" src="https://github.com/user-attachments/assets/25c4f336-0c1f-489a-9ef8-e368df7eebf3" />
<img width="240" height="150" alt="image" src="https://github.com/user-attachments/assets/5405f09a-6970-457f-9180-4f4c2f7a83f7" />
<img width="240" height="150" alt="image" src="https://github.com/user-attachments/assets/c17d5613-40a3-4f64-a5b3-1fdf7e53fdc8" />




## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
