### PR TITLE
fix(files_external/S3): normalize paths in touch()

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -450,6 +450,17 @@ class AmazonS3 extends Common {
 	}
 
 	public function touch(string $path, ?int $mtime = null): bool {
+		if ($this->file_exists($path)) {
+			// If the object already exists, return false so the higher filesystem layer
+			// (View::touch()) can emulate touch by updating the cached mtime.
+			// This avoids an extra remote request against S3 and improves performance.
+			//
+			// Note: this does not change the object's native LastModified timestamp in S3.
+			// External consumers that only observe S3 metadata (not Nextcloud's cache) will
+			// not see the updated mtime.
+			return false;
+		}
+
 		if (is_null($mtime)) {
 			$mtime = time();
 		}
@@ -458,10 +469,6 @@ class AmazonS3 extends Common {
 		];
 
 		try {
-			if ($this->file_exists($path)) {
-				return false;
-			}
-
 			$mimeType = $this->mimeDetector->detectPath($path);
 			$this->getConnection()->putObject([
 				'Bucket' => $this->bucket,

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -477,7 +477,6 @@ class AmazonS3 extends Common {
 				'Metadata' => [
 					'lastmodified' => $lastModified,
 				],
-				'MetadataDirective' => 'REPLACE',
 			] + $this->getSSECParameters());
 			$this->testTimeout();
 		} catch (S3Exception $e) {

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -461,21 +461,22 @@ class AmazonS3 extends Common {
 			return false;
 		}
 
-		if (is_null($mtime)) {
+		if ($mtime === null) {
 			$mtime = time();
 		}
-		$metadata = [
-			'lastmodified' => gmdate(\DateTime::RFC1123, $mtime)
-		];
 
 		try {
 			$mimeType = $this->mimeDetector->detectPath($path);
+			$lastModified = gmdate(\DateTime::RFC1123, $mtime);
+
 			$this->getConnection()->putObject([
 				'Bucket' => $this->bucket,
 				'Key' => $this->cleanKey($path),
-				'Metadata' => $metadata,
 				'Body' => '',
 				'ContentType' => $mimeType,
+				'Metadata' => [
+					'lastmodified' => $lastModified,
+				],
 				'MetadataDirective' => 'REPLACE',
 			] + $this->getSSECParameters());
 			$this->testTimeout();
@@ -489,6 +490,12 @@ class AmazonS3 extends Common {
 
 		$this->invalidateCache($path);
 		return true;
+		// NOTES/WIP:
+		//	- Not sure we actually refer to the Metadata field's `lastmodified` value ever (we seem to use the S3 LastModified)
+		// 	- When $mtime = null, perhaps just rely on S3's automatic LastModified field?
+		//	- mtime handling possibly inconsistent with other remote storages (i.e. SMB) - TBD
+		//	- why isn't $this->normalizePath utilized? also cleanKey usage
+		//	- Is the MetadataDirective value correct?
 	}
 
 	public function copy(string $source, string $target, ?bool $isFile = null): bool {

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -450,6 +450,8 @@ class AmazonS3 extends Common {
 	}
 
 	public function touch(string $path, ?int $mtime = null): bool {
+		$path = $this->normalizePath($path);
+
 		if ($this->file_exists($path)) {
 			// If the object already exists, return false so the higher filesystem layer
 			// (View::touch()) can emulate touch by updating the cached mtime.
@@ -468,10 +470,11 @@ class AmazonS3 extends Common {
 		try {
 			$mimeType = $this->mimeDetector->detectPath($path);
 			$lastModified = gmdate(\DateTime::RFC1123, $mtime);
+			$key = $this->cleanKey($path);
 
 			$this->getConnection()->putObject([
 				'Bucket' => $this->bucket,
-				'Key' => $this->cleanKey($path),
+				'Key' => $key,
 				'Body' => '',
 				'ContentType' => $mimeType,
 				'Metadata' => [
@@ -494,7 +497,7 @@ class AmazonS3 extends Common {
 		// 	- When $mtime = null, perhaps just rely on S3's automatic LastModified field?
 		//	- mtime handling possibly inconsistent with other remote storages (i.e. SMB) - TBD
 		//	- why isn't $this->normalizePath utilized? also cleanKey usage
-		//	- Is the MetadataDirective value correct?
+		//	- mtime range validation guard?
 	}
 
 	public function copy(string $source, string $target, ?bool $isFile = null): bool {

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -468,10 +468,15 @@ class AmazonS3 extends Common {
 		}
 
 		try {
+			$key = $this->cleanKey($path);
 			$mimeType = $this->mimeDetector->detectPath($path);
 			$lastModified = gmdate(\DateTime::RFC1123, $mtime);
-			$key = $this->cleanKey($path);
 
+			// When creating a missing object via touch() and the caller provided a non-null $mtime,
+			// upper layers (View::touch()) will not emulate mtime (because we return true here).
+			// As a result, the cached mtime will reflect S3's LastModified (write time), not the
+			// requested $mtime. The custom 'lastmodified' metadata is currently not read by this
+			// storage when building stat()/filecache entries.
 			$this->getConnection()->putObject([
 				'Bucket' => $this->bucket,
 				'Key' => $key,
@@ -492,12 +497,6 @@ class AmazonS3 extends Common {
 
 		$this->invalidateCache($path);
 		return true;
-		// NOTES/WIP:
-		//	- Not sure we actually refer to the Metadata field's `lastmodified` value ever (we seem to use the S3 LastModified)
-		// 	- When $mtime = null, perhaps just rely on S3's automatic LastModified field?
-		//	- mtime handling possibly inconsistent with other remote storages (i.e. SMB) - TBD
-		//	- why isn't $this->normalizePath utilized? also cleanKey usage
-		//	- mtime range validation guard?
 	}
 
 	public function copy(string $source, string $target, ?bool $isFile = null): bool {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Normalizes the incoming path up front, ensuring consistent key derivation and cache invalidation for edge-case paths (leading/trailing slashes, root-like values).
  - The existence check called here already does this internally already, but others (i.e. `cleanKey()`) do not. Doing it upfront is more consistent with the rest of the class and avoids weird `Key` values.
- Clarifies the intended behavior via comments with regard to `mtime` handling at this layer: 
  - For existing objects we return `false` to let `View::touch()` emulate `mtime` updates in our filecache without performing a remote S3 operation
  - For `create-if-missing` the resulting cached `mtime` reflects S3’s `LastModified` rather than any caller-provided `$mtime` (since custom `lastmodified` metadata isn’t currently used even though we store it here).
- Some minor changes to improve code clarity

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
