### PR TITLE
refactor(AppConfig): readability improvements for `loadConfig()`

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1327,29 +1327,31 @@ class AppConfig implements IAppConfig {
 	 * @param bool        $lazy Whether to ensure lazy values are loaded
 	 */
 	private function loadConfig(?string $app = null, bool $lazy = false): void {
+		// If the relevant config values (based on $lazy) are already cached in memory,
+		// skip database/cache loading and return immediately for efficiency.
 		if ($this->isLoaded($lazy)) {
 			return;
 		}
 
 		// Emit debug context for the caller that triggered lazy loading.
 		if ($lazy === true && $app !== null) {
-			$exception = new \RuntimeException('The loading of lazy AppConfig values have been triggered by app "' . $app . '"');
-			$this->logger->debug($exception->getMessage(), ['exception' => $exception, 'app' => $app]);
+			$lazyLoadTriggerException = new \RuntimeException('The loading of lazy AppConfig values have been triggered by app "' . $app . '"');
+			$this->logger->debug($lazyLoadTriggerException->getMessage(), ['exception' => $lazyLoadTriggerException, 'app' => $app]);
 		}
 
 		// If non-lazy config is already loaded, a lazy load can query only lazy rows.
-		$loadLazyOnly = $this->isLoaded() && $lazy;
+		$shouldLoadLazyOnly = $this->isLoaded() && $lazy;
 
 		// Prefer local cache when it contains the required data subset.
 		/** @var array<mixed> */
-		$cacheContent = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
-		$includesLazyValues = !empty($cacheContent) && !empty($cacheContent['lazyCache']);
-		if (!empty($cacheContent) && (!$lazy || $includesLazyValues)) {
-			$this->valueTypes = $cacheContent['valueTypes'];
-			$this->fastCache = $cacheContent['fastCache'];
+		$cachedConfig = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
+		$cachedConfigIncludesLazyValues = !empty($cachedConfig) && !empty($cachedConfig['lazyCache']);
+		if (!empty($cachedConfig) && (!$lazy || $cachedConfigIncludesLazyValues)) {
+			$this->valueTypes = $cachedConfig['valueTypes'];
+			$this->fastCache = $cachedConfig['fastCache'];
 			$this->fastLoaded = !empty($this->fastCache);
-			if ($includesLazyValues) {
-				$this->lazyCache = $cacheContent['lazyCache'];
+			if ($cachedConfigIncludesLazyValues) {
+				$this->lazyCache = $cachedConfig['lazyCache'];
 				$this->lazyLoaded = !empty($this->lazyCache);
 			}
 			return;
@@ -1365,26 +1367,26 @@ class AppConfig implements IAppConfig {
 			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
 		} else {
 			// Lazy load path; restrict to lazy rows if non-lazy is already in memory.
-			if ($loadLazyOnly) {
+			if ($shouldLoadLazyOnly) {
 				$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
 			}
 			// Include row laziness so mixed result sets can be routed to the right cache.
 			$qb->addSelect('lazy');
 		}
 
-		$result = $qb->executeQuery();
-		$rows = $result->fetchAll();
-		foreach ($rows as $row) {
+		$queryResult = $qb->executeQuery();
+		$configRows = $queryResult->fetchAll();
+		foreach ($configRows as $configRow) {
 			// Route each row to the corresponding in-memory cache.
-			if ($lazy && ((int)$row['lazy']) === 1) {
-				$this->lazyCache[$row['appid']][$row['configkey']] = $row['configvalue'] ?? '';
+			if ($lazy && ((int)$configRow['lazy']) === 1) {
+				$this->lazyCache[$configRow['appid']][$configRow['configkey']] = $configRow['configvalue'] ?? '';
 			} else {
-				$this->fastCache[$row['appid']][$row['configkey']] = $row['configvalue'] ?? '';
+				$this->fastCache[$configRow['appid']][$configRow['configkey']] = $configRow['configvalue'] ?? '';
 			}
-			$this->valueTypes[$row['appid']][$row['configkey']] = (int)($row['type'] ?? 0);
+			$this->valueTypes[$configRow['appid']][$configRow['configkey']] = (int)($configRow['type'] ?? 0);
 		}
 
-		$result->closeCursor();
+		$queryResult->closeCursor();
 
 		// Persist refreshed in-memory caches to local cache.
 		$this->localCache?->set(

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -43,9 +43,9 @@ use Psr\Log\LoggerInterface;
  * Warning: When a lazy config value is requested, all lazy config values for that specific app
  * are loaded into memory.
  *
- * Note: Some methods (such as `getKeys()` or `getAllValues()`) bypass lazy loading and will 
+ * Note: Some methods (such as `getKeys()` or `getAllValues()`) bypass lazy loading and will
  * forcibly load all lazy config values for the app.
- * Use these methods carefully: they should only be called in code paths that run as part of 
+ * Use these methods carefully: they should only be called in code paths that run as part of
  * specific actions (like admin pages or background jobs), not on every user request.
  *
  * @since 7.0.0
@@ -1323,7 +1323,7 @@ class AppConfig implements IAppConfig {
 	 * - $lazy = true: ensure lazy values are loaded; may also load non-lazy values if they're not loaded yet.
 	 *
 	 * @param string|null $app App ID used for debug logging when lazy loading is triggered
-	 * @param bool        $lazy Whether to ensure lazy values are loaded
+	 * @param bool $lazy Whether to ensure lazy values are loaded
 	 */
 	private function loadConfig(?string $app = null, bool $lazy = false): void {
 		// Already loaded for the requested mode; skip.
@@ -1341,7 +1341,7 @@ class AppConfig implements IAppConfig {
 		if ($this->tryLoadFromLocalCache($lazy)) {
 			return;
 		}
-	
+
 		// If fast/non-lazy config is already loaded, a lazy load can query only lazy rows.
 		$shouldLoadLazyOnly = $this->isLoaded() && $lazy;
 

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1350,7 +1350,6 @@ class AppConfig implements IAppConfig {
 
 		$queryResult = $qb->executeQuery();
 		$configRows = $queryResult->fetchAll();
-
 		foreach ($configRows as $configRow) {
 			$appId = $configRow['appid'];
 			$configKey = $configRow['configkey'];
@@ -1394,15 +1393,26 @@ class AppConfig implements IAppConfig {
 	private function tryLoadFromLocalCache(bool $lazy): bool {
 		/** @var array<mixed> $cachedConfig */
 		$cachedConfig = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
-		$cachedConfigIncludesLazyValues = !empty($cachedConfig) && !empty($cachedConfig['lazyCache']);
 
-		if (empty($cachedConfig) || ($lazy && !$cachedConfigIncludesLazyValues)) {
+		if (
+			empty($cachedConfig)
+			|| !isset($cachedConfig['valueTypes'], $cachedConfig['fastCache'])
+			|| ($lazy && !isset($cachedConfig['lazyCache']))
+		) {
+			$this->logger->debug('Ignoring malformed local AppConfig cache payload', [
+				'hasValueTypes' => isset($cachedConfig['valueTypes']),
+				'hasFastCache' => isset($cachedConfig['fastCache']),
+				'hasLazyCache' => isset($cachedConfig['lazyCache']),
+				'lazyRequested' => $lazy,
+			]);
 			return false;
 		}
 
 		$this->valueTypes = $cachedConfig['valueTypes'];
 		$this->fastCache = $cachedConfig['fastCache'];
 		$this->fastLoaded = !empty($this->fastCache);
+
+		$cachedConfigIncludesLazyValues = !empty($cachedConfig['lazyCache']);
 
 		if ($cachedConfigIncludesLazyValues) {
 			$this->lazyCache = $cachedConfig['lazyCache'];
@@ -1413,7 +1423,7 @@ class AppConfig implements IAppConfig {
 	}
 
 	/**
-	 * Build the appConfig query for lazy/non-lazy loading mode.
+	 * Build the appconfig query for lazy/non-lazy loading mode.
 	 */
 	private function buildLoadConfigQuery(bool $lazy, bool $shouldLoadLazyOnly): IQueryBuilder {
 		$qb = $this->connection->getQueryBuilder();
@@ -1431,7 +1441,7 @@ class AppConfig implements IAppConfig {
 			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
 		}
 
-		// Include laziness, when result set may contain both types, so can be routed to the right cache.
+		// Include laziness when result set may contain both types, so can be routed to the right cache.
 		$qb->addSelect('lazy');
 		return $qb;
 	}

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1314,23 +1314,33 @@ class AppConfig implements IAppConfig {
 	}
 
 	/**
-	 * Load normal config or config set as lazy loaded
+	 * Ensures app config is loaded into in-memory caches.
 	 *
-	 * @param bool $lazy set to TRUE to also load config values set as lazy loaded
+	 * Reads from local cache when available; otherwise queries the database and refreshes local cache.
+	 *
+	 * Behavior:
+	 * - $lazy = false: loads non-lazy config values.
+	 * - $lazy = true: ensures lazy values are loaded; may load both non-lazy and lazy values
+	 *   if non-lazy values are not loaded yet.
+	 *
+	 * @param string|null $app App ID used for debug logging when lazy loading is triggered
+	 * @param bool        $lazy Whether to ensure lazy values are loaded
 	 */
 	private function loadConfig(?string $app = null, bool $lazy = false): void {
 		if ($this->isLoaded($lazy)) {
 			return;
 		}
 
-		// if lazy is null or true, we debug log
+		// Emit debug context for the caller that triggered lazy loading.
 		if ($lazy === true && $app !== null) {
 			$exception = new \RuntimeException('The loading of lazy AppConfig values have been triggered by app "' . $app . '"');
 			$this->logger->debug($exception->getMessage(), ['exception' => $exception, 'app' => $app]);
 		}
 
-		$loadLazyOnly = $lazy && $this->isLoaded();
+		// If non-lazy config is already loaded, a lazy load can query only lazy rows.
+		$loadLazyOnly = $this->isLoaded() && $lazy;
 
+		// Prefer local cache when it contains the required data subset.
 		/** @var array<mixed> */
 		$cacheContent = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
 		$includesLazyValues = !empty($cacheContent) && !empty($cacheContent['lazyCache']);
@@ -1345,24 +1355,27 @@ class AppConfig implements IAppConfig {
 			return;
 		}
 
-		// Otherwise no cache available and we need to fetch from database
+		// Cache miss (or missing lazy subset): fetch the required rows from DB.
 		$qb = $this->connection->getQueryBuilder();
 		$qb->from('appconfig')
 			->select('appid', 'configkey', 'configvalue', 'type');
 
 		if ($lazy === false) {
+			// Non-lazy load path.
 			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
 		} else {
+			// Lazy load path; restrict to lazy rows if non-lazy is already in memory.
 			if ($loadLazyOnly) {
 				$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
 			}
+			// Include row laziness so mixed result sets can be routed to the right cache.
 			$qb->addSelect('lazy');
 		}
 
 		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
 		foreach ($rows as $row) {
-			// most of the time, 'lazy' is not in the select because its value is already known
+			// Route each row to the corresponding in-memory cache.
 			if ($lazy && ((int)$row['lazy']) === 1) {
 				$this->lazyCache[$row['appid']][$row['configkey']] = $row['configvalue'] ?? '';
 			} else {
@@ -1372,6 +1385,8 @@ class AppConfig implements IAppConfig {
 		}
 
 		$result->closeCursor();
+
+		// Persist refreshed in-memory caches to local cache.
 		$this->localCache?->set(
 			self::LOCAL_CACHE_KEY,
 			[

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1333,31 +1333,17 @@ class AppConfig implements IAppConfig {
 
 		// Log which app triggered lazy loading and include context to help with optimization follow-up.
 		if ($lazy === true && $app !== null) {
-			$lazyLoadTriggerException = new \RuntimeException('The loading of lazy AppConfig values have been triggered by app "' . $app . '"');
+			$lazyLoadTriggerException = new \RuntimeException('The loading of lazy AppConfig values has been triggered by app "' . $app . '"');
 			$this->logger->debug($lazyLoadTriggerException->getMessage(), ['exception' => $lazyLoadTriggerException, 'app' => $app]);
 		}
 
-		// If fast/non-lazy config is already loaded, a lazy load can query only lazy rows.
-		$shouldLoadLazyOnly = $this->isLoaded() && $lazy;
-
 		// Prefer local cache when it contains the required data subset.
-		/** @var array<mixed> */
-		$cachedConfig = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
-		$cachedConfigIncludesLazyValues = !empty($cachedConfig['lazyCache']);
-		$canHydrateFromLocalCache = !empty($cachedConfig) && (!$lazy || $cachedConfigIncludesLazyValues);
-
-		if ($canHydrateFromLocalCache) {
-			$this->valueTypes = $cachedConfig['valueTypes'];
-			$this->fastCache = $cachedConfig['fastCache'];
-			$this->fastLoaded = !empty($this->fastCache);
-
-			if ($cachedConfigIncludesLazyValues) {
-				$this->lazyCache = $cachedConfig['lazyCache'];
-				$this->lazyLoaded = !empty($this->lazyCache);
-			}
-
+		if ($this->tryLoadFromLocalCache($lazy)) {
 			return;
 		}
+	
+		// If fast/non-lazy config is already loaded, a lazy load can query only lazy rows.
+		$shouldLoadLazyOnly = $this->isLoaded() && $lazy;
 
 		// Cache miss (or missing lazy subset): fetch from DB.
 		$qb = $this->connection->getQueryBuilder();
@@ -1407,6 +1393,27 @@ class AppConfig implements IAppConfig {
 
 		$this->fastLoaded = true;
 		$this->lazyLoaded = $lazy;
+	}
+
+	private function tryLoadFromLocalCache(bool $lazy): bool {
+		/** @var array<mixed> $cachedConfig */
+		$cachedConfig = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
+		$cachedConfigIncludesLazyValues = !empty($cachedConfig) && !empty($cachedConfig['lazyCache']);
+
+		if (empty($cachedConfig) || ($lazy && !$cachedConfigIncludesLazyValues)) {
+			return false;
+		}
+
+		$this->valueTypes = $cachedConfig['valueTypes'];
+		$this->fastCache = $cachedConfig['fastCache'];
+		$this->fastLoaded = !empty($this->fastCache);
+
+		if ($cachedConfigIncludesLazyValues) {
+			$this->lazyCache = $cachedConfig['lazyCache'];
+			$this->lazyLoaded = !empty($this->lazyCache);
+		}
+
+		return true;
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1352,15 +1352,21 @@ class AppConfig implements IAppConfig {
 		$configRows = $queryResult->fetchAll();
 
 		foreach ($configRows as $configRow) {
+			$appId = $configRow['appid'];
+			$configKey = $configRow['configkey'];
+			$configValue = $configRow['configvalue'] ?? '';
+			$valueType = (int)($configRow['type'] ?? 0);
+
 			$isLazyRow = $lazy && ((int)$configRow['lazy']) === 1;
 
 			// Route each config row to the corresponding in-memory cache.
 			if ($isLazyRow) {
-				$this->lazyCache[$configRow['appid']][$configRow['configkey']] = $configRow['configvalue'] ?? '';
+				$this->lazyCache[$appId][$configKey] = $configValue;
 			} else {
-				$this->fastCache[$configRow['appid']][$configRow['configkey']] = $configRow['configvalue'] ?? '';
+				$this->fastCache[$appId][$configKey] = $configValue;
 			}
-			$this->valueTypes[$configRow['appid']][$configRow['configkey']] = (int)($configRow['type'] ?? 0);
+
+			$this->valueTypes[$appId][$configKey] = $valueType;
 		}
 
 		$queryResult->closeCursor();

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -33,23 +33,23 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
- * This class provides an easy way for apps to store config values in the
- * database.
+ * Stores and retrieves per-app configuration values in the database,
+ * with support for type safety and lazy loading.
  *
- * **Note:** since 29.0.0, it supports **lazy loading**
+ * ### Lazy Loading (since 29.0.0)
+ * To minimize (unnecessary) memory usage, only non-lazy configuration values are loaded by default.
+ * Lazy config values are fetched from the database only when specifically requested.
  *
- * ### What is lazy loading ?
- * In order to avoid loading useless config values into memory for each request,
- * only non-lazy values are now loaded.
+ * Warning: When a lazy config value is requested, all lazy config values for that specific app
+ * are loaded into memory.
  *
- * Once a value that is lazy is requested, all lazy values will be loaded.
- *
- * Similarly, some methods from this class are marked with a warning about ignoring
- * lazy loading. Use them wisely and only on parts of the code that are called
- * during specific requests or actions to avoid loading the lazy values all the time.
+ * Note: Some methods (such as `getKeys()` or `getAllValues()`) bypass lazy loading and will 
+ * forcibly load all lazy config values for the app.
+ * Use these methods carefully: they should only be called in code paths that run as part of 
+ * specific actions (like admin pages or background jobs), not on every user request.
  *
  * @since 7.0.0
- * @since 29.0.0 - Supporting types and lazy loading
+ * @since 29.0.0 Added support for type safety and lazy loading.
  */
 class AppConfig implements IAppConfig {
 	private const APP_MAX_LENGTH = 32;

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1346,22 +1346,7 @@ class AppConfig implements IAppConfig {
 		$shouldLoadLazyOnly = $this->isLoaded() && $lazy;
 
 		// Cache miss (or missing lazy subset): fetch from DB.
-		$qb = $this->connection->getQueryBuilder();
-		$qb->from('appconfig')
-			->select('appid', 'configkey', 'configvalue', 'type');
-
-		if ($lazy === false) {
-			// Non-lazy load path.
-			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
-		// Lazy load paths...
-		} elseif ($shouldLoadLazyOnly) {
-			// Restrict to lazy rows if non-lazy is already in memory.
-			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
-			$qb->addSelect('lazy');
-		} else {
-			// Include laziness, when result set may contain both types, so can be routed to the right cache.
-			$qb->addSelect('lazy');
-		}
+		$qb = $this->buildLoadConfigQuery($lazy, $shouldLoadLazyOnly);
 
 		$queryResult = $qb->executeQuery();
 		$configRows = $queryResult->fetchAll();
@@ -1395,6 +1380,11 @@ class AppConfig implements IAppConfig {
 		$this->lazyLoaded = $lazy;
 	}
 
+	/**
+	 * Hydrate in-memory caches from local cache when it contains the required subset.
+	 *
+	 * @return bool True when hydration succeeded; false when DB load is still required.
+	 */
 	private function tryLoadFromLocalCache(bool $lazy): bool {
 		/** @var array<mixed> $cachedConfig */
 		$cachedConfig = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
@@ -1414,6 +1404,30 @@ class AppConfig implements IAppConfig {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Build the appConfig query for lazy/non-lazy loading mode.
+	 */
+	private function buildLoadConfigQuery(bool $lazy, bool $shouldLoadLazyOnly): IQueryBuilder {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->from('appconfig')
+			->select('appid', 'configkey', 'configvalue', 'type');
+
+		// Non-lazy load path.
+		if ($lazy === false) {
+			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+			return $qb;
+		}
+
+		// Restrict to lazy rows if non-lazy is already in memory.
+		if ($shouldLoadLazyOnly) {
+			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
+		}
+
+		// Include laziness, when result set may contain both types, so can be routed to the right cache.
+		$qb->addSelect('lazy');
+		return $qb;
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1394,9 +1394,12 @@ class AppConfig implements IAppConfig {
 		/** @var array<mixed> $cachedConfig */
 		$cachedConfig = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
 
+		if (empty($cachedConfig)) {
+			return false;
+		}
+
 		if (
-			empty($cachedConfig)
-			|| !isset($cachedConfig['valueTypes'], $cachedConfig['fastCache'])
+			!isset($cachedConfig['valueTypes'], $cachedConfig['fastCache'])
 			|| ($lazy && !isset($cachedConfig['lazyCache']))
 		) {
 			$this->logger->debug('Ignoring malformed local AppConfig cache payload', [

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1343,15 +1343,19 @@ class AppConfig implements IAppConfig {
 		// Prefer local cache when it contains the required data subset.
 		/** @var array<mixed> */
 		$cachedConfig = $this->localCache?->get(self::LOCAL_CACHE_KEY) ?? [];
-		$cachedConfigIncludesLazyValues = !empty($cachedConfig) && !empty($cachedConfig['lazyCache']);
-		if (!empty($cachedConfig) && (!$lazy || $cachedConfigIncludesLazyValues)) {
+		$cachedConfigIncludesLazyValues = !empty($cachedConfig['lazyCache']);
+		$canHydrateFromLocalCache = !empty($cachedConfig) && (!$lazy || $cachedConfigIncludesLazyValues);
+
+		if ($canHydrateFromLocalCache) {
 			$this->valueTypes = $cachedConfig['valueTypes'];
 			$this->fastCache = $cachedConfig['fastCache'];
 			$this->fastLoaded = !empty($this->fastCache);
+
 			if ($cachedConfigIncludesLazyValues) {
 				$this->lazyCache = $cachedConfig['lazyCache'];
 				$this->lazyLoaded = !empty($this->lazyCache);
 			}
+
 			return;
 		}
 
@@ -1363,20 +1367,24 @@ class AppConfig implements IAppConfig {
 		if ($lazy === false) {
 			// Non-lazy load path.
 			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+		// Lazy load paths...
+		} elseif ($shouldLoadLazyOnly) {
+			// Restrict to lazy rows if non-lazy is already in memory.
+			$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
+			$qb->addSelect('lazy');
 		} else {
-			// Lazy load path; restrict to lazy rows if non-lazy is already in memory.
-			if ($shouldLoadLazyOnly) {
-				$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
-			}
 			// Include laziness, when result set may contain both types, so can be routed to the right cache.
 			$qb->addSelect('lazy');
 		}
 
 		$queryResult = $qb->executeQuery();
 		$configRows = $queryResult->fetchAll();
+
 		foreach ($configRows as $configRow) {
-			// Route each row to the corresponding in-memory cache.
-			if ($lazy && ((int)$configRow['lazy']) === 1) {
+			$isLazyRow = $lazy && ((int)$configRow['lazy']) === 1;
+
+			// Route each config row to the corresponding in-memory cache.
+			if ($isLazyRow) {
 				$this->lazyCache[$configRow['appid']][$configRow['configkey']] = $configRow['configvalue'] ?? '';
 			} else {
 				$this->fastCache[$configRow['appid']][$configRow['configkey']] = $configRow['configvalue'] ?? '';

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1316,30 +1316,28 @@ class AppConfig implements IAppConfig {
 	/**
 	 * Ensures app config is loaded into in-memory caches.
 	 *
-	 * Reads from local cache when available; otherwise queries the database and refreshes local cache.
+	 * Uses local cache when possible; otherwise reads from DB and refreshes local cache.
 	 *
 	 * Behavior:
-	 * - $lazy = false: loads non-lazy config values.
-	 * - $lazy = true: ensures lazy values are loaded; may load both non-lazy and lazy values
-	 *   if non-lazy values are not loaded yet.
+	 * - $lazy = false: load non-lazy values.
+	 * - $lazy = true: ensure lazy values are loaded; may also load non-lazy values if they're not loaded yet.
 	 *
 	 * @param string|null $app App ID used for debug logging when lazy loading is triggered
 	 * @param bool        $lazy Whether to ensure lazy values are loaded
 	 */
 	private function loadConfig(?string $app = null, bool $lazy = false): void {
-		// If the relevant config values (based on $lazy) are already cached in memory,
-		// skip database/cache loading and return immediately for efficiency.
+		// Already loaded for the requested mode; skip.
 		if ($this->isLoaded($lazy)) {
 			return;
 		}
 
-		// Emit debug context for the caller that triggered lazy loading.
+		// Log which app triggered lazy loading and include context to help with optimization follow-up.
 		if ($lazy === true && $app !== null) {
 			$lazyLoadTriggerException = new \RuntimeException('The loading of lazy AppConfig values have been triggered by app "' . $app . '"');
 			$this->logger->debug($lazyLoadTriggerException->getMessage(), ['exception' => $lazyLoadTriggerException, 'app' => $app]);
 		}
 
-		// If non-lazy config is already loaded, a lazy load can query only lazy rows.
+		// If fast/non-lazy config is already loaded, a lazy load can query only lazy rows.
 		$shouldLoadLazyOnly = $this->isLoaded() && $lazy;
 
 		// Prefer local cache when it contains the required data subset.
@@ -1357,7 +1355,7 @@ class AppConfig implements IAppConfig {
 			return;
 		}
 
-		// Cache miss (or missing lazy subset): fetch the required rows from DB.
+		// Cache miss (or missing lazy subset): fetch from DB.
 		$qb = $this->connection->getQueryBuilder();
 		$qb->from('appconfig')
 			->select('appid', 'configkey', 'configvalue', 'type');
@@ -1370,7 +1368,7 @@ class AppConfig implements IAppConfig {
 			if ($shouldLoadLazyOnly) {
 				$qb->where($qb->expr()->eq('lazy', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
 			}
-			// Include row laziness so mixed result sets can be routed to the right cache.
+			// Include laziness, when result set may contain both types, so can be routed to the right cache.
 			$qb->addSelect('lazy');
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Refactors `AppConfig::loadConfig()` for readability and maintainability without changing intended behavior.

*What's changed*

* Improved variable names for intent clarity 
* Extracted some logic into helper methods
* Added defensive shape checks
* Added/tightened comments/docblocks

*Why*

* Makes `loadConfig()` easier to reason about and review.
* Isolates cache hydration and query construction.
* Preserves behavior/performance characteristics 
* Minor: Adds robustness against malformed/partial local-cache payloads.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
