### PR TITLE
test(ldap): align expectation for unset `ldapUserDisplayName2` with implementation to avoid PHP 8.5 warning

### DIFF
--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -713,7 +713,7 @@ class AccessTest extends TestCase {
 			->method('__get')
 			->willReturnMap([
 				[ 'ldapUserDisplayName', 'displayName' ],
-				[ 'ldapUserDisplayName2', null],
+				[ 'ldapUserDisplayName2', ''],
 			]);
 
 		$offlineUserMock = $this->createMock(OfflineUser::class);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fixes this test warning with PHP 8.5:

```
7) /home/runner/actions-runner/_work/server/server/apps/user_ldap/lib/Access.php:706
Using null as an array offset is deprecated, use an empty string instead

Triggered by:

* OCA\User_LDAP\Tests\AccessTest::testUserStateUpdate
  /home/runner/actions-runner/_work/server/server/apps/user_ldap/tests/AccessTest.php:711
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
