### PR TITLE
fix(dav): return 401 instead of 503 for disabled user login attempts

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Connector\Sabre;
 use Exception;
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\TwoFactorAuth\Manager;
+use OC\User\LoginException;
 use OC\User\Session;
 use OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden;
 use OCA\DAV\Connector\Sabre\Exception\TooManyRequests;
@@ -109,6 +110,9 @@ class Auth extends AbstractBasic {
 			return $this->auth($request, $response);
 		} catch (NotAuthenticated $e) {
 			throw $e;
+		} catch (LoginException $e) {
+			Server::get(LoggerInterface::class)->info($e->getMessage(), ['exception' => $e]);
+			throw new NotAuthenticated($e->getMessage(), 0, $e);
 		} catch (Exception $e) {
 			$class = get_class($e);
 			$msg = $e->getMessage();

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\TwoFactorAuth\Manager;
+use OC\User\LoginException;
 use OC\User\Session;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden;
@@ -584,6 +585,35 @@ class AuthTest extends TestCase {
 			->willReturn($user);
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);
 		$this->assertEquals([true, 'principals/users/MyTestUser'], $response);
+	}
+
+	public function testCheckWithLoginExceptionThrowsNotAuthenticated(): void {
+		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
+		$this->expectExceptionMessage('User disabled');
+
+		$httpRequest = $this->createMock(RequestInterface::class);
+		$httpResponse = $this->createMock(ResponseInterface::class);
+		$this->userSession
+			->expects($this->any())
+			->method('isLoggedIn')
+			->willReturn(false);
+		$httpRequest
+			->expects($this->any())
+			->method('getHeader')
+			->willReturnMap([
+				['Authorization', 'basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+				['X-Requested-With', null],
+			]);
+		$this->userSession
+			->expects($this->once())
+			->method('logClientIn')
+			->with('username', 'password')
+			->willThrowException(new LoginException('User disabled'));
+		$this->session
+			->expects($this->once())
+			->method('close');
+
+		$this->auth->check($httpRequest, $httpResponse);
 	}
 
 	public function testAuthenticateInvalidCredentials(): void {


### PR DESCRIPTION
Fixes #22758

When a disabled user's device tries to sync via WebDAV, the `LoginException` was caught by the generic `Exception` handler in `Auth::check()`, causing a 503 ServiceUnavailable logged at error/fatal level. This spams logs when disabled users have devices that keep trying to sync.

This PR catches `LoginException` specifically and returns 401 NotAuthenticated instead, logging at info level since a disabled user attempting login is expected behavior, not a server error.