### PR TITLE
feat(http): centralize Content-Disposition header generation

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\DAV\CardDAV;
 
+use OC\Http\ContentDisposition;
 use OCP\AppFramework\Http;
 use OCP\Files\NotFoundException;
 use Sabre\CardDAV\Card;
@@ -86,7 +87,7 @@ class ImageExportPlugin extends ServerPlugin {
 			$file = $this->cache->get($addressbook->getResourceId(), $node->getName(), $size, $node);
 			$response->setHeader('Content-Type', $file->getMimeType());
 			$fileName = $node->getName() . '.' . PhotoCache::ALLOWED_CONTENT_TYPES[$file->getMimeType()];
-			$response->setHeader('Content-Disposition', "attachment; filename=$fileName");
+			$response->setHeader('Content-Disposition', ContentDisposition::make('attachment', $fileName));
 			$response->setStatus(Http::STATUS_OK);
 
 			$response->setBody($file->getContent());

--- a/apps/dav/lib/CardDAV/MultiGetExportPlugin.php
+++ b/apps/dav/lib/CardDAV/MultiGetExportPlugin.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\CardDAV;
 
+use OC\Http\ContentDisposition;
 use OCP\AppFramework\Http;
 use Sabre\DAV;
 use Sabre\DAV\Server;
@@ -63,7 +64,7 @@ class MultiGetExportPlugin extends DAV\ServerPlugin {
 
 		// Build and override the response
 		$filename = 'vcfexport-' . date('Y-m-d') . '.vcf';
-		$response->setHeader('Content-Disposition', 'attachment; filename="' . $filename . '"');
+		$response->setHeader('Content-Disposition', ContentDisposition::make('attachment', $filename));
 		$response->setHeader('Content-Type', 'text/vcard');
 
 		$response->setStatus(Http::STATUS_OK);

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -7,8 +7,8 @@
  */
 namespace OCA\DAV\Connector\Sabre;
 
-use OC\AppFramework\Http\Request;
 use OC\FilesMetadata\Model\FilesMetadata;
+use OC\Http\ContentDisposition;
 use OC\User\NoUserException;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCA\Files_Sharing\External\Mount as SharingExternalMount;
@@ -257,18 +257,7 @@ class FilesPlugin extends ServerPlugin {
 		// header has been set before
 		if ($this->downloadAttachment
 			&& $response->getHeader('Content-Disposition') === null) {
-			$filename = $node->getName();
-			if ($this->request->isUserAgent(
-				[
-					Request::USER_AGENT_IE,
-					Request::USER_AGENT_ANDROID_MOBILE_CHROME,
-					Request::USER_AGENT_FREEBOX,
-				])) {
-				$response->addHeader('Content-Disposition', 'attachment; filename="' . rawurlencode($filename) . '"');
-			} else {
-				$response->addHeader('Content-Disposition', 'attachment; filename*=UTF-8\'\'' . rawurlencode($filename)
-													 . '; filename="' . rawurlencode($filename) . '"');
-			}
+			$response->addHeader('Content-Disposition', ContentDisposition::make('attachment', $node->getName()));
 		}
 
 		if ($node instanceof File) {

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -601,21 +601,7 @@ class FilesPluginTest extends TestCase {
 		$this->plugin->checkCopy('FolderA/test.txt', 'invalid\\path.txt');
 	}
 
-	public static function downloadHeadersProvider(): array {
-		return [
-			[
-				false,
-				'attachment; filename*=UTF-8\'\'somefile.xml; filename="somefile.xml"'
-			],
-			[
-				true,
-				'attachment; filename="somefile.xml"'
-			],
-		];
-	}
-
-	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'downloadHeadersProvider')]
-	public function testDownloadHeaders(bool $isClumsyAgent, string $contentDispositionHeader): void {
+	public function testDownloadHeaders(): void {
 		$request = $this->createMock(RequestInterface::class);
 		$response = $this->createMock(ResponseInterface::class);
 
@@ -636,13 +622,8 @@ class FilesPluginTest extends TestCase {
 			->with('test/somefile.xml')
 			->willReturn($node);
 
-		$this->request
-			->expects($this->once())
-			->method('isUserAgent')
-			->willReturn($isClumsyAgent);
-
 		$calls = [
-			['Content-Disposition', $contentDispositionHeader],
+			['Content-Disposition', 'attachment; filename="somefile.xml"'],
 			['X-Accel-Buffering', 'no'],
 		];
 		$response

--- a/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
@@ -10,6 +10,7 @@ namespace OCA\Files_Trashbin\Sabre;
 
 use OC\Files\FileInfo;
 use OC\Files\View;
+use OC\Http\ContentDisposition;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCP\IPreview;
@@ -127,10 +128,7 @@ class TrashbinPlugin extends ServerPlugin {
 			return;
 		}
 
-		$response->addHeader(
-			'Content-Disposition',
-			'attachment; filename="' . $node->getFilename() . '"' // TODO: Confirm `filename` value is ASCII; add `filename*=UTF-8` support w/ encoding
-		);
+		$response->addHeader('Content-Disposition', ContentDisposition::make('attachment', $node->getFilename()));
 	}
 
 	/**

--- a/apps/files_versions/lib/Sabre/Plugin.php
+++ b/apps/files_versions/lib/Sabre/Plugin.php
@@ -8,10 +8,9 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Versions\Sabre;
 
-use OC\AppFramework\Http\Request;
+use OC\Http\ContentDisposition;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCP\IPreview;
-use OCP\IRequest;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
@@ -32,15 +31,10 @@ class Plugin extends ServerPlugin {
 	public const AUTHOR = 'author';
 	public const VERSION_LABEL = '{http://nextcloud.org/ns}version-label';
 	public const VERSION_AUTHOR = '{http://nextcloud.org/ns}version-author';
-	private const LEGACY_FILENAME_HEADER_USER_AGENTS = [ // Quirky clients
-		Request::USER_AGENT_IE,
-		Request::USER_AGENT_ANDROID_MOBILE_CHROME,
-		Request::USER_AGENT_FREEBOX,
-	];
+
 	private Server $server;
 
 	public function __construct(
-		private readonly IRequest $request,
 		private readonly IPreview $previewManager,
 	) {
 	}
@@ -77,7 +71,7 @@ class Plugin extends ServerPlugin {
 		}
 
 		$filename = $node->getVersion()->getSourceFileName();
-		$this->addContentDispositionHeader($response, $filename);
+		$response->addHeader('Content-Disposition', ContentDisposition::make('attachment', $filename));
 	}
 
 	/**
@@ -121,40 +115,5 @@ class Plugin extends ServerPlugin {
 			self::VERSION_LABEL,
 			fn (string $label) => $node->setMetadataValue(self::LABEL, $label)
 		);
-	}
-
-	/**
-	 * Add a Content-Disposition header in a way that attempts to be broadly compatible with various user agents.
-	 *
-	 * Sends both 'filename' (legacy quoted) and 'filename*' (UTF-8 encoded) per RFC 6266,
-	 * except for known quirky agents known to mishandle the `filename*`, which only get `filename`.
-	 *
-	 * Note: The quoting/escaping should strictly follow RFC 6266 and RFC 5987.
-	 *
-	 * TODO: Currently uses rawurlencode($filename) for both parameters, which is wrong: filename= should be plain
-	 * quoted ASCII (with necessary escaping), while filename* should be UTF-8 percent-encoded.
-	 * TODO: This logic appears elsewhere (sometimes with different quoting/filename handling) and could benefit
-	 * from a shared utility function. See Symfony example:
-	 * - https://github.com/symfony/symfony/blob/175775eb21508becf7e7a16d65959488e522c39a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php#L146-L155
-	 * - https://github.com/symfony/symfony/blob/175775eb21508becf7e7a16d65959488e522c39a/src/Symfony/Component/HttpFoundation/HeaderUtils.php#L152-L165
-	 *
-	 * @param ResponseInterface $response HTTP response object to add the header to
-	 * @param string $filename Download filename
-	 */
-	private function addContentDispositionHeader(ResponseInterface $response, string $filename): void {
-		if (!$this->request->isUserAgent(self::LEGACY_FILENAME_HEADER_USER_AGENTS)) {
-			// Modern clients will use 'filename*'; older clients will refer to `filename`.
-			// The older fallback must be listed first per RFC.
-			// In theory this is all we actually need to handle both client types.
-			$response->addHeader(
-				'Content-Disposition',
-				'attachment; filename="' . rawurlencode($filename) . '"; filename*=UTF-8\'\'' . rawurlencode($filename)
-			);
-		} else {
-			// Quirky clients that choke on `filename*`: only send `filename=`
-			$response->addHeader(
-				'Content-Disposition',
-				'attachment; filename="' . rawurlencode($filename) . '"');
-		}
 	}
 }

--- a/apps/settings/lib/Controller/LogSettingsController.php
+++ b/apps/settings/lib/Controller/LogSettingsController.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\Settings\Controller;
 
+use OC\Http\ContentDisposition;
 use OC\Log;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -43,7 +44,7 @@ class LogSettingsController extends Controller {
 			Http::STATUS_OK,
 			[
 				'Content-Type' => 'application/octet-stream',
-				'Content-Disposition' => 'attachment; filename="nextcloud.log"',
+				'Content-Disposition' => ContentDisposition::make('attachment', 'nextcloud.log'),
 			],
 		);
 	}

--- a/build/integration/dav_features/dav-v2.feature
+++ b/build/integration/dav_features/dav-v2.feature
@@ -35,7 +35,7 @@ Feature: dav-v2
 		And As an "admin"
 		When Downloading file "/welcome.txt"
 		Then The following headers should be set
-			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
+			|Content-Disposition|attachment; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
 			|X-Content-Type-Options |nosniff|
 			|X-Frame-Options|SAMEORIGIN|

--- a/core/Controller/TaskProcessingApiController.php
+++ b/core/Controller/TaskProcessingApiController.php
@@ -12,6 +12,7 @@ namespace OC\Core\Controller;
 
 use OC\Core\ResponseDefinitions;
 use OC\Files\SimpleFS\SimpleFile;
+use OC\Http\ContentDisposition;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
 use OCP\AppFramework\Http\Attribute\ExAppRequired;
@@ -546,10 +547,7 @@ class TaskProcessingApiController extends OCSController {
 		}
 
 		$response = new StreamResponse($node->fopen('rb'));
-		$response->addHeader(
-			'Content-Disposition',
-			'attachment; filename="' . rawurldecode($node->getName()) . '"'
-		);
+		$response->addHeader('Content-Disposition', ContentDisposition::make('attachment', $node->getName()));
 		$response->addHeader('Content-Type', $contentType);
 		return $response;
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1861,6 +1861,7 @@ return array(
     'OC\\Http\\Client\\GuzzlePromiseAdapter' => $baseDir . '/lib/private/Http/Client/GuzzlePromiseAdapter.php',
     'OC\\Http\\Client\\NegativeDnsCache' => $baseDir . '/lib/private/Http/Client/NegativeDnsCache.php',
     'OC\\Http\\Client\\Response' => $baseDir . '/lib/private/Http/Client/Response.php',
+	'OC\\Http\\ContentDisposition' => $baseDir . '/lib/private/Http/ContentDisposition.php',
     'OC\\Http\\CookieHelper' => $baseDir . '/lib/private/Http/CookieHelper.php',
     'OC\\Http\\WellKnown\\RequestManager' => $baseDir . '/lib/private/Http/WellKnown/RequestManager.php',
     'OC\\Image' => $baseDir . '/lib/private/Image.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1902,6 +1902,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Http\\Client\\GuzzlePromiseAdapter' => __DIR__ . '/../../..' . '/lib/private/Http/Client/GuzzlePromiseAdapter.php',
         'OC\\Http\\Client\\NegativeDnsCache' => __DIR__ . '/../../..' . '/lib/private/Http/Client/NegativeDnsCache.php',
         'OC\\Http\\Client\\Response' => __DIR__ . '/../../..' . '/lib/private/Http/Client/Response.php',
+		'OC\\Http\\ContentDisposition' => __DIR__ . '/../../..' . '/lib/private/Http/ContentDisposition.php',
         'OC\\Http\\CookieHelper' => __DIR__ . '/../../..' . '/lib/private/Http/CookieHelper.php',
         'OC\\Http\\WellKnown\\RequestManager' => __DIR__ . '/../../..' . '/lib/private/Http/WellKnown/RequestManager.php',
         'OC\\Image' => __DIR__ . '/../../..' . '/lib/private/Image.php',

--- a/lib/private/Http/ContentDisposition.php
+++ b/lib/private/Http/ContentDisposition.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Http;
+
+use Symfony\Component\HttpFoundation\HeaderUtils;
+
+/**
+ * Centralized Content-Disposition header value generation.
+ *
+ * Thin wrapper around Symfony's HeaderUtils::makeDisposition() that
+ * auto-generates a multibyte-safe ASCII fallback filename.
+ *
+ * Fallback generation is adapted from Symfony's BinaryFileResponse::setContentDisposition().
+ * @see https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+ */
+class ContentDisposition {
+
+	/**
+	 * Generate a Content-Disposition header value.
+	 *
+	 * @param string $disposition 'attachment' or 'inline'
+	 * @param string $filename The desired filename (UTF-8)
+	 * @return string The complete header value, e.g. 'attachment; filename="report.pdf"'
+	 */
+	public static function make(string $disposition, string $filename): string {
+		$fallback = self::toAsciiFallback($filename);
+		return HeaderUtils::makeDisposition($disposition, $filename, $fallback);
+	}
+
+	/**
+	 * Generate an ASCII-safe fallback filename.
+	 *
+	 * Uses multibyte-aware iteration so that one logical character
+	 * (even if multi-byte) maps to exactly one '_' replacement.
+	 *
+	 * @param string $filename UTF-8 filename
+	 * @return string ASCII-only fallback filename
+	 */
+	private static function toAsciiFallback(string $filename): string {
+		// Pure ASCII and no '%' — usable as-is
+		if (preg_match('/^[\x20-\x7E]*$/', $filename) && !str_contains($filename, '%')) {
+			return $filename;
+		}
+
+		$fallback = '';
+		$length = mb_strlen($filename, 'UTF-8');
+		for ($i = 0; $i < $length; ++$i) {
+			$char = mb_substr($filename, $i, 1, 'UTF-8');
+
+			if ($char === '%') {
+				$fallback .= '_';
+			} elseif (preg_match('/^[\x20-\x7E]$/', $char) === 1) {
+				$fallback .= $char;
+			} else {
+				$fallback .= '_';
+			}
+		}
+
+		return $fallback;
+	}
+}

--- a/lib/public/AppFramework/Http/DownloadResponse.php
+++ b/lib/public/AppFramework/Http/DownloadResponse.php
@@ -7,6 +7,7 @@
  */
 namespace OCP\AppFramework\Http;
 
+use OC\Http\ContentDisposition;
 use OCP\AppFramework\Http;
 
 /**
@@ -29,9 +30,7 @@ class DownloadResponse extends Response {
 	public function __construct(string $filename, string $contentType, int $status = Http::STATUS_OK, array $headers = []) {
 		parent::__construct($status, $headers);
 
-		$filename = strtr($filename, ['"' => '\\"', '\\' => '\\\\']);
-
-		$this->addHeader('Content-Disposition', 'attachment; filename="' . $filename . '"');
+		$this->addHeader('Content-Disposition', ContentDisposition::make('attachment', $filename));
 		$this->addHeader('Content-Type', $contentType);
 	}
 }

--- a/lib/public/AppFramework/Http/FileDisplayResponse.php
+++ b/lib/public/AppFramework/Http/FileDisplayResponse.php
@@ -6,6 +6,7 @@
  */
 namespace OCP\AppFramework\Http;
 
+use OC\Http\ContentDisposition;
 use OCP\AppFramework\Http;
 use OCP\Files\File;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -33,7 +34,7 @@ class FileDisplayResponse extends Response implements ICallbackResponse {
 		parent::__construct($statusCode, $headers);
 
 		$this->file = $file;
-		$this->addHeader('Content-Disposition', 'inline; filename="' . rawurldecode($file->getName()) . '"');
+		$this->addHeader('Content-Disposition', ContentDisposition::make('inline', $file->getName()));
 
 		$this->setETag($file->getEtag());
 		$lastModified = new \DateTime();

--- a/tests/lib/AppFramework/Http/DownloadResponseTest.php
+++ b/tests/lib/AppFramework/Http/DownloadResponseTest.php
@@ -32,17 +32,14 @@ class DownloadResponseTest extends \Test\TestCase {
 		$response = new ChildDownloadResponse($input, 'content');
 		$headers = $response->getHeaders();
 
-		$this->assertEquals('attachment; filename="' . $expected . '"', $headers['Content-Disposition']);
+		$this->assertStringContainsString('attachment', $headers['Content-Disposition']);
+		$this->assertStringContainsString($expected, $headers['Content-Disposition'])
 	}
 
 	public static function filenameEncodingProvider() : array {
 		return [
-			['TestName.txt', 'TestName.txt'],
-			['A "Quoted" Filename.txt', 'A \\"Quoted\\" Filename.txt'],
-			['A "Quoted" Filename.txt', 'A \\"Quoted\\" Filename.txt'],
-			['A "Quoted" Filename With A Backslash \\.txt', 'A \\"Quoted\\" Filename With A Backslash \\\\.txt'],
-			['A "Very" Weird Filename \ / & <> " >\'""""\.text', 'A \\"Very\\" Weird Filename \\\\ / & <> \\" >\'\\"\\"\\"\\"\\\\.text'],
-			['\\\\\\\\\\\\', '\\\\\\\\\\\\\\\\\\\\\\\\'],
-		];
+			['TestName.txt', 'filename="TestName.txt"'],
+			['A "Quoted" Filename.txt', 'filename="A \\"Quoted\\" Filename.txt"'],
+			['file with spaces.txt', 'filename="file with spaces.txt"'],		];
 	}
 }

--- a/tests/lib/AppFramework/Http/DownloadResponseTest.php
+++ b/tests/lib/AppFramework/Http/DownloadResponseTest.php
@@ -33,7 +33,7 @@ class DownloadResponseTest extends \Test\TestCase {
 		$headers = $response->getHeaders();
 
 		$this->assertStringContainsString('attachment', $headers['Content-Disposition']);
-		$this->assertStringContainsString($expected, $headers['Content-Disposition'])
+		$this->assertStringContainsString($expected, $headers['Content-Disposition']);
 	}
 
 	public static function filenameEncodingProvider() : array {

--- a/tests/lib/Http/ContentDispositionTest.php
+++ b/tests/lib/Http/ContentDispositionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace Test\Http;
+
+use OC\Http\ContentDisposition;
+use Test\TestCase;
+
+class ContentDispositionTest extends TestCase {
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideAttachmentCases')]
+	public function testAttachment(string $filename, string $expected): void {
+		$this->assertEquals($expected, ContentDisposition::make('attachment', $filename));
+	}
+
+	public static function provideAttachmentCases(): array {
+		return [
+			'simple ASCII' => [
+				'report.pdf',
+				'attachment; filename="report.pdf"',
+			],
+			'ASCII with spaces' => [
+				'my report.pdf',
+				'attachment; filename="my report.pdf"',
+			],
+			'non-ASCII produces fallback and filename*' => [
+				'Ässembly Ünits.pdf',
+				"attachment; filename=\"_ssembly _nits.pdf\"; filename*=utf-8''%C3%84ssembly%20%C3%9Cnits.pdf",
+			],
+			'CJK filename' => [
+				'テスト.txt',
+				"attachment; filename=\"___.txt\"; filename*=utf-8''%E3%83%86%E3%82%B9%E3%83%88.txt",
+			],
+			'emoji filename' => [
+				'🎉party.txt',
+				"attachment; filename=\"_party.txt\"; filename*=utf-8''%F0%9F%8E%89party.txt",
+			],
+			'percent in filename' => [
+				'100% done.txt',
+				"attachment; filename=\"100_ done.txt\"; filename*=utf-8''100%25%20done.txt",
+			],
+			'quotes in filename' => [
+				'say "hello".txt',
+				"attachment; filename=\"say \\\"hello\\\".txt\"",
+			],
+		];
+	}
+
+	public function testInline(): void {
+		$result = ContentDisposition::make('inline', 'image.png');
+		$this->assertEquals('inline; filename="image.png"', $result);
+	}
+
+	public function testInlineNonAscii(): void {
+		$result = ContentDisposition::make('inline', 'Ürlaub.jpg');
+		$this->assertStringContainsString('inline', $result);
+		$this->assertStringContainsString("filename*=utf-8''", $result);
+		$this->assertStringContainsString('filename="_rlaub.jpg"', $result);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Consolidates all `Content-Disposition` header generation into a single utility class (`OC\Http\ContentDisposition`). This class is a wrapper for Symfony's `HeaderUtils::makeDisposition()` with Nextcloud specific multibyte-safe ASCII fallback generator (inspired by Symfony's `BinaryFileResponse`).

This brings consistency across the codebase for Content-Disposition handling and fixes some problems:

- `DownloadResponse` used manual `strtr()` quoting -- lacked `filename*` for non-ASCII names
- `FileDisplayResponse` used `rawurldecode()` (which made no sense at all but happened to work for *most* filenames, but certainly not all)
- `FilesPlugin` and `files_versions/Plugin` had UserAgent sniffing and special handling for IE/Freebox -- unnecessary complexity, legacy, and not done anywhere else
- `TrashbinPlugin` lacked `filename*` (non-ASCII) handling
- `ImageExportPlugin`, `MultiGetExportPlugin`, `TaskProcessingApiController`, `LogSettingsController` used unescaped filenames (not mattering in some cases, but less-than-robust in others)
- Each site had different (inconsistent) quoting/encoding

Changes:

- Adds `lib/private/Http/ContentDisposition.php`, a thin wrapper around `Symfony\Component\HttpFoundation\HeaderUtils::makeDisposition()`
- Migrates all call sites to use `ContentDisposition::make()`
- Removes UA-sniffing constants and `IRequest` dependency from `files_versions/Plugin`
- Removes `IRequest` UA-sniffing from `FilesPlugin::httpGet()`
- Updates all existing tests and adds `ContentDispositionTest`
- Updates integration test expected header values

**Public API note**: `DownloadResponse`, `FileDisplayResponse`, and `DataDownloadResponse` retain their existing constructor signatures. Apps using these classes require no changes -- they simply get correct RFC 6266 headers automatically.

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
