### PR TITLE
feat(CalDAV): Add function to get the token of a publicly shared calendar

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarImpl.php
+++ b/apps/dav/lib/CalDAV/CalendarImpl.php
@@ -16,6 +16,7 @@ use OCP\Calendar\CalendarExportOptions;
 use OCP\Calendar\Exceptions\CalendarException;
 use OCP\Calendar\ICalendarExport;
 use OCP\Calendar\ICalendarIsEnabled;
+use OCP\Calendar\ICalendarIsPublic;
 use OCP\Calendar\ICalendarIsShared;
 use OCP\Calendar\ICalendarIsWritable;
 use OCP\Calendar\ICreateFromString;
@@ -32,7 +33,7 @@ use Sabre\VObject\Reader;
 
 use function Sabre\Uri\split as uriSplit;
 
-class CalendarImpl implements ICreateFromString, IHandleImipMessage, ICalendarIsWritable, ICalendarIsShared, ICalendarExport, ICalendarIsEnabled {
+class CalendarImpl implements ICreateFromString, IHandleImipMessage, ICalendarIsWritable, ICalendarIsShared, ICalendarExport, ICalendarIsEnabled, ICalendarIsPublic {
 	public function __construct(
 		private Calendar $calendar,
 		/** @var array<string, mixed> */
@@ -166,6 +167,13 @@ class CalendarImpl implements ICreateFromString, IHandleImipMessage, ICalendarIs
 	 */
 	public function isShared(): bool {
 		return $this->calendar->isShared();
+	}
+
+	/**
+	 * @since 33.0.1, 32.0.7, 31.0.14.1, 30.0.17.8
+	 */
+	public function getPublicToken(): ?string {
+		return $this->calendar->getPublishStatus() ?: null;
 	}
 
 	/**
@@ -336,5 +344,4 @@ class CalendarImpl implements ICreateFromString, IHandleImipMessage, ICalendarIs
 			}
 		}
 	}
-
 }

--- a/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
@@ -33,7 +33,7 @@ class CalendarImplTest extends \Test\TestCase {
 		$this->backend = $this->createMock(CalDavBackend::class);
 		$this->calendar = $this->createMock(Calendar::class);
 		$this->calendarInfo = [
-			'id' => 'fancy_id_123',
+			'id' => 123,
 			'{DAV:}displayname' => 'user readable name 123',
 			'{http://apple.com/ns/ical/}calendar-color' => '#AABBCC',
 			'uri' => '/this/is/a/uri',
@@ -62,7 +62,7 @@ class CalendarImplTest extends \Test\TestCase {
 
 
 	public function testGetKey(): void {
-		$this->assertEquals($this->calendarImpl->getKey(), 'fancy_id_123');
+		$this->assertEquals($this->calendarImpl->getKey(), '123');
 	}
 
 	public function testGetDisplayname(): void {
@@ -71,6 +71,18 @@ class CalendarImplTest extends \Test\TestCase {
 
 	public function testGetDisplayColor(): void {
 		$this->assertEquals($this->calendarImpl->getDisplayColor(), '#AABBCC');
+	}
+
+	public function testGetPublicToken(): void {
+		$publicToken = $this->calendar->setPublishStatus(true);
+
+		$this->assertEquals($this->calendarImpl->getPublicToken(), $publicToken);
+	}
+
+	public function testGetPublicTokenWithPrivateCalendar(): void {
+		$this->calendar->setPublishStatus(false);
+
+		$this->assertNull($this->calendarImpl->getPublicToken());
 	}
 
 	public function testSearch(): void {
@@ -266,5 +278,4 @@ class CalendarImplTest extends \Test\TestCase {
 
 		$calendarImpl->handleIMipMessage('fakeUser', $vObject->serialize());
 	}
-
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -222,6 +222,7 @@ return array(
     'OCP\\Calendar\\ICalendarEventBuilder' => $baseDir . '/lib/public/Calendar/ICalendarEventBuilder.php',
     'OCP\\Calendar\\ICalendarExport' => $baseDir . '/lib/public/Calendar/ICalendarExport.php',
     'OCP\\Calendar\\ICalendarIsEnabled' => $baseDir . '/lib/public/Calendar/ICalendarIsEnabled.php',
+    'OCP\\Calendar\\ICalendarIsPublic' => $baseDir . '/lib/public/Calendar/ICalendarIsPublic.php',
     'OCP\\Calendar\\ICalendarIsShared' => $baseDir . '/lib/public/Calendar/ICalendarIsShared.php',
     'OCP\\Calendar\\ICalendarIsWritable' => $baseDir . '/lib/public/Calendar/ICalendarIsWritable.php',
     'OCP\\Calendar\\ICalendarProvider' => $baseDir . '/lib/public/Calendar/ICalendarProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -263,6 +263,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Calendar\\ICalendarEventBuilder' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendarEventBuilder.php',
         'OCP\\Calendar\\ICalendarExport' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendarExport.php',
         'OCP\\Calendar\\ICalendarIsEnabled' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendarIsEnabled.php',
+        'OCP\\Calendar\\ICalendarIsPublic' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendarIsPublic.php',
         'OCP\\Calendar\\ICalendarIsShared' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendarIsShared.php',
         'OCP\\Calendar\\ICalendarIsWritable' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendarIsWritable.php',
         'OCP\\Calendar\\ICalendarProvider' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendarProvider.php',

--- a/lib/public/Calendar/ICalendarIsPublic.php
+++ b/lib/public/Calendar/ICalendarIsPublic.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Calendar;
+
+/**
+ * @since 33.0.1, 32.0.7, 31.0.14.1, 30.0.17.8
+ */
+interface ICalendarIsPublic {
+	/**
+	 * Gets the token of a publicly shared calendar.
+	 *
+	 * @since 33.0.1, 32.0.7, 31.0.14.1, 30.0.17.8
+	 */
+	public function getPublicToken(): ?string;
+}


### PR DESCRIPTION
## Summary

The public interface for calendars don't expose the information about the public sharing token. This PR adds that implementation.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
