### PR TITLE
Remove leftover useless path assignements in View

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1649,9 +1649,6 @@ class View {
 						$rootEntry['permissions'] = $rootEntry['permissions'] & ~Constants::PERMISSION_SHARE;
 					}
 
-					// FIXME: $user is null in encrypt:all occ command
-					$rootEntry['path'] = substr(Filesystem::normalizePath($path . '/' . $rootEntry['name']), strlen($user?->getUID() ?? '') + 2); // full path without /$user/
-
 					$ownerId = $subStorage->getOwner('');
 					if ($ownerId !== false) {
 						$owner = $this->getUserObjectForOwner($ownerId);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1762,7 +1762,6 @@ class View {
 				if (substr($mountPoint . $result['path'], 0, $rootLength + 1) === $this->fakeRoot . '/') {
 					$internalPath = $result['path'];
 					$path = $mountPoint . $result['path'];
-					$result['path'] = substr($mountPoint . $result['path'], $rootLength);
 					$ownerId = $storage->getOwner($internalPath);
 					if ($ownerId !== false) {
 						$owner = $userManager->get($ownerId);
@@ -1785,7 +1784,6 @@ class View {
 					if ($results) {
 						foreach ($results as $result) {
 							$internalPath = $result['path'];
-							$result['path'] = rtrim($relativeMountPoint . $result['path'], '/');
 							$path = rtrim($mountPoint . $internalPath, '/');
 							$ownerId = $storage->getOwner($internalPath);
 							if ($ownerId !== false) {


### PR DESCRIPTION
## Summary

Follow-up of both #58593 and #58827 
Clean-up useless assignments of 'path' key in View.php.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
