### PR TITLE
[stable33] fix: show configuration options for external storage backends

### DIFF
--- a/apps/files_external/lib/Command/Backends.php
+++ b/apps/files_external/lib/Command/Backends.php
@@ -95,7 +95,7 @@ class Backends extends Base {
 	 */
 	private function formatConfiguration(array $parameters): array {
 		$configuration = array_filter($parameters, function (DefinitionParameter $parameter) {
-			return $parameter->isFlagSet(DefinitionParameter::FLAG_HIDDEN);
+			return !$parameter->isFlagSet(DefinitionParameter::FLAG_HIDDEN);
 		});
 		return array_map(function (DefinitionParameter $parameter) {
 			return $parameter->getTypeName();


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/58205


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary

The occ files_external_backends command is supposed to list available backends along with their configuration options.

For the SMB backend, only the timeout option is currently shown, while options like host, share, root, and domain are missing. This makes configuring external storage via occ complicated.

Since the timeout option is marked as hidden but still shown, while the other options are not, the logic needs to be inverted so that all relevant configuration options are displayed correctly.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
