### PR TITLE
[stable32] feat: Add memcache_customprefix

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1688,6 +1688,16 @@ $CONFIG = [
 'memcache.distributed' => '\\OC\\Memcache\\Memcached',
 
 /**
+ * Cache Key Prefix for Redis or Memcached
+ *
+ * * Used for avoiding collisions in the cache system
+ * * May be used for ACL restrictions in Redis
+ *
+ * Defaults to ``''`` (empty string)
+ */
+'memcache_customprefix' => 'mycustomprefix',
+
+/**
  * Connection details for Redis to use for memory caching in a single server configuration.
  *
  * For enhanced security, it is recommended to configure Redis

--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -113,6 +113,7 @@ class Factory implements ICacheFactory {
 	protected function getGlobalPrefix(): string {
 		if ($this->globalPrefix === null) {
 			$config = \OCP\Server::get(SystemConfig::class);
+			$customprefix = $config->getValue('memcache_customprefix', '');
 			$maintenanceMode = $config->getValue('maintenance', false);
 			$versions = [];
 			if ($config->getValue('installed', false) && !$maintenanceMode) {
@@ -129,7 +130,7 @@ class Factory implements ICacheFactory {
 			// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
 			$instanceid = $config->getValue('instanceid');
 			$installedApps = implode(',', array_keys($versions)) . implode(',', array_values($versions));
-			$this->globalPrefix = hash('xxh128', $instanceid . $installedApps);
+			$this->globalPrefix = $customprefix . hash('xxh128', $instanceid . $installedApps);
 		}
 		return $this->globalPrefix;
 	}
@@ -143,9 +144,11 @@ class Factory implements ICacheFactory {
 	public function withServerVersionPrefix(\Closure $closure): void {
 		$backupPrefix = $this->globalPrefix;
 
+		$config = \OCP\Server::get(SystemConfig::class);
+		$customprefix = $config->getValue('memcache_customprefix', '');
 		// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
-		$instanceid = \OCP\Server::get(SystemConfig::class)->getValue('instanceid');
-		$this->globalPrefix = hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
+		$instanceid = $config->getValue('instanceid');
+		$this->globalPrefix = $customprefix . hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
 		$closure($this);
 		$this->globalPrefix = $backupPrefix;
 	}


### PR DESCRIPTION
Closes https://github.com/nextcloud/server/pull/58740

Backport of https://github.com/nextcloud/server/pull/58705

Did it manually again as the backportbot did a poor job with https://github.com/nextcloud/server/pull/58740

## Checklist

- [ ] Review and resolve any conflicts
- [ ] Amend HEAD commit to remove the line stating to skip CI