### PR TITLE
fix(dav): `AddExtraHeadersPlugin` should not be handled on error

### DIFF
--- a/apps/dav/lib/Connector/Sabre/AddExtraHeadersPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AddExtraHeadersPlugin.php
@@ -40,6 +40,11 @@ class AddExtraHeadersPlugin extends \Sabre\DAV\ServerPlugin {
 			return;
 		}
 
+		// skip setting the headers if the PUT request failed
+		if ($response->getStatus() >= 400) {
+			return;
+		}
+
 		$node = null;
 		try {
 			$node = $this->server->tree->getNodeForPath($request->getPath());


### PR DESCRIPTION
## Summary

When a request failed (failed upload) the file is not created, thus this will spam the log with "cannot set extra headers" error. To reproduce use e.g. files_antivirus with eicar test files.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
