### PR TITLE
feat(files): include favorite state in unified search results

### DIFF
--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -24,6 +24,7 @@ use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchOrder;
 use OCP\IL10N;
 use OCP\IPreview;
+use OCP\ITagManager;
 use OCP\ITags;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -42,6 +43,7 @@ class FilesSearchProvider implements IFilteringProvider {
 		private IMimeTypeDetector $mimeTypeDetector,
 		private IRootFolder $rootFolder,
 		private IPreview $previewManager,
+		private ITagManager $tagManager,
 	) {
 	}
 
@@ -104,22 +106,35 @@ class FilesSearchProvider implements IFilteringProvider {
 	public function search(IUser $user, ISearchQuery $query): SearchResult {
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 		$fileQuery = $this->buildSearchQuery($query, $user);
+		$results = $userFolder->search($fileQuery);
+
+		$fileIds = array_map(static fn (Node $result): string => (string)$result->getId(), $results);
+		$favoriteMap = $this->getFavoriteStatesByFileId($fileIds);
+	
 		return SearchResult::paginated(
 			$this->l10n->t('Files'),
-			array_map(function (Node $result) use ($userFolder) {
+			array_map(function (Node $result) use ($userFolder, $favoriteMap) {
+				$nodeId = $result->getId();
 				$thumbnailUrl = $this->previewManager->isMimeSupported($result->getMimetype())
-					? $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', ['x' => 32, 'y' => 32, 'fileId' => $result->getId()])
+					? $this->urlGenerator->linkToRouteAbsolute(
+						'core.Preview.getPreviewByFileId', [
+							'x' => 32,
+							'y' => 32,
+							'fileId' => $nodeId,
+						])
 					: '';
+
 				$icon = $result->getMimetype() === FileInfo::MIMETYPE_FOLDER
 					? 'icon-folder'
 					: $this->mimeTypeDetector->mimeTypeIcon($result->getMimetype());
-				$path = $userFolder->getRelativePath($result->getPath());
 
+				$path = $userFolder->getRelativePath($result->getPath());
 				// Use shortened link to centralize the various
 				// files/folder url redirection in files.View.showFile
 				$link = $this->urlGenerator->linkToRoute(
-					'files.View.showFile',
-					['fileid' => $result->getId()]
+					'files.View.showFile', [
+						'fileid' => $nodeId,
+					]
 				);
 
 				$searchResultEntry = new SearchResultEntry(
@@ -129,28 +144,41 @@ class FilesSearchProvider implements IFilteringProvider {
 					$this->urlGenerator->getAbsoluteURL($link),
 					$icon,
 				);
-				$searchResultEntry->addAttribute('fileId', (string)$result->getId());
+
+				$searchResultEntry->addAttribute('fileId', $fileId);
 				$searchResultEntry->addAttribute('path', $path);
-				$searchResultEntry->addAttribute('favorite', $this->isFavorite((string)$result->getId()) ? "true" : "false");
+				$searchResultEntry->addAttribute('favorite', ($favoriteMap[$nodeId] ?? false) ? 'true' : 'false');
 				return $searchResultEntry;
-			}, $userFolder->search($fileQuery)),
+			}, $results),
 			$query->getCursor() + $query->getLimit()
 		);
 	}
 
-	private function isFavorite(string $fileId): bool {
-		$tagManager = \OCP\Server::get(\OCP\ITagManager::class);
-		$tagger = $tagManager->load('files');
+	/**
+	 * @param list<string> $fileIds
+	 * @return array<string, bool>
+	 */
+	private function getFavoriteStatesByFileId(array $fileIds): array {
+		if ($fileIds === []) {
+			return [];
+		}
+
+		$tagger = $this->tagManager->load('files');
 		if ($tagger === null) {
-			return false;
-		}
-		$tags = $tagger->getTagsForObjects([$fileId]);
-
-		if ($tags === false || empty($tags)) {
-			return false;
+			return [];
 		}
 
-		return array_search(ITags::TAG_FAVORITE, current($tags)) !== false;
+		$tags = $tagger->getTagsForObjects($fileIds);
+		if ($tags === false || $tags === []) {
+			return [];
+		}
+
+		$favoriteMap = [];
+		foreach ($fileIds as $fileId) {
+			$favoriteMap[$fileId] = in_array(ITags::TAG_FAVORITE, $tags[$fileId] ?? [], true);
+		}
+
+		return $favoriteMap;
 	}
 
 	private function buildSearchQuery(ISearchQuery $query, IUser $user): SearchQuery {
@@ -209,11 +237,11 @@ class FilesSearchProvider implements IFilteringProvider {
 	 */
 	private function formatSubline(string $path): string {
 		// Do not show the location if the file is in root
-		if (strrpos($path, '/') > 0) {
-			$path = ltrim(dirname($path), '/');
-			return $this->l10n->t('in %s', [$path]);
-		} else {
+		if (strrpos($path, '/') <= 0) {
 			return '';
 		}
+
+		$path = ltrim(dirname($path), '/');
+		return $this->l10n->t('in %s', [$path]);
 	}
 }

--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -108,7 +108,7 @@ class FilesSearchProvider implements IFilteringProvider {
 		$fileQuery = $this->buildSearchQuery($query, $user);
 		$results = $userFolder->search($fileQuery);
 
-		$fileIds = array_map(static fn (Node $result): string => (string)$result->getId(), $results);
+		$fileIds = array_map(static fn (Node $result): string => $result->getId(), $results);
 		$favoriteMap = $this->getFavoriteStatesByFileId($fileIds);
 	
 		return SearchResult::paginated(
@@ -145,7 +145,7 @@ class FilesSearchProvider implements IFilteringProvider {
 					$icon,
 				);
 
-				$searchResultEntry->addAttribute('fileId', $fileId);
+				$searchResultEntry->addAttribute('fileId', (string)$nodeId);
 				$searchResultEntry->addAttribute('path', $path);
 				$searchResultEntry->addAttribute('favorite', ($favoriteMap[$nodeId] ?? false) ? 'true' : 'false');
 				return $searchResultEntry;
@@ -155,8 +155,8 @@ class FilesSearchProvider implements IFilteringProvider {
 	}
 
 	/**
-	 * @param list<string> $fileIds
-	 * @return array<string, bool>
+	 * @param list<int> $fileIds
+	 * @return array<int, bool>
 	 */
 	private function getFavoriteStatesByFileId(array $fileIds): array {
 		if ($fileIds === []) {

--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -24,6 +24,7 @@ use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchOrder;
 use OCP\IL10N;
 use OCP\IPreview;
+use OCP\ITags;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Search\FilterDefinition;
@@ -130,10 +131,26 @@ class FilesSearchProvider implements IFilteringProvider {
 				);
 				$searchResultEntry->addAttribute('fileId', (string)$result->getId());
 				$searchResultEntry->addAttribute('path', $path);
+				$searchResultEntry->addAttribute('favorite', $this->isFavorite((string)$result->getId()) ? "true" : "false");
 				return $searchResultEntry;
 			}, $userFolder->search($fileQuery)),
 			$query->getCursor() + $query->getLimit()
 		);
+	}
+
+	private function isFavorite(string $fileId): bool {
+		$tagManager = \OCP\Server::get(\OCP\ITagManager::class);
+		$tagger = $tagManager->load('files');
+		if ($tagger === null) {
+			return false;
+		}
+		$tags = $tagger->getTagsForObjects([$fileId]);
+
+		if ($tags === false || empty($tags)) {
+			return false;
+		}
+
+		return array_search(ITags::TAG_FAVORITE, current($tags)) !== false;
 	}
 
 	private function buildSearchQuery(ISearchQuery $query, IUser $user): SearchQuery {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

* Add `favorite` attribute to file unified-search results
* Batch-fetch tags for returned file IDs

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
