### PR TITLE
fix(getDisabledUsers): fix `occ user:list --disabled --limit 0` command not returning any user even though some disabled users exist on the instance

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -330,6 +330,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			}
 		}
 
+		$limit = $limit === 0 ? null : $limit;
 		return array_slice($users, $offset, $limit);
 	}
 


### PR DESCRIPTION
- fix `occ user:list --disabled --limit 0` command not returning any user even though some disabled users exist on the instance.
- Fix is done as suggested by a customer.