### PR TITLE
fix: provide `canDownload` helper for shares and use it where appropriate

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -18,7 +18,6 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\Constants;
 use OCP\Federation\ICloudIdManager;
 use OCP\HintException;
 use OCP\Http\Client\IClientService;
@@ -108,9 +107,9 @@ class MountPublicLinkController extends Controller {
 			return $response;
 		}
 
-		if (($share->getPermissions() & Constants::PERMISSION_READ) === 0) {
+		if (!$share->canDownload()) {
 			$response = new JSONResponse(
-				['message' => 'Mounting file drop not supported'],
+				['message' => 'Mounting download restricted share is not allowed'],
 				Http::STATUS_BAD_REQUEST
 			);
 			$response->throttle();

--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -153,7 +153,7 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 
 		// Create the header action menu
 		$headerActions = [];
-		if ($view !== 'public-file-drop' && !$share->getHideDownload()) {
+		if ($share->canDownload() && !$share->getHideDownload()) {
 			// The download URL is used for the "download" header action as well as in some cases for the direct link
 			$downloadUrl = $this->urlGenerator->getAbsoluteURL('/public.php/dav/files/' . $token . '/?accept=zip');
 

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -7,6 +7,7 @@
  */
 namespace OC\Share20;
 
+use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
@@ -586,6 +587,19 @@ class Share implements IShare {
 		return $this->reminderSent;
 	}
 
+	public function canDownload(): bool {
+		if (($this->getPermissions() & Constants::PERMISSION_READ) === 0) {
+			return false;
+		}
+
+		$attributes = $this->getAttributes();
+		if ($attributes?->getAttribute('permissions', 'download') === false) {
+			return false;
+		}
+
+		return true;
+	}
+
 	public function canSeeContent(): bool {
 		$shareManager = Server::get(IManager::class);
 
@@ -595,13 +609,6 @@ class Share implements IShare {
 			return true;
 		}
 
-		// No "allow preview" header set, so we must check if
-		// the share has not explicitly disabled download permissions
-		$attributes = $this->getAttributes();
-		if ($attributes?->getAttribute('permissions', 'download') === false) {
-			return false;
-		}
-
-		return true;
+		return $this->canDownload();
 	}
 }

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -645,6 +645,15 @@ interface IShare {
 	 * Check if the current user can see this share files contents.
 	 * This will check the download permissions as well as the global
 	 * admin setting to allow viewing files without downloading.
+	 *
+	 * @since 32.0.0
 	 */
 	public function canSeeContent(): bool;
+
+	/**
+	 * Check if it is allowed to download this share.
+	 *
+	 * @since 34.0.0
+	 */
+	public function canDownload(): bool;
 }


### PR DESCRIPTION
## Summary

Use consistent logic for checking permissions of shares

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
