### PR TITLE
fix(apporder): Load custom app order before resolving closures

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -36,7 +36,7 @@ class NavigationManager implements INavigationManager {
 	protected array $unreadCounters = [];
 	protected bool $init = false;
 	/** User defined app order (cached for the `add` function) */
-	private array $customAppOrder;
+	private ?array $customAppOrder = null;
 
 	public function __construct(
 		protected IAppManager $appManager,
@@ -182,6 +182,15 @@ class NavigationManager implements INavigationManager {
 	}
 
 	private function init(bool $resolveClosures = true): void {
+		if ($this->customAppOrder === null) {
+			if ($this->userSession->isLoggedIn()) {
+				$user = $this->userSession->getUser();
+				$this->customAppOrder = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
+			} else {
+				$this->customAppOrder = [];
+			}
+		}
+
 		if ($resolveClosures) {
 			while ($c = array_pop($this->closureEntries)) {
 				$this->add($c());
@@ -302,10 +311,8 @@ class NavigationManager implements INavigationManager {
 		if ($this->userSession->isLoggedIn()) {
 			$user = $this->userSession->getUser();
 			$apps = $this->appManager->getEnabledAppsForUser($user);
-			$this->customAppOrder = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
 		} else {
 			$apps = $this->appManager->getEnabledApps();
-			$this->customAppOrder = [];
 		}
 
 		foreach ($apps as $app) {


### PR DESCRIPTION
* Resolves: nextcloud/spreed#16678

## Summary
Ref: https://github.com/nextcloud/spreed/issues/16678#issuecomment-4063110701

> It required an app that registers a page alphabetically after Talk (spreed) via the add method (closure or not does not matter).
The problem is this resolves the closure of Talk, but does not load the custom app order before, so Talk is still -5.

## Steps

1. Enable Talk
2. Enable thesearchpage app, external app, or something similar
3. Change app order and move Talk lower
4. Talk is still first

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
