### PR TITLE
[local] fix(group): pass previous display name in GroupChangedEvent

### DIFF
--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -75,11 +75,12 @@ class Group implements IGroup {
 		$displayName = trim($displayName);
 		if ($displayName !== '') {
 			$this->dispatcher->dispatchTyped(new BeforeGroupChangedEvent($this, 'displayName', $displayName, $this->displayName));
+			$oldDisplayName = $this->displayName;
 			foreach ($this->backends as $backend) {
 				if (($backend instanceof ISetDisplayNameBackend)
 					&& $backend->setDisplayName($this->gid, $displayName)) {
 					$this->displayName = $displayName;
-					$this->dispatcher->dispatchTyped(new GroupChangedEvent($this, 'displayName', $displayName, ''));
+					$this->dispatcher->dispatchTyped(new GroupChangedEvent($this, 'displayName', $displayName, $oldDisplayName));
 					return true;
 				}
 			}

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -11,6 +11,8 @@ namespace Test\Group;
 use OC\Group\Group;
 use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Group\Events\BeforeGroupChangedEvent;
+use OCP\Group\Events\GroupChangedEvent;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -455,6 +457,41 @@ class GroupTest extends \Test\TestCase {
 		$users = $group->count('2');
 
 		$this->assertSame(false, $users);
+	}
+
+	public function testSetDisplayNameDispatchesOldValue(): void {
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$userManager = $this->getUserManager();
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$invocation = 0;
+		$dispatcher->expects($this->exactly(2))
+			->method('dispatchTyped')
+			->willReturnCallback(function ($event) use (&$invocation): void {
+				$invocation++;
+				if ($invocation === 1) {
+					$this->assertInstanceOf(BeforeGroupChangedEvent::class, $event);
+					$this->assertSame('displayName', $event->getFeature());
+					$this->assertSame('New Name', $event->getValue());
+					$this->assertSame('Old Name', $event->getOldValue());
+					return;
+				}
+
+				$this->assertInstanceOf(GroupChangedEvent::class, $event);
+				$this->assertSame('displayName', $event->getFeature());
+				$this->assertSame('New Name', $event->getValue());
+				$this->assertSame('Old Name', $event->getOldValue());
+			});
+
+		$backend->expects($this->once())
+			->method('setDisplayName')
+			->with('group1', 'New Name')
+			->willReturn(true);
+
+		$group = new Group('group1', [$backend], $dispatcher, $userManager, null, 'Old Name');
+		$this->assertTrue($group->setDisplayName('New Name'));
 	}
 
 	public function testDelete(): void {


### PR DESCRIPTION
Local version of https://github.com/nextcloud/server/pull/58990 for CI