### PR TITLE
fix: Add missing Attribute and fix parameter type in renewpassword route

### DIFF
--- a/apps/user_ldap/lib/Controller/RenewPasswordController.php
+++ b/apps/user_ldap/lib/Controller/RenewPasswordController.php
@@ -8,6 +8,7 @@ namespace OCA\User_LDAP\Controller;
 
 use OCA\User_LDAP\AppInfo\Application;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\Attribute\PublicPage;
@@ -84,17 +85,20 @@ class RenewPasswordController extends Controller {
 
 	#[PublicPage]
 	#[UseSession]
-	public function tryRenewPassword(?string $user, string $oldPassword, ?string $newPassword): RedirectResponse {
-		if ($user !== null && !$this->userConfig->getValueBool($user, 'user_ldap', 'needsPasswordReset')) {
+	#[BruteForceProtection(action: 'login')]
+	public function tryRenewPassword(string $user, string $oldPassword, ?string $newPassword): RedirectResponse {
+		if (!$this->userConfig->getValueBool($user, 'user_ldap', 'needsPasswordReset')) {
 			return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
 		}
-		$args = !is_null($user) ? ['user' => $user] : [];
+		$args = ['user' => $user];
 		$loginResult = $this->userManager->checkPassword($user, $oldPassword);
 		if ($loginResult === false) {
 			$this->session->set('renewPasswordMessages', [
 				['invalidpassword'], []
 			]);
-			return new RedirectResponse($this->urlGenerator->linkToRoute('user_ldap.renewPassword.showRenewPasswordForm', $args));
+			$response = new RedirectResponse($this->urlGenerator->linkToRoute('user_ldap.renewPassword.showRenewPasswordForm', $args));
+			$response->throttle(['user' => $user]);
+			return $response;
 		}
 
 		try {


### PR DESCRIPTION
## Summary

`$user` cannot be `null` or `checkPassword` and `setPassword` calls would be invalid.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
