### PR TITLE
fix(files_sharing): respect config to skip certificate verification

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -52,6 +52,7 @@ use OCP\Group\Events\GroupChangedEvent;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\Share\Events\BeforeShareDeletedEvent;
@@ -77,7 +78,8 @@ class Application extends App implements IBootstrap {
 				function () use ($c) {
 					return $c->get(Manager::class);
 				},
-				$c->get(ICloudIdManager::class)
+				$c->get(ICloudIdManager::class),
+				$c->get(IConfig::class),
 			);
 		});
 

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -26,6 +26,7 @@ use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -56,6 +57,7 @@ class Manager {
 		private ISetupManager $setupManager,
 		private ICertificateManager $certificateManager,
 		private ExternalShareMapper $externalShareMapper,
+		private IConfig $config,
 	) {
 		$this->user = $userSession->getUser();
 	}
@@ -113,6 +115,7 @@ class Manager {
 			'password' => $externalShare->getPassword(),
 			'mountpoint' => $externalShare->getMountpoint(),
 			'owner' => $externalShare->getOwner(),
+			'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates'),
 		];
 		return $this->mountShare($options, $user);
 	}

--- a/apps/files_sharing/lib/External/MountProvider.php
+++ b/apps/files_sharing/lib/External/MountProvider.php
@@ -17,6 +17,7 @@ use OCP\Files\Config\IPartialMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\Server;
@@ -37,6 +38,7 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 		private readonly IDBConnection $connection,
 		callable $managerProvider,
 		private readonly ICloudIdManager $cloudIdManager,
+		private IConfig $config,
 	) {
 		$this->managerProvider = $managerProvider;
 	}
@@ -50,6 +52,7 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 		$data['cloudId'] = $this->cloudIdManager->getCloudId($data['owner'], $data['remote']);
 		$data['certificateManager'] = Server::get(ICertificateManager::class);
 		$data['HttpClientService'] = Server::get(IClientService::class);
+		$data['verify'] = !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates');
 
 		return new Mount(self::STORAGE, $mountPoint, $data, $manager, $storageFactory);
 	}

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -30,6 +30,7 @@ use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\ICacheFactory;
 use OCP\ICertificateManager;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -71,6 +72,7 @@ class ManagerTest extends TestCase {
 	protected ISetupManager&MockObject $setupManager;
 	protected ICertificateManager&MockObject $certificateManager;
 	private ExternalShareMapper $externalShareMapper;
+	private IConfig $config;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -81,6 +83,7 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->cloudFederationProviderManager = $this->createMock(ICloudFederationProviderManager::class);
 		$this->cloudFederationFactory = $this->createMock(ICloudFederationFactory::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -119,7 +122,7 @@ class ManagerTest extends TestCase {
 			$this->contactsManager,
 			$this->createMock(IURLGenerator::class),
 			$this->userManager,
-		));
+		), $this->config);
 
 		$this->group1 = $this->createMock(IGroup::class);
 		$this->group1->expects($this->any())->method('getGID')->willReturn('group1');
@@ -169,6 +172,7 @@ class ManagerTest extends TestCase {
 					$this->setupManager,
 					$this->certificateManager,
 					$this->externalShareMapper,
+					$this->config,
 				]
 			)->onlyMethods(['tryOCMEndPoint'])->getMock();
 	}

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -54,6 +54,7 @@ class DAV extends Common {
 	protected $host;
 	/** @var bool */
 	protected $secure;
+	protected bool $verify;
 	/** @var string */
 	protected $root;
 	/** @var string */
@@ -108,12 +109,14 @@ class DAV extends Common {
 				$this->authType = $parameters['authType'];
 			}
 			if (isset($parameters['secure'])) {
+				$this->verify = $parameters['verify'] ?? true;
 				if (is_string($parameters['secure'])) {
 					$this->secure = ($parameters['secure'] === 'true');
 				} else {
 					$this->secure = (bool)$parameters['secure'];
 				}
 			} else {
+				$this->verify = false;
 				$this->secure = false;
 			}
 			if ($this->secure === true) {
@@ -157,6 +160,9 @@ class DAV extends Common {
 		$this->client->setThrowExceptions(true);
 
 		if ($this->secure === true) {
+			if ($this->verify === false) {
+				$this->client->addCurlSetting(CURLOPT_SSL_VERIFYPEER, false);
+			}
 			$certPath = $this->certManager->getAbsoluteBundlePath();
 			if (file_exists($certPath)) {
 				$this->certPath = $certPath;
@@ -363,7 +369,8 @@ class DAV extends Common {
 							'auth' => [$this->user, $this->password],
 							'stream' => true,
 							// set download timeout for users with slow connections or large files
-							'timeout' => $this->timeout
+							'timeout' => $this->timeout,
+							'verify' => $this->verify,
 						]);
 				} catch (\GuzzleHttp\Exception\ClientException $e) {
 					if ($e->getResponse() instanceof ResponseInterface
@@ -513,7 +520,8 @@ class DAV extends Common {
 				'body' => $source,
 				'auth' => [$this->user, $this->password],
 				// set upload timeout for users with slow connections or large files
-				'timeout' => $this->timeout
+				'timeout' => $this->timeout,
+				'verify' => $this->verify,
 			]);
 
 		$this->removeCachedFile($target);


### PR DESCRIPTION
This is important especially for local development, as certificate are self-signed.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Federated sharing is broken locally and on instances using `sharing.federation.allowSelfSignedCertificates` and connecting to instances with a self-signed SSL certificate. Since we have a config setting for this, let's use it :+1:

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
