### PR TITLE
fix(files_sharing): validate input in PublicPreviewController#getPreview

### DIFF
--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\PublicShareController;
 use OCP\Constants;
+use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
 use OCP\IPreview;
@@ -28,8 +29,7 @@ use OCP\Share\IShare;
 
 class PublicPreviewController extends PublicShareController {
 
-	/** @var IShare */
-	private $share;
+	private IShare $share;
 
 	public function __construct(
 		string $appName,
@@ -62,7 +62,7 @@ class PublicPreviewController extends PublicShareController {
 	/**
 	 * Get a preview for a public share.
 	 *
-	 * For shares pointing to a single file, the $file parameter is ignored and may be empty.
+	 * For shares pointing to a single file, the $file parameter is ignored.
 	 * For folder shares, $file must be the relative path to a file inside the shared folder.
 	 *
 	 * @param string $token Token of the share
@@ -121,25 +121,36 @@ class PublicPreviewController extends PublicShareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		$previewFile = null;
+
 		try {
-			$node = $share->getNode();
-			if ($node instanceof Folder) {
+			$shareNode = $share->getNode();
+			if ($shareNode instanceof Folder) {
 				if ($file === '') {
 					return new DataResponse([], Http::STATUS_BAD_REQUEST);
 				}
-				$fileNode = $node->get($file);
+
+				$previewFile = $shareNode->get($file);
+				if ($previewFile instanceof Folder) {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
 			} else {
-				$fileNode = $node;
+				$previewFile = $shareNode;
 			}
 
-			$f = $this->previewManager->getPreview($fileNode, $x, $y, !$a);
-			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$preview = $this->previewManager->getPreview($previewFile, $x, $y, !$a);
+			$response = new FileDisplayResponse(
+				$preview,
+				Http::STATUS_OK,
+				['Content-Type' => $preview->getMimeType()]
+			);
+
 			$response->cacheFor($cacheForSeconds);
 			return $response;
 		} catch (NotFoundException $e) {
-			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($mimeFallback && isset($fileNode) && !($fileNode instanceof Folder)) {
-				if ($url = $this->mimeIconProvider->getMimeIconUrl($fileNode->getMimeType())) {
+			// If a preview could not be generated for a resolved file, we can redirect to the mime icon if any
+			if ($mimeFallback && $previewFile instanceof File) {
+				if ($url = $this->mimeIconProvider->getMimeIconUrl($previewFile->getMimeType())) {
 					return new RedirectResponse($url);
 				}
 			}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -19,6 +19,7 @@ use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\ISession;
@@ -147,7 +148,7 @@ class PublicPreviewController extends PublicShareController {
 
 			$response->cacheFor($cacheForSeconds);
 			return $response;
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException) {
 			// If a preview could not be generated for a resolved file, we can redirect to the mime icon if any
 			if ($mimeFallback && $previewFile instanceof File) {
 				if ($url = $this->mimeIconProvider->getMimeIconUrl($previewFile->getMimeType())) {
@@ -155,7 +156,9 @@ class PublicPreviewController extends PublicShareController {
 				}
 			}
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
-		} catch (\InvalidArgumentException $e) {
+		} catch (NotPermittedException) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		} catch (\InvalidArgumentException) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 	}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -59,12 +59,14 @@ class PublicPreviewController extends PublicShareController {
 		return $this->share->getPassword() !== null;
 	}
 
-
 	/**
-	 * Get a preview for a shared file
+	 * Get a preview for a public share.
+	 *
+	 * For shares pointing to a single file, the $file parameter is ignored and may be empty.
+	 * For folder shares, $file must be the relative path to a file inside the shared folder.
 	 *
 	 * @param string $token Token of the share
-	 * @param string $file File in the share
+	 * @param string $file Relative path to a file inside a shared folder; ignored for single-file shares
 	 * @param int $x Width of the preview
 	 * @param int $y Height of the preview
 	 * @param bool $a Whether to not crop the preview

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -122,19 +122,22 @@ class PublicPreviewController extends PublicShareController {
 		try {
 			$node = $share->getNode();
 			if ($node instanceof Folder) {
-				$file = $node->get($file);
+				if ($file === '') {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
+				$fileNode = $node->get($file);
 			} else {
-				$file = $node;
+				$fileNode = $node;
 			}
 
-			$f = $this->previewManager->getPreview($file, $x, $y, !$a);
+			$f = $this->previewManager->getPreview($fileNode, $x, $y, !$a);
 			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
 			$response->cacheFor($cacheForSeconds);
 			return $response;
 		} catch (NotFoundException $e) {
 			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($mimeFallback) {
-				if ($url = $this->mimeIconProvider->getMimeIconUrl($file->getMimeType())) {
+			if ($mimeFallback && isset($fileNode) && !($fileNode instanceof Folder)) {
+				if ($url = $this->mimeIconProvider->getMimeIconUrl($fileNode->getMimeType())) {
 					return new RedirectResponse($url);
 				}
 			}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -20,6 +20,7 @@ use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\ISession;
@@ -151,7 +152,7 @@ class PublicPreviewController extends PublicShareController {
 
 			$response->cacheFor($cacheForSeconds);
 			return $response;
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException) {
 			// If a preview could not be generated for a resolved file, we can redirect to the mime icon if any
 			if ($mimeFallback && $previewFile instanceof File) {
 				if ($url = $this->mimeIconProvider->getMimeIconUrl($previewFile->getMimeType())) {
@@ -159,7 +160,9 @@ class PublicPreviewController extends PublicShareController {
 				}
 			}
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
-		} catch (\InvalidArgumentException $e) {
+		} catch (NotPermittedException) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		} catch (\InvalidArgumentException) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 	}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -64,10 +64,13 @@ class PublicPreviewController extends PublicShareController {
 	}
 
 	/**
-	 * Get a preview for a shared file
+	 * Get a preview for a public share.
+	 *
+	 * For shares pointing to a single file, the $file parameter is ignored and may be empty.
+	 * For folder shares, $file must be the relative path to a file inside the shared folder.
 	 *
 	 * @param string $token Token of the share
-	 * @param string $file File in the share
+	 * @param string $file Relative path to a file inside a shared folder; ignored for single-file shares
 	 * @param int $x Width of the preview
 	 * @param int $y Height of the preview
 	 * @param bool $a Whether to not crop the preview

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -220,8 +220,10 @@ class PublicPreviewController extends PublicShareController {
 			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
 			$response->cacheFor(3600 * 24);
 			return $response;
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (NotPermittedException) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		} catch (\InvalidArgumentException $e) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -125,19 +125,22 @@ class PublicPreviewController extends PublicShareController {
 		try {
 			$node = $share->getNode();
 			if ($node instanceof Folder) {
-				$file = $node->get($file);
+				if ($file === '') {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
+				$fileNode = $node->get($file);
 			} else {
-				$file = $node;
+				$fileNode = $node;
 			}
 
-			$f = $this->previewManager->getPreview($file, $x, $y, !$a);
+			$f = $this->previewManager->getPreview($fileNode, $x, $y, !$a);
 			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
 			$response->cacheFor($cacheForSeconds);
 			return $response;
 		} catch (NotFoundException $e) {
 			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($mimeFallback) {
-				if ($url = $this->mimeIconProvider->getMimeIconUrl($file->getMimeType())) {
+			if ($mimeFallback && isset($fileNode) && !($fileNode instanceof Folder)) {
+				if ($url = $this->mimeIconProvider->getMimeIconUrl($fileNode->getMimeType())) {
 					return new RedirectResponse($url);
 				}
 			}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\PublicShareController;
 use OCP\Constants;
+use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
 use OCP\IPreview;
@@ -29,8 +30,7 @@ use OCP\Share\IShare;
 
 class PublicPreviewController extends PublicShareController {
 
-	/** @var IShare */
-	private $share;
+	private IShare $share;
 
 	public function __construct(
 		string $appName,
@@ -66,7 +66,7 @@ class PublicPreviewController extends PublicShareController {
 	/**
 	 * Get a preview for a public share.
 	 *
-	 * For shares pointing to a single file, the $file parameter is ignored and may be empty.
+	 * For shares pointing to a single file, the $file parameter is ignored.
 	 * For folder shares, $file must be the relative path to a file inside the shared folder.
 	 *
 	 * @param string $token Token of the share
@@ -125,25 +125,36 @@ class PublicPreviewController extends PublicShareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		$previewFile = null;
+
 		try {
-			$node = $share->getNode();
-			if ($node instanceof Folder) {
+			$shareNode = $share->getNode();
+			if ($shareNode instanceof Folder) {
 				if ($file === '') {
 					return new DataResponse([], Http::STATUS_BAD_REQUEST);
 				}
-				$fileNode = $node->get($file);
+
+				$previewFile = $shareNode->get($file);
+				if ($previewFile instanceof Folder) {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
 			} else {
-				$fileNode = $node;
+				$previewFile = $shareNode;
 			}
 
-			$f = $this->previewManager->getPreview($fileNode, $x, $y, !$a);
-			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$preview = $this->previewManager->getPreview($previewFile, $x, $y, !$a);
+			$response = new FileDisplayResponse(
+				$preview,
+				Http::STATUS_OK,
+				['Content-Type' => $preview->getMimeType()]
+			);
+
 			$response->cacheFor($cacheForSeconds);
 			return $response;
 		} catch (NotFoundException $e) {
-			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($mimeFallback && isset($fileNode) && !($fileNode instanceof Folder)) {
-				if ($url = $this->mimeIconProvider->getMimeIconUrl($fileNode->getMimeType())) {
+			// If a preview could not be generated for a resolved file, we can redirect to the mime icon if any
+			if ($mimeFallback && $previewFile instanceof File) {
+				if ($url = $this->mimeIconProvider->getMimeIconUrl($previewFile->getMimeType())) {
 					return new RedirectResponse($url);
 				}
 			}

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -1474,7 +1474,7 @@
         "/index.php/apps/files_sharing/publicpreview/{token}": {
             "get": {
                 "operationId": "public_preview-get-preview",
-                "summary": "Get a preview for a shared file",
+                "summary": "Get a preview for a public share",
                 "tags": [
                     "public_preview"
                 ],
@@ -1500,7 +1500,7 @@
                     {
                         "name": "file",
                         "in": "query",
-                        "description": "File in the share",
+                        "description": "Relative path to a file inside a shared folder; ignored for single-file shares",
                         "schema": {
                             "type": "string",
                             "default": ""

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -10,6 +10,7 @@ use OCA\Files_Sharing\Controller\PublicPreviewController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
 use OCP\Files\File;
@@ -32,6 +33,7 @@ class PublicPreviewControllerTest extends TestCase {
 	private IManager&MockObject $shareManager;
 	private ITimeFactory&MockObject $timeFactory;
 	private IRequest&MockObject $request;
+	private IMimeIconProvider&MockObject $mimeIconProvider;
 
 	private PublicPreviewController $controller;
 
@@ -42,6 +44,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->request = $this->createMock(IRequest::class);
+		$this->mimeIconProvider = $this->createMock(IMimeIconProvider::class);
 
 		$this->timeFactory->method('getTime')
 			->willReturn(1337);
@@ -54,7 +57,7 @@ class PublicPreviewControllerTest extends TestCase {
 			$this->shareManager,
 			$this->createMock(ISession::class),
 			$this->previewManager,
-			$this->createMock(IMimeIconProvider::class),
+			$this->mimeIconProvider,
 		);
 	}
 
@@ -252,6 +255,91 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->assertEquals($expected, $res);
 	}
 
+	public function testPreviewFolderEmptyFileReturnsBadRequest(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$res = $this->controller->getPreview('token', '', 10, 10, true);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderInvalidFileWithMimeFallbackReturnsNotFound(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$folder->method('get')
+			->with($this->equalTo('file'))
+			->willThrowException(new NotFoundException());
+
+		$this->mimeIconProvider->expects($this->never())
+			->method('getMimeIconUrl');
+
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderValidFileMimeFallbackRedirectsWhenPreviewMissing(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$file = $this->createMock(File::class);
+		$folder->method('get')
+			->with($this->equalTo('file'))
+			->willReturn($file);
+
+		$file->method('getMimeType')
+			->willReturn('text/plain');
+
+		$this->previewManager->method('getPreview')
+			->with($this->equalTo($file), 10, 10, false)
+			->willThrowException(new NotFoundException());
+
+		$this->mimeIconProvider->method('getMimeIconUrl')
+			->with('text/plain')
+			->willReturn('/icon-url');
+
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$expected = new RedirectResponse('/icon-url');
+		$this->assertEquals($expected, $res);
+	}
 
 	public function testPreviewFolderValidFile(): void {
 		$share = $this->createMock(IShare::class);

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -329,7 +329,7 @@ class PublicPreviewControllerTest extends TestCase {
 			->willReturn('text/plain');
 
 		$this->previewManager->method('getPreview')
-			->with($this->equalTo($file), 10, 10, false)
+			->with($this->equalTo($file), 10, 10, true)
 			->willThrowException(new NotFoundException());
 
 		$this->mimeIconProvider->method('getMimeIconUrl')

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -276,6 +276,32 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->assertEquals($expected, $res);
 	}
 
+	public function testPreviewFolderSubfolderReturnsBadRequest(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$subfolder = $this->createMock(Folder::class);
+		$folder->method('get')
+			->with($this->equalTo('nested'))
+			->willReturn($subfolder);
+
+		$res = $this->controller->getPreview('token', 'nested', 10, 10, false, false);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
 	public function testPreviewFolderInvalidFileWithMimeFallbackReturnsNotFound(): void {
 		$share = $this->createMock(IShare::class);
 		$this->shareManager->method('getShareByToken')

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -156,7 +156,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(15 * 60);
 		$this->assertEquals($expected, $res);
@@ -192,7 +192,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
@@ -224,7 +224,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
@@ -250,7 +250,7 @@ class PublicPreviewControllerTest extends TestCase {
 			->with($this->equalTo('file'))
 			->willThrowException(new NotFoundException());
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expected, $res);
 	}
@@ -271,7 +271,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$share->method('canSeeContent')
 			->willReturn(true);
 
-		$res = $this->controller->getPreview('token', '', 10, 10, true);
+		$res = $this->controller->getPreview('token', '', 10, 10, false, false);
 		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
 		$this->assertEquals($expected, $res);
 	}
@@ -299,7 +299,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->mimeIconProvider->expects($this->never())
 			->method('getMimeIconUrl');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, false, true);
 		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expected, $res);
 	}
@@ -336,7 +336,7 @@ class PublicPreviewControllerTest extends TestCase {
 			->with('text/plain')
 			->willReturn('/icon-url');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, false, true);
 		$expected = new RedirectResponse('/icon-url');
 		$this->assertEquals($expected, $res);
 	}
@@ -372,7 +372,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -330,7 +330,7 @@ class PublicPreviewControllerTest extends TestCase {
 			->willReturn('text/plain');
 
 		$this->previewManager->method('getPreview')
-			->with($this->equalTo($file), 10, 10, false)
+			->with($this->equalTo($file), 10, 10, true)
 			->willThrowException(new NotFoundException());
 
 		$this->mimeIconProvider->method('getMimeIconUrl')

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -277,6 +277,32 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->assertEquals($expected, $res);
 	}
 
+	public function testPreviewFolderSubfolderReturnsBadRequest(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$subfolder = $this->createMock(Folder::class);
+		$folder->method('get')
+			->with($this->equalTo('nested'))
+			->willReturn($subfolder);
+
+		$res = $this->controller->getPreview('token', 'nested', 10, 10, false, false);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
 	public function testPreviewFolderInvalidFileWithMimeFallbackReturnsNotFound(): void {
 		$share = $this->createMock(IShare::class);
 		$this->shareManager->method('getShareByToken')

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -11,6 +11,7 @@ use OCA\Files_Sharing\Controller\PublicPreviewController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
 use OCP\Files\File;
@@ -33,6 +34,7 @@ class PublicPreviewControllerTest extends TestCase {
 	private IManager&MockObject $shareManager;
 	private ITimeFactory&MockObject $timeFactory;
 	private IRequest&MockObject $request;
+	private IMimeIconProvider&MockObject $mimeIconProvider;
 
 	private PublicPreviewController $controller;
 
@@ -43,6 +45,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->request = $this->createMock(IRequest::class);
+		$this->mimeIconProvider = $this->createMock(IMimeIconProvider::class);
 
 		$this->timeFactory->method('getTime')
 			->willReturn(1337);
@@ -55,7 +58,7 @@ class PublicPreviewControllerTest extends TestCase {
 			$this->shareManager,
 			$this->createMock(ISession::class),
 			$this->previewManager,
-			$this->createMock(IMimeIconProvider::class),
+			$this->mimeIconProvider,
 		);
 	}
 
@@ -250,6 +253,92 @@ class PublicPreviewControllerTest extends TestCase {
 
 		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
 		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderEmptyFileReturnsBadRequest(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$res = $this->controller->getPreview('token', '', 10, 10, true);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderInvalidFileWithMimeFallbackReturnsNotFound(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$folder->method('get')
+			->with($this->equalTo('file'))
+			->willThrowException(new NotFoundException());
+
+		$this->mimeIconProvider->expects($this->never())
+			->method('getMimeIconUrl');
+
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderValidFileMimeFallbackRedirectsWhenPreviewMissing(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$file = $this->createMock(File::class);
+		$folder->method('get')
+			->with($this->equalTo('file'))
+			->willReturn($file);
+
+		$file->method('getMimeType')
+			->willReturn('text/plain');
+
+		$this->previewManager->method('getPreview')
+			->with($this->equalTo($file), 10, 10, false)
+			->willThrowException(new NotFoundException());
+
+		$this->mimeIconProvider->method('getMimeIconUrl')
+			->with('text/plain')
+			->willReturn('/icon-url');
+
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$expected = new RedirectResponse('/icon-url');
 		$this->assertEquals($expected, $res);
 	}
 

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -157,7 +157,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(15 * 60);
 		$this->assertEquals($expected, $res);
@@ -193,7 +193,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
@@ -225,7 +225,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
@@ -251,7 +251,7 @@ class PublicPreviewControllerTest extends TestCase {
 			->with($this->equalTo('file'))
 			->willThrowException(new NotFoundException());
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expected, $res);
 	}
@@ -272,7 +272,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$share->method('canSeeContent')
 			->willReturn(true);
 
-		$res = $this->controller->getPreview('token', '', 10, 10, true);
+		$res = $this->controller->getPreview('token', '', 10, 10, false, false);
 		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
 		$this->assertEquals($expected, $res);
 	}
@@ -300,7 +300,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->mimeIconProvider->expects($this->never())
 			->method('getMimeIconUrl');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, false, true);
 		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expected, $res);
 	}
@@ -337,7 +337,7 @@ class PublicPreviewControllerTest extends TestCase {
 			->with('text/plain')
 			->willReturn('/icon-url');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, false, true);
 		$expected = new RedirectResponse('/icon-url');
 		$this->assertEquals($expected, $res);
 	}
@@ -373,7 +373,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);

--- a/openapi.json
+++ b/openapi.json
@@ -25590,7 +25590,7 @@
         "/index.php/apps/files_sharing/publicpreview/{token}": {
             "get": {
                 "operationId": "files_sharing-public_preview-get-preview",
-                "summary": "Get a preview for a shared file",
+                "summary": "Get a preview for a public share",
                 "tags": [
                     "files_sharing/public_preview"
                 ],
@@ -25616,7 +25616,7 @@
                     {
                         "name": "file",
                         "in": "query",
-                        "description": "File in the share",
+                        "description": "Relative path to a file inside a shared folder; ignored for single-file shares",
                         "schema": {
                             "type": "string",
                             "default": ""


### PR DESCRIPTION
## Summary

Fixes two cases where `PublicPreviewController::getPreview()` triggers an
internal server error due to incomplete input validation:

**Case A** - Empty `$file` parameter on folder shares:
`$node->get('')` returns the Folder itself, then `getPreview()` fails because
it expects a File. Now returns 400 Bad Request early.

**Case B** - Non-existent file with `mimeFallback=1`:
When `$node->get($file)` throws `NotFoundException`, the catch block called
`$file->getMimeType()` on the original string parameter. Renamed the local
variable to `$fileNode` and added an `isset()` guard so the mime fallback
only runs when the file node was successfully resolved.

Fixes #59229