### PR TITLE
fix(ICalendar): allow to search for event URI

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2062,6 +2062,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$outerQuery->andWhere($outerQuery->expr()->eq('uid', $outerQuery->createNamedParameter($options['uid'])));
 		}
 
+		if (isset($options['uri'])) {
+			$outerQuery->andWhere($outerQuery->expr()->eq('uri', $outerQuery->createNamedParameter($options['uri'])));
+		}
+
 		if (!empty($options['types'])) {
 			$or = [];
 			foreach ($options['types'] as $type) {

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -1840,6 +1840,72 @@ EOD;
 		$this->assertEquals('Missing DTSTART 2', $results[3]['objects'][0]['SUMMARY'][0]);
 	}
 
+	public function testSearchByUri(): void {
+		$calendarId = $this->createTestCalendar();
+		$uris = [];
+		$calData = [];
+
+		$uris[] = static::getUniqueID('calobj');
+		$calData[] = <<<'EOD'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:Nextcloud Calendar
+BEGIN:VEVENT
+CREATED;VALUE=DATE-TIME:20260323T093039Z
+UID:search-by-uri-test1
+LAST-MODIFIED;VALUE=DATE-TIME:20260323T093039Z
+DTSTAMP;VALUE=DATE-TIME:20260323T093039Z
+SUMMARY:First Test Event
+DTSTART;VALUE=DATE-TIME:20260323T093039Z
+DTEND;VALUE=DATE-TIME:20260323T093039Z
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+EOD;
+
+		$uris[] = static::getUniqueID('calobj');
+		$calData[] = <<<'EOD'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:Nextcloud Calendar
+BEGIN:VEVENT
+CREATED;VALUE=DATE-TIME:20260323T093039Z
+UID:search-by-uri-test2
+LAST-MODIFIED;VALUE=DATE-TIME:20260323T093039Z
+DTSTAMP;VALUE=DATE-TIME:20260323T093039Z
+SUMMARY:Second Test Event
+DTSTART;VALUE=DATE-TIME:20260323T093039Z
+DTEND;VALUE=DATE-TIME:20260323T093039Z
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+EOD;
+
+		foreach ($uris as $i => $uri) {
+			$this->backend->createCalendarObject($calendarId, $uri, $calData[$i]);
+		}
+
+		$calendarInfo = [
+			'id' => $calendarId,
+			'principaluri' => 'user1',
+			'{http://owncloud.org/ns}owner-principal' => 'user1',
+		];
+
+		// Searching by first event's URI returns this event
+		$results = $this->backend->search($calendarInfo, '', [], ['uri' => $uris[0]], null, null);
+		$this->assertCount(1, $results);
+		$this->assertEquals($uris[0], $results[0]['uri']);
+
+		// Searching by second event's URI returns this event
+		$results = $this->backend->search($calendarInfo, '', [], ['uri' => $uris[1]], null, null);
+		$this->assertCount(1, $results);
+		$this->assertEquals($uris[1], $results[0]['uri']);
+
+		// Searching by a non-existent URI returns nothing
+		$result = $this->backend->search($calendarInfo, '', [], ['uri' => 'nonexistant.ical'], null, null);
+		$this->assertCount(0, $result);
+	}
+
 	public function testUnshare(): void {
 		$principalGroup = 'principal:' . self::UNIT_TEST_GROUP;
 		$principalUser = 'principal:' . self::UNIT_TEST_USER;

--- a/lib/public/Calendar/ICalendar.php
+++ b/lib/public/Calendar/ICalendar.php
@@ -18,6 +18,7 @@ use DateTimeInterface;
  * @psalm-type CalendarSearchOptions = array{
  *     timerange?: array{start?: DateTimeInterface, end?: DateTimeInterface},
  *     uid?: string,
+ *     uri?: string,
  *     types?: string[],
  * }
  */
@@ -60,6 +61,7 @@ interface ICalendar {
 	 * @param array $options Optional parameters for the search:
 	 *                       - 'timerange' element that can have 'start' (DateTimeInterface), 'end' (DateTimeInterface), or both.
 	 *                       - 'uid' element to look for events with a given uid.
+	 *                       - 'uri' element to look for events with a given uri.
 	 *                       - 'types' element to only return events for a given type (e.g. VEVENT or VTODO)
 	 * @psalm-param CalendarSearchOptions $options
 	 * @param int|null $limit Limit the number of search results.


### PR DESCRIPTION
Required for https://github.com/nextcloud/calendar/pull/8048

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
