### PR TITLE
docs(config): `part_file_in_storage` only applies to non-chunked

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2473,12 +2473,24 @@ $CONFIG = [
 	'filesystem_check_changes' => 0,
 
 	/**
-	 * Store part files created during upload in the same storage as the upload
-	 * target. Setting this to false stores part files in the root of the user's
-	 * folder, which may be necessary for external storage with limited rename
-	 * capabilities.
+	 * Control where temporary ".part" files are written during direct (non-chunked)
+	 * uploads.
 	 *
-	 * Defaults to ``true``
+	 * While an upload is in progress, Nextcloud writes data to a temporary ".part"
+	 * file and renames it to the final filename when the upload completes.
+	 *
+	 * - true: create the temporary ".part" file in the destination storage/path.
+	 *   This typically avoids cross-storage moves and can improve reliability and
+	 *   performance on backends where rename within the same storage is cheap/atomic.
+	 * - false: create the temporary ".part" file in the user's root folder first.
+	 *   This may help with some external storages that have limited rename/move
+	 *   behavior, but can add extra copy/move overhead.
+	 *
+	 * Note: This setting applies to direct (non-chunked) uploads only. Chunked/
+	 * resumable uploads use a separate uploads staging mechanism and are not
+	 * controlled by this option.
+	 *
+	 * Defaults to ``true``.
 	 */
 	'part_file_in_storage' => true,
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Having this parameter is a bit confusing since it doesn't apply to chunked uploading at all.

- Clarified use cases
- Added performance note

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
