### PR TITLE
perf(storage): optimize search traversal and exact-case existence checks

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -44,6 +44,8 @@ class Local extends Common {
 
 	protected bool $caseInsensitive = false;
 
+	protected bool $allowSymlinks = false;
+
 	public function __construct(array $parameters) {
 		if (!isset($parameters['datadir']) || !is_string($parameters['datadir'])) {
 			throw new \InvalidArgumentException('No data directory set for local storage');
@@ -64,6 +66,7 @@ class Local extends Common {
 		$this->mimeTypeDetector = Server::get(IMimeTypeDetector::class);
 		$this->defUMask = $this->config->getSystemValue('localstorage.umask', 0022);
 		$this->caseInsensitive = $this->config->getSystemValueBool('localstorage.case_insensitive', false);
+		$this->allowSymlinks = $this->config->getSystemValueBool('localstorage.allowsymlinks', false);
 
 		// support Write-Once-Read-Many file systems
 		$this->unlinkOnTruncate = $this->config->getSystemValueBool('localstorage.unlink_on_truncate', false);
@@ -480,6 +483,11 @@ class Local extends Common {
 			$relativePath = $dir . '/' . $item;
 			$physicalItem = $physicalDir . '/' . $item;
 
+			// Enforce no-symlink policy during search traversal as well.
+			if (!$this->allowSymlinks && is_link($physicalItem)) {
+				continue;
+			}
+
 			if (strstr(strtolower($item), $queryLower) !== false) {
 				$files[] = $relativePath;
 			}
@@ -510,8 +518,7 @@ class Local extends Common {
 
 		$fullPath = $this->datadir . $path;
 		$currentPath = $path;
-		$allowSymlinks = $this->config->getSystemValueBool('localstorage.allowsymlinks', false);
-		if ($allowSymlinks || $currentPath === '') {
+		if ($this->allowSymlinks || $currentPath === '') {
 			return $fullPath;
 		}
 		$pathToResolve = $fullPath;

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -250,17 +250,31 @@ class Local extends Common {
 	}
 
 	public function file_exists(string $path): bool {
-		if ($this->caseInsensitive) {
-			$fullPath = $this->getSourcePath($path);
-			$parentPath = dirname($fullPath);
-			if (!is_dir($parentPath)) {
-				return false;
-			}
-			$content = scandir($parentPath, SCANDIR_SORT_NONE);
-			return is_array($content) && array_search(basename($fullPath), $content, true) !== false;
-		} else {
-			return file_exists($this->getSourcePath($path));
+		$fullPath = $this->getSourcePath($path);
+
+		// Standard (default) path
+		if (!$this->caseInsensitive) {
+			return file_exists($fullPath);
 		}
+
+		// Operational heuristic for case-only rename validation on
+		// case-insensitive filesystems (bypassed by default) - expensive!
+		$parentPath = dirname($fullPath);
+		if (!is_dir($parentPath)) {
+			return false;
+		}
+
+		$baseName = basename($fullPath);
+		$content = scandir($parentPath, SCANDIR_SORT_NONE);		
+		// When `localstorage.case_insensitive` is enabled, we intentionally do an exact
+		// basename lookup in the parent directory (instead of trusting file_exists()
+		// alone). Why: On case-insensitive filesystems, path lookup can succeed even
+		// if the on-disk/canonical filename casing is not what was requested. We need
+		// this best-effort check so case-only renames (e.g. "Foo" -> "foo") are
+		// reflected with the expected casing, avoiding cache/client/sync inconsistencies.
+		// Filesystem behavior varies (incl. Unicode normalization), so this is a
+		// pragmatic guard, not a strict invariant.
+		return is_array($content) && array_search($baseName, $content, true) !== false;
 	}
 
 	public function filemtime(string $path): int|false {

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -456,21 +456,38 @@ class Local extends Common {
 
 	protected function searchInDir(string $query, string $dir = ''): array {
 		$files = [];
+		$this->searchInDirRecursive($query, $dir, $files);
+		return $files;
+	}
+
+	/**
+	 * @param list<string> $files
+	 */
+	private function searchInDirRecursive(string $query, string $dir, array &$files): void {
 		$physicalDir = $this->getSourcePath($dir);
-		foreach (scandir($physicalDir) as $item) {
+		$items = scandir($physicalDir);
+		if (!is_array($items)) {
+			return;
+		}
+
+		$queryLower = strtolower($query);
+
+		foreach ($items as $item) {
 			if (Filesystem::isIgnoredDir($item)) {
 				continue;
 			}
+
+			$relativePath = $dir . '/' . $item;
 			$physicalItem = $physicalDir . '/' . $item;
 
-			if (strstr(strtolower($item), strtolower($query)) !== false) {
-				$files[] = $dir . '/' . $item;
+			if (strstr(strtolower($item), $queryLower) !== false) {
+				$files[] = $relativePath;
 			}
+
 			if (is_dir($physicalItem)) {
-				$files = array_merge($files, $this->searchInDir($query, $dir . '/' . $item));
+				$this->searchInDirRecursive($query, $relativePath, $files);
 			}
 		}
-		return $files;
 	}
 
 	public function hasUpdated(string $path, int $time): bool {

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -257,23 +257,28 @@ class Local extends Common {
 			return file_exists($fullPath);
 		}
 
-		// Operational heuristic for case-only rename validation on
-		// case-insensitive filesystems (bypassed by default) - expensive!
+		return $this->fileExistsWithExactCase($fullPath);
+	}
+
+	/**
+	 * Best-effort exact-case existence check for case-insensitive filesystems.
+	 */
+	private function fileExistsWithExactCase(string $fullPath): bool {
+		// We intentionally do an exact basename lookup (instead of trusting
+		// file_exists() alone): on case-insensitive filesystems, path lookup can
+		// succeed even if canonical on-disk casing differs from the requested name.
+		// This best-effort guard helps ensure case-only renames (e.g. "Foo" -> "foo")
+		// are reflected with expected casing, reducing cache/client/sync inconsistencies.
+		// Filesystem behavior varies (including Unicode normalization), so this is
+		// pragmatic, not a strict invariant.
 		$parentPath = dirname($fullPath);
 		if (!is_dir($parentPath)) {
 			return false;
 		}
 
 		$baseName = basename($fullPath);
-		$content = scandir($parentPath, SCANDIR_SORT_NONE);		
-		// When `localstorage.case_insensitive` is enabled, we intentionally do an exact
-		// basename lookup in the parent directory (instead of trusting file_exists()
-		// alone). Why: On case-insensitive filesystems, path lookup can succeed even
-		// if the on-disk/canonical filename casing is not what was requested. We need
-		// this best-effort check so case-only renames (e.g. "Foo" -> "foo") are
-		// reflected with the expected casing, avoiding cache/client/sync inconsistencies.
-		// Filesystem behavior varies (incl. Unicode normalization), so this is a
-		// pragmatic guard, not a strict invariant.
+		$content = scandir($parentPath, SCANDIR_SORT_NONE);
+
 		return is_array($content) && array_search($baseName, $content, true) !== false;
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This PR improves `Local` storage traversal and existence checks:

* **Optimizes `searchInDir()`**
  - Replaces recursive `array_merge()` accumulation with a single in-place traversal.
  - This reduces allocations and should scale better on large directory trees.
* **Tightens symlink handling during search**
  - When `localstorage.allowsymlinks` is disabled, symlinked entries are now skipped during search traversal as well.
  - This keeps search behavior aligned with the storage symlink policy.
* **Refactors case-insensitive `file_exists()` handling**
  - Extracts and documents the exact-case existence check into a dedicated helper.
  - This preserves canonical casing for case-only renames/copies and helps avoid cache/client sync inconsistencies on case-insensitive filesystems.

## Notes

- No functional changes are intended for the default case-sensitive path.
- The case-insensitive lookup remains a best-effort check because filesystem behavior varies across platforms.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
