### PR TITLE
fix(oauth2): Do not store the code in throttle metadata

### DIFF
--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -93,7 +93,7 @@ class OauthApiController extends Controller {
 			$response = new JSONResponse([
 				'error' => 'invalid_request',
 			], Http::STATUS_BAD_REQUEST);
-			$response->throttle(['invalid_request' => 'token not found', 'code' => $code]);
+			$response->throttle(['invalid_request' => 'token not found']);
 			return $response;
 		}
 

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -98,7 +98,7 @@ class OauthApiControllerTest extends TestCase {
 		$expected = new JSONResponse([
 			'error' => 'invalid_request',
 		], Http::STATUS_BAD_REQUEST);
-		$expected->throttle(['invalid_request' => 'token not found', 'code' => 'invalidcode']);
+		$expected->throttle(['invalid_request' => 'token not found']);
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('invalidcode')
@@ -194,7 +194,7 @@ class OauthApiControllerTest extends TestCase {
 		$expected = new JSONResponse([
 			'error' => 'invalid_request',
 		], Http::STATUS_BAD_REQUEST);
-		$expected->throttle(['invalid_request' => 'token not found', 'code' => 'invalidrefresh']);
+		$expected->throttle(['invalid_request' => 'token not found']);
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('invalidrefresh')


### PR DESCRIPTION
## Summary


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
