### PR TITLE
[stable32] feat: Add memcache_customprefix

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1688,6 +1688,16 @@ $CONFIG = [
 'memcache.distributed' => '\\OC\\Memcache\\Memcached',
 
 /**
+ * Cache Key Prefix for Redis or Memcached
+ *
+ * * Used for avoiding collisions in the cache system
+ * * May be used for ACL restrictions in Redis
+ *
+ * Defaults to ``''`` (empty string)
+ */
+'memcache_customprefix' => 'mycustomprefix',
+
+/**
  * Connection details for Redis to use for memory caching in a single server configuration.
  *
  * For enhanced security, it is recommended to configure Redis

--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -113,6 +113,7 @@ class Factory implements ICacheFactory {
 	protected function getGlobalPrefix(): string {
 		if ($this->globalPrefix === null) {
 			$config = \OCP\Server::get(SystemConfig::class);
+			$customprefix = $config->getValue('memcache_customprefix', '');
 			$maintenanceMode = $config->getValue('maintenance', false);
 			$versions = [];
 			if ($config->getValue('installed', false) && !$maintenanceMode) {
@@ -129,7 +130,7 @@ class Factory implements ICacheFactory {
 			// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
 			$instanceid = $config->getValue('instanceid');
 			$installedApps = implode(',', array_keys($versions)) . implode(',', array_values($versions));
-			$this->globalPrefix = hash('xxh128', $instanceid . $installedApps);
+			$this->globalPrefix = $customprefix . hash('xxh128', $instanceid . $installedApps);
 		}
 		return $this->globalPrefix;
 	}
@@ -143,9 +144,11 @@ class Factory implements ICacheFactory {
 	public function withServerVersionPrefix(\Closure $closure): void {
 		$backupPrefix = $this->globalPrefix;
 
+		$config = \OCP\Server::get(SystemConfig::class);
+		$customprefix = $config->getValue('memcache_customprefix', '');
 		// Include instanceid in the prefix, in case multiple instances use the same cache (e.g. same FPM pool)
-		$instanceid = \OCP\Server::get(SystemConfig::class)->getValue('instanceid');
-		$this->globalPrefix = hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
+		$instanceid = $config->getValue('instanceid');
+		$this->globalPrefix = $customprefix . hash('xxh128', $instanceid . implode('.', $this->serverVersion->getVersion()));
 		$closure($this);
 		$this->globalPrefix = $backupPrefix;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Manual backport of https://github.com/nextcloud/server/pull/58705

Automated backport failed because of code style / class imports.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
