### PR TITLE
refactor(storage): improve LocalTempFileTrait docs and harden toTmpFile stream handling

### DIFF
--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -26,7 +26,7 @@ trait LocalTempFileTrait {
 	/**
 	 * Returns the temporary local file path associated with the specified storage file.
 	 *
-	 * Creates temp file on first use if necessary. Caches for repeated (instance-level) access.
+	 * Creates a temp file on first use if necessary. Caches for repeated (instance-level) access.
 	 *
 	 * @param string $path Storage-internal path
 	 * @return string|false Local temp file path, or false if the source cannot be opened/copied
@@ -55,22 +55,30 @@ trait LocalTempFileTrait {
 	 * @param string $path Storage-internal path
 	 * @return string|false Local temp file path, or false on failure
 	 */
-	protected function toTmpFile(string $path): string|false { //no longer in the storage api, still useful here
+	protected function toTmpFile(string $path): string|false {
 		$source = $this->fopen($path, 'r');
 		if (!$source) {
 			return false;
 		}
-		if ($pos = strrpos($path, '.')) {
-			$extension = substr($path, $pos);
-		} else {
-			$extension = '';
-		}
+
+		$ext = pathinfo($path, PATHINFO_EXTENSION);
+		$extension = $ext !== '' ? '.' . $ext : '';
+
 		$tmpFile = Server::get(ITempManager::class)->getTemporaryFile($extension);
 		$target = fopen($tmpFile, 'w');
-		$result = stream_copy_to_stream($source, $target);
-		fclose($target);
-		if ($result === false) {
+		if ($target === false) {
+			fclose($source);
 			return false;
+		}
+
+		try {
+			$result = stream_copy_to_stream($source, $target);
+			if ($result === false) {
+				return false;
+			}
+		} finally {
+			fclose($target);
+			fclose($source);
 		}
 
 		return $tmpFile;

--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -11,20 +11,26 @@ use OCP\ITempManager;
 use OCP\Server;
 
 /**
- * Storage backend class for providing common filesystem operation methods
- * which are not storage-backend specific.
+ * Helper methods for temporary local file handling for storage paths.
  *
- * \OC\Files\Storage\Common is never used directly; it is extended by all other
- * storage backends, where its methods may be overridden, and additional
- * (backend-specific) methods are defined.
+ * Intended for use by storage implementations such as \OC\Files\Storage\Common.
  *
- * Some \OC\Files\Storage\Common methods call functions which are first defined
- * in classes which extend it, e.g. $this->stat() .
+ * This trait caches per-path temporary local copies created from storage streams,
+ * so repeated local-file access can reuse the same temp file during the instance
+ * lifetime.
  */
 trait LocalTempFileTrait {
 	/** @var array<string,string|false> */
 	protected array $cachedFiles = [];
 
+	/**
+	 * Returns the temporary local file path associated with the specified storage file.
+	 *
+	 * Creates temp file on first use if necessary. Caches for repeated (instance-level) access.
+	 *
+	 * @param string $path Storage-internal path
+	 * @return string|false Local temp file path, or false if the source cannot be opened/copied
+	 */
 	protected function getCachedFile(string $path): string|false {
 		if (!isset($this->cachedFiles[$path])) {
 			$this->cachedFiles[$path] = $this->toTmpFile($path);
@@ -32,10 +38,23 @@ trait LocalTempFileTrait {
 		return $this->cachedFiles[$path];
 	}
 
+	/**
+	 * Invalidate the cached temp local file entry for the specified storage file.
+	 *
+	 * @param string $path Storage-internal path
+	 */
 	protected function removeCachedFile(string $path): void {
 		unset($this->cachedFiles[$path]);
 	}
 
+	/**
+	 * Copies a storage file stream into a temporary local file.
+	 *
+	 * The temporary local file keeps the same extension (if any) as the source file.
+	 *
+	 * @param string $path Storage-internal path
+	 * @return string|false Local temp file path, or false on failure
+	 */
 	protected function toTmpFile(string $path): string|false { //no longer in the storage api, still useful here
 		$source = $this->fopen($path, 'r');
 		if (!$source) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

- Replaces inherited/outdated trait docblock text with trait-specific documentation.
  - Existing docblock was just a copy/paste of the one from `Common` and thus was not adding anything and was inaccurate.
- Adds focused method-level docblocks
- Refactors `toTmpFile()` for robustness and readability:
  - use `pathinfo(..., PATHINFO_EXTENSION)` for clearer/consistent extension extraction
  - handle target `fopen` failure explicitly
  - ensure both source and target streams are always closed via `try/finally`

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
