### PR TITLE
chore(tests): check Snowflake ID preserved in 32 bits

### DIFF
--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/phpunit-32bits.yml"
       - "tests/phpunit-autotest.xml"
       - "lib/private/Snowflake/*"
+      - "tests/lib/Preview/PreviewMapperTest.php"
   workflow_dispatch:
   schedule:
     - cron: "15 1 * * 1-6"

--- a/tests/lib/Preview/PreviewMapperTest.php
+++ b/tests/lib/Preview/PreviewMapperTest.php
@@ -64,7 +64,7 @@ class PreviewMapperTest extends TestCase {
 		$this->assertEquals('default', $previews[43][0]->getObjectStoreName());
 	}
 
-	private function createPreviewForFileId(int $fileId, ?int $bucket = null): void {
+	private function createPreviewForFileId(int $fileId, ?int $bucket = null): string {
 		$locationId = null;
 		if ($bucket) {
 			$qb = $this->connection->getQueryBuilder();
@@ -95,5 +95,16 @@ class PreviewMapperTest extends TestCase {
 			$preview->setLocationId($locationId);
 		}
 		$this->previewMapper->insert($preview);
+
+		return $preview->id;
+	}
+
+	public function testLargeIdInsertRetrieve(): void {
+		$fileId = PHP_INT_MAX;
+		$originalPreviewId = $this->createPreviewForFileId($fileId);
+
+		$dbPreview = $this->previewMapper->getAvailablePreviews([$fileId])[$fileId][0];
+		$this->assertEquals($originalPreviewId, $dbPreview->id);
+		$this->assertEquals($fileId, $dbPreview->getFileId());
 	}
 }


### PR DESCRIPTION
## Summary

Add test to verify 32 bit int retrieval from database

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
