### PR TITLE
refactor(View): clearer control flow and stronger edge-case handling for getFileInfo

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1423,53 +1423,79 @@ class View {
 	}
 
 	/**
-	 * get the filesystem info
+	 * Get filesystem metadata for a path within this view.
 	 *
-	 * @param string $path
-	 * @param bool|string $includeMountPoints true to add mountpoint sizes,
-	 *                                        'ext' to add only ext storage mount point sizes. Defaults to true.
-	 * @return FileInfo|false False if file does not exist
+	 * @param string $path Path relative to the current view root.
+	 * @param bool|'ext' $includeMountPoints
+	 *     true to include sub-mount sizes for directories,
+	 *     'ext' to include only external-storage sub-mount sizes,
+	 *     false to skip sub-mount size aggregation.
+	 * @return FileInfo|false
+	 *     Returns FileInfo when metadata is available.
+	 *     Returns false if the path is invalid, cannot be resolved from cache/storage,
+	 *     or does not exist. 
+	 *     NOTE: For partial-upload paths, metadata is resolved via
+	 *     the partial-file fallback path.
 	 */
-	public function getFileInfo($path, $includeMountPoints = true) {
+	public function getFileInfo(string $path, bool|string $includeMountPoints = true): FileInfo|false {
+		// Enforce path length limits early (security / DB constraints / backend constraints)
 		$this->assertPathLength($path);
+
+		// Reject invalid user-provided paths before normalization/mount resolution
 		if (!Filesystem::isValidPath($path)) {
 			return false;
 		}
+
+		// Keep the original (caller-relative) path for cache lookup and partial-file handling
 		$relativePath = $path;
+
+		// Build normalized absolute path inside the view's fake root
 		$path = Filesystem::normalizePath($this->fakeRoot . '/' . $path);
 
+		// Resolve the mount/storage responsible for this path
 		$mount = Filesystem::getMountManager()->find($path);
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($path);
+
 		if ($storage) {
+			// Fetch cache metadata for this storage/path
 			$data = $this->getCacheEntry($storage, $internalPath, $relativePath);
 
+			// If no cache entry: allow partial-upload files to resolve via specialized handling
 			if (!$data instanceof ICacheEntry) {
 				if (Scanner::isPartialFile($relativePath)) {
 					return $this->getPartFileInfo($relativePath);
 				}
 
+				// Not found in cache and not a known partial file => treat as non-existent
 				return false;
 			}
 
+			// Mount root of a moveable mount should be deletable by design
 			if ($mount instanceof MoveableMount && $internalPath === '') {
 				$data['permissions'] |= Constants::PERMISSION_DELETE;
 			}
+
+			// For mount root entries, overwrite cached name with current basename of resolved path
 			if ($internalPath === '' && $data['name']) {
 				$data['name'] = basename($path);
 			}
 
+			// Resolve owner object (may be null/false for token-based access without FS owner context)
 			$ownerId = $storage->getOwner($internalPath);
 			$owner = null;
 			if ($ownerId !== false) {
 				// ownerId might be null if files are accessed with an access token without file system access
 				$owner = $this->getUserObjectForOwner($ownerId);
 			}
+
+			// Build final FileInfo object from resolved storage/cache/mount data
 			$info = new FileInfo($path, $storage, $internalPath, $data, $mount, $owner);
 
+			// Optionally include sizes from sub-mounts when this entry is a directory
 			if (isset($data['fileid'])) {
 				if ($includeMountPoints && $data['mimetype'] === 'httpd/unix-directory') {
-					//add the sizes of other mount points to the folder
+					// add the sizes of other mount points to the folder
 					$extOnly = ($includeMountPoints === 'ext');
 					$this->addSubMounts($info, $extOnly);
 				}
@@ -1477,6 +1503,7 @@ class View {
 
 			return $info;
 		} else {
+			// Mount exists but storage is unavailable/invalid
 			$this->logger->warning('Storage not valid for mountpoint: ' . $mount->getMountPoint(), ['app' => 'core']);
 		}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1483,8 +1483,8 @@ class View {
 		}
 
 		// Ensure mount root entries use current basename rather than stale cache name
-		if ($internalPath === '' && $data['name']) {
-			$data['name'] = basename($path);
+		if ($internalPath === '' && $data['name'] !== '' && $data['name'] !== null) {
+			$data['name'] = basename($fullPath);
 		}
 
 		// Resolve owner object (may remain null for token-only access contexts)
@@ -1496,7 +1496,7 @@ class View {
 		}
 
 		// Build final FileInfo object from resolved storage/cache/mount data
-		$info = new FileInfo($path, $storage, $internalPath, $data, $mount, $owner);
+		$info = new FileInfo($fullPath, $storage, $internalPath, $data, $mount, $owner);
 
 		// Optionally include sizes from sub-mounts when this entry is a directory
 		if (isset($data['fileid']) && $includeMountPoints && $data['mimetype'] === 'httpd/unix-directory') {

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1438,7 +1438,7 @@ class View {
 	 *     the partial-file fallback path.
 	 */
 	public function getFileInfo(string $path, bool|string $includeMountPoints = true): FileInfo|false {
-		// Enforce path length limits early (security / DB constraints / backend constraints)
+		// Enforce path length limits early (security / backend constraints)
 		$this->assertPathLength($path);
 
 		// Reject invalid user-provided paths before normalization/mount resolution
@@ -1452,62 +1452,58 @@ class View {
 		// Build normalized absolute path inside the view's fake root
 		$path = Filesystem::normalizePath($this->fakeRoot . '/' . $path);
 
-		// Resolve the mount/storage responsible for this path
+		// Resolve mount + storage context for the path
 		$mount = Filesystem::getMountManager()->find($path);
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($path);
 
-		if ($storage) {
-			// Fetch cache metadata for this storage/path
-			$data = $this->getCacheEntry($storage, $internalPath, $relativePath);
-
-			// If no cache entry: allow partial-upload files to resolve via specialized handling
-			if (!$data instanceof ICacheEntry) {
-				if (Scanner::isPartialFile($relativePath)) {
-					return $this->getPartFileInfo($relativePath);
-				}
-
-				// Not found in cache and not a known partial file => treat as non-existent
-				return false;
-			}
-
-			// Mount root of a moveable mount should be deletable by design
-			if ($mount instanceof MoveableMount && $internalPath === '') {
-				$data['permissions'] |= Constants::PERMISSION_DELETE;
-			}
-
-			// For mount root entries, overwrite cached name with current basename of resolved path
-			if ($internalPath === '' && $data['name']) {
-				$data['name'] = basename($path);
-			}
-
-			// Resolve owner object (may be null/false for token-based access without FS owner context)
-			$ownerId = $storage->getOwner($internalPath);
-			$owner = null;
-			if ($ownerId !== false) {
-				// ownerId might be null if files are accessed with an access token without file system access
-				$owner = $this->getUserObjectForOwner($ownerId);
-			}
-
-			// Build final FileInfo object from resolved storage/cache/mount data
-			$info = new FileInfo($path, $storage, $internalPath, $data, $mount, $owner);
-
-			// Optionally include sizes from sub-mounts when this entry is a directory
-			if (isset($data['fileid'])) {
-				if ($includeMountPoints && $data['mimetype'] === 'httpd/unix-directory') {
-					// add the sizes of other mount points to the folder
-					$extOnly = ($includeMountPoints === 'ext');
-					$this->addSubMounts($info, $extOnly);
-				}
-			}
-
-			return $info;
-		} else {
+		if (!$storage) {
 			// Mount exists but storage is unavailable/invalid
 			$this->logger->warning('Storage not valid for mountpoint: ' . $mount->getMountPoint(), ['app' => 'core']);
+			return false;
+		}
+		
+		// Fetch cache metadata for the resolved storage/path
+		$data = $this->getCacheEntry($storage, $internalPath, $relativePath);
+
+		// Allow partial-upload files to resolve via specialized handling; otherwise path is considered missing
+		if (!$data instanceof ICacheEntry) {
+			if (Scanner::isPartialFile($relativePath)) {
+				return $this->getPartFileInfo($relativePath);
+			}
+			// Not found in cache and not a known partial file => treat as non-existent
+			return false;
 		}
 
-		return false;
+		// Ensure delete permission on moveable mount roots
+		if ($mount instanceof MoveableMount && $internalPath === '') {
+			$data['permissions'] |= Constants::PERMISSION_DELETE;
+		}
+
+		// Ensure mount root entries use current basename rather than stale cache name
+		if ($internalPath === '' && $data['name']) {
+			$data['name'] = basename($path);
+		}
+
+		// Resolve owner object (may remain null for token-only access contexts)
+		$ownerId = $storage->getOwner($internalPath);
+		$owner = null;
+		if ($ownerId !== false) {
+			// ownerId might be null if files are accessed with an access token without file system access
+			$owner = $this->getUserObjectForOwner($ownerId);
+		}
+
+		// Build final FileInfo object from resolved storage/cache/mount data
+		$info = new FileInfo($path, $storage, $internalPath, $data, $mount, $owner);
+
+		// Optionally include sizes from sub-mounts when this entry is a directory
+		if (isset($data['fileid']) && $includeMountPoints && $data['mimetype'] === 'httpd/unix-directory') {
+			// add the sizes of other mount points to the folder
+			$extOnly = ($includeMountPoints === 'ext');
+			$this->addSubMounts($info, $extOnly);
+		}
+
+		return $info;
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1438,69 +1438,59 @@ class View {
 	 *     the partial-file fallback path.
 	 */
 	public function getFileInfo(string $path, bool|string $includeMountPoints = true): FileInfo|false {
-		// Enforce path length limits early (security / backend constraints)
 		$this->assertPathLength($path);
 
-		// Reject invalid user-provided paths before normalization/mount resolution
 		if (!Filesystem::isValidPath($path)) {
 			return false;
 		}
 
-		// Use the original (caller-relative) path for cache lookup and partial-file handling
 		$relativePath = $path;
-		// Build normalized absolute path inside the view's fake root
 		$fullPath = Filesystem::normalizePath($this->fakeRoot . '/' . $relativePath);
 
-		// Resolve mount + storage context for the path
 		$mount = Filesystem::getMountManager()->find($fullPath);
 		if (!$mount) {
         	$this->logger->warning('No mount found for path', ['app' => 'core', 'path' => $fullPath]);
         	return false;
     	}
+
 		$storage = $mount->getStorage();
 		if (!$storage) {
-			// Mount exists but storage is unavailable/invalid
-			$this->logger->warning('Storage not valid for mountpoint', ['mountpoint' => $mount->getMountPoint(), 'path' => $fullPath, 'app' => 'core']);
+			$this->logger->warning('Storage not valid for mountpoint', ['app' => 'core', 'mountpoint' => $mount->getMountPoint(), 'path' => $fullPath]);
 			return false;
 		}
-		$internalPath = $mount->getInternalPath($fullPath);
 
-		// Fetch cache metadata for the resolved storage/path
+		$internalPath = $mount->getInternalPath($fullPath);
 		$data = $this->getCacheEntry($storage, $internalPath, $relativePath);
-		if ($data === false) {
+
+		if ($data === false) { // cache miss
 			if (!Scanner::isPartialFile($relativePath)) {
-				// Not found in cache and not a known partial file => truly non-existent
 				return false;
 			}
-			// Partial (upload) files get a second chance
+			// Partial uploads can exist without a regular cache entry.
 			return $this->getPartFileInfo($relativePath);
 		}
 
-		// Ensure moveable mount roots get delete permission 
+		// Moveable mount roots must remain deletable.
 		if ($internalPath === '' && $mount instanceof MoveableMount) {
 			$data['permissions'] |= Constants::PERMISSION_DELETE;
 		}
 
-		// Ensure mount roots use current basename rather than stale cache name
+		// Root cache names can be stale; derive from the resolved full path.
 		if ($internalPath === '' && ($data['name'] ?? '') !== '') {
 			$data['name'] = basename($fullPath);
 		}
 
-		// Resolve owner object if storage can provide an owner id
 		// @todo: lazy load owner resolution in FileInfo instead?
 		$ownerId = $storage->getOwner($internalPath);
 		$owner = ($ownerId !== false)
 			? $this->getUserObjectForOwner($ownerId)
 			: null;
 
-		// Build final FileInfo object from resolved storage/cache/mount data
 		$info = new FileInfo($fullPath, $storage, $internalPath, $data, $mount, $owner);
 
-		// Optionally include sizes from sub-mounts when this entry is a directory
-		if (isset($data['fileid']) && $includeMountPoints && $data['mimetype'] === 'httpd/unix-directory') {
-			// add the sizes of other mount points to the folder (expensive?)
+		if ($includeMountPoints && $data['mimetype'] === 'httpd/unix-directory' && isset($data['fileid'])) {
 			$extOnly = ($includeMountPoints === 'ext');
-			$this->addSubMounts($info, $extOnly);
+			$this->addSubMounts($info, $extOnly); // expensive?
 		}
 
 		return $info;

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1467,14 +1467,13 @@ class View {
 
 		// Fetch cache metadata for the resolved storage/path
 		$data = $this->getCacheEntry($storage, $internalPath, $relativePath);
-
-		// Allow partial-upload files to resolve via specialized handling; otherwise path is considered missing
-		if (!$data instanceof ICacheEntry) {
-			if (Scanner::isPartialFile($relativePath)) {
-				return $this->getPartFileInfo($relativePath);
+		if ($data === false) {
+			if (!Scanner::isPartialFile($relativePath)) {
+				// Not found in cache and not a known partial file => truly non-existent
+				return false;
 			}
-			// Not found in cache and not a known partial file => treat as non-existent
-			return false;
+			// Partial (upload) files get a second chance
+			return $this->getPartFileInfo($relativePath);
 		}
 
 		// Ensure delete permission on moveable mount roots

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1446,23 +1446,25 @@ class View {
 			return false;
 		}
 
-		// Keep the original (caller-relative) path for cache lookup and partial-file handling
+		// Use the original (caller-relative) path for cache lookup and partial-file handling
 		$relativePath = $path;
-
 		// Build normalized absolute path inside the view's fake root
-		$path = Filesystem::normalizePath($this->fakeRoot . '/' . $path);
+		$fullPath = Filesystem::normalizePath($this->fakeRoot . '/' . $relativePath);
 
 		// Resolve mount + storage context for the path
-		$mount = Filesystem::getMountManager()->find($path);
+		$mount = Filesystem::getMountManager()->find($fullPath);
+		if (!$mount) {
+        	$this->logger->warning('No mount found for path', ['app' => 'core', 'path' => $fullPath]);
+        	return false;
+    	}
 		$storage = $mount->getStorage();
-		$internalPath = $mount->getInternalPath($path);
-
 		if (!$storage) {
 			// Mount exists but storage is unavailable/invalid
-			$this->logger->warning('Storage not valid for mountpoint: ' . $mount->getMountPoint(), ['app' => 'core']);
+			$this->logger->warning('Storage not valid for mountpoint', ['mountpoint' => $mount->getMountPoint(), 'path' => $fullPath, 'app' => 'core']);
 			return false;
 		}
-		
+		$internalPath = $mount->getInternalPath($fullPath);
+
 		// Fetch cache metadata for the resolved storage/path
 		$data = $this->getCacheEntry($storage, $internalPath, $relativePath);
 
@@ -1498,7 +1500,7 @@ class View {
 
 		// Optionally include sizes from sub-mounts when this entry is a directory
 		if (isset($data['fileid']) && $includeMountPoints && $data['mimetype'] === 'httpd/unix-directory') {
-			// add the sizes of other mount points to the folder
+			// add the sizes of other mount points to the folder (expensive?)
 			$extOnly = ($includeMountPoints === 'ext');
 			$this->addSubMounts($info, $extOnly);
 		}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1476,13 +1476,13 @@ class View {
 			return $this->getPartFileInfo($relativePath);
 		}
 
-		// Ensure delete permission on moveable mount roots
-		if ($mount instanceof MoveableMount && $internalPath === '') {
+		// Ensure moveable mount roots get delete permission 
+		if ($internalPath === '' && $mount instanceof MoveableMount) {
 			$data['permissions'] |= Constants::PERMISSION_DELETE;
 		}
 
-		// Ensure mount root entries use current basename rather than stale cache name
-		if ($internalPath === '' && $data['name'] !== '' && $data['name'] !== null) {
+		// Ensure mount roots use current basename rather than stale cache name
+		if ($internalPath === '' && ($data['name'] ?? '') !== '') {
 			$data['name'] = basename($fullPath);
 		}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1486,13 +1486,11 @@ class View {
 			$data['name'] = basename($fullPath);
 		}
 
-		// Resolve owner object (may remain null for token-only access contexts)
+		// Resolve owner object if storage can provide an owner id
 		$ownerId = $storage->getOwner($internalPath);
-		$owner = null;
-		if ($ownerId !== false) {
-			// ownerId might be null if files are accessed with an access token without file system access
-			$owner = $this->getUserObjectForOwner($ownerId);
-		}
+		$owner = ($ownerId !== false)
+			? $this->getUserObjectForOwner($ownerId)
+			: null;
 
 		// Build final FileInfo object from resolved storage/cache/mount data
 		$info = new FileInfo($fullPath, $storage, $internalPath, $data, $mount, $owner);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1487,6 +1487,7 @@ class View {
 		}
 
 		// Resolve owner object if storage can provide an owner id
+		// @todo: lazy load owner resolution in FileInfo instead?
 		$ownerId = $storage->getOwner($internalPath);
 		$owner = ($ownerId !== false)
 			? $this->getUserObjectForOwner($ownerId)


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

* Added clearer inline comments and improved method phpdoc (including the partial-file fallback behavior).
* Flattened control flow with early returns for invalid path, missing mount, and invalid storage.
* Split path handling into explicit `relativePath` and `fullPath` variables for readability.
* Improved logging context for mount/storage resolution failures.

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
