### PR TITLE
fix(comments): Correctly treat end of message as end of code block/in…

### DIFF
--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -198,7 +198,7 @@ class Comment implements IComment {
 		$message = $this->getMessage();
 		if ($supportMarkdown) {
 			// Strip fenced code blocks and inline code so mentions inside them are ignored
-			$message = preg_replace('/^```.*?^```|^~~~.*?^~~~/sm', '', $message);
+			$message = preg_replace('/^```.*?(^```|\z)|^~~~.*?(^~~~|\z)/sm', '', $message);
 			$message = preg_replace('/`[^`\n]*`/', '', $message);
 		}
 

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -240,6 +240,18 @@ class CommentTest extends TestCase {
 				null,
 				false,
 			],
+			[
+				'Mention @alice and `also @bob as end of text only applies to code blocks',
+				[['type' => 'user', 'id' => 'alice'], ['type' => 'user', 'id' => 'bob']],
+			],
+			[
+				"Mention @alice but not in unclosed fenced code block\n```\n@bob\n@charlie",
+				[['type' => 'user', 'id' => 'alice']],
+			],
+			[
+				"Mention @alice but not in unclosed tilde code block\n~~~\n@bob",
+				[['type' => 'user', 'id' => 'alice']],
+			],
 		];
 	}
 


### PR DESCRIPTION
…line

- Ref https://github.com/nextcloud/server/pull/58974#issuecomment-4074229888

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
