### PR TITLE
refactor(dbal): move from deprecated to modern calls

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1570,8 +1570,12 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			}
 
 			if ($forceDeletePermanently || $this->config->getAppValue(Application::APP_ID, RetentionService::RETENTION_CONFIG_KEY) === '0') {
-				$stmt = $this->db->prepare('DELETE FROM `*PREFIX*calendarobjects` WHERE `calendarid` = ? AND `uri` = ? AND `calendartype` = ?');
-				$stmt->execute([$calendarId, $objectUri, $calendarType]);
+				$qb = $this->db->getQueryBuilder();
+				$qb->delete('calendarobjects')
+					->where($qb->expr()->eq('calendarid', $qb->createNamedParameter($calendarId)))
+					->andWhere($qb->expr()->eq('uri', $qb->createNamedParameter($objectUri)))
+					->andWhere($qb->expr()->eq('calendartype', $qb->createNamedParameter($calendarType)))
+					->executeStatement();
 
 				$this->purgeProperties($calendarId, $data['id']);
 

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1778,8 +1778,12 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			}
 
 			if ($forceDeletePermanently || $this->config->getAppValue(Application::APP_ID, RetentionService::RETENTION_CONFIG_KEY) === '0') {
-				$stmt = $this->db->prepare('DELETE FROM `*PREFIX*calendarobjects` WHERE `calendarid` = ? AND `uri` = ? AND `calendartype` = ?');
-				$stmt->execute([$calendarId, $objectUri, $calendarType]);
+				$qb = $this->db->getQueryBuilder();
+				$qb->delete('calendarobjects')
+					->where($qb->expr()->eq('calendarid', $qb->createNamedParameter($calendarId)))
+					->andWhere($qb->expr()->eq('uri', $qb->createNamedParameter($objectUri)))
+					->andWhere($qb->expr()->eq('calendartype', $qb->createNamedParameter($calendarType)))
+					->executeStatement();
 
 				$this->purgeProperties($calendarId, $data['id']);
 

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -104,7 +104,10 @@ class DeleteOrphanedFilesTest extends TestCase {
 		$this->assertEquals(1, $this->getMountsCount($numericStorageId), 'Asserts that mount is still available');
 
 
-		$deletedRows = $this->connection->executeUpdate('DELETE FROM `*PREFIX*storages` WHERE `id` = ?', [$storageId]);
+		$qb = $this->connection->getQueryBuilder();
+		$deletedRows = $qb->delete('storages')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($storageId)))
+			->executeStatement();
 		$this->assertNotNull($deletedRows, 'Asserts that storage got deleted');
 		$this->assertSame(1, $deletedRows, 'Asserts that storage got deleted');
 

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -104,7 +104,10 @@ class DeleteOrphanedFilesTest extends TestCase {
 		$this->assertCount(1, $this->getFile($fileInfo->getId()), 'Asserts that file is still available');
 		$this->assertEquals(1, $this->getMountsCount($numericStorageId), 'Asserts that mount is still available');
 
-		$deletedRows = $this->connection->executeUpdate('DELETE FROM `*PREFIX*storages` WHERE `id` = ?', [$storageId]);
+		$qb = $this->connection->getQueryBuilder();
+		$deletedRows = $qb->delete('storages')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($storageId)))
+			->executeStatement();
 		$this->assertNotNull($deletedRows, 'Asserts that storage got deleted');
 		$this->assertSame(1, $deletedRows, 'Asserts that storage got deleted');
 

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -70,7 +70,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		$this->connection = Server::get(IDBConnection::class);
 		// clear occasional leftover shares from other tests
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->connection->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
@@ -85,7 +85,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->connection->getQueryBuilder()->delete('share')->executeStatement();
 
 		$userManager = Server::get(IUserManager::class);
 		$user1 = $userManager->get($this->user1);
@@ -104,7 +104,10 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 	private function getShares() {
 		$shares = [];
-		$result = $this->connection->executeQuery('SELECT * FROM `*PREFIX*share`');
+		$result = $this->connection->getQueryBuilder()
+			->select('*')
+			->from('share')
+			->executeQuery();
 		while ($row = $result->fetchAssociative()) {
 			$shares[] = $row;
 		}

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -75,7 +75,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		$this->connection = Server::get(IDBConnection::class);
 		// clear occasional leftover shares from other tests
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->connection->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
@@ -89,7 +89,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->connection->getQueryBuilder()->delete('share')->executeStatement();
 
 		$userManager = Server::get(IUserManager::class);
 		$user1 = $userManager->get($this->user1);
@@ -108,7 +108,10 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 	private function getShares() {
 		$shares = [];
-		$result = $this->connection->executeQuery('SELECT * FROM `*PREFIX*share`');
+		$result = $this->connection->getQueryBuilder()
+			->select('*')
+			->from('share')
+			->executeQuery();
 		while ($row = $result->fetchAssociative()) {
 			$shares[] = $row;
 		}

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -51,7 +51,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 		$this->mailer = $this->createMock(IMailer::class);
 
 		// Clear occasional leftover shares from other tests
-		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->db->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
@@ -78,7 +78,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->db->getQueryBuilder()->delete('share')->executeStatement();
 
 		$userManager = Server::get(IUserManager::class);
 		$user1 = $userManager->get($this->user1);

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -55,7 +55,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 		$this->mailer = $this->createMock(IMailer::class);
 
 		// Clear occasional leftover shares from other tests
-		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->db->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
@@ -82,7 +82,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
+		$this->db->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->logout();
 

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -144,7 +144,7 @@ class TrashbinTest extends \Test\TestCase {
 
 		// clear trash table
 		$connection = Server::get(IDBConnection::class);
-		$connection->executeUpdate('DELETE FROM `*PREFIX*files_trash`');
+		$connection->getQueryBuilder()->delete('files_trash')->executeStatement();
 
 		parent::tearDown();
 	}

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -8,7 +8,6 @@
 namespace OCA\User_LDAP\Mapping;
 
 use Doctrine\DBAL\Exception;
-use OCP\DB\IPreparedStatement;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IAppConfig;
 use OCP\ICache;
@@ -154,23 +153,6 @@ abstract class AbstractMapping {
 		}
 	}
 
-	/**
-	 * Performs a DELETE or UPDATE query to the database.
-	 *
-	 * @param IPreparedStatement $statement
-	 * @param array $parameters
-	 * @return bool true if at least one row was modified, false otherwise
-	 */
-	protected function modify(IPreparedStatement $statement, $parameters) {
-		try {
-			$result = $statement->execute($parameters);
-			$updated = $result->rowCount() > 0;
-			$result->closeCursor();
-			return $updated;
-		} catch (Exception $e) {
-			return false;
-		}
-	}
 
 	/**
 	 * Gets the LDAP DN based on the provided name.
@@ -199,13 +181,16 @@ abstract class AbstractMapping {
 	 */
 	public function setDNbyUUID($fdn, $uuid) {
 		$oldDn = $this->getDnByUUID($uuid);
-		$statement = $this->dbc->prepare('
-			UPDATE `' . $this->getTableName() . '`
-			SET `ldap_dn_hash` = ?, `ldap_dn` = ?
-			WHERE `directory_uuid` = ?
-		');
-
-		$r = $this->modify($statement, [$this->getDNHash($fdn), $fdn, $uuid]);
+		$qb = $this->dbc->getQueryBuilder();
+		try {
+			$r = $qb->update($this->getTableName(false))
+				->set('ldap_dn_hash', $qb->createNamedParameter($this->getDNHash($fdn)))
+				->set('ldap_dn', $qb->createNamedParameter($fdn))
+				->where($qb->expr()->eq('directory_uuid', $qb->createNamedParameter($uuid)))
+				->executeStatement() > 0;
+		} catch (Exception $e) {
+			$r = false;
+		}
 		if ($r) {
 			if (is_string($oldDn) && isset($this->cache[$oldDn])) {
 				$userId = $this->cache[$oldDn];
@@ -231,15 +216,17 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function setUUIDbyDN($uuid, $fdn): bool {
-		$statement = $this->dbc->prepare('
-			UPDATE `' . $this->getTableName() . '`
-			SET `directory_uuid` = ?
-			WHERE `ldap_dn_hash` = ?
-		');
-
 		unset($this->cache[$fdn]);
 
-		return $this->modify($statement, [$uuid, $this->getDNHash($fdn)]);
+		$qb = $this->dbc->getQueryBuilder();
+		try {
+			return $qb->update($this->getTableName(false))
+				->set('directory_uuid', $qb->createNamedParameter($uuid))
+				->where($qb->expr()->eq('ldap_dn_hash', $qb->createNamedParameter($this->getDNHash($fdn))))
+				->executeStatement() > 0;
+		} catch (Exception $e) {
+			return false;
+		}
 	}
 
 	/**
@@ -333,14 +320,14 @@ abstract class AbstractMapping {
 	 * @return string[]
 	 */
 	public function getNamesBySearch(string $search, string $prefixMatch = '', string $postfixMatch = ''): array {
-		$statement = $this->dbc->prepare('
-			SELECT `owncloud_name`
-			FROM `' . $this->getTableName() . '`
-			WHERE `owncloud_name` LIKE ?
-		');
-
+		$qb = $this->dbc->getQueryBuilder();
 		try {
-			$res = $statement->execute([$prefixMatch . $this->dbc->escapeLikeParameter($search) . $postfixMatch]);
+			$res = $qb->select('owncloud_name')
+				->from($this->getTableName(false))
+				->where($qb->expr()->like('owncloud_name', $qb->createNamedParameter(
+					$prefixMatch . $this->dbc->escapeLikeParameter($search) . $postfixMatch
+				)))
+				->executeQuery();
 		} catch (Exception $e) {
 			return [];
 		}
@@ -348,6 +335,7 @@ abstract class AbstractMapping {
 		while ($row = $res->fetchAssociative()) {
 			$names[] = $row['owncloud_name'];
 		}
+		$res->closeCursor();
 		return $names;
 	}
 
@@ -443,17 +431,20 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function unmap($name) {
-		$statement = $this->dbc->prepare('
-			DELETE FROM `' . $this->getTableName() . '`
-			WHERE `owncloud_name` = ?');
-
 		$dn = array_search($name, $this->cache, true);
 		if ($dn !== false) {
 			unset($this->cache[$dn]);
 		}
 		$this->localNameToDnCache?->remove($name);
 
-		return $this->modify($statement, [$name]);
+		$qb = $this->dbc->getQueryBuilder();
+		try {
+			return $qb->delete($this->getTableName(false))
+				->where($qb->expr()->eq('owncloud_name', $qb->createNamedParameter($name)))
+				->executeStatement() > 0;
+		} catch (Exception $e) {
+			return false;
+		}
 	}
 
 	/**

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -9,7 +9,6 @@
 namespace OCA\User_LDAP\Mapping;
 
 use Doctrine\DBAL\Exception;
-use OCP\DB\IPreparedStatement;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IAppConfig;
 use OCP\ICache;
@@ -156,24 +155,6 @@ abstract class AbstractMapping {
 	}
 
 	/**
-	 * Performs a DELETE or UPDATE query to the database.
-	 *
-	 * @param IPreparedStatement $statement
-	 * @param array $parameters
-	 * @return bool true if at least one row was modified, false otherwise
-	 */
-	protected function modify(IPreparedStatement $statement, $parameters) {
-		try {
-			$result = $statement->execute($parameters);
-			$updated = $result->rowCount() > 0;
-			$result->closeCursor();
-			return $updated;
-		} catch (Exception $e) {
-			return false;
-		}
-	}
-
-	/**
 	 * Gets the LDAP DN based on the provided name.
 	 */
 	public function getDNByName(string $name): string|false {
@@ -200,13 +181,16 @@ abstract class AbstractMapping {
 	 */
 	public function setDNbyUUID($fdn, $uuid) {
 		$oldDn = $this->getDnByUUID($uuid);
-		$statement = $this->dbc->prepare('
-			UPDATE `' . $this->getTableName() . '`
-			SET `ldap_dn_hash` = ?, `ldap_dn` = ?
-			WHERE `directory_uuid` = ?
-		');
-
-		$r = $this->modify($statement, [$this->getDNHash($fdn), $fdn, $uuid]);
+		$qb = $this->dbc->getQueryBuilder();
+		try {
+			$r = $qb->update($this->getTableName(false))
+				->set('ldap_dn_hash', $qb->createNamedParameter($this->getDNHash($fdn)))
+				->set('ldap_dn', $qb->createNamedParameter($fdn))
+				->where($qb->expr()->eq('directory_uuid', $qb->createNamedParameter($uuid)))
+				->executeStatement() > 0;
+		} catch (Exception $e) {
+			$r = false;
+		}
 		if ($r) {
 			if (is_string($oldDn) && isset($this->cache[$oldDn])) {
 				$userId = $this->cache[$oldDn];
@@ -232,15 +216,17 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function setUUIDbyDN($uuid, $fdn): bool {
-		$statement = $this->dbc->prepare('
-			UPDATE `' . $this->getTableName() . '`
-			SET `directory_uuid` = ?
-			WHERE `ldap_dn_hash` = ?
-		');
-
 		unset($this->cache[$fdn]);
 
-		return $this->modify($statement, [$uuid, $this->getDNHash($fdn)]);
+		$qb = $this->dbc->getQueryBuilder();
+		try {
+			return $qb->update($this->getTableName(false))
+				->set('directory_uuid', $qb->createNamedParameter($uuid))
+				->where($qb->expr()->eq('ldap_dn_hash', $qb->createNamedParameter($this->getDNHash($fdn))))
+				->executeStatement() > 0;
+		} catch (Exception $e) {
+			return false;
+		}
 	}
 
 	/**
@@ -340,14 +326,14 @@ abstract class AbstractMapping {
 	 * @return string[]
 	 */
 	public function getNamesBySearch(string $search, string $prefixMatch = '', string $postfixMatch = ''): array {
-		$statement = $this->dbc->prepare('
-			SELECT `owncloud_name`
-			FROM `' . $this->getTableName() . '`
-			WHERE `owncloud_name` LIKE ?
-		');
-
+		$qb = $this->dbc->getQueryBuilder();
 		try {
-			$res = $statement->execute([$prefixMatch . $this->dbc->escapeLikeParameter($search) . $postfixMatch]);
+			$res = $qb->select('owncloud_name')
+				->from($this->getTableName(false))
+				->where($qb->expr()->like('owncloud_name', $qb->createNamedParameter(
+					$prefixMatch . $this->dbc->escapeLikeParameter($search) . $postfixMatch
+				)))
+				->executeQuery();
 		} catch (Exception $e) {
 			return [];
 		}
@@ -355,6 +341,7 @@ abstract class AbstractMapping {
 		while ($row = $res->fetchAssociative()) {
 			$names[] = $row['owncloud_name'];
 		}
+		$res->closeCursor();
 		return $names;
 	}
 
@@ -450,17 +437,20 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function unmap($name) {
-		$statement = $this->dbc->prepare('
-			DELETE FROM `' . $this->getTableName() . '`
-			WHERE `owncloud_name` = ?');
-
 		$dn = array_search($name, $this->cache, true);
 		if ($dn !== false) {
 			unset($this->cache[$dn]);
 		}
 		$this->localNameToDnCache?->remove($name);
 
-		return $this->modify($statement, [$name]);
+		$qb = $this->dbc->getQueryBuilder();
+		try {
+			return $qb->delete($this->getTableName(false))
+				->where($qb->expr()->eq('owncloud_name', $qb->createNamedParameter($name)))
+				->executeStatement() > 0;
+		} catch (Exception $e) {
+			return false;
+		}
 	}
 
 	/**

--- a/lib/base.php
+++ b/lib/base.php
@@ -269,7 +269,7 @@ class OC {
 				$result = $qb->select($qb->func()->count('*', 'user_count'))
 					->from('ldap_user_mapping')
 					->executeQuery();
-				$row = $result->fetch();
+				$row = $result->fetchAssociative();
 				$result->closeCursor();
 
 				$tooBig = ($row['user_count'] > 50);
@@ -280,7 +280,7 @@ class OC {
 				$result = $qb->select($qb->func()->count('*', 'user_count'))
 					->from('user_saml_users')
 					->executeQuery();
-				$row = $result->fetch();
+				$row = $result->fetchAssociative();
 				$result->closeCursor();
 
 				$tooBig = ($row['user_count'] > 50);

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -197,7 +197,7 @@ class AccountManager implements IAccountManager {
 			->where($query->expr()->eq('uid', $query->createParameter('uid')))
 			->setParameter('uid', $uid);
 		$result = $query->executeQuery();
-		$accountData = $result->fetchAll();
+		$accountData = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		if (empty($accountData)) {
@@ -233,7 +233,7 @@ class AccountManager implements IAccountManager {
 			$query->setParameter('values', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $query->executeQuery();
 
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$matches[$row['uid']] = $row['value'];
 			}
 			$result->closeCursor();

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -196,7 +196,7 @@ class AccountManager implements IAccountManager {
 			->where($query->expr()->eq('uid', $query->createParameter('uid')))
 			->setParameter('uid', $uid);
 		$result = $query->executeQuery();
-		$accountData = $result->fetchAll();
+		$accountData = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		if (empty($accountData)) {
@@ -233,7 +233,7 @@ class AccountManager implements IAccountManager {
 			$query->setParameter('values', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $query->executeQuery();
 
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$matches[$row['uid']] = $row['value'];
 			}
 			$result->closeCursor();

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1360,7 +1360,7 @@ class AppConfig implements IAppConfig {
 		}
 
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		foreach ($rows as $row) {
 			// most of the time, 'lazy' is not in the select because its value is already known
 			if ($lazy && ((int)$row['lazy']) === 1) {

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1427,7 +1427,7 @@ class AppConfig implements IAppConfig {
 			return;
 		}
 
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		foreach ($rows as $row) {
 			// most of the time, 'lazy' is not in the select because its value is already known
 			if ($this->migrationCompleted && $lazy && ((int)$row['lazy']) === 1) {

--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -75,7 +75,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
 			->executeQuery();
 
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 		if ($data === false) {
 			throw new DoesNotExistException('token does not exist');
@@ -97,7 +97,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
 			->executeQuery();
 
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 		if ($data === false) {
 			throw new DoesNotExistException('token does not exist');
@@ -123,7 +123,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
 			->setMaxResults(1000);
 		$result = $qb->executeQuery();
-		$data = $result->fetchAll();
+		$data = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$entities = array_map(function ($row) {
@@ -178,7 +178,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->setMaxResults(1);
 
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetchAll();
+		$data = $cursor->fetchAllAssociative();
 		$cursor->closeCursor();
 
 		return count($data) === 1;
@@ -242,7 +242,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->orderBy('id');
 		$result = $qb->executeQuery();
 
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 		if ($data === false) {
 			return null;

--- a/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
+++ b/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
@@ -37,7 +37,7 @@ class ProviderUserAssignmentDao {
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
 		$result = $query->executeQuery();
 		$providers = [];
-		foreach ($result->fetchAll() as $row) {
+		foreach ($result->fetchAllAssociative() as $row) {
 			$providers[(string)$row['provider_id']] = (int)$row['enabled'] === 1;
 		}
 		$result->closeCursor();
@@ -80,7 +80,7 @@ class ProviderUserAssignmentDao {
 			->from(self::TABLE_NAME)
 			->where($qb1->expr()->eq('uid', $qb1->createNamedParameter($uid)));
 		$selectResult = $selectQuery->executeQuery();
-		$rows = $selectResult->fetchAll();
+		$rows = $selectResult->fetchAllAssociative();
 		$selectResult->closeCursor();
 
 		$qb2 = $this->conn->getQueryBuilder();

--- a/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
+++ b/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
@@ -38,7 +38,7 @@ class ProviderUserAssignmentDao {
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
 		$result = $query->executeQuery();
 		$providers = [];
-		foreach ($result->fetchAll() as $row) {
+		foreach ($result->fetchAllAssociative() as $row) {
 			$providers[(string)$row['provider_id']] = (int)$row['enabled'] === 1;
 		}
 		$result->closeCursor();
@@ -81,7 +81,7 @@ class ProviderUserAssignmentDao {
 			->from(self::TABLE_NAME)
 			->where($qb1->expr()->eq('uid', $qb1->createNamedParameter($uid)));
 		$selectResult = $selectQuery->executeQuery();
-		$rows = $selectResult->fetchAll();
+		$rows = $selectResult->fetchAllAssociative();
 		$selectResult->closeCursor();
 
 		$qb2 = $this->conn->getQueryBuilder();

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -129,7 +129,7 @@ class JobList implements IJobList {
 			->setMaxResults(1);
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (bool)$row;
@@ -158,7 +158,7 @@ class JobList implements IJobList {
 
 		$result = $query->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$job = $this->buildJob($row);
 			if ($job) {
 				yield $job;
@@ -190,7 +190,7 @@ class JobList implements IJobList {
 		}
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {
@@ -293,7 +293,7 @@ class JobList implements IJobList {
 			->from('jobs')
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {
@@ -407,7 +407,7 @@ class JobList implements IJobList {
 
 		try {
 			$result = $query->executeQuery();
-			$hasReservedJobs = $result->fetch() !== false;
+			$hasReservedJobs = $result->fetchAssociative() !== false;
 			$result->closeCursor();
 			return $hasReservedJobs;
 		} catch (Exception $e) {
@@ -429,7 +429,7 @@ class JobList implements IJobList {
 
 		$jobs = [];
 
-		while (($row = $result->fetch()) !== false) {
+		while (($row = $result->fetchAssociative()) !== false) {
 			/**
 			 * @var array{count:int, class:class-string<IJob>} $row
 			 */

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -133,7 +133,7 @@ class JobList implements IJobList {
 			->setMaxResults(1);
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (bool)$row;
@@ -162,7 +162,7 @@ class JobList implements IJobList {
 
 		$result = $query->executeQuery();
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$job = $this->buildJob($row);
 			if ($job) {
 				yield $job;
@@ -194,7 +194,7 @@ class JobList implements IJobList {
 		}
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {
@@ -297,7 +297,7 @@ class JobList implements IJobList {
 			->from('jobs')
 			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {
@@ -412,7 +412,7 @@ class JobList implements IJobList {
 
 		try {
 			$result = $query->executeQuery();
-			$hasReservedJobs = $result->fetch() !== false;
+			$hasReservedJobs = $result->fetchAssociative() !== false;
 			$result->closeCursor();
 			return $hasReservedJobs;
 		} catch (Exception $e) {
@@ -434,7 +434,7 @@ class JobList implements IJobList {
 
 		$jobs = [];
 
-		while (($row = $result->fetch()) !== false) {
+		while (($row = $result->fetchAssociative()) !== false) {
 			/**
 			 * @var array{count:int, class:class-string<IJob>} $row
 			 */

--- a/lib/private/Calendar/ResourcesRoomsUpdater.php
+++ b/lib/private/Calendar/ResourcesRoomsUpdater.php
@@ -344,7 +344,7 @@ class ResourcesRoomsUpdater {
 			->from($table)
 			->where($query->expr()->eq($foreignKey, $query->createNamedParameter($id)));
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		$metadata = [];
@@ -370,7 +370,7 @@ class ResourcesRoomsUpdater {
 			->from($tableName)
 			->where($query->expr()->eq('backend_id', $query->createNamedParameter($backendId)));
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return array_map(function ($row): string {

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -130,7 +130,7 @@ readonly class UserPlugin implements ISearchPlugin {
 					->where($qb->expr()->eq($qb->func()->lower('value'), $qb->createNamedParameter($lowerSearch)))
 					->andWhere($qb->expr()->in('name', $qb->createNamedParameter(['email', 'additional_mail'], IQueryBuilder::PARAM_STR_ARRAY)));
 				$result = $qb->executeQuery();
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					$uid = $row['uid'];
 					$email = $row['value'];
 					$isAdditional = $row['name'] === 'additional_mail';

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -137,7 +137,7 @@ readonly class UserPlugin implements ISearchPlugin {
 					->where($qb->expr()->eq($qb->func()->lower('value'), $qb->createNamedParameter($lowerSearch)))
 					->andWhere($qb->expr()->in('name', $qb->createNamedParameter(['email', 'additional_mail'], IQueryBuilder::PARAM_STR_ARRAY)));
 				$result = $qb->executeQuery();
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					$uid = $row['uid'];
 					$email = $row['value'];
 					$isAdditional = $row['name'] === 'additional_mail';

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -46,7 +46,7 @@ class Manager implements IManager {
 			->from(self::TABLE_COLLECTIONS)
 			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!$row) {
@@ -75,7 +75,7 @@ class Manager implements IManager {
 			)
 			->where($query->expr()->eq('c.id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!$row) {
@@ -120,7 +120,7 @@ class Manager implements IManager {
 		$collections = [];
 
 		$foundResults = 0;
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$foundResults++;
 			$access = $row['access'] === null ? null : (bool)$row['access'];
 			$collection = new Collection($this, $this->connection, (int)$row['id'], (string)$row['name'], $user, $access);
@@ -179,7 +179,7 @@ class Manager implements IManager {
 			->where($query->expr()->eq('r.resource_type', $query->createNamedParameter($type, IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('r.resource_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_STR)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!$row) {
@@ -216,7 +216,7 @@ class Manager implements IManager {
 
 		$resources = [];
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$access = $row['access'] === null ? null : (bool)$row['access'];
 			$resources[] = new Resource($this, $this->connection, $row['resource_type'], $row['resource_id'], $user, $access);
 		}
@@ -310,7 +310,7 @@ class Manager implements IManager {
 
 		$hasAccess = null;
 		$result = $query->executeQuery();
-		if ($row = $result->fetch()) {
+		if ($row = $result->fetchAssociative()) {
 			$hasAccess = (bool)$row['access'];
 		}
 		$result->closeCursor();
@@ -330,7 +330,7 @@ class Manager implements IManager {
 
 		$hasAccess = null;
 		$result = $query->executeQuery();
-		if ($row = $result->fetch()) {
+		if ($row = $result->fetchAssociative()) {
 			$hasAccess = (bool)$row['access'];
 		}
 		$result->closeCursor();

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -48,7 +48,7 @@ class Manager implements IManager {
 			->from(self::TABLE_COLLECTIONS)
 			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!$row) {
@@ -78,7 +78,7 @@ class Manager implements IManager {
 			)
 			->where($query->expr()->eq('c.id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!$row) {
@@ -123,7 +123,7 @@ class Manager implements IManager {
 		$collections = [];
 
 		$foundResults = 0;
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$foundResults++;
 			$access = $row['access'] === null ? null : (bool)$row['access'];
 			$collection = new Collection($this, $this->connection, (int)$row['id'], (string)$row['name'], $user, $access);
@@ -185,7 +185,7 @@ class Manager implements IManager {
 			->where($query->expr()->eq('r.resource_type', $query->createNamedParameter($type, IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('r.resource_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_STR)));
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if (!$row) {
@@ -222,7 +222,7 @@ class Manager implements IManager {
 
 		$resources = [];
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$access = $row['access'] === null ? null : (bool)$row['access'];
 			$resources[] = new Resource($this, $this->connection, $row['resource_type'], $row['resource_id'], $user, $access);
 		}
@@ -319,7 +319,7 @@ class Manager implements IManager {
 
 		$hasAccess = null;
 		$result = $query->executeQuery();
-		if ($row = $result->fetch()) {
+		if ($row = $result->fetchAssociative()) {
 			$hasAccess = (bool)$row['access'];
 		}
 		$result->closeCursor();
@@ -339,7 +339,7 @@ class Manager implements IManager {
 
 		$hasAccess = null;
 		$result = $query->executeQuery();
-		if ($row = $result->fetch()) {
+		if ($row = $result->fetchAssociative()) {
 			$hasAccess = (bool)$row['access'];
 		}
 		$result->closeCursor();

--- a/lib/private/Collaboration/Resources/Resource.php
+++ b/lib/private/Collaboration/Resources/Resource.php
@@ -103,7 +103,7 @@ class Resource implements IResource {
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($this->getId())));
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$collections[] = $this->manager->getCollection((int)$row['collection_id']);
 		}
 		$result->closeCursor();

--- a/lib/private/Collaboration/Resources/Resource.php
+++ b/lib/private/Collaboration/Resources/Resource.php
@@ -109,7 +109,7 @@ class Resource implements IResource {
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($this->getId())));
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$collections[] = $this->manager->getCollection((int)$row['collection_id']);
 		}
 		$result->closeCursor();

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -180,7 +180,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $id);
 
 		$resultStatement = $query->executeQuery();
-		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
+		$data = $resultStatement->fetchNumeric();
 		$resultStatement->closeCursor();
 		$children = (int)$data[0];
 
@@ -255,7 +255,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $id, IQueryBuilder::PARAM_INT)
 			->executeQuery();
 
-		$data = $resultStatement->fetch();
+		$data = $resultStatement->fetchAssociative();
 		$resultStatement->closeCursor();
 		if (!$data) {
 			throw new NotFoundException();
@@ -290,7 +290,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$tree['replies'][] = [
@@ -349,7 +349,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$comments[] = $comment;
@@ -511,7 +511,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$comments[] = $comment;
@@ -537,7 +537,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {
@@ -609,7 +609,7 @@ class Manager implements ICommentsManager {
 
 		$comments = [];
 		$result = $query->executeQuery();
-		while ($data = $result->fetch()) {
+		while ($data = $result->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$comments[] = $comment;
@@ -653,7 +653,7 @@ class Manager implements ICommentsManager {
 		$query->groupBy('object_id');
 		$comments = array_fill_keys($objectIds, 0);
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comments[$data['object_id']] = (int)$data['num_comments'];
 		}
 		$resultStatement->closeCursor();
@@ -697,7 +697,7 @@ class Manager implements ICommentsManager {
 			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$unreadComments[$row['object_id']] = (int)$row['num_comments'];
 			}
 			$result->closeCursor();
@@ -743,7 +743,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)($data['num_messages'] ?? 0);
@@ -771,7 +771,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)($data['id'] ?? 0);
@@ -808,7 +808,7 @@ class Manager implements ICommentsManager {
 			->groupBy('actor_id');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$lastComments[$row['actor_id']] = $this->timeFactory->getDateTime($row['last_comment']);
 		}
 		$result->closeCursor();
@@ -976,7 +976,7 @@ class Manager implements ICommentsManager {
 			->executeQuery();
 
 		$commentIds = [];
-		while ($data = $result->fetch()) {
+		while ($data = $result->fetchAssociative()) {
 			$commentIds[] = $data['message_id'];
 		}
 
@@ -1006,7 +1006,7 @@ class Manager implements ICommentsManager {
 			->executeQuery();
 
 		$commentIds = [];
-		while ($data = $result->fetch()) {
+		while ($data = $result->fetchAssociative()) {
 			$commentIds[] = $data['message_id'];
 		}
 		$comments = [];
@@ -1063,7 +1063,7 @@ class Manager implements ICommentsManager {
 			$query->setParameter('ids', $ids, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();
-			while ($data = $result->fetch()) {
+			while ($data = $result->fetchAssociative()) {
 				$comment = $this->getCommentFromData($data);
 				$this->cache($comment);
 				$comments[] = $comment;
@@ -1415,7 +1415,7 @@ class Manager implements ICommentsManager {
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
 			->executeQuery();
 
-		$data = $resultStatement->fetch();
+		$data = $resultStatement->fetchAssociative();
 		$resultStatement->closeCursor();
 		if (!$data || is_null($data['marker_datetime'])) {
 			return null;

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -184,7 +184,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $id);
 
 		$resultStatement = $query->executeQuery();
-		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
+		$data = $resultStatement->fetchNumeric();
 		$resultStatement->closeCursor();
 		$children = (int)$data[0];
 
@@ -260,7 +260,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $id, IQueryBuilder::PARAM_INT)
 			->executeQuery();
 
-		$data = $resultStatement->fetch();
+		$data = $resultStatement->fetchAssociative();
 		$resultStatement->closeCursor();
 		if (!$data) {
 			throw new NotFoundException();
@@ -295,7 +295,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$tree['replies'][] = [
@@ -355,7 +355,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$comments[] = $comment;
@@ -519,7 +519,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$comments[] = $comment;
@@ -545,7 +545,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {
@@ -619,7 +619,7 @@ class Manager implements ICommentsManager {
 
 		$comments = [];
 		$result = $query->executeQuery();
-		while ($data = $result->fetch()) {
+		while ($data = $result->fetchAssociative()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
 			$comments[] = $comment;
@@ -665,7 +665,7 @@ class Manager implements ICommentsManager {
 		$query->groupBy('object_id');
 		$comments = array_fill_keys($objectIds, 0);
 		$resultStatement = $query->executeQuery();
-		while ($data = $resultStatement->fetch()) {
+		while ($data = $resultStatement->fetchAssociative()) {
 			$comments[$data['object_id']] = (int)$data['num_comments'];
 		}
 		$resultStatement->closeCursor();
@@ -710,7 +710,7 @@ class Manager implements ICommentsManager {
 			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$unreadComments[$row['object_id']] = (int)$row['num_comments'];
 			}
 			$result->closeCursor();
@@ -758,7 +758,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)($data['num_messages'] ?? 0);
@@ -787,7 +787,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)($data['id'] ?? 0);
@@ -825,7 +825,7 @@ class Manager implements ICommentsManager {
 			->groupBy('actor_id');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$lastComments[$row['actor_id']] = $this->timeFactory->getDateTime($row['last_comment']);
 		}
 		$result->closeCursor();
@@ -998,7 +998,7 @@ class Manager implements ICommentsManager {
 			->executeQuery();
 
 		$commentIds = [];
-		while ($data = $result->fetch()) {
+		while ($data = $result->fetchAssociative()) {
 			$commentIds[] = $data['message_id'];
 		}
 
@@ -1029,7 +1029,7 @@ class Manager implements ICommentsManager {
 			->executeQuery();
 
 		$commentIds = [];
-		while ($data = $result->fetch()) {
+		while ($data = $result->fetchAssociative()) {
 			$commentIds[] = $data['message_id'];
 		}
 		$comments = [];
@@ -1087,7 +1087,7 @@ class Manager implements ICommentsManager {
 			$query->setParameter('ids', $ids, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();
-			while ($data = $result->fetch()) {
+			while ($data = $result->fetchAssociative()) {
 				$comment = $this->getCommentFromData($data);
 				$this->cache($comment);
 				$comments[] = $comment;
@@ -1445,7 +1445,7 @@ class Manager implements ICommentsManager {
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
 			->executeQuery();
 
-		$data = $resultStatement->fetch();
+		$data = $resultStatement->fetchAssociative();
 		$resultStatement->closeCursor();
 		if (!$data || is_null($data['marker_datetime'])) {
 			return null;

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -102,7 +102,7 @@ class UserConfig implements IUserConfig {
 		}
 
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$userIds = [];
 		foreach ($rows as $row) {
 			$userIds[] = $row['userid'];
@@ -375,7 +375,7 @@ class UserConfig implements IUserConfig {
 		// this nested function will execute current Query and store result within $values.
 		$executeAndStoreValue = function (IQueryBuilder $qb) use (&$values, $typedAs): IResult {
 			$result = $qb->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$value = $row['configvalue'];
 				try {
 					$value = $this->convertTypedValue($value, $typedAs ?? ValueType::from((int)$row['type']));
@@ -535,7 +535,7 @@ class UserConfig implements IUserConfig {
 
 		$qb->andWhere($where);
 		$result = $qb->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			yield $row['userid'];
 		}
 	}
@@ -1773,7 +1773,7 @@ class UserConfig implements IUserConfig {
 		}
 
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		foreach ($rows as $row) {
 			if (($row['lazy'] ?? ($lazy ?? 0) ? 1 : 0) === 1) {
 				$this->lazyCache[$userId][$row['appid']][$row['configkey']] = $row['configvalue'] ?? '';

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -113,7 +113,7 @@ class UserConfig implements IUserConfig {
 		}
 
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$userIds = [];
 		foreach ($rows as $row) {
 			$userIds[] = $row['userid'];
@@ -395,7 +395,7 @@ class UserConfig implements IUserConfig {
 		// this nested function will execute current Query and store result within $values.
 		$executeAndStoreValue = function (IQueryBuilder $qb) use (&$values, $typedAs): IResult {
 			$result = $qb->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$value = $row['configvalue'];
 				try {
 					$value = $this->convertTypedValue($value, $typedAs ?? ValueType::from((int)$row['type']));
@@ -559,7 +559,7 @@ class UserConfig implements IUserConfig {
 
 		$qb->andWhere($where);
 		$result = $qb->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			yield $row['userid'];
 		}
 	}
@@ -1848,7 +1848,7 @@ class UserConfig implements IUserConfig {
 			return;
 		}
 
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		foreach ($rows as $row) {
 			if ($this->migrationCompleted && (($row['lazy'] ?? ($lazy ?? 0) ? 1 : 0) === 1)) {
 				$this->lazyCache[$userId][$row['appid']][$row['configkey']] = $row['configvalue'] ?? '';

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -47,7 +47,7 @@ class Adapter {
 	 */
 	public function lockTable(string $tableName) {
 		$this->conn->beginTransaction();
-		$this->conn->executeUpdate('LOCK TABLE `' . $tableName . '` IN EXCLUSIVE MODE');
+		$this->conn->executeStatement('LOCK TABLE `' . $tableName . '` IN EXCLUSIVE MODE');
 	}
 
 	/**
@@ -99,7 +99,7 @@ class Adapter {
 		$query .= ' HAVING COUNT(*) = 0';
 
 		try {
-			return $this->conn->executeUpdate($query, $inserts);
+			return $this->conn->executeStatement($query, $inserts);
 		} catch (UniqueConstraintViolationException $e) {
 			// This exception indicates a concurrent insert happened between
 			// the insert and the sub-select in the insert, which is safe to ignore.

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -48,7 +48,7 @@ class Adapter {
 	 */
 	public function lockTable(string $tableName) {
 		$this->conn->beginTransaction();
-		$this->conn->executeUpdate('LOCK TABLE `' . $tableName . '` IN EXCLUSIVE MODE');
+		$this->conn->executeStatement('LOCK TABLE `' . $tableName . '` IN EXCLUSIVE MODE');
 	}
 
 	/**
@@ -100,7 +100,7 @@ class Adapter {
 		$query .= ' HAVING COUNT(*) = 0';
 
 		try {
-			return $this->conn->executeUpdate($query, $inserts);
+			return $this->conn->executeStatement($query, $inserts);
 		} catch (UniqueConstraintViolationException $e) {
 			// This exception indicates a concurrent insert happened between
 			// the insert and the sub-select in the insert, which is safe to ignore.

--- a/lib/private/DB/AdapterMySQL.php
+++ b/lib/private/DB/AdapterMySQL.php
@@ -15,11 +15,11 @@ class AdapterMySQL extends Adapter {
 	 * @param string $tableName
 	 */
 	public function lockTable($tableName) {
-		$this->conn->executeUpdate('LOCK TABLES `' . $tableName . '` WRITE');
+		$this->conn->executeStatement('LOCK TABLES `' . $tableName . '` WRITE');
 	}
 
 	public function unlockTable() {
-		$this->conn->executeUpdate('UNLOCK TABLES');
+		$this->conn->executeStatement('UNLOCK TABLES');
 	}
 
 	public function fixupStatement($statement) {

--- a/lib/private/DB/AdapterMySQL.php
+++ b/lib/private/DB/AdapterMySQL.php
@@ -17,12 +17,12 @@ class AdapterMySQL extends Adapter {
 	 */
 	#[\Override]
 	public function lockTable($tableName) {
-		$this->conn->executeUpdate('LOCK TABLES `' . $tableName . '` WRITE');
+		$this->conn->executeStatement('LOCK TABLES `' . $tableName . '` WRITE');
 	}
 
 	#[\Override]
 	public function unlockTable() {
-		$this->conn->executeUpdate('UNLOCK TABLES');
+		$this->conn->executeStatement('UNLOCK TABLES');
 	}
 
 	#[\Override]

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -32,6 +32,6 @@ class AdapterPgSql extends Adapter {
 			$builder->setValue($key, $builder->createNamedParameter($value));
 		}
 		$queryString = $builder->getSQL() . ' ON CONFLICT DO NOTHING';
-		return $this->conn->executeUpdate($queryString, $builder->getParameters(), $builder->getParameterTypes());
+		return $this->conn->executeStatement($queryString, $builder->getParameters(), $builder->getParameterTypes());
 	}
 }

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -36,6 +36,6 @@ class AdapterPgSql extends Adapter {
 			$builder->setValue($key, $builder->createNamedParameter($value));
 		}
 		$queryString = $builder->getSQL() . ' ON CONFLICT DO NOTHING';
-		return $this->conn->executeUpdate($queryString, $builder->getParameters(), $builder->getParameterTypes());
+		return $this->conn->executeStatement($queryString, $builder->getParameters(), $builder->getParameterTypes());
 	}
 }

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -14,11 +14,11 @@ class AdapterSqlite extends Adapter {
 	 * @param string $tableName
 	 */
 	public function lockTable($tableName) {
-		$this->conn->executeUpdate('BEGIN EXCLUSIVE TRANSACTION');
+		$this->conn->executeStatement('BEGIN EXCLUSIVE TRANSACTION');
 	}
 
 	public function unlockTable() {
-		$this->conn->executeUpdate('COMMIT TRANSACTION');
+		$this->conn->executeStatement('COMMIT TRANSACTION');
 	}
 
 	public function fixupStatement($statement) {
@@ -67,7 +67,7 @@ class AdapterSqlite extends Adapter {
 		$query .= ')';
 
 		try {
-			return $this->conn->executeUpdate($query, $inserts);
+			return $this->conn->executeStatement($query, $inserts);
 		} catch (UniqueConstraintViolationException $e) {
 			// if this is thrown then a concurrent insert happened between the insert and the sub-select in the insert, that should have avoided it
 			// it's fine to ignore this then

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -16,12 +16,12 @@ class AdapterSqlite extends Adapter {
 	 */
 	#[\Override]
 	public function lockTable($tableName) {
-		$this->conn->executeUpdate('BEGIN EXCLUSIVE TRANSACTION');
+		$this->conn->executeStatement('BEGIN EXCLUSIVE TRANSACTION');
 	}
 
 	#[\Override]
 	public function unlockTable() {
-		$this->conn->executeUpdate('COMMIT TRANSACTION');
+		$this->conn->executeStatement('COMMIT TRANSACTION');
 	}
 
 	#[\Override]
@@ -72,7 +72,7 @@ class AdapterSqlite extends Adapter {
 		$query .= ')';
 
 		try {
-			return $this->conn->executeUpdate($query, $inserts);
+			return $this->conn->executeStatement($query, $inserts);
 		} catch (UniqueConstraintViolationException $e) {
 			// if this is thrown then a concurrent insert happened between the insert and the sub-select in the insert, that should have avoided it
 			// it's fine to ignore this then

--- a/lib/private/DB/ArrayResult.php
+++ b/lib/private/DB/ArrayResult.php
@@ -65,42 +65,35 @@ class ArrayResult implements IResult {
 
 	#[Override]
 	public function fetchOne() {
-		$row = $this->fetch();
-		if ($row) {
-			return current($row);
-		}
-
-		return false;
+		$row = array_shift($this->rows);
+		return $row !== null ? current($row) : false;
 	}
 
 	#[Override]
 	public function fetchAssociative(): array|false {
-		$row = $this->fetch();
-		if ($row) {
-			return $row;
-		}
-
-		return false;
+		$row = array_shift($this->rows);
+		return $row !== null ? $row : false;
 	}
 
 	#[Override]
 	public function fetchNumeric(): array|false {
-		return $this->fetch(PDO::FETCH_NUM);
+		$row = array_shift($this->rows);
+		return $row !== null ? array_values($row) : false;
 	}
 
 	#[Override]
 	public function fetchAllNumeric(): array {
-		return $this->fetchAll(PDO::FETCH_NUM);
+		return array_map(static fn (array $row): array => array_values($row), $this->rows);
 	}
 
 	#[Override]
 	public function fetchAllAssociative(): array {
-		return $this->fetchAll();
+		return $this->rows;
 	}
 
 	#[Override]
 	public function fetchFirstColumn(): array {
-		return $this->fetchAll(PDO::FETCH_COLUMN);
+		return array_map(static fn (array $row): mixed => current($row), $this->rows);
 	}
 
 	#[Override]

--- a/lib/private/DB/ConnectionAdapter.php
+++ b/lib/private/DB/ConnectionAdapter.php
@@ -59,7 +59,7 @@ class ConnectionAdapter implements IDBConnection {
 
 	public function executeUpdate(string $sql, array $params = [], array $types = []): int {
 		try {
-			return $this->inner->executeUpdate($sql, $params, $types);
+			return $this->inner->executeStatement($sql, $params, $types);
 		} catch (Exception $e) {
 			throw DbalException::wrap($e, '', $sql);
 		}

--- a/lib/private/DB/ConnectionAdapter.php
+++ b/lib/private/DB/ConnectionAdapter.php
@@ -65,7 +65,7 @@ class ConnectionAdapter implements IDBConnection {
 	#[\Override]
 	public function executeUpdate(string $sql, array $params = [], array $types = []): int {
 		try {
-			return $this->inner->executeUpdate($sql, $params, $types);
+			return $this->inner->executeStatement($sql, $params, $types);
 		} catch (Exception $e) {
 			throw DbalException::wrap($e, '', $sql);
 		}

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -173,7 +173,7 @@ class MigrationService {
 			->orderBy('version');
 
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll(\PDO::FETCH_COLUMN);
+		$rows = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		usort($rows, $this->sortMigrations(...));

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -179,7 +179,7 @@ class MigrationService {
 			->where($qb->expr()->eq('app', $qb->createNamedParameter($this->getApp())));
 
 		$result = $qb->executeQuery();
-		$rows = $result->fetchAll(\PDO::FETCH_COLUMN);
+		$rows = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		usort($rows, $this->sortMigrations(...));

--- a/lib/private/DB/MySqlTools.php
+++ b/lib/private/DB/MySqlTools.php
@@ -25,7 +25,7 @@ class MySqlTools {
 
 		foreach ($variables as $var => $val) {
 			$result = $connection->executeQuery("SHOW VARIABLES LIKE '$var'");
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 			if ($row === false) {
 				return false;
@@ -39,7 +39,7 @@ class MySqlTools {
 
 	protected function isMariaDBWithLargePrefix(IDBConnection $connection) {
 		$result = $connection->executeQuery('SELECT VERSION()');
-		$row = strtolower($result->fetchColumn());
+		$row = strtolower($result->fetchOne());
 		$result->closeCursor();
 
 		if ($row === false) {

--- a/lib/private/DB/MySqlTools.php
+++ b/lib/private/DB/MySqlTools.php
@@ -26,7 +26,7 @@ class MySqlTools {
 
 		foreach ($variables as $var => $val) {
 			$result = $connection->executeQuery("SHOW VARIABLES LIKE '$var'");
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 			if ($row === false) {
 				return false;
@@ -40,7 +40,7 @@ class MySqlTools {
 
 	protected function isMariaDBWithLargePrefix(IDBConnection $connection) {
 		$result = $connection->executeQuery('SELECT VERSION()');
-		$row = strtolower($result->fetchColumn());
+		$row = strtolower($result->fetchOne());
 		$result->closeCursor();
 
 		if ($row === false) {

--- a/lib/private/DB/PreparedStatement.php
+++ b/lib/private/DB/PreparedStatement.php
@@ -42,11 +42,21 @@ class PreparedStatement implements IPreparedStatement {
 	}
 
 	public function fetch(int $fetchMode = PDO::FETCH_ASSOC) {
-		return $this->getResult()->fetch($fetchMode);
+		return match ($fetchMode) {
+			PDO::FETCH_ASSOC => $this->getResult()->fetchAssociative(),
+			PDO::FETCH_NUM => $this->getResult()->fetchNumeric(),
+			PDO::FETCH_COLUMN => $this->getResult()->fetchOne(),
+			default => $this->getResult()->fetch($fetchMode),
+		};
 	}
 
 	public function fetchAll(int $fetchMode = PDO::FETCH_ASSOC): array {
-		return $this->getResult()->fetchAll($fetchMode);
+		return match ($fetchMode) {
+			PDO::FETCH_ASSOC => $this->getResult()->fetchAllAssociative(),
+			PDO::FETCH_NUM => $this->getResult()->fetchAllNumeric(),
+			PDO::FETCH_COLUMN => $this->getResult()->fetchFirstColumn(),
+			default => $this->getResult()->fetchAll($fetchMode),
+		};
 	}
 
 	public function fetchColumn() {
@@ -66,7 +76,7 @@ class PreparedStatement implements IPreparedStatement {
 	}
 
 	public function execute($params = null): IResult {
-		return ($this->result = new ResultAdapter($this->statement->execute($params)));
+		return ($this->result = new ResultAdapter($this->statement->execute($params ?? [])));
 	}
 
 	public function rowCount(): int {

--- a/lib/private/DB/PreparedStatement.php
+++ b/lib/private/DB/PreparedStatement.php
@@ -45,12 +45,22 @@ class PreparedStatement implements IPreparedStatement {
 
 	#[\Override]
 	public function fetch(int $fetchMode = PDO::FETCH_ASSOC) {
-		return $this->getResult()->fetch($fetchMode);
+		return match ($fetchMode) {
+			PDO::FETCH_ASSOC => $this->getResult()->fetchAssociative(),
+			PDO::FETCH_NUM => $this->getResult()->fetchNumeric(),
+			PDO::FETCH_COLUMN => $this->getResult()->fetchOne(),
+			default => $this->getResult()->fetch($fetchMode),
+		};
 	}
 
 	#[\Override]
 	public function fetchAll(int $fetchMode = PDO::FETCH_ASSOC): array {
-		return $this->getResult()->fetchAll($fetchMode);
+		return match ($fetchMode) {
+			PDO::FETCH_ASSOC => $this->getResult()->fetchAllAssociative(),
+			PDO::FETCH_NUM => $this->getResult()->fetchAllNumeric(),
+			PDO::FETCH_COLUMN => $this->getResult()->fetchFirstColumn(),
+			default => $this->getResult()->fetchAll($fetchMode),
+		};
 	}
 
 	#[\Override]
@@ -75,7 +85,7 @@ class PreparedStatement implements IPreparedStatement {
 
 	#[\Override]
 	public function execute($params = null): IResult {
-		return ($this->result = new ResultAdapter($this->statement->execute($params)));
+		return ($this->result = new ResultAdapter($this->statement->execute($params ?? [])));
 	}
 
 	#[\Override]

--- a/lib/private/DB/QueryBuilder/Partitioned/PartitionQuery.php
+++ b/lib/private/DB/QueryBuilder/Partitioned/PartitionQuery.php
@@ -49,7 +49,7 @@ class PartitionQuery {
 		$this->query->andWhere($this->query->expr()->in($this->joinToColumn, $this->query->createNamedParameter($joinFromValues, IQueryBuilder::PARAM_STR_ARRAY, ':' . uniqid())));
 
 		$s = $this->query->getSQL();
-		$partitionedRows = $this->query->executeQuery()->fetchAll();
+		$partitionedRows = $this->query->executeQuery()->fetchAllAssociative();
 
 		$columns = $this->query->getOutputColumns();
 		$nullResult = array_combine($columns, array_fill(0, count($columns), null));

--- a/lib/private/DB/QueryBuilder/Partitioned/PartitionedResult.php
+++ b/lib/private/DB/QueryBuilder/Partitioned/PartitionedResult.php
@@ -43,6 +43,36 @@ class PartitionedResult extends ArrayResult {
 		return parent::fetchAll($fetchMode);
 	}
 
+	public function fetchAssociative(): array|false {
+		$this->fetchRows();
+		return parent::fetchAssociative();
+	}
+
+	public function fetchNumeric(): array|false {
+		$this->fetchRows();
+		return parent::fetchNumeric();
+	}
+
+	public function fetchOne(): mixed {
+		$this->fetchRows();
+		return parent::fetchOne();
+	}
+
+	public function fetchAllAssociative(): array {
+		$this->fetchRows();
+		return parent::fetchAllAssociative();
+	}
+
+	public function fetchAllNumeric(): array {
+		$this->fetchRows();
+		return parent::fetchAllNumeric();
+	}
+
+	public function fetchFirstColumn(): array {
+		$this->fetchRows();
+		return parent::fetchFirstColumn();
+	}
+
 	public function rowCount(): int {
 		$this->fetchRows();
 		return parent::rowCount();
@@ -51,7 +81,7 @@ class PartitionedResult extends ArrayResult {
 	private function fetchRows(): void {
 		if (!$this->fetched) {
 			$this->fetched = true;
-			$this->rows = $this->result->fetchAll();
+			$this->rows = $this->result->fetchAllAssociative();
 			foreach ($this->splitOfParts as $part) {
 				$this->rows = $part->mergeWith($this->rows);
 			}

--- a/lib/private/DB/QueryBuilder/Sharded/CrossShardMoveHelper.php
+++ b/lib/private/DB/QueryBuilder/Sharded/CrossShardMoveHelper.php
@@ -90,7 +90,7 @@ class CrossShardMoveHelper {
 		$results = [];
 		foreach ($chunks as $chunk) {
 			$query->setParameter('keys', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
-			$results = array_merge($results, $query->executeQuery()->fetchAll());
+			$results = array_merge($results, $query->executeQuery()->fetchAllAssociative());
 		}
 
 		return $results;
@@ -138,7 +138,7 @@ class CrossShardMoveHelper {
 		$query->update($table)
 			->set($shardColumn, $query->createNamedParameter($targetShardKey, IQueryBuilder::PARAM_INT))
 			->where($query->expr()->in($primaryColumn, $query->createNamedParameter($primaryKeys, IQueryBuilder::PARAM_INT_ARRAY)));
-		$query->executeQuery()->fetchAll();
+		$query->executeQuery()->fetchAllAssociative();
 	}
 
 	/**

--- a/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
@@ -104,7 +104,7 @@ class ShardQueryRunner {
 			foreach ($shards as $shard) {
 				$shardConnection = $this->shardConnectionManager->getConnection($this->shardDefinition, $shard);
 				$subResult = $query->executeQuery($shardConnection);
-				$results = array_merge($results, $subResult->fetchAll());
+				$results = array_merge($results, $subResult->fetchAllAssociative());
 				$subResult->closeCursor();
 			}
 		} else {
@@ -118,7 +118,7 @@ class ShardQueryRunner {
 			foreach ($shards as $shard) {
 				$shardConnection = $this->shardConnectionManager->getConnection($this->shardDefinition, $shard);
 				$subResult = $query->executeQuery($shardConnection);
-				$rows = $subResult->fetchAll();
+				$rows = $subResult->fetchAllAssociative();
 				$results = array_merge($results, $rows);
 				$subResult->closeCursor();
 

--- a/lib/private/DB/SQLiteSessionInit.php
+++ b/lib/private/DB/SQLiteSessionInit.php
@@ -23,8 +23,8 @@ class SQLiteSessionInit implements EventSubscriber {
 
 	public function postConnect(ConnectionEventArgs $args): void {
 		$sensitive = $this->caseSensitiveLike ? 'true' : 'false';
-		$args->getConnection()->executeUpdate('PRAGMA case_sensitive_like = ' . $sensitive);
-		$args->getConnection()->executeUpdate('PRAGMA journal_mode = ' . $this->journalMode);
+		$args->getConnection()->executeStatement('PRAGMA case_sensitive_like = ' . $sensitive);
+		$args->getConnection()->executeStatement('PRAGMA journal_mode = ' . $this->journalMode);
 		/** @var \Doctrine\DBAL\Driver\PDO\Connection $connection */
 		$connection = $args->getConnection()->getWrappedConnection();
 		$pdo = $connection->getWrappedConnection();

--- a/lib/private/DB/SQLiteSessionInit.php
+++ b/lib/private/DB/SQLiteSessionInit.php
@@ -24,9 +24,9 @@ class SQLiteSessionInit implements EventSubscriber {
 
 	public function postConnect(ConnectionEventArgs $args): void {
 		$sensitive = $this->caseSensitiveLike ? 'true' : 'false';
-		$args->getConnection()->executeUpdate('PRAGMA case_sensitive_like = ' . $sensitive);
-		$args->getConnection()->executeUpdate('PRAGMA journal_mode = ' . $this->journalMode);
-		$args->getConnection()->executeUpdate('PRAGMA foreign_keys = true');
+		$args->getConnection()->executeStatement('PRAGMA case_sensitive_like = ' . $sensitive);
+		$args->getConnection()->executeStatement('PRAGMA journal_mode = ' . $this->journalMode);
+		$args->getConnection()->executeStatement('PRAGMA foreign_keys = true');
 		/** @var \Doctrine\DBAL\Driver\PDO\Connection $connection */
 		$connection = $args->getConnection()->getWrappedConnection();
 		$pdo = $connection->getWrappedConnection();

--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -6,7 +6,6 @@
  */
 namespace OC\DirectEditing;
 
-use Doctrine\DBAL\FetchMode;
 use OCA\Encryption\Util;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\Response;
@@ -198,7 +197,7 @@ class Manager implements IManager {
 		$query->select('*')->from(self::TABLE_TOKENS)
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
 		$result = $query->executeQuery();
-		if ($tokenRow = $result->fetch(FetchMode::ASSOCIATIVE)) {
+		if ($tokenRow = $result->fetchAssociative()) {
 			return new Token($this, $tokenRow);
 		}
 		throw new \RuntimeException('Failed to validate the token');

--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -7,7 +7,6 @@
 
 namespace OC\DirectEditing;
 
-use Doctrine\DBAL\FetchMode;
 use OCA\Encryption\Util;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\Response;
@@ -205,7 +204,7 @@ class Manager implements IManager {
 		$query->select('*')->from(self::TABLE_TOKENS)
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
 		$result = $query->executeQuery();
-		if ($tokenRow = $result->fetch(FetchMode::ASSOCIATIVE)) {
+		if ($tokenRow = $result->fetchAssociative()) {
 			return new Token($this, $tokenRow);
 		}
 		throw new \RuntimeException('Failed to validate the token');

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -136,7 +136,7 @@ class Cache implements ICache {
 		$query->whereStorageId($this->getNumericStorageId());
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($data !== false) {
@@ -231,7 +231,7 @@ class Cache implements ICache {
 			$metadataQuery = $query->selectMetadata();
 
 			$result = $query->executeQuery();
-			$files = $result->fetchAll();
+			$files = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			return array_map(function (array $data) use ($metadataQuery): ICacheEntry {
@@ -858,7 +858,7 @@ class Cache implements ICache {
 			->from('filecache')
 			->where($query->expr()->eq('storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->like('path', $query->createNamedParameter($this->connection->escapeLikeParameter($path) . '/%')));
-		return $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		return $query->executeQuery()->fetchFirstColumn();
 	}
 
 	/**
@@ -1038,7 +1038,7 @@ class Cache implements ICache {
 			}
 
 			$result = $query->executeQuery();
-			$rows = $result->fetchAll();
+			$rows = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			if ($rows) {
@@ -1112,7 +1112,7 @@ class Cache implements ICache {
 			->whereStorageId($this->getNumericStorageId());
 
 		$result = $query->executeQuery();
-		$files = $result->fetchAll(\PDO::FETCH_COLUMN);
+		$files = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		return array_map(function ($id) {
@@ -1185,7 +1185,7 @@ class Cache implements ICache {
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -141,7 +141,7 @@ class Cache implements ICache {
 		$query->whereStorageId($this->getNumericStorageId());
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($data !== false) {
@@ -235,7 +235,7 @@ class Cache implements ICache {
 			$metadataQuery = $query->selectMetadata();
 
 			$result = $query->executeQuery();
-			$files = $result->fetchAll();
+			$files = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			return array_map(function (array $data) use ($metadataQuery): ICacheEntry {
@@ -868,7 +868,7 @@ class Cache implements ICache {
 			->from('filecache')
 			->where($query->expr()->eq('storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->like('path', $query->createNamedParameter($this->connection->escapeLikeParameter($path) . '/%')));
-		return $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		return $query->executeQuery()->fetchFirstColumn();
 	}
 
 	/**
@@ -1051,7 +1051,7 @@ class Cache implements ICache {
 			}
 
 			$result = $query->executeQuery();
-			$rows = $result->fetchAll();
+			$rows = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			if ($rows) {
@@ -1125,7 +1125,7 @@ class Cache implements ICache {
 			->whereStorageId($this->getNumericStorageId());
 
 		$result = $query->executeQuery();
-		$files = $result->fetchAll(\PDO::FETCH_COLUMN);
+		$files = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		return array_map(function ($id) {
@@ -1200,7 +1200,7 @@ class Cache implements ICache {
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($row) {

--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -49,7 +49,7 @@ class FileAccess implements IFileAccess {
 		$query->andWhere($query->expr()->eq('filecache.path_hash', $query->createNamedParameter(md5($path))));
 		$query->andWhere($query->expr()->eq('filecache.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
 
-		$row = $query->executeQuery()->fetch();
+		$row = $query->executeQuery()->fetchAssociative();
 		return $row ? Cache::cacheEntryFromData($row, $this->mimeTypeLoader) : null;
 	}
 
@@ -79,7 +79,7 @@ class FileAccess implements IFileAccess {
 		$query = $this->getQuery()->selectFileCache();
 		$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
 
-		$rows = $query->executeQuery()->fetchAll();
+		$rows = $query->executeQuery()->fetchAllAssociative();
 		return $this->rowsToEntries($rows);
 	}
 
@@ -94,7 +94,7 @@ class FileAccess implements IFileAccess {
 		$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
 		$query->andWhere($query->expr()->eq('filecache.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
 
-		$rows = $query->executeQuery()->fetchAll();
+		$rows = $query->executeQuery()->fetchAllAssociative();
 		return $this->rowsToEntries($rows);
 	}
 
@@ -105,7 +105,7 @@ class FileAccess implements IFileAccess {
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
 		$result = $qb->executeQuery();
 		/** @var array{path:string}|false $root */
-		$root = $result->fetch();
+		$root = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($root === false) {
@@ -153,7 +153,7 @@ class FileAccess implements IFileAccess {
 			// If the filecache table is sharded we need to check with a separate query if the parent is encrypted
 			$rows = [];
 			do {
-				while (count($rows) < 1000 && ($row = $files->fetch())) {
+				while (count($rows) < 1000 && ($row = $files->fetchAssociative())) {
 					$rows[] = $row;
 				}
 				$parents = array_map(function ($row) {
@@ -165,7 +165,7 @@ class FileAccess implements IFileAccess {
 				$parentQuery->where($parentQuery->expr()->in('fileid', $parentQuery->createNamedParameter($parents, IQueryBuilder::PARAM_INT_ARRAY)));
 				$parentQuery->hintShardKey('storage', $storageId);
 				$result = $parentQuery->executeQuery();
-				$parentRows = $result->fetchAll();
+				$parentRows = $result->fetchAllAssociative();
 				$result->closeCursor();
 
 				$encryptedByFileId = array_column($parentRows, 'encrypted', 'fileid');
@@ -176,11 +176,11 @@ class FileAccess implements IFileAccess {
 					yield Cache::cacheEntryFromData($row, $this->mimeTypeLoader);
 				}
 				$rows = [];
-			} while ($rows[] = $files->fetch());
+			} while ($rows[] = $files->fetchAssociative());
 		} else {
 			while (
 				/** @var array */
-				$row = $files->fetch()
+				$row = $files->fetchAssociative()
 			) {
 				yield Cache::cacheEntryFromData($row, $this->mimeTypeLoader);
 			}
@@ -212,7 +212,7 @@ class FileAccess implements IFileAccess {
 
 		while (
 			/** @var array{storage_id:int, root_id:int,mount_provider_class:string} $row */
-			$row = $result->fetch()
+			$row = $result->fetchAssociative()
 		) {
 			$storageId = (int)$row['storage_id'];
 			$rootId = (int)$row['root_id'];
@@ -232,7 +232,7 @@ class FileAccess implements IFileAccess {
 						->andWhere($qb->expr()->eq('parent', $qb->createNamedParameter($rootId, IQueryBuilder::PARAM_INT)))
 						->andWhere($qb->expr()->eq('path', $qb->createNamedParameter('files')));
 					/** @var array|false $root */
-					$root = $qb->executeQuery()->fetch();
+					$root = $qb->executeQuery()->fetchAssociative();
 					if ($root !== false) {
 						$overrideRoot = (int)$root['fileid'];
 					}

--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -52,7 +52,7 @@ class FileAccess implements IFileAccess {
 		$query->andWhere($query->expr()->eq('filecache.path_hash', $query->createNamedParameter(md5($path))));
 		$query->andWhere($query->expr()->eq('filecache.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
 
-		$row = $query->executeQuery()->fetch();
+		$row = $query->executeQuery()->fetchAssociative();
 		return $row ? Cache::cacheEntryFromData($row, $this->mimeTypeLoader) : null;
 	}
 
@@ -84,7 +84,7 @@ class FileAccess implements IFileAccess {
 		$query = $this->getQuery()->selectFileCache();
 		$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
 
-		$rows = $query->executeQuery()->fetchAll();
+		$rows = $query->executeQuery()->fetchAllAssociative();
 		return $this->rowsToEntries($rows);
 	}
 
@@ -100,7 +100,7 @@ class FileAccess implements IFileAccess {
 		$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
 		$query->andWhere($query->expr()->eq('filecache.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
 
-		$rows = $query->executeQuery()->fetchAll();
+		$rows = $query->executeQuery()->fetchAllAssociative();
 		return $this->rowsToEntries($rows);
 	}
 
@@ -112,7 +112,7 @@ class FileAccess implements IFileAccess {
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
 		$result = $qb->executeQuery();
 		/** @var array{path:string}|false $root */
-		$root = $result->fetch();
+		$root = $result->fetchAssociative();
 		$result->closeCursor();
 
 		if ($root === false) {
@@ -160,7 +160,7 @@ class FileAccess implements IFileAccess {
 			// If the filecache table is sharded we need to check with a separate query if the parent is encrypted
 			$rows = [];
 			do {
-				while (count($rows) < 1000 && ($row = $files->fetch())) {
+				while (count($rows) < 1000 && ($row = $files->fetchAssociative())) {
 					$rows[] = $row;
 				}
 				$parents = array_map(function ($row) {
@@ -172,7 +172,7 @@ class FileAccess implements IFileAccess {
 				$parentQuery->where($parentQuery->expr()->in('fileid', $parentQuery->createNamedParameter($parents, IQueryBuilder::PARAM_INT_ARRAY)));
 				$parentQuery->hintShardKey('storage', $storageId);
 				$result = $parentQuery->executeQuery();
-				$parentRows = $result->fetchAll();
+				$parentRows = $result->fetchAllAssociative();
 				$result->closeCursor();
 
 				$encryptedByFileId = array_column($parentRows, 'encrypted', 'fileid');
@@ -183,11 +183,11 @@ class FileAccess implements IFileAccess {
 					yield Cache::cacheEntryFromData($row, $this->mimeTypeLoader);
 				}
 				$rows = [];
-			} while ($rows[] = $files->fetch());
+			} while ($rows[] = $files->fetchAssociative());
 		} else {
 			while (
 				/** @var array */
-				$row = $files->fetch()
+				$row = $files->fetchAssociative()
 			) {
 				yield Cache::cacheEntryFromData($row, $this->mimeTypeLoader);
 			}
@@ -220,7 +220,7 @@ class FileAccess implements IFileAccess {
 
 		while (
 			/** @var array{storage_id:int, root_id:int,mount_provider_class:string} $row */
-			$row = $result->fetch()
+			$row = $result->fetchAssociative()
 		) {
 			$storageId = (int)$row['storage_id'];
 			$rootId = (int)$row['root_id'];
@@ -240,7 +240,7 @@ class FileAccess implements IFileAccess {
 						->andWhere($qb->expr()->eq('parent', $qb->createNamedParameter($rootId, IQueryBuilder::PARAM_INT)))
 						->andWhere($qb->expr()->eq('path', $qb->createNamedParameter('files')));
 					/** @var array|false $root */
-					$root = $qb->executeQuery()->fetch();
+					$root = $qb->executeQuery()->fetchAssociative();
 					if ($root !== false) {
 						$overrideRoot = (int)$root['fileid'];
 					}

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -91,7 +91,7 @@ class QuerySearchHelper {
 
 		$result = $query->executeQuery();
 		/** @var list<array{id: int, name: string, visibility: int, editable: int, ref_file_id: int, number_files: int}> $tags */
-		$tags = $result->fetchAll();
+		$tags = $result->fetchAllAssociative();
 		$result->closeCursor();
 		return $tags;
 	}
@@ -172,7 +172,7 @@ class QuerySearchHelper {
 		$this->applySearchConstraints($query, $searchQuery, $caches, $metadataQuery);
 
 		$result = $query->executeQuery();
-		$files = $result->fetchAll();
+		$files = $result->fetchAllAssociative();
 
 		$rawEntries = array_map(function (array $data) use ($metadataQuery) {
 			$data['metadata'] = $metadataQuery->extractMetadata($data)->asArray();

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -91,7 +91,7 @@ class QuerySearchHelper {
 
 		$result = $query->executeQuery();
 		/** @var list<array{id: int, name: string, visibility: int, editable: int, ref_file_id: int, number_files: int}> $tags */
-		$tags = $result->fetchAll();
+		$tags = $result->fetchAllAssociative();
 		$result->closeCursor();
 		return $tags;
 	}
@@ -178,7 +178,7 @@ class QuerySearchHelper {
 		$this->applySearchConstraints($query, $searchQuery, $caches, $metadataQuery);
 
 		$result = $query->executeQuery();
-		$files = $result->fetchAll();
+		$files = $result->fetchAllAssociative();
 
 		$rawEntries = array_map(function (array $data) use ($metadataQuery) {
 			$data['metadata'] = $metadataQuery->extractMetadata($data)->asArray();

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -174,7 +174,7 @@ class Storage {
 			$query->select('storage_id')
 				->from('mounts')
 				->where($query->expr()->eq('mount_id', $query->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
-			$storageIds = $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+			$storageIds = $query->executeQuery()->fetchFirstColumn();
 			$storageIds = array_unique($storageIds);
 
 			$query = $db->getQueryBuilder();

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -170,7 +170,7 @@ class Storage {
 			$query->select('storage_id')
 				->from('mounts')
 				->where($query->expr()->eq('mount_id', $query->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
-			$storageIds = $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+			$storageIds = $query->executeQuery()->fetchFirstColumn();
 			$storageIds = array_unique($storageIds);
 
 			$query = $db->getQueryBuilder();

--- a/lib/private/Files/Cache/StorageGlobal.php
+++ b/lib/private/Files/Cache/StorageGlobal.php
@@ -44,7 +44,7 @@ class StorageGlobal {
 			->where($builder->expr()->in('id', $builder->createNamedParameter(array_values($storageIds), IQueryBuilder::PARAM_STR_ARRAY)));
 
 		$result = $query->executeQuery();
-		while (($row = $result->fetch()) !== false) {
+		while (($row = $result->fetchAssociative()) !== false) {
 			$normalizedRow = [
 				'id' => (string)$row['id'],
 				'numeric_id' => (int)$row['numeric_id'],
@@ -69,7 +69,7 @@ class StorageGlobal {
 				->where($builder->expr()->eq('id', $builder->createNamedParameter($storageId)));
 
 			$result = $query->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 
 			if ($row !== false) {
@@ -99,7 +99,7 @@ class StorageGlobal {
 				->where($builder->expr()->eq('numeric_id', $builder->createNamedParameter($numericId)));
 
 			$result = $query->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 
 			if ($row !== false) {

--- a/lib/private/Files/Cache/StorageGlobal.php
+++ b/lib/private/Files/Cache/StorageGlobal.php
@@ -73,7 +73,7 @@ class StorageGlobal {
 				->where($builder->expr()->eq('id', $builder->createNamedParameter($storageId)));
 
 			$result = $query->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 
 			if ($row !== false) {
@@ -103,7 +103,7 @@ class StorageGlobal {
 				->where($builder->expr()->eq('numeric_id', $builder->createNamedParameter($numericId)));
 
 			$result = $query->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 
 			if ($row !== false) {

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -267,7 +267,7 @@ class UserMountCache implements IUserMountCache {
 				->where($builder->expr()->eq('user_id', $builder->createNamedParameter($userUID)));
 
 			$result = $query->executeQuery();
-			$rows = $result->fetchAll();
+			$rows = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			/** @var array<string, ICachedMountInfo> $mounts */
@@ -312,7 +312,7 @@ class UserMountCache implements IUserMountCache {
 		}
 
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return array_filter(array_map([$this, 'dbRowToMountInfo'], $rows));
@@ -330,7 +330,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('root_id', $builder->createNamedParameter($rootFileId, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return array_filter(array_map([$this, 'dbRowToMountInfo'], $rows));
@@ -349,7 +349,7 @@ class UserMountCache implements IUserMountCache {
 				->where($builder->expr()->eq('fileid', $builder->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
 
 			$result = $query->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 
 			if (is_array($row)) {
@@ -408,7 +408,7 @@ class UserMountCache implements IUserMountCache {
 		$result = $query->executeQuery();
 
 		$mounts = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			if ($user === null && !$this->userManager->userExists($row['user_id'])) {
 				continue;
 			}
@@ -481,7 +481,7 @@ class UserMountCache implements IUserMountCache {
 		$result = $query->executeQuery();
 
 		$results = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$results[$row['user_id']] = $row['size'];
 		}
 		$result->closeCursor();

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -263,7 +263,7 @@ class UserMountCache implements IUserMountCache {
 				->where($builder->expr()->eq('user_id', $builder->createNamedParameter($userUID)));
 
 			$result = $query->executeQuery();
-			$rows = $result->fetchAll();
+			$rows = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			/** @var array<string, ICachedMountInfo> $mounts */
@@ -309,7 +309,7 @@ class UserMountCache implements IUserMountCache {
 		}
 
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return array_filter(array_map([$this, 'dbRowToMountInfo'], $rows));
@@ -328,7 +328,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('root_id', $builder->createNamedParameter($rootFileId, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		return array_filter(array_map([$this, 'dbRowToMountInfo'], $rows));
@@ -347,7 +347,7 @@ class UserMountCache implements IUserMountCache {
 				->where($builder->expr()->eq('fileid', $builder->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
 
 			$result = $query->executeQuery();
-			$row = $result->fetch();
+			$row = $result->fetchAssociative();
 			$result->closeCursor();
 
 			if (is_array($row)) {
@@ -407,7 +407,7 @@ class UserMountCache implements IUserMountCache {
 		$result = $query->executeQuery();
 
 		$mounts = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			if ($user === null && !$this->userManager->userExists($row['user_id'])) {
 				continue;
 			}
@@ -484,7 +484,7 @@ class UserMountCache implements IUserMountCache {
 		$result = $query->executeQuery();
 
 		$results = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$results[$row['user_id']] = $row['size'];
 		}
 		$result->closeCursor();

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -131,7 +131,7 @@ class Loader implements IMimeTypeLoader {
 			->from('mimetypes');
 
 		$result = $qb->executeQuery();
-		$results = $result->fetchAll();
+		$results = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		foreach ($results as $row) {

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -136,7 +136,7 @@ class Loader implements IMimeTypeLoader {
 			->from('mimetypes');
 
 		$result = $qb->executeQuery();
-		$results = $result->fetchAll();
+		$results = $result->fetchAllAssociative();
 		$result->closeCursor();
 
 		foreach ($results as $row) {

--- a/lib/private/FilesMetadata/Service/MetadataRequestService.php
+++ b/lib/private/FilesMetadata/Service/MetadataRequestService.php
@@ -41,7 +41,7 @@ class MetadataRequestService {
 		$query->select('storage')
 			->from('filecache')
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($filesMetadata->getFileId(), IQueryBuilder::PARAM_INT)));
-		$storageId = $query->executeQuery()->fetchColumn();
+		$storageId = (int)$query->executeQuery()->fetchOne();
 
 		if ($filesMetadata instanceof FilesMetadata) {
 			$filesMetadata->setStorageId($storageId);
@@ -81,7 +81,7 @@ class MetadataRequestService {
 			$qb->select('json', 'sync_token')->from(self::TABLE_METADATA);
 			$qb->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
 			$result = $qb->executeQuery();
-			$data = $result->fetch();
+			$data = $result->fetchAssociative();
 			$result->closeCursor();
 		} catch (Exception $e) {
 			$this->logger->warning('exception while getMetadataFromDatabase()', ['exception' => $e, 'fileId' => $fileId]);
@@ -115,7 +115,7 @@ class MetadataRequestService {
 
 		$list = [];
 		$result = $qb->executeQuery();
-		while ($data = $result->fetch()) {
+		while ($data = $result->fetchAssociative()) {
 			$fileId = (int)$data['file_id'];
 			$metadata = new FilesMetadata($fileId);
 			try {

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -146,7 +146,7 @@ class Database extends ABackend implements
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->executeQuery();
 
-		$result = $cursor->fetch();
+		$result = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		return $result ? true : false;
@@ -221,7 +221,7 @@ class Database extends ABackend implements
 			->executeQuery();
 
 		$groups = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$groups[] = $row['gid'];
 			$this->groupCache[$row['gid']] = [
 				'gid' => $row['gid'],
@@ -268,7 +268,7 @@ class Database extends ABackend implements
 		$result = $query->executeQuery();
 
 		$groups = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$this->groupCache[$row['gid']] = [
 				'displayname' => $row['displayname'],
 				'gid' => $row['gid'],
@@ -298,7 +298,7 @@ class Database extends ABackend implements
 			->from('groups')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
 			->executeQuery();
-		$result = $cursor->fetch();
+		$result = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($result !== false) {
@@ -335,7 +335,7 @@ class Database extends ABackend implements
 		foreach (array_chunk($notFoundGids, 1000) as $chunk) {
 			$qb->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $qb->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$this->groupCache[(string)$row['gid']] = [
 					'displayname' => (string)$row['displayname'],
 					'gid' => (string)$row['gid'],
@@ -413,7 +413,7 @@ class Database extends ABackend implements
 
 		$users = [];
 		$userManager = Server::get(IUserManager::class);
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$users[$row['uid']] = new LazyUser($row['uid'], $userManager, $row['displayname'] ?? null);
 		}
 		$result->closeCursor();
@@ -544,7 +544,7 @@ class Database extends ABackend implements
 				->where($query->expr()->in('gid', $query->createNamedParameter($chunk, IQueryBuilder::PARAM_STR_ARRAY)));
 
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$details[(string)$row['gid']] = ['displayName' => (string)$row['displayname']];
 				$this->groupCache[(string)$row['gid']] = [
 					'displayname' => (string)$row['displayname'],

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -150,7 +150,7 @@ class Database extends ABackend implements
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->executeQuery();
 
-		$result = $cursor->fetch();
+		$result = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		return $result ? true : false;
@@ -228,7 +228,7 @@ class Database extends ABackend implements
 			->executeQuery();
 
 		$groups = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$groups[] = $row['gid'];
 			$this->groupCache[$row['gid']] = [
 				'gid' => $row['gid'],
@@ -276,7 +276,7 @@ class Database extends ABackend implements
 		$result = $query->executeQuery();
 
 		$groups = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$this->groupCache[$row['gid']] = [
 				'displayname' => $row['displayname'],
 				'gid' => $row['gid'],
@@ -307,7 +307,7 @@ class Database extends ABackend implements
 			->from('groups')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
 			->executeQuery();
-		$result = $cursor->fetch();
+		$result = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($result !== false) {
@@ -345,7 +345,7 @@ class Database extends ABackend implements
 		foreach (array_chunk($notFoundGids, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$qb->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $qb->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$this->groupCache[(string)$row['gid']] = [
 					'displayname' => (string)$row['displayname'],
 					'gid' => (string)$row['gid'],
@@ -424,7 +424,7 @@ class Database extends ABackend implements
 
 		$users = [];
 		$userManager = Server::get(IUserManager::class);
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$users[$row['uid']] = new LazyUser($row['uid'], $userManager, $row['displayname'] ?? null);
 		}
 		$result->closeCursor();
@@ -560,7 +560,7 @@ class Database extends ABackend implements
 				->where($query->expr()->in('gid', $query->createNamedParameter($chunk, IQueryBuilder::PARAM_STR_ARRAY)));
 
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$details[(string)$row['gid']] = ['displayName' => (string)$row['displayname']];
 				$this->groupCache[(string)$row['gid']] = [
 					'displayname' => (string)$row['displayname'],

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -83,7 +83,7 @@ class BackgroundCleanupJob extends TimedJob {
 		}
 
 		$cursor = $qb->executeQuery();
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			yield (int)$row['file_id'];
 		}
 		$cursor->closeCursor();
@@ -101,7 +101,7 @@ class BackgroundCleanupJob extends TimedJob {
 				$qb->expr()->in('fileid', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)),
 				$qb->expr()->eq('storage', $qb->createNamedParameter($storage, IQueryBuilder::PARAM_INT)),
 			));
-		$found = $qb->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		$found = $qb->executeQuery()->fetchFirstColumn();
 		return array_diff($ids, $found);
 	}
 }

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -85,7 +85,7 @@ class BackgroundCleanupJob extends TimedJob {
 		}
 
 		$cursor = $qb->executeQuery();
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			yield (int)$row['file_id'];
 		}
 		$cursor->closeCursor();
@@ -103,7 +103,7 @@ class BackgroundCleanupJob extends TimedJob {
 				$qb->expr()->in('fileid', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)),
 				$qb->expr()->eq('storage', $qb->createNamedParameter($storage, IQueryBuilder::PARAM_INT)),
 			));
-		$found = $qb->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		$found = $qb->executeQuery()->fetchFirstColumn();
 		return array_diff($ids, $found);
 	}
 }

--- a/lib/private/Preview/PreviewService.php
+++ b/lib/private/Preview/PreviewService.php
@@ -66,7 +66,7 @@ class PreviewService {
 
 			$found = false;
 			// Previews next to each others in the database are likely in the same storage, so group them
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$found = true;
 				if ($lastStorageId !== (int)$row['storage_id']) {
 					if ($lastStorageId !== -1) {

--- a/lib/private/Preview/PreviewService.php
+++ b/lib/private/Preview/PreviewService.php
@@ -67,7 +67,7 @@ class PreviewService {
 
 			$found = false;
 			// Previews next to each others in the database are likely in the same storage, so group them
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$found = true;
 				if ($lastStorageId !== (int)$row['storage_id']) {
 					if ($lastStorageId !== -1) {

--- a/lib/private/Repair/CleanTags.php
+++ b/lib/private/Repair/CleanTags.php
@@ -66,7 +66,7 @@ class CleanTags implements IRepairStep {
 
 		$users = [];
 		$hadResults = false;
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$hadResults = true;
 			if (!$this->userManager->userExists($row['uid'])) {
 				$users[] = $row['uid'];
@@ -149,7 +149,7 @@ class CleanTags implements IRepairStep {
 		$result = $qb->executeQuery();
 
 		$orphanItems = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$orphanItems[] = (int)$row[$deleteId];
 		}
 

--- a/lib/private/Repair/CleanTags.php
+++ b/lib/private/Repair/CleanTags.php
@@ -69,7 +69,7 @@ class CleanTags implements IRepairStep {
 
 		$users = [];
 		$hadResults = false;
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$hadResults = true;
 			if (!$this->userManager->userExists($row['uid'])) {
 				$users[] = $row['uid'];
@@ -152,7 +152,7 @@ class CleanTags implements IRepairStep {
 		$result = $qb->executeQuery();
 
 		$orphanItems = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$orphanItems[] = (int)$row[$deleteId];
 		}
 

--- a/lib/private/Repair/Collation.php
+++ b/lib/private/Repair/Collation.php
@@ -87,7 +87,7 @@ class Collation implements IRepairStep {
 			. "	AND TABLE_NAME LIKE '*PREFIX*%'",
 			[$dbName]
 		);
-		$rows = $statement->fetchAll();
+		$rows = $statement->fetchAllAssociative();
 		$result = [];
 		foreach ($rows as $row) {
 			$result[$row['table']] = true;
@@ -102,7 +102,7 @@ class Collation implements IRepairStep {
 			. "	AND TABLE_NAME LIKE '*PREFIX*%'",
 			[$dbName]
 		);
-		$rows = $statement->fetchAll();
+		$rows = $statement->fetchAllAssociative();
 		foreach ($rows as $row) {
 			$result[$row['table']] = true;
 		}

--- a/lib/private/Repair/Collation.php
+++ b/lib/private/Repair/Collation.php
@@ -90,7 +90,7 @@ class Collation implements IRepairStep {
 			. "	AND TABLE_NAME LIKE '*PREFIX*%'",
 			[$dbName]
 		);
-		$rows = $statement->fetchAll();
+		$rows = $statement->fetchAllAssociative();
 		$result = [];
 		foreach ($rows as $row) {
 			$result[$row['table']] = true;
@@ -105,7 +105,7 @@ class Collation implements IRepairStep {
 			. "	AND TABLE_NAME LIKE '*PREFIX*%'",
 			[$dbName]
 		);
-		$rows = $statement->fetchAll();
+		$rows = $statement->fetchAllAssociative();
 		foreach ($rows as $row) {
 			$result[$row['table']] = true;
 		}

--- a/lib/private/Repair/OldGroupMembershipShares.php
+++ b/lib/private/Repair/OldGroupMembershipShares.php
@@ -53,7 +53,7 @@ class OldGroupMembershipShares implements IRepairStep {
 			->where($query->expr()->eq('id', $deleteQuery->createParameter('share')));
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			if (!$this->isMember($row['group'], $row['user'])) {
 				$deletedEntries += $deleteQuery->setParameter('share', (int)$row['id'])
 					->executeStatement();

--- a/lib/private/Repair/OldGroupMembershipShares.php
+++ b/lib/private/Repair/OldGroupMembershipShares.php
@@ -56,7 +56,7 @@ class OldGroupMembershipShares implements IRepairStep {
 			->where($query->expr()->eq('id', $deleteQuery->createParameter('share')));
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			if (!$this->isMember($row['group'], $row['user'])) {
 				$deletedEntries += $deleteQuery->setParameter('share', (int)$row['id'])
 					->executeStatement();

--- a/lib/private/Repair/Owncloud/MigrateOauthTables.php
+++ b/lib/private/Repair/Owncloud/MigrateOauthTables.php
@@ -109,7 +109,7 @@ class MigrateOauthTables implements IRepairStep {
 				->from('oauth2_clients');
 
 			$result = $qbSelect->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$id = $row['id'];
 				$shortenedName = mb_substr($row['name'], 0, 64);
 				$qb->setParameter('theId', $id, IQueryBuilder::PARAM_INT);
@@ -147,7 +147,7 @@ class MigrateOauthTables implements IRepairStep {
 			$selectQuery = $this->db->getQueryBuilder();
 			$selectQuery->select('id', 'identifier')->from('oauth2_clients');
 			$result = $selectQuery->executeQuery();
-			$identifiers = $result->fetchAll();
+			$identifiers = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			// 2. Insert them into the client_identifier column.
@@ -218,7 +218,7 @@ class MigrateOauthTables implements IRepairStep {
 			$result = $qbSelect->executeQuery();
 			$now = $this->timeFactory->now()->getTimestamp();
 			$index = 0;
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$clientId = $row['client_id'];
 				$refreshToken = $row['token'];
 

--- a/lib/private/Repair/Owncloud/MigrateOauthTables.php
+++ b/lib/private/Repair/Owncloud/MigrateOauthTables.php
@@ -111,7 +111,7 @@ class MigrateOauthTables implements IRepairStep {
 				->from('oauth2_clients');
 
 			$result = $qbSelect->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$id = $row['id'];
 				$shortenedName = mb_substr($row['name'], 0, 64);
 				$qb->setParameter('theId', $id, IQueryBuilder::PARAM_INT);
@@ -149,7 +149,7 @@ class MigrateOauthTables implements IRepairStep {
 			$selectQuery = $this->db->getQueryBuilder();
 			$selectQuery->select('id', 'identifier')->from('oauth2_clients');
 			$result = $selectQuery->executeQuery();
-			$identifiers = $result->fetchAll();
+			$identifiers = $result->fetchAllAssociative();
 			$result->closeCursor();
 
 			// 2. Insert them into the client_identifier column.
@@ -220,7 +220,7 @@ class MigrateOauthTables implements IRepairStep {
 			$result = $qbSelect->executeQuery();
 			$now = $this->timeFactory->now()->getTimestamp();
 			$index = 0;
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$clientId = $row['client_id'];
 				$refreshToken = $row['token'];
 

--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -110,7 +110,7 @@ class SaveAccountsTableData implements IRepairStep {
 			->where($update->expr()->eq('uid', $update->createParameter('userid')));
 
 		$updatedUsers = 0;
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			try {
 				$this->migrateUserInfo($update, $row);
 			} catch (PreConditionNotMetException|\UnexpectedValueException) {

--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -113,7 +113,7 @@ class SaveAccountsTableData implements IRepairStep {
 			->where($update->expr()->eq('uid', $update->createParameter('userid')));
 
 		$updatedUsers = 0;
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			try {
 				$this->migrateUserInfo($update, $row);
 			} catch (PreConditionNotMetException|\UnexpectedValueException) {

--- a/lib/private/Repair/RemoveBrokenProperties.php
+++ b/lib/private/Repair/RemoveBrokenProperties.php
@@ -35,7 +35,7 @@ class RemoveBrokenProperties implements IRepairStep {
 		$result = $qb->executeQuery();
 		// find broken object properties
 		$brokenIds = [];
-		while ($entry = $result->fetch()) {
+		while ($entry = $result->fetchAssociative()) {
 			if (!empty($entry['propertyvalue'])) {
 				$object = @unserialize(str_replace('\x00', chr(0), $entry['propertyvalue']));
 				if ($object === false) {

--- a/lib/private/Repair/RemoveBrokenProperties.php
+++ b/lib/private/Repair/RemoveBrokenProperties.php
@@ -36,7 +36,7 @@ class RemoveBrokenProperties implements IRepairStep {
 		$result = $qb->executeQuery();
 		// find broken object properties
 		$brokenIds = [];
-		while ($entry = $result->fetch()) {
+		while ($entry = $result->fetchAssociative()) {
 			if (!empty($entry['propertyvalue'])) {
 				$object = @unserialize(str_replace('\x00', chr(0), $entry['propertyvalue']), ['allowed_classes' => false]);
 				if ($object === false) {

--- a/lib/private/Repair/RemoveLinkShares.php
+++ b/lib/private/Repair/RemoveLinkShares.php
@@ -87,7 +87,7 @@ class RemoveLinkShares implements IRepairStep {
 			->where($query->expr()->in('id', $query->createFunction($subQuery->getSQL())));
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)$data['total'];
@@ -166,7 +166,7 @@ class RemoveLinkShares implements IRepairStep {
 		$output->startProgress($total);
 
 		$shareResult = $this->getShares();
-		while ($data = $shareResult->fetch()) {
+		while ($data = $shareResult->fetchAssociative()) {
 			$this->processShare($data);
 			$output->advance();
 		}

--- a/lib/private/Repair/RemoveLinkShares.php
+++ b/lib/private/Repair/RemoveLinkShares.php
@@ -89,7 +89,7 @@ class RemoveLinkShares implements IRepairStep {
 			->where($query->expr()->in('id', $query->createFunction($subQuery->getSQL())));
 
 		$result = $query->executeQuery();
-		$data = $result->fetch();
+		$data = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)$data['total'];
@@ -168,7 +168,7 @@ class RemoveLinkShares implements IRepairStep {
 		$output->startProgress($total);
 
 		$shareResult = $this->getShares();
-		while ($data = $shareResult->fetch()) {
+		while ($data = $shareResult->fetchAssociative()) {
 			$this->processShare($data);
 			$output->advance();
 		}

--- a/lib/private/Repair/RepairDavShares.php
+++ b/lib/private/Repair/RepairDavShares.php
@@ -49,7 +49,7 @@ class RepairDavShares implements IRepairStep {
 			->where($updateQuery->expr()->eq('id', $updateQuery->createParameter('shareId')));
 
 		$statement = $qb->executeQuery();
-		while ($share = $statement->fetch()) {
+		while ($share = $statement->fetchAssociative()) {
 			$gid = substr($share['principaluri'], strlen(self::GROUP_PRINCIPAL_PREFIX));
 			$decodedGid = urldecode($gid);
 			$encodedGid = urlencode($gid);

--- a/lib/private/Repair/RepairDavShares.php
+++ b/lib/private/Repair/RepairDavShares.php
@@ -51,7 +51,7 @@ class RepairDavShares implements IRepairStep {
 			->where($updateQuery->expr()->eq('id', $updateQuery->createParameter('shareId')));
 
 		$statement = $qb->executeQuery();
-		while ($share = $statement->fetch()) {
+		while ($share = $statement->fetchAssociative()) {
 			$gid = substr($share['principaluri'], strlen(self::GROUP_PRINCIPAL_PREFIX));
 			$decodedGid = urldecode($gid);
 			$encodedGid = urlencode($gid);

--- a/lib/private/Repair/RepairInvalidShares.php
+++ b/lib/private/Repair/RepairInvalidShares.php
@@ -72,7 +72,7 @@ class RepairInvalidShares implements IRepairStep {
 		while ($deletedInLastChunk === self::CHUNK_SIZE) {
 			$deletedInLastChunk = 0;
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$deletedInLastChunk++;
 				$deletedEntries += $deleteQuery->setParameter('parent', (int)$row['parent'])
 					->executeStatement();

--- a/lib/private/Repair/RepairInvalidShares.php
+++ b/lib/private/Repair/RepairInvalidShares.php
@@ -74,7 +74,7 @@ class RepairInvalidShares implements IRepairStep {
 		while ($deletedInLastChunk === self::CHUNK_SIZE) {
 			$deletedInLastChunk = 0;
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$deletedInLastChunk++;
 				$deletedEntries += $deleteQuery->setParameter('parent', (int)$row['parent'])
 					->executeStatement();

--- a/lib/private/Security/Bruteforce/Backend/DatabaseBackend.php
+++ b/lib/private/Security/Bruteforce/Backend/DatabaseBackend.php
@@ -43,7 +43,7 @@ class DatabaseBackend implements IBackend {
 		}
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)$row['attempts'];

--- a/lib/private/Security/Bruteforce/Backend/DatabaseBackend.php
+++ b/lib/private/Security/Bruteforce/Backend/DatabaseBackend.php
@@ -45,7 +45,7 @@ class DatabaseBackend implements IBackend {
 		}
 
 		$result = $query->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return (int)$row['attempts'];

--- a/lib/private/Security/CredentialsManager.php
+++ b/lib/private/Security/CredentialsManager.php
@@ -61,7 +61,7 @@ class CredentialsManager implements ICredentialsManager {
 		}
 
 		$qResult = $qb->executeQuery();
-		$result = $qResult->fetch();
+		$result = $qResult->fetchAssociative();
 		$qResult->closeCursor();
 
 		if (!$result) {

--- a/lib/private/Security/CredentialsManager.php
+++ b/lib/private/Security/CredentialsManager.php
@@ -64,7 +64,7 @@ class CredentialsManager implements ICredentialsManager {
 		}
 
 		$qResult = $qb->executeQuery();
-		$result = $qResult->fetch();
+		$result = $qResult->fetchAssociative();
 		$qResult->closeCursor();
 
 		if (!$result) {

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -65,7 +65,7 @@ class MySQL extends AbstractDatabase {
 			//we can't use OC_DB functions here because we need to connect as the administrative user.
 			$characterSet = $this->config->getValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
 			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET $characterSet COLLATE {$characterSet}_bin;";
-			$connection->executeUpdate($query);
+			$connection->executeStatement($query);
 		} catch (\Exception $ex) {
 			$this->logger->error('Database creation failed.', [
 				'exception' => $ex,
@@ -77,7 +77,7 @@ class MySQL extends AbstractDatabase {
 		try {
 			//this query will fail if there aren't the right permissions, ignore the error
 			$query = "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON `$name` . * TO '$user'";
-			$connection->executeUpdate($query);
+			$connection->executeStatement($query);
 		} catch (\Exception $ex) {
 			$this->logger->debug('Could not automatically grant privileges, this can be ignored if database user already had privileges.', [
 				'exception' => $ex,
@@ -152,7 +152,7 @@ class MySQL extends AbstractDatabase {
 					$result = $connection->executeQuery($query, [$adminUser]);
 
 					//current dbuser has admin rights
-					$data = $result->fetchAll();
+					$data = $result->fetchAllAssociative();
 					$result->closeCursor();
 					//new dbuser does not exist
 					if (count($data) === 0) {

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -87,7 +87,7 @@ class MySQL extends AbstractDatabase {
 			//we can't use OC_DB functions here because we need to connect as the administrative user.
 			$characterSet = $this->config->getValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
 			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET $characterSet COLLATE {$characterSet}_bin;";
-			$connection->executeUpdate($query);
+			$connection->executeStatement($query);
 		} catch (\Exception $ex) {
 			$this->logger->error('Database creation failed.', [
 				'exception' => $ex,
@@ -99,7 +99,7 @@ class MySQL extends AbstractDatabase {
 		try {
 			//this query will fail if there aren't the right permissions, ignore the error
 			$query = "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON `$name` . * TO '$user'";
-			$connection->executeUpdate($query);
+			$connection->executeStatement($query);
 		} catch (\Exception $ex) {
 			$this->logger->debug('Could not automatically grant privileges, this can be ignored if database user already had privileges.', [
 				'exception' => $ex,
@@ -162,7 +162,7 @@ class MySQL extends AbstractDatabase {
 					$result = $connection->executeQuery($query, [$adminUser]);
 
 					//current dbuser has admin rights
-					$data = $result->fetchAll();
+					$data = $result->fetchAllAssociative();
 					$result->closeCursor();
 					//new dbuser does not exist
 					if (count($data) === 0) {

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -340,7 +340,7 @@ class DefaultShareProvider implements
 				->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
 				->executeQuery();
 
-			$data = $stmt->fetch();
+			$data = $stmt->fetchAssociative();
 			$stmt->closeCursor();
 
 			/*
@@ -392,7 +392,7 @@ class DefaultShareProvider implements
 			->orderBy('id');
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$children[] = $this->createShare($data);
 		}
 		$cursor->closeCursor();
@@ -454,7 +454,7 @@ class DefaultShareProvider implements
 				->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
 				->executeQuery();
 
-			$data = $stmt->fetch();
+			$data = $stmt->fetchAssociative();
 
 			/*
 			 * Check if there already is a user specific group share.
@@ -533,7 +533,7 @@ class DefaultShareProvider implements
 				$qb->expr()->eq('id', $qb->createNamedParameter($share->getId()))
 			);
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		$originalPermission = $data['permissions'];
@@ -577,7 +577,7 @@ class DefaultShareProvider implements
 				->setMaxResults(1)
 				->executeQuery();
 
-			$data = $stmt->fetch();
+			$data = $stmt->fetchAssociative();
 			$stmt->closeCursor();
 
 			$shareAttributes = $this->formatShareAttributes(
@@ -687,7 +687,7 @@ class DefaultShareProvider implements
 		foreach ($chunks as $chunk) {
 			$qb->setParameter('chunk', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$cursor = $qb->executeQuery();
-			while ($data = $cursor->fetch()) {
+			while ($data = $cursor->fetchAssociative()) {
 				$shares[$data['fileid']][] = $this->createShare($data);
 			}
 			$cursor->closeCursor();
@@ -736,7 +736,7 @@ class DefaultShareProvider implements
 
 		$cursor = $qb->executeQuery();
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShare($data);
 		}
 		$cursor->closeCursor();
@@ -766,7 +766,7 @@ class DefaultShareProvider implements
 			->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
 
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($data === false) {
@@ -805,7 +805,7 @@ class DefaultShareProvider implements
 			->executeQuery();
 
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShare($data);
 		}
 		$cursor->closeCursor();
@@ -927,7 +927,7 @@ class DefaultShareProvider implements
 
 			$cursor = $qb->executeQuery();
 
-			while ($data = $cursor->fetch()) {
+			while ($data = $cursor->fetchAssociative()) {
 				if ($data['fileid'] && $data['path'] === null) {
 					$data['path'] = (string)$data['path'];
 					$data['name'] = (string)$data['name'];
@@ -1018,7 +1018,7 @@ class DefaultShareProvider implements
 					->andWhere($qb->expr()->in('s.item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
 
 				$cursor = $qb->executeQuery();
-				while ($data = $cursor->fetch()) {
+				while ($data = $cursor->fetchAssociative()) {
 					if ($offset > 0) {
 						$offset--;
 						continue;
@@ -1061,7 +1061,7 @@ class DefaultShareProvider implements
 			->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
 			->executeQuery();
 
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 
 		if ($data === false) {
 			throw new ShareNotFound();
@@ -1176,7 +1176,7 @@ class DefaultShareProvider implements
 
 		$stmt = $query->executeQuery();
 
-		while ($data = $stmt->fetch()) {
+		while ($data = $stmt->fetchAssociative()) {
 			if (array_key_exists($data['parent'], $shareMap)) {
 				$shareMap[$data['parent']]->setPermissions((int)$data['permissions']);
 				$shareMap[$data['parent']]->setStatus((int)$data['accepted']);
@@ -1272,7 +1272,7 @@ class DefaultShareProvider implements
 
 		$cursor = $qb->executeQuery();
 		$ids = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$ids[] = (int)$row['id'];
 		}
 		$cursor->closeCursor();
@@ -1320,7 +1320,7 @@ class DefaultShareProvider implements
 
 		$cursor = $qb->executeQuery();
 		$ids = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$ids[] = (int)$row['id'];
 		}
 		$cursor->closeCursor();
@@ -1423,7 +1423,7 @@ class DefaultShareProvider implements
 
 		$users = [];
 		$link = false;
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$type = (int)$row['share_type'];
 			if ($type === IShare::TYPE_USER) {
 				$uid = $row['share_with'];
@@ -1726,7 +1726,7 @@ class DefaultShareProvider implements
 			->where($qb->expr()->in('share_type', $qb->createNamedParameter([IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_LINK], IQueryBuilder::PARAM_INT_ARRAY)));
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			try {
 				$share = $this->createShare($data);
 			} catch (InvalidShare $e) {

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -343,7 +343,7 @@ class DefaultShareProvider implements
 				->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
 				->executeQuery();
 
-			$data = $stmt->fetch();
+			$data = $stmt->fetchAssociative();
 			$stmt->closeCursor();
 
 			/*
@@ -395,7 +395,7 @@ class DefaultShareProvider implements
 			->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$children[] = $this->createShare($data);
 		}
 		$cursor->closeCursor();
@@ -459,7 +459,7 @@ class DefaultShareProvider implements
 				->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
 				->executeQuery();
 
-			$data = $stmt->fetch();
+			$data = $stmt->fetchAssociative();
 
 			/*
 			 * Check if there already is a user specific group share.
@@ -539,7 +539,7 @@ class DefaultShareProvider implements
 				$qb->expr()->eq('id', $qb->createNamedParameter($share->getId()))
 			);
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		$originalPermission = $data['permissions'];
@@ -584,7 +584,7 @@ class DefaultShareProvider implements
 				->setMaxResults(1)
 				->executeQuery();
 
-			$data = $stmt->fetch();
+			$data = $stmt->fetchAssociative();
 			$stmt->closeCursor();
 
 			$shareAttributes = $this->formatShareAttributes(
@@ -695,7 +695,7 @@ class DefaultShareProvider implements
 		foreach ($chunks as $chunk) {
 			$qb->setParameter('chunk', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$cursor = $qb->executeQuery();
-			while ($data = $cursor->fetch()) {
+			while ($data = $cursor->fetchAssociative()) {
 				$shares[$data['fileid']][] = $this->createShare($data);
 			}
 			$cursor->closeCursor();
@@ -747,7 +747,7 @@ class DefaultShareProvider implements
 
 		$cursor = $qb->executeQuery();
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShare($data);
 		}
 		$cursor->closeCursor();
@@ -778,7 +778,7 @@ class DefaultShareProvider implements
 			->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
 
 		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 		$cursor->closeCursor();
 
 		if ($data === false) {
@@ -817,7 +817,7 @@ class DefaultShareProvider implements
 			->executeQuery();
 
 		$shares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			$shares[] = $this->createShare($data);
 		}
 		$cursor->closeCursor();
@@ -943,7 +943,7 @@ class DefaultShareProvider implements
 
 			$cursor = $qb->executeQuery();
 
-			while ($data = $cursor->fetch()) {
+			while ($data = $cursor->fetchAssociative()) {
 				if ($data['fileid'] && $data['path'] === null) {
 					$data['path'] = (string)$data['path'];
 					$data['name'] = (string)$data['name'];
@@ -1037,7 +1037,7 @@ class DefaultShareProvider implements
 					->andWhere($qb->expr()->in('s.item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
 
 				$cursor = $qb->executeQuery();
-				while ($data = $cursor->fetch()) {
+				while ($data = $cursor->fetchAssociative()) {
 					if ($offset > 0) {
 						$offset--;
 						continue;
@@ -1080,7 +1080,7 @@ class DefaultShareProvider implements
 			->andWhere($qb->expr()->in('item_type', $qb->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)))
 			->executeQuery();
 
-		$data = $cursor->fetch();
+		$data = $cursor->fetchAssociative();
 
 		if ($data === false) {
 			throw new ShareNotFound();
@@ -1189,7 +1189,7 @@ class DefaultShareProvider implements
 
 		$stmt = $query->executeQuery();
 
-		while ($data = $stmt->fetch()) {
+		while ($data = $stmt->fetchAssociative()) {
 			if (array_key_exists($data['parent'], $shareMap)) {
 				$shareMap[$data['parent']]->setPermissions((int)$data['permissions']);
 				$shareMap[$data['parent']]->setStatus((int)$data['accepted']);
@@ -1287,7 +1287,7 @@ class DefaultShareProvider implements
 
 		$cursor = $qb->executeQuery();
 		$ids = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$ids[] = (int)$row['id'];
 		}
 		$cursor->closeCursor();
@@ -1336,7 +1336,7 @@ class DefaultShareProvider implements
 
 		$cursor = $qb->executeQuery();
 		$ids = [];
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$ids[] = (int)$row['id'];
 		}
 		$cursor->closeCursor();
@@ -1440,7 +1440,7 @@ class DefaultShareProvider implements
 
 		$users = [];
 		$link = false;
-		while ($row = $cursor->fetch()) {
+		while ($row = $cursor->fetchAssociative()) {
 			$type = (int)$row['share_type'];
 			if ($type === IShare::TYPE_USER) {
 				$uid = $row['share_with'];
@@ -1745,7 +1745,7 @@ class DefaultShareProvider implements
 			->where($qb->expr()->in('share_type', $qb->createNamedParameter([IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_LINK], IQueryBuilder::PARAM_INT_ARRAY)));
 
 		$cursor = $qb->executeQuery();
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			try {
 				$share = $this->createShare($data);
 			} catch (InvalidShare $e) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1069,7 +1069,7 @@ class Manager implements IManager {
 		$cursor = $qb->executeQuery();
 		/** @var array<string, list<array{IShare::TYPE_*, Node}>> $rawShare */
 		$rawShares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			if (!isset($rawShares[$data['uid_initiator']])) {
 				$rawShares[$data['uid_initiator']] = [];
 			}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -962,7 +962,7 @@ class Manager implements IManager {
 		$cursor = $qb->executeQuery();
 		/** @var array<string, list<array{IShare::TYPE_*, Node}>> $rawShare */
 		$rawShares = [];
-		while ($data = $cursor->fetch()) {
+		while ($data = $cursor->fetchAssociative()) {
 			if (!isset($rawShares[$data['uid_initiator']])) {
 				$rawShares[$data['uid_initiator']] = [];
 			}

--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -106,7 +106,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->executeQuery();
 
 		$groups = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$groups[] = $row['gid'];
 		}
 		$result->closeCursor();
@@ -139,7 +139,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->executeQuery();
 
 		$users = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$user = $this->userManager->get($row['uid']);
 			if (!is_null($user)) {
 				$users[] = $user;
@@ -162,7 +162,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->executeQuery();
 
 		$subadmins = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$user = $this->userManager->get($row['uid']);
 			$group = $this->groupManager->get($row['gid']);
 			if (!is_null($user) && !is_null($group)) {
@@ -195,7 +195,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
 			->executeQuery();
 
-		$fetch = $result->fetch();
+		$fetch = $result->fetchAssociative();
 		$result->closeCursor();
 		$result = !empty($fetch) ? true : false;
 
@@ -226,7 +226,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->setMaxResults(1)
 			->executeQuery();
 
-		$isSubAdmin = $result->fetch();
+		$isSubAdmin = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return $isSubAdmin !== false;

--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -110,7 +110,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->executeQuery();
 
 		$groups = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$groups[] = $row['gid'];
 		}
 		$result->closeCursor();
@@ -144,7 +144,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->executeQuery();
 
 		$users = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$user = $this->userManager->get($row['uid']);
 			if (!is_null($user)) {
 				$users[] = $user;
@@ -167,7 +167,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->executeQuery();
 
 		$subadmins = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$user = $this->userManager->get($row['uid']);
 			$group = $this->groupManager->get($row['gid']);
 			if (!is_null($user) && !is_null($group)) {
@@ -201,7 +201,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
 			->executeQuery();
 
-		$fetch = $result->fetch();
+		$fetch = $result->fetchAssociative();
 		$result->closeCursor();
 		$result = !empty($fetch) ? true : false;
 
@@ -233,7 +233,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->setMaxResults(1)
 			->executeQuery();
 
-		$isSubAdmin = $result->fetch();
+		$isSubAdmin = $result->fetchAssociative();
 		$result->closeCursor();
 
 		return $isSubAdmin !== false;

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -75,7 +75,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY);
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$tag = $this->createSystemTagFromRow($row);
 			if ($user && !$this->canUserSeeTag($tag, $user)) {
 				// if a user is given, hide invisible tags
@@ -121,7 +121,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('editable', 'ASC');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$tags[$row['id']] = $this->createSystemTagFromRow($row);
 		}
 
@@ -139,7 +139,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('editable', $userAssignable ? 1 : 0)
 			->executeQuery();
 
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 		if (!$row) {
 			throw new TagNotFoundException(
@@ -452,7 +452,7 @@ class SystemTagManager implements ISystemTagManager {
 			->orderBy('gid');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$groupIds[] = $row['gid'];
 		}
 

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -81,7 +81,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY);
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$tag = $this->createSystemTagFromRow($row);
 			if ($user && !$this->canUserSeeTag($tag, $user)) {
 				// if a user is given, hide invisible tags
@@ -128,7 +128,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('editable', 'ASC');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$tags[$row['id']] = $this->createSystemTagFromRow($row);
 		}
 
@@ -147,7 +147,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('editable', $userAssignable ? 1 : 0)
 			->executeQuery();
 
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 		if (!$row) {
 			throw new TagNotFoundException(
@@ -476,7 +476,7 @@ class SystemTagManager implements ISystemTagManager {
 			->orderBy('gid');
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$groupIds[] = $row['gid'];
 		}
 

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -56,7 +56,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		foreach ($chunks as $chunk) {
 			$query->setParameter('objectids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$objectId = $row['objectid'];
 				$mapping[$objectId][] = (string)$row['systemtagid'];
 			}
@@ -99,7 +99,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		$objectIds = [];
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$objectIds[] = $row['objectid'];
 		}
 		$result->closeCursor();
@@ -123,7 +123,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->andWhere($query->expr()->eq('objecttype', $query->createNamedParameter($objectType)))
 			->andWhere($query->expr()->eq('objectid', $query->createNamedParameter($objId)));
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$existingTags = [];
 		foreach ($rows as $row) {
 			$existingTags[] = $row['systemtagid'];
@@ -259,7 +259,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->setParameter('objecttype', $objectType);
 
 		$result = $query->executeQuery();
-		$row = $result->fetch(\PDO::FETCH_NUM);
+		$row = $result->fetchNumeric();
 		$result->closeCursor();
 
 		if ($all) {
@@ -376,7 +376,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 
 		$result = $query->executeQuery();
 		$objectTypes = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$objectTypes[] = $row['objecttype'];
 		}
 		$result->closeCursor();

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -57,7 +57,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		foreach ($chunks as $chunk) {
 			$query->setParameter('objectids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $query->executeQuery();
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$objectId = $row['objectid'];
 				$mapping[$objectId][] = (string)$row['systemtagid'];
 			}
@@ -101,7 +101,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		$objectIds = [];
 
 		$result = $query->executeQuery();
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$objectIds[] = $row['objectid'];
 		}
 		$result->closeCursor();
@@ -125,7 +125,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->andWhere($query->expr()->eq('objecttype', $query->createNamedParameter($objectType)))
 			->andWhere($query->expr()->eq('objectid', $query->createNamedParameter($objId)));
 		$result = $query->executeQuery();
-		$rows = $result->fetchAll();
+		$rows = $result->fetchAllAssociative();
 		$existingTags = [];
 		foreach ($rows as $row) {
 			$existingTags[] = $row['systemtagid'];
@@ -262,7 +262,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->setParameter('objecttype', $objectType);
 
 		$result = $query->executeQuery();
-		$row = $result->fetch(\PDO::FETCH_NUM);
+		$row = $result->fetchNumeric();
 		$result->closeCursor();
 
 		if ($all) {
@@ -381,7 +381,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 
 		$result = $query->executeQuery();
 		$objectTypes = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$objectTypes[] = $row['objecttype'];
 		}
 		$result->closeCursor();

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -79,7 +79,7 @@ class TagManager implements ITagManager, IEventListener {
 			->andWhere($query->expr()->eq('c.category', $query->createNamedParameter(ITags::TAG_FAVORITE)));
 
 		$result = $query->executeQuery();
-		$users = $result->fetchAll(\PDO::FETCH_COLUMN);
+		$users = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		return $users;
@@ -106,7 +106,7 @@ class TagManager implements ITagManager, IEventListener {
 			return;
 		}
 
-		$tagsIds = array_map(fn (array $row) => (int)$row['id'], $result->fetchAll());
+		$tagsIds = array_map(fn (array $row) => (int)$row['id'], $result->fetchAllAssociative());
 		$result->closeCursor();
 
 		if (count($tagsIds) === 0) {

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -83,7 +83,7 @@ class TagManager implements ITagManager, IEventListener {
 			->andWhere($query->expr()->eq('c.category', $query->createNamedParameter(ITags::TAG_FAVORITE)));
 
 		$result = $query->executeQuery();
-		$users = $result->fetchAll(\PDO::FETCH_COLUMN);
+		$users = $result->fetchFirstColumn();
 		$result->closeCursor();
 
 		return $users;
@@ -111,7 +111,7 @@ class TagManager implements ITagManager, IEventListener {
 			return;
 		}
 
-		$tagsIds = array_map(fn (array $row) => (int)$row['id'], $result->fetchAll());
+		$tagsIds = array_map(fn (array $row) => (int)$row['id'], $result->fetchAllAssociative());
 		$result->closeCursor();
 
 		if (count($tagsIds) === 0) {

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -159,7 +159,7 @@ class Tags implements ITags {
 				$qb->setParameter('type', $this->type, IQueryBuilder::PARAM_STR);
 				$qb->setParameter('chunk', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 				$result = $qb->executeQuery();
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					$objId = (int)$row['objid'];
 					if (!isset($entries[$objId])) {
 						$entries[$objId] = [];
@@ -223,7 +223,7 @@ class Tags implements ITags {
 			return false;
 		}
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$ids[] = (int)$row['objid'];
 		}
 		$result->closeCursor();

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -164,7 +164,7 @@ class Tags implements ITags {
 				$qb->setParameter('type', $this->type, IQueryBuilder::PARAM_STR);
 				$qb->setParameter('chunk', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 				$result = $qb->executeQuery();
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					$objId = (int)$row['objid'];
 					if (!isset($entries[$objId])) {
 						$entries[$objId] = [];
@@ -229,7 +229,7 @@ class Tags implements ITags {
 			return false;
 		}
 
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$ids[] = (int)$row['objid'];
 		}
 		$result->closeCursor();

--- a/lib/private/TaskProcessing/Db/TaskMapper.php
+++ b/lib/private/TaskProcessing/Db/TaskMapper.php
@@ -276,7 +276,7 @@ class TaskMapper extends QBMapper {
 		$qb->andWhere($qb->expr()->eq('status', $qb->createNamedParameter(\OCP\TaskProcessing\Task::STATUS_RUNNING, IQueryBuilder::PARAM_INT)));
 		$qb->setMaxResults(1);
 		$result = $qb->executeQuery();
-		$hasRunningTasks = $result->fetch() !== false;
+		$hasRunningTasks = $result->fetchAssociative() !== false;
 		$result->closeCursor();
 		return $hasRunningTasks;
 	}

--- a/lib/private/TaskProcessing/Db/TaskMapper.php
+++ b/lib/private/TaskProcessing/Db/TaskMapper.php
@@ -479,7 +479,7 @@ class TaskMapper extends QBMapper {
 		$qb->andWhere($qb->expr()->eq('status', $qb->createNamedParameter(\OCP\TaskProcessing\Task::STATUS_RUNNING, IQueryBuilder::PARAM_INT)));
 		$qb->setMaxResults(1);
 		$result = $qb->executeQuery();
-		$hasRunningTasks = $result->fetch() !== false;
+		$hasRunningTasks = $result->fetchAssociative() !== false;
 		$result->closeCursor();
 		return $hasRunningTasks;
 	}

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -289,7 +289,7 @@ class Database extends ABackend implements
 
 		$result = $query->executeQuery();
 		$displayNames = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$displayNames[(string)$row['uid']] = (string)$row['displayname'];
 		}
 
@@ -328,7 +328,7 @@ class Database extends ABackend implements
 
 		$result = $query->executeQuery();
 		$displayNames = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$displayNames[(string)$row['uid']] = (string)$row['displayname'];
 		}
 
@@ -389,7 +389,7 @@ class Database extends ABackend implements
 				)
 			);
 		$result = $qb->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		// "uid" is primary key, so there can only be a single result

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -298,7 +298,7 @@ class Database extends ABackend implements
 
 		$result = $query->executeQuery();
 		$displayNames = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$displayNames[(string)$row['uid']] = (string)$row['displayname'];
 		}
 
@@ -338,7 +338,7 @@ class Database extends ABackend implements
 
 		$result = $query->executeQuery();
 		$displayNames = [];
-		while ($row = $result->fetch()) {
+		while ($row = $result->fetchAssociative()) {
 			$displayNames[(string)$row['uid']] = (string)$row['displayname'];
 		}
 
@@ -400,7 +400,7 @@ class Database extends ABackend implements
 				)
 			);
 		$result = $qb->executeQuery();
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		$result->closeCursor();
 
 		// "uid" is primary key, so there can only be a single result

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -651,7 +651,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		$query = $queryBuilder->executeQuery();
 		$result = [];
 
-		while ($row = $query->fetch()) {
+		while ($row = $query->fetchAssociative()) {
 			$result[] = $row['userid'];
 		}
 
@@ -774,7 +774,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		}
 
 		/** @var list<string> */
-		$list = $queryBuilder->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		$list = $queryBuilder->executeQuery()->fetchFirstColumn();
 
 		return $list;
 	}

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -676,7 +676,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		$query = $queryBuilder->executeQuery();
 		$result = [];
 
-		while ($row = $query->fetch()) {
+		while ($row = $query->fetchAssociative()) {
 			$result[] = $row['userid'];
 		}
 
@@ -802,7 +802,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		}
 
 		/** @var list<string> */
-		$list = $queryBuilder->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		$list = $queryBuilder->executeQuery()->fetchFirstColumn();
 
 		return $list;
 	}

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -275,7 +275,7 @@ abstract class QBMapper {
 	protected function findOneQuery(IQueryBuilder $query): array {
 		$result = $query->executeQuery();
 
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		if ($row === false) {
 			$result->closeCursor();
 			$msg = $this->buildDebugMessage(
@@ -284,7 +284,7 @@ abstract class QBMapper {
 			throw new DoesNotExistException($msg);
 		}
 
-		$row2 = $result->fetch();
+		$row2 = $result->fetchAssociative();
 		$result->closeCursor();
 		if ($row2 !== false) {
 			$msg = $this->buildDebugMessage(
@@ -336,7 +336,7 @@ abstract class QBMapper {
 		$result = $query->executeQuery();
 		try {
 			$entities = [];
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$entities[] = $this->mapRowToEntity($row);
 			}
 			return $entities;
@@ -357,7 +357,7 @@ abstract class QBMapper {
 	protected function yieldEntities(IQueryBuilder $query): Generator {
 		$result = $query->executeQuery();
 		try {
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				yield $this->mapRowToEntity($row);
 			}
 		} finally {

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -274,7 +274,7 @@ abstract class QBMapper {
 	protected function findOneQuery(IQueryBuilder $query): array {
 		$result = $query->executeQuery();
 
-		$row = $result->fetch();
+		$row = $result->fetchAssociative();
 		if ($row === false) {
 			$result->closeCursor();
 			$msg = $this->buildDebugMessage(
@@ -283,7 +283,7 @@ abstract class QBMapper {
 			throw new DoesNotExistException($msg);
 		}
 
-		$row2 = $result->fetch();
+		$row2 = $result->fetchAssociative();
 		$result->closeCursor();
 		if ($row2 !== false) {
 			$msg = $this->buildDebugMessage(
@@ -333,7 +333,7 @@ abstract class QBMapper {
 		$result = $query->executeQuery();
 		try {
 			$entities = [];
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				$entities[] = $this->mapRowToEntity($row);
 			}
 			return $entities;
@@ -354,7 +354,7 @@ abstract class QBMapper {
 	protected function yieldEntities(IQueryBuilder $query): Generator {
 		$result = $query->executeQuery();
 		try {
-			while ($row = $result->fetch()) {
+			while ($row = $result->fetchAssociative()) {
 				yield $this->mapRowToEntity($row);
 			}
 		} finally {

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -23,6 +23,43 @@ class AllConfigTest extends \Test\TestCase {
 	/** @var IDBConnection */
 	protected $connection;
 
+	/** Insert one row into oc_preferences */
+	private function insertPreferenceRow(string $userid, string $appid, string $configkey, string $configvalue): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('preferences')
+			->values([
+				'userid' => $qb->createNamedParameter($userid),
+				'appid' => $qb->createNamedParameter($appid),
+				'configkey' => $qb->createNamedParameter($configkey),
+				'configvalue' => $qb->createNamedParameter($configvalue),
+			])
+			->executeStatement();
+	}
+
+	/** Return all oc_preferences rows for the given user */
+	private function getPreferenceRows(string $userid): array {
+		$qb = $this->connection->getQueryBuilder();
+		return $qb->select('userid', 'appid', 'configkey', 'configvalue')
+			->from('preferences')
+			->where($qb->expr()->eq('userid', $qb->createNamedParameter($userid)))
+			->executeQuery()
+			->fetchAllAssociative();
+	}
+
+	/** Return the total number of rows in oc_preferences */
+	private function countPreferenceRows(): int {
+		$qb = $this->connection->getQueryBuilder();
+		return (int)$qb->select($qb->func()->count('*'))
+			->from('preferences')
+			->executeQuery()
+			->fetchOne();
+	}
+
+	/** Truncate oc_preferences */
+	private function clearPreferences(): void {
+		$this->connection->getQueryBuilder()->delete('preferences')->executeStatement();
+	}
+
 	protected function getConfig($systemConfig = null, $connection = null) {
 		if ($this->connection === null) {
 			$this->connection = Server::get(IDBConnection::class);
@@ -42,30 +79,21 @@ class AllConfigTest extends \Test\TestCase {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$this->connection->executeUpdate(
-			'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-			. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-			['userDelete', 'appDelete', 'keyDelete', 'valueDelete']
-		);
+		$this->insertPreferenceRow('userDelete', 'appDelete', 'keyDelete', 'valueDelete');
 
 		$config->deleteUserValue('userDelete', 'appDelete', 'keyDelete');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences` WHERE `userid` = ?',
-			['userDelete']
-		)->fetchAssociative();
-		$actualCount = $result['count'];
+		$actualCount = count($this->getPreferenceRows('userDelete'));
 
 		$this->assertEquals(0, $actualCount, 'There was one value in the database and after the tests there should be no entry left.');
 	}
 
 	public function testSetUserValue(): void {
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 		$config = $this->getConfig();
 
 		$config->setUserValue('userSet', 'appSet', 'keySet', 'valueSet');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userSet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -78,7 +106,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries
 		$config->setUserValue('userSet', 'appSet', 'keySet', 'valueSet2');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userSet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -97,12 +125,11 @@ class AllConfigTest extends \Test\TestCase {
 	 * This way we can skip the expensive casing change on the database.
 	 */
 	public function testSetUserValueSettingsEmail(): void {
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 		$config = $this->getConfig();
 
 		$config->setUserValue('userSet', 'settings', 'email', 'mixed.CASE@domain.COM');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userSet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -116,11 +143,9 @@ class AllConfigTest extends \Test\TestCase {
 	public function testSetUserValueWithPreCondition(): void {
 		$config = $this->getConfig();
 
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
-
 		$config->setUserValue('userPreCond', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -133,7 +158,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries with valid precond
 		$config->setUserValue('userPreCond', 'appPreCond', 'keyPreCond', 'valuePreCond2', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -173,11 +198,9 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config = $this->getConfig();
 
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
-
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -190,7 +213,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries with valid precond
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond2', 'valuePreCond3');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -209,11 +232,9 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config = $this->getConfig();
 
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
-
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertCount(1, $result);
 		$this->assertEquals([
@@ -226,7 +247,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method throws with invalid precondition when the value is the same
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond', 'valuePreCond3');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertCount(1, $result);
 		$this->assertEquals([
@@ -247,7 +268,7 @@ class AllConfigTest extends \Test\TestCase {
 		$resultMock = $this->getMockBuilder('\Doctrine\DBAL\Driver\Statement')
 			->disableOriginalConstructor()->getMock();
 		$resultMock->expects($this->once())
-			->method('fetchColumn')
+			->method('fetchOne')
 			->willReturn('valueSetUnchanged');
 
 		$connectionMock = $this->createMock(IDBConnection::class);
@@ -258,7 +279,7 @@ class AllConfigTest extends \Test\TestCase {
 				$this->equalTo(['userSetUnchanged', 'appSetUnchanged', 'keySetUnchanged']))
 			->willReturn($resultMock);
 		$connectionMock->expects($this->never())
-			->method('executeUpdate');
+			->method('executeStatement');
 
 		$config = $this->getConfig(null, $connectionMock);
 
@@ -274,10 +295,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$this->assertEquals('valueGet', $value);
 
-		$result = $this->connection->executeQuery(
-			'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?',
-			['userGet']
-		)->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userGet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -288,41 +306,30 @@ class AllConfigTest extends \Test\TestCase {
 		], $result[0]);
 
 		// drop data from database - but the config option should be cached in the config object
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences` WHERE `userid` = ?', ['userGet']);
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('preferences')
+			->where($qb->expr()->eq('userid', $qb->createNamedParameter('userGet')))
+			->executeStatement();
 
 		// testing the caching mechanism
 		$value = $config->getUserValue('userGet', 'appGet', 'keyGet');
 
 		$this->assertEquals('valueGet', $value);
 
-		$result = $this->connection->executeQuery(
-			'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?',
-			['userGet']
-		)->fetchAllAssociative();
-
-		$this->assertEquals(0, count($result));
+		$this->assertEquals(0, count($this->getPreferenceRows('userGet')));
 	}
 
 	public function testGetUserKeys(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch', 'appFetch1', 'keyFetch1', 'value1'],
-			['userFetch', 'appFetch1', 'keyFetch2', 'value2'],
-			['userFetch', 'appFetch2', 'keyFetch3', 'value3'],
-			['userFetch', 'appFetch1', 'keyFetch4', 'value4'],
-			['userFetch', 'appFetch4', 'keyFetch1', 'value5'],
-			['userFetch', 'appFetch5', 'keyFetch1', 'value6'],
-			['userFetch2', 'appFetch', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch', 'appFetch1', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch', 'appFetch1', 'keyFetch2', 'value2');
+		$this->insertPreferenceRow('userFetch', 'appFetch2', 'keyFetch3', 'value3');
+		$this->insertPreferenceRow('userFetch', 'appFetch1', 'keyFetch4', 'value4');
+		$this->insertPreferenceRow('userFetch', 'appFetch4', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch', 'appFetch5', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch2', 'appFetch', 'keyFetch1', 'value7');
 
 		$value = $config->getUserKeys('userFetch', 'appFetch1');
 		$this->assertEquals(['keyFetch1', 'keyFetch2', 'keyFetch4'], $value);
@@ -331,24 +338,15 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(['keyFetch1'], $value);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testGetUserKeysAllInts(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch8', 'appFetch1', '123', 'value'],
-			['userFetch8', 'appFetch1', '456', 'value'],
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch8', 'appFetch1', '123', 'value');
+		$this->insertPreferenceRow('userFetch8', 'appFetch1', '456', 'value');
 
 		$value = $config->getUserKeys('userFetch8', 'appFetch1');
 		$this->assertEquals(['123', '456'], $value);
@@ -356,7 +354,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertIsString($value[1]);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testGetUserValueDefault(): void {
@@ -371,22 +369,13 @@ class AllConfigTest extends \Test\TestCase {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch1', 'appFetch2', 'keyFetch1', 'value1'],
-			['userFetch2', 'appFetch2', 'keyFetch1', 'value2'],
-			['userFetch3', 'appFetch2', 'keyFetch1', 3],
-			['userFetch4', 'appFetch2', 'keyFetch1', 'value4'],
-			['userFetch5', 'appFetch2', 'keyFetch1', 'value5'],
-			['userFetch6', 'appFetch2', 'keyFetch1', 'value6'],
-			['userFetch7', 'appFetch2', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch1', 'appFetch2', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch2', 'appFetch2', 'keyFetch1', 'value2');
+		$this->insertPreferenceRow('userFetch3', 'appFetch2', 'keyFetch1', '3');
+		$this->insertPreferenceRow('userFetch4', 'appFetch2', 'keyFetch1', 'value4');
+		$this->insertPreferenceRow('userFetch5', 'appFetch2', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch6', 'appFetch2', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch7', 'appFetch2', 'keyFetch1', 'value7');
 
 		$value = $config->getUserValueForUsers('appFetch2', 'keyFetch1',
 			['userFetch1', 'userFetch2', 'userFetch3', 'userFetch5']);
@@ -405,84 +394,51 @@ class AllConfigTest extends \Test\TestCase {
 		], $value, 'userFetch9 is an non-existent user and should not be shown.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testDeleteAllUserValues(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch3', 'appFetch1', 'keyFetch1', 'value1'],
-			['userFetch3', 'appFetch1', 'keyFetch2', 'value2'],
-			['userFetch3', 'appFetch2', 'keyFetch3', 'value3'],
-			['userFetch3', 'appFetch1', 'keyFetch4', 'value4'],
-			['userFetch3', 'appFetch4', 'keyFetch1', 'value5'],
-			['userFetch3', 'appFetch5', 'keyFetch1', 'value6'],
-			['userFetch4', 'appFetch2', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch3', 'appFetch1', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch3', 'appFetch1', 'keyFetch2', 'value2');
+		$this->insertPreferenceRow('userFetch3', 'appFetch2', 'keyFetch3', 'value3');
+		$this->insertPreferenceRow('userFetch3', 'appFetch1', 'keyFetch4', 'value4');
+		$this->insertPreferenceRow('userFetch3', 'appFetch4', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch3', 'appFetch5', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch4', 'appFetch2', 'keyFetch1', 'value7');
 
 		$config->deleteAllUserValues('userFetch3');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetchAssociative();
-		$actualCount = $result['count'];
-
-		$this->assertEquals(1, $actualCount, 'After removing `userFetch3` there should be exactly 1 entry left.');
+		$this->assertEquals(1, $this->countPreferenceRows(), 'After removing `userFetch3` there should be exactly 1 entry left.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testDeleteAppFromAllUsers(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch5', 'appFetch1', 'keyFetch1', 'value1'],
-			['userFetch5', 'appFetch1', 'keyFetch2', 'value2'],
-			['userFetch5', 'appFetch2', 'keyFetch3', 'value3'],
-			['userFetch5', 'appFetch1', 'keyFetch4', 'value4'],
-			['userFetch5', 'appFetch4', 'keyFetch1', 'value5'],
-			['userFetch5', 'appFetch5', 'keyFetch1', 'value6'],
-			['userFetch6', 'appFetch2', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch5', 'appFetch1', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch5', 'appFetch1', 'keyFetch2', 'value2');
+		$this->insertPreferenceRow('userFetch5', 'appFetch2', 'keyFetch3', 'value3');
+		$this->insertPreferenceRow('userFetch5', 'appFetch1', 'keyFetch4', 'value4');
+		$this->insertPreferenceRow('userFetch5', 'appFetch4', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch5', 'appFetch5', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch6', 'appFetch2', 'keyFetch1', 'value7');
 
 		$config->deleteAppFromAllUsers('appFetch1');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetchAssociative();
-		$actualCount = $result['count'];
-
-		$this->assertEquals(4, $actualCount, 'After removing `appFetch1` there should be exactly 4 entries left.');
+		$this->assertEquals(4, $this->countPreferenceRows(), 'After removing `appFetch1` there should be exactly 4 entries left.');
 
 		$config->deleteAppFromAllUsers('appFetch2');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetchAssociative();
-		$actualCount = $result['count'];
-
-		$this->assertEquals(2, $actualCount, 'After removing `appFetch2` there should be exactly 2 entries left.');
+		$this->assertEquals(2, $this->countPreferenceRows(), 'After removing `appFetch2` there should be exactly 2 entries left.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testGetUsersForUserValue(): void {
@@ -493,26 +449,17 @@ class AllConfigTest extends \Test\TestCase {
 		$config = $this->getConfig($systemConfig);
 
 		// preparation - add something to the database
-		$data = [
-			['user1', 'appFetch9', 'keyFetch9', 'value9'],
-			['user2', 'appFetch9', 'keyFetch9', 'value9'],
-			['user3', 'appFetch9', 'keyFetch9', 'value8'],
-			['user4', 'appFetch9', 'keyFetch8', 'value9'],
-			['user5', 'appFetch8', 'keyFetch9', 'value9'],
-			['user6', 'appFetch9', 'keyFetch9', 'value9'],
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('user1', 'appFetch9', 'keyFetch9', 'value9');
+		$this->insertPreferenceRow('user2', 'appFetch9', 'keyFetch9', 'value9');
+		$this->insertPreferenceRow('user3', 'appFetch9', 'keyFetch9', 'value8');
+		$this->insertPreferenceRow('user4', 'appFetch9', 'keyFetch8', 'value9');
+		$this->insertPreferenceRow('user5', 'appFetch8', 'keyFetch9', 'value9');
+		$this->insertPreferenceRow('user6', 'appFetch9', 'keyFetch9', 'value9');
 
 		$value = $config->getUsersForUserValue('appFetch9', 'keyFetch9', 'value9');
 		$this->assertEquals(['user1', 'user2', 'user6'], $value);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 }

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -23,6 +23,43 @@ class AllConfigTest extends \Test\TestCase {
 	/** @var IDBConnection */
 	protected $connection;
 
+	/** Insert one row into oc_preferences */
+	private function insertPreferenceRow(string $userid, string $appid, string $configkey, string $configvalue): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('preferences')
+			->values([
+				'userid' => $qb->createNamedParameter($userid),
+				'appid' => $qb->createNamedParameter($appid),
+				'configkey' => $qb->createNamedParameter($configkey),
+				'configvalue' => $qb->createNamedParameter($configvalue),
+			])
+			->executeStatement();
+	}
+
+	/** Return all oc_preferences rows for the given user */
+	private function getPreferenceRows(string $userid): array {
+		$qb = $this->connection->getQueryBuilder();
+		return $qb->select('userid', 'appid', 'configkey', 'configvalue')
+			->from('preferences')
+			->where($qb->expr()->eq('userid', $qb->createNamedParameter($userid)))
+			->executeQuery()
+			->fetchAllAssociative();
+	}
+
+	/** Return the total number of rows in oc_preferences */
+	private function countPreferenceRows(): int {
+		$qb = $this->connection->getQueryBuilder();
+		return (int)$qb->select($qb->func()->count('*'))
+			->from('preferences')
+			->executeQuery()
+			->fetchOne();
+	}
+
+	/** Truncate oc_preferences */
+	private function clearPreferences(): void {
+		$this->connection->getQueryBuilder()->delete('preferences')->executeStatement();
+	}
+
 	protected function getConfig($systemConfig = null, $connection = null) {
 		if ($this->connection === null) {
 			$this->connection = Server::get(IDBConnection::class);
@@ -42,30 +79,21 @@ class AllConfigTest extends \Test\TestCase {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$this->connection->executeUpdate(
-			'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-			. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-			['userDelete', 'appDelete', 'keyDelete', 'valueDelete']
-		);
+		$this->insertPreferenceRow('userDelete', 'appDelete', 'keyDelete', 'valueDelete');
 
 		$config->deleteUserValue('userDelete', 'appDelete', 'keyDelete');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences` WHERE `userid` = ?',
-			['userDelete']
-		)->fetchAssociative();
-		$actualCount = $result['count'];
+		$actualCount = count($this->getPreferenceRows('userDelete'));
 
 		$this->assertEquals(0, $actualCount, 'There was one value in the database and after the tests there should be no entry left.');
 	}
 
 	public function testSetUserValue(): void {
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 		$config = $this->getConfig();
 
 		$config->setUserValue('userSet', 'appSet', 'keySet', 'valueSet');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userSet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -78,7 +106,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries
 		$config->setUserValue('userSet', 'appSet', 'keySet', 'valueSet2');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userSet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -97,12 +125,11 @@ class AllConfigTest extends \Test\TestCase {
 	 * This way we can skip the expensive casing change on the database.
 	 */
 	public function testSetUserValueSettingsEmail(): void {
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 		$config = $this->getConfig();
 
 		$config->setUserValue('userSet', 'settings', 'email', 'mixed.CASE@domain.COM');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userSet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -116,11 +143,9 @@ class AllConfigTest extends \Test\TestCase {
 	public function testSetUserValueWithPreCondition(): void {
 		$config = $this->getConfig();
 
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
-
 		$config->setUserValue('userPreCond', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -133,7 +158,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries with valid precond
 		$config->setUserValue('userPreCond', 'appPreCond', 'keyPreCond', 'valuePreCond2', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -172,11 +197,9 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config = $this->getConfig();
 
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
-
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -189,7 +212,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method overwrites existing database entries with valid precond
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond2', 'valuePreCond3');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -208,11 +231,9 @@ class AllConfigTest extends \Test\TestCase {
 
 		$config = $this->getConfig();
 
-		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
-
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertCount(1, $result);
 		$this->assertEquals([
@@ -225,7 +246,7 @@ class AllConfigTest extends \Test\TestCase {
 		// test if the method throws with invalid precondition when the value is the same
 		$config->setUserValue('userPreCond1', 'appPreCond', 'keyPreCond', 'valuePreCond', 'valuePreCond3');
 
-		$result = $this->connection->executeQuery($selectAllSQL, ['userPreCond1'])->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userPreCond1');
 
 		$this->assertCount(1, $result);
 		$this->assertEquals([
@@ -246,7 +267,7 @@ class AllConfigTest extends \Test\TestCase {
 		$resultMock = $this->getMockBuilder('\Doctrine\DBAL\Driver\Statement')
 			->disableOriginalConstructor()->getMock();
 		$resultMock->expects($this->once())
-			->method('fetchColumn')
+			->method('fetchOne')
 			->willReturn('valueSetUnchanged');
 
 		$connectionMock = $this->createMock(IDBConnection::class);
@@ -257,7 +278,7 @@ class AllConfigTest extends \Test\TestCase {
 				$this->equalTo(['userSetUnchanged', 'appSetUnchanged', 'keySetUnchanged']))
 			->willReturn($resultMock);
 		$connectionMock->expects($this->never())
-			->method('executeUpdate');
+			->method('executeStatement');
 
 		$config = $this->getConfig(null, $connectionMock);
 
@@ -273,10 +294,7 @@ class AllConfigTest extends \Test\TestCase {
 
 		$this->assertEquals('valueGet', $value);
 
-		$result = $this->connection->executeQuery(
-			'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?',
-			['userGet']
-		)->fetchAllAssociative();
+		$result = $this->getPreferenceRows('userGet');
 
 		$this->assertEquals(1, count($result));
 		$this->assertEquals([
@@ -287,41 +305,30 @@ class AllConfigTest extends \Test\TestCase {
 		], $result[0]);
 
 		// drop data from database - but the config option should be cached in the config object
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences` WHERE `userid` = ?', ['userGet']);
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('preferences')
+			->where($qb->expr()->eq('userid', $qb->createNamedParameter('userGet')))
+			->executeStatement();
 
 		// testing the caching mechanism
 		$value = $config->getUserValue('userGet', 'appGet', 'keyGet');
 
 		$this->assertEquals('valueGet', $value);
 
-		$result = $this->connection->executeQuery(
-			'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?',
-			['userGet']
-		)->fetchAllAssociative();
-
-		$this->assertEquals(0, count($result));
+		$this->assertEquals(0, count($this->getPreferenceRows('userGet')));
 	}
 
 	public function testGetUserKeys(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch', 'appFetch1', 'keyFetch1', 'value1'],
-			['userFetch', 'appFetch1', 'keyFetch2', 'value2'],
-			['userFetch', 'appFetch2', 'keyFetch3', 'value3'],
-			['userFetch', 'appFetch1', 'keyFetch4', 'value4'],
-			['userFetch', 'appFetch4', 'keyFetch1', 'value5'],
-			['userFetch', 'appFetch5', 'keyFetch1', 'value6'],
-			['userFetch2', 'appFetch', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch', 'appFetch1', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch', 'appFetch1', 'keyFetch2', 'value2');
+		$this->insertPreferenceRow('userFetch', 'appFetch2', 'keyFetch3', 'value3');
+		$this->insertPreferenceRow('userFetch', 'appFetch1', 'keyFetch4', 'value4');
+		$this->insertPreferenceRow('userFetch', 'appFetch4', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch', 'appFetch5', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch2', 'appFetch', 'keyFetch1', 'value7');
 
 		$value = $config->getUserKeys('userFetch', 'appFetch1');
 		$this->assertEquals(['keyFetch1', 'keyFetch2', 'keyFetch4'], $value);
@@ -330,24 +337,15 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(['keyFetch1'], $value);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testGetUserKeysAllInts(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch8', 'appFetch1', '123', 'value'],
-			['userFetch8', 'appFetch1', '456', 'value'],
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch8', 'appFetch1', '123', 'value');
+		$this->insertPreferenceRow('userFetch8', 'appFetch1', '456', 'value');
 
 		$value = $config->getUserKeys('userFetch8', 'appFetch1');
 		$this->assertEquals(['123', '456'], $value);
@@ -355,7 +353,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertIsString($value[1]);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testGetUserValueDefault(): void {
@@ -370,22 +368,13 @@ class AllConfigTest extends \Test\TestCase {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch1', 'appFetch2', 'keyFetch1', 'value1'],
-			['userFetch2', 'appFetch2', 'keyFetch1', 'value2'],
-			['userFetch3', 'appFetch2', 'keyFetch1', 3],
-			['userFetch4', 'appFetch2', 'keyFetch1', 'value4'],
-			['userFetch5', 'appFetch2', 'keyFetch1', 'value5'],
-			['userFetch6', 'appFetch2', 'keyFetch1', 'value6'],
-			['userFetch7', 'appFetch2', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch1', 'appFetch2', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch2', 'appFetch2', 'keyFetch1', 'value2');
+		$this->insertPreferenceRow('userFetch3', 'appFetch2', 'keyFetch1', '3');
+		$this->insertPreferenceRow('userFetch4', 'appFetch2', 'keyFetch1', 'value4');
+		$this->insertPreferenceRow('userFetch5', 'appFetch2', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch6', 'appFetch2', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch7', 'appFetch2', 'keyFetch1', 'value7');
 
 		$value = $config->getUserValueForUsers('appFetch2', 'keyFetch1',
 			['userFetch1', 'userFetch2', 'userFetch3', 'userFetch5']);
@@ -404,84 +393,51 @@ class AllConfigTest extends \Test\TestCase {
 		], $value, 'userFetch9 is an non-existent user and should not be shown.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testDeleteAllUserValues(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch3', 'appFetch1', 'keyFetch1', 'value1'],
-			['userFetch3', 'appFetch1', 'keyFetch2', 'value2'],
-			['userFetch3', 'appFetch2', 'keyFetch3', 'value3'],
-			['userFetch3', 'appFetch1', 'keyFetch4', 'value4'],
-			['userFetch3', 'appFetch4', 'keyFetch1', 'value5'],
-			['userFetch3', 'appFetch5', 'keyFetch1', 'value6'],
-			['userFetch4', 'appFetch2', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch3', 'appFetch1', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch3', 'appFetch1', 'keyFetch2', 'value2');
+		$this->insertPreferenceRow('userFetch3', 'appFetch2', 'keyFetch3', 'value3');
+		$this->insertPreferenceRow('userFetch3', 'appFetch1', 'keyFetch4', 'value4');
+		$this->insertPreferenceRow('userFetch3', 'appFetch4', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch3', 'appFetch5', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch4', 'appFetch2', 'keyFetch1', 'value7');
 
 		$config->deleteAllUserValues('userFetch3');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetchAssociative();
-		$actualCount = $result['count'];
-
-		$this->assertEquals(1, $actualCount, 'After removing `userFetch3` there should be exactly 1 entry left.');
+		$this->assertEquals(1, $this->countPreferenceRows(), 'After removing `userFetch3` there should be exactly 1 entry left.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testDeleteAppFromAllUsers(): void {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$data = [
-			['userFetch5', 'appFetch1', 'keyFetch1', 'value1'],
-			['userFetch5', 'appFetch1', 'keyFetch2', 'value2'],
-			['userFetch5', 'appFetch2', 'keyFetch3', 'value3'],
-			['userFetch5', 'appFetch1', 'keyFetch4', 'value4'],
-			['userFetch5', 'appFetch4', 'keyFetch1', 'value5'],
-			['userFetch5', 'appFetch5', 'keyFetch1', 'value6'],
-			['userFetch6', 'appFetch2', 'keyFetch1', 'value7']
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('userFetch5', 'appFetch1', 'keyFetch1', 'value1');
+		$this->insertPreferenceRow('userFetch5', 'appFetch1', 'keyFetch2', 'value2');
+		$this->insertPreferenceRow('userFetch5', 'appFetch2', 'keyFetch3', 'value3');
+		$this->insertPreferenceRow('userFetch5', 'appFetch1', 'keyFetch4', 'value4');
+		$this->insertPreferenceRow('userFetch5', 'appFetch4', 'keyFetch1', 'value5');
+		$this->insertPreferenceRow('userFetch5', 'appFetch5', 'keyFetch1', 'value6');
+		$this->insertPreferenceRow('userFetch6', 'appFetch2', 'keyFetch1', 'value7');
 
 		$config->deleteAppFromAllUsers('appFetch1');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetchAssociative();
-		$actualCount = $result['count'];
-
-		$this->assertEquals(4, $actualCount, 'After removing `appFetch1` there should be exactly 4 entries left.');
+		$this->assertEquals(4, $this->countPreferenceRows(), 'After removing `appFetch1` there should be exactly 4 entries left.');
 
 		$config->deleteAppFromAllUsers('appFetch2');
 
-		$result = $this->connection->executeQuery(
-			'SELECT COUNT(*) AS `count` FROM `*PREFIX*preferences`'
-		)->fetchAssociative();
-		$actualCount = $result['count'];
-
-		$this->assertEquals(2, $actualCount, 'After removing `appFetch2` there should be exactly 2 entries left.');
+		$this->assertEquals(2, $this->countPreferenceRows(), 'After removing `appFetch2` there should be exactly 2 entries left.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 
 	public function testGetUsersForUserValue(): void {
@@ -492,26 +448,17 @@ class AllConfigTest extends \Test\TestCase {
 		$config = $this->getConfig($systemConfig);
 
 		// preparation - add something to the database
-		$data = [
-			['user1', 'appFetch9', 'keyFetch9', 'value9'],
-			['user2', 'appFetch9', 'keyFetch9', 'value9'],
-			['user3', 'appFetch9', 'keyFetch9', 'value8'],
-			['user4', 'appFetch9', 'keyFetch8', 'value9'],
-			['user5', 'appFetch8', 'keyFetch9', 'value9'],
-			['user6', 'appFetch9', 'keyFetch9', 'value9'],
-		];
-		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
-				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, '
-				. '`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
-				$entry
-			);
-		}
+		$this->insertPreferenceRow('user1', 'appFetch9', 'keyFetch9', 'value9');
+		$this->insertPreferenceRow('user2', 'appFetch9', 'keyFetch9', 'value9');
+		$this->insertPreferenceRow('user3', 'appFetch9', 'keyFetch9', 'value8');
+		$this->insertPreferenceRow('user4', 'appFetch9', 'keyFetch8', 'value9');
+		$this->insertPreferenceRow('user5', 'appFetch8', 'keyFetch9', 'value9');
+		$this->insertPreferenceRow('user6', 'appFetch9', 'keyFetch9', 'value9');
 
 		$value = $config->getUsersForUserValue('appFetch9', 'keyFetch9', 'value9');
 		$this->assertEquals(['user1', 'user2', 'user6'], $value);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->clearPreferences();
 	}
 }

--- a/tests/lib/AppConfigMigrationFallbackTest.php
+++ b/tests/lib/AppConfigMigrationFallbackTest.php
@@ -98,7 +98,7 @@ class AppConfigMigrationFallbackTest extends TestCase {
 		$exception = $this->createInvalidFieldNameException();
 
 		$successResult = $this->createMock(IResult::class);
-		$successResult->method('fetchAll')->willReturn([
+		$successResult->method('fetchAllAssociative')->willReturn([
 			['appid' => 'core', 'configkey' => 'vendor', 'configvalue' => 'owncloud'],
 			['appid' => 'core', 'configkey' => 'installedat', 'configvalue' => '1234567890'],
 		]);
@@ -146,7 +146,7 @@ class AppConfigMigrationFallbackTest extends TestCase {
 		$exception = $this->createInvalidFieldNameException();
 
 		$loadResult = $this->createMock(IResult::class);
-		$loadResult->method('fetchAll')->willReturn([]);
+		$loadResult->method('fetchAllAssociative')->willReturn([]);
 
 		$qb = $this->createMockQueryBuilder();
 

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -149,7 +149,7 @@ class AppConfigTest extends TestCase {
 			]);
 
 		$result = $this->createMock(IResult::class);
-		$result->method('fetchAll')->willReturn([
+		$result->method('fetchAllAssociative')->willReturn([
 			['lazy' => 1, 'appid' => 'appid', 'configkey' => 'lazy-key', 'configvalue' => 'lazy value'],
 		]);
 		$expression = $this->createMock(IExpressionBuilder::class);

--- a/tests/lib/Config/UserConfigMigrationFallbackTest.php
+++ b/tests/lib/Config/UserConfigMigrationFallbackTest.php
@@ -95,7 +95,7 @@ class UserConfigMigrationFallbackTest extends TestCase {
 		$exception = $this->createInvalidFieldNameException();
 
 		$successResult = $this->createMock(IResult::class);
-		$successResult->method('fetchAll')->willReturn([
+		$successResult->method('fetchAllAssociative')->willReturn([
 			['appid' => 'settings', 'configkey' => 'email', 'configvalue' => 'user@example.com'],
 		]);
 
@@ -140,7 +140,7 @@ class UserConfigMigrationFallbackTest extends TestCase {
 		$exception = $this->createInvalidFieldNameException();
 
 		$loadResult = $this->createMock(IResult::class);
-		$loadResult->method('fetchAll')->willReturn([]);
+		$loadResult->method('fetchAllAssociative')->willReturn([]);
 
 		$qb = $this->createMockQueryBuilder();
 

--- a/tests/lib/Repair/RepairDavSharesTest.php
+++ b/tests/lib/Repair/RepairDavSharesTest.php
@@ -110,9 +110,9 @@ class RepairDavSharesTest extends TestCase {
 
 		$shareResults = $this->createMock(IResult::class);
 		$shareResults->expects($this->any())
-			->method('fetch')
+			->method('fetchAssociative')
 			->willReturnCallback(function () use (&$shareResultData) {
-				return array_pop($shareResultData);
+				return array_pop($shareResultData) ?? false;
 			});
 
 		$expressionBuilder = $this->createMock(IExpressionBuilder::class);

--- a/tests/lib/Repair/RepairDavSharesTest.php
+++ b/tests/lib/Repair/RepairDavSharesTest.php
@@ -111,9 +111,9 @@ class RepairDavSharesTest extends TestCase {
 
 		$shareResults = $this->createMock(IResult::class);
 		$shareResults->expects($this->any())
-			->method('fetch')
+			->method('fetchAssociative')
 			->willReturnCallback(function () use (&$shareResultData) {
-				return array_pop($shareResultData);
+				return array_pop($shareResultData) ?? false;
 			});
 
 		$expressionBuilder = $this->createMock(IExpressionBuilder::class);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -517,7 +517,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
 				false,
@@ -613,7 +613,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 41],
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
@@ -670,7 +670,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
 				false,
@@ -764,7 +764,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
 				['uid_initiator' => 'userC', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -544,7 +544,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
 				false,
@@ -640,7 +640,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 41],
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
@@ -697,7 +697,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
 				false,
@@ -791,7 +791,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($result);
 		$this->connection->method('getQueryBuilder')
 			->willReturn($qb);
-		$result->method('fetch')
+		$result->method('fetchAssociative')
 			->willReturnOnConsecutiveCalls(
 				['uid_initiator' => 'userB', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],
 				['uid_initiator' => 'userC', 'share_type' => IShare::TYPE_USER, 'uid_owner' => 'userA', 'file_source' => 42],

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -10,6 +10,7 @@ namespace Test;
 
 use OC\Tagging\TagMapper;
 use OC\TagManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -28,15 +29,11 @@ use Psr\Log\LoggerInterface;
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class TagsTest extends \Test\TestCase {
 	protected $objectType;
-	/** @var IUser */
-	protected $user;
-	/** @var IUserSession */
-	protected $userSession;
+	protected IUser $user;
+	protected IUserSession $userSession;
 	protected $backupGlobals = false;
-	/** @var TagMapper */
-	protected $tagMapper;
-	/** @var ITagManager */
-	protected $tagMgr;
+	protected TagMapper $tagMapper;
+	protected ITagManager $tagMgr;
 	protected IRootFolder $rootFolder;
 
 	protected function setUp(): void {
@@ -75,8 +72,8 @@ class TagsTest extends \Test\TestCase {
 
 	protected function tearDown(): void {
 		$conn = Server::get(IDBConnection::class);
-		$conn->executeQuery('DELETE FROM `*PREFIX*vcategory_to_object`');
-		$conn->executeQuery('DELETE FROM `*PREFIX*vcategory`');
+		$conn->getQueryBuilder()->delete('vcategory_to_object')->executeStatement();
+		$conn->getQueryBuilder()->delete('vcategory')->executeStatement();
 
 		parent::tearDown();
 	}
@@ -214,16 +211,18 @@ class TagsTest extends \Test\TestCase {
 		$tagType = $tagData[0]['type'];
 
 		$conn = Server::get(IDBConnection::class);
-		$statement = $conn->prepare(
-			'INSERT INTO `*PREFIX*vcategory_to_object` '
-			. '(`objid`, `categoryid`, `type`) VALUES '
-			. '(?, ?, ?)'
-		);
 
 		// insert lots of entries
 		$idsArray = [];
 		for ($i = 1; $i <= 1500; $i++) {
-			$statement->execute([$i, $tagId, $tagType]);
+			$qb = $conn->getQueryBuilder();
+			$qb->insert('vcategory_to_object')
+				->values([
+					'objid' => $qb->createNamedParameter($i, IQueryBuilder::PARAM_INT),
+					'categoryid' => $qb->createNamedParameter($tagId, IQueryBuilder::PARAM_INT),
+					'type' => $qb->createNamedParameter($tagType),
+				])
+				->executeStatement();
 			$idsArray[] = $i;
 		}
 

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -10,6 +10,7 @@ namespace Test;
 
 use OC\Tagging\TagMapper;
 use OC\TagManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -87,8 +88,8 @@ class TagsTest extends \Test\TestCase {
 	#[\Override]
 	protected function tearDown(): void {
 		$conn = Server::get(IDBConnection::class);
-		$conn->executeQuery('DELETE FROM `*PREFIX*vcategory_to_object`');
-		$conn->executeQuery('DELETE FROM `*PREFIX*vcategory`');
+		$conn->getQueryBuilder()->delete('vcategory_to_object')->executeStatement();
+		$conn->getQueryBuilder()->delete('vcategory')->executeStatement();
 
 		parent::tearDown();
 	}
@@ -234,16 +235,18 @@ class TagsTest extends \Test\TestCase {
 		$tagType = $tagData[0]['type'];
 
 		$conn = Server::get(IDBConnection::class);
-		$statement = $conn->prepare(
-			'INSERT INTO `*PREFIX*vcategory_to_object` '
-			. '(`objid`, `categoryid`, `type`) VALUES '
-			. '(?, ?, ?)'
-		);
 
 		// insert lots of entries
 		$idsArray = [];
 		for ($i = 1; $i <= 1500; $i++) {
-			$statement->execute([$i, $tagId, $tagType]);
+			$qb = $conn->getQueryBuilder();
+			$qb->insert('vcategory_to_object')
+				->values([
+					'objid' => $qb->createNamedParameter($i, IQueryBuilder::PARAM_INT),
+					'categoryid' => $qb->createNamedParameter($tagId, IQueryBuilder::PARAM_INT),
+					'type' => $qb->createNamedParameter($tagType),
+				])
+				->executeStatement();
 			$idsArray[] = $i;
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Give Doctrine DBAL some love 💘 by moving away from deprecated calls and a few RAW queries.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
