### PR TITLE
fix: Deprecate OC_App::getCurrentApp and remove its only use

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -58,6 +58,7 @@ class TemplateLayout {
 		private INavigationManager $navigationManager,
 		private ITemplateManager $templateManager,
 		private ServerVersion $serverVersion,
+		private IRequest $request,
 	) {
 	}
 
@@ -72,7 +73,8 @@ class TemplateLayout {
 		switch ($renderAs) {
 			case TemplateResponse::RENDER_AS_USER:
 				$page = $this->templateManager->getTemplate('core', 'layout.user');
-				if (in_array(\OC_App::getCurrentApp(), ['settings','admin', 'help']) !== false) {
+				$pathInfo = $this->request->getPathInfo();
+				if ($pathInfo !== false && str_starts_with($pathInfo, '/settings/')) {
 					$page->assign('bodyid', 'body-settings');
 				} else {
 					$page->assign('bodyid', 'body-user');
@@ -254,10 +256,8 @@ class TemplateLayout {
 			$page->append('jsfiles', $web . '/' . $file . $this->getVersionHashSuffix());
 		}
 
-		$request = Server::get(IRequest::class);
-
 		try {
-			$pathInfo = $request->getPathInfo();
+			$pathInfo = $this->request->getPathInfo();
 		} catch (\Exception $e) {
 			$pathInfo = '';
 		}
@@ -298,7 +298,7 @@ class TemplateLayout {
 			}
 		}
 
-		if ($request->isUserAgent([Request::USER_AGENT_CLIENT_IOS, Request::USER_AGENT_SAFARI, Request::USER_AGENT_SAFARI_MOBILE])) {
+		if ($this->request->isUserAgent([Request::USER_AGENT_CLIENT_IOS, Request::USER_AGENT_SAFARI, Request::USER_AGENT_SAFARI_MOBILE])) {
 			// Prevent auto zoom with iOS but still allow user zoom
 			// On chrome (and others) this does not work (will also disable user zoom)
 			$page->assign('viewport_maximum_scale', '1.0');

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -261,6 +261,7 @@ class OC_App {
 
 	/**
 	 * get the id of loaded app
+	 * @deprecated 34.0.0 Don’t do that
 	 */
 	public static function getCurrentApp(): string {
 		if (\OC::$CLI) {

--- a/tests/lib/TemplateLayoutTest.php
+++ b/tests/lib/TemplateLayoutTest.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\INavigationManager;
+use OCP\IRequest;
 use OCP\ServerVersion;
 use OCP\Template\ITemplateManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,6 +29,7 @@ class TemplateLayoutTest extends \Test\TestCase {
 	private INavigationManager&MockObject $navigationManager;
 	private ITemplateManager&MockObject $templateManager;
 	private ServerVersion&MockObject $serverVersion;
+	private IRequest&MockObject $request;
 
 	private TemplateLayout $templateLayout;
 
@@ -41,6 +43,7 @@ class TemplateLayoutTest extends \Test\TestCase {
 		$this->navigationManager = $this->createMock(INavigationManager::class);
 		$this->templateManager = $this->createMock(ITemplateManager::class);
 		$this->serverVersion = $this->createMock(ServerVersion::class);
+		$this->request = $this->createMock(IRequest::class);
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataVersionHash')]
@@ -73,6 +76,9 @@ class TemplateLayoutTest extends \Test\TestCase {
 			->with('theming', 'cachebuster', '0')
 			->willReturn('42');
 
+		$this->request->method('getPathInfo')
+			->willReturn('/' . $path);
+
 		$this->templateLayout = $this->getMockBuilder(TemplateLayout::class)
 			->onlyMethods(['getAppNamefromPath'])
 			->setConstructorArgs([
@@ -83,6 +89,7 @@ class TemplateLayoutTest extends \Test\TestCase {
 				$this->navigationManager,
 				$this->templateManager,
 				$this->serverVersion,
+				$this->request,
 			])
 			->getMock();
 


### PR DESCRIPTION
## Summary

The method was weird and specific, in the end it was only used to check if the current path is a settings page.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
