### PR TITLE
ci: Simplify Psalm static analysis workflow, clarify push behavior, and cache Composer dependencies

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -70,6 +70,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-8.2-composer-
+
       - name: Composer install
         run: composer i
 
@@ -103,6 +114,17 @@ jobs:
           php-version: '8.2'
           extensions: ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache-security
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.composer-cache-security.outputs.dir }}
+          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-8.2-composer-
 
       - name: Composer install
         run: composer i
@@ -143,6 +165,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get Composer cache directory
+        id: composer-cache-ocp
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.composer-cache-ocp.outputs.dir }}
+          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-8.2-composer-
+
       - name: Composer install
         run: composer i
 
@@ -175,6 +208,16 @@ jobs:
           coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Composer cache directory
+        id: composer-cache-ncu
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.composer-cache-ncu.outputs.dir }}
+          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-8.2-composer-
 
       - name: Composer install
         run: composer i
@@ -203,6 +246,17 @@ jobs:
           coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Composer cache directory
+        id: composer-cache-strict
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.composer-cache-strict.outputs.dir }}
+          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-8.2-composer-
 
       - name: Composer install
         run: composer i

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -48,10 +48,28 @@ jobs:
               - '**.php'
 
   static-code-analysis:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
 
     needs: changes
     if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Psalm
+            command: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline
+            check_baseline_diff: true
+          - name: Psalm OCP
+            command: composer run psalm:ocp -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline
+            check_baseline_diff: true
+          - name: Psalm NCU
+            command: composer run psalm:ncu -- --threads=1 --monochrome --no-progress --output-format=github
+            check_baseline_diff: false
+          - name: Psalm strict
+            command: composer run psalm:strict -- --threads=1 --monochrome --no-progress --output-format=github
+            check_baseline_diff: false
 
     steps:
       - name: Checkout
@@ -84,11 +102,11 @@ jobs:
       - name: Composer install
         run: composer i
 
-      - name: Psalm
-        run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline
+      - name: Run analysis
+        run: ${{ matrix.command }}
 
       - name: Show potential changes in Psalm baseline
-        if: always()
+        if: ${{ always() && matrix.check_baseline_diff }}
         run: git diff --exit-code -- . ':!lib/composer'
 
   static-code-analysis-security:
@@ -142,133 +160,11 @@ jobs:
         with:
           sarif_file: results.sarif
 
-  static-code-analysis-ocp:
-    runs-on: ubuntu-latest
-
-    needs: changes
-    if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Set up php
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 #v2.36.0
-        timeout-minutes: 5
-        with:
-          php-version: '8.2'
-          extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
-          coverage: none
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer cache directory
-        id: composer-cache-ocp
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ steps.composer-cache-ocp.outputs.dir }}
-          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-8.2-composer-
-
-      - name: Composer install
-        run: composer i
-
-      - name: Psalm
-        run: composer run psalm:ocp -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline
-
-      - name: Show potential changes in Psalm baseline
-        if: always()
-        run: git diff --exit-code -- . ':!lib/composer'
-
-  static-code-analysis-ncu:
-    runs-on: ubuntu-latest
-
-    needs: changes
-    if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Set up php
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 #v2.36.0
-        timeout-minutes: 5
-        with:
-          php-version: '8.2'
-          extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
-          coverage: none
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get Composer cache directory
-        id: composer-cache-ncu
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ steps.composer-cache-ncu.outputs.dir }}
-          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-8.2-composer-
-
-      - name: Composer install
-        run: composer i
-
-      - name: Psalm
-        run: composer run psalm:ncu -- --threads=1 --monochrome --no-progress --output-format=github
-
-  static-code-analysis-strict:
-    runs-on: ubuntu-latest
-
-    needs: changes
-    if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          submodules: true
-
-      - name: Set up php
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 #v2.36.0
-        with:
-          php-version: '8.2'
-          extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
-          coverage: none
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer cache directory
-        id: composer-cache-strict
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ steps.composer-cache-strict.outputs.dir }}
-          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-8.2-composer-
-
-      - name: Composer install
-        run: composer i
-
-      - name: Psalm
-        run: composer run psalm:strict -- --threads=1 --monochrome --no-progress --output-format=github
-
   summary:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, static-code-analysis, static-code-analysis-security, static-code-analysis-ocp, static-code-analysis-ncu, static-code-analysis-strict]
+    needs: [changes, static-code-analysis, static-code-analysis-security]
 
     if: always()
 
@@ -279,12 +175,8 @@ jobs:
         run: |
           if ${{ needs.changes.outputs.src != 'false' && (
             needs.static-code-analysis-security.result != 'success' ||
-            (github.event_name != 'push' && (
-              needs.static-code-analysis.result != 'success' ||
-              needs.static-code-analysis-ocp.result != 'success' ||
-              needs.static-code-analysis-ncu.result != 'success' ||
-              needs.static-code-analysis-strict.result != 'success'
-            ))
+            (github.event_name == 'pull_request' &&
+              needs.static-code-analysis.result != 'success')
           ) }}; then
             exit 1
           fi

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -9,6 +9,8 @@ on:
       - main
       - master
       - stable*
+    # Push runs are intentionally kept because the security analysis job
+    # below also runs on push; the other analysis jobs are PR-only.
     paths:
       - '.github/workflows/static-code-analysis.yml'
       - '**.php'
@@ -49,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: changes
-    if: ${{ needs.changes.outputs.src != 'false' && github.event_name != 'push' && github.repository_owner != 'nextcloud-gmbh' }}
+    if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
 
     steps:
       - name: Checkout
@@ -122,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: changes
-    if: ${{ needs.changes.outputs.src != 'false' && github.event_name != 'push' && github.repository_owner != 'nextcloud-gmbh' }}
+    if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
 
     steps:
       - name: Checkout
@@ -155,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: changes
-    if: ${{ needs.changes.outputs.src != 'false' && github.event_name != 'push' && github.repository_owner != 'nextcloud-gmbh' }}
+    if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
 
     steps:
       - name: Checkout
@@ -184,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: changes
-    if: ${{ needs.changes.outputs.src != 'false' && github.event_name != 'push' && github.repository_owner != 'nextcloud-gmbh' }}
+    if: ${{ needs.changes.outputs.src != 'false' && github.event_name == 'pull_request' && github.repository_owner != 'nextcloud-gmbh' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -138,7 +138,7 @@ jobs:
         timeout-minutes: 5
         with:
           php-version: '8.2'
-          extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
+          extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
         timeout-minutes: 5
         with:
           php-version: '8.2'
-          extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
+          extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -199,7 +199,7 @@ jobs:
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 #v2.36.0
         with:
           php-version: '8.2'
-          extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
+          extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Improve the Psalm static analysis workflow by reducing duplication and making its behavior easier to understand.

Changes:

- clarify that the non-security Psalm jobs are pull-request-only, while keeping push runs for security analysis
- refactor the PR analysis jobs into a matrix job
- preserve the existing (recently added) `changes` gating and update the summary job accordingly
- add Composer cache reuse to reduce repeated dependency download time
- align PHP extension setup across the PR analysis variants

Notes:

- push behavior remains in the same workflow because of existing dependencies elsewhere (i.e. repo-level security config)
- the workflow path filters remain unchanged

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
