### PR TITLE
fix(lookup-server): accept self-signed lus on globalscale

### DIFF
--- a/lib/private/Collaboration/Collaborators/LookupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/LookupPlugin.php
@@ -54,11 +54,16 @@ class LookupPlugin implements ISearchPlugin {
 
 		try {
 			$client = $this->clientService->newClient();
+			/**
+			 * @psalm-suppress TypeDoesNotContainType - $isGlobalScaleEnabled always true at this point
+			 * @psalm-suppress RedundantCondition - guard rail in case we re-activate LUS out of GlobalScale
+			 */
 			$response = $client->get(
 				$lookupServerUrl . '/users?search=' . urlencode($search),
 				[
 					'timeout' => 10,
 					'connect_timeout' => 3,
+					'verify' => !($isGlobalScaleEnabled && $this->config->getSystemValueBool('gss.selfsigned.allow', false) === true)
 				]
 			);
 

--- a/lib/private/Collaboration/Collaborators/LookupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/LookupPlugin.php
@@ -55,11 +55,16 @@ class LookupPlugin implements ISearchPlugin {
 
 		try {
 			$client = $this->clientService->newClient();
+			/**
+			 * @psalm-suppress TypeDoesNotContainType - $isGlobalScaleEnabled always true at this point
+			 * @psalm-suppress RedundantCondition - guard rail in case we re-activate LUS out of GlobalScale
+			 */
 			$response = $client->get(
 				$lookupServerUrl . '/users?search=' . urlencode($search),
 				[
 					'timeout' => 10,
 					'connect_timeout' => 3,
+					'verify' => !($isGlobalScaleEnabled && $this->config->getSystemValueBool('gss.selfsigned.allow', false) === true)
 				]
 			);
 

--- a/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
@@ -139,11 +139,12 @@ class LookupPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('files_sharing', 'lookupServerEnabled', 'no')
 			->willReturn('yes');
-		$this->config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(3))
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['gs.enabled', false, true],
 				['has_internet_connection', true, true],
+				['gss.selfsigned.allow', false, false],
 			]);
 
 		$this->config->expects($this->once())
@@ -201,11 +202,12 @@ class LookupPluginTest extends TestCase {
 				->method('addResultSet')
 				->with($type, $searchParams['expectedResult'], []);
 
-			$this->config->expects($this->exactly(2))
+			$this->config->expects($this->exactly(3))
 				->method('getSystemValueBool')
 				->willReturnMap([
 					['gs.enabled', false, $GSEnabled],
 					['has_internet_connection', true, true],
+					['gss.selfsigned.allow', false, false],
 				]);
 			$this->config->expects($this->once())
 				->method('getSystemValueString')

--- a/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
@@ -145,10 +145,11 @@ class LookupPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('files_sharing', 'lookupServerEnabled', 'no')
 			->willReturn('yes');
-		$this->config->expects($this->once())
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['has_internet_connection', true, true],
+				['gss.selfsigned.allow', false, false],
 			]);
 
 		$this->globalScaleConfig->expects($this->once())
@@ -209,10 +210,11 @@ class LookupPluginTest extends TestCase {
 				->method('addResultSet')
 				->with($type, $searchParams['expectedResult'], []);
 
-			$this->config->expects($this->once())
+			$this->config->expects($this->exactly(2))
 				->method('getSystemValueBool')
 				->willReturnMap([
 					['has_internet_connection', true, true],
+					['gss.selfsigned.allow', false, false],
 				]);
 
 			$this->globalScaleConfig->expects($this->once())


### PR DESCRIPTION
- on globalscale, do not verify if gss is configured to support self signed certificate.
- known `RedundantCondition` as we _currently_ do not search on lookup-server out of globalscale.