### PR TITLE
fix(weather_status): add all missing met.no symbol codes to weatherOptions

### DIFF
--- a/apps/weather_status/src/App.vue
+++ b/apps/weather_status/src/App.vue
@@ -244,6 +244,296 @@ const weatherOptions = {
 			? t('weather_status', '{temperature} {unit} heavy rainfall showers later today', { temperature, unit })
 			: t('weather_status', '{temperature} {unit} heavy rainfall showers', { temperature, unit }),
 	},
+	clearsky_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} clear sky and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} clear sky and polar twilight', { temperature, unit }),
+	},
+	fair_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} fair weather and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} fair weather and polar twilight', { temperature, unit }),
+	},
+	partlycloudy_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} partly cloudy and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} partly cloudy and polar twilight', { temperature, unit }),
+	},
+	lightrainandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light rain and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light rain and thunder', { temperature, unit }),
+	},
+	rainandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} rain and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} rain and thunder', { temperature, unit }),
+	},
+	heavyrainandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy rain and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy rain and thunder', { temperature, unit }),
+	},
+	lightrainshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light rainfall showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light rainfall showers and thunder', { temperature, unit }),
+	},
+	lightrainshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light rainfall showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light rainfall showers and thunder', { temperature, unit }),
+	},
+	lightrainshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light rainfall showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light rainfall showers, thunder and polar twilight', { temperature, unit }),
+	},
+	rainshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} rainfall showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} rainfall showers and thunder', { temperature, unit }),
+	},
+	rainshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} rainfall showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} rainfall showers and thunder', { temperature, unit }),
+	},
+	rainshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} rainfall showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} rainfall showers, thunder and polar twilight', { temperature, unit }),
+	},
+	heavyrainshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy rainfall showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy rainfall showers and thunder', { temperature, unit }),
+	},
+	heavyrainshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy rainfall showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy rainfall showers and thunder', { temperature, unit }),
+	},
+	heavyrainshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy rainfall showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy rainfall showers, thunder and polar twilight', { temperature, unit }),
+	},
+	lightrainshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light rainfall showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light rainfall showers and polar twilight', { temperature, unit }),
+	},
+	rainshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} rainfall showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} rainfall showers and polar twilight', { temperature, unit }),
+	},
+	heavyrainshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy rainfall showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy rainfall showers and polar twilight', { temperature, unit }),
+	},
+	lightsleet: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet', { temperature, unit }),
+	},
+	sleet: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet', { temperature, unit }),
+	},
+	heavysleet: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet', { temperature, unit }),
+	},
+	lightsleetandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet and thunder', { temperature, unit }),
+	},
+	sleetandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet and thunder', { temperature, unit }),
+	},
+	heavysleetandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet and thunder', { temperature, unit }),
+	},
+	lightsleetshowers_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet showers', { temperature, unit }),
+	},
+	lightsleetshowers_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet showers', { temperature, unit }),
+	},
+	lightsleetshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet showers and polar twilight', { temperature, unit }),
+	},
+	sleetshowers_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet showers', { temperature, unit }),
+	},
+	sleetshowers_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet showers', { temperature, unit }),
+	},
+	sleetshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet showers and polar twilight', { temperature, unit }),
+	},
+	heavysleetshowers_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet showers', { temperature, unit }),
+	},
+	heavysleetshowers_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet showers', { temperature, unit }),
+	},
+	heavysleetshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet showers and polar twilight', { temperature, unit }),
+	},
+	lightssleetshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet showers and thunder', { temperature, unit }),
+	},
+	lightssleetshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet showers and thunder', { temperature, unit }),
+	},
+	lightssleetshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light sleet showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light sleet showers, thunder and polar twilight', { temperature, unit }),
+	},
+	sleetshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet showers and thunder', { temperature, unit }),
+	},
+	sleetshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet showers and thunder', { temperature, unit }),
+	},
+	sleetshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} sleet showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} sleet showers, thunder and polar twilight', { temperature, unit }),
+	},
+	heavysleetshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet showers and thunder', { temperature, unit }),
+	},
+	heavysleetshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet showers and thunder', { temperature, unit }),
+	},
+	heavysleetshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy sleet showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy sleet showers, thunder and polar twilight', { temperature, unit }),
+	},
+	lightsnow: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow', { temperature, unit }),
+	},
+	heavysnow: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow', { temperature, unit }),
+	},
+	lightsnowandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow and thunder', { temperature, unit }),
+	},
+	heavysnowandthunder: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow and thunder', { temperature, unit }),
+	},
+	lightsnowshowers_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow showers', { temperature, unit }),
+	},
+	lightsnowshowers_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow showers', { temperature, unit }),
+	},
+	lightsnowshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow showers and polar twilight', { temperature, unit }),
+	},
+	heavysnowshowers_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow showers', { temperature, unit }),
+	},
+	heavysnowshowers_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow showers later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow showers', { temperature, unit }),
+	},
+	heavysnowshowers_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow showers and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow showers and polar twilight', { temperature, unit }),
+	},
+	lightssnowshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow showers and thunder', { temperature, unit }),
+	},
+	lightssnowshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow showers and thunder', { temperature, unit }),
+	},
+	lightssnowshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} light snow showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} light snow showers, thunder and polar twilight', { temperature, unit }),
+	},
+	heavysnowshowersandthunder_day: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow showers and thunder', { temperature, unit }),
+	},
+	heavysnowshowersandthunder_night: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow showers and thunder later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow showers and thunder', { temperature, unit }),
+	},
+	heavysnowshowersandthunder_polartwilight: {
+		text: (temperature, unit, later = false) => later
+			? t('weather_status', '{temperature} {unit} heavy snow showers, thunder and polar twilight later today', { temperature, unit })
+			: t('weather_status', '{temperature} {unit} heavy snow showers, thunder and polar twilight', { temperature, unit }),
+	},
 }
 
 export default {


### PR DESCRIPTION
## Summary

- Add all 58 missing met.no Locationforecast API `symbol_code` values to the `weatherOptions` object in `apps/weather_status/src/App.vue`
- The widget now maps all 83 valid symbol codes (previously only 25), eliminating "Unknown weather code" messages
- Includes all sleet codes, rain/snow thunder combinations, polartwilight variants, and light/heavy snow variants

## Details

The `weatherOptions` object only mapped 25 of the 83 valid `symbol_code` values returned by the [met.no Locationforecast API](https://api.met.no/weatherapi/locationforecast/2.0/documentation). Any unmapped code caused the weather status widget to display "Unknown weather code" instead of a proper weather description.

The added codes follow the exact same pattern as the existing entries — each with a `text` function using `t('weather_status', ...)` for translation, supporting both current and "later today" variants. Polartwilight variants follow the established convention (e.g., "snow showers and polar twilight").

**Note:** The met.no API contains known typos in two symbol codes (`lightssleetshowersandthunder` and `lightssnowshowersandthunder` — extra "s" after "light"). These are included as-is to match the actual API responses. Met.no has confirmed they won't fix this until a future API version to avoid breaking existing consumers.

Fixes #59292

## Test plan

- [ ] Set a location where the met.no API returns a previously unmapped code (e.g., a location with sleet conditions)
- [ ] Verify the weather widget shows the correct weather description instead of "Unknown weather code"
- [ ] Verify existing weather codes still display correctly
- [ ] Verify polartwilight variant descriptions are consistent with the existing pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)