### PR TITLE
fix(sharing): Surface specific error message on share update failure

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1390,6 +1390,8 @@ class ShareAPIController extends OCSController {
 		} catch (HintException $e) {
 			$code = $e->getCode() === 0 ? 403 : $e->getCode();
 			throw new OCSException($e->getHint(), (int)$code);
+		} catch (\InvalidArgumentException $e) {
+			throw new OCSBadRequestException($e->getMessage(), $e);
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new OCSBadRequestException('Failed to update share.', $e);


### PR DESCRIPTION
InvalidArgumentException from the share manager (e.g. "Cannot enable sending the password by Talk with an empty password") was caught by the generic Exception handler and re-thrown as "Failed to update share.", hiding the actual cause from the user. Catch it separately to preserve the original message.

