### PR TITLE
fix(files): allow file owner to unlock files locked by others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules/
 !/apps/sharebymail
 !/apps/encryption
 !/apps/files_external
+!/apps/files_lock
 !/apps/files_reminders
 !/apps/files_sharing
 !/apps/files_trashbin

--- a/apps/files_lock/src/api.ts
+++ b/apps/files_lock/src/api.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+import { type Node } from '@nextcloud/files'
+
+export const lockFile = async (node: Node) => {
+	const result = await axios.put(
+		generateOcsUrl(`/apps/files_lock/lock/${node.fileid}`),
+	)
+	console.debug('lock result', result)
+	return result?.data?.ocs?.data
+}
+
+export const unlockFile = async (node: Node) => {
+	const result = await axios.delete(
+		generateOcsUrl(`/apps/files_lock/lock/${node.fileid}`),
+	)
+	console.debug('lock result', result)
+	return result?.data?.ocs?.data
+}

--- a/apps/files_lock/src/helper.spec.ts
+++ b/apps/files_lock/src/helper.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { File, Permission } from '@nextcloud/files'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { canLock, canUnlock } from './helper'
+import { LockType } from './types'
+
+vi.mock('@nextcloud/auth', () => ({
+	getCurrentUser: vi.fn(() => ({ uid: 'alice', displayName: 'Alice' })),
+}))
+
+const lockedByBob = {
+	lock: '1',
+	'lock-owner': 'bob',
+	'lock-owner-displayname': 'Bob',
+	'lock-owner-type': LockType.User,
+	'lock-owner-editor': '',
+	'lock-time': Date.now(),
+	'share-permissions': Permission.ALL,
+}
+
+const lockedByAlice = {
+	lock: '1',
+	'lock-owner': 'alice',
+	'lock-owner-displayname': 'Alice',
+	'lock-owner-type': LockType.User,
+	'lock-owner-editor': '',
+	'lock-time': Date.now(),
+	'share-permissions': Permission.ALL,
+}
+
+const tokenLockedByBob = {
+	lock: '1',
+	'lock-owner': 'bob',
+	'lock-owner-displayname': 'Bob',
+	'lock-owner-type': LockType.Token,
+	'lock-owner-editor': '',
+	'lock-time': Date.now(),
+	'share-permissions': Permission.ALL,
+}
+
+const unlocked = {
+	lock: '',
+	'lock-owner': '',
+	'lock-owner-displayname': '',
+	'lock-owner-type': LockType.User,
+	'lock-owner-editor': '',
+	'lock-time': 0,
+	'share-permissions': Permission.ALL,
+}
+
+const makeFile = (owner: string, attributes: Record<string, unknown>, permissions = Permission.ALL) => {
+	return new File({
+		id: 1,
+		source: 'https://cloud.domain.com/remote.php/dav/files/admin/test.txt',
+		owner,
+		mime: 'text/plain',
+		root: '/files/admin',
+		permissions,
+		attributes,
+	})
+}
+
+describe('canUnlock', () => {
+	test('lock owner can unlock their own lock', () => {
+		const file = makeFile('bob', lockedByAlice)
+		expect(canUnlock(file)).toBe(true)
+	})
+
+	test('file owner can unlock a lock created by another user', () => {
+		const file = makeFile('alice', lockedByBob)
+		expect(canUnlock(file)).toBe(true)
+	})
+
+	test('file owner can unlock a token lock created by another user', () => {
+		const file = makeFile('alice', tokenLockedByBob)
+		expect(canUnlock(file)).toBe(true)
+	})
+
+	test('non-owner non-lock-creator cannot unlock', () => {
+		// Current user is alice, file owned by bob, locked by bob
+		const file = makeFile('bob', lockedByBob)
+		expect(canUnlock(file)).toBe(false)
+	})
+
+	test('cannot unlock if file is not locked', () => {
+		const file = makeFile('alice', unlocked)
+		expect(canUnlock(file)).toBe(false)
+	})
+})
+
+describe('canLock', () => {
+	test('can lock an unlocked updatable file', () => {
+		const file = makeFile('alice', unlocked)
+		expect(canLock(file)).toBe(true)
+	})
+
+	test('cannot lock an already locked file', () => {
+		const file = makeFile('alice', lockedByBob)
+		expect(canLock(file)).toBe(false)
+	})
+
+	test('cannot lock a file without update permission', () => {
+		const file = makeFile('alice', unlocked, Permission.READ)
+		expect(canLock(file)).toBe(false)
+	})
+})

--- a/apps/files_lock/src/helper.ts
+++ b/apps/files_lock/src/helper.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Permission, type Node } from '@nextcloud/files'
+import { generateUrl } from '@nextcloud/router'
+import { type LockState, LockType } from './types'
+import { translate as t } from '@nextcloud/l10n'
+import { getCurrentUser } from '@nextcloud/auth'
+
+export const getLockStateFromAttributes = (node: Node): LockState => {
+	return {
+		isLocked: !!node.attributes.lock,
+		lockOwner: node.attributes['lock-owner'],
+		lockOwnerDisplayName: node.attributes['lock-owner-displayname'],
+		lockOwnerType: parseInt(node.attributes['lock-owner-type']),
+		lockOwnerEditor: node.attributes['lock-owner-editor'],
+		lockTime: parseInt(node.attributes['lock-time']),
+	}
+}
+
+export const canLock = (node: Node): boolean => {
+	const state = getLockStateFromAttributes(node)
+
+	if (!state.isLocked && isUpdatable(node)) {
+		return true
+	}
+
+	return false
+}
+
+export const canUnlock = (node: Node): boolean => {
+	const state = getLockStateFromAttributes(node)
+
+	if (!state.isLocked) {
+		return false
+	}
+
+	// File owners can always unlock any lock on their files
+	if (node.owner === getCurrentUser()?.uid) {
+		return true
+	}
+
+	if (!isUpdatable(node)) {
+		return false
+	}
+
+	if (state.lockOwnerType === LockType.User && state.lockOwner === getCurrentUser()?.uid) {
+		return true
+	}
+
+	if (state.lockOwnerType === LockType.Token && state.lockOwner === getCurrentUser()?.uid) {
+		return true
+	}
+
+	return false
+}
+
+export const generateAvatarSvg = (userId: string) => {
+	const avatarUrl = generateUrl('/avatar/{userId}/32', { userId })
+	return `<svg width="32" height="32" viewBox="0 0 32 32"
+		xmlns="http://www.w3.org/2000/svg" class="sharing-status__avatar">
+		<image href="${avatarUrl}" height="32" width="32" />
+	</svg>`
+}
+
+export const getInfoLabel = (node: Node): string => {
+	const state = getLockStateFromAttributes(node)
+
+	if (state.lockOwnerType === LockType.User) {
+		return state.isLocked
+			? t('files_lock', 'Manually locked by {user}', { user: state.lockOwnerDisplayName })
+			: ''
+
+	} else if (state.lockOwnerType === LockType.App) {
+		return state.isLocked
+			? t('files_lock', 'Locked by editing online in {app}', { app: state.lockOwnerDisplayName })
+			: ''
+	} else {
+		return state.isLocked
+			? t('files_lock', 'Automatically locked by {user}', { user: state.lockOwnerDisplayName })
+			: ''
+	}
+
+	return ''
+}
+
+export const isUpdatable = (node: Node): boolean => {
+	return (node.permissions & Permission.UPDATE) !== 0 && (node.attributes['share-permissions'] & Permission.UPDATE) !== 0
+}

--- a/apps/files_lock/src/init.ts
+++ b/apps/files_lock/src/init.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { registerDavProperty } from '@nextcloud/files/dav'
+
+registerDavProperty('nc:lock', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:lock-owner', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:lock-owner-displayname', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:lock-owner-type', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:lock-owner-editor', { nc: 'http://nextcloud.org/ns' })
+registerDavProperty('nc:lock-time', { nc: 'http://nextcloud.org/ns' })

--- a/apps/files_lock/src/main.ts
+++ b/apps/files_lock/src/main.ts
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+	FileAction,
+	type Node,
+	type INode,
+	FileType,
+	registerFileAction,
+} from '@nextcloud/files'
+import { getDialogBuilder } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
+import { emit } from '@nextcloud/event-bus'
+import { lockFile, unlockFile } from './api'
+import { LockType } from './types'
+import {
+	canLock, canUnlock,
+	getInfoLabel,
+	getLockStateFromAttributes,
+	isUpdatable,
+} from './helper'
+import { getCurrentUser } from '@nextcloud/auth'
+
+import '@nextcloud/dialogs/style.css'
+import './styles.css'
+
+import LockSvg from '@mdi/svg/svg/lock-outline.svg?raw'
+import LockOpenSvg from '@mdi/svg/svg/lock-open-variant-outline.svg?raw'
+import LockEditSvg from '@mdi/svg/svg/pencil-lock-outline.svg?raw'
+import LockMonitorSvg from '@mdi/svg/svg/monitor-lock.svg?raw'
+import LockAccountSvg from '@mdi/svg/svg/account-lock-outline.svg?raw'
+
+const switchLock = async (node: Node) => {
+	try {
+		const state = getLockStateFromAttributes(node)
+		if (!state.isLocked) {
+			const data = await lockFile(node)
+			node.attributes.lock = '1'
+			node.attributes['lock-owner'] = data.userId
+			node.attributes['lock-owner-displayname'] = data.displayName
+			node.attributes['lock-owner-type'] = data.type
+			node.attributes['lock-time'] = data.creation
+		} else {
+			await unlockFile(node)
+			node.attributes.lock = ''
+			node.attributes['lock-owner'] = ''
+			node.attributes['lock-owner-displayname'] = ''
+			node.attributes['lock-owner-type'] = ''
+			node.attributes['lock-time'] = ''
+		}
+		emit('files:node:updated', node)
+		return true
+	} catch (e) {
+		console.error('Failed to switch lock', e)
+		return false
+	}
+}
+
+const getLockStateIcon = (node: Node) => {
+	const state = getLockStateFromAttributes(node)
+
+	if (!state.isLocked) {
+		return ''
+	}
+
+	if (state.lockOwnerType === LockType.Token) {
+		return LockMonitorSvg
+	}
+
+	if (state.lockOwnerType === LockType.App) {
+		return LockEditSvg
+	}
+
+	if (state.lockOwner !== getCurrentUser()?.uid) {
+		return LockAccountSvg
+	}
+
+	return LockSvg
+}
+
+const inlineAction = new FileAction({
+	id: 'lock_inline',
+	title: ({ nodes }: { nodes: INode[] }) => nodes.length === 1 ? getInfoLabel(nodes[0] as Node) : '',
+	inline: () => true,
+	displayName: () => '',
+	exec: async () => null,
+	order: -10,
+
+	iconSvgInline({ nodes }: { nodes: INode[] }) {
+		const node = nodes[0] as Node
+		return getLockStateIcon(node)
+	},
+
+	enabled({ nodes }: { nodes: INode[] }) {
+		// Only works on single node
+		if (nodes.length !== 1) {
+			return false
+		}
+
+		const node = nodes[0] as Node
+		const state = getLockStateFromAttributes(node)
+
+		return state.isLocked
+	},
+})
+
+const menuInfo = new FileAction({
+	id: 'lock_info',
+	order: 25,
+	displayName: ({ nodes }: { nodes: INode[] }) => getInfoLabel(nodes[0] as Node),
+	iconSvgInline: ({ nodes }: { nodes: INode[] }) => {
+		const node = nodes[0] as Node
+		return getLockStateIcon(node)
+	},
+	enabled({ nodes }: { nodes: INode[] }) {
+		// Only works on single node
+		if (nodes.length !== 1) {
+			return false
+		}
+		const node = nodes[0] as Node
+		const state = getLockStateFromAttributes(node)
+		return state.isLocked
+	},
+	async exec() {
+		return null
+	},
+})
+const menuAction = new FileAction({
+	id: 'lock',
+	order: 25,
+
+	iconSvgInline({ nodes }: { nodes: INode[] }) {
+		const node = nodes[0] as Node
+		const state = getLockStateFromAttributes(node)
+		return state.isLocked ? LockOpenSvg : LockSvg
+	},
+
+	displayName({ nodes }: { nodes: INode[] }) {
+		if (nodes.length !== 1) {
+			return ''
+		}
+		const node = nodes[0] as Node
+		return getLockStateFromAttributes(node).isLocked ? t('files_lock', 'Unlock file') : t('files_lock', 'Lock file')
+	},
+
+	enabled({ nodes }: { nodes: INode[] }) {
+		// Only works on single node
+		const node = nodes.length === 1 ? (nodes[0] as Node) : null
+		if (!node) {
+			return false
+		}
+
+		const canToggleLock = canLock(node) || canUnlock(node)
+		const isLocked = getLockStateFromAttributes(node).isLocked
+
+		return node.type === FileType.File && canToggleLock && (isUpdatable(node) || isLocked)
+	},
+
+	async exec({ nodes }: { nodes: INode[] }) {
+		const node = nodes[0] as Node
+		const lock = getLockStateFromAttributes(node)
+
+		if (lock?.lockOwnerType === LockType.Token) {
+			const dialog = getDialogBuilder(t('files_lock', 'files_lock', 'Unlock file manually'))
+				.setText(t('files_lock', 'This file has been locked automatically by a client. Removing the lock may lead to a conflict saving the file.'))
+				.setSeverity('warning')
+				.addButton({
+					label: t('files_lock', 'Keep lock'),
+					callback: () => {
+						// Dialog will close automatically
+					},
+				})
+				.addButton({
+					label: t('files_lock', 'Force unlock'),
+					callback: () => {
+						switchLock(node)
+					},
+				})
+				.build()
+			dialog.show()
+			return null
+		}
+
+		return await switchLock(node)
+	},
+
+})
+
+registerFileAction(inlineAction)
+registerFileAction(menuInfo)
+registerFileAction(menuAction)

--- a/apps/files_lock/src/styles.css
+++ b/apps/files_lock/src/styles.css
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* The grid view currently does not properly handle inline actions, we hide them for now */
+.action-item__popper .action.files-list__row-action-lock_inline,
+.files-list--grid .action.files-list__row-action-lock_inline {
+    display: none;
+}

--- a/apps/files_lock/src/types.ts
+++ b/apps/files_lock/src/types.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export enum LockType {
+	User = 0,
+	App = 1,
+	Token = 2,
+}
+
+export type LockState = {
+	isLocked: boolean,
+	lockOwner: string,
+	lockOwnerDisplayName: string,
+	lockOwnerType: LockType,
+	lockOwnerEditor: string,
+	lockTime: number,
+}


### PR DESCRIPTION
Fixes #58797

The `canUnlock` function in the files_lock app only checked whether the current user was the lock creator. This meant file owners could not unlock files locked by other users through the UI, even though the backend API already supports this.

The fix adds a file ownership check to `canUnlock()` so that file owners can always unlock any lock on their files, matching the existing backend behavior.

Also adds unit tests for `canLock` and `canUnlock` covering the owner-unlock scenario.