### PR TITLE
fix: Force Imagick to only accept HEIC/HEIF images

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -262,6 +262,12 @@ SPDX-FileCopyrightText = "2025 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
+path = ["tests/data/testimage-disguised-svg.heic"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
 path = ["composer.json", "composer.lock", ".github/CODEOWNERS", "__tests__/tsconfig.json", "tsconfig.json", "apps/**/composer/composer.json", "apps/**/composer/composer.lock", "apps/**/composer/composer/installed.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2011-2016 ownCloud, Inc., 2016-2024 Nextcloud GmbH and Nextcloud contributors"

--- a/lib/private/Preview/HEIC.php
+++ b/lib/private/Preview/HEIC.php
@@ -65,6 +65,9 @@ class HEIC extends ProviderV2 {
 					'app' => 'core',
 				]
 			);
+			if (defined('PHPUNIT_COMPOSER_INSTALL') || defined('__PHPUNIT_PHAR__')) {
+				throw $e;
+			}
 			return null;
 		}
 
@@ -96,16 +99,15 @@ class HEIC extends ProviderV2 {
 	private function getResizedPreview($tmpPath, $maxX, $maxY) {
 		$bp = new \Imagick();
 
-		// Some HEIC files just contain (or at least are identified as) other formats
-		// like JPEG. We just need to check if the image is safe to process.
-		$bp->pingImage($tmpPath . '[0]');
+		// Force Imagick to only accept HEIC or HEIF images
+		$bp->pingImage('heic:' . $tmpPath . '[0]');
 		$mimeType = $bp->getImageMimeType();
-		if (!preg_match('/^image\/(x-)?(png|jpeg|gif|bmp|tiff|webp|hei(f|c)|avif)$/', $mimeType)) {
+		if (!preg_match('/^image\/(x-)?hei(f|c)$/', $mimeType)) {
 			throw new \Exception('File mime type does not match the preview provider: ' . $mimeType);
 		}
 
 		// Layer 0 contains either the bitmap or a flat representation of all vector layers
-		$bp->readImage($tmpPath . '[0]');
+		$bp->readImage('heic:' . $tmpPath . '[0]');
 
 		// Fix orientation from EXIF
 		$bp->autoOrient();

--- a/lib/private/Preview/HEIC.php
+++ b/lib/private/Preview/HEIC.php
@@ -100,16 +100,15 @@ class HEIC extends ProviderV2 {
 	private function getResizedPreview($tmpPath, $maxX, $maxY) {
 		$bp = new \Imagick();
 
-		// Some HEIC files just contain (or at least are identified as) other formats
-		// like JPEG. We just need to check if the image is safe to process.
-		$bp->pingImage($tmpPath . '[0]');
+		// Force Imagick to only accept HEIC or HEIF images
+		$bp->pingImage('heic:' . $tmpPath . '[0]');
 		$mimeType = $bp->getImageMimeType();
-		if (!preg_match('/^image\/(x-)?(png|jpeg|gif|bmp|tiff|webp|hei(f|c)|avif)$/', $mimeType)) {
+		if (!preg_match('/^image\/(x-)?hei(f|c)$/', $mimeType)) {
 			throw new \Exception('File mime type does not match the preview provider: ' . $mimeType);
 		}
 
 		// Layer 0 contains either the bitmap or a flat representation of all vector layers
-		$bp->readImage($tmpPath . '[0]');
+		$bp->readImage('heic:' . $tmpPath . '[0]');
 
 		// Fix orientation from EXIF
 		$bp->autoOrient();

--- a/tests/data/testimage-disguised-svg.heic
+++ b/tests/data/testimage-disguised-svg.heic
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   style="overflow: hidden; position: relative;"
+   width="500"
+   height="500">
+    <image x="0" y="0" width="500" height="500" xlink:href="/var/www/html/secret.png" stroke-width="1" id="image3204" />
+</svg>

--- a/tests/lib/Preview/HEICDisguisedSVGTest.php
+++ b/tests/lib/Preview/HEICDisguisedSVGTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Preview;
+
+use OC\Preview\HEIC;
+
+/**
+ * Class HEICDisguisedSVGTest
+ *
+ *
+ * @package Test\Preview
+ */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
+class HEICDisguisedSVGTest extends Provider {
+	protected function setUp(): void {
+		if (!in_array('HEIC', \Imagick::queryFormats('HEI*'))) {
+			$this->markTestSkipped('ImageMagick is not HEIC aware. Skipping tests');
+		} else {
+			parent::setUp();
+
+			$fileName = 'testimage-disguised-svg.heic';
+			$this->imgPath = $this->prepareTestFile($fileName, \OC::$SERVERROOT . '/tests/data/' . $fileName);
+			$this->width = 1680;
+			$this->height = 1050;
+			$this->provider = new HEIC;
+		}
+	}
+
+	/**
+	 * Launches all the tests we have
+	 *
+	 *
+	 * @param int $widthAdjustment
+	 * @param int $heightAdjustment
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dimensionsDataProvider')]
+	#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('imagick')]
+	public function testGetThumbnail($widthAdjustment, $heightAdjustment): void {
+		try {
+			parent::testGetThumbnail($widthAdjustment, $heightAdjustment);
+			$this->fail('Expected ImagickException was not thrown.');
+		} catch (\ImagickException $e) {
+			$this->assertStringStartsWith('ImageTypeNotSupported', $e->getMessage());
+		}
+	}
+}

--- a/tests/lib/Preview/HEICDisguisedSVGTest.php
+++ b/tests/lib/Preview/HEICDisguisedSVGTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Preview;
+
+use OC\Preview\HEIC;
+
+/**
+ * Class HEICDisguisedSVGTest
+ *
+ *
+ * @package Test\Preview
+ */
+#[\PHPUnit\Framework\Attributes\Group('DB')]
+class HEICDisguisedSVGTest extends Provider {
+	protected function setUp(): void {
+		if (!in_array('HEIC', \Imagick::queryFormats('HEI*'))) {
+			$this->markTestSkipped('ImageMagick is not HEIC aware. Skipping tests');
+		} else {
+			parent::setUp();
+
+			$this->width = 1680;
+			$this->height = 1050;
+			$this->provider = new HEIC;
+		}
+	}
+
+	/**
+	 * Launches all the tests we have
+	 *
+	 *
+	 * @param int $widthAdjustment
+	 * @param int $heightAdjustment
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dimensionsDataProvider')]
+	#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('imagick')]
+	public function testGetThumbnail($widthAdjustment, $heightAdjustment): void {
+		# HEIC->getThumbnail will always return null if there is an exception, be we want to check why getResizedPreview fails
+		$reflection = new \ReflectionClass($this->provider);
+		$method = $reflection->getMethod('getResizedPreview');
+		$method->setAccessible(true);
+
+		$absolutePath = \OC::$SERVERROOT . '/tests/data/' . 'testimage-disguised-svg.heic';
+
+		try {
+			$method->invoke(
+				$this->provider,
+				$absolutePath,
+				$this->width,
+				$this->height
+			);
+			$this->fail('Expected ImagickException was not thrown.');
+		} catch (\ImagickException $e) {
+			$this->assertStringStartsWith('ImageTypeNotSupported', $e->getMessage());
+		}
+	}
+}


### PR DESCRIPTION
* Resolves: #58393 

## Summary
The HEIC preview provider was disabled in the past due to security issues ([HackerOne](https://hackerone.com/reports/1261413), #28077). While #44710 added MIME-checking as a security measure, the reliability of these checks is debatable. Furthermore, malicious files cause Imagick's pingImage to attempt unauthorized file access even before the check occurs (see below). This PR restricts Imagick to only accept HEIC/HEIF files, strengthening the defense against SVG SSRF attacks.

### The issue with pingImage
When targeted by an SVG SSRF attack, Imagick's pingImage attempts to access files before the MIME type is verified. For a file named malicious.heic with the following content:
`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg
   xmlns:svg="http://www.w3.org/2000/svg"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   style="overflow: hidden; position: relative;"
   width="500"
   height="500">
    <image x="0" y="0" width="500" height="500" xlink:href="/var/www/html/secret.png" stroke-width="1" id="image3204" />
</svg>`
pingImage will throw an exception if secret.png does not exist. I.e.:
`nextcloud-1  | {(..) "message":"File: /admin/files/malicious.heic Imagick says:" (..) "occ_command":["occ","preview:generate-all"],"exception":{"Exception":"ImagickException","Message":"unable to open image '/var/www/html/secret.png': No such file or directory (..)`
TThe preview code should fail consistently regardless of whether secret.png exists. It should not try to access secret.png at all. With this PR, the preview will always fail like:
`nextcloud-1  | {(..) "message":"File: /admin/files/malicious.heic Imagick says:" (..) "occ_command":["occ","preview:generate-all"],"exception":{"Exception":"ImagickException","Message":"ImageTypeNotSupported /var/www/html/data/admin/files/malicious.heic'`

### Mislabeled files
 #44710 attempted to preserve preview generation for JPEG/PNG files incorrectly ending in .heic. This functionality is removed by the stricter Imagick check. This is unlikely to be a common issue; I would prefer to reduce attack surface. For clarity, I removed JPEG, PNG etc. from the allowed MIME types. In theory, the MIME check is redundant as non-HEIC/HEIF images will fail in pingImage. I decided to leave it in the code, but I can also remove it, if wanted.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)