### PR TITLE
chore(quota): hide available space from error

### DIFF
--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -258,8 +258,8 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 
 		if ($length > $freeSpace) {
 			$msg = $isDir
-				? "Insufficient space in $normalizedPath. $freeSpace available. Cannot create directory"
-				: "Insufficient space in $normalizedPath, $length required, $freeSpace available";
+				? "Insufficient space in $normalizedPath. Cannot create directory"
+				: "Insufficient space in $normalizedPath";
 			throw new InsufficientStorage($msg);
 		}
 


### PR DESCRIPTION
## Summary

Update error message when disk is full

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
