### PR TITLE
feat(systemtag): Add $user context to create and update tag

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -159,8 +159,8 @@ class SystemTagManager implements ISystemTagManager {
 		}
 	}
 
-	public function createTag(string $tagName, bool $userVisible, bool $userAssignable): ISystemTag {
-		$user = $this->userSession->getUser();
+	public function createTag(string $tagName, bool $userVisible, bool $userAssignable, ?IUser $user = null): ISystemTag {
+		$user ??= $this->userSession->getUser();
 		if (!$this->canUserCreateTag($user)) {
 			throw new TagCreationForbiddenException();
 		}
@@ -219,6 +219,7 @@ class SystemTagManager implements ISystemTagManager {
 		bool $userVisible,
 		bool $userAssignable,
 		?string $color,
+		?IUser $user = null,
 	): void {
 		try {
 			$tags = $this->getTagsByIds($tagId);
@@ -228,7 +229,7 @@ class SystemTagManager implements ISystemTagManager {
 			);
 		}
 
-		$user = $this->userSession->getUser();
+		$user ??= $this->userSession->getUser();
 		if (!$this->canUserUpdateTag($user)) {
 			throw new TagUpdateForbiddenException();
 		}

--- a/lib/public/SystemTag/ISystemTagManager.php
+++ b/lib/public/SystemTag/ISystemTagManager.php
@@ -61,6 +61,7 @@ interface ISystemTagManager {
 	 * @param string $tagName tag name
 	 * @param bool $userVisible whether the tag is visible by users
 	 * @param bool $userAssignable whether the tag is assignable by users
+	 * @param ?IUser $user the user that wants to create a tag. Null to use the one in session.
 	 *
 	 * @return ISystemTag system tag
 	 *
@@ -69,8 +70,9 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 * @since 31.0.0 Can throw TagCreationForbiddenExceptionif user doesn't have the right to create a new tag
+	 * @since 34.0.0 Added nullable $user parameter
 	 */
-	public function createTag(string $tagName, bool $userVisible, bool $userAssignable): ISystemTag;
+	public function createTag(string $tagName, bool $userVisible, bool $userAssignable, ?IUser $user = null): ISystemTag;
 
 	/**
 	 * Returns all known tags, optionally filtered by visibility.
@@ -92,6 +94,7 @@ interface ISystemTagManager {
 	 * @param bool $userVisible whether the tag is visible by users
 	 * @param bool $userAssignable whether the tag is assignable by users
 	 * @param string $color color
+	 * @param ?IUser $user the user that wants to update a tag. Null to use the one in session.
 	 *
 	 * @throws TagNotFoundException if tag with the given id does not exist
 	 * @throws TagAlreadyExistsException if there is already another tag
@@ -99,8 +102,9 @@ interface ISystemTagManager {
 	 *
 	 * @since 9.0.0
 	 * @since 31.0.0 `$color` parameter added
+	 * @since 34.0.0 Added nullable $user parameter
 	 */
-	public function updateTag(string $tagId, string $newName, bool $userVisible, bool $userAssignable, ?string $color);
+	public function updateTag(string $tagId, string $newName, bool $userVisible, bool $userAssignable, ?string $color, ?IUser $user = null): void;
 
 	/**
 	 * Delete the given tags from the database and all their relationships.

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -296,22 +296,22 @@ class SystemTagManagerTest extends TestCase {
 		return [
 			[
 				// update name
-				['one', true, true, '0082c9'],
+				['one', true, true],
 				['two', true, true, '0082c9']
 			],
 			[
 				// update one flag
-				['one', false, true, null],
+				['one', false, true],
 				['one', true, true, '0082c9']
 			],
 			[
 				// update all flags
-				['one', false, false, '0082c9'],
+				['one', false, false],
 				['one', true, true, null]
 			],
 			[
 				// update all
-				['one', false, false, '0082c9'],
+				['one', false, false],
 				['two', true, true, '0082c9']
 			],
 		];
@@ -323,7 +323,6 @@ class SystemTagManagerTest extends TestCase {
 			$tagCreate[0],
 			$tagCreate[1],
 			$tagCreate[2],
-			$tagCreate[3],
 		);
 		$this->tagManager->updateTag(
 			$tag1->getId(),
@@ -336,7 +335,6 @@ class SystemTagManagerTest extends TestCase {
 			$tagUpdated[0],
 			$tagUpdated[1],
 			$tagUpdated[2],
-			$tagUpdated[3],
 		);
 
 		$this->assertEquals($tag2->getId(), $tag1->getId());


### PR DESCRIPTION
This would allow different use cases than what is possible now.