### PR TITLE
fix(chunkedUploads): Ensure max parallel count is at least 1

### DIFF
--- a/apps/files/lib/Service/ChunkedUploadConfig.php
+++ b/apps/files/lib/Service/ChunkedUploadConfig.php
@@ -25,6 +25,6 @@ class ChunkedUploadConfig {
 	}
 
 	public static function getMaxParallelCount(): int {
-		return Server::get(IConfig::class)->getSystemValueInt(self::KEY_MAX_PARALLEL_COUNT, 5);
+		return max(1, Server::get(IConfig::class)->getSystemValueInt(self::KEY_MAX_PARALLEL_COUNT, 5));
 	}
 }

--- a/apps/files/tests/Service/ChunkedUploadConfigTest.php
+++ b/apps/files/tests/Service/ChunkedUploadConfigTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files\Tests\Service;
+
+use OCA\Files\Service\ChunkedUploadConfig;
+use OCP\IConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class ChunkedUploadConfigTest extends TestCase {
+	private IConfig&MockObject $config;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->overwriteService(IConfig::class, $this->config);
+	}
+
+	protected function tearDown(): void {
+		$this->restoreAllServices();
+		parent::tearDown();
+	}
+
+	public static function dataGetMaxParallelCount(): array {
+		return [
+			'configured positive value' => [3, 3],
+			'boundary minimum' => [1, 1],
+			'zero becomes one' => [0, 1],
+			'negative becomes one' => [-2, 1],
+			'large value passes through' => [100, 100],
+		];
+	}
+
+	#[DataProvider('dataGetMaxParallelCount')]
+	public function testGetMaxParallelCount(int $configuredValue, int $expectedValue): void {
+		$this->config->expects($this->once())
+			->method('getSystemValueInt')
+			->with('files.chunked_upload.max_parallel_count', 5)
+			->willReturn($configuredValue);
+
+		$this->assertSame($expectedValue, ChunkedUploadConfig::getMaxParallelCount());
+	}
+}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2916,7 +2916,7 @@ $CONFIG = [
 	/**
 	 * Maximum number of chunks uploaded in parallel during chunked uploads. Higher
 	 * counts increase throughput but consume more server resources, with diminishing
-	 * returns.
+	 * returns. Value must be a positive integer.
 	 *
 	 * Defaults to ``5``
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/59269

## Summary

If value is smaller than 1, return 1.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
