### PR TITLE
feat(files_external/s3): make some auth labels clearer

### DIFF
--- a/apps/files_external/lib/Lib/Auth/AmazonS3/AccessKey.php
+++ b/apps/files_external/lib/Lib/Auth/AmazonS3/AccessKey.php
@@ -23,10 +23,10 @@ class AccessKey extends AuthMechanism {
 		$this
 			->setIdentifier('amazons3::accesskey')
 			->setScheme(self::SCHEME_AMAZONS3_ACCESSKEY)
-			->setText($l->t('Access key'))
+			->setText($l->t('Static credentials'))
 			->addParameters([
-				new DefinitionParameter('key', $l->t('Access key')),
-				(new DefinitionParameter('secret', $l->t('Secret key')))
+				new DefinitionParameter('key', $l->t('Access key ID')),
+				(new DefinitionParameter('secret', $l->t('Secret access key')))
 					->setType(DefinitionParameter::VALUE_PASSWORD),
 			]);
 	}

--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -41,7 +41,7 @@ class AmazonS3 extends Backend {
 					->setDefaultValue(true),
 				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
-				(new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))
+				(new DefinitionParameter('legacy_auth', $l->t('Use Legacy S3 signing (v2)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('useMultipartCopy', $l->t('Enable multipart copy')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

**Changes**

Improve the S3 external storage UI by making two labels more explicit:

- rename the S3 auth method label from "Access key" to a clearer static-credentials label and update the parameter names
- rename "Legacy (v2) authentication" to explicitly refer to legacy S3 signature v2 and avoid confusion with "authentication" methods (and prefix with "Use..." for consistent with other elements).

<img width="512" height="1184" alt="image" src="https://github.com/user-attachments/assets/df44b931-8844-4b73-97b0-736b0801be4c" />


**Why**

The current S3 wording is confusing in two ways:

1. "Access key" is too vague
It does not clearly communicate that this option expects long-lived static credentials, and it is easily confused with the field label itself.

2. "Legacy (v2) authentication" is ambiguous
This setting is really about legacy S3 request signing compatibility, not the general authentication method.

These changes make the S3 configuration UI more self-explanatory without changing behavior.

**Future follow-up**

There is a related UX issue where "None" is misleading for S3. I was also hoping to change that (to something like "Instance metadata"). However, that is being left for a follow-up PR because it has additional design/compatibility hurdles:

- `SCHEME_NULL` is generic across `files_external`
- we re-used `null::null` rather than creating an S3 specific one
- `Backend::addAuthScheme()` works at the scheme level, not per-backend label override
- introducing an S3-specific replacement likely needs either framework changes or careful compatibility (migration) handling for existing config

For now that one will have to remain labeled "None" as-is in the UI unfortunately...

<img width="600" height="1150" alt="image" src="https://github.com/user-attachments/assets/70b81bc1-8a24-4db2-8ad2-62abddaff512" />


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
