### PR TITLE
chore(.htaccess): :broom: drop no-op QSA flag from RewriteRules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -129,11 +129,10 @@
 ## Rule: Map /remote* --> /remote.php* including the query string
 ##
 ## Context:
-##    - XXX: `QSA` seems unnecessary (no-op) here (query string is passed by default when the replacement URI doesn't contain a query string)
 ##    - XXX: Is this even used anymore? Seems a relic from <NC12
 ##
 
-    RewriteRule ^remote/(.*) remote.php [QSA,L]
+    RewriteRule ^remote/(.*) remote.php [L]
 
 ##
 ## Rule: Prevent access to non-public files
@@ -148,21 +147,19 @@
 ##    - Intentionally excludes URIs used for HTTPS certificate verifications
 ##        - RFC 8555 / ACME HTTP Challenges (acme-challenge) 
 ##        - File-based Validations (pki-validation)
-##    - XXX: `QSA` seems unnecessary (no-op) here (query string is passed by default when the replacement URI doesn't contain a query string)
 ##    - XXX: Sometimes we are using `/index.php` and other times `index.php` as our replacement URI; this may be incorrect
 ##
 
-    RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) /index.php [QSA,L]
+    RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) /index.php [L]
 
 ##
 ## Rule: Map the ocm-provider handling to our main frontend controller (/index.php)
 ##
 ## Context:
-##    - XXX: `QSA` seems unnecessary (no-op) here (query string is passed by default when the replacement URI doesn't contain a query string)
 ##    - XXX: Sometimes we are using `/index.php` and other times `index.php` as our replacement URI; this may be incorrect
 ##
 
-    RewriteRule ^ocm-provider/?$ index.php [QSA,L]
+    RewriteRule ^ocm-provider/?$ index.php [L]
 
 ##
 ## Rule: Prevent access to more non-public files


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

:broom: 
- For Apache `RewriteRule`, if the substitution (right side) has no `?` query part, the original query string is already preserved by default.
- So `QSA` adds nothing in these rules.

Note for the future: QSA will be needed if we ever add a query string on the right (substitution) side. We don't currently so this is just noise in the htaccess rules.

https://httpd.apache.org/docs/trunk/rewrite/flags.html#flag_qsa
https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule

P.S. In case it comes up, no current counterpart adjustments need to be made to our Nginx configuration at this time.

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
