### PR TITLE
fix: update email button text to 'Open shared item'

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -359,7 +359,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		}
 
 		$emailTemplate->addBodyButton(
-			$this->l->t('Open %s', [$filename]),
+			$this->l->t('Open shared item'),
 			$link
 		);
 
@@ -533,7 +533,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		$link = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare',
 			['token' => $share->getToken()]);
 		$emailTemplate->addBodyButton(
-			$this->l->t('Open %s', [$filename]),
+			$this->l->t('Open shared item'),
 			$link
 		);
 

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -1307,7 +1307,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('addBodyButton')
 			->with(
-				'Open file.txt',
+				'Open shared item',
 				'https://example.com/file.txt'
 			);
 		$message
@@ -1426,7 +1426,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('addBodyButton')
 			->with(
-				'Open file.txt',
+				'Open shared item',
 				'https://example.com/file.txt'
 			);
 		$message
@@ -1550,7 +1550,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('addBodyButton')
 			->with(
-				'Open file.txt',
+				'Open shared item',
 				'https://example.com/file.txt'
 			);
 		$message
@@ -1654,7 +1654,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('addBodyButton')
 			->with(
-				'Open file.txt',
+				'Open shared item',
 				'https://example.com/file.txt'
 			);
 		$message
@@ -1748,7 +1748,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('addBodyButton')
 			->with(
-				'Open file.txt',
+				'Open shared item',
 				'https://example.com/file.txt'
 			);
 		$message
@@ -1846,7 +1846,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('addBodyButton')
 			->with(
-				'Open file.txt',
+				'Open shared item',
 				'https://example.com/file.txt'
 			);
 		$message


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

No need to list the same content (file/folder name) twice in the mail ([less is better](https://updivision.com/blog/post/ux-writing-how-microcopy-can-enhance-the-user-journey)).
_Also, when share name is long, it breaks the button on small devices._

### Before

<img width="1292" height="522" alt="image" src="https://github.com/user-attachments/assets/c5de0d49-eba3-4e16-9375-3aa79e54ffde" />

### After

<img width="1224" height="509" alt="image" src="https://github.com/user-attachments/assets/da70218a-a398-4746-bc2a-505957cb0235" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
