### PR TITLE
dav: Fix fatal error when ORGANIZER is missing in CalDAV schedule

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -765,7 +765,7 @@ EOF;
 
 		$addresses = $this->getAddressesForPrincipal($calendarNode->getOwner());
 		foreach ($vCal->VEVENT as $vevent) {
-			if (in_array($vevent->ORGANIZER->getNormalizedValue(), $addresses, true)) {
+			if (isset($vevent->ORGANIZER) && in_array($vevent->ORGANIZER->getNormalizedValue(), $addresses, true)) {
 				// User is an organizer => throw the exception
 				throw $e;
 			}


### PR DESCRIPTION
* Resolves: #59266

## Summary
This PR fixes a `Fatal Error: Call to a member function getNormalizedValue() on null` in the CalDAV Schedule Plugin. 

The error occurs when an event (e.g., synchronized from external sources like Google Calendar) does not contain an `ORGANIZER` property. Using the PHP 8 null-safe operator ensures the synchronization doesn't crash with a 500 error.

## Checklist
- [x] Code is properly formatted
- [x] Sign-off message is added to all commits (DCO)

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI