### PR TITLE
fix(View): safer lock life-cycle handling in `basicOperation()` + clearer control flow 

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1208,6 +1208,14 @@ class View {
 		// Build and normalize absolute path from the provided relative path.
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 
+		// Precompute hook intent flags once for readability and consistency.
+		$isWrite = in_array('write', $hooks, true);
+		$isDelete = in_array('delete', $hooks, true);
+		$isRead = in_array('read', $hooks, true);
+		$isTouch = in_array('touch', $hooks, true);
+		$isCreateHook = in_array('create', $hooks, true);
+		$needsLock = $isWrite || $isDelete || $isRead;
+
 		// Only proceed for valid, non-blacklisted paths.
 		if (Filesystem::isValidPath($path)
 			&& !Filesystem::isFileBlacklisted($path)
@@ -1219,20 +1227,20 @@ class View {
 			}
 
 			// Pre-hook phase: acquire a shared lock so hooks can safely read metadata/content.
-			if (in_array('write', $hooks) || in_array('delete', $hooks) || in_array('read', $hooks)) {
+			if ($needsLock) {
 				$this->lockFile($path, ILockingProvider::LOCK_SHARED);
 			}
 
 			// Run pre-hooks; hooks can veto execution by returning false.
 			$run = $this->runHooks($hooks, $path);
 
+			/** @var Storage $storage */
 			// Resolve absolute path to storage backend + internal path.
 			[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
-			/** @var Storage $storage */
-			if ($run && $storage) {
 
+			if ($run && $storage) {
 				// For mutating operations, upgrade shared lock to exclusive before actual write/delete.
-				if (in_array('write', $hooks) || in_array('delete', $hooks)) {
+				if ($isWrite || $isDelete) {
 					try {
 						$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
 					} catch (LockedException $e) {
@@ -1244,41 +1252,39 @@ class View {
 
 				try {
 					// Delegate operation to storage backend, with optional extra parameter.
-					if (!is_null($extraParam)) {
-						$result = $storage->$operation($internalPath, $extraParam);
-					} else {
-						$result = $storage->$operation($internalPath);
-					}
+					$result = !is_null($extraParam)
+						? $storage->$operation($internalPath, $extraParam)
+						: $storage->$operation($internalPath);
 				} catch (\Exception $e) {
 					// On backend error, release whichever lock this branch currently owns.
-					if (in_array('write', $hooks) || in_array('delete', $hooks)) {
+					if ($isWrite || $isDelete) {
 						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-					} elseif (in_array('read', $hooks)) {
+					} elseif ($isRead) {
 						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 					}
 					throw $e;
 				}
 
 				// Update delete bookkeeping only on successful delete-like operation.
-				if ($result !== false && in_array('delete', $hooks)) {
+				if ($result !== false && $isDelete) {
 					$this->removeUpdate($storage, $internalPath);
 				}
 
 				// Update write bookkeeping for successful write-like operations except stream/touch special cases.
-				if ($result !== false && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
-					$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && in_array('create', $hooks, true));
+				if ($result !== false && $isWrite && $operation !== 'fopen' && $operation !== 'touch') {
+					$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && $isCreateHook);
 					$sizeDifference = $operation === 'mkdir' ? 0 : $result;
 					$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
 				}
 
 				// touch has dedicated bookkeeping behavior.
-				if ($result !== false && in_array('touch', $hooks)) {
+				if ($result !== false && $isTouch) {
 					$this->writeUpdate($storage, $internalPath, $extraParam, 0);
 				}
 
 				// For mutating operations, downgrade the lock from exclusive to shared after the write/delete step.
 				// Keep it exclusive for successful fopen; it will be unlocked later when the stream closes.
-				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {
+				if (($isWrite || $isDelete) && ($operation !== 'fopen' || $result === false)) {
 					$this->changeLock($path, ILockingProvider::LOCK_SHARED);
 				}
 
@@ -1290,10 +1296,10 @@ class View {
 					ignore_user_abort(true);
 
 					// Defer unlock until stream close.
-					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path): void {
-						if (in_array('write', $hooks)) {
+					$result = CallbackWrapper::wrap($result, null, null, function () use ($isWrite, $isRead, $path): void {
+						if ($isWrite)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-						} elseif (in_array('read', $hooks)) {
+						} elseif ($isRead) {
 							$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 						}
 					});
@@ -1307,17 +1313,17 @@ class View {
 				}
 
 				// Normal unlock path when lock ownership was not transferred to stream close callback.
-				if (!$unlockLater
-					&& (in_array('write', $hooks) || in_array('delete', $hooks) || in_array('read', $hooks))
-				) {
+				if (!$unlockLater && $needsLock) {
 					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 				}
+
 				return $result;
 			} else {
 				// If pre-hooks vetoed or no storage resolved, release pre-hook shared lock.
 				$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 			}
 		}
+
 		return null;
 	}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1208,6 +1208,11 @@ class View {
 		// Build and normalize absolute path from the provided relative path.
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 
+		// Guard clause: invalid or blacklisted path.
+		if (!Filesystem::isValidPath($path) || Filesystem::isFileBlacklisted($path)) {
+			return null;
+		}
+
 		// Precompute hook intent flags once for readability and consistency.
 		$isWrite = in_array('write', $hooks, true);
 		$isDelete = in_array('delete', $hooks, true);
@@ -1216,115 +1221,108 @@ class View {
 		$isCreateHook = in_array('create', $hooks, true);
 		$needsLock = $isWrite || $isDelete || $isRead;
 
-		// Only proceed for valid, non-blacklisted paths.
-		if (Filesystem::isValidPath($path)
-			&& !Filesystem::isFileBlacklisted($path)
-		) {
-			// Convert back (post-normalized) to relative path in the current view context.
-			$path = $this->getRelativePath($absolutePath);
-			if ($path === null) {
-				return false;
-			}
+		// Convert back (post-normalized) to relative path in the current view context.
+		$path = $this->getRelativePath($absolutePath);
+		if ($path === null) {
+			return false;
+		}
 
-			// Pre-hook phase: acquire a shared lock so hooks can safely read metadata/content.
-			if ($needsLock) {
-				$this->lockFile($path, ILockingProvider::LOCK_SHARED);
-			}
+		// Pre-hook phase: acquire a shared lock so hooks can safely read metadata/content.
+		if ($needsLock) {
+			$this->lockFile($path, ILockingProvider::LOCK_SHARED);
+		}
 
-			// Run pre-hooks; hooks can veto execution by returning false.
-			$run = $this->runHooks($hooks, $path);
+		// Run pre-hooks; hooks can veto execution by returning false.
+		$run = $this->runHooks($hooks, $path);
 
-			/** @var Storage $storage */
-			// Resolve absolute path to storage backend + internal path.
-			[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
+		/** @var Storage $storage */
+		// Resolve absolute path to storage backend + internal path.
+		[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
 
-			if ($run && $storage) {
-				// For mutating operations, upgrade shared lock to exclusive before actual write/delete.
-				if ($isWrite || $isDelete) {
-					try {
-						$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
-					} catch (LockedException $e) {
-						// If lock upgrade fails, release previously acquired shared lock.
-						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-						throw $e;
-					}
-				}
+		// Guard clause: pre-hooks vetoed or storage unresolved.
+		if (!$run || !$storage) {
+			// NOTE: preserves original behavior (unconditional unlock in this branch).
+			$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+			return null;
+		}
 
-				try {
-					// Delegate operation to storage backend, with optional extra parameter.
-					$result = !is_null($extraParam)
-						? $storage->$operation($internalPath, $extraParam)
-						: $storage->$operation($internalPath);
-				} catch (\Exception $e) {
-					// On backend error, release whichever lock this branch currently owns.
-					if ($isWrite || $isDelete) {
-						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-					} elseif ($isRead) {
-						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-					}
-					throw $e;
-				}
-
-				// Update delete bookkeeping only on successful delete-like operation.
-				if ($result !== false && $isDelete) {
-					$this->removeUpdate($storage, $internalPath);
-				}
-
-				// Update write bookkeeping for successful write-like operations except stream/touch special cases.
-				if ($result !== false && $isWrite && $operation !== 'fopen' && $operation !== 'touch') {
-					$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && $isCreateHook);
-					$sizeDifference = $operation === 'mkdir' ? 0 : $result;
-					$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
-				}
-
-				// touch has dedicated bookkeeping behavior.
-				if ($result !== false && $isTouch) {
-					$this->writeUpdate($storage, $internalPath, $extraParam, 0);
-				}
-
-				// For mutating operations, downgrade the lock from exclusive to shared after the write/delete step.
-				// Keep it exclusive for successful fopen; it will be unlocked later when the stream closes.
-				if (($isWrite || $isDelete) && ($operation !== 'fopen' || $result === false)) {
-					$this->changeLock($path, ILockingProvider::LOCK_SHARED);
-				}
-
-				$unlockLater = false;
-				if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
-					$unlockLater = true;
-
-					// Ensure unlock callback still runs even if client disconnects.
-					ignore_user_abort(true);
-
-					// Defer unlock until stream close.
-					$result = CallbackWrapper::wrap($result, null, null, function () use ($isWrite, $isRead, $path): void {
-						if ($isWrite)) {
-							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-						} elseif ($isRead) {
-							$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-						}
-					});
-				}
-
-				// Emit post-hooks on success, except for fopen (stream still open at this point).
-				if ($this->shouldEmitHooks($path) && $result !== false) {
-					if ($operation !== 'fopen') {
-						$this->runHooks($hooks, $path, true);
-					}
-				}
-
-				// Normal unlock path when lock ownership was not transferred to stream close callback.
-				if (!$unlockLater && $needsLock) {
-					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-				}
-
-				return $result;
-			} else {
-				// If pre-hooks vetoed or no storage resolved, release pre-hook shared lock.
+		// For mutating operations, upgrade shared lock to exclusive before actual write/delete.
+		if ($isWrite || $isDelete) {
+			try {
+				$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
+			} catch (LockedException $e) {
+				// If lock upgrade fails, release previously acquired shared lock.
 				$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+				throw $e;
 			}
 		}
 
-		return null;
+		try {
+			// Delegate operation to storage backend, with optional extra parameter.
+			$result = !is_null($extraParam)
+				? $storage->$operation($internalPath, $extraParam)
+				: $storage->$operation($internalPath);
+		} catch (\Exception $e) {
+			// On backend error, release whichever lock this branch currently owns.
+			if ($isWrite || $isDelete) {
+				$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
+			} elseif ($isRead) {
+				$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+			}
+			throw $e;
+		}
+
+		// Update delete bookkeeping only on successful delete-like operation.
+		if ($result !== false && $isDelete) {
+			$this->removeUpdate($storage, $internalPath);
+		}
+
+		// Update write bookkeeping for successful write-like operations except stream/touch special cases.
+		if ($result !== false && $isWrite && $operation !== 'fopen' && $operation !== 'touch') {
+			$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && $isCreateHook);
+			$sizeDifference = $operation === 'mkdir' ? 0 : $result;
+			$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
+		}
+
+		// touch has dedicated bookkeeping behavior.
+		if ($result !== false && $isTouch) {
+			$this->writeUpdate($storage, $internalPath, $extraParam, 0);
+		}
+
+		// For mutating operations, downgrade the lock from exclusive to shared after the write/delete step.
+		// Keep it exclusive for successful fopen; it will be unlocked later when the stream closes.
+		if (($isWrite || $isDelete) && ($operation !== 'fopen' || $result === false)) {
+			$this->changeLock($path, ILockingProvider::LOCK_SHARED);
+		}
+
+		$unlockLater = false;
+		if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
+			$unlockLater = true;
+
+			// Ensure unlock callback still runs even if client disconnects.
+			ignore_user_abort(true);
+
+			// Defer unlock until stream close.
+			$result = CallbackWrapper::wrap($result, null, null, function () use ($isWrite, $isRead, $path): void {
+				if ($isWrite)) {
+					$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
+				} elseif ($isRead) {
+					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+				}
+			});
+		}
+
+		// Emit post-hooks on success, except for fopen (stream still open at this point).
+		if ($this->shouldEmitHooks($path) && $result !== false) && $operation !== 'fopen') {
+			$this->runHooks($hooks, $path, true);
+		}
+
+		// Normal unlock path when lock ownership was not transferred to stream close callback.
+		if (!$unlockLater && $needsLock) {
+			$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1241,104 +1241,101 @@ class View {
 			return false;
 		}
 
-		// Pre-hook phase: acquire a shared lock so hooks can safely read metadata/content.
-		if ($needsLock) {
-			$this->lockFile($path, ILockingProvider::LOCK_SHARED);
-		}
-
-		// Run pre-hooks; hooks can veto execution by returning false.
-		$run = $this->runHooks($hooks, $path);
-
-		/** @var Storage $storage */
-		// Resolve absolute path to storage backend + internal path.
-		[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
-
-		// Guard clause: pre-hooks vetoed or storage unresolved.
-		if (!$run || !$storage) {
-			// NOTE: preserves original behavior (unconditional unlock in this branch).
-			$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-			return null;
-		}
-
-		// For mutating operations, upgrade shared lock to exclusive before actual write/delete.
-		if ($isWrite || $isDelete) {
-			try {
-				$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
-			} catch (LockedException $e) {
-				// If lock upgrade fails, release previously acquired shared lock.
-				$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-				throw $e;
-			}
-		}
+		/** @var null|int $lockState null means no lock currently held */
+		$lockState = null;
+		$unlockLater = false; // true only for successful fopen stream wrapper path
 
 		try {
+			// Pre-hook phase: acquire a shared lock so hooks can safely read metadata/content.
+			if ($needsLock) {
+				$this->lockFile($path, ILockingProvider::LOCK_SHARED);
+				$lockState = ILockingProvider::LOCK_SHARED;
+			}
+
+			// Run pre-hooks; hooks can veto execution by returning false.
+			$run = $this->runHooks($hooks, $path);
+
+			// Resolve absolute path to storage backend + internal path.
+			[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
+
+			// Guard clause: pre-hooks vetoed or storage unresolved.
+			/** @var Storage $storage */
+			if (!$run || !$storage) {
+				return null;
+			}
+
+			// For mutating operations, upgrade shared lock to exclusive before actual write/delete.
+			if ($isWrite || $isDelete) {
+				$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
+				$lockState = ILockingProvider::LOCK_EXCLUSIVE;
+			}
+
 			// Delegate operation to storage backend, with optional extra parameter.
 			$result = !is_null($extraParam)
 				? $storage->$operation($internalPath, $extraParam)
 				: $storage->$operation($internalPath);
-		} catch (\Exception $e) {
-			// On backend error, release whichever lock this branch currently owns.
-			if ($isWrite || $isDelete) {
-				$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-			} elseif ($isRead) {
-				$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+
+			// Update delete bookkeeping only on successful delete-like operation.
+			if ($result !== false && $isDelete) {
+				$this->removeUpdate($storage, $internalPath);
 			}
-			throw $e;
+
+			// Update write bookkeeping for successful write-like operations except stream/touch special cases.
+			if ($result !== false && $isWrite && $operation !== 'fopen' && $operation !== 'touch') {
+				$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && $isCreateHook);
+				$sizeDifference = $operation === 'mkdir' ? 0 : $result;
+				$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
+			}
+
+			// touch has dedicated bookkeeping behavior.
+			if ($result !== false && $isTouch) {
+				$this->writeUpdate($storage, $internalPath, $extraParam, 0);
+			}
+
+			// For mutating operations, downgrade the lock from exclusive to shared after the write/delete step.
+			// Keep it exclusive for successful fopen; it will be unlocked later when the stream closes.
+			if (($isWrite || $isDelete)
+				&& ($operation !== 'fopen' || $result === false)
+				&& $lockState === ILockingProvider::LOCK_EXCLUSIVE
+			) {
+				$this->changeLock($path, ILockingProvider::LOCK_SHARED);
+				$lockState = ILockingProvider::LOCK_SHARED;
+			}
+
+			if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
+				$unlockLater = true;
+				// Ensure unlock callback still runs even if client disconnects.
+				ignore_user_abort(true);
+
+				// Defer unlock until stream close.
+				$result = CallbackWrapper::wrap($result, null, null, function () use ($isWrite, $isRead, $path): void {
+					if ($isWrite) {
+						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
+					} elseif ($isRead) {
+						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+					}
+				});
+			}
+
+			// Emit post-hooks on success, except for fopen (stream still open at this point).
+			if ($this->shouldEmitHooks($path) && $result !== false && $operation !== 'fopen') {
+				$this->runHooks($hooks, $path, true);
+			}
+		
+			return $result;
+		} finally {
+			// In successful fopen stream path, callback owns unlock responsibility.
+			if ($unlockLater) {
+				return;
+			}
+
+			// Normal as well as failsafe unlock path (when lock ownership was not transferred to stream close callback).
+			if ($lockState !== null) {
+				$this->unlockFile($path, $lockState);
+			}
 		}
-
-		// Update delete bookkeeping only on successful delete-like operation.
-		if ($result !== false && $isDelete) {
-			$this->removeUpdate($storage, $internalPath);
-		}
-
-		// Update write bookkeeping for successful write-like operations except stream/touch special cases.
-		if ($result !== false && $isWrite && $operation !== 'fopen' && $operation !== 'touch') {
-			$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && $isCreateHook);
-			$sizeDifference = $operation === 'mkdir' ? 0 : $result;
-			$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
-		}
-
-		// touch has dedicated bookkeeping behavior.
-		if ($result !== false && $isTouch) {
-			$this->writeUpdate($storage, $internalPath, $extraParam, 0);
-		}
-
-		// For mutating operations, downgrade the lock from exclusive to shared after the write/delete step.
-		// Keep it exclusive for successful fopen; it will be unlocked later when the stream closes.
-		if (($isWrite || $isDelete) && ($operation !== 'fopen' || $result === false)) {
-			$this->changeLock($path, ILockingProvider::LOCK_SHARED);
-		}
-
-		$unlockLater = false;
-		if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
-			$unlockLater = true;
-
-			// Ensure unlock callback still runs even if client disconnects.
-			ignore_user_abort(true);
-
-			// Defer unlock until stream close.
-			$result = CallbackWrapper::wrap($result, null, null, function () use ($isWrite, $isRead, $path): void {
-				if ($isWrite)) {
-					$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-				} elseif ($isRead) {
-					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-				}
-			});
-		}
-
-		// Emit post-hooks on success, except for fopen (stream still open at this point).
-		if ($this->shouldEmitHooks($path) && $result !== false) && $operation !== 'fopen') {
-			$this->runHooks($hooks, $path, true);
-		}
-
-		// Normal unlock path when lock ownership was not transferred to stream close callback.
-		if (!$unlockLater && $needsLock) {
-			$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-		}
-
-		return $result;
 	}
-
+	
 	/**
 	 * get the path relative to the default root for hook usage
 	 *

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1191,17 +1191,31 @@ class View {
 	}
 
 	/**
-	 * abstraction layer for basic filesystem functions: wrapper for \OC\Files\Storage\Storage
+	 * Execute a low-level filesystem operation on the resolved storage (\OC\Files\Storage\Storage) backend.
 	 *
-	 * @param mixed $extraParam (optional)
-	 * @return mixed
-	 * @throws LockedException
+	 * Flow:
+	 * 1) Validate/sanitize the view-relative path.
+	 * 2) Resolve to concrete storage + internal path.
+	 * 3) Run pre-hooks (which may veto execution).
+	 * 4) Acquire/upgrade locks based on hook intent (read/write/delete).
+	 * 5) Delegate the operation to the storage implementation.
+	 * 6) Apply write/delete/touch cache/update bookkeeping.
+	 * 7) Run post-hooks (except for fopen; stream may still be open).
 	 *
-	 * This method takes requests for basic filesystem functions (e.g. reading & writing
-	 * files), processes hooks and proxies, sanitises paths, and finally passes them on to
-	 * \OC\Files\Storage\Storage for delegation to a storage backend for execution
+	 * @param non-empty-string $operation Storage method name to call dynamically on the resolved Storage.
+	 * @param string $path View-relative path.
+	 * @param list<'read'|'write'|'delete'|'touch'|'create'|string> $hooks
+	 *        Hook tags controlling locking, hook execution, and update behavior.
+	 * @param mixed $extraParam Optional second argument forwarded to the storage operation.
+	 *
+	 * @return mixed Storage operation result.
+	 *               - `null` when execution is skipped (e.g. invalid/blacklisted path, hook veto, unresolved storage)
+	 *               - otherwise backend-defined return value (often `false` on operation failure)
+	 *
+	 * @throws LockedException If lock acquisition/upgrade fails.
+	 * @throws \Exception Re-thrown from the delegated storage operation.
 	 */
-	private function basicOperation(string $operation, string $path, array $hooks = [], $extraParam = null) {
+	private function basicOperation(string $operation, string $path, array $hooks = [], $extraParam = null): mixed {
 		// Preserve trailing slash semantics when resolving storage paths.
 		$postFix = (substr($path, -1) === '/') ? '/' : '';
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1202,41 +1202,55 @@ class View {
 	 * \OC\Files\Storage\Storage for delegation to a storage backend for execution
 	 */
 	private function basicOperation(string $operation, string $path, array $hooks = [], $extraParam = null) {
+		// Preserve trailing slash semantics when resolving storage paths.
 		$postFix = (substr($path, -1) === '/') ? '/' : '';
+
+		// Build and normalize absolute path from the provided relative path.
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
+
+		// Only proceed for valid, non-blacklisted paths.
 		if (Filesystem::isValidPath($path)
 			&& !Filesystem::isFileBlacklisted($path)
 		) {
+			// Convert back (post-normalized) to relative path in the current view context.
 			$path = $this->getRelativePath($absolutePath);
 			if ($path === null) {
 				return false;
 			}
 
+			// Pre-hook phase: acquire a shared lock so hooks can safely read metadata/content.
 			if (in_array('write', $hooks) || in_array('delete', $hooks) || in_array('read', $hooks)) {
-				// always a shared lock during pre-hooks so the hook can read the file
 				$this->lockFile($path, ILockingProvider::LOCK_SHARED);
 			}
 
+			// Run pre-hooks; hooks can veto execution by returning false.
 			$run = $this->runHooks($hooks, $path);
+
+			// Resolve absolute path to storage backend + internal path.
 			[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
+			/** @var Storage $storage */
 			if ($run && $storage) {
-				/** @var Storage $storage */
+
+				// For mutating operations, upgrade shared lock to exclusive before actual write/delete.
 				if (in_array('write', $hooks) || in_array('delete', $hooks)) {
 					try {
 						$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
 					} catch (LockedException $e) {
-						// release the shared lock we acquired before quitting
+						// If lock upgrade fails, release previously acquired shared lock.
 						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 						throw $e;
 					}
 				}
+
 				try {
+					// Delegate operation to storage backend, with optional extra parameter.
 					if (!is_null($extraParam)) {
 						$result = $storage->$operation($internalPath, $extraParam);
 					} else {
 						$result = $storage->$operation($internalPath);
 					}
 				} catch (\Exception $e) {
+					// On backend error, release whichever lock this branch currently owns.
 					if (in_array('write', $hooks) || in_array('delete', $hooks)) {
 						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
 					} elseif (in_array('read', $hooks)) {
@@ -1245,18 +1259,25 @@ class View {
 					throw $e;
 				}
 
+				// Update delete bookkeeping only on successful delete-like operation.
 				if ($result !== false && in_array('delete', $hooks)) {
 					$this->removeUpdate($storage, $internalPath);
 				}
+
+				// Update write bookkeeping for successful write-like operations except stream/touch special cases.
 				if ($result !== false && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
 					$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && in_array('create', $hooks, true));
 					$sizeDifference = $operation === 'mkdir' ? 0 : $result;
 					$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
 				}
+
+				// touch has dedicated bookkeeping behavior.
 				if ($result !== false && in_array('touch', $hooks)) {
 					$this->writeUpdate($storage, $internalPath, $extraParam, 0);
 				}
 
+				// For mutating operations, downgrade the lock from exclusive to shared after the write/delete step.
+				// Keep it exclusive for successful fopen; it will be unlocked later when the stream closes.
 				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {
 					$this->changeLock($path, ILockingProvider::LOCK_SHARED);
 				}
@@ -1264,8 +1285,11 @@ class View {
 				$unlockLater = false;
 				if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
 					$unlockLater = true;
-					// make sure our unlocking callback will still be called if connection is aborted
+
+					// Ensure unlock callback still runs even if client disconnects.
 					ignore_user_abort(true);
+
+					// Defer unlock until stream close.
 					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path): void {
 						if (in_array('write', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
@@ -1275,12 +1299,14 @@ class View {
 					});
 				}
 
+				// Emit post-hooks on success, except for fopen (stream still open at this point).
 				if ($this->shouldEmitHooks($path) && $result !== false) {
-					if ($operation !== 'fopen') { //no post hooks for fopen, the file stream is still open
+					if ($operation !== 'fopen') {
 						$this->runHooks($hooks, $path, true);
 					}
 				}
 
+				// Normal unlock path when lock ownership was not transferred to stream close callback.
 				if (!$unlockLater
 					&& (in_array('write', $hooks) || in_array('delete', $hooks) || in_array('read', $hooks))
 				) {
@@ -1288,6 +1314,7 @@ class View {
 				}
 				return $result;
 			} else {
+				// If pre-hooks vetoed or no storage resolved, release pre-hook shared lock.
 				$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 			}
 		}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1205,7 +1205,7 @@ class View {
 	 * @param non-empty-string $operation Storage method name to call dynamically on the resolved Storage.
 	 * @param string $path View-relative path.
 	 * @param list<'read'|'write'|'delete'|'touch'|'create'|string> $hooks
-	 *        Hook tags controlling locking, hook execution, and update behavior.
+	 *                                                                     Hook tags controlling locking, hook execution, and update behavior.
 	 * @param mixed $extraParam Optional second argument forwarded to the storage operation.
 	 *
 	 * @return mixed Storage operation result.
@@ -1321,12 +1321,11 @@ class View {
 			if ($this->shouldEmitHooks($path) && $result !== false && $operation !== 'fopen') {
 				$this->runHooks($hooks, $path, true);
 			}
-		
-			return $result;
+
 		} finally {
 			// In successful fopen stream path, callback owns unlock responsibility.
 			if ($unlockLater) {
-				return;
+				return null;
 			}
 
 			// Normal as well as failsafe unlock path (when lock ownership was not transferred to stream close callback).
@@ -1334,6 +1333,8 @@ class View {
 				$this->unlockFile($path, $lockState);
 			}
 		}
+
+		return $result;
 	}
 	
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Key changes:

* Remove unconditional unlock paths; only unlock locks were actually acquired
  - Most flows were already correct; this closes remaining edge cases and reduces lock-handling boilerplate.
* Improve readability and maintainability of `basicOperation()`.

Safer lock lifecycle handling:

* Add explicit lock-state tracking (using `ILockingProvider` lock constants).
* Centralize unlock handling in `finally` for consistent cleanup on both success and error paths.
* Preserve special `fopen` behavior:
  - lock ownership is transferred to the wrapped stream close callback,
  - `finally` skips unlock when ownership is transferred.

Refactoring:

* Rework control flow with clearer guard clauses and inline comments.
* Extract hook intent flags (`read`/`write`/`delete`/`touch`/`create`) into local booleans.
* Update method docblock with stricter parameter/behavior notes and and explicit flow documentation.

This is primarily a maintainability/safety refactor with no intended functional change.

The previous structure made lock transitions and cleanup paths harder to reason about; this makes lock ownership and release paths explicit and lowers regression risk.

**Review tip:** Easiest to review commit-by-commit

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
