### PR TITLE
refactor(setup): unify generated DB password handling across MySQL and PostgreSQL

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -76,6 +76,27 @@ abstract class AbstractDatabase {
 	}
 
 	/**
+	 * Generate a strong random password suitable for database user accounts.
+	 *
+	 * Guarantees at least 2 uppercase, 2 lowercase, 2 digit, and 2 symbol
+	 * characters are present, with symbols filtered to exclude characters
+	 * that are problematic in SQL string contexts (", \, ', `).
+	 *
+	 * @return string A 30-character random password
+	 */
+	protected function generateDbPassword(): string {
+		$safeSymbols = str_replace(['\"', '\\', '\'', '`'], '', ISecureRandom::CHAR_SYMBOLS);
+
+		$password = $this->random->generate(22, ISecureRandom::CHAR_ALPHANUMERIC . $safeSymbols)
+			. $this->random->generate(2, ISecureRandom::CHAR_UPPER)
+			. $this->random->generate(2, ISecureRandom::CHAR_LOWER)
+			. $this->random->generate(2, ISecureRandom::CHAR_DIGITS)
+			. $this->random->generate(2, $safeSymbols);
+
+		return str_shuffle($password);
+	}
+
+	/**
 	 * @param array $configOverwrite
 	 * @return \OC\DB\Connection
 	 */

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -13,7 +13,6 @@ use OC\DatabaseSetupException;
 use OC\DB\ConnectionAdapter;
 use OC\DB\MySqlTools;
 use OCP\IDBConnection;
-use OCP\Security\ISecureRandom;
 
 class MySQL extends AbstractDatabase {
 	public string $dbprettyname = 'MySQL/MariaDB';
@@ -127,14 +126,8 @@ class MySQL extends AbstractDatabase {
 		$rootUser = $this->dbUser;
 		$rootPassword = $this->dbPassword;
 
-		//create a random password so we don't need to store the admin password in the config file
-		$saveSymbols = str_replace(['\"', '\\', '\'', '`'], '', ISecureRandom::CHAR_SYMBOLS);
-		$password = $this->random->generate(22, ISecureRandom::CHAR_ALPHANUMERIC . $saveSymbols)
-			. $this->random->generate(2, ISecureRandom::CHAR_UPPER)
-			. $this->random->generate(2, ISecureRandom::CHAR_LOWER)
-			. $this->random->generate(2, ISecureRandom::CHAR_DIGITS)
-			. $this->random->generate(2, $saveSymbols);
-		$this->dbPassword = str_shuffle($password);
+		// Create a random password so we don't need to store the admin password in the config file
+		$this->dbPassword = $this->generateDbPassword();
 
 		try {
 			//user already specified in config

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -11,8 +11,6 @@ use OC\DatabaseException;
 use OC\DatabaseSetupException;
 use OC\DB\Connection;
 use OC\DB\QueryBuilder\Literal;
-use OCP\Security\ISecureRandom;
-use OCP\Server;
 
 class PostgreSQL extends AbstractDatabase {
 	public $dbprettyname = 'PostgreSQL';
@@ -48,8 +46,9 @@ class PostgreSQL extends AbstractDatabase {
 
 					//add prefix to the postgresql user name to prevent collisions
 					$this->dbUser = 'oc_admin';
-					//create a new password so we don't need to store the admin config in the config file
-					$this->dbPassword = Server::get(ISecureRandom::class)->generate(30, ISecureRandom::CHAR_ALPHANUMERIC);
+
+					// Create a new password so we don't need to store the admin config in the config file
+					$this->dbPassword = $this->generateDbPassword();
 
 					$this->createDBUser($connection);
 				}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This refactor moves generated database-password creation into `AbstractDatabase` and reuses it in both MySQL and PostgreSQL setup flows.

Previously:

* MySQL generated a 30-character password with mixed character classes
* PostgreSQL generated a 30-character alphanumeric password via `Server::get(ISecureRandom::class)`

With this change:

* password generation is centralized in one helper
* MySQL keeps the existing stronger generation strategy
* PostgreSQL now uses the same generation strategy
* the PostgreSQL setup no longer relies on `Server::get()`

Why:

* removes duplicated password-generation logic
* keeps setup behavior consistent across database backends
* avoids service-locator usage where dependency injection is already available

Notes:

* generated symbols are filtered to avoid characters that are problematic in SQL string contexts: `"`, `\`, `'`, and ```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
