### PR TITLE
refactor(files_external/SMB): modernize constructor + start unifying caching

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -95,8 +95,8 @@ class SMB extends Common implements INotifyStorage {
 		}
 
 		// Create server + share handles used by all subsequent filesystem operations.
-		$system = \OCP\Server::get(SystemBridge::class);
-		$serverFactory = new ServerFactory($options, $system);
+		$systemBridge = \OCP\Server::get(SystemBridge::class);
+		$serverFactory = new ServerFactory($options, $systemBridge);
 		$this->server = $serverFactory->createServer($parameters['host'], $auth);
 		$this->share = $this->server->getShare(trim($parameters['share'], '/'));
 
@@ -112,6 +112,7 @@ class SMB extends Common implements INotifyStorage {
 
 		// Per-instance metadata cache for stat() results.
 		$this->statCache = new CappedMemoryCache();
+
 		parent::__construct($parameters);
 	}
 

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -43,7 +43,6 @@ use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 class SMB extends Common implements INotifyStorage {
-
 	protected \Icewind\SMB\IServer $server;
 	protected \Icewind\SMB\IShare $share;
 	protected string $root;
@@ -110,10 +109,16 @@ class SMB extends Common implements INotifyStorage {
 		$this->caseSensitive = (bool)($parameters['case_sensitive'] ?? true);
 		$this->checkAcl = isset($parameters['check_acl']) && $parameters['check_acl'];
 
-		// Per-instance metadata cache for stat() results.
-		$this->statCache = new CappedMemoryCache();
-
+		$this->initCaches();
 		parent::__construct($parameters);
+	}
+
+	private function initCaches(): void {
+		$this->statCache = new CappedMemoryCache();
+	}
+
+	private function clearCaches(): void {
+		$this->statCache->clear();
 	}
 
 	private function splitUser(string $user): array {
@@ -497,7 +502,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 
 		try {
-			$this->statCache = new CappedMemoryCache();
+			$this->clearCaches();
 			$content = $this->share->dir($this->buildPath($path));
 			foreach ($content as $file) {
 				if ($file->isDirectory()) {

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -59,15 +59,7 @@ class SMB extends Common implements INotifyStorage {
 			throw new \Exception('Invalid configuration, no host provided');
 		}
 
-		// Resolve SMB authentication: prefer prebuilt auth, otherwise build from user/password.
-		if (isset($parameters['auth'])) {
-			$auth = $parameters['auth'];
-		} elseif (isset($parameters['user']) && isset($parameters['password']) && isset($parameters['share'])) {
-			[$workgroup, $user] = $this->splitUser($parameters['user']);
-			$auth = new BasicAuth($user, $workgroup, $parameters['password']);
-		} else {
-			throw new \Exception('Invalid configuration, no credentials provided');
-		}
+		$auth = $this->resolveAuth($parameters);
 
 		$this->logger = \OCP\Server::get(LoggerInterface::class);
 
@@ -97,9 +89,31 @@ class SMB extends Common implements INotifyStorage {
 		$this->checkAcl = isset($parameters['check_acl']) && $parameters['check_acl'];
 
 		$this->initCaches();
+
+		// Call parent last: SMB-specific dependencies/state must be initialized first.
 		parent::__construct($parameters);
 	}
 
+	/**
+	 * Resolve SMB authentication from config.
+	 *
+	 * Prefer prebuilt auth, otherwise build from user/password.
+	 *
+	 * @throws \Exception when credentials are missing/invalid
+	 */
+	private function resolveAuth(array $parameters) {
+		if (isset($parameters['auth'])) {
+			return $parameters['auth'];
+		}
+
+		if (isset($parameters['user']) && isset($parameters['password']) && isset($parameters['share'])) {
+			[$workgroup, $username] = $this->splitUser($parameters['user']);
+			return new BasicAuth($username, $workgroup, $parameters['password']);
+		}
+
+		throw new \Exception('Invalid configuration, no credentials provided');
+	}
+	
 	private function initCaches(): void {
 		$this->statCache = new CappedMemoryCache();
 	}

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -43,40 +43,24 @@ use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 class SMB extends Common implements INotifyStorage {
-	/**
-	 * @var \Icewind\SMB\IServer
-	 */
-	protected $server;
 
-	/**
-	 * @var \Icewind\SMB\IShare
-	 */
-	protected $share;
-
-	/**
-	 * @var string
-	 */
-	protected $root;
-
+	protected \Icewind\SMB\IServer $server;
+	protected \Icewind\SMB\IShare $share;
+	protected string $root;
 	/** @var CappedMemoryCache<IFileInfo> */
 	protected CappedMemoryCache $statCache;
-
-	/** @var LoggerInterface */
-	protected $logger;
-
-	/** @var bool */
-	protected $showHidden;
-
+	protected LoggerInterface $logger;
+	protected bool $showHidden;
 	private bool $caseSensitive;
-
-	/** @var bool */
-	protected $checkAcl;
+	protected bool $checkAcl;
 
 	public function __construct(array $parameters) {
+		// Validate required connection target
 		if (!isset($parameters['host'])) {
 			throw new \Exception('Invalid configuration, no host provided');
 		}
 
+		// Resolve SMB authentication: prefer prebuilt auth, otherwise build from user/password.
 		if (isset($parameters['auth'])) {
 			$auth = $parameters['auth'];
 		} elseif (isset($parameters['user']) && isset($parameters['password']) && isset($parameters['share'])) {
@@ -86,6 +70,8 @@ class SMB extends Common implements INotifyStorage {
 			throw new \Exception('Invalid configuration, no credentials provided');
 		}
 
+		// Use injected logger when provided; otherwise fall back to the server logger.
+		// @todo: I suspect $parameters['logger'] is legacy since I don't see it supported elsewhere...
 		if (isset($parameters['logger'])) {
 			if (!$parameters['logger'] instanceof LoggerInterface) {
 				throw new \Exception(
@@ -99,6 +85,7 @@ class SMB extends Common implements INotifyStorage {
 			$this->logger = \OCP\Server::get(LoggerInterface::class);
 		}
 
+		// Build SMB client options from configuration.
 		$options = new Options();
 		if (isset($parameters['timeout'])) {
 			$timeout = (int)$parameters['timeout'];
@@ -106,19 +93,24 @@ class SMB extends Common implements INotifyStorage {
 				$options->setTimeout($timeout);
 			}
 		}
+
+		// Create server + share handles used by all subsequent filesystem operations.
 		$system = \OCP\Server::get(SystemBridge::class);
 		$serverFactory = new ServerFactory($options, $system);
 		$this->server = $serverFactory->createServer($parameters['host'], $auth);
 		$this->share = $this->server->getShare(trim($parameters['share'], '/'));
 
+		// Normalize root to canonical internal form: leading slash, trailing slash.
 		$this->root = $parameters['root'] ?? '/';
 		$this->root = '/' . ltrim($this->root, '/');
 		$this->root = rtrim($this->root, '/') . '/';
 
+		// Normalize root to canonical internal form: leading slash, trailing slash.
 		$this->showHidden = isset($parameters['show_hidden']) && $parameters['show_hidden'];
 		$this->caseSensitive = (bool)($parameters['case_sensitive'] ?? true);
 		$this->checkAcl = isset($parameters['check_acl']) && $parameters['check_acl'];
 
+		// Per-instance metadata cache for stat() results.
 		$this->statCache = new CappedMemoryCache();
 		parent::__construct($parameters);
 	}

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -58,13 +58,32 @@ class SMB extends Common implements INotifyStorage {
 		if (!isset($parameters['host'])) {
 			throw new \Exception('Invalid configuration, no host provided');
 		}
-
+		// SMB auth
 		$auth = $this->resolveAuth($parameters);
-
+		// SMB client options
+		$options = $this->buildSmbOptions($parameters);
 		$this->logger = \OCP\Server::get(LoggerInterface::class);
+		// Create server + share handles used by all subsequent filesystem operations.
+		$systemBridge = \OCP\Server::get(SystemBridge::class);
+		$serverFactory = new ServerFactory($options, $systemBridge);
+		$this->server = $serverFactory->createServer($parameters['host'], $auth);
+		$this->share = $this->server->getShare(trim($parameters['share'], '/'));
+		// Normalize root to canonical internal form: leading slash, trailing slash.
+		$this->root = $parameters['root'] ?? '/';
+		$this->root = '/' . ltrim($this->root, '/');
+		$this->root = rtrim($this->root, '/') . '/';
+		// Normalize root to canonical internal form: leading slash, trailing slash.
+		$this->showHidden = isset($parameters['show_hidden']) && $parameters['show_hidden'];
+		$this->caseSensitive = (bool)($parameters['case_sensitive'] ?? true);
+		$this->checkAcl = isset($parameters['check_acl']) && $parameters['check_acl'];
+		$this->initCaches();
+		// Call parent last: SMB-specific dependencies/state must be initialized first.
+		parent::__construct($parameters);
+	}
 
-		// Build SMB client options from configuration.
+	private function buildSmbOptions(array $parameters): Options {
 		$options = new Options();
+
 		if (isset($parameters['timeout'])) {
 			$timeout = (int)$parameters['timeout'];
 			if ($timeout > 0) {
@@ -72,26 +91,7 @@ class SMB extends Common implements INotifyStorage {
 			}
 		}
 
-		// Create server + share handles used by all subsequent filesystem operations.
-		$systemBridge = \OCP\Server::get(SystemBridge::class);
-		$serverFactory = new ServerFactory($options, $systemBridge);
-		$this->server = $serverFactory->createServer($parameters['host'], $auth);
-		$this->share = $this->server->getShare(trim($parameters['share'], '/'));
-
-		// Normalize root to canonical internal form: leading slash, trailing slash.
-		$this->root = $parameters['root'] ?? '/';
-		$this->root = '/' . ltrim($this->root, '/');
-		$this->root = rtrim($this->root, '/') . '/';
-
-		// Normalize root to canonical internal form: leading slash, trailing slash.
-		$this->showHidden = isset($parameters['show_hidden']) && $parameters['show_hidden'];
-		$this->caseSensitive = (bool)($parameters['case_sensitive'] ?? true);
-		$this->checkAcl = isset($parameters['check_acl']) && $parameters['check_acl'];
-
-		$this->initCaches();
-
-		// Call parent last: SMB-specific dependencies/state must be initialized first.
-		parent::__construct($parameters);
+		return $options;
 	}
 
 	/**

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -69,20 +69,7 @@ class SMB extends Common implements INotifyStorage {
 			throw new \Exception('Invalid configuration, no credentials provided');
 		}
 
-		// Use injected logger when provided; otherwise fall back to the server logger.
-		// @todo: I suspect $parameters['logger'] is legacy since I don't see it supported elsewhere...
-		if (isset($parameters['logger'])) {
-			if (!$parameters['logger'] instanceof LoggerInterface) {
-				throw new \Exception(
-					'Invalid logger. Got '
-					. get_class($parameters['logger'])
-					. ' Expected ' . LoggerInterface::class
-				);
-			}
-			$this->logger = $parameters['logger'];
-		} else {
-			$this->logger = \OCP\Server::get(LoggerInterface::class);
-		}
+		$this->logger = \OCP\Server::get(LoggerInterface::class);
 
 		// Build SMB client options from configuration.
 		$options = new Options();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Minor changes to start unifying the structure with recent counterpart changes made in the AmazonS3 storage class:

- new helpers (cache management, SMB option building, SMB authentication resolver)
- constructor property promotion

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
