### PR TITLE
feat(core): cast valid booleans when setting system configs

### DIFF
--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -61,6 +61,14 @@ class SetConfig extends Base {
 		$configValue = $this->castHelper->castValue($input->getOption('value'), $input->getOption('type'));
 		$updateOnly = $input->getOption('update-only');
 
+		// If value is string false or true, cast them too
+		if (is_string($configValue['value'])) {
+			$lowerValue = strtolower($configValue['value']);
+			if ($lowerValue === 'false' || $lowerValue === 'true') {
+				$configValue = $this->castHelper->castValue($input->getOption('value'), 'boolean');
+			}
+		}
+
 		if (count($configNames) > 1) {
 			$existingValue = $this->systemConfig->getValue($configName);
 


### PR DESCRIPTION
I think we could be smarter with primitive values like those :see_no_evil: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
