### PR TITLE
fix(ShareApiController): fix listing of remote shares for the owner

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1729,8 +1729,8 @@ class ShareAPIController extends OCSController {
 			'deck' => IShare::TYPE_DECK,
 		];
 
-		// Include federated sharing whenever the provider is available for the user.
-		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE)) {
+		// Add federated sharing as a provider only if it's allowed
+		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
 			$providers['ocFederatedSharing'] = null; // No type check needed
 		}
 
@@ -1996,12 +1996,12 @@ class ShareAPIController extends OCSController {
 		$deckShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_DECK, $path, $reshares, -1, 0);
 
 		// FEDERATION
-		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE)) {
+		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
 			$federatedShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_REMOTE, $path, $reshares, -1, 0);
 		} else {
 			$federatedShares = [];
 		}
-		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE_GROUP)) {
+		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
 			$federatedGroupShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_REMOTE_GROUP, $path, $reshares, -1, 0);
 		} else {
 			$federatedGroupShares = [];

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1729,8 +1729,8 @@ class ShareAPIController extends OCSController {
 			'deck' => IShare::TYPE_DECK,
 		];
 
-		// Add federated sharing as a provider only if it's allowed
-		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
+		// Include federated sharing whenever the provider is available for the user.
+		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE)) {
 			$providers['ocFederatedSharing'] = null; // No type check needed
 		}
 
@@ -1854,14 +1854,14 @@ class ShareAPIController extends OCSController {
 			$shares = array_merge($shares, $providerShares);
 		}
 
-		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
+		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE)) {
 			$federatedShares = $this->shareManager->getSharesBy(
 				$this->userId, IShare::TYPE_REMOTE, $node, $reShares, -1, 0
 			);
 			$shares = array_merge($shares, $federatedShares);
 		}
 
-		if ($this->shareManager->outgoingServer2ServerGroupSharesAllowed()) {
+		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE_GROUP)) {
 			$federatedShares = $this->shareManager->getSharesBy(
 				$this->userId, IShare::TYPE_REMOTE_GROUP, $node, $reShares, -1, 0
 			);
@@ -1996,12 +1996,12 @@ class ShareAPIController extends OCSController {
 		$deckShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_DECK, $path, $reshares, -1, 0);
 
 		// FEDERATION
-		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
+		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE)) {
 			$federatedShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_REMOTE, $path, $reshares, -1, 0);
 		} else {
 			$federatedShares = [];
 		}
-		if ($this->shareManager->outgoingServer2ServerGroupSharesAllowed()) {
+		if ($this->shareManager->shareProviderExists(IShare::TYPE_REMOTE_GROUP)) {
 			$federatedGroupShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_REMOTE_GROUP, $path, $reshares, -1, 0);
 		} else {
 			$federatedGroupShares = [];

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1305,6 +1305,8 @@ class ShareAPIControllerTest extends TestCase {
 					$file1EmailShareOwnerExpected,
 					$file1CircleShareOwnerExpected,
 					$file1RoomShareOwnerExpected,
+					$file1RemoteShareOwnerExpected,
+					$file1RemoteGroupShareOwnerExpected,
 				]
 			],
 			[
@@ -1475,6 +1477,8 @@ class ShareAPIControllerTest extends TestCase {
 					$file1EmailShareOwnerExpected,
 					$file1CircleShareOwnerExpected,
 					$file1RoomShareOwnerExpected,
+					$file1RemoteShareOwnerExpected,
+					$file1RemoteGroupShareOwnerExpected,
 				]
 			],
 			[
@@ -2167,6 +2171,65 @@ class ShareAPIControllerTest extends TestCase {
 			->willReturn(false);
 
 		$this->ocs->createShare('valid-path', Constants::PERMISSION_ALL, IShare::TYPE_GROUP, 'invalidGroup');
+	}
+
+	public function testGetFederatedShareWhenOutgoingFederationDisabled(): void {
+		$share = $this->createMock(IShare::class);
+		$share->method('getId')->willReturn('42');
+		$share->method('getShareType')->willReturn(IShare::TYPE_REMOTE);
+
+		/** @var ShareAPIController&MockObject $ocs */
+		$ocs = $this->getMockBuilder(ShareAPIController::class)
+			->setConstructorArgs([
+				$this->appName,
+				$this->request,
+				$this->shareManager,
+				$this->groupManager,
+				$this->userManager,
+				$this->rootFolder,
+				$this->urlGenerator,
+				$this->l,
+				$this->config,
+				$this->appConfig,
+				$this->appManager,
+				$this->serverContainer,
+				$this->userStatusManager,
+				$this->previewManager,
+				$this->dateTimeZone,
+				$this->logger,
+				$this->factory,
+				$this->mailer,
+				$this->tagManager,
+				$this->getEmailValidatorWithStrictEmailCheck(),
+				$this->trustedServers,
+				$this->currentUser,
+			])
+			->onlyMethods(['canAccessShare', 'formatShare'])
+			->getMock();
+
+		$ocs->method('canAccessShare')->willReturn(true);
+		$ocs->method('formatShare')->with($share)->willReturn([
+			'id' => '42',
+			'share_type' => IShare::TYPE_REMOTE,
+		]);
+
+		$this->shareManager
+			->method('getShareById')
+			->willReturnCallback(function (string $id, string $recipient) use ($share) {
+				$this->assertSame($this->currentUser, $recipient);
+				if ($id === 'ocFederatedSharing:42') {
+					return $share;
+				}
+
+				throw new ShareNotFound();
+			});
+
+		$this->assertSame([
+			[
+				'id' => '42',
+				'share_type' => IShare::TYPE_REMOTE,
+			],
+		], $ocs->getShare('42')->getData());
 	}
 
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1305,8 +1305,6 @@ class ShareAPIControllerTest extends TestCase {
 					$file1EmailShareOwnerExpected,
 					$file1CircleShareOwnerExpected,
 					$file1RoomShareOwnerExpected,
-					$file1RemoteShareOwnerExpected,
-					$file1RemoteGroupShareOwnerExpected,
 				]
 			],
 			[
@@ -1477,8 +1475,6 @@ class ShareAPIControllerTest extends TestCase {
 					$file1EmailShareOwnerExpected,
 					$file1CircleShareOwnerExpected,
 					$file1RoomShareOwnerExpected,
-					$file1RemoteShareOwnerExpected,
-					$file1RemoteGroupShareOwnerExpected,
 				]
 			],
 			[


### PR DESCRIPTION
Fixes the following problem:

> Create a folder (called "Door delen"), which I shared as Projectadmin1 with DashboardAdmin1, with all permissions.
> 
> DashboardAdmin1 reshares this folder;
> 1. Local with Wes Schibo
> 2. Via mail to a user
> 3. Via public link
> 4. Via OCM FedShare with user@example.com
> 
> As Projectadmin1, I can only see reshare number 1, 2 and 3, not the federated reshare (4)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
