### PR TITLE
fix(sharebymail): hide Forgot Password when send password by mail is disabled

### DIFF
--- a/apps/files/src/components/FilesAppSettings/FilesAppSettingsGeneral.vue
+++ b/apps/files/src/components/FilesAppSettings/FilesAppSettingsGeneral.vue
@@ -37,6 +37,7 @@ const store = useUserConfigStore()
 		</NcFormBox>
 		<NcRadioGroup
 			v-model="store.userConfig.default_view"
+			name="default_view"
 			:label="t('files', 'Default view')"
 			@update:modelValue="store.update('default_view', $event)">
 			<NcRadioGroupButton :label="t('files', 'All files')" value="files">

--- a/core/templates/publicshareauth.php
+++ b/core/templates/publicshareauth.php
@@ -11,11 +11,13 @@
 
 $initialState = \OCP\Server::get(\OCP\IInitialStateService::class);
 $initialState->provideInitialState('files_sharing', 'sharingToken', $_['share']->getToken());
+$config = \OCP\Server::get(\OCP\IConfig::class);
+$sendPasswordByMail = $config->getAppValue('sharebymail', 'sendpasswordmail', 'yes') === 'yes';
 $initialState->provideInitialState('core', 'publicShareAuth', [
 	'identityOk' => $_['identityOk'] ?? null,
 	'shareType' => $_['share']->getShareType(),
 	'invalidPassword' => $_['wrongpw'] ?? null,
-	'canResendPassword' => $_['share']->getShareType() === \OCP\Share\IShare::TYPE_EMAIL && !$_['share']->getSendPasswordByTalk(),
+	'canResendPassword' => $_['share']->getShareType() === \OCP\Share\IShare::TYPE_EMAIL && !$_['share']->getSendPasswordByTalk() && $sendPasswordByMail,
 ]);
 ?>
 


### PR DESCRIPTION
Fixes #58748

## Summary
When the admin setting "Send password by mail" is disabled in Share by Mail settings, the "Forgot Password?" button on public share auth pages was still visible. Clicking it would generate a new password that was never sent to the external user, effectively breaking their access to the shared file.

This fix checks the `sharebymail:sendpasswordmail` app config value and only shows the "Forgot Password?" button when mail sending is enabled. This aligns with the behavior in `ShareByMailProvider::sendPassword()` which already checks this setting.

## Changes
- `core/templates/publicshareauth.php`: Added check for `sendpasswordmail` app config to the `canResendPassword` flag

## Test plan
1. Disable "Send password by mail" in admin settings under Share by Mail
2. Create a password-protected share via email
3. Open the public share link
4. Verify "Forgot Password?" button is NOT shown
5. Re-enable "Send password by mail"
6. Verify "Forgot Password?" button IS shown again