### PR TITLE
fix(DB): Ignore intentionally missing fs_storage_path_prefix index on PostgreSQL

### DIFF
--- a/core/Listener/AddMissingIndicesListener.php
+++ b/core/Listener/AddMissingIndicesListener.php
@@ -12,11 +12,16 @@ namespace OC\Core\Listener;
 use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IDBConnection;
 
 /**
  * @template-implements IEventListener<AddMissingIndicesEvent>
  */
 class AddMissingIndicesListener implements IEventListener {
+	public function __construct(
+		private readonly IDBConnection $connection,
+	) {
+	}
 
 	public function handle(Event $event): void {
 		if (!($event instanceof AddMissingIndicesEvent)) {
@@ -54,12 +59,14 @@ class AddMissingIndicesListener implements IEventListener {
 			'fs_size',
 			['size']
 		);
-		$event->addMissingIndex(
-			'filecache',
-			'fs_storage_path_prefix',
-			['storage', 'path'],
-			['lengths' => [null, 64]]
-		);
+		if ($this->connection->getDatabaseProvider() !== IDBConnection::PLATFORM_POSTGRES) {
+			$event->addMissingIndex(
+				'filecache',
+				'fs_storage_path_prefix',
+				['storage', 'path'],
+				['lengths' => [null, 64]]
+			);
+		}
 		$event->addMissingIndex(
 			'filecache',
 			'fs_parent',


### PR DESCRIPTION
The index is not created on PostgreSQL in the migration: https://github.com/nextcloud/server/blob/c29c7023d9eaa244dacac55da30b75e4baaa6437/core/Migrations/Version13000Date20170718121200.php#L243-L245

Any new instance with PostgreSQL shows a warning for this missing index.
When the index was added in https://github.com/nextcloud/server/pull/28541 it was correctly excluded, but the condition got lost in some refactoring.