### PR TITLE
fix: call log normalizer by reference

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -159,7 +159,9 @@ class Log implements ILogger, IDataLogger {
 			return; // no crash reporter, no listeners, we can stop for lower log level
 		}
 
-		$context = array_map($this->normalizer->format(...), $context);
+		foreach ($context as $val) {
+			$this->normalizer->format($val);
+		}
 
 		$app = $context['app'] ?? 'no app in context';
 		$entry = $this->interpolateMessage($context, $message);
@@ -341,7 +343,9 @@ class Log implements ILogger, IDataLogger {
 			return;
 		}
 
-		$context = array_map($this->normalizer->format(...), $context);
+		foreach ($context as $val) {
+			$this->normalizer->format($val);
+		}
 		$data = $context;
 		unset($data['app'], $data['level']);
 
@@ -372,7 +376,9 @@ class Log implements ILogger, IDataLogger {
 		$level = $context['level'] ?? ILogger::ERROR;
 
 		$minLevel = $this->getLogLevel($context, $message);
-		$data = array_map($this->normalizer->format(...), $data);
+		foreach ($data as $val) {
+			$this->normalizer->format($val);
+		}
 
 		try {
 			if ($level >= $minLevel) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Apparently the function reference syntax doesn't allow PHP to pass by ref.

1. ``Nextcloud\\LogNormalizer\\Normalizer::format(): Argument #1 ($data) must be passed by reference, value given at /nextcloud/lib/private/Log.php#162``
2. ``Nextcloud\\LogNormalizer\\Normalizer::format(): Argument #1 ($data) must be passed by reference, value given at /nextcloud/lib/private/Log.php#347``
3. ``"Nextcloud\\LogNormalizer\\Normalizer::format(): Argument #1 ($data) must be passed by reference, value given at /nextcloud/lib/private/Log.php#349``

## TODO

- [x] fix

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
