### PR TITLE
fix(files): only disable template creation when both skeleton directories are empty

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -194,7 +194,7 @@ class ViewController extends Controller {
 			$this->eventDispatcher->dispatchTyped(new LoadViewer());
 		}
 
-		$this->initialState->provideInitialState('templates_enabled', ($this->config->getSystemValueString('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton') !== '') || ($this->config->getSystemValueString('templatedirectory', \OC::$SERVERROOT . '/core/skeleton/Templates') !== ''));
+		$this->initialState->provideInitialState('templates_enabled', true);
 		$this->initialState->provideInitialState('templates_path', $this->templateManager->hasTemplateDirectory() ? $this->templateManager->getTemplatePath() : false);
 		$this->initialState->provideInitialState('templates', $this->templateManager->listCreators());
 

--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -328,7 +328,7 @@ class TemplateManager implements ITemplateManager {
 		$isDefaultTemplates = $skeletonTemplatePath === $defaultTemplateDirectory;
 		$userLang = $this->l10nFactory->getUserLanguage($this->userManager->get($this->userId));
 
-		if ($skeletonTemplatePath === '') {
+		if ($path === null && $skeletonTemplatePath === '' && $skeletonPath === '') {
 			$this->setTemplatePath('');
 			return '';
 		}


### PR DESCRIPTION
## Problem
When `templatedirectory` was set to an empty string, clicking "Create templates folder" resulted in a "folder not found" error, when `skeletondirectory` was still configured (not an empty string).

## Root cause
`initializeTemplateDirectory()` returns early when only `templatedirectory` is empty, while the frontend showed the button with an || condition, so if either of them is not an empty string.

## Fix
As it is documented in `config.sample.php`:
> To disable creating a template directory, set both skeletondirectory and templatedirectory to empty strings.

The early return now only happens when both are empty, and only for automatic initialization, not when the user manually requests template folder creation.

## Note
`skeletondirectory` and `templatedirectory` are used for provisioning files during initialization. In my opinion it should not take the manual "Create templates folder" feature away from users, that could remain in the users control while still preventing the automatic creation as expected from the config. Every user can create and use their own templates. If an admin wants to explicitly disable this feature, there should be a new config option for that, not a side effect of the file provisioning configuration.


Open for discussion, I am happy to hear if there is a different opinion on how this should be handled.