### PR TITLE
docs(dav): correct `Node::touch` docblock and add property promotion

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -35,15 +35,10 @@ use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\INode;
 
 abstract class Node implements INode {
-	/**
-	 * The path to the current node
-	 */
+
+	// The path to the current node
 	protected string $path;
-
-	protected FileInfo $info;
-
 	protected IManager $shareManager;
-
 	protected \OCP\Files\Node $node;
 
 	/**
@@ -52,7 +47,7 @@ abstract class Node implements INode {
 	 */
 	public function __construct(
 		protected View $fileView,
-		FileInfo $info,
+		protected FileInfo $info,
 		?IManager $shareManager = null,
 	) {
 		$relativePath = $this->fileView->getRelativePath($info->getPath());
@@ -61,7 +56,6 @@ abstract class Node implements INode {
 		}
 
 		$this->path = $relativePath;
-		$this->info = $info;
 		$this->shareManager = $shareManager instanceof IManager ? $shareManager : Server::get(IManager::class);
 
 		if ($info instanceof Folder || $info instanceof File) {
@@ -157,9 +151,10 @@ abstract class Node implements INode {
 	}
 
 	/**
-	 *  sets the last modification time of the file (mtime) to the value given
-	 *  in the second parameter or to now if the second param is empty.
-	 *  Even if the modification time is set to a custom value the access time is set to now.
+	 * Sets the file's modification time (mtime) to the given Unix timestamp.
+	 *
+	 * @param string $mtime Valid Unix timestamp (seconds since epoch, must be > 1 day).
+	 * @throws \InvalidArgumentException If $mtime is not a valid timestamp.
 	 */
 	public function touch(string $mtime): void {
 		$mtime = $this->sanitizeMtime($mtime);

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -40,7 +40,9 @@ abstract class Node implements INode {
 
 	// The path to the current node
 	protected string $path;
+
 	protected IManager $shareManager;
+
 	protected \OCP\Files\Node $node;
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -37,15 +37,10 @@ use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\INode;
 
 abstract class Node implements INode {
-	/**
-	 * The path to the current node
-	 */
+
+	// The path to the current node
 	protected string $path;
-
-	protected FileInfo $info;
-
 	protected IManager $shareManager;
-
 	protected \OCP\Files\Node $node;
 
 	/**
@@ -54,7 +49,7 @@ abstract class Node implements INode {
 	 */
 	public function __construct(
 		protected View $fileView,
-		FileInfo $info,
+		protected FileInfo $info,
 		?IManager $shareManager = null,
 	) {
 		$relativePath = $this->fileView->getRelativePath($info->getPath());
@@ -63,7 +58,6 @@ abstract class Node implements INode {
 		}
 
 		$this->path = $relativePath;
-		$this->info = $info;
 		$this->shareManager = $shareManager instanceof IManager ? $shareManager : Server::get(IManager::class);
 
 		if ($info instanceof Folder || $info instanceof File) {
@@ -167,9 +161,10 @@ abstract class Node implements INode {
 	}
 
 	/**
-	 *  sets the last modification time of the file (mtime) to the value given
-	 *  in the second parameter or to now if the second param is empty.
-	 *  Even if the modification time is set to a custom value the access time is set to now.
+	 * Sets the file's modification time (mtime) to the given Unix timestamp.
+	 *
+	 * @param string $mtime Valid Unix timestamp (seconds since epoch, must be > 1 day).
+	 * @throws \InvalidArgumentException If $mtime is not a valid timestamp.
 	 */
 	public function touch(string $mtime): void {
 		$mtime = $this->sanitizeMtime($mtime);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Updates the `Node::touch()` docblock to match the implementation (instead of describing non-existent parameters) and promotes `FileInfo` to a constructor property.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
