### PR TITLE
WIP: fix(encryption): store key by fileId for CollectiveMountPoint

### DIFF
--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -246,6 +246,16 @@ class Util {
 		return $result;
 	}
 
+	public function isCollectiveMountPoint(string $path, string $uid) {
+		$mount = Filesystem::getMountManager()->find('/' . $uid . $path);
+		if (!$mount) {
+			return false;
+		}
+
+		// We use class name to avoid hard dependency on collectives app
+		return strpos(get_class($mount), 'CollectiveMountPoint') !== false;
+	}
+
 	/**
 	 * check if the file is stored on a system wide mount point
 	 * @param string $path relative to /data/user with leading '/'
@@ -357,6 +367,23 @@ class Util {
 		$root = $this->getKeyStorageRoot();
 
 		// in case of system-wide mount points the keys are stored directly in the data directory
+		if ($this->isCollectiveMountPoint($filename, $owner)) {
+			$fileId === null;
+			try {
+				$fileInfo = $this->rootView->getFileInfo($path);
+				if ($fileInfo) {
+					$fileId = $fileInfo['fileid'] ?? null;
+				}
+			} catch (\Exception) {
+				// continue
+			}
+
+			if ($fileId !== null) {
+				$keyPath = $root . '/files_encryption/keys_by_fileId/' . $fileId . '/';
+				return Filesystem::normalizePath($keyPath . $encryptionModuleId . '/', false);
+			}
+		}
+
 		if ($this->isSystemWideMountPoint($filename, $owner)) {
 			$keyPath = $root . '/' . '/files_encryption/keys' . $filename . '/';
 		} else {


### PR DESCRIPTION
## Summary

In Collectives, we can have different paths to a file by user (when a user changes their `user_folder` user setting). This leads to inaccessible files with server-side encryption as the encryption keys are stored by file path. In order to fix this, we should switch to `fileId` based key storage instead of file path based key storage.

## TODO

- [ ] Decide whether we want to *always* store encryption keys by `fileId`, or just for `ISystemMountPoint` or just for `CollectiveMountPoint`
- [ ] Decide whether we change all the interfaces and functions to pass `$fileId` through encryption storage wrapper or whether it's acceptable to use `$this->rootView->getFileInfo()` in `Util.php`.
- [ ] 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
