### PR TITLE
feat(files_reminders): add explicit UTC indicators to `list` command headers

### DIFF
--- a/apps/files_reminders/lib/Command/ListCommand.php
+++ b/apps/files_reminders/lib/Command/ListCommand.php
@@ -82,7 +82,7 @@ class ListCommand extends Base {
 				}
 
 				$io->table(
-					['User Id', 'File Id', 'Path', 'Due Date', 'Updated At', 'Created At', 'Notified'],
+					['User Id', 'File Id', 'Path', 'Due Date (UTC)', 'Updated At (UTC)', 'Created At (UTC)', 'Notified'],
 					array_map(
 						fn (RichReminder $reminder) => [
 							$reminder->getUserId(),


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #52515 <!-- related github issue -->

## Summary

Just makes the "always UTC" (for backend storage and `occ` command) more apparent to avoid confusion (and there's plenty of empty header space available to use).

Doesn't change json output; just for humans.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
