### PR TITLE
test(cypress): improve resilience of files-copy-move sharing tests

### DIFF
--- a/cypress/e2e/files_sharing/files-copy-move.cy.ts
+++ b/cypress/e2e/files_sharing/files-copy-move.cy.ts
@@ -19,44 +19,52 @@ export function copyFileForbidden(fileName: string, dirPath: string) {
 	getRowForFile(fileName).should('be.visible')
 	triggerActionForFile(fileName, ACTION_COPY_MOVE)
 
-	cy.get('.file-picker').within(() => {
-		// intercept the copy so we can wait for it
-		cy.intercept('COPY', /\/(remote|public)\.php\/dav\/files\//).as('copyFile')
+	cy.get('.file-picker').should('be.visible')
 
-		const directories = dirPath.split('/')
-		directories.forEach((directory) => {
-			// select the folder
-			cy.get(`[data-filename="${CSS.escape(directory)}"]`).should('be.visible').click()
-		})
-
-		// check copy button
-		cy.contains('button', `Copy to ${directories.at(-1)}`).should('be.disabled')
+	const directories = dirPath.split('/')
+	directories.forEach((directory) => {
+		cy.get('.file-picker')
+			.find(`[data-filename="${CSS.escape(directory)}"]`)
+			.should('be.visible')
+			.click()
 	})
+
+	// Re-query after possible re-render and assert eventual disabled state
+	cy.get('.file-picker')
+		.contains('button', `Copy to ${directories.at(-1)}`, { timeout: 10000 })
+		.should('be.visible')
+		.and('be.disabled')
 }
 
 export function moveFileForbidden(fileName: string, dirPath: string) {
 	getRowForFile(fileName).should('be.visible')
 	triggerActionForFile(fileName, ACTION_COPY_MOVE)
 
-	cy.get('.file-picker').within(() => {
-		// intercept the copy so we can wait for it
-		cy.intercept('MOVE', /\/(remote|public)\.php\/dav\/files\//).as('moveFile')
+	cy.get('.file-picker').should('be.visible')
 
-		// select home folder
-		cy.get('.breadcrumb')
-			.findByRole('button', { name: 'All files' })
+	// Avoid stale chained subject when breadcrumb re-renders
+	cy.get('.file-picker .breadcrumb')
+		.findByRole('button', { name: 'All files' })
+		.should('be.visible')
+		.click()
+
+	// Re-acquire file picker after navigation click
+	cy.get('.file-picker').should('be.visible')
+
+	const directories = dirPath.split('/')
+	directories.forEach((directory) => {
+		cy.get('.file-picker')
+			.find(`[data-filename="${CSS.escape(directory)}"]`)
 			.should('be.visible')
 			.click()
-
-		const directories = dirPath.split('/')
-		directories.forEach((directory) => {
-			// select the folder
-			cy.get(`[data-filename="${directory}"]`).should('be.visible').click()
-		})
-
-		// click move
-		cy.contains('button', `Move to ${directories.at(-1)}`).should('not.exist')
 	})
+
+	// If move is forbidden, the move button should not be present.
+	// Use should('not.contain') on the parent to avoid the cy.contains() + should('not.exist')
+	// anti-pattern, where cy.contains() must first find the element before the negation can pass,
+	// causing unnecessary waits or false failures.
+	cy.get('.file-picker', { timeout: 10000 })
+		.should('not.contain', `Move to ${directories.at(-1)}`)
 }
 
 describe('files_sharing: Move or copy files', { testIsolation: true }, () => {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Hardens the `files-copy-move.cy.ts` Cypress tests against flaky failures caused by DOM re-renders inside the file picker.

Changes:

- **Drop `.within()` scoping** in `copyFileForbidden` and `moveFileForbidden` — the file picker can re-render during navigation, leaving `.within()` bound to a detached element. Each command now re-queries from the root.
- **Remove dead `cy.intercept()` calls** — both helpers registered intercepts that were never `cy.wait()`-ed on.
- **Add visibility gates** — `cy.get('.file-picker').should('be.visible')` before first interaction and after breadcrumb navigation.
- **Fix missing `CSS.escape()`** in `moveFileForbidden` directory selector, matching the existing pattern in `copyFileForbidden`.
- **Fix `should('not.exist')` anti-pattern** — `cy.contains(selector)` must find an element before a chained `.should('not.exist')` can negate it, causing unnecessary full-timeout waits. Replaced with `cy.get('.file-picker').should('not.contain', text)`.
- **Increase assertion timeouts** to 10 s for button state checks on slower CI runners.

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
