### PR TITLE
feat(config): add Sentry CSP Report URL to sensitive values

### DIFF
--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -44,6 +44,7 @@ class SystemConfig {
 		'proxyuserpwd' => true,
 		'sentry.dsn' => true,
 		'sentry.public-dsn' => true,
+	    'sentry.csp-report-url' => true,
 		'zammad.download.secret' => true,
 		'zammad.portal.secret' => true,
 		'zammad.secret' => true,

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -44,7 +44,7 @@ class SystemConfig {
 		'proxyuserpwd' => true,
 		'sentry.dsn' => true,
 		'sentry.public-dsn' => true,
-	    'sentry.csp-report-url' => true,
+		'sentry.csp-report-url' => true,
 		'zammad.download.secret' => true,
 		'zammad.portal.secret' => true,
 		'zammad.secret' => true,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Helps with: https://github.com/nextcloud/issuetemplate/issues/27#issuecomment-592931385

## Summary
Adds the Sentry app config entry `sentry.csp-report-url` to the sensive values.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
