### PR TITLE
docs(config): expand `quota_include_external_storage` docs

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2445,9 +2445,28 @@ $CONFIG = [
 	'localstorage.unlink_on_truncate' => false,
 
 	/**
-	 * EXPERIMENTAL: Include external storage in quota calculations.
+	 * Include external storage mounts in quota calculations.
 	 *
-	 * Defaults to ``false``
+	 * When enabled, user storage quotas will also include files stored on
+	 * external storage mounts (such as SMB, SFTP, S3, etc.) that are
+	 * configured for the user (either as personal or global/system mounts).
+	 *
+	 * Only files visible to the user at these mount points are counted towards
+	 * their quota. Files only visible to other users (on their own mounts) are
+	 * not counted.
+	 *
+	 * By default, system/global external storage mounts are shared: every user
+	 * given access sees the same files and folders from the external storage. To
+	 * have per-user isolation, configure the mount with user-specific path or
+	 * credentials, or utilize a personal mount.
+	 *
+	 * Enabling this option may impact performance if external storages are slow
+	 * or unreliable.
+	 *
+	 * Warning: This setting is considered EXPERIMENTAL and may not work with all
+	 * external storage backends.
+	 *
+	 * Defaults to ``false``.
 	 */
 	'quota_include_external_storage' => false,
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2434,9 +2434,28 @@ $CONFIG = [
 	'localstorage.unlink_on_truncate' => false,
 
 	/**
-	 * EXPERIMENTAL: Include external storage in quota calculations.
+	 * Include external storage mounts in quota calculations.
 	 *
-	 * Defaults to ``false``
+	 * When enabled, user storage quotas will also include files stored on
+	 * external storage mounts (such as SMB, SFTP, S3, etc.) that are
+	 * configured for the user (either as personal or global/system mounts).
+	 *
+	 * Only files visible to the user at these mount points are counted towards
+	 * their quota. Files only visible to other users (on their own mounts) are
+	 * not counted.
+	 *
+	 * By default, system/global external storage mounts are shared: every user
+	 * given access sees the same files and folders from the external storage. To
+	 * have per-user isolation, configure the mount with user-specific path or
+	 * credentials, or utilize a personal mount.
+	 *
+	 * Enabling this option may impact performance if external storages are slow
+	 * or unreliable.
+	 *
+	 * Warning: This setting is considered EXPERIMENTAL and may not work with all
+	 * external storage backends.
+	 *
+	 * Defaults to ``false``.
 	 */
 	'quota_include_external_storage' => false,
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- Add specifics about how it interacts with different scenarios
- Overall make the entry more informative for operators/admins

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
