### PR TITLE
fix(dav): Stop sending reminders for deleted calendar events

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/Backend.php
+++ b/apps/dav/lib/CalDAV/Reminder/Backend.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2019-2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 namespace OCA\DAV\CalDAV\Reminder;
@@ -11,19 +11,7 @@ namespace OCA\DAV\CalDAV\Reminder;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
 
-/**
- * Class Backend
- *
- * @package OCA\DAV\CalDAV\Reminder
- */
 class Backend {
-
-	/**
-	 * Backend constructor.
-	 *
-	 * @param IDBConnection $db
-	 * @param ITimeFactory $timeFactory
-	 */
 	public function __construct(
 		protected IDBConnection $db,
 		protected ITimeFactory $timeFactory,
@@ -31,64 +19,73 @@ class Backend {
 	}
 
 	/**
-	 * Get all reminders with a notification date before now
-	 *
-	 * @return array
-	 * @throws \Exception
+	 * Get all reminders with a notification date before now,
+	 * excluding objects that have been moved to the trashbin.
 	 */
-	public function getRemindersToProcess():array {
+	public function getRemindersToProcess(): array {
 		$query = $this->db->getQueryBuilder();
-		$query->select(['cr.id', 'cr.calendar_id','cr.object_id','cr.is_recurring','cr.uid','cr.recurrence_id','cr.is_recurrence_exception','cr.event_hash','cr.alarm_hash','cr.type','cr.is_relative','cr.notification_date','cr.is_repeat_based','co.calendardata', 'c.displayname', 'c.principaluri'])
-			->from('calendar_reminders', 'cr')
-			->where($query->expr()->lte('cr.notification_date', $query->createNamedParameter($this->timeFactory->getTime())))
-			->join('cr', 'calendarobjects', 'co', $query->expr()->eq('cr.object_id', 'co.id'))
-			->join('cr', 'calendars', 'c', $query->expr()->eq('cr.calendar_id', 'c.id'))
-			->groupBy('cr.event_hash', 'cr.notification_date', 'cr.type', 'cr.id', 'cr.calendar_id', 'cr.object_id', 'cr.is_recurring', 'cr.uid', 'cr.recurrence_id', 'cr.is_recurrence_exception', 'cr.alarm_hash', 'cr.is_relative', 'cr.is_repeat_based', 'co.calendardata', 'c.displayname', 'c.principaluri');
-		$stmt = $query->executeQuery();
 
-		return array_map(
-			[$this, 'fixRowTyping'],
-			$stmt->fetchAllAssociative()
-		);
+		$columns = [
+			'cr.id',
+			'cr.calendar_id',
+			'cr.object_id',
+			'cr.is_recurring',
+			'cr.uid',
+			'cr.recurrence_id',
+			'cr.is_recurrence_exception',
+			'cr.event_hash',
+			'cr.alarm_hash',
+			'cr.type',
+			'cr.is_relative',
+			'cr.notification_date',
+			'cr.is_repeat_based',
+			'co.calendardata',
+			'c.displayname',
+			'c.principaluri',
+		];
+
+		$query->select($columns)
+			->from('calendar_reminders', 'cr')
+			->where($query->expr()->lte(
+				'cr.notification_date',
+				$query->createNamedParameter($this->timeFactory->getTime())
+			))
+			->join('cr', 'calendarobjects', 'co', $query->expr()->andX(
+				$query->expr()->eq('cr.object_id', 'co.id'),
+				$query->expr()->isNull('co.deleted_at')
+			))
+			->join('cr', 'calendars', 'c', $query->expr()->eq('cr.calendar_id', 'c.id'));
+
+		$stmt = $query->executeQuery();
+		$rows = $stmt->fetchAllAssociative();
+		$stmt->free();
+
+		return array_map([$this, 'fixRowTyping'], $rows);
 	}
 
 	/**
-	 * Get all scheduled reminders for an event
-	 *
-	 * @param int $objectId
-	 * @return array
+	 * Get all scheduled reminders for an event.
 	 */
-	public function getAllScheduledRemindersForEvent(int $objectId):array {
+	public function getAllScheduledRemindersForEvent(int $objectId): array {
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from('calendar_reminders')
 			->where($query->expr()->eq('object_id', $query->createNamedParameter($objectId)));
-		$stmt = $query->executeQuery();
 
-		return array_map(
-			[$this, 'fixRowTyping'],
-			$stmt->fetchAllAssociative()
-		);
+		$stmt = $query->executeQuery();
+		$rows = $stmt->fetchAllAssociative();
+		$stmt->free();
+
+		return array_map([$this, 'fixRowTyping'], $rows);
 	}
 
 	/**
-	 * Insert a new reminder into the database
+	 * Insert a new reminder into the database.
 	 *
-	 * @param int $calendarId
-	 * @param int $objectId
-	 * @param string $uid
-	 * @param bool $isRecurring
-	 * @param int $recurrenceId
-	 * @param bool $isRecurrenceException
-	 * @param string $eventHash
-	 * @param string $alarmHash
-	 * @param string $type
-	 * @param bool $isRelative
-	 * @param int $notificationDate
-	 * @param bool $isRepeatBased
 	 * @return int The insert id
 	 */
-	public function insertReminder(int $calendarId,
+	public function insertReminder(
+		int $calendarId,
 		int $objectId,
 		string $uid,
 		bool $isRecurring,
@@ -99,7 +96,8 @@ class Backend {
 		string $type,
 		bool $isRelative,
 		int $notificationDate,
-		bool $isRepeatBased):int {
+		bool $isRepeatBased,
+	): int {
 		$query = $this->db->getQueryBuilder();
 		$query->insert('calendar_reminders')
 			->values([
@@ -122,13 +120,12 @@ class Backend {
 	}
 
 	/**
-	 * Sets a new notificationDate on an existing reminder
-	 *
-	 * @param int $reminderId
-	 * @param int $newNotificationDate
+	 * Set a new notification date on an existing reminder.
 	 */
-	public function updateReminder(int $reminderId,
-		int $newNotificationDate):void {
+	public function updateReminder(
+		int $reminderId,
+		int $newNotificationDate
+	): void {
 		$query = $this->db->getQueryBuilder();
 		$query->update('calendar_reminders')
 			->set('notification_date', $query->createNamedParameter($newNotificationDate))
@@ -137,12 +134,9 @@ class Backend {
 	}
 
 	/**
-	 * Remove a reminder by it's id
-	 *
-	 * @param integer $reminderId
-	 * @return void
+	 * Remove a reminder by its id.
 	 */
-	public function removeReminder(int $reminderId):void {
+	public function removeReminder(int $reminderId): void {
 		$query = $this->db->getQueryBuilder();
 
 		$query->delete('calendar_reminders')
@@ -151,11 +145,9 @@ class Backend {
 	}
 
 	/**
-	 * Cleans reminders in database
-	 *
-	 * @param int $objectId
+	 * Remove all reminders for a calendar object.
 	 */
-	public function cleanRemindersForEvent(int $objectId):void {
+	public function cleanRemindersForEvent(int $objectId): void {
 		$query = $this->db->getQueryBuilder();
 
 		$query->delete('calendar_reminders')
@@ -164,12 +156,9 @@ class Backend {
 	}
 
 	/**
-	 * Remove all reminders for a calendar
-	 *
-	 * @param int $calendarId
-	 * @return void
+	 * Remove all reminders for a calendar.
 	 */
-	public function cleanRemindersForCalendar(int $calendarId):void {
+	public function cleanRemindersForCalendar(int $calendarId): void {
 		$query = $this->db->getQueryBuilder();
 
 		$query->delete('calendar_reminders')
@@ -177,10 +166,6 @@ class Backend {
 			->executeStatement();
 	}
 
-	/**
-	 * @param array $row
-	 * @return array
-	 */
 	private function fixRowTyping(array $row): array {
 		$row['id'] = (int)$row['id'];
 		$row['calendar_id'] = (int)$row['calendar_id'];

--- a/apps/dav/lib/CalDAV/Reminder/Backend.php
+++ b/apps/dav/lib/CalDAV/Reminder/Backend.php
@@ -58,7 +58,7 @@ class Backend {
 
 		$stmt = $query->executeQuery();
 		$rows = $stmt->fetchAllAssociative();
-		$stmt->free();
+		$stmt->closeCursor();
 
 		return array_map([$this, 'fixRowTyping'], $rows);
 	}
@@ -74,7 +74,7 @@ class Backend {
 
 		$stmt = $query->executeQuery();
 		$rows = $stmt->fetchAllAssociative();
-		$stmt->free();
+		$stmt->closeCursor();
 
 		return array_map([$this, 'fixRowTyping'], $rows);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #53497 <!-- related github issue -->

## Summary

Notifications were still being sent for calendar events that had been deleted (moved to the trashbin).

Changes

- **Bug fix**: Added `co.deleted_at IS NULL` to the `calendarobjects` join condition so trashed objects are excluded from reminder processing
  - Reviewer note: this is the main change - involving lines 53-55 (mapping to former line 44).
- Other:
  - Removed unnecessary `GROUP BY`
    - The query joins on primary keys with no aggregate functions, so duplicate rows are not possible
  - Added `$stmt->free()` to both query methods to release database cursors
  - Code cleanup:
    - Removed redundant docblocks
    - Fixed typos
    - Extracted column list for readability
    - Misc formatting

Only true changes: lines 53-55 (former line 43) and the dropping of the `groupBy` (former line 46).

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
