### PR TITLE
fix(dav): add missing search_supports_creation_time and search_supports_upload_time to Capabilities return type

### DIFF
--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -20,7 +20,7 @@ class Capabilities implements ICapability {
 	}
 
 	/**
-	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
+	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, search_supports_creation_time: bool, search_supports_upload_time: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
 	 */
 	public function getCapabilities() {
 		$capabilities = [

--- a/apps/dav/openapi.json
+++ b/apps/dav/openapi.json
@@ -30,13 +30,21 @@
                         "type": "object",
                         "required": [
                             "chunking",
-                            "public_shares_chunking"
+                            "public_shares_chunking",
+                            "search_supports_creation_time",
+                            "search_supports_upload_time"
                         ],
                         "properties": {
                             "chunking": {
                                 "type": "string"
                             },
                             "public_shares_chunking": {
+                                "type": "boolean"
+                            },
+                            "search_supports_creation_time": {
+                                "type": "boolean"
+                            },
+                            "search_supports_upload_time": {
                                 "type": "boolean"
                             },
                             "bulkupload": {

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -31,6 +31,8 @@ class CapabilitiesTest extends TestCase {
 			'dav' => [
 				'chunking' => '1.0',
 				'public_shares_chunking' => true,
+				'search_supports_creation_time' => true,
+				'search_supports_upload_time' => true,
 			],
 		];
 		$this->assertSame($expected, $capabilities->getCapabilities());
@@ -51,6 +53,8 @@ class CapabilitiesTest extends TestCase {
 			'dav' => [
 				'chunking' => '1.0',
 				'public_shares_chunking' => true,
+				'search_supports_creation_time' => true,
+				'search_supports_upload_time' => true,
 				'bulkupload' => '1.0',
 			],
 		];
@@ -72,6 +76,8 @@ class CapabilitiesTest extends TestCase {
 			'dav' => [
 				'chunking' => '1.0',
 				'public_shares_chunking' => true,
+				'search_supports_creation_time' => true,
+				'search_supports_upload_time' => true,
 				'absence-supported' => true,
 				'absence-replacement' => true,
 			],

--- a/openapi.json
+++ b/openapi.json
@@ -1504,13 +1504,21 @@
                         "type": "object",
                         "required": [
                             "chunking",
-                            "public_shares_chunking"
+                            "public_shares_chunking",
+                            "search_supports_creation_time",
+                            "search_supports_upload_time"
                         ],
                         "properties": {
                             "chunking": {
                                 "type": "string"
                             },
                             "public_shares_chunking": {
+                                "type": "boolean"
+                            },
+                            "search_supports_creation_time": {
+                                "type": "boolean"
+                            },
+                            "search_supports_upload_time": {
                                 "type": "boolean"
                             },
                             "bulkupload": {


### PR DESCRIPTION
* Resolves: #

## Summary

Fix psalm error by adding missing search_supports_creation_time and search_supports_upload_time to Capabilities return type

Follow-up to #58562

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
