### PR TITLE
refactor(setup): extract DB user collision handling and normalize PostgreSQL suffixing

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -66,11 +66,13 @@ class MySQL extends AbstractDatabase {
 	 */
 	private function userExists(IDBConnection $connection, string $username): bool {
 		$result = $connection->executeQuery(
-			'SELECT user FROM mysql.user WHERE user=?',
+			'SELECT user FROM mysql.user WHERE user = ?',
 			[$username]
 		);
-		$exists = count($result->fetchAll()) > 0;
+
+		$exists = count($result->fetch() !== false;
 		$result->closeCursor();
+
 		return $exists;
 	}
 

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -18,6 +18,9 @@ use OCP\Security\ISecureRandom;
 class MySQL extends AbstractDatabase {
 	public string $dbprettyname = 'MySQL/MariaDB';
 
+	/** @var int MySQL username length limit */
+	private const MAX_USERNAME_LENGTH = 16;
+
 	public function setupDatabase(): void {
 		//check if the database user has admin right
 		$connection = $this->connect(['dbname' => null]);
@@ -56,6 +59,36 @@ class MySQL extends AbstractDatabase {
 			throw new DatabaseSetupException($this->trans->t('MySQL Login and/or password not valid'),
 				$this->trans->t('You need to enter details of an existing account.'), 0, $e);
 		}
+	}
+
+	/**
+	 * Check whether a MySQL user account already exists.
+	 */
+	private function userExists(IDBConnection $connection, string $username): bool {
+		$result = $connection->executeQuery(
+			'SELECT user FROM mysql.user WHERE user=?',
+			[$username]
+		);
+		$exists = count($result->fetchAll()) > 0;
+		$result->closeCursor();
+		return $exists;
+	}
+
+	/**
+	 * Find a username starting from $base that doesn't already exist,
+	 * respecting MySQL's 16-character username limit.
+	 */
+	private function findAvailableUsername(IDBConnection $connection, string $base): string {
+		$candidate = substr($base, 0, self::MAX_USERNAME_LENGTH);
+
+		$i = 1;
+		while ($this->userExists($connection, $candidate)) {
+			$suffix = (string)$i;
+			$candidate = substr($base, 0, self::MAX_USERNAME_LENGTH - strlen($suffix)) . $suffix;
+			$i++;
+		}
+
+		return $candidate;
 	}
 
 	private function createDatabase(\OC\DB\Connection $connection): void {
@@ -143,35 +176,12 @@ class MySQL extends AbstractDatabase {
 			//we don't have a dbuser specified in config
 			if ($this->dbUser !== $oldUser) {
 				//add prefix to the admin username to prevent collisions
-				$adminUser = substr('oc_' . $username, 0, 16);
-
-				$i = 1;
-				while (true) {
-					//this should be enough to check for admin rights in mysql
-					$query = 'SELECT user FROM mysql.user WHERE user=?';
-					$result = $connection->executeQuery($query, [$adminUser]);
-
-					//current dbuser has admin rights
-					$data = $result->fetchAll();
-					$result->closeCursor();
-					//new dbuser does not exist
-					if (count($data) === 0) {
-						//use the admin login data for the new database user
-						$this->dbUser = $adminUser;
-						$this->createDBUser($connection);
-						// if sharding is used we need to manually call this for every shard as those also need the user setup!
-						/** @var ConnectionAdapter $connection */
-						foreach ($connection->getInner()->getShardConnections() as $shard) {
-							$this->createDBUser($shard);
-						}
-
-						break;
-					} else {
-						//repeat with different username
-						$length = strlen((string)$i);
-						$adminUser = substr('oc_' . $username, 0, 16 - $length) . $i;
-						$i++;
-					}
+				$this->dbUser = $this->findAvailableUsername($connection, 'oc_' . $username);
+				$this->createDBUser($connection);
+				// if sharding is used we need to manually call this for every shard as those also need the user setup!
+				/** @var ConnectionAdapter $connection */
+				foreach ($connection->getInner()->getShardConnections() as $shard) {
+					$this->createDBUser($shard);
 				}
 			} else {
 				// Reuse existing password if a database config is already present

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -70,7 +70,7 @@ class MySQL extends AbstractDatabase {
 			[$username]
 		);
 
-		$exists = count($result->fetch() !== false;
+		$exists = $result->fetch() !== false;
 		$result->closeCursor();
 
 		return $exists;

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -103,6 +103,21 @@ class PostgreSQL extends AbstractDatabase {
 		}
 	}
 
+	/**
+	 * Find a role name starting from $base that doesn't already exist.
+	 */
+	private function findAvailableUsername(Connection $connection, string $base): string {
+		$candidate = $base;
+
+		$i = 1;
+		while ($this->userExists($connection, $candidate)) {
+			$i++;
+			$candidate = $base . $i;
+		}
+
+		return $candidate;
+	}
+
 	private function createDatabase(Connection $connection): void {
 		if (!$this->databaseExists($connection)) {
 			//The database does not exists... let's create it
@@ -126,12 +141,15 @@ class PostgreSQL extends AbstractDatabase {
 		}
 	}
 
-	private function userExists(Connection $connection): bool {
+	/**
+	 * Check whether a PostgreSQL role already exists.
+	 */
+	private function userExists(Connection $connection, string $username): bool {
 		$builder = $connection->getQueryBuilder();
 		$builder->automaticTablePrefix(false);
-		$query = $builder->select('*')
+		$query = $builder->select('rolname')
 			->from('pg_roles')
-			->where($builder->expr()->eq('rolname', $builder->createNamedParameter($this->dbUser)));
+			->where($builder->expr()->eq('rolname', $builder->createNamedParameter($username)));
 		$result = $query->executeQuery();
 		return $result->rowCount() > 0;
 	}
@@ -147,14 +165,8 @@ class PostgreSQL extends AbstractDatabase {
 	}
 
 	private function createDBUser(Connection $connection): void {
-		$dbUser = $this->dbUser;
+		$this->dbUser = $this->findAvailableUsername($connection, $this->dbUser);
 		try {
-			$i = 1;
-			while ($this->userExists($connection)) {
-				$i++;
-				$this->dbUser = $dbUser . $i;
-			}
-
 			// create the user
 			$query = $connection->prepare('CREATE USER "' . addslashes($this->dbUser) . "\" CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
 			$query->executeStatement();

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -108,11 +108,11 @@ class PostgreSQL extends AbstractDatabase {
 	 */
 	private function findAvailableUsername(Connection $connection, string $base): string {
 		$candidate = $base;
+		$suffix = 1;
 
-		$i = 1;
 		while ($this->userExists($connection, $candidate)) {
-			$i++;
-			$candidate = $base . $i;
+			$candidate = $base . $suffix;
+			$suffix++;
 		}
 
 		return $candidate;

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -150,19 +150,36 @@ class PostgreSQL extends AbstractDatabase {
 	private function userExists(Connection $connection, string $username): bool {
 		$builder = $connection->getQueryBuilder();
 		$builder->automaticTablePrefix(false);
+
 		$query = $builder->select('rolname')
 			->from('pg_roles')
-			->where($builder->expr()->eq('rolname', $builder->createNamedParameter($username)));
+			->where(
+				$builder->expr()->eq(
+					'rolname',
+					$builder->createNamedParameter($username)
+				)
+			);
+
 		$result = $query->executeQuery();
-		return $result->rowCount() > 0;
+		$exists = $result->fetch() !== false;
+		$result->closeCursor();
+
+		return $exists;
 	}
 
 	private function databaseExists(Connection $connection): bool {
 		$builder = $connection->getQueryBuilder();
 		$builder->automaticTablePrefix(false);
+
 		$query = $builder->select('datname')
 			->from('pg_database')
-			->where($builder->expr()->eq('datname', $builder->createNamedParameter($this->dbName)));
+			->where(
+				$builder->expr()->eq(
+					'datname',
+					$builder->createNamedParameter($this->dbName)
+				)
+			);
+
 		$result = $query->executeQuery();
 		return $result->rowCount() > 0;
 	}

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -15,6 +15,8 @@ use OCP\Security\ISecureRandom;
 use OCP\Server;
 
 class PostgreSQL extends AbstractDatabase {
+	/** @var int PostgreSQL identifier length limit */
+	private const MAX_USERNAME_LENGTH = 63;
 	public $dbprettyname = 'PostgreSQL';
 
 	/**
@@ -107,11 +109,12 @@ class PostgreSQL extends AbstractDatabase {
 	 * Find a role name starting from $base that doesn't already exist.
 	 */
 	private function findAvailableUsername(Connection $connection, string $base): string {
-		$candidate = $base;
+		$candidate = substr($base, 0, self::MAX_USERNAME_LENGTH);
 		$suffix = 1;
 
 		while ($this->userExists($connection, $candidate)) {
-			$candidate = $base . $suffix;
+			$suffixString = (string)$suffix;
+			$candidate = substr($base, 0, self::MAX_USERNAME_LENGTH - strlen($suffixString)) . $suffixString;
 			$suffix++;
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This refactor extracts the database user/role collision handling into dedicated helpers in the MySQL and PostgreSQL setup classes, reduces hidden mutation, and makes DB-specific naming constraints explicit.

### What changed

- extract `userExists()` helpers so existence checks no longer rely on implicit reads from `$this->dbUser`
- extract `findAvailableUsername()` helpers to isolate collision-avoidance logic
- make MySQL’s username-length limit explicit via a named constant
- add explicit PostgreSQL identifier-length handling
- move `$this->dbUser` assignment out of collision loops for better readability and less mutation
- normalize PostgreSQL suffixing to use `base`, `base1`, `base2`, ... when collisions occur

### Why

This makes the setup flow easier to follow, reduces duplicated loop logic, and makes future refactors in the database setup classes safer and easier to reason about.

### Notes

- MySQL/MariaDB username truncation and suffixing behavior is preserved
- PostgreSQL collision handling is now implemented in a dedicated helper
- PostgreSQL collision suffixing now starts at `1` instead of skipping to `2`

Related: #59092

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
