### PR TITLE
fix: cache validation of system keys

### DIFF
--- a/apps/encryption/lib/Users/Setup.php
+++ b/apps/encryption/lib/Users/Setup.php
@@ -9,13 +9,18 @@ namespace OCA\Encryption\Users;
 
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\KeyManager;
+use OCP\ICache;
+use OCP\ICacheFactory;
 
 class Setup {
+	private readonly ICache $cache;
 
 	public function __construct(
 		private Crypt $crypt,
 		private KeyManager $keyManager,
+		ICacheFactory $cacheFactory,
 	) {
+		$this->cache = $cacheFactory->createLocal('encryption-setup');
 	}
 
 	/**
@@ -35,7 +40,10 @@ class Setup {
 	 * make sure that all system keys exists
 	 */
 	public function setupSystem() {
-		$this->keyManager->validateShareKey();
-		$this->keyManager->validateMasterKey();
+		if (!$this->cache->get('keys-validated')) {
+			$this->keyManager->validateShareKey();
+			$this->keyManager->validateMasterKey();
+			$this->cache->set('keys-validated', true);
+		}
 	}
 }

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -12,6 +12,7 @@ namespace OCA\Encryption\Tests\Command;
 
 use OC\Files\View;
 use OCA\Encryption\Command\FixEncryptedVersion;
+use OCA\Encryption\KeyManager;
 use OCA\Encryption\Util;
 use OCP\Encryption\IManager;
 use OCP\Files\ISetupManager;
@@ -49,6 +50,8 @@ class FixEncryptedVersionTest extends TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		Server::get(KeyManager::class)->validateMasterKey();
+		Server::get(KeyManager::class)->validateShareKey();
 
 		Server::get(IAppConfig::class)->setValueBool('encryption', 'useMasterKey', true);
 

--- a/apps/encryption/tests/EncryptedStorageTest.php
+++ b/apps/encryption/tests/EncryptedStorageTest.php
@@ -11,6 +11,7 @@ namespace OCA\encryption\tests;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
+use OCA\Encryption\KeyManager;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\Server;
@@ -30,6 +31,8 @@ class EncryptedStorageTest extends TestCase {
 	use UserTrait;
 
 	public function testMoveFromEncrypted(): void {
+		Server::get(KeyManager::class)->validateMasterKey();
+		Server::get(KeyManager::class)->validateShareKey();
 		$this->createUser('test1', 'test2');
 		$this->setupForUser('test1', 'test2');
 

--- a/apps/encryption/tests/Users/SetupTest.php
+++ b/apps/encryption/tests/Users/SetupTest.php
@@ -12,6 +12,8 @@ namespace OCA\Encryption\Tests\Users;
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -32,9 +34,16 @@ class SetupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$cache = $this->createMock(ICache::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createLocal')
+			->willReturn($cache);
+
 		$this->instance = new Setup(
 			$this->cryptMock,
-			$this->keyManagerMock);
+			$this->keyManagerMock,
+			$cacheFactory,
+		);
 	}
 
 


### PR DESCRIPTION
Validating the share and master key involves a minimum of reading 3 files from storage, something which can take a non-trivial amount of time with object store setups.

This adds some basic caching to prevent having to do the validation on every request.