### PR TITLE
docs(auth): clarify login chain sequencing and security ordering requirements

### DIFF
--- a/lib/private/Authentication/Login/Chain.php
+++ b/lib/private/Authentication/Login/Chain.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\Login;
 
+/**
+ * Orchestrates the login command chain in a security-sensitive order for interactive authentication.
+ */
 class Chain {
 	public function __construct(
 		private PreLoginHookCommand $preLoginHookCommand,
@@ -25,19 +28,36 @@ class Chain {
 	) {
 	}
 
+	/**
+	 * Runs the login pipeline for one login attempt.
+	 *
+	 * Commands share mutable LoginData and may have side effects.
+	 * A command may opt to permit processing to continue or return a final LoginResult early.
+	 *
+	 * If order changes, review login-flow invariants and related tests.
+	 */
 	public function process(LoginData $loginData): LoginResult {
+		// Phase 1: pre-auth hooks and eligibility checks
 		$chain = $this->preLoginHookCommand;
 		$chain
 			->setNext($this->userDisabledCheckCommand)
+
+			// Phase 2: primary authentication and login-state transition
 			->setNext($this->uidLoginCommand)
 			->setNext($this->loggedInCheckCommand)
 			->setNext($this->completeLoginCommand)
-			->setNext($this->flowV2EphemeralSessionsCommand)
+
+			// Phase 3: session strategy and token materialization
+			->setNext($this->flowV2EphemeralSessionsCommand) // must precede standard token creation
 			->setNext($this->createSessionTokenCommand)
+
+			// Phase 4: post-auth maintenance and context updates
 			->setNext($this->clearLostPasswordTokensCommand)
 			->setNext($this->updateLastPasswordConfirmCommand)
 			->setNext($this->setUserTimezoneCommand)
-			->setNext($this->twoFactorCommand)
+
+			// Phase 5: assurance/finalization gates
+			->setNext($this->twoFactorCommand) // before remembered-login finalization
 			->setNext($this->finishRememberedLoginCommand);
 
 		return $chain->process($loginData);

--- a/lib/private/Authentication/Login/WebAuthnChain.php
+++ b/lib/private/Authentication/Login/WebAuthnChain.php
@@ -12,7 +12,7 @@ namespace OC\Authentication\Login;
  * Orchestrates the WebAuthn (passkeys/security keys) login command chain in a
  * security-sensitive order for interactive authentication.
  *
- * Mirrors the main login-chain {@see Chain} with adaptations to the 
+ * Mirrors the main login-chain {@see Chain} with adaptations to the
  * WebAuthn-specific authentication flow (i.e., no pre-login hook or Flow v2
  * ephemeral-session step).
  */

--- a/lib/private/Authentication/Login/WebAuthnChain.php
+++ b/lib/private/Authentication/Login/WebAuthnChain.php
@@ -8,6 +8,14 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\Login;
 
+/**
+ * Orchestrates the WebAuthn (passkeys/security keys) login command chain in a
+ * security-sensitive order for interactive authentication.
+ *
+ * Mirrors the main login-chain {@see Chain} with adaptations to the 
+ * WebAuthn-specific authentication flow (i.e., no pre-login hook or Flow v2
+ * ephemeral-session step).
+ */
 class WebAuthnChain {
 	public function __construct(
 		private UserDisabledCheckCommand $userDisabledCheckCommand,
@@ -23,17 +31,28 @@ class WebAuthnChain {
 	) {
 	}
 
+	/**
+	 * Runs the WebAuthn login pipeline for one login attempt.
+	 */
 	public function process(LoginData $loginData): LoginResult {
+		// Phase 1: pre-auth eligibility checks
 		$chain = $this->userDisabledCheckCommand;
 		$chain
+			// Phase 2: primary authentication and login-state transition
 			->setNext($this->webAuthnLoginCommand)
 			->setNext($this->loggedInCheckCommand)
 			->setNext($this->completeLoginCommand)
+
+			// Phase 3: session strategy and token materialization
 			->setNext($this->createSessionTokenCommand)
+
+			// Phase 4: post-auth maintenance and context updates
 			->setNext($this->clearLostPasswordTokensCommand)
 			->setNext($this->updateLastPasswordConfirmCommand)
 			->setNext($this->setUserTimezoneCommand)
-			->setNext($this->twoFactorCommand)
+
+			// Phase 5: assurance/finalization gates
+			->setNext($this->twoFactorCommand) // before remembered-login finalization
 			->setNext($this->finishRememberedLoginCommand);
 
 		return $chain->process($loginData);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

* Refines `Chain` documentation to better describe its role in interactive authentication.
* Documents phase-based sequencing in `process()` for readability and reviewability.
* Clarifies command behavior (shared mutable `LoginData`, possible early return).
* Adds concise inline notes for critical ordering constraints:
  - Flow v2 ephemeral session handling before standard token creation.
  - 2FA before remembered-login finalization.
* No functional behavior changes; documentation/readability only.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
