### PR TITLE
fix: PostgreSQL transaction aborts when caching user mounts

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -7,10 +7,8 @@
  */
 namespace OC\Files\Config;
 
-use OC\DB\Exceptions\DbalException;
 use OC\User\LazyUser;
 use OCP\Cache\CappedMemoryCache;
-use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -167,25 +165,15 @@ class UserMountCache implements IUserMountCache {
 
 	private function addToCache(ICachedMountInfo $mount) {
 		if ($mount->getStorageId() !== -1) {
-			$qb = $this->connection->getQueryBuilder();
-			$qb
-				->insert('mounts')
-				->values([
-					'storage_id' => $qb->createNamedParameter($mount->getStorageId(), IQueryBuilder::PARAM_INT),
-					'root_id' => $qb->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT),
-					'user_id' => $qb->createNamedParameter($mount->getUser()->getUID()),
-					'mount_point' => $qb->createNamedParameter($mount->getMountPoint()),
-					'mount_point_hash' => $qb->createNamedParameter(hash('xxh128', $mount->getMountPoint())),
-					'mount_id' => $qb->createNamedParameter($mount->getMountId(), IQueryBuilder::PARAM_INT),
-					'mount_provider_class' => $qb->createNamedParameter($mount->getMountProvider()),
-				]);
-			try {
-				$qb->executeStatement();
-			} catch (Exception $e) {
-				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-					throw $e;
-				}
-			}
+			$this->connection->insertIgnoreConflict('mounts', [
+				'storage_id' => $mount->getStorageId(),
+				'root_id' => $mount->getRootId(),
+				'user_id' => $mount->getUser()->getUID(),
+				'mount_point' => $mount->getMountPoint(),
+				'mount_point_hash' => hash('xxh128', $mount->getMountPoint()),
+				'mount_id' => $mount->getMountId(),
+				'mount_provider_class' => $mount->getMountProvider(),
+			]);
 		} else {
 			// in some cases this is legitimate, like orphaned shares
 			$this->logger->debug('Could not get storage info for mount at ' . $mount->getMountPoint());
@@ -539,25 +527,15 @@ class UserMountCache implements IUserMountCache {
 	}
 
 	public function addMount(IUser $user, string $mountPoint, ICacheEntry $rootCacheEntry, string $mountProvider, ?int $mountId = null): void {
-		$query = $this->connection->getQueryBuilder();
-		$query->insert('mounts')
-			->values([
-				'storage_id' => $query->createNamedParameter($rootCacheEntry->getStorageId()),
-				'root_id' => $query->createNamedParameter($rootCacheEntry->getId()),
-				'user_id' => $query->createNamedParameter($user->getUID()),
-				'mount_point' => $query->createNamedParameter($mountPoint),
-				'mount_point_hash' => $query->createNamedParameter(hash('xxh128', $mountPoint)),
-				'mount_id' => $query->createNamedParameter($mountId),
-				'mount_provider_class' => $query->createNamedParameter($mountProvider)
-			]);
-
-		try {
-			$query->executeStatement();
-		} catch (DbalException $e) {
-			if ($e->getReason() !== DbalException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-				throw $e;
-			}
-		}
+		$this->connection->insertIgnoreConflict('mounts', [
+			'storage_id' => $rootCacheEntry->getStorageId(),
+			'root_id' => $rootCacheEntry->getId(),
+			'user_id' => $user->getUID(),
+			'mount_point' => $mountPoint,
+			'mount_point_hash' => hash('xxh128', $mountPoint),
+			'mount_id' => $mountId,
+			'mount_provider_class' => $mountProvider
+		]);
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #57572

## Summary

On PostgreSQL, the current implementation of UserMountCache::registerMounts() / addToCache() is not transaction‑safe. When a duplicate entry hits the unique index on mounts, the code catches the unique-constraint exception but the surrounding transaction on PostgreSQL remains in the aborted state. All subsequent statements in that transaction then fail with SQLSTATE[25P02]: current transaction is aborted, commands ignored until end of transaction block when mounts are registered.

Why this matters:

1. Not PostgreSQL-compatible: Silently swallowing the unique-constraint exception works on MySQL/SQLite, but breaks transaction semantics on PostgreSQL.
2. Potentially fixes nextcloud/server#57572, which is related to the new mount_point_hash / mounts_user_root_path_index migration and mount cache.
3. Cleaner solution: Using IDBConnection::insertIgnoreConflict('mounts', [...]) (which maps to INSERT ... ON CONFLICT DO NOTHING on PostgreSQL) is more idiomatic, avoids exceptions entirely, and keeps the transaction valid across all supported databases.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
