### PR TITLE
fix: Fix user in Tags class, do not depend upon session

### DIFF
--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -17,6 +17,7 @@ use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
 use OCP\ITagManager;
 use OCP\ITags;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\User\Events\UserDeletedEvent;
 use Psr\Log\LoggerInterface;
@@ -29,6 +30,7 @@ class TagManager implements ITagManager, IEventListener {
 	public function __construct(
 		private TagMapper $mapper,
 		private IUserSession $userSession,
+		private IUserManager $userManager,
 		private IDBConnection $connection,
 		private LoggerInterface $logger,
 		private IEventDispatcher $dispatcher,
@@ -59,7 +61,7 @@ class TagManager implements ITagManager, IEventListener {
 			$userId = $this->userSession->getUser()->getUId();
 		}
 		$userFolder = $this->rootFolder->getUserFolder($userId);
-		return new Tags($this->mapper, $userId, $type, $this->logger, $this->connection, $this->dispatcher, $this->userSession, $userFolder, $defaultTags);
+		return new Tags($this->mapper, $userId, $type, $this->logger, $this->connection, $this->dispatcher, $this->userManager, $userFolder, $defaultTags);
 	}
 
 	/**

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -17,7 +17,7 @@ use OCP\Files\Events\NodeRemovedFromFavorite;
 use OCP\Files\Folder;
 use OCP\IDBConnection;
 use OCP\ITags;
-use OCP\IUserSession;
+use OCP\IUserManager;
 use OCP\Server;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -55,7 +55,7 @@ class Tags implements ITags {
 		private LoggerInterface $logger,
 		private IDBConnection $db,
 		private IEventDispatcher $dispatcher,
-		private IUserSession $userSession,
+		private IUserManager $userManager,
 		private Folder $userFolder,
 		array $defaultTags = [],
 	) {
@@ -528,7 +528,7 @@ class Tags implements ITags {
 				}
 			}
 
-			$this->dispatcher->dispatchTyped(new NodeAddedToFavorite($this->userSession->getUser(), $objid, $path));
+			$this->dispatcher->dispatchTyped(new NodeAddedToFavorite($this->userManager->getExistingUser($this->user), $objid, $path));
 		}
 		return true;
 	}
@@ -573,7 +573,7 @@ class Tags implements ITags {
 				}
 			}
 
-			$this->dispatcher->dispatchTyped(new NodeRemovedFromFavorite($this->userSession->getUser(), $objid, $path));
+			$this->dispatcher->dispatchTyped(new NodeRemovedFromFavorite($this->userManager->getExistingUser($this->user), $objid, $path));
 		}
 		return true;
 	}

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -15,11 +15,11 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\IDBConnection;
-use OCP\ITagManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -28,16 +28,13 @@ use Psr\Log\LoggerInterface;
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class TagsTest extends \Test\TestCase {
 	protected $objectType;
-	/** @var IUser */
-	protected $user;
-	/** @var IUserSession */
-	protected $userSession;
-	protected $backupGlobals = false;
-	/** @var TagMapper */
-	protected $tagMapper;
-	/** @var ITagManager */
-	protected $tagMgr;
-	protected IRootFolder $rootFolder;
+	protected IUser&MockObject $user;
+	protected IUserSession&MockObject $userSession;
+	protected IUserManager&MockObject $userManager;
+	protected IRootFolder&MockObject $rootFolder;
+
+	protected TagMapper $tagMapper;
+	protected TagManager $tagMgr;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -50,6 +47,11 @@ class TagsTest extends \Test\TestCase {
 		$this->user = $this->createMock(IUser::class);
 		$this->user->method('getUID')
 			->willReturn($userId);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userManager
+			->expects($this->any())
+			->method('getExistingUser')
+			->willReturn($this->user);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userSession
 			->expects($this->any())
@@ -70,7 +72,15 @@ class TagsTest extends \Test\TestCase {
 
 		$this->objectType = $this->getUniqueID('type_');
 		$this->tagMapper = new TagMapper(Server::get(IDBConnection::class));
-		$this->tagMgr = new TagManager($this->tagMapper, $this->userSession, Server::get(IDBConnection::class), Server::get(LoggerInterface::class), Server::get(IEventDispatcher::class), $this->rootFolder);
+		$this->tagMgr = new TagManager(
+			$this->tagMapper,
+			$this->userSession,
+			$this->userManager,
+			Server::get(IDBConnection::class),
+			Server::get(LoggerInterface::class),
+			Server::get(IEventDispatcher::class),
+			$this->rootFolder
+		);
 	}
 
 	protected function tearDown(): void {
@@ -87,7 +97,15 @@ class TagsTest extends \Test\TestCase {
 			->expects($this->any())
 			->method('getUser')
 			->willReturn(null);
-		$this->tagMgr = new TagManager($this->tagMapper, $this->userSession, Server::get(IDBConnection::class), Server::get(LoggerInterface::class), Server::get(IEventDispatcher::class), $this->rootFolder);
+		$this->tagMgr = new TagManager(
+			$this->tagMapper,
+			$this->userSession,
+			$this->userManager,
+			Server::get(IDBConnection::class),
+			Server::get(LoggerInterface::class),
+			Server::get(IEventDispatcher::class),
+			$this->rootFolder
+		);
 		$this->assertNull($this->tagMgr->load($this->objectType));
 	}
 


### PR DESCRIPTION
* Resolves: #58893

## Summary

The user used for the Tags class is not guaranteed to be the one in session, and sometimes there is no session (occ).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
