### PR TITLE
feat(files_external): modernize storage backend labels and descriptions

### DIFF
--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -39,7 +39,7 @@ class AmazonS3 extends Backend {
 				(new DefinitionParameter('use_ssl', $l->t('Use HTTPS')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
-				(new DefinitionParameter('use_path_style', $l->t('Use Path Style (https://domain.com/bucket)')))
+				(new DefinitionParameter('use_path_style', $l->t('Use Path Style (https://example.com/bucket)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('legacy_auth', $l->t('Use Legacy S3 signing (v2)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),

--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -23,7 +23,7 @@ class AmazonS3 extends Backend {
 			->setIdentifier('amazons3')
 			->addIdentifierAlias('\OC\Files\Storage\AmazonS3') // legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\AmazonS3')
-			->setText($l->t('S3 Storage'))
+			->setText($l->t('S3-Compatible Object Storage'))
 			->addParameters([
 				new DefinitionParameter('bucket', $l->t('Bucket')),
 				(new DefinitionParameter('hostname', $l->t('Hostname')))
@@ -36,17 +36,17 @@ class AmazonS3 extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('storageClass', $l->t('Storage Class')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('use_ssl', $l->t('Enable SSL')))
+				(new DefinitionParameter('use_ssl', $l->t('Use HTTPS')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
-				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
+				(new DefinitionParameter('use_path_style', $l->t('Use Path Style (https://domain.com/bucket)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('legacy_auth', $l->t('Use Legacy S3 signing (v2)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('useMultipartCopy', $l->t('Enable multipart copy')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
-				(new DefinitionParameter('use_presigned_url', $l->t('Use presigned S3 url')))
+				(new DefinitionParameter('use_presigned_url', $l->t('Enable Direct Downloads (presigned URLs)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(false),
 				(new DefinitionParameter('sse_c_key', $l->t('SSE-C encryption key')))

--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -23,7 +23,7 @@ class AmazonS3 extends Backend {
 			->setIdentifier('amazons3')
 			->addIdentifierAlias('\OC\Files\Storage\AmazonS3') // legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\AmazonS3')
-			->setText($l->t('S3 Storage'))
+			->setText($l->t('S3-Compatible Object Storage'))
 			->addParameters([
 				new DefinitionParameter('bucket', $l->t('Bucket')),
 				(new DefinitionParameter('hostname', $l->t('Hostname')))
@@ -36,17 +36,17 @@ class AmazonS3 extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('storageClass', $l->t('Storage Class')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('use_ssl', $l->t('Enable SSL')))
+				(new DefinitionParameter('use_ssl', $l->t('Use HTTPS')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
-				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
+				(new DefinitionParameter('use_path_style', $l->t('Use Path Style (https://domain.com/bucket)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('useMultipartCopy', $l->t('Enable multipart copy')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
-				(new DefinitionParameter('use_presigned_url', $l->t('Use presigned S3 url')))
+				(new DefinitionParameter('use_presigned_url', $l->t('Enable Direct Downloads (presigned URLs)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(false),
 				(new DefinitionParameter('sse_c_key', $l->t('SSE-C encryption key')))

--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -39,7 +39,7 @@ class AmazonS3 extends Backend {
 				(new DefinitionParameter('use_ssl', $l->t('Use HTTPS')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
-				(new DefinitionParameter('use_path_style', $l->t('Use Path Style (https://domain.com/bucket)')))
+				(new DefinitionParameter('use_path_style', $l->t('Use Path Style (https://example.com/bucket)')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),

--- a/apps/files_external/lib/Lib/Backend/FTP.php
+++ b/apps/files_external/lib/Lib/Backend/FTP.php
@@ -23,7 +23,7 @@ class FTP extends Backend {
 			->setIdentifier('ftp')
 			->addIdentifierAlias('\OC\Files\Storage\FTP') // legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\FTP')
-			->setText($l->t('FTP'))
+			->setText($l->t('FTP / FTPS'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				(new DefinitionParameter('port', $l->t('Port')))

--- a/apps/files_external/lib/Lib/Backend/Local.php
+++ b/apps/files_external/lib/Lib/Backend/Local.php
@@ -23,7 +23,7 @@ class Local extends Backend {
 			->setIdentifier('local')
 			->addIdentifierAlias('\OC\Files\Storage\Local') // legacy compat
 			->setStorageClass('\OC\Files\Storage\Local')
-			->setText($l->t('Local'))
+			->setText($l->t('Local (server storage)'))
 			->addParameters([
 				new DefinitionParameter('datadir', $l->t('Location')),
 			])

--- a/apps/files_external/lib/Lib/Backend/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Backend/OwnCloud.php
@@ -20,7 +20,7 @@ class OwnCloud extends Backend {
 			->setIdentifier('owncloud')
 			->addIdentifierAlias('\OC\Files\Storage\OwnCloud') // legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\OwnCloud')
-			->setText($l->t('Nextcloud'))
+			->setText($l->t('Nextcloud (WebDAV)'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('URL')),
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))

--- a/apps/files_external/lib/Lib/Backend/SFTP.php
+++ b/apps/files_external/lib/Lib/Backend/SFTP.php
@@ -20,7 +20,7 @@ class SFTP extends Backend {
 			->setIdentifier('sftp')
 			->addIdentifierAlias('\OC\Files\Storage\SFTP') // legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\SFTP')
-			->setText($l->t('SFTP'))
+			->setText($l->t('SFTP (SSH file transfer)'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				(new DefinitionParameter('port', $l->t('Port')))

--- a/apps/files_external/lib/Lib/Backend/SFTP_Key.php
+++ b/apps/files_external/lib/Lib/Backend/SFTP_Key.php
@@ -19,7 +19,7 @@ class SFTP_Key extends Backend {
 		$this
 			->setIdentifier('\OC\Files\Storage\SFTP_Key')
 			->setStorageClass('\OCA\Files_External\Lib\Storage\SFTP')
-			->setText($l->t('SFTP with secret key login'))
+			->setText($l->t('SFTP with public key authentication'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -30,7 +30,7 @@ class SMB extends Backend {
 			->setIdentifier('smb')
 			->addIdentifierAlias('\OC\Files\Storage\SMB')// legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
-			->setText($l->t('SMB/CIFS'))
+			->setText($l->t('SMB / CIFS (Windows network share)'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				new DefinitionParameter('share', $l->t('Share')),

--- a/apps/files_external/lib/Lib/Backend/SMB_OC.php
+++ b/apps/files_external/lib/Lib/Backend/SMB_OC.php
@@ -28,7 +28,7 @@ class SMB_OC extends Backend {
 		$this
 			->setIdentifier('\OC\Files\Storage\SMB_OC')
 			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
-			->setText($l->t('SMB/CIFS using OC login'))
+			->setText($l->t('SMB / CIFS using Nextcloud login'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				(new DefinitionParameter('username_as_share', $l->t('Login as share')))

--- a/apps/files_external/lib/Lib/Backend/Swift.php
+++ b/apps/files_external/lib/Lib/Backend/Swift.php
@@ -24,7 +24,7 @@ class Swift extends Backend {
 			->setIdentifier('swift')
 			->addIdentifierAlias('\OC\Files\Storage\Swift') // legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\Swift')
-			->setText($l->t('OpenStack Object Storage'))
+			->setText($l->t('OpenStack Swift Object Storage'))
 			->addParameters([
 				(new DefinitionParameter('service_name', $l->t('Service name')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),

--- a/apps/files_external/lib/Service/BackendService.php
+++ b/apps/files_external/lib/Service/BackendService.php
@@ -178,7 +178,9 @@ class BackendService {
 	 * @return Backend[]
 	 */
 	public function getAvailableBackends() {
-		return array_filter($this->getBackends(), fn (Backend $backend) => $backend->checkRequiredDependencies() === []);
+		$backends = array_filter($this->getBackends(), fn (Backend $backend) => $backend->checkRequiredDependencies() === []);
+		uasort($backends, [Backend::class, 'lexicalCompare']);
+		return $backends;
 	}
 
 	/**

--- a/cypress/e2e/files_external/settings.cy.ts
+++ b/cypress/e2e/files_external/settings.cy.ts
@@ -63,8 +63,7 @@ describe('files_external settings', () => {
 					.click()
 				cy.root().closest('body')
 					.findByRole('option', { name: 'WebDAV' })
-					.should('be.visible')
-					.click()
+					.click({ force: true }) // forced due to ordering + `position: fixed` usage
 
 				getComboBox(/Authentication/)
 					.should('be.visible')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Refresh external storage backend labels and descriptions for clearer, more consistent terminology:

<img width="520" height="612" alt="image" src="https://github.com/user-attachments/assets/836a82e2-38ee-4b46-b4e1-da9cd570ff63" />

<img width="420" height="959" alt="image" src="https://github.com/user-attachments/assets/a83f3b44-7787-4a09-ab7d-dd89e8818afc" />

Related PR: #59204

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
