### PR TITLE
refactor(session): DRY cleanup logic exception handling

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -58,19 +58,19 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 					512,
 					JSON_THROW_ON_ERROR,
 				);
-			} catch (\RuntimeException $e) {
-				// Even though this might be critical in general, we are automatically trying again and will likely succeed.
-				// We only log to info to not spam the logs with a well-known problem the admin cannot do anything about.
-				// See https://github.com/nextcloud/server/issues/42157
-				logger('core')->info('Could not decrypt or decode encrypted session data', [
-					'exception' => $e,
-				]);
-				$this->sessionValues = [];
-				$this->regenerateId(true, false);
 			} catch (\Exception $e) {
-				logger('core')->critical('Could not decrypt or decode encrypted session data', [
-					'exception' => $e,
-				]);
+				if ($e instanceof \RuntimeException) {
+					// Even though this might be critical in general, we are automatically trying again and will likely succeed.
+					// We only log to info to not spam the logs with a well-known problem the admin cannot do anything about.
+					// See https://github.com/nextcloud/server/issues/42157
+					logger('core')->info('Could not decrypt or decode encrypted session data', [
+						'exception' => $e,
+					]);
+				} else {
+					logger('core')->critical('Could not decrypt or decode encrypted session data', [
+						'exception' => $e,
+					]);
+				}
 				$this->sessionValues = [];
 				$this->regenerateId(true, false);
 			}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The session cleanup code (resetting session values and regenerating the ID) is actually duplicated between the catch RuntimeException and Exception blocks.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
