### PR TITLE
refactor(user_ldap): add type hints, harden TTL restore, improve comments/docblock in `dn2ocname`

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -596,40 +596,40 @@ class Access extends LDAPUtility {
 			$intName = $this->sanitizeGroupIDCandidate($ldapName);
 		}
 
-		//a new user/group! Add it only if it doesn't conflict with other backend's users or existing groups
-		//disabling Cache is required to avoid that the new user is cached as not-existing in fooExists check
-		//NOTE: mind, disabling cache affects only this instance! Using it
-		// outside of core user management will still cache the user as non-existing.
+		// Map a new user/group only if the candidate ID does not collide with existing users/groups.
+	
+		// Disable LDAP cache for this connection instance so conflict-detection existence
+		// checks are evaluated fresh and, more importantly, their results are not cached before mapping.
 		$originalTTL = $this->connection->ldapCacheTTL;
 		$this->connection->setConfiguration(['ldapCacheTTL' => 0]);
-		if ($intName !== ''
-			&& (($isUser && !$this->ncUserManager->userExists($intName))
-				|| (!$isUser && !Server::get(IGroupManager::class)->groupExists($intName))
-			)
-		) {
-			$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
-			$newlyMapped = $this->mapAndAnnounceIfApplicable($mapper, $fdn, $intName, $uuid, $isUser);
-			if ($newlyMapped) {
-				$this->logger->debug('Mapped {fdn} as {name}', ['fdn' => $fdn,'name' => $intName]);
-				return $intName;
-			}
-		}
 
-		$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
-		$altName = $this->createAltInternalOwnCloudName($intName, $isUser);
-		if (is_string($altName)) {
-			if ($this->mapAndAnnounceIfApplicable($mapper, $fdn, $altName, $uuid, $isUser)) {
-				$this->logger->warning(
-					'Mapped {fdn} as {altName} because of a name collision on {intName}.',
-					[
-						'fdn' => $fdn,
-						'altName' => $altName,
-						'intName' => $intName,
-					]
-				);
-				$newlyMapped = true;
-				return $altName;
+		try {
+			if ($intName !== '') {
+				$noUserConflict = $isUser && !$this->ncUserManager->userExists($intName);
+				$noGroupConflict = !$isUser && !Server::get(IGroupManager::class)->groupExists($intName);
+
+				if ($noUserConflict || $noGroupConflict) {
+					$newlyMapped = $this->mapAndAnnounceIfApplicable($mapper, $fdn, $intName, $uuid, $isUser);
+					if ($newlyMapped) {
+						$this->logger->debug('Mapped {fdn} as {name}', ['fdn' => $fdn, 'name' => $intName]);
+						return $intName;
+					}
+				}
 			}
+
+			$altName = $this->createAltInternalOwnCloudName($intName, $isUser);
+			if (is_string($altName)) {
+				if ($this->mapAndAnnounceIfApplicable($mapper, $fdn, $altName, $uuid, $isUser)) {
+					$this->logger->warning(
+						'Mapped {fdn} as {altName} because of a name collision on {intName}.',
+						['fdn' => $fdn, 'altName' => $altName, 'intName' => $intName]
+					);
+					$newlyMapped = true;
+					return $altName;
+				}
+			}
+		} finally {
+			$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
 		}
 
 		//if everything else did not help..

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -487,7 +487,7 @@ class Access extends LDAPUtility {
 	 */
 	public function dn2ocname(
 		string $fdn,
-		?string = $ldapName = null,
+		?string $ldapName = null,
 		bool $isUser = true,
 		?bool &$newlyMapped = null,
 		?array $record = null,

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -471,18 +471,28 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * returns an internal Nextcloud name for the given LDAP DN, false on DN outside of search DN
+	 * Resolves an LDAP DN to an internal Nextcloud user/group ID, optionally creating a new mapping.
 	 *
-	 * @param string $fdn the dn of the user object
-	 * @param string|null $ldapName optional, the display name of the object
-	 * @param bool $isUser optional, whether it is a user object (otherwise group assumed)
-	 * @param bool|null $newlyMapped
-	 * @param array|null $record
-	 * @param bool $autoMapping Should the group be mapped if not yet mapped
-	 * @return false|string with with the name to use in Nextcloud
-	 * @throws \Exception
+	 * Order: existing DN mapping, UUID mapping (updates DN), then optional auto-mapping (with collision fallback).
+	 *
+	 * @param string $fdn Full LDAP DN to resolve.
+	 * @param string|null $ldapName Optional group display-name candidate (used only if $isUser is false).
+	 * @param bool $isUser Whether the entry is a user (true) or a group (false).
+	 * @param bool|null &$newlyMapped Tracks whether a new mapping gets created in this call.
+	 * @param-out bool $newlyMapped True iff this call created a new mapping; false otherwise.
+	 * @param array|null $record Optional pre-fetched LDAP record; if null, attributes are read from LDAP.
+	 * @param bool $autoMapping If false, only existing mappings are resolved and no new mapping is created.
+	 * @return string|false Internal Nextcloud name, or false if resolution/mapping fails.
+	 * @throws ServerNotAvailableException
 	 */
-	public function dn2ocname($fdn, $ldapName = null, $isUser = true, &$newlyMapped = null, ?array $record = null, bool $autoMapping = true) {
+	public function dn2ocname(
+		string $fdn,
+		?string = $ldapName = null,
+		bool $isUser = true,
+		?bool &$newlyMapped = null,
+		?array $record = null,
+		bool $autoMapping = true,
+	): string|false {
 		static $intermediates = [];
 		if (isset($intermediates[($isUser ? 'user-' : 'group-') . $fdn])) {
 			return false; // is a known intermediate

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -600,7 +600,7 @@ class Access extends LDAPUtility {
 		}
 
 		// Map a new user/group only if the candidate ID does not collide with existing users/groups.
-	
+
 		// Disable LDAP cache for this connection instance so conflict-detection existence
 		// checks are evaluated fresh and, more importantly, their results are not cached before mapping.
 		$originalTTL = $this->connection->ldapCacheTTL;

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -493,9 +493,12 @@ class Access extends LDAPUtility {
 		?array $record = null,
 		bool $autoMapping = true,
 	): string|false {
+		// Use a static cache to track DNs already identified as intermediates
+		// within this request, avoiding redundant processing for the same DN.
 		static $intermediates = [];
-		if (isset($intermediates[($isUser ? 'user-' : 'group-') . $fdn])) {
-			return false; // is a known intermediate
+		$key = ($isUser ? 'user-' : 'group-') . $fdn;
+		if (isset($intermediates[$key])) {
+			return false; // already known intermediate
 		}
 
 		$newlyMapped = false;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

* Adds more type hints and aligns the method docblock with actual behavior and arguments
* Clarifies the purpose of the `$intermediates` static variable
* Refactors cache TTL logic to ensure TTL is always restored and reduce code duplication
* Updates related comments and clarifies conditionals for easier maintenance

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
