### PR TITLE
fix(files): add name attribute to default view radio group

### DIFF
--- a/apps/files/src/components/FilesAppSettings/FilesAppSettingsGeneral.vue
+++ b/apps/files/src/components/FilesAppSettings/FilesAppSettingsGeneral.vue
@@ -37,6 +37,7 @@ const store = useUserConfigStore()
 		</NcFormBox>
 		<NcRadioGroup
 			v-model="store.userConfig.default_view"
+			name="default_view"
 			:label="t('files', 'Default view')"
 			@update:modelValue="store.update('default_view', $event)">
 			<NcRadioGroupButton :label="t('files', 'All files')" value="files">


### PR DESCRIPTION
Fixes #58729

## Summary
Added `name="default_view"` to the `NcRadioGroup` component in `FilesAppSettingsGeneral.vue` so the underlying radio buttons are properly grouped with a shared `name` attribute.

This enables keyboard navigation between radio options using arrow keys, improving accessibility as described in the [HTML radio button spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/radio#defining_a_radio_group).

## Test plan
1. Open Files app settings
2. Navigate to "Default view" radio buttons with keyboard
3. Verify arrow keys now switch between "All files" and "Personal files"