### PR TITLE
fix: duplicate dashboard widget

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardApiController.php
+++ b/apps/dashboard/lib/Controller/DashboardApiController.php
@@ -202,6 +202,7 @@ class DashboardApiController extends OCSController {
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'POST', url: '/api/v3/layout')]
 	public function updateLayout(array $layout): DataResponse {
+		$layout = $this->service->sanitizeLayout($layout);
 		$this->userConfig->setValueString($this->userId, 'dashboard', 'layout', implode(',', $layout));
 		return new DataResponse(['layout' => $layout]);
 	}

--- a/apps/dashboard/lib/Service/DashboardService.php
+++ b/apps/dashboard/lib/Service/DashboardService.php
@@ -31,7 +31,7 @@ class DashboardService {
 	 */
 	public function getLayout(): array {
 		$systemDefault = $this->appConfig->getAppValueString('layout', 'recommendations,spreed,mail,calendar');
-		return $this->sanitizeStringList(
+		return $this->sanitizeLayout(
 			explode(',', $this->userConfig->getValueString($this->userId, 'dashboard', 'layout', $systemDefault)),
 		);
 	}
@@ -41,7 +41,18 @@ class DashboardService {
 	 * @return list<string>
 	 */
 	public function sanitizeLayout(array $layout): array {
-		return $this->sanitizeStringList($layout);
+		$seen = [];
+		$result = [];
+		foreach ($layout as $value) {
+			if ($value === '' || isset($seen[$value])) {
+				continue;
+			}
+
+			$seen[$value] = true;
+			$result[] = $value;
+		}
+
+		return $result;
 	}
 
 	/**
@@ -79,26 +90,5 @@ class DashboardService {
 		}
 
 		return $birthdate->getValue();
-	}
-
-	/**
-	 * Keep insertion order while removing empty and duplicate values.
-	 *
-	 * @param list<string> $values
-	 * @return list<string>
-	 */
-	private function sanitizeStringList(array $values): array {
-		$seen = [];
-		$result = [];
-		foreach ($values as $value) {
-			if ($value === '' || isset($seen[$value])) {
-				continue;
-			}
-
-			$seen[$value] = true;
-			$result[] = $value;
-		}
-
-		return $result;
 	}
 }

--- a/apps/dashboard/lib/Service/DashboardService.php
+++ b/apps/dashboard/lib/Service/DashboardService.php
@@ -31,10 +31,17 @@ class DashboardService {
 	 */
 	public function getLayout(): array {
 		$systemDefault = $this->appConfig->getAppValueString('layout', 'recommendations,spreed,mail,calendar');
-		return array_values(array_filter(
+		return $this->sanitizeStringList(
 			explode(',', $this->userConfig->getValueString($this->userId, 'dashboard', 'layout', $systemDefault)),
-			fn (string $value) => $value !== '')
 		);
+	}
+
+	/**
+	 * @param list<string> $layout
+	 * @return list<string>
+	 */
+	public function sanitizeLayout(array $layout): array {
+		return $this->sanitizeStringList($layout);
 	}
 
 	/**
@@ -72,5 +79,26 @@ class DashboardService {
 		}
 
 		return $birthdate->getValue();
+	}
+
+	/**
+	 * Keep insertion order while removing empty and duplicate values.
+	 *
+	 * @param list<string> $values
+	 * @return list<string>
+	 */
+	private function sanitizeStringList(array $values): array {
+		$seen = [];
+		$result = [];
+		foreach ($values as $value) {
+			if ($value === '' || isset($seen[$value])) {
+				continue;
+			}
+
+			$seen[$value] = true;
+			$result[] = $value;
+		}
+
+		return $result;
 	}
 }

--- a/apps/dashboard/tests/DashboardServiceTest.php
+++ b/apps/dashboard/tests/DashboardServiceTest.php
@@ -44,6 +44,25 @@ class DashboardServiceTest extends TestCase {
 		);
 	}
 
+	public function testGetLayoutRemovesEmptyAndDuplicateEntries(): void {
+		$this->appConfig->method('getAppValueString')
+			->with('layout', 'recommendations,spreed,mail,calendar')
+			->willReturn('recommendations,spreed,mail,calendar');
+		$this->userConfig->method('getValueString')
+			->with('alice', 'dashboard', 'layout', 'recommendations,spreed,mail,calendar')
+			->willReturn('spreed,,mail,mail,calendar,spreed');
+
+		$layout = $this->service->getLayout();
+
+		$this->assertSame(['spreed', 'mail', 'calendar'], $layout);
+	}
+
+	public function testSanitizeLayoutRemovesEmptyAndDuplicateEntries(): void {
+		$layout = $this->service->sanitizeLayout(['files', 'calendar', 'files', '', 'mail', 'calendar']);
+
+		$this->assertSame(['files', 'calendar', 'mail'], $layout);
+	}
+
 	public function testGetBirthdate(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userManager->method('get')


### PR DESCRIPTION

* Resolves: #59146 

## Summary
This PR fixes a dashboard layout edge case where duplicate widget IDs can be sent to the layout update endpoint.
Even though the UI only allows selecting a widget once, crafted requests could still submit duplicates (e.g. `layout[]=files&layout[]=files`). This caused duplicated entries to be persisted.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
