### PR TITLE
 ci: centralize path filtering across workflows

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+#
+# Centralized path-change detection for use by other workflows.
+# Emits boolean outputs for the two main code domains (php, js)
+# so callers don't need to duplicate dorny/paths-filter config.
+
+name: Detect changes
+
+on:
+  workflow_call:
+    outputs:
+      php:
+        description: 'true if PHP-relevant files changed'
+        value: ${{ jobs.detect.outputs.php }}
+      js:
+        description: 'true if JS/frontend-relevant files changed'
+        value: ${{ jobs.detect.outputs.js }}
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      php: ${{ steps.changes.outputs.php }}
+      js: ${{ steps.changes.outputs.js }}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            php:
+              - '.github/workflows/**'
+              - '3rdparty/**'
+              - '**/appinfo/**'
+              - '**/lib/**'
+              - '**/templates/**'
+              - '**/tests/**'
+              - 'resources/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - '.php-cs-fixer.dist.php'
+              - 'composer.json'
+              - 'composer.lock'
+              - '**.php'
+            js:
+              - '.github/workflows/**'
+              - '**/src/**'
+              - '**/__tests__/**'
+              - '**/__mocks__/**'
+              - '**/appinfo/info.xml'
+              - 'core/css/*'
+              - 'core/img/**'
+              - 'package.json'
+              - '**/package-lock.json'
+              - 'tsconfig.json'
+              - '.eslintrc.*'
+              - '.eslintignore'
+              - '.stylelintrc.*'
+              - 'version.php'
+              - '**.js'
+              - '**.ts'
+              - '**.vue'
+              - '**.css'
+              - '**.scss'

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -19,35 +19,27 @@ concurrency:
 
 jobs:
   changes:
+    uses: ./.github/workflows/detect-changes.yml
+
+  extra-changes:
     runs-on: ubuntu-latest-low
-
     outputs:
-      src: ${{ steps.changes.outputs.src}}
-
+      integration: ${{ steps.changes.outputs.integration }}
     steps:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         continue-on-error: true
         with:
           filters: |
-            src:
-              - '.github/workflows/**'
-              - '3rdparty/**'
-              - '**/*.php'
-              - '**/lib/**'
-              - '**/tests/**'
-              - '**/vendor-bin/**'
+            integration:
               - 'build/integration/**'
-              - '.php-cs-fixer.dist.php'
-              - 'composer.json'
-              - 'composer.lock'
               - 'core/shipped.json'
 
   integration-sqlite:
     runs-on: ubuntu-latest
 
-    needs: changes
-    if: needs.changes.outputs.src != 'false'
+    needs: [changes, extra-changes]
+    if: needs.changes.outputs.php != 'false' || needs.extra-changes.outputs.integration != 'false'
 
     strategy:
       fail-fast: false
@@ -173,7 +165,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, integration-sqlite]
+    needs: [changes, extra-changes, integration-sqlite]
 
     if: always()
 
@@ -181,4 +173,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.integration-sqlite.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.php != 'false' && needs.extra-changes.outputs.integration && needs.integration-sqlite.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -19,38 +19,13 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest-low
-    permissions:
-      contents: read
-      pull-requests: read
-
-    outputs:
-      src: ${{ steps.changes.outputs.src}}
-
-    steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        continue-on-error: true
-        with:
-          filters: |
-            src:
-              - '.github/workflows/**'
-              - '**/src/**'
-              - '**/appinfo/info.xml'
-              - 'package.json'
-              - 'package-lock.json'
-              - 'tsconfig.json'
-              - '.eslintrc.*'
-              - '.eslintignore'
-              - '**.js'
-              - '**.ts'
-              - '**.vue'
+    uses: ./.github/workflows/detect-changes.yml
 
   lint:
     runs-on: ubuntu-latest
 
     needs: changes
-    if: needs.changes.outputs.src != 'false'
+    if: needs.changes.outputs.js != 'false'
 
     name: NPM lint
 
@@ -97,4 +72,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.lint.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.js != 'false' && needs.lint.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -19,31 +19,13 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest-low
-    outputs:
-      src: ${{ steps.changes.outputs.src}}
-    steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        continue-on-error: true
-        with:
-          filters: |
-            src:
-              - '.github/workflows/**'
-              - '3rdparty/**'
-              - '**/lib/**'
-              - '**/tests/**'
-              - '**/vendor-bin/**'
-              - '.php-cs-fixer.dist.php'
-              - 'composer.json'
-              - 'composer.lock'
-              - '**.php'
+    uses: ./.github/workflows/detect-changes.yml
 
   lint:
     runs-on: ubuntu-latest
 
     needs: changes
-    if: needs.changes.outputs.src != 'false'
+    if: needs.changes.outputs.php != 'false'
 
     strategy:
       matrix:
@@ -83,4 +65,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.lint.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.php != 'false' && needs.lint.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This change centralizes CI path filtering so workflows can share one filtering implementation instead of duplicating file-matching logic.

This reduces maintenance overhead, improves consistency between workflows, and helps avoid running CI jobs when a changeset does not affect them.

This can be used for all workflows that currently use (or will use) `changes` jobs to do path filtering. Today that is ~30 files where this logic is currently distributed around.

Instead of doing all 30 at once, this migrates a straightforward variation of each one supported type (PHP, JS, PHP+Custom) -- using the newly introduced re-usable central workflow. This keeps the PR easier to review. Once this passes well, the other ~27 can be done in a single follow-up PR.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
