### PR TITLE
fix(DnsPinning): Ensure to always lookup based on FQDN

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -26,6 +26,17 @@ class DnsPinMiddleware {
 	}
 
 	/**
+	 * DNS lookups must end with a dot to be marked as
+	 * FQDN. Otherwise, a record without answer may trigger
+	 * a lookup on the local domain name. See GitHub
+	 * issue #56489 for details.
+	 */
+	private function enforceFqdn(string $hostname): string {
+		$trimmedHostname = rtrim($hostname, '.');
+		return "$trimmedHostname.";
+	}
+
+	/**
 	 * Fetch soa record for a target
 	 */
 	private function soaRecord(string $target): ?array {
@@ -35,7 +46,7 @@ class DnsPinMiddleware {
 		$second = array_pop($labels);
 
 		$hostname = $second . '.' . $top;
-		$responses = $this->dnsGetRecord($hostname, DNS_SOA);
+		$responses = $this->dnsGetRecord($this->enforceFqdn($hostname), DNS_SOA);
 
 		if ($responses === false || count($responses) === 0) {
 			return null;
@@ -68,7 +79,7 @@ class DnsPinMiddleware {
 				continue;
 			}
 
-			$dnsResponses = $this->dnsGetRecord($target, $dnsType);
+			$dnsResponses = $this->dnsGetRecord($this->enforceFqdn($target), $dnsType);
 			if ($dnsResponses !== false && count($dnsResponses) > 0) {
 				foreach ($dnsResponses as $dnsResponse) {
 					if (isset($dnsResponse['ip'])) {

--- a/tests/lib/Http/Client/DnsPinMiddlewareTest.php
+++ b/tests/lib/Http/Client/DnsPinMiddlewareTest.php
@@ -61,7 +61,7 @@ class DnsPinMiddlewareTest extends TestCase {
 			->method('dnsGetRecord')
 			->willReturnCallback(function (string $hostname, int $type) {
 				// example.com SOA
-				if ($hostname === 'example.com') {
+				if ($hostname === 'example.com.') {
 					return match ($type) {
 						DNS_SOA => [
 							[
@@ -76,7 +76,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.com A, AAAA, CNAME
-				if ($hostname === 'www.example.com') {
+				if ($hostname === 'www.example.com.') {
 					return match ($type) {
 						DNS_A => [],
 						DNS_AAAA => [],
@@ -93,7 +93,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.net SOA
-				if ($hostname === 'example.net') {
+				if ($hostname === 'example.net.') {
 					return match ($type) {
 						DNS_SOA => [
 							[
@@ -108,7 +108,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.net A, AAAA, CNAME
-				if ($hostname === 'www.example.net') {
+				if ($hostname === 'www.example.net.') {
 					return match ($type) {
 						DNS_A => [
 							[
@@ -154,7 +154,7 @@ class DnsPinMiddlewareTest extends TestCase {
 			->method('dnsGetRecord')
 			->willReturnCallback(function (string $hostname, int $type) {
 				// example.com SOA
-				if ($hostname === 'example.com') {
+				if ($hostname === 'example.com.') {
 					return match ($type) {
 						DNS_SOA => [
 							[
@@ -169,7 +169,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.com A, AAAA, CNAME
-				if ($hostname === 'www.example.com') {
+				if ($hostname === 'www.example.com.') {
 					return match ($type) {
 						DNS_A => [],
 						DNS_AAAA => [],
@@ -186,7 +186,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.net SOA
-				if ($hostname === 'example.net') {
+				if ($hostname === 'example.net.') {
 					return match ($type) {
 						DNS_SOA => [
 							[
@@ -201,7 +201,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.net A, AAAA, CNAME
-				if ($hostname === 'www.example.net') {
+				if ($hostname === 'www.example.net.') {
 					return match ($type) {
 						DNS_A => [
 							[
@@ -378,7 +378,7 @@ class DnsPinMiddlewareTest extends TestCase {
 			->method('dnsGetRecord')
 			->willReturnCallback(function (string $hostname, int $type) {
 				// example.com SOA
-				if ($hostname === 'example.com') {
+				if ($hostname === 'example.com.') {
 					return match ($type) {
 						DNS_SOA => [
 							[
@@ -393,7 +393,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.com A, AAAA, CNAME
-				if ($hostname === 'www.example.com') {
+				if ($hostname === 'www.example.com.') {
 					return match ($type) {
 						DNS_A => [],
 						DNS_AAAA => [],
@@ -410,7 +410,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.net SOA
-				if ($hostname === 'example.net') {
+				if ($hostname === 'example.net.') {
 					return match ($type) {
 						DNS_SOA => [
 							[
@@ -425,7 +425,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.net A, AAAA, CNAME
-				if ($hostname === 'www.example.net') {
+				if ($hostname === 'www.example.net.') {
 					return match ($type) {
 						DNS_A => [
 							[
@@ -496,7 +496,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				$dnsQueries[] = $hostname . $type;
 
 				// example.com SOA
-				if ($hostname === 'example.com') {
+				if ($hostname === 'example.com.') {
 					return match ($type) {
 						DNS_SOA => [
 							[
@@ -511,7 +511,7 @@ class DnsPinMiddlewareTest extends TestCase {
 				}
 
 				// example.net A, AAAA, CNAME
-				if ($hostname === 'subsubdomain.subdomain.example.com') {
+				if ($hostname === 'subsubdomain.subdomain.example.com.') {
 					return match ($type) {
 						DNS_A => [
 							[
@@ -540,10 +540,10 @@ class DnsPinMiddlewareTest extends TestCase {
 		);
 
 		$this->assertCount(3, $dnsQueries);
-		$this->assertContains('example.com' . DNS_SOA, $dnsQueries);
-		$this->assertContains('subsubdomain.subdomain.example.com' . DNS_A, $dnsQueries);
-		$this->assertContains('subsubdomain.subdomain.example.com' . DNS_AAAA, $dnsQueries);
+		$this->assertContains('example.com.' . DNS_SOA, $dnsQueries);
+		$this->assertContains('subsubdomain.subdomain.example.com.' . DNS_A, $dnsQueries);
+		$this->assertContains('subsubdomain.subdomain.example.com.' . DNS_AAAA, $dnsQueries);
 		// CNAME should not be queried if A or AAAA succeeded already
-		$this->assertNotContains('subsubdomain.subdomain.example.com' . DNS_CNAME, $dnsQueries);
+		$this->assertNotContains('subsubdomain.subdomain.example.com.' . DNS_CNAME, $dnsQueries);
 	}
 }


### PR DESCRIPTION
* Resolves: #56489 

## Summary
After upgrading my private server from Debian 12 to Debian 13, I've experienced the same issue mentioned in #56489 which resulted in the app store to be totally unusable. Upgrading the Nextcloud version worked without any issues tho.

The investigation got the following results:
- The main issue is the DNS Pinning
- When looking up `github.com`, it tried to resolve A, AAAA and CNAME records
- It only got an A and AAAA record back
- The A record had the correct host and IP, but the AAAA record didn't. It was the result for `github.com.dreschner.net`
- cURL tries to connect via the (incorrectly) provided IPv6 address first
- The certificate doesn't match the expected hostname and resulting in the error 60

For reproducing the issue on command line level, you can use the following command on a server with IPv6 connectivity:

```
curl -v https://github.com/nextcloud-releases/integration_giphy/releases/download/v2.2.0/integration_giphy-v2.2.0.tar.gz --resolve 'github.com:443:140.82.121.4,2a0a:4cc0:c1:71d6:1876:e0ff:fe86:4038'
```

The reason is that we don't use FQDNs for resolving the DNS records and GitHub doesn't provide an AAAA record. Therefore, the program behind `dns_get_records()` looks for the host as subdomain of the local domain name. This works as I have a wildcard AAAA record set-up.

The fix is easy: just add a `.` at the end to make the requested domain name a FQDN and prevent the lookup under the local domain name when no record is being found in the first lookup.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
