### PR TITLE
fix: add fallback to raw path info

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -717,7 +717,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			$requestUri = substr($requestUri, 0, $pos);
 		}
 
-		$scriptName = $this->server['SCRIPT_NAME'];
+		$scriptName = $this->server['SCRIPT_NAME'] ?? '';
 		$pathInfo = $requestUri;
 
 		// strip off the script name's dir and file name

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -1614,6 +1614,68 @@ class RequestTest extends \Test\TestCase {
 		];
 	}
 
+	public function testGetRawPathInfoWithoutScriptName(): void {
+		$request = new Request(
+			[
+				'server' => [
+					'REQUEST_URI' => '/index.php/apps/files/',
+				]
+			],
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame('index.php/apps/files/', $request->getRawPathInfo());
+	}
+
+	public function testGetPathInfoWithoutScriptName(): void {
+		$request = new Request(
+			[
+				'server' => [
+					'REQUEST_URI' => '/index.php/apps/files/',
+				]
+			],
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame('index.php/apps/files/', $request->getPathInfo());
+	}
+
+	public function testGetRawPathInfoWithoutScriptNameRoot(): void {
+		$request = new Request(
+			[
+				'server' => [
+					'REQUEST_URI' => '/',
+				]
+			],
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame('', $request->getRawPathInfo());
+	}
+
+	public function testGetRawPathInfoWithoutScriptNameOrRequestUri(): void {
+		$request = new Request(
+			[
+				'server' => []
+			],
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame('', $request->getRawPathInfo());
+	}
+
 	public function testGetRequestUriWithoutOverwrite(): void {
 		$this->config
 			->expects($this->once())


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/56843

## Summary

The raw path info method has no fallback for an empty array parameter, causing tests in the activity app to fail.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
