### PR TITLE
fix(sharing): Align userid config key in UserPlugin with Manager

### DIFF
--- a/build/integration/features/bootstrap/ShareesContext.php
+++ b/build/integration/features/bootstrap/ShareesContext.php
@@ -30,7 +30,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_email');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_dn');
-		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_userid');
+		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_user_id');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_to_group');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_to_phone');
 	}

--- a/build/integration/sharees_features/sharees_user.feature
+++ b/build/integration/sharees_features/sharees_user.feature
@@ -345,7 +345,7 @@ Feature: sharees_user
 		And user "test2" belongs to group "groupA"
 		And As an "test"
 		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-		And parameter "shareapi_restrict_user_enumeration_full_match_userid" of app "core" is set to "no"
+		And parameter "shareapi_restrict_user_enumeration_full_match_user_id" of app "core" is set to "no"
 		When getting sharees for
 			| search   | test1 |
 			| itemType | file  |

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -103,7 +103,7 @@ readonly class UserPlugin implements ISearchPlugin {
 		// Even if normal sharee enumeration is not allowed, full matches are still allowed.
 		$shareeEnumerationFullMatch = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match', 'yes') === 'yes';
 		if ($shareeEnumerationFullMatch && $search !== '') {
-			$shareeEnumerationFullMatchUserId = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_userid', 'yes') === 'yes';
+			$shareeEnumerationFullMatchUserId = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_user_id', 'yes') === 'yes';
 			$shareeEnumerationFullMatchEmail = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_email', 'yes') === 'yes';
 			$shareeEnumerationFullMatchIgnoreSecondDisplayName = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_dn', 'no') === 'yes';
 


### PR DESCRIPTION
- resolves https://github.com/nextcloud/server/issues/58858

UserPlugin reads `shareapi_restrict_user_enumeration_full_match_userid` (no underscore) while Manager.php and the frontend both use `shareapi_restrict_user_enumeration_full_match_user_id` (with underscore).

This mismatch causes the "disable exact match by user ID" admin setting to have no effect on actual sharee search results.
