### PR TITLE
Add 'user_migration' to relevant quick presets

### DIFF
--- a/lib/private/Config/PresetManager.php
+++ b/lib/private/Config/PresetManager.php
@@ -243,11 +243,15 @@ class PresetManager {
 					'disabled' => []],
 			Preset::SHARED
 				=> [
-					'enabled' => ['external','twofactor_backupcodes','twofactor_totp','twofactor_webauthn'],
+					'enabled' => ['external','twofactor_backupcodes','twofactor_totp','twofactor_webauthn', 'user_migration'],
 					'disabled' => ['user_status']],
 			Preset::PRIVATE
 				=> [
-					'enabled' => ['twofactor_backupcodes','twofactor_totp','twofactor_webauthn'],
+					'enabled' => ['twofactor_backupcodes','twofactor_totp','twofactor_webauthn', 'user_migration'],
+					'disabled' => []],
+			Preset::CLUB, Preset::FAMILY, Preset::SCHOOL, Preset::UNIVERSITY,
+				=> [
+					'enabled' => ['user_migration'],
 					'disabled' => []],
 			default => ['enabled' => [], 'disabled' => []],
 		};

--- a/lib/private/Config/PresetManager.php
+++ b/lib/private/Config/PresetManager.php
@@ -233,25 +233,57 @@ class PresetManager {
 	 */
 	private function getPresetApps(Preset $preset): array {
 		return match ($preset) {
-			Preset::CLUB, Preset::FAMILY, Preset::SCHOOL, Preset::SMALL, Preset::MEDIUM
+			Preset::CLUB, Preset::FAMILY, Preset::SCHOOL
 				=> [
-					'enabled' => ['user_status','guests','twofactor_backupcodes','twofactor_totp','twofactor_webauthn'],
+					'enabled' => [
+						'user_status',
+						'guests',
+						'twofactor_backupcodes',
+						'twofactor_totp',
+						'twofactor_webauthn',
+						'user_migration',
+					],
 					'disabled' => []],
-			Preset::UNIVERSITY, Preset::LARGE
+			Preset::SMALL, Preset::MEDIUM
+				=> [
+					'enabled' => [
+						'user_status',
+						'guests',
+						'twofactor_backupcodes',
+						'twofactor_totp',
+						'twofactor_webauthn',
+					],
+					'disabled' => []],
+			Preset::UNIVERSITY
+				=> [
+					'enabled' => [
+						'user_status',
+						'guests',
+						'user_migration',
+					],
+					'disabled' => []],
+			Preset::LARGE
 				=> [
 					'enabled' => ['user_status','guests'],
 					'disabled' => []],
 			Preset::SHARED
 				=> [
-					'enabled' => ['external','twofactor_backupcodes','twofactor_totp','twofactor_webauthn', 'user_migration'],
+					'enabled' => [
+						'external',
+						'twofactor_backupcodes',
+						'twofactor_totp',
+						'twofactor_webauthn',
+						'user_migration',
+					],
 					'disabled' => ['user_status']],
 			Preset::PRIVATE
 				=> [
-					'enabled' => ['twofactor_backupcodes','twofactor_totp','twofactor_webauthn', 'user_migration'],
-					'disabled' => []],
-			Preset::CLUB, Preset::FAMILY, Preset::SCHOOL, Preset::UNIVERSITY,
-				=> [
-					'enabled' => ['user_migration'],
+					'enabled' => [
+						'twofactor_backupcodes',
+						'twofactor_totp',
+						'twofactor_webauthn',
+						'user_migration',
+					],
 					'disabled' => []],
 			default => ['enabled' => [], 'disabled' => []],
 		};


### PR DESCRIPTION
closes https://github.com/nextcloud/server/issues/57406

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/57406

## Summary
Adding the user_migration app to relevant quick presets. Should be backported to 33.0.1.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
