### PR TITLE
fix: use unjailed source path when moving jailed files

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -68,6 +68,14 @@ class CacheJail extends CacheWrapper {
 		}
 	}
 
+	protected function getUnjailedSourcePath(string $path): string {
+		if ($path === '') {
+			return $this->getGetUnjailedRoot();
+		} else {
+			return $this->getGetUnjailedRoot() . '/' . ltrim($path, '/');
+		}
+	}
+
 	/**
 	 * @param string $path
 	 * @param null|string $root
@@ -189,7 +197,7 @@ class CacheJail extends CacheWrapper {
 	 * @return array [$storageId, $internalPath]
 	 */
 	protected function getMoveInfo($path) {
-		return [$this->getNumericStorageId(), $this->getSourcePath($path)];
+		return [$this->getNumericStorageId(), $this->getUnjailedSourcePath($path)];
 	}
 
 	/**

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -198,7 +198,7 @@ class CacheWrapper extends Cache {
 	}
 
 	protected function getMoveInfo($path) {
-		/** @var Cache $cache */
+		/** @var Cache|CacheJail $cache */
 		$cache = $this->getCache();
 		return $cache->getMoveInfo($path);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Attempt to resolve: https://github.com/nextcloud/server/issues/53934 although I was not able to reproduce this without using groupfolders. But the issue can be triggered in other ways.

## Summary

When moving directories across storages wrapped in multiple Jails, paths of contained files are not updated correctly and lead to shares being broken.

## How to reproduce the issue

1. As admin A
2. Create a group folder and share it with a group where user B is part of
3. Create folders Share 1 and Share 2 inside the group folder and share them with User B
4. Add a directory with files inside one of the two Share folders using user A
5. Using B navigate into the Share folder containing the directory (not the group folder)
6. Move the directory to the other Share folder without going through the groupfolder

**Expected result:** the share folder is accessible and navigating into the moved folder using the share works
**Actual result:** the share folder or the moved folder become inaccessible causing the exception visible in the attached ticket (getOwner receiving null).

The reason for this is that the path of the storage and the path of the files inside the directory become off-sync.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
