### PR TITLE
fix updating cached mounts with multiple entries for root id

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -194,15 +194,15 @@ class UserMountCache implements IUserMountCache {
 
 	private function updateCachedMount(ICachedMountInfo $mount) {
 		$builder = $this->connection->getQueryBuilder();
+		$hash = hash('xxh128', $mount->getMountPoint());
 
 		$query = $builder->update('mounts')
 			->set('storage_id', $builder->createNamedParameter($mount->getStorageId()))
-			->set('mount_point', $builder->createNamedParameter($mount->getMountPoint()))
-			->set('mount_point_hash', $builder->createNamedParameter(hash('xxh128', $mount->getMountPoint())))
 			->set('mount_id', $builder->createNamedParameter($mount->getMountId(), IQueryBuilder::PARAM_INT))
 			->set('mount_provider_class', $builder->createNamedParameter($mount->getMountProvider()))
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($mount->getUser()->getUID())))
-			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)));
+			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($builder->expr()->eq('mount_point_hash', $builder->createNamedParameter($hash)));
 
 		$query->executeStatement();
 	}

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -184,7 +184,7 @@ class UserMountCacheTest extends TestCase {
 			->expects($this->exactly(2))
 			->method('dispatchTyped')
 			->with($this->callback(function (UserMountAddedEvent|UserMountRemovedEvent $event) use (&$operation) {
-				return match(++$operation) {
+				return match (++$operation) {
 					1 => $event instanceof UserMountAddedEvent && $event->mountPoint->getMountPoint() === '/asd/',
 					2 => $event instanceof UserMountRemovedEvent && $event->mountPoint->getMountPoint() === '/asd/',
 					default => false,
@@ -215,7 +215,7 @@ class UserMountCacheTest extends TestCase {
 			->expects($this->exactly(3))
 			->method('dispatchTyped')
 			->with($this->callback(function (UserMountAddedEvent|UserMountRemovedEvent $event) use (&$operation) {
-				return match(++$operation) {
+				return match (++$operation) {
 					1 => $event instanceof UserMountAddedEvent && $event->mountPoint->getMountPoint() === '/bar/',
 					2 => $event instanceof UserMountAddedEvent && $event->mountPoint->getMountPoint() === '/foo/',
 					3 => $event instanceof UserMountRemovedEvent && $event->mountPoint->getMountPoint() === '/bar/',
@@ -251,7 +251,7 @@ class UserMountCacheTest extends TestCase {
 			->expects($this->exactly(2))
 			->method('dispatchTyped')
 			->with($this->callback(function (UserMountAddedEvent|UserMountUpdatedEvent $event) use (&$operation) {
-				return match(++$operation) {
+				return match (++$operation) {
 					1 => $event instanceof UserMountAddedEvent && $event->mountPoint->getMountPoint() === '/foo/',
 					2 => $event instanceof UserMountUpdatedEvent && $event->oldMountPoint->getMountId() === null && $event->newMountPoint->getMountId() === 1,
 					default => false,
@@ -595,5 +595,28 @@ class UserMountCacheTest extends TestCase {
 		$cachedMounts = $this->cache->getMountsForUser($user1);
 		$this->assertCount(1, $cachedMounts);
 		$this->assertEquals('dummy', $cachedMounts[$this->keyForMount($mount1)]->getMountProvider());
+	}
+
+	public function testChangedSameRootId(): void {
+		$user = $this->userManager->get('u1');
+
+		[$storage] = $this->getStorage(10);
+		$mount1 = new MountPoint($storage, '/asd/');
+		$mount2 = new MountPoint($storage, '/asd2/');
+
+		$this->cache->registerMounts($user, [$mount1, $mount2]);
+
+		$mount2 = new MountPoint($storage, '/asd2/', null, null, null, 1);
+		$this->cache->registerMounts($user, [$mount1, $mount2]);
+
+		$this->cache->flush();
+		$cached = $this->cache->getMountsForUser($user);
+		usort($cached, fn (ICachedMountInfo $a, ICachedMountInfo $b) => $a->getMountPoint() <=> $b->getMountPoint());
+
+		$mountPoints = array_map(fn (ICachedMountInfo $mountInfo) => $mountInfo->getMountPoint(), $cached);
+		$this->assertEquals(['/asd/', '/asd2/'], $mountPoints);
+
+		$mountIds = array_map(fn (ICachedMountInfo $mountInfo) => $mountInfo->getMountId(), $cached);
+		$this->assertEquals([null, 1], $mountIds);
 	}
 }


### PR DESCRIPTION
- Also filter for `mount_point_hash`
- We don't need to update the `mount_point` since if that changes they won't be counted as "changed mounts"