### PR TITLE
test(auth): add Chain orchestration coverage for login command order and short-circuiting

### DIFF
--- a/tests/lib/Authentication/Login/ChainTest.php
+++ b/tests/lib/Authentication/Login/ChainTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Test\Authentication\Login;
+
+use OC\Authentication\Login\ALoginCommand;
+use OC\Authentication\Login\Chain;
+use OC\Authentication\Login\LoginData;
+use OC\Authentication\Login\LoginResult;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class ChainTest extends TestCase {
+	/** @var IRequest|MockObject */
+	private $request;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->request = $this->createMock(IRequest::class);
+	}
+
+	public function testProcessBuildsExpectedOrderAndTraversesChain(): void {
+		$links = [];
+		$processed = [];
+
+		$preLogin = new RecordingCommand('preLogin', $links, $processed);
+		$userDisabled = new RecordingCommand('userDisabled', $links, $processed);
+		$uidLogin = new RecordingCommand('uidLogin', $links, $processed);
+		$loggedInCheck = new RecordingCommand('loggedInCheck', $links, $processed);
+		$completeLogin = new RecordingCommand('completeLogin', $links, $processed);
+		$createSessionToken = new RecordingCommand('createSessionToken', $links, $processed);
+		$clearLostPasswordTokens = new RecordingCommand('clearLostPasswordTokens', $links, $processed);
+		$updateLastPasswordConfirm = new RecordingCommand('updateLastPasswordConfirm', $links, $processed);
+		$setUserTimezone = new RecordingCommand('setUserTimezone', $links, $processed);
+		$twoFactor = new RecordingCommand('twoFactor', $links, $processed);
+		$finishRememberedLogin = new RecordingCommand('finishRememberedLogin', $links, $processed);
+		$flowV2EphemeralSessions = new RecordingCommand('flowV2EphemeralSessions', $links, $processed);
+
+		$chain = new Chain(
+			$preLogin,
+			$userDisabled,
+			$uidLogin,
+			$loggedInCheck,
+			$completeLogin,
+			$createSessionToken,
+			$clearLostPasswordTokens,
+			$updateLastPasswordConfirm,
+			$setUserTimezone,
+			$twoFactor,
+			$finishRememberedLogin,
+			$flowV2EphemeralSessions,
+		);
+
+		$loginData = new LoginData($this->request, 'user123', 'secret');
+		$result = $chain->process($loginData);
+
+		$this->assertTrue($result->isSuccess());
+
+		$this->assertSame([
+			['preLogin', 'userDisabled'],
+			['userDisabled', 'uidLogin'],
+			['uidLogin', 'loggedInCheck'],
+			['loggedInCheck', 'completeLogin'],
+			['completeLogin', 'flowV2EphemeralSessions'],
+			['flowV2EphemeralSessions', 'createSessionToken'],
+			['createSessionToken', 'clearLostPasswordTokens'],
+			['clearLostPasswordTokens', 'updateLastPasswordConfirm'],
+			['updateLastPasswordConfirm', 'setUserTimezone'],
+			['setUserTimezone', 'twoFactor'],
+			['twoFactor', 'finishRememberedLogin'],
+		], $links);
+
+		$this->assertSame([
+			'preLogin',
+			'userDisabled',
+			'uidLogin',
+			'loggedInCheck',
+			'completeLogin',
+			'flowV2EphemeralSessions',
+			'createSessionToken',
+			'clearLostPasswordTokens',
+			'updateLastPasswordConfirm',
+			'setUserTimezone',
+			'twoFactor',
+			'finishRememberedLogin',
+		], $processed);
+	}
+
+	public function testProcessReturnsHeadFailureResult(): void {
+		$links = [];
+		$processed = [];
+
+		$preLogin = new RecordingCommand(
+			'preLogin',
+			$links,
+			$processed,
+			LoginResult::failure('boom'),
+			false // stop chain here
+		);
+
+		// Remaining commands should never process when head short-circuits
+		$userDisabled = new RecordingCommand('userDisabled', $links, $processed);
+		$uidLogin = new RecordingCommand('uidLogin', $links, $processed);
+		$loggedInCheck = new RecordingCommand('loggedInCheck', $links, $processed);
+		$completeLogin = new RecordingCommand('completeLogin', $links, $processed);
+		$createSessionToken = new RecordingCommand('createSessionToken', $links, $processed);
+		$clearLostPasswordTokens = new RecordingCommand('clearLostPasswordTokens', $links, $processed);
+		$updateLastPasswordConfirm = new RecordingCommand('updateLastPasswordConfirm', $links, $processed);
+		$setUserTimezone = new RecordingCommand('setUserTimezone', $links, $processed);
+		$twoFactor = new RecordingCommand('twoFactor', $links, $processed);
+		$finishRememberedLogin = new RecordingCommand('finishRememberedLogin', $links, $processed);
+		$flowV2EphemeralSessions = new RecordingCommand('flowV2EphemeralSessions', $links, $processed);
+
+		$chain = new Chain(
+			$preLogin,
+			$userDisabled,
+			$uidLogin,
+			$loggedInCheck,
+			$completeLogin,
+			$createSessionToken,
+			$clearLostPasswordTokens,
+			$updateLastPasswordConfirm,
+			$setUserTimezone,
+			$twoFactor,
+			$finishRememberedLogin,
+			$flowV2EphemeralSessions,
+		);
+
+		$loginData = new LoginData($this->request, 'user123', 'secret');
+		$result = $chain->process($loginData);
+
+		$this->assertFalse($result->isSuccess());
+		$this->assertSame('boom', $result->getErrorMessage());
+		$this->assertSame(['preLogin'], $processed);
+	}
+}
+
+/**
+ * Small test double for chain orchestration tests.
+ */
+class RecordingCommand extends ALoginCommand {
+	/** @var array<int, array{0:string,1:string}> */
+	private array &$links;
+	/** @var array<int, string> */
+	private array &$processed;
+
+	public function __construct(
+		private string $name,
+		array &$links,
+		array &$processed,
+		private ?LoginResult $forcedResult = null,
+		private bool $continueChain = true,
+	) {
+		$this->links = &$links;
+		$this->processed = &$processed;
+	}
+
+	public function setNext(ALoginCommand $next): ALoginCommand {
+		if ($next instanceof self) {
+			$this->links[] = [$this->name, $next->name];
+		}
+		return parent::setNext($next);
+	}
+
+	public function process(LoginData $loginData): LoginResult {
+		$this->processed[] = $this->name;
+
+		if ($this->forcedResult !== null) {
+			return $this->forcedResult;
+		}
+
+		if ($this->continueChain) {
+			return $this->processNextOrFinishSuccessfully($loginData);
+		}
+
+		return LoginResult::success();
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

While existing tests validate individual command logic, they don’t protect against regressions in chain composition (missing/reordered links). This test suite closes that gap and safeguards login flow integrity, especially around sequencing-sensitive steps like Flow V2 session handling, token creation, and 2FA handoff.

This PR adds focused unit coverage for `OC\Authentication\Login\Chain` to validate orchestration behavior that command-level tests do not cover:

- exact `setNext()` wiring order across all login commands
- end-to-end traversal through the configured chain
- correct propagation of the head command’s return result
- short-circuit behavior when the head returns failure

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
