### PR TITLE
fix(encryption): cache decrypted master key in APCu to avoid PBKDF2 on every request

### DIFF
--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -131,8 +131,34 @@ class KeyManager {
 		}
 
 		if (!$this->session->isPrivateKeySet()) {
-			$masterKey = $this->getSystemPrivateKey($this->masterKeyId);
-			$decryptedMasterKey = $this->crypt->decryptPrivateKey($masterKey, $this->getMasterKeyPassword(), $this->masterKeyId);
+			// Check APCu cache first to avoid expensive PBKDF2 decryption on every request.
+			// DAV/API clients using HTTP Basic Auth create a new PHP session on every request,
+			// so the session never has the private key set. Without caching, decryptPrivateKey()
+			// would run on EVERY request, calling generatePasswordHash() with 600,000 PBKDF2 iterations.
+			// APCu is safe here: all PHP-FPM workers run as www-data and already have full
+			// read access to all user files. Caching the decrypted master key does not expand
+			// the attack surface.
+			$cacheKey = $this->getMasterKeyCacheKey();
+			$decryptedMasterKey = null;
+
+			if (function_exists('apcu_fetch') && apcu_enabled()) {
+				$cached = apcu_fetch($cacheKey, $success);
+				if ($success) {
+					$decryptedMasterKey = $cached;
+				}
+			}
+
+			if ($decryptedMasterKey === null) {
+				// Cache miss: decrypt the master key (expensive PBKDF2 operation)
+				$masterKey = $this->getSystemPrivateKey($this->masterKeyId);
+				$decryptedMasterKey = $this->crypt->decryptPrivateKey($masterKey, $this->getMasterKeyPassword(), $this->masterKeyId);
+
+				if ($decryptedMasterKey !== false && function_exists('apcu_store') && apcu_enabled()) {
+					// Store in APCu with 1 hour TTL - key rotation would require process restart anyway
+					apcu_store($cacheKey, $decryptedMasterKey, 3600);
+				}
+			}
+
 			if ($decryptedMasterKey === false) {
 				$this->logger->error('A public master key is available but decrypting it failed. This should never happen.');
 			} else {
@@ -662,6 +688,19 @@ class KeyManager {
 	 */
 	public function getMasterKeyId() {
 		return $this->masterKeyId;
+	}
+
+	/**
+	 * Get APCu cache key for decrypted master private key
+	 *
+	 * Cache key is stable per Nextcloud instance, no user data in key.
+	 * Format: nc_enc_mk_{instanceId}_{masterKeyId}
+	 *
+	 * @return string
+	 */
+	private function getMasterKeyCacheKey(): string {
+		$instanceId = $this->config->getSystemValueString('instanceid', '');
+		return 'nc_enc_mk_' . $instanceId . '_' . $this->masterKeyId;
 	}
 
 	/**


### PR DESCRIPTION
## Problem

DAV/API clients using HTTP Basic Auth (Thunderbird CalDAV, WebDAV mounts, mobile sync clients, etc.) experience ~800-900ms overhead on **every non-static HTTP request** when server-side encryption (SSE) with master key mode is enabled.

### Root cause

`validateMasterKey()` in `KeyManager.php` has an existing guard:

```php
if (!$this->session->isPrivateKeySet()) {
    $decryptedMasterKey = $this->crypt->decryptPrivateKey(...);
    $this->session->setPrivateKey($decryptedMasterKey);
}
```

This guard works correctly for **browser users** (cookie sessions persist the private key across requests). But **Basic Auth clients create a new PHP session on every request** — the session is always empty, so `decryptPrivateKey()` runs unconditionally on every request.

`decryptPrivateKey()` calls `generatePasswordHash()` with **600,000 PBKDF2-SHA256 iterations** (for `keyFormat: hash2`). This is intentionally slow for brute-force resistance, but it means every API/DAV request pays ~800-900ms of pure CPU cost.

### Profiling evidence (local deployment, files on local disk — ruling out network IO)

```
framework init:      296ms
keymanager init:       6ms
validateShareKey:     76ms
validateMasterKey:   873ms
  ├─ read master key:   35ms
  └─ decrypt master key: 866ms  ← entirely PBKDF2
```

This matches the report in #47092.

## Fix

Add an APCu in-process cache for the decrypted master private key in `validateMasterKey()`.

- **Cache key**: `nc_enc_mk_{instanceId}_{masterKeyId}` — stable per NC instance, no user data in key
- **TTL**: 3600 seconds (1 hour)
- **Fallback**: If APCu is not available (`!function_exists('apcu_fetch')` or `!apcu_enabled()`), falls back to the existing session-based behavior unchanged
- **Security**: All PHP-FPM workers already run as `www-data` with full read access to all user files. Caching the decrypted master key in APCu does not expand the attack surface

## Impact

- **Before**: Every Basic Auth request → 600k PBKDF2 iterations → ~800-900ms overhead
- **After**: First request per worker process → decrypt + cache; subsequent requests → APCu lookup (~microseconds)

## Related

Closes #47092