### PR TITLE
refactor(setup): extract/add canCreateUsers() helper for MySQL and PostgreSQL

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -32,7 +32,7 @@ class MySQL extends AbstractDatabase {
 			$connection = $this->connect(['dbname' => null]);
 		}
 
-		if ($this->tryCreateDbUser) {
+		if ($this->tryCreateDbUser && $this->canCreateUsers($connection)) {
 			$this->createSpecificUser('oc_admin', new ConnectionAdapter($connection));
 		}
 
@@ -73,6 +73,24 @@ class MySQL extends AbstractDatabase {
 		$result->closeCursor();
 		return $exists;
 	}
+
+	/**
+	 * Check whether the current connection user has rights to create other users.
+	 *
+	 * In MySQL, the ability to SELECT from mysql.user is a sufficient proxy
+	 * for administrative privileges — unprivileged users cannot read it.
+	 * The actual createDBUser() call will fail with a clear error if the
+	 * privilege assumption is wrong.
+	 */
+	private function canCreateUsers(IDBConnection $connection): bool {
+		try {
+			$connection->executeQuery('SELECT COUNT(*) FROM mysql.user LIMIT 1');
+			return true;
+		} catch (\Exception $e) {
+			return false;
+		}
+	}
+
 
 	/**
 	 * Find a username starting from $base that doesn't already exist,

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -27,22 +27,7 @@ class PostgreSQL extends AbstractDatabase {
 			]);
 			if ($this->tryCreateDbUser) {
 				//check for roles creation rights in postgresql
-				$builder = $connection->getQueryBuilder();
-				$builder->automaticTablePrefix(false);
-				$query = $builder
-					->select('rolname')
-					->from('pg_roles')
-					->where($builder->expr()->eq('rolcreaterole', new Literal('TRUE')))
-					->andWhere($builder->expr()->eq('rolname', $builder->createNamedParameter($this->dbUser)));
-
-				try {
-					$result = $query->executeQuery();
-					$canCreateRoles = $result->rowCount() > 0;
-				} catch (DatabaseException $e) {
-					$canCreateRoles = false;
-				}
-
-				if ($canCreateRoles) {
+				if ($this->canCreateUsers($connection)) {
 					$connectionMainDatabase = $this->connect();
 					//use the admin login data for the new database user
 
@@ -52,21 +37,12 @@ class PostgreSQL extends AbstractDatabase {
 					$this->dbPassword = Server::get(ISecureRandom::class)->generate(30, ISecureRandom::CHAR_ALPHANUMERIC);
 
 					$this->createDBUser($connection);
-				}
-			}
 
-			$this->config->setValues([
-				'dbuser' => $this->dbUser,
-				'dbpassword' => $this->dbPassword,
-			]);
+					//create the database
+					$this->createDatabase($connection);
+					// the connection to dbname=postgres is not needed anymore
+					$connection->close();
 
-			//create the database
-			$this->createDatabase($connection);
-			// the connection to dbname=postgres is not needed anymore
-			$connection->close();
-
-			if ($this->tryCreateDbUser) {
-				if ($canCreateRoles) {
 					// Go to the main database and grant create on the public schema
 					// The code below is implemented to make installing possible with PostgreSQL version 15:
 					// https://www.postgresql.org/docs/release/15.0/
@@ -76,10 +52,26 @@ class PostgreSQL extends AbstractDatabase {
 					// Also see https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PATTERNS
 					$connectionMainDatabase->executeQuery('GRANT CREATE ON SCHEMA public TO "' . addslashes($this->dbUser) . '"');
 					$connectionMainDatabase->close();
+				} else {
+					//create the database
+					$this->createDatabase($connection);
+					// the connection to dbname=postgres is not needed anymore
+					$connection->close();
 				}
+			} else {
+				//create the database
+				$this->createDatabase($connection);
+				// the connection to dbname=postgres is not needed anymore
+				$connection->close();
 			}
+
+			$this->config->setValues([
+				'dbuser' => $this->dbUser,
+				'dbpassword' => $this->dbPassword,
+			]);
 		} catch (\Exception $e) {
-			$this->logger->warning('Error trying to connect as "postgres", assuming database is setup and tables need to be created', [
+			$this->logger->warning(
+				'Error trying to connect as "postgres", assuming database is setup and tables need to be created', [
 				'exception' => $e,
 			]);
 			$this->config->setValues([
@@ -152,6 +144,26 @@ class PostgreSQL extends AbstractDatabase {
 			->where($builder->expr()->eq('rolname', $builder->createNamedParameter($username)));
 		$result = $query->executeQuery();
 		return $result->rowCount() > 0;
+	}
+
+	/**
+	 * Check whether the current connection user has the CREATEROLE privilege.
+	 */
+	private function canCreateUsers(Connection $connection): bool {
+		$builder = $connection->getQueryBuilder();
+		$builder->automaticTablePrefix(false);
+		$query = $builder
+			->select('rolname')
+			->from('pg_roles')
+			->where($builder->expr()->eq('rolcreaterole', new Literal('TRUE')))
+			->andWhere($builder->expr()->eq('rolname', $builder->createNamedParameter($this->dbUser)));
+
+		try {
+			$result = $query->executeQuery();
+			return $result->rowCount() > 0;
+		} catch (DatabaseException $e) {
+			return false;
+		}
 	}
 
 	private function databaseExists(Connection $connection): bool {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
