### PR TITLE
[stable30] feat: backport command to cleanup previews

### DIFF
--- a/core/Command/Preview/Cleanup.php
+++ b/core/Command/Preview/Cleanup.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Command\Preview;
+
+use OC\Core\Command\Base;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Cleanup extends Base {
+
+	public function __construct(
+		private IRootFolder $rootFolder,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('preview:cleanup')
+			->setDescription('Removes existing preview files');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		try {
+			$appDataFolder = $this->rootFolder->get($this->rootFolder->getAppDataDirectoryName());
+
+			if (!$appDataFolder instanceof Folder) {
+				$this->logger->error("Previews can't be removed: appdata is not a folder");
+				$output->writeln("Previews can't be removed: appdata is not a folder");
+				return 1;
+			}
+
+			/** @var Folder $previewFolder */
+			$previewFolder = $appDataFolder->get('preview');
+
+		} catch (NotFoundException $e) {
+			$this->logger->error("Previews can't be removed: appdata folder can't be found", ['exception' => $e]);
+			$output->writeln("Previews can't be removed: preview folder isn't deletable");
+			return 1;
+		}
+
+		if (!$previewFolder->isDeletable()) {
+			$this->logger->error("Previews can't be removed: preview folder isn't deletable");
+			$output->writeln("Previews can't be removed: preview folder isn't deletable");
+			return 1;
+		}
+
+		try {
+			$previewFolder->delete();
+			$this->logger->debug('Preview folder deleted');
+			$output->writeln('Preview folder deleted', OutputInterface::VERBOSITY_VERBOSE);
+		} catch (NotFoundException $e) {
+			$output->writeln("Previews weren't deleted: preview folder was not found while deleting it");
+			$this->logger->error("Previews weren't deleted: preview folder was not found while deleting it", ['exception' => $e]);
+			return 1;
+		} catch (NotPermittedException $e) {
+			$output->writeln("Previews weren't deleted: you don't have the permission to delete preview folder");
+			$this->logger->error("Previews weren't deleted: you don't have the permission to delete preview folder", ['exception' => $e]);
+			return 1;
+		}
+
+		try {
+			$createdFolder = $appDataFolder->newFolder('preview');
+			$this->logger->error('newly created appdata folder', ['folder' => $createdFolder->getPath()]);
+			$this->logger->debug('Preview folder recreated');
+			$output->writeln('Preview folder recreated', OutputInterface::VERBOSITY_VERBOSE);
+		} catch (NotPermittedException $e) {
+			$output->writeln("Preview folder was deleted, but you don't have the permission to create preview folder");
+			$this->logger->error("Preview folder was deleted, but you don't have the permission to create preview folder", ['exception' => $e]);
+			return 1;
+		}
+
+		$output->writeln('Previews removed');
+		return 0;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -102,6 +102,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\Maintenance\Repair::class));
 	$application->add(Server::get(Command\Maintenance\RepairShareOwnership::class));
 
+	$application->add(Server::get(Command\Preview\Cleanup::class));
 	$application->add(Server::get(Command\Preview\Generate::class));
 	$application->add(Server::get(Command\Preview\Repair::class));
 	$application->add(Server::get(Command\Preview\ResetRenderedTexts::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1219,6 +1219,7 @@ return array(
     'OC\\Core\\Command\\Memcache\\DistributedDelete' => $baseDir . '/core/Command/Memcache/DistributedDelete.php',
     'OC\\Core\\Command\\Memcache\\DistributedGet' => $baseDir . '/core/Command/Memcache/DistributedGet.php',
     'OC\\Core\\Command\\Memcache\\DistributedSet' => $baseDir . '/core/Command/Memcache/DistributedSet.php',
+    'OC\\Core\\Command\\Preview\\Cleanup' => $baseDir . '/core/Command/Preview/Cleanup.php',
     'OC\\Core\\Command\\Preview\\Generate' => $baseDir . '/core/Command/Preview/Generate.php',
     'OC\\Core\\Command\\Preview\\Repair' => $baseDir . '/core/Command/Preview/Repair.php',
     'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => $baseDir . '/core/Command/Preview/ResetRenderedTexts.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1252,6 +1252,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Memcache\\DistributedDelete' => __DIR__ . '/../../..' . '/core/Command/Memcache/DistributedDelete.php',
         'OC\\Core\\Command\\Memcache\\DistributedGet' => __DIR__ . '/../../..' . '/core/Command/Memcache/DistributedGet.php',
         'OC\\Core\\Command\\Memcache\\DistributedSet' => __DIR__ . '/../../..' . '/core/Command/Memcache/DistributedSet.php',
+        'OC\\Core\\Command\\Preview\\Cleanup' => __DIR__ . '/../../..' . '/core/Command/Preview/Cleanup.php',
         'OC\\Core\\Command\\Preview\\Generate' => __DIR__ . '/../../..' . '/core/Command/Preview/Generate.php',
         'OC\\Core\\Command\\Preview\\Repair' => __DIR__ . '/../../..' . '/core/Command/Preview/Repair.php',
         'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => __DIR__ . '/../../..' . '/core/Command/Preview/ResetRenderedTexts.php',


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

~* Resolves: #~ <!-- related github issue -->

## Summary
Backport of the preview cleanup command (available in stable31 and higher)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
