### PR TITLE
fix(fileDrop): don't escape Folder calls

### DIFF
--- a/apps/files_sharing/src/public-nickname-handler.ts
+++ b/apps/files_sharing/src/public-nickname-handler.ts
@@ -57,14 +57,14 @@ window.addEventListener('DOMContentLoaded', () => {
 
 	const options = {
 		nickname,
-		notice: t('files_sharing', 'To upload files to {folder}, you need to provide your name first.', { folder }),
+		notice: t('files_sharing', 'To upload files to {folder}, you need to provide your name first.', { folder }, { escape: false }),
 		subtitle: undefined as string | undefined,
-		title: t('files_sharing', 'Upload files to {folder}', { folder }),
+		title: t('files_sharing', 'Upload files to {folder}', { folder }, { escape: false }),
 	}
 
 	// If the guest already has a nickname, we just make them double check
 	if (nickname) {
-		options.notice = t('files_sharing', 'Please confirm your name to upload files to {folder}', { folder })
+		options.notice = t('files_sharing', 'Please confirm your name to upload files to {folder}', { folder }, { escape: false })
 	}
 
 	// If the account owner set their name as public,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Since `{ folder }` name is already filtered on folder creation (folder names can't have `<, >, &`...) don't (re)escape here so folder names like `We're the best` don't become `We&#39;re the best`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
