### PR TITLE
fix(group): pass previous display name in GroupChangedEvent

### DIFF
--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -75,11 +75,12 @@ class Group implements IGroup {
 		$displayName = trim($displayName);
 		if ($displayName !== '') {
 			$this->dispatcher->dispatchTyped(new BeforeGroupChangedEvent($this, 'displayName', $displayName, $this->displayName));
+			$oldDisplayName = $this->displayName;
 			foreach ($this->backends as $backend) {
 				if (($backend instanceof ISetDisplayNameBackend)
 					&& $backend->setDisplayName($this->gid, $displayName)) {
 					$this->displayName = $displayName;
-					$this->dispatcher->dispatchTyped(new GroupChangedEvent($this, 'displayName', $displayName, ''));
+					$this->dispatcher->dispatchTyped(new GroupChangedEvent($this, 'displayName', $displayName, $oldDisplayName));
 					return true;
 				}
 			}

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -11,6 +11,8 @@ namespace Test\Group;
 use OC\Group\Group;
 use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Group\Events\BeforeGroupChangedEvent;
+use OCP\Group\Events\GroupChangedEvent;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -455,6 +457,41 @@ class GroupTest extends \Test\TestCase {
 		$users = $group->count('2');
 
 		$this->assertSame(false, $users);
+	}
+
+	public function testSetDisplayNameDispatchesOldValue(): void {
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$userManager = $this->getUserManager();
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$invocation = 0;
+		$dispatcher->expects($this->exactly(2))
+			->method('dispatchTyped')
+			->willReturnCallback(function ($event) use (&$invocation): void {
+				$invocation++;
+				if ($invocation === 1) {
+					$this->assertInstanceOf(BeforeGroupChangedEvent::class, $event);
+					$this->assertSame('displayName', $event->getFeature());
+					$this->assertSame('New Name', $event->getValue());
+					$this->assertSame('Old Name', $event->getOldValue());
+					return;
+				}
+
+				$this->assertInstanceOf(GroupChangedEvent::class, $event);
+				$this->assertSame('displayName', $event->getFeature());
+				$this->assertSame('New Name', $event->getValue());
+				$this->assertSame('Old Name', $event->getOldValue());
+			});
+
+		$backend->expects($this->once())
+			->method('setDisplayName')
+			->with('group1', 'New Name')
+			->willReturn(true);
+
+		$group = new Group('group1', [$backend], $dispatcher, $userManager, null, 'Old Name');
+		$this->assertTrue($group->setDisplayName('New Name'));
 	}
 
 	public function testDelete(): void {


### PR DESCRIPTION

## Summary
GroupChangedEvent old value was empty string,

## TODO

- [x] fix: now passes previous display name,

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
