### PR TITLE
chore(storage): drop `addLocalFolder` (unused)

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -255,23 +255,6 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $this->getCachedFile($path);
 	}
 
-	private function addLocalFolder(string $path, string $target): void {
-		$dh = $this->opendir($path);
-		if (is_resource($dh)) {
-			while (($file = readdir($dh)) !== false) {
-				if (!Filesystem::isIgnoredDir($file)) {
-					if ($this->is_dir($path . '/' . $file)) {
-						mkdir($target . '/' . $file);
-						$this->addLocalFolder($path . '/' . $file, $target . '/' . $file);
-					} else {
-						$tmp = $this->toTmpFile($path . '/' . $file);
-						rename($tmp, $target . '/' . $file);
-					}
-				}
-			}
-		}
-	}
-
 	protected function searchInDir(string $query, string $dir = ''): array {
 		$files = [];
 		$dh = $this->opendir($dir);

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -273,23 +273,6 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $this->getCachedFile($path);
 	}
 
-	private function addLocalFolder(string $path, string $target): void {
-		$dh = $this->opendir($path);
-		if (is_resource($dh)) {
-			while (($file = readdir($dh)) !== false) {
-				if (!Filesystem::isIgnoredDir($file)) {
-					if ($this->is_dir($path . '/' . $file)) {
-						mkdir($target . '/' . $file);
-						$this->addLocalFolder($path . '/' . $file, $target . '/' . $file);
-					} else {
-						$tmp = $this->toTmpFile($path . '/' . $file);
-						rename($tmp, $target . '/' . $file);
-					}
-				}
-			}
-		}
-	}
-
 	protected function searchInDir(string $query, string $dir = ''): array {
 		$files = [];
 		$dh = $this->opendir($dir);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

:broom: 
Unused since fb76d7de69e0f13f196a644cfded0a6e079e7200
Related clean-up: 4393b96542be6b0495d93cf9ed87e9b51b36121f

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
