### PR TITLE
fix(files_reminders): switch from DB-side `NOW()` to PHP-side generation

### DIFF
--- a/apps/files_reminders/lib/Db/ReminderMapper.php
+++ b/apps/files_reminders/lib/Db/ReminderMapper.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2023-2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -12,6 +12,7 @@ namespace OCA\FilesReminders\Db;
 use DateTime;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Folder;
 use OCP\Files\Node;
@@ -25,12 +26,11 @@ use OCP\IUser;
 class ReminderMapper extends QBMapper {
 	public const TABLE_NAME = 'files_reminders';
 
-	public function __construct(IDBConnection $db) {
-		parent::__construct(
-			$db,
-			static::TABLE_NAME,
-			Reminder::class,
-		);
+	public function __construct(
+		IDBConnection $db,
+		private ITimeFactory $timeFactory,
+	) {
+		parent::__construct($db, self::TABLE_NAME, Reminder::class);
 	}
 
 	public function markNotified(Reminder $reminder): Reminder {
@@ -108,9 +108,18 @@ class ReminderMapper extends QBMapper {
 	public function findOverdue() {
 		$qb = $this->db->getQueryBuilder();
 
+		$now = $this->timeFactory->getDateTime();
+		$now->setTimezone(new \DateTimeZone('UTC'));
+		
 		$qb->select('id', 'user_id', 'file_id', 'due_date', 'updated_at', 'created_at', 'notified')
 			->from($this->getTableName())
-			->where($qb->expr()->lt('due_date', $qb->createFunction('NOW()')))
+			->where(
+				$qb->expr()->lt(
+					'due_date',
+					$qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE),
+					IQueryBuilder::PARAM_DATETIME_MUTABLE,
+				)
+			)
 			->andWhere($qb->expr()->eq('notified', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
 			->orderBy('due_date', 'ASC');
 

--- a/apps/files_reminders/lib/Db/ReminderMapper.php
+++ b/apps/files_reminders/lib/Db/ReminderMapper.php
@@ -110,7 +110,7 @@ class ReminderMapper extends QBMapper {
 
 		$now = $this->timeFactory->getDateTime();
 		$now->setTimezone(new \DateTimeZone('UTC'));
-		
+
 		$qb->select('id', 'user_id', 'file_id', 'due_date', 'updated_at', 'created_at', 'notified')
 			->from($this->getTableName())
 			->where(


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #52515 <!-- related github issue -->

## Summary

DB-side `NOW()` is dependent on database server/session config. We want to know it's always UTC. We already generate timestamps PHP-side typically. This switches the now timestamp generate to be PHP-side for consistency, robustness in all environments, and also to make unit testing easier.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
