### PR TITLE
fix(phpunit): migrate from deprecated syntax for PHPUnit 11.1

### DIFF
--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -56,4 +56,4 @@ jobs:
       - name: PHPUnit
         uses: docker://ghcr.io/nextcloud/continuous-integration-php8.4-32bit:latest
         with:
-          args: /bin/sh -c "composer run test -- --exclude-group PRIMARY-azure,PRIMARY-s3,PRIMARY-swift,Memcached,Redis,RoutingWeirdness"
+          args: /bin/sh -c "composer run test -- --exclude-group PRIMARY-azure --exclude-group PRIMARY-s3 --exclude-group PRIMARY-swift --exclude-group Memcached --exclude-group Redis --exclude-group RoutingWeirdness"

--- a/autotest.sh
+++ b/autotest.sh
@@ -371,13 +371,13 @@ function execute_tests {
 	fi
 	GROUP=''
 	if [ "$TEST_SELECTION" == "QUICKDB" ]; then
-		GROUP='--group DB --exclude-group=SLOWDB'
+		GROUP='--group DB --exclude-group SLOWDB'
 	fi
 	if [ "$TEST_SELECTION" == "DB" ]; then
-		GROUP='--group DB,SLOWDB'
+		GROUP='--group DB --group SLOWDB'
 	fi
 	if [ "$TEST_SELECTION" == "NODB" ]; then
-		GROUP='--exclude-group DB,SLOWDB'
+		GROUP='--exclude-group DB --exclude-group SLOWDB'
 	fi
 	if [ "$TEST_SELECTION" == "PRIMARY-s3" ]; then
 		GROUP='--group PRIMARY-s3'


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Ref: https://github.com/sebastianbergmann/phpunit/blob/11.5/DEPRECATIONS.md

## Summary

comma-separated-values for some PHPUnit CLI were deprecated for some time, but not migrated in all search hits (see changelog and deprecations)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
