### PR TITLE
fix(files): Fix FileInfo['path'] situation

### DIFF
--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -230,14 +230,14 @@ class CacheTest extends TestCase {
 			[
 				[
 					'name' => 'shareddir',
-					'path' => 'files/shareddir',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER2 . '/files/shareddir',
 					'mimetype' => 'httpd/unix-directory',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',
 				],
 				[
 					'name' => 'shared single file.txt',
-					'path' => 'files/shared single file.txt',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER2 . '/files/shared single file.txt',
 					'mimetype' => 'text/plain',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',
@@ -254,21 +254,21 @@ class CacheTest extends TestCase {
 			[
 				[
 					'name' => 'bar.txt',
-					'path' => 'bar.txt',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER2 . '/files/shareddir/bar.txt',
 					'mimetype' => 'text/plain',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',
 				],
 				[
 					'name' => 'emptydir',
-					'path' => 'emptydir',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER2 . '/files/shareddir/emptydir',
 					'mimetype' => 'httpd/unix-directory',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',
 				],
 				[
 					'name' => 'subdir',
-					'path' => 'subdir',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER2 . '/files/shareddir/subdir',
 					'mimetype' => 'httpd/unix-directory',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',
@@ -336,21 +336,21 @@ class CacheTest extends TestCase {
 			[
 				[
 					'name' => 'another too.txt',
-					'path' => 'another too.txt',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER3 . '/files/subdir/another too.txt',
 					'mimetype' => 'text/plain',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',
 				],
 				[
 					'name' => 'another.txt',
-					'path' => 'another.txt',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER3 . '/files/subdir/another.txt',
 					'mimetype' => 'text/plain',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',
 				],
 				[
 					'name' => 'not a text file.xml',
-					'path' => 'not a text file.xml',
+					'path' => '/' . self::TEST_FILES_SHARING_API_USER3 . '/files/subdir/not a text file.xml',
 					'mimetype' => 'application/xml',
 					'uid_owner' => self::TEST_FILES_SHARING_API_USER1,
 					'displayname_owner' => 'User One',

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -82,6 +82,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 
 	public function offsetGet(mixed $offset): mixed {
 		return match ($offset) {
+			'path' => $this->getPath(),
 			'type' => $this->getType(),
 			'etag' => $this->getEtag(),
 			'size' => $this->getSize(),

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1642,8 +1642,6 @@ class View {
 						$rootEntry['permissions'] = $permissions & (Constants::PERMISSION_ALL - (Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE));
 					}
 
-					$rootEntry['path'] = substr(Filesystem::normalizePath($path . '/' . $rootEntry['name']), strlen($user) + 2); // full path without /$user/
-
 					// if sharing was disabled for the user we remove the share permissions
 					if ($sharingDisabled) {
 						$rootEntry['permissions'] = $rootEntry['permissions'] & ~Constants::PERMISSION_SHARE;

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -414,8 +414,8 @@ class ViewTest extends \Test\TestCase {
 		foreach ($results as $result) {
 			$paths[] = $result['path'];
 		}
-		$this->assertContains('/anotherstorage/folder/bar.txt', $paths);
-		$this->assertContains('/bar.txt', $paths);
+		$this->assertContains('/folder/anotherstorage/folder/bar.txt', $paths);
+		$this->assertContains('/folder/bar.txt', $paths);
 
 		$results = $folderView->search('foo');
 		$this->assertCount(2, $results);
@@ -423,8 +423,8 @@ class ViewTest extends \Test\TestCase {
 		foreach ($results as $result) {
 			$paths[] = $result['path'];
 		}
-		$this->assertContains('/anotherstorage/foo.txt', $paths);
-		$this->assertContains('/anotherstorage/foo.png', $paths);
+		$this->assertContains('/folder/anotherstorage/foo.txt', $paths);
+		$this->assertContains('/folder/anotherstorage/foo.png', $paths);
 
 		$this->assertCount(6, $rootView->searchByMime('text'));
 		$this->assertCount(3, $folderView->searchByMime('text'));


### PR DESCRIPTION
## Summary

Previously `$fileInfo->getPath()` and `$fileInfo['path']` would return different things. The `[]` version was not consistent, being sometimes relative and sometimes kind of absolute, and sometimes plenty wrong (like when used from occ commands, because there is no user in session).
So this is always returning absolute now.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
