### PR TITLE
fix: increase bucket_name column length to 63 chars

### DIFF
--- a/core/Migrations/Version33000Date20250819110529.php
+++ b/core/Migrations/Version33000Date20250819110529.php
@@ -31,7 +31,7 @@ class Version33000Date20250819110529 extends SimpleMigrationStep {
 		if (!$schema->hasTable('preview_locations')) {
 			$table = $schema->createTable('preview_locations');
 			$table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20, 'unsigned' => true]);
-			$table->addColumn('bucket_name', Types::STRING, ['notnull' => true, 'length' => 40]);
+			$table->addColumn('bucket_name', Types::STRING, ['notnull' => true, 'length' => 63]);
 			$table->addColumn('object_store_name', Types::STRING, ['notnull' => true, 'length' => 40]);
 			$table->setPrimaryKey(['id']);
 		}

--- a/core/Migrations/Version33000Date20260306120000.php
+++ b/core/Migrations/Version33000Date20260306120000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\ModifyColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * Increase bucket_name column length to 63 to match AWS bucket naming rules
+ */
+#[ModifyColumn(table: 'preview_locations', name: 'bucket_name', description: 'Increase column length to 63 to match AWS bucket naming rules')]
+class Version33000Date20260306120000 extends SimpleMigrationStep {
+
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('preview_locations')) {
+			$table = $schema->getTable('preview_locations');
+			$column = $table->getColumn('bucket_name');
+
+			if ($column->getLength() < 63) {
+				$column->setLength(63);
+			}
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
## Summary

- Increase `bucket_name` column length in `oc_preview_locations` from `varchar(40)` to `varchar(63)`
- AWS allows bucket names up to 63 characters per [bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html), but the column was too short to store them
- Updates the initial table creation migration (for fresh installs) and adds a new migration to alter the column for existing installs

## Changes

1. **`core/Migrations/Version33000Date20250819110529.php`** - Updated initial schema to define `bucket_name` with length 63 instead of 40
2. **`core/Migrations/Version33000Date20260306120000.php`** - New migration that increases the `bucket_name` column length to 63 for existing installations

Fixes #58755

## Test plan

- [ ] Fresh install: verify `oc_preview_locations.bucket_name` column is created as `varchar(63)`
- [ ] Existing install with `varchar(40)`: verify the new migration alters the column to `varchar(63)`
- [ ] Verify previews still work correctly with bucket names up to 63 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)