### PR TITLE
fix(files): preserve destination path for dropped directories

### DIFF
--- a/apps/files/src/services/DropService.spec.ts
+++ b/apps/files/src/services/DropService.spec.ts
@@ -1,0 +1,85 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { IFolder } from '@nextcloud/files'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { onDropExternalFiles } from './DropService.ts'
+import { createDirectoryIfNotExists, Directory } from './DropServiceUtils.ts'
+
+const { getUploaderMock, hasConflictMock } = vi.hoisted(() => {
+	return {
+		getUploaderMock: vi.fn(),
+		hasConflictMock: vi.fn(),
+	}
+})
+
+vi.mock('@nextcloud/dialogs', () => ({
+	showError: vi.fn(),
+	showInfo: vi.fn(),
+	showSuccess: vi.fn(),
+	showWarning: vi.fn(),
+}))
+
+vi.mock('@nextcloud/upload', () => ({
+	getUploader: getUploaderMock,
+	hasConflict: hasConflictMock,
+}))
+
+vi.mock('../logger.ts', () => ({
+	default: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}))
+
+vi.mock('./DropServiceUtils.ts', async () => {
+	const actual = await vi.importActual<typeof import('./DropServiceUtils.ts')>('./DropServiceUtils.ts')
+	return {
+		...actual,
+		createDirectoryIfNotExists: vi.fn(),
+		resolveConflict: vi.fn(async (files) => files),
+	}
+})
+
+describe('DropService onDropExternalFiles', () => {
+	const uploaderMock = {
+		pause: vi.fn(),
+		start: vi.fn(),
+		upload: vi.fn(async () => ({})),
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		getUploaderMock.mockReturnValue(uploaderMock)
+		hasConflictMock.mockResolvedValue(false)
+	})
+
+	it('creates dropped directories under the destination path', async () => {
+		const root = new Directory('root') as Directory & { name: 'root' }
+		root.contents = [
+			new Directory('py-vetlog-buddy-main', [
+				new Directory('.venv', [
+					new Directory('lib', [
+						new File(['content'], 'hello.txt', { type: 'text/plain' }),
+					]),
+				]),
+			]),
+		]
+
+		const destination = {
+			path: '/archive',
+			source: '/remote.php/dav/files/devadmin/archive',
+		} as unknown as IFolder
+
+		await onDropExternalFiles(root, destination, [])
+
+		expect(createDirectoryIfNotExists).toHaveBeenCalledWith('/archive/py-vetlog-buddy-main')
+		expect(createDirectoryIfNotExists).toHaveBeenCalledWith('/archive/py-vetlog-buddy-main/.venv')
+		expect(createDirectoryIfNotExists).toHaveBeenCalledWith('/archive/py-vetlog-buddy-main/.venv/lib')
+	})
+})

--- a/apps/files/src/services/DropService.ts
+++ b/apps/files/src/services/DropService.ts
@@ -124,7 +124,7 @@ export async function onDropExternalFiles(root: RootDirectory, destination: IFol
 			if (file instanceof Directory) {
 				try {
 					logger.debug('Processing directory', { relativePath })
-					await createDirectoryIfNotExists(relativePath)
+					await createDirectoryIfNotExists(join(destination.path, relativePath))
 					await uploadDirectoryContents(file, relativePath)
 				} catch (error) {
 					showError(t('files', 'Unable to create the directory {directory}', { directory: file.name }))


### PR DESCRIPTION
* Resolves: #58760

## Summary

Dropping a folder into a subdirectory was creating missing directories with a path that did not include the destination folder.

In practice, that sent WebDAV requests to the wrong location and produced `PROPFIND 404` / `PUT 404` for nested folder uploads.

This change keeps directory creation anchored to `destination.path`, so folder drops into subdirectories stay in the selected target.

I also added a regression test that verifies nested directories are created under the destination path.

## TODO

- [x] Add regression test coverage for nested directory drops into a subdirectory target
- [ ] Run post-fix manual checks in the browser (drag/drop into root and into nested subdirectories, then confirm no DAV 404 in logs)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
