### PR TITLE
refactor(view): `getLocalFile` path handling

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -97,7 +97,7 @@ class View {
 
 	/**
 	 * Returns an absolute path in Nextcloud's virtual filesystem for this view.
-	 * 
+	 *
 	 * The returned path is scoped by this view's fake root.
 	 *
 	 * @psalm-template S as string|null

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -96,12 +96,15 @@ class View {
 	}
 
 	/**
-	 * @param ?string $path
+	 * Returns an absolute path in Nextcloud's virtual filesystem for this view.
+	 * 
+	 * The returned path is scoped by this view's fake root.
+	 *
 	 * @psalm-template S as string|null
 	 * @psalm-param S $path
 	 * @psalm-return (S is string ? string : null)
 	 */
-	public function getAbsolutePath($path = '/'): ?string {
+	public function getAbsolutePath(?string $path = '/'): ?string {
 		if ($path === null) {
 			return null;
 		}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -185,33 +185,42 @@ class View {
 	}
 
 	/**
-	 * Resolve a path to a storage and internal path
+	 * Resolve a path to a storage and internal path.
 	 *
-	 * @param string $path
-	 * @return array{?IStorage, string} an array consisting of the storage and the internal path
+	 * Accepts both:
+	 * - relative paths (interpreted relative to this view root), and
+	 * - absolute paths in Nextcloud's virtual filesystem (leading '/').
+	 *
+	 * @param string $path Relative path, or absolute virtual filesystem path
+	 * @return array{?IStorage, string} An array containing [storage, internalPath]
 	 */
-	public function resolvePath($path): array {
-		$a = $this->getAbsolutePath($path);
-		$p = Filesystem::normalizePath($a);
-		return Filesystem::resolvePath($p);
+	public function resolvePath(string $path): array {
+		$absolutePath = $this->getAbsolutePath($path);
+		$normalizedPath = Filesystem::normalizePath($absolutePath);
+		return Filesystem::resolvePath($normalizedPath);
 	}
 
 	/**
-	 * Return the path to a local version of the file
-	 * we need this because we can't know if a file is stored local or not from
-	 * outside the filestorage and for some purposes a local file is needed
+	 * Return the path to a local representation of a file.
 	 *
-	 * @param string $path
+	 * For local storages this is usually the real on-disk path.
+	 * For non-local storages this may be a temporary local file.
+	 *
+	 * @param string $path Path relative to this view, or absolute virtual filesystem path
+	 * @return string|false Local file path, or false if unavailable
 	 */
-	public function getLocalFile($path): string|false {
-		$parent = substr($path, 0, strrpos($path, '/') ?: 0);
-		$path = $this->getAbsolutePath($path);
-		[$storage, $internalPath] = Filesystem::resolvePath($path);
-		if (Filesystem::isValidPath($parent) && $storage) {
-			return $storage->getLocalFile($internalPath);
-		} else {
+	public function getLocalFile(string $path): string|false {
+		$parentPath = dirname($path);
+		if (!Filesystem::isValidPath($parentPath)) {
 			return false;
 		}
+
+		[$storage, $internalPath] = $this->resolvePath($path);
+		if (!$storage) {
+			return false;
+		}
+
+		return $storage->getLocalFile($internalPath);
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

:broom: 
The previous `getLocalFile()` logic worked, but used less-intuitive parent extraction and duplicated resolution steps. It now uses View's `resolvePath()` rather than duplicating logic.

Also adds type hinting for and clarifies `resolvePath` and `getAbsolutePath()` contracts.

This is primarily a readability/maintainability refactor plus doc clarity.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
