### PR TITLE
fix(lib): templates core path detection

### DIFF
--- a/lib/private/Template/Template.php
+++ b/lib/private/Template/Template.php
@@ -73,7 +73,7 @@ class Template extends Base implements ITemplate {
 	 */
 	protected function findTemplate(string $theme, string $app, string $name): array {
 		// Check if it is a app template or not.
-		if ($app !== '') {
+		if ($app !== '' && $app !== 'core') {
 			try {
 				$appDir = Server::get(IAppManager::class)->getAppPath($app);
 			} catch (AppPathNotFoundException) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary

For some reason, since NC32, the `getAppTemplateDirs` function returns `themes/example/apps/core/templates` for core templates, while it used to return `themes/example/core/templates`.
In any case, seeign the method below, I fully assume this was a mistake initially and that if the app was core, the `getCoreTemplateDirs` should have been used :shrug: 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
