### PR TITLE
fix: use mount_point_hash instead of mount_point in removeMount

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -522,7 +522,8 @@ class UserMountCache implements IUserMountCache {
 	public function removeMount(string $mountPoint): void {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('mounts')
-			->where($query->expr()->eq('mount_point', $query->createNamedParameter($mountPoint)));
+			->where($query->expr()->eq('mount_point_hash', $query->createNamedParameter(hash('xxh128', $mountPoint))))
+			->andWhere($query->expr()->eq('mount_point', $query->createNamedParameter($mountPoint)));
 		$query->executeStatement();
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

There is no index on `mount_point` any longer, so this delete blocks the whole table.

## TODO

- [ ] Add migration to add index on `mount_point_hash`
- [ ] On 24.03.2026 the index was enabled on our instance and **may** have degraded performance. Needs to be double-checked.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
