### PR TITLE
fix: handle null mime type in preview generation

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -400,7 +400,12 @@ class Generator {
 					$previewEntry->setMax($max);
 					$previewEntry->setCropped($crop);
 					$previewEntry->setEncrypted(false);
-					$previewEntry->setMimetype($preview->dataMimeType());
+					$previewMimeType = $preview->dataMimeType();
+					if ($previewMimeType === null) {
+						$this->logger->warning('Preview provider returned null MIME type for {path}, skipping provider.', ['path' => $file->getPath()]);
+						continue;
+					}
+					$previewEntry->setMimetype($previewMimeType);
 					$previewEntry->setEtag($file->getEtag());
 					$previewEntry->setMtime((new \DateTime())->getTimestamp());
 					return $this->savePreview($previewEntry, $preview);
@@ -554,7 +559,11 @@ class Generator {
 		$previewEntry->setMax(false);
 		$previewEntry->setCropped($crop);
 		$previewEntry->setEncrypted(false);
-		$previewEntry->setMimeType($preview->dataMimeType());
+		$previewMimeType = $preview->dataMimeType();
+		if ($previewMimeType === null) {
+			throw new NotFoundException('Generated preview has no MIME type for file ' . $file->getPath());
+		}
+		$previewEntry->setMimeType($previewMimeType);
 		$previewEntry->setEtag($file->getEtag());
 		$previewEntry->setMtime((new \DateTime())->getTimestamp());
 		if ($cacheResult) {


### PR DESCRIPTION
Fixes #58784

When generating previews for images with unusual dimensions (e.g. 18x4312 GIF), `IImage::dataMimeType()` can return null. This null value gets passed to `Preview::setMimeType(string)`, causing a TypeError that crashes the entire `occ preview:generate-all` batch.

This adds null checks for the MIME type returned by `dataMimeType()` in both preview generation paths:
- In `generateProviderPreview()`: skip to the next provider with a warning log
- In `generatePreview()`: throw `NotFoundException` so the file is skipped gracefully

Both are already handled by callers, so one bad file no longer terminates the batch.