### PR TITLE
feat(updater): add a config toggle to disable adding the BackgroundCleanupUpdaterBackupsJob

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -983,6 +983,14 @@ $CONFIG = [
 	'updater.release.channel' => 'stable',
 
 	/**
+	 * Does Nextcloud needs to cleanup old backups after an update has been
+	 * performed?
+	 *
+	 * Defaults to ``true``
+	 */
+	'updater.cleanup_backups' => true,
+
+	/**
 	 * Is Nextcloud connected to the Internet or running in a closed network?
 	 *
 	 * Defaults to ``true``

--- a/lib/private/Repair/AddCleanupUpdaterBackupsJob.php
+++ b/lib/private/Repair/AddCleanupUpdaterBackupsJob.php
@@ -10,12 +10,14 @@ namespace OC\Repair;
 
 use OC\Core\BackgroundJobs\BackgroundCleanupUpdaterBackupsJob;
 use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class AddCleanupUpdaterBackupsJob implements IRepairStep {
 	public function __construct(
 		protected readonly IJobList $jobList,
+		protected readonly IConfig $config,
 	) {
 	}
 
@@ -24,6 +26,8 @@ class AddCleanupUpdaterBackupsJob implements IRepairStep {
 	}
 
 	public function run(IOutput $output): void {
-		$this->jobList->add(BackgroundCleanupUpdaterBackupsJob::class);
+		if ($this->config->getSystemValueBool('updater.cleanup_backups', true)) {
+			$this->jobList->add(BackgroundCleanupUpdaterBackupsJob::class);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Since the updater can be used with `--no-backup`, which doesn't create the backups folder in the first place, it isn't required to make this check in this case, which sends a warning-level log if it doesn't find the folder. So let's add a way to at least skip this.

Follow-up to #48674

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
