### PR TITLE
fix: manually set modified time to SFTP files after editing

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -333,7 +333,10 @@ class SFTP extends Common {
 					$fh = fopen('sftpwrite://' . trim($absPath, '/'), 'w', false, $context);
 					if ($fh) {
 						$fh = CallbackWrapper::wrap($fh, null, null, function () use ($path): void {
-							$this->knownMTimes->set($path, time());
+							$mtime = time();
+							$this->knownMTimes->set($path, $mtime);
+							$this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
+							$this->getConnection()->clearStatCache();
 						});
 					}
 					return $fh;
@@ -429,6 +432,11 @@ class SFTP extends Common {
 	public function file_put_contents(string $path, mixed $data): int|float|false {
 		/** @psalm-suppress InternalMethod */
 		$result = $this->getConnection()->put($this->absPath($path), $data);
+		$mtime = time();
+		$this->knownMTimes->set($path, $mtime);
+		$this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
+		$this->getConnection()->clearStatCache();
+
 		if ($result) {
 			return strlen($data);
 		} else {
@@ -448,6 +456,11 @@ class SFTP extends Common {
 		/** @psalm-suppress InternalMethod */
 		$result = $this->getConnection()->put($this->absPath($path), $stream);
 		fclose($stream);
+		$mtime = time();
+		$this->knownMTimes->set($path, $mtime);
+		$this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
+		$this->getConnection()->clearStatCache();
+
 		if ($result) {
 			if ($size === null) {
 				throw new \Exception('Failed to get written size from sftp storage wrapper');

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -333,10 +333,7 @@ class SFTP extends Common {
 					$fh = fopen('sftpwrite://' . trim($absPath, '/'), 'w', false, $context);
 					if ($fh) {
 						$fh = CallbackWrapper::wrap($fh, null, null, function () use ($path): void {
-							$mtime = time();
-							$this->knownMTimes->set($path, $mtime);
-							$this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
-							$this->getConnection()->clearStatCache();
+							$this->touch($path, time());
 						});
 					}
 					return $fh;
@@ -360,18 +357,17 @@ class SFTP extends Common {
 	}
 
 	public function touch(string $path, ?int $mtime = null): bool {
-		try {
+		
+		$result = $this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
+
+		if ($result) {
+			$this->getConnection()->clearStatCache($this->absPath($path));
 			if (!is_null($mtime)) {
-				return false;
+				$this->knownMTimes->set($path, $mtime);
 			}
-			if (!$this->file_exists($path)) {
-				return $this->getConnection()->put($this->absPath($path), '');
-			} else {
-				return false;
-			}
-		} catch (\Exception $e) {
-			return false;
 		}
+
+		return $result;
 	}
 
 	/**
@@ -432,10 +428,8 @@ class SFTP extends Common {
 	public function file_put_contents(string $path, mixed $data): int|float|false {
 		/** @psalm-suppress InternalMethod */
 		$result = $this->getConnection()->put($this->absPath($path), $data);
-		$mtime = time();
-		$this->knownMTimes->set($path, $mtime);
-		$this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
-		$this->getConnection()->clearStatCache();
+
+		$this->touch($path, time());
 
 		if ($result) {
 			return strlen($data);
@@ -456,10 +450,8 @@ class SFTP extends Common {
 		/** @psalm-suppress InternalMethod */
 		$result = $this->getConnection()->put($this->absPath($path), $stream);
 		fclose($stream);
-		$mtime = time();
-		$this->knownMTimes->set($path, $mtime);
-		$this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
-		$this->getConnection()->clearStatCache();
+
+		$this->touch($path, time());
 
 		if ($result) {
 			if ($size === null) {

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -357,11 +357,11 @@ class SFTP extends Common {
 	}
 
 	public function touch(string $path, ?int $mtime = null): bool {
-		
+
 		$result = $this->getConnection()->touch($this->absPath($path), $mtime, $mtime);
 
 		if ($result) {
-			$this->getConnection()->clearStatCache($this->absPath($path));
+			$this->getConnection()->clearStatCache();
 			if (!is_null($mtime)) {
 				$this->knownMTimes->set($path, $mtime);
 			}

--- a/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
@@ -32,6 +32,8 @@ class SFTPWriteStream implements File {
 
 	private $buffer = '';
 
+	private string $path;
+
 	public static function register($protocol = 'sftpwrite') {
 		if (in_array($protocol, stream_get_wrappers(), true)) {
 			return false;
@@ -71,6 +73,8 @@ class SFTPWriteStream implements File {
 		}
 
 		$remote_file = $this->sftp->_realpath($path);
+
+		$this->path = $remote_file;
 		if ($remote_file === false) {
 			return false;
 		}
@@ -160,6 +164,8 @@ class SFTPWriteStream implements File {
 		if (!$this->sftp->_close_handle($this->handle)) {
 			return false;
 		}
+		$this->sftp->touch($this->path, time(), time());
+
 		return true;
 	}
 }

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1359,7 +1359,6 @@
     <InternalMethod>
       <code><![CDATA[getLocalFile]]></code>
       <code><![CDATA[new View('/' . $userId . '/files_external')]]></code>
-      <code><![CDATA[put]]></code>
     </InternalMethod>
   </file>
   <file src="apps/files_external/lib/Lib/Storage/SMB.php">


### PR DESCRIPTION

## Summary

This PR fixes SFTP file writes. When uploading a file to the SFTP server, the files original modified date is not preserved. The SFTP server typically sets the modified date to the time of upload. This leads to issues, for example, with Nextcloud Office, which expects the mtime to match the mtime of the file. Nextcloud office then repeatedly throws errors indicating that the file has been modified externally. In this PR the SFTP implementation explicitely sets the modified date of the file.

## Caution

I am not sure about the knownMTimes. I set them everywhere the data is written to the SFTP server, but I'm not sure if that's correct, since I'm not entirely sure what the purpose of this memory cache is.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
