### PR TITLE
fix(dav): apply client-provided mtime before cache update

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -342,7 +342,7 @@ class File extends Node implements IFile {
 			if ($mtime !== null) {
 				$nativeTouchSucceeded = $storage->touch($internalPath, $mtime);
 			}
-	
+
 			// Since we skipped the view we need to scan and emit the hooks ourselves
 			$storage->getUpdater()->update($internalPath);
 

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -333,7 +333,17 @@ class File extends Node implements IFile {
 				}
 			}
 
-			// since we skipped the view we need to scan and emit the hooks ourselves
+			// allow sync clients to send the mtime along in a header
+			$mtimeHeader = $this->request->getHeader('x-oc-mtime');
+			$mtime = ($mtimeHeader !== '') ? $this->sanitizeMtime($mtimeHeader) : null;
+
+			// Apply mtime to storage before the scanner picks it up
+			$nativeTouchSucceeded = false;
+			if ($mtime !== null) {
+				$nativeTouchSucceeded = $storage->touch($internalPath, $mtime);
+			}
+	
+			// Since we skipped the view we need to scan and emit the hooks ourselves
 			$storage->getUpdater()->update($internalPath);
 
 			try {
@@ -342,18 +352,17 @@ class File extends Node implements IFile {
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
 
-			// allow sync clients to send the mtime along in a header
-			$mtimeHeader = $this->request->getHeader('x-oc-mtime');
-			if ($mtimeHeader !== '') {
-				$mtime = $this->sanitizeMtime($mtimeHeader);
-				if ($this->fileView->touch($this->path, $mtime)) {
+			$fileInfoUpdate = [
+				'upload_time' => time(),
+			];
+
+			if ($mtime !== null) {
+				if (!$nativeTouchSucceeded) {
+					// Native touch unsupported — write mtime directly to cache
+					$fileInfoUpdate['mtime'] = $mtime;
 					$this->header('X-OC-MTime: accepted');
 				}
 			}
-
-			$fileInfoUpdate = [
-				'upload_time' => time()
-			];
 
 			// allow sync clients to send the creation time along in a header
 			$ctimeHeader = $this->request->getHeader('x-oc-ctime');

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -569,7 +569,6 @@
       <code><![CDATA[resolvePath]]></code>
       <code><![CDATA[resolvePath]]></code>
       <code><![CDATA[resolvePath]]></code>
-      <code><![CDATA[touch]]></code>
       <code><![CDATA[unlink]]></code>
     </InternalMethod>
     <LessSpecificReturnStatement>


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #58978 <!-- related github issue -->

## Summary

When a sync client uploads a file with an `x-oc-mtime header`, the provided mtime is applied after `$storage->getUpdater()->update()` runs. The scanner inside `update()` reads the filesystem mtime via `stat()`, which at that point reflects the current server time -- not the client-provided value. This means the cache is briefly populated with the wrong mtime before `View::touch()` corrects it.

Additionally, `View::touch()` goes through `basicOperation`, which can trigger `writeUpdate()` hooks/updater side effects depending on the view's state -- an unnecessary risk given the DAV code already manages the updater manually.

Changes introduced by this PR:

* Call `$storage->touch($internalPath, $mtime)` before the updater, so the scanner sees the correct mtime from the filesystem.
* If the native touch fails (some backends don't support it), write `mtime` directly to the filecache via `putFileInfo`.
  - This is essentially what the existing implementation did; we should perhaps document that behavior could still be problematic on storage backends that don't support it
* Consolidate `upload_time`, `mtime` (fallback), and `creation_time` into a single `putFileInfo` call.
* Remove the `View::touch()` call entirely.

## TODO

- [ ] Test 
- [ ] Decide whether to backport or not (I vote yes, but...)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
