### PR TITLE
docs(config): explain auth failure retry delay for external storage

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2441,10 +2441,14 @@ $CONFIG = [
 	'quota_include_external_storage' => false,
 
 	/**
-	 * When an external storage is unavailable (e.g., due to failed authentication),
-	 * it is flagged as such for a specified duration. For authentication failures,
-	 * this delay can be customized to reduce the likelihood of account lockouts in
-	 * systems like Active Directory.
+	 * Delay (in seconds) before retrying an external storage after an
+	 * authentication-related failure (StorageAuthException).
+	 *
+	 * On auth failures, the storage is marked unavailable for this duration
+	 * to avoid repeated login attempts (for example, reducing risk of AD lockouts).
+	 *
+	 * The effective delay is clamped to a minimum of ``600`` seconds, so lower
+	 * values have no effect.
 	 *
 	 * Defaults to ``1800`` seconds (30 minutes)
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

:broom: 

Clarify auth retry delay behavior for external storage, including the hard-coded clamp value.

Some historical context: #16836

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
