### PR TITLE
fix(objectstore): Add retry logic and structured error handling to S3 `readObject()`

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2017-2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 namespace OC\Files\ObjectStore;
@@ -49,7 +49,7 @@ trait S3ObjectTrait {
 		// via an abstract method (e.g. getLogger()) rather than inline container lookups
 		$logger = \OCP\Server::get(\Psr\Log\LoggerInterface::class);
 
-		$fh = SeekableHttpStream::open(function ($range) use ($urn, $maxAttempts, &$lastError, $logger) {
+		$fh = SeekableHttpStream::open(function ($range) use ($urn, $maxAttempts, &$lastError, &$firstError, $logger) {
 			$command = $this->getConnection()->getCommand('GetObject', [
 				'Bucket' => $this->bucket,
 				'Key' => $urn,
@@ -134,8 +134,14 @@ trait S3ObjectTrait {
 				}
 
 				// fopen returned false - i.e. connection-level failure (DNS, timeout, TLS, etc.)
-				// log occurences for operator visibility even if retried
-				$lastError = "connection failure while reading object $urn range $range on attempt $attempt/$maxAttempts (no HTTP response received)";
+				// log occurrences for operator visibility even if retried
+				$currentError = "connection failure while reading object $urn range $range on attempt $attempt/$maxAttempts (no HTTP response received)";
+				if ($firstError === 'unknown error') {
+					$firstError = $currentError;
+				} else {
+					$lastError = $currentError;
+				}
+
 				$logger->warning($lastError, ['app' => 'objectstore']);
 
 				if ($attempt < $maxAttempts) {
@@ -235,7 +241,7 @@ trait S3ObjectTrait {
 
 		if ($statusCode === 416) {
 			return sprintf(
-				'HTTP 416 reading object %s range %s on attempt %d/%d: requested range not satisfiable',
+				'HTTP 416 reading object %s range %s on attempt %d/%d: requested range not satisfiable [%s - %s (RequestId: %s, ExtendedRequestId: %s)]',
 				$urn,
 				$range,
 				$attempt,

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -110,7 +110,7 @@ trait S3ObjectTrait {
 
 					if ($this->isRetryableHttpStatus($statusCode) && $attempt < $maxAttempts) {
 						// gives operators visibility into transient S3 issues even when retries succeed by logging
-						$logger->warning($lastError, ['app' => 'objectstore']);
+						$logger->info($lastError, ['app' => 'objectstore']);
 						$this->sleepBeforeRetry($attempt);
 						continue;
 					}
@@ -213,6 +213,19 @@ trait S3ObjectTrait {
 		int $attempt,
 		int $maxAttempts,
 	): string {
+		if ($statusCode === 416) {
+			return sprintf(
+				'HTTP 416 reading object %s range %s on attempt %d/%d: requested range not satisfiable',
+				$urn,
+				$range,
+				$attempt,
+				$maxAttempts,
+				$errorInfo['code'],
+				$errorInfo['message'],
+				$errorInfo['requestId'],
+				$errorInfo['extendedRequestId'],
+			);
+		}
 		return sprintf(
 			'HTTP %s reading object %s range %s on attempt %d/%d: %s - %s (RequestId: %s, ExtendedRequestId: %s)',
 			$statusCode !== null ? (string)$statusCode : 'unknown',

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -42,8 +42,8 @@ trait S3ObjectTrait {
 	 */
 	public function readObject($urn) {
 		$maxAttempts = max(1, $this->retriesMaxAttempts);
-		$lastError = 'unknown error';
-		$firstError = 'unknown error';
+		$lastError = null;
+		$firstError = null;
 
 		// TODO: consider unifying logger access across S3ConnectionTrait and S3ObjectTrait
 		// via an abstract method (e.g. getLogger()) rather than inline container lookups
@@ -115,8 +115,9 @@ trait S3ObjectTrait {
 					);
 					$currentError = $this->formatS3ReadError($urn, $range, $statusCode, $errorInfo, $attempt, $maxAttempts);
 					// on retries, the last or the first failure can be most informative, but can't know which so track both
-					if ($firstError === 'unknown error') {
+					if ($firstError === null) {
 						$firstError = $currentError;
+						$lastError = $currentError;
 					} else {
 						$lastError = $currentError;
 					}
@@ -136,19 +137,24 @@ trait S3ObjectTrait {
 				// fopen returned false - i.e. connection-level failure (DNS, timeout, TLS, etc.)
 				// log occurrences for operator visibility even if retried
 				$currentError = "connection failure while reading object $urn range $range on attempt $attempt/$maxAttempts (no HTTP response received)";
-				if ($firstError === 'unknown error') {
+				if ($firstError === null) {
 					$firstError = $currentError;
+					$lastError = $currentError;
 				} else {
 					$lastError = $currentError;
 				}
 
-				$logger->warning($lastError, ['app' => 'objectstore']);
+				$logger->warning($currentError, ['app' => 'objectstore']);
 
 				if ($attempt < $maxAttempts) {
 					$this->sleepBeforeRetry($attempt);
 				}
 			}
 
+			$logger->error(
+				"Failed to read object $urn after $maxAttempts attempts. First failure: $firstError. Last failure: $lastError".
+				['app' => 'objectstore'],
+			);
 			return false;
 		});
 

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -41,87 +41,186 @@ trait S3ObjectTrait {
 	 * @since 7.0.0
 	 */
 	public function readObject($urn) {
-		$fh = SeekableHttpStream::open(function ($range) use ($urn) {
-    		$command = $this->getConnection()->getCommand('GetObject', [
-        		'Bucket' => $this->bucket,
-        		'Key' => $urn,
-        		'Range' => 'bytes=' . $range,
-    		] + $this->getSSECParameters());
-    		$request = \Aws\serialize($command);
-    		$headers = [];
-    		foreach ($request->getHeaders() as $key => $values) {
-        		foreach ($values as $value) {
-            		$headers[] = "$key: $value";
-        		}
-    		}
-    		$opts = [
-        		'http' => [
-            		'protocol_version' => $request->getProtocolVersion(),
-            		'header' => $headers,
-            		'ignore_errors' => true, // prevent fopen from failing on 4xx/5xx
-        		]
-    		];
+		$maxAttempts = max(1, $this->retriesMaxAttempts);
+		$lastError = 'unknown error';
 
-		    $bundle = $this->getCertificateBundlePath();
-    		if ($bundle) {
-        		$opts['ssl'] = [
-            		'cafile' => $bundle
-        		];
-    		}
+		$fh = SeekableHttpStream::open(function ($range) use ($urn, $maxAttempts, &$lastError) {
+			$command = $this->getConnection()->getCommand('GetObject', [
+				'Bucket' => $this->bucket,
+				'Key' => $urn,
+				'Range' => 'bytes=' . $range,
+			] + $this->getSSECParameters());
 
-	    	if ($this->getProxy()) {
-    	    	$opts['http']['proxy'] = $this->getProxy();
-        		$opts['http']['request_fulluri'] = true;
-    		}
+			$request = \Aws\serialize($command);
+			$requestUri = (string)$request->getUri();
 
-    		$context = stream_context_create($opts);
+			$headers = [];
+			foreach ($request->getHeaders() as $key => $values) {
+				foreach ($values as $value) {
+					$headers[] = "$key: $value";
+				}
+			}
 
-    		$maxAttempts = $this->retriesMaxAttempts;
-   			for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-        		$result = @fopen($request->getUri(), 'r', false, $context);
+			$opts = [
+				'http' => [
+					'protocol_version' => $request->getProtocolVersion(),
+					'header' => $headers,
+					'ignore_errors' => true,
+				],
+			];
 
-        		if ($result !== false) {
-            		$meta = stream_get_meta_data($result);
-            		$statusLine = $meta['wrapper_data'][0] ?? '';
-            		if (preg_match('#^HTTP/\S+\s+(\d{3})#', $statusLine, $matches)) {
-                		$statusCode = (int)$matches[1];
+			$bundle = $this->getCertificateBundlePath();
+			if ($bundle) {
+				$opts['ssl'] = [
+					'cafile' => $bundle,
+				];
+			}
 
-                		if ($statusCode < 400) {
-                    		return $result;
-                		}
+			if ($this->getProxy()) {
+				$opts['http']['proxy'] = $this->getProxy();
+				$opts['http']['request_fulluri'] = true;
+			}
 
-                		fclose($result);
+			$context = stream_context_create($opts);
 
-                		// Only retry on server errors or throttling
-                		if ($statusCode === 429 || $statusCode >= 500) {
-                    		if ($attempt < $maxAttempts) {
-                        		usleep(min(1000000, 100000 * (2 ** ($attempt - 1))));
-                        		continue;
-                    		}
-                		}
+			for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+				$result = @fopen($requestUri, 'r', false, $context);
 
-                		// 4xx (except 429) — don't retry, fail immediately
-                		return false;
-            		}
+				if ($result !== false) {
+					$meta = stream_get_meta_data($result);
+					$responseHead = is_array($meta['wrapper_data'] ?? null) ? $meta['wrapper_data'] : [];
+					$statusCode = $this->parseHttpStatusCode($responseHead);
 
-            		// Couldn't parse status but got a stream — use it
-            		return $result;
-        		}
+					if ($statusCode !== null && $statusCode < 400) {
+						return $result;
+					}
 
-        		// fopen returned false — connection-level failure (DNS, timeout, etc.)
-        		// These are retryable
-        		if ($attempt < $maxAttempts) {
-            		usleep(min(1000000, 100000 * (2 ** ($attempt - 1))));
-        		}
-    		}
+					$errorBody = stream_get_contents($result);
+					fclose($result);
 
-    		return false;
+					$errorInfo = $this->parseS3ErrorResponse($errorBody, $responseHead);
+					$lastError = $this->formatS3ReadError($urn, $range, $statusCode, $errorInfo, $attempt, $maxAttempts);
+
+					if ($this->isRetryableHttpStatus($statusCode) && $attempt < $maxAttempts) {
+						$this->sleepBeforeRetry($attempt);
+						continue;
+					}
+
+					return false;
+				}
+
+				$lastError = "connection failure while reading object $urn range $range on attempt $attempt/$maxAttempts";
+
+				if ($attempt < $maxAttempts) {
+					$this->sleepBeforeRetry($attempt);
+				}
+			}
+
+			return false;
 		});
 
 		if (!$fh) {
-			throw new \Exception("Failed to read object $urn");
+			throw new \Exception("Failed to read object $urn after $maxAttempts attempts: $lastError");
 		}
+
 		return $fh;
+	}
+
+	/**
+	 * Parse the effective HTTP status code from stream wrapper metadata.
+	 *
+	 * wrapper_data can contain multiple status lines, for example due to redirects,
+	 * proxy responses, or interim 100 responses. We want the last HTTP status line.
+	 *
+	 * @param array|string $responseHead The wrapper_data from stream_get_meta_data
+	 */
+	private function parseHttpStatusCode(array|string $responseHead): ?int {
+		$lines = is_array($responseHead) ? $responseHead : [$responseHead];
+
+		foreach (array_reverse($lines) as $line) {
+			if (is_string($line) && preg_match('#^HTTP/\S+\s+(\d{3})#', $line, $matches)) {
+				return (int)$matches[1];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parse S3 error response XML and response headers into a structured array.
+	 *
+	 * @param string|false $body The response body
+	 * @param array $responseHead The wrapper_data from stream_get_meta_data
+	 * @return array{code: string, message: string, requestId: string, extendedRequestId: string}
+	 */
+	private function parseS3ErrorResponse(string|false $body, array $responseHead): array {
+		$errorCode = 'Unknown';
+		$errorMessage = '';
+		$requestId = '';
+		$extendedRequestId = '';
+
+		if ($body) {
+			$xml = @simplexml_load_string($body);
+			if ($xml !== false) {
+				$errorCode = (string)($xml->Code ?? 'Unknown');
+				$errorMessage = (string)($xml->Message ?? '');
+				$requestId = (string)($xml->RequestId ?? '');
+			}
+		}
+
+		foreach ($responseHead as $header) {
+			if (!is_string($header)) {
+				continue;
+			}
+
+			if (stripos($header, 'x-amz-request-id:') === 0) {
+				$requestId = trim(substr($header, strlen('x-amz-request-id:')));
+			} elseif (stripos($header, 'x-amz-id-2:') === 0) {
+				$extendedRequestId = trim(substr($header, strlen('x-amz-id-2:')));
+			}
+		}
+
+		return [
+			'code' => $errorCode,
+			'message' => $errorMessage,
+			'requestId' => $requestId,
+			'extendedRequestId' => $extendedRequestId,
+		];
+	}
+
+	/**
+	 * @param array{code: string, message: string, requestId: string, extendedRequestId: string} $errorInfo
+	 */
+	private function formatS3ReadError(
+		string $urn,
+		string $range,
+		?int $statusCode,
+		array $errorInfo,
+		int $attempt,
+		int $maxAttempts,
+	): string {
+		return sprintf(
+			'HTTP %s reading object %s range %s on attempt %d/%d: %s - %s (RequestId: %s, ExtendedRequestId: %s)',
+			$statusCode !== null ? (string)$statusCode : 'unknown',
+			$urn,
+			$range,
+			$attempt,
+			$maxAttempts,
+			$errorInfo['code'],
+			$errorInfo['message'],
+			$errorInfo['requestId'],
+			$errorInfo['extendedRequestId'],
+		);
+	}
+
+	private function isRetryableHttpStatus(?int $statusCode): bool {
+		return $statusCode === 429 || ($statusCode !== null && $statusCode >= 500);
+	}
+
+	private function sleepBeforeRetry(int $attempt): void {
+		$delay = min(1000000, 100000 * (2 ** ($attempt - 1)));
+		$delay += random_int(0, 100000);
+		usleep($delay);
 	}
 
 	private function buildS3Metadata(array $metadata): array {

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -43,6 +43,7 @@ trait S3ObjectTrait {
 	public function readObject($urn) {
 		$maxAttempts = max(1, $this->retriesMaxAttempts);
 		$lastError = 'unknown error';
+		$firstError = 'unknown error';
 
 		// TODO: consider unifying logger access across S3ConnectionTrait and S3ObjectTrait
 		// via an abstract method (e.g. getLogger()) rather than inline container lookups
@@ -106,17 +107,23 @@ trait S3ObjectTrait {
 						$errorBody,
 						is_array($responseHead) ? $responseHead : [$responseHead]
 					);
-					$lastError = $this->formatS3ReadError($urn, $range, $statusCode, $errorInfo, $attempt, $maxAttempts);
+					$currentError = $this->formatS3ReadError($urn, $range, $statusCode, $errorInfo, $attempt, $maxAttempts);
+					// on retries, the last or the first failure can be most informative, but can't know which so track both
+					if ($firstError === 'unknown error') {
+						$firstError = $currentError;
+					} else {
+						$lastError = $currentError;
+					}
 
 					if ($this->isRetryableHttpStatus($statusCode) && $attempt < $maxAttempts) {
 						// gives operators visibility into transient S3 issues even when retries succeed by logging
-						$logger->info($lastError, ['app' => 'objectstore']);
+						$logger->warning($currentError, ['app' => 'objectstore']);
 						$this->sleepBeforeRetry($attempt);
 						continue;
 					}
 
 					// for non-retryable HTTP errors or exhausted retries, log the final failure with full S3 error context
-					$logger->error($lastError, ['app' => 'objectstore']);
+					$logger->error($currentError, ['app' => 'objectstore']);
 					return false;
 				}
 
@@ -134,7 +141,9 @@ trait S3ObjectTrait {
 		});
 
 		if (!$fh) {
-			throw new \Exception("Failed to read object $urn after $maxAttempts attempts: $lastError");
+			throw new \Exception(
+				"Failed to read object $urn after $maxAttempts attempts. First failure: $firstError. Last failure: $lastError"
+			);
 		}
 
 		return $fh;

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -222,6 +222,11 @@ trait S3ObjectTrait {
 		int $attempt,
 		int $maxAttempts,
 	): string {
+		$errorCode = $errorInfo['code'] !== '' ? $errorInfo['code'] : 'Unknown';
+		$errorMessage = $errorInfo['message'] !== '' ? $errorInfo['message'] : 'No error message';
+		$requestId = $errorInfo['requestId'] !== '' ? $errorInfo['requestId'] : 'n/a';
+		$extendedRequestId = $errorInfo['extendedRequestId'] !== '' ? $errorInfo['extendedRequestId'] : 'n/a';
+
 		if ($statusCode === 416) {
 			return sprintf(
 				'HTTP 416 reading object %s range %s on attempt %d/%d: requested range not satisfiable',
@@ -229,10 +234,10 @@ trait S3ObjectTrait {
 				$range,
 				$attempt,
 				$maxAttempts,
-				$errorInfo['code'],
-				$errorInfo['message'],
-				$errorInfo['requestId'],
-				$errorInfo['extendedRequestId'],
+				$errorCode,
+				$errorMessage,
+				$requestId,
+				$extendedRequestId,
 			);
 		}
 		return sprintf(
@@ -242,10 +247,10 @@ trait S3ObjectTrait {
 			$range,
 			$attempt,
 			$maxAttempts,
-			$errorInfo['code'],
-			$errorInfo['message'],
-			$errorInfo['requestId'],
-			$errorInfo['extendedRequestId'],
+			$errorCode,
+			$errorMessage,
+			$requestId,
+			$extendedRequestId,
 		);
 	}
 

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -92,7 +92,7 @@ trait S3ObjectTrait {
 
 				if ($result !== false) {
 					$meta = stream_get_meta_data($result);
-					$responseHead = is_array($meta['wrapper_data'] ?? null) ? $meta['wrapper_data'] : [];
+					$responseHead = $meta['wrapper_data'] ?? [];
 					$statusCode = $this->parseHttpStatusCode($responseHead);
 
 					if ($statusCode !== null && $statusCode < 400) {
@@ -102,7 +102,10 @@ trait S3ObjectTrait {
 					$errorBody = stream_get_contents($result);
 					fclose($result);
 
-					$errorInfo = $this->parseS3ErrorResponse($errorBody, $responseHead);
+					$errorInfo = $this->parseS3ErrorResponse(
+						$errorBody,
+						is_array($responseHead) ? $responseHead : [$responseHead]
+					);
 					$lastError = $this->formatS3ReadError($urn, $range, $statusCode, $errorInfo, $attempt, $maxAttempts);
 
 					if ($this->isRetryableHttpStatus($statusCode) && $attempt < $maxAttempts) {

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -129,7 +129,7 @@ trait S3ObjectTrait {
 
 				// fopen returned false - i.e. connection-level failure (DNS, timeout, TLS, etc.)
 				// log occurences for operator visibility even if retried
-				$lastError = "connection failure while reading object $urn range $range on attempt $attempt/$maxAttempts";
+				$lastError = "connection failure while reading object $urn range $range on attempt $attempt/$maxAttempts (no HTTP response received)";
 				$logger->warning($lastError, ['app' => 'objectstore']);
 
 				if ($attempt < $maxAttempts) {

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -42,39 +42,82 @@ trait S3ObjectTrait {
 	 */
 	public function readObject($urn) {
 		$fh = SeekableHttpStream::open(function ($range) use ($urn) {
-			$command = $this->getConnection()->getCommand('GetObject', [
-				'Bucket' => $this->bucket,
-				'Key' => $urn,
-				'Range' => 'bytes=' . $range,
-			] + $this->getSSECParameters());
-			$request = \Aws\serialize($command);
-			$headers = [];
-			foreach ($request->getHeaders() as $key => $values) {
-				foreach ($values as $value) {
-					$headers[] = "$key: $value";
-				}
-			}
-			$opts = [
-				'http' => [
-					'protocol_version' => $request->getProtocolVersion(),
-					'header' => $headers,
-				]
-			];
-			$bundle = $this->getCertificateBundlePath();
-			if ($bundle) {
-				$opts['ssl'] = [
-					'cafile' => $bundle
-				];
-			}
+    		$command = $this->getConnection()->getCommand('GetObject', [
+        		'Bucket' => $this->bucket,
+        		'Key' => $urn,
+        		'Range' => 'bytes=' . $range,
+    		] + $this->getSSECParameters());
+    		$request = \Aws\serialize($command);
+    		$headers = [];
+    		foreach ($request->getHeaders() as $key => $values) {
+        		foreach ($values as $value) {
+            		$headers[] = "$key: $value";
+        		}
+    		}
+    		$opts = [
+        		'http' => [
+            		'protocol_version' => $request->getProtocolVersion(),
+            		'header' => $headers,
+            		'ignore_errors' => true, // prevent fopen from failing on 4xx/5xx
+        		]
+    		];
 
-			if ($this->getProxy()) {
-				$opts['http']['proxy'] = $this->getProxy();
-				$opts['http']['request_fulluri'] = true;
-			}
+		    $bundle = $this->getCertificateBundlePath();
+    		if ($bundle) {
+        		$opts['ssl'] = [
+            		'cafile' => $bundle
+        		];
+    		}
 
-			$context = stream_context_create($opts);
-			return fopen($request->getUri(), 'r', false, $context);
+	    	if ($this->getProxy()) {
+    	    	$opts['http']['proxy'] = $this->getProxy();
+        		$opts['http']['request_fulluri'] = true;
+    		}
+
+    		$context = stream_context_create($opts);
+
+    		$maxAttempts = $this->retriesMaxAttempts;
+   			for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+        		$result = @fopen($request->getUri(), 'r', false, $context);
+
+        		if ($result !== false) {
+            		$meta = stream_get_meta_data($result);
+            		$statusLine = $meta['wrapper_data'][0] ?? '';
+            		if (preg_match('#^HTTP/\S+\s+(\d{3})#', $statusLine, $matches)) {
+                		$statusCode = (int)$matches[1];
+
+                		if ($statusCode < 400) {
+                    		return $result;
+                		}
+
+                		fclose($result);
+
+                		// Only retry on server errors or throttling
+                		if ($statusCode === 429 || $statusCode >= 500) {
+                    		if ($attempt < $maxAttempts) {
+                        		usleep(min(1000000, 100000 * (2 ** ($attempt - 1))));
+                        		continue;
+                    		}
+                		}
+
+                		// 4xx (except 429) — don't retry, fail immediately
+                		return false;
+            		}
+
+            		// Couldn't parse status but got a stream — use it
+            		return $result;
+        		}
+
+        		// fopen returned false — connection-level failure (DNS, timeout, etc.)
+        		// These are retryable
+        		if ($attempt < $maxAttempts) {
+            		usleep(min(1000000, 100000 * (2 ** ($attempt - 1))));
+        		}
+    		}
+
+    		return false;
 		});
+
 		if (!$fh) {
 			throw new \Exception("Failed to read object $urn");
 		}

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -44,7 +44,11 @@ trait S3ObjectTrait {
 		$maxAttempts = max(1, $this->retriesMaxAttempts);
 		$lastError = 'unknown error';
 
-		$fh = SeekableHttpStream::open(function ($range) use ($urn, $maxAttempts, &$lastError) {
+		// TODO: consider unifying logger access across S3ConnectionTrait and S3ObjectTrait
+		// via an abstract method (e.g. getLogger()) rather than inline container lookups
+		$logger = \OCP\Server::get(\Psr\Log\LoggerInterface::class);
+
+		$fh = SeekableHttpStream::open(function ($range) use ($urn, $maxAttempts, &$lastError, $logger) {
 			$command = $this->getConnection()->getCommand('GetObject', [
 				'Bucket' => $this->bucket,
 				'Key' => $urn,
@@ -102,14 +106,21 @@ trait S3ObjectTrait {
 					$lastError = $this->formatS3ReadError($urn, $range, $statusCode, $errorInfo, $attempt, $maxAttempts);
 
 					if ($this->isRetryableHttpStatus($statusCode) && $attempt < $maxAttempts) {
+						// gives operators visibility into transient S3 issues even when retries succeed by logging
+						$logger->warning($lastError, ['app' => 'objectstore']);
 						$this->sleepBeforeRetry($attempt);
 						continue;
 					}
 
+					// for non-retryable HTTP errors or exhausted retries, log the final failure with full S3 error context
+					$logger->error($lastError, ['app' => 'objectstore']);
 					return false;
 				}
 
+				// fopen returned false - i.e. connection-level failure (DNS, timeout, TLS, etc.)
+				// log occurences for operator visibility even if retried
 				$lastError = "connection failure while reading object $urn range $range on attempt $attempt/$maxAttempts";
+				$logger->warning($lastError, ['app' => 'objectstore']);
 
 				if ($attempt < $maxAttempts) {
 					$this->sleepBeforeRetry($attempt);
@@ -129,8 +140,8 @@ trait S3ObjectTrait {
 	/**
 	 * Parse the effective HTTP status code from stream wrapper metadata.
 	 *
-	 * wrapper_data can contain multiple status lines, for example due to redirects,
-	 * proxy responses, or interim 100 responses. We want the last HTTP status line.
+	 * wrapper_data can contain multiple status lines (e.g. 100 Continue,
+	 * redirects, proxy responses). We want the last HTTP status line.
 	 *
 	 * @param array|string $responseHead The wrapper_data from stream_get_meta_data
 	 */

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -88,6 +88,12 @@ trait S3ObjectTrait {
 
 			$context = stream_context_create($opts);
 
+			// Retries here are per ranged HTTP fetch, not per high-level readObject() call.
+			// A single read may therefore trigger multiple retry sequences across seeks/reopens.
+			// sleepBeforeRetry() deliberately caps backoff to limit per-range delay.
+			// If this ever becomes an issue we might:
+			// - use a smaller retry count for read ranges than for write operations, or
+			// - cap total sleep time more aggressively.
 			for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
 				$result = @fopen($requestUri, 'r', false, $context);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

`readObject()` bypasses the AWS SDK's HTTP transport to enable seekable reads via HTTP range requests (`SeekableHttpStream`). A side effect is that the SDK's retry middleware and error parsing -- configured via `retriesMaxAttempts` -- have no effect on read operations. This means transient S3 failures (503, 429,
connection timeouts) cause immediate failure, and all errors surface as the generic `"Failed to read object"` with no S3 error context.

Changes:

- **Retry with backoff and jitter** for transient failures (5xx, 429) and connection-level errors, honoring the existing `retriesMaxAttempts` config
- **`ignore_errors` stream context option** so `fopen()` returns a stream on 4xx/5xx instead of bare `false`, allowing inspection of the actual response
- **S3 error response parsing** -- extracts error code, message, `x-amz-request-id`, and `x-amz-id-2` from both the XML body and response headers
- **Per-attempt logging** at `warning` for retryable failures (visible even when retries succeed) and `error` for terminal failures
- **Improved exception messages** including attempt count and structured S3 error detail instead of `"Failed to read object $urn"`
- **Correct status code parsing** -- scans `wrapper_data` in reverse to handle 100 Continue / redirect / proxy response chains

Context:

See [PR #20033](https://github.com/nextcloud/server/pull/20033) for the original motivation behind the `SeekableHttpStream` approach. The SDK bypass remains necessary for seekable range-request streams; this change brings the error handling closer to parity with what the SDK provides for all other S3 operations.

Not in scope:

- Refactoring logger access across `S3ConnectionTrait` / `S3ObjectTrait` into a shared abstract method (flagged with a TODO for a follow-up)
- Response checksum validation and permanent redirect handling, which are also bypassed but require deeper architectural changes

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
