### PR TITLE
docs(config): improve `filesystem_cache_readonly` docs

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2490,10 +2490,31 @@ $CONFIG = [
 	'mount_file' => '/var/www/nextcloud/data/mount.json',
 
 	/**
-	 * Prevent Nextcloud from updating the cache due to filesystem changes for all
-	 * storage.
+	 * Read-only mode for scan/detection reconciliation writes to filecache.
 	 *
-	 * Defaults to ``false``
+	 * When true, Nextcloud does not store filecache metadata changes that are
+	 * identified through scanner/change-detection reconciliation paths (global: 
+	 * all storages).
+	 *
+	 * Scope note:
+	 *
+	 * - Nextcloud-originated operations (UI/WebDAV/clients) are generally
+	 *   handled through normal application write paths and thus will still
+	 *   update filecache even when this is set to true.
+	 * - Reconciliation/refresh paths are prevented from writing back discovered
+	 *   metadata deltas while this is enabled.
+	 *
+	 * Practical effect:
+	 *
+	 * - Changes made directly on storage outside Nextcloud are generally not
+	 *   reflected while enabled.
+	 * - Some metadata-dependent behavior can appear stale until this parameter
+	 *   is disabled (permitting reconciliation writes again).
+	 *
+	 * Warning: This is an expert/global setting for specialized environments and
+	 * is intentionally not default-safe for general deployments.
+	 *
+	 * Defaults to ``false``.
 	 */
 	'filesystem_cache_readonly' => false,
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2493,7 +2493,7 @@ $CONFIG = [
 	 * Read-only mode for scan/detection reconciliation writes to filecache.
 	 *
 	 * When true, Nextcloud does not store filecache metadata changes that are
-	 * identified through scanner/change-detection reconciliation paths (global: 
+	 * identified through scanner/change-detection reconciliation paths (global:
 	 * all storages).
 	 *
 	 * Scope note:


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- Add more extensive explanation
- Explain interaction/relation to more commonly used option: `filesystem_check_changes`
- Add warning

Related: #58708

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
