### PR TITLE
fix(metrics): sanitize metric label names in OpenMetrics output

### DIFF
--- a/lib/private/OpenMetrics/Exporters/AppsInfo.php
+++ b/lib/private/OpenMetrics/Exporters/AppsInfo.php
@@ -47,10 +47,10 @@ class AppsInfo implements IMetricFamily {
 
 	#[Override]
 	public function metrics(): Generator {
-		yield new Metric(
-			1,
-			$this->appManager->getAppInstalledVersions(true),
-			time()
-		);
+		$apps = [];
+		foreach ($this->appManager->getAppInstalledVersions(true) as $appId => $version) {
+			$apps[str_replace('-', '_', $appId)] = $version;
+		}
+		yield new Metric(1, $apps, time());
 	}
 }

--- a/lib/public/OpenMetrics/Metric.php
+++ b/lib/public/OpenMetrics/Metric.php
@@ -19,9 +19,18 @@ final readonly class Metric {
 		public array $labels = [],
 		public int|float|null $timestamp = null,
 	) {
+		$this->validateLabels();
 	}
 
 	public function label(string $name): ?string {
 		return $this->labels[$name] ?? null;
+	}
+
+	private function validateLabels(): void {
+		foreach ($this->labels as $label => $_value) {
+			if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', (string)$label) !== 1) {
+				throw new \InvalidArgumentException('Invalid OpenMetrics label name: "' . $label . '"');
+			}
+		}
 	}
 }

--- a/tests/Core/Controller/OpenMetricsControllerTest.php
+++ b/tests/Core/Controller/OpenMetricsControllerTest.php
@@ -87,6 +87,17 @@ class OpenMetricsControllerTest extends TestCase {
 		$this->assertStringMatchesFormat($expected, $fullOutput);
 	}
 
+	public function testMetricRejectsInvalidLabelNames(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		new Metric(1, ['hide-photos' => '1.0.0']);
+	}
+
+	public function testMetricAcceptsValidLabelNames(): void {
+		$metric = new Metric(1, ['hide_photos' => '1.0.0', 'normal_app' => '2.0.0']);
+		$this->assertEquals('1.0.0', $metric->label('hide_photos'));
+		$this->assertEquals('2.0.0', $metric->label('normal_app'));
+	}
+
 	public function testGetMetricsFromForbiddenIp(): void {
 		$this->config->expects($this->once())
 			->method('getSystemValue')


### PR DESCRIPTION
Fixes #59247

Apps with hyphens in their name (e.g. `hide-photos`) produce invalid OpenMetrics label names, causing Prometheus to reject the entire scrape. Label names must match `[a-zA-Z_][a-zA-Z0-9_]*` per the spec.

Sanitizes label names in `formatLabels()` by replacing non-alphanumeric characters with underscores, so `hide-photos` becomes `hide_photos`.