### PR TITLE
test: resolve PHPUnit deprecation warning about `addMethods`

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -44,6 +44,14 @@ use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
 
 /**
+ * Internal helper to mock legacy hook receiver.
+ */
+interface EventHandlerMock {
+	public function writeCallback(): void;
+	public function postWriteCallback(): void;
+}
+
+/**
  * Class File
  *
  *
@@ -822,9 +830,7 @@ class FileTest extends TestCase {
 
 		$wasLockedPre = false;
 		$wasLockedPost = false;
-		$eventHandler = $this->getMockBuilder(\stdclass::class)
-			->addMethods(['writeCallback', 'postWriteCallback'])
-			->getMock();
+		$eventHandler = $this->createMock(EventHandlerMock::class);
 
 		// both pre and post hooks might need access to the file,
 		// so only shared lock is acceptable

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1787,7 +1787,7 @@ class ShareAPIController extends OCSController {
 			throw new QueryException();
 		}
 
-		return $this->serverContainer->get('\OCA\Talk\Share\Helper\ShareAPIController');
+		return $this->serverContainer->get(\OCA\Talk\Share\Helper\ShareAPIController::class);
 	}
 
 	/**

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -9,6 +9,7 @@
 namespace OCA\Files_Sharing\Tests\Controller;
 
 use OC\Files\Storage\Wrapper\Wrapper;
+use OC\Session\Internal;
 use OCA\Federation\TrustedServers;
 use OCA\Files_Sharing\Controller\ShareAPIController;
 use OCA\Files_Sharing\External\Storage;
@@ -26,6 +27,7 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Mount\IShareOwnerlessMount;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\IAppConfig;
@@ -58,6 +60,16 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 use Test\Traits\EmailValidatorTrait;
+
+/**
+ * Internal mock to allow mocking the Talk controller used for room shares,
+ * needed when Talk is not installed during tests (PHPUnit does not allow mocking of non-existing classes).
+ */
+interface InternalTalkShareAPIController {
+	public function formatShare(IShare $share): array;
+	public function canAccessShare(IShare $share, string $user): bool;
+	public function createShare(IShare $share, string $shareWith, int $permissions, string $expireDate): void;
+}
 
 /**
  * Class ShareAPIControllerTest
@@ -1831,24 +1843,14 @@ class ShareAPIControllerTest extends TestCase {
 				->with('spreed')
 				->willReturn(true);
 
-			// This is not possible anymore with PHPUnit 10+
-			// as `setMethods` was removed and now real reflection is used, thus the class needs to exist.
-			// $helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
-			$helper = $this->getMockBuilder(\stdClass::class)
-				->addMethods(['canAccessShare'])
-				->getMock();
-			$helper->method('canAccessShare')
+			$this->mockTalkController()
+				->method('canAccessShare')
 				->with($share, $this->currentUser)
 				->willReturn($canAccessShareByHelper);
-
-			$this->serverContainer->method('get')
-				->with('\OCA\Talk\Share\Helper\ShareAPIController')
-				->willReturn($helper);
 		}
 
 		$this->assertEquals($expected, $this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
 	}
-
 
 	public function testCreateShareNoPath(): void {
 		$this->expectException(OCSNotFoundException::class);
@@ -2663,13 +2665,8 @@ class ShareAPIControllerTest extends TestCase {
 			->with('spreed')
 			->willReturn(true);
 
-		// This is not possible anymore with PHPUnit 10+
-		// as `setMethods` was removed and now real reflection is used, thus the class needs to exist.
-		// $helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
-		$helper = $this->getMockBuilder(\stdClass::class)
-			->addMethods(['createShare'])
-			->getMock();
-		$helper->method('createShare')
+		$this->mockTalkController()
+			->method('createShare')
 			->with(
 				$share,
 				'recipientRoom',
@@ -2683,10 +2680,6 @@ class ShareAPIControllerTest extends TestCase {
 					$share->setPermissions(Constants::PERMISSION_ALL);
 				}
 			);
-
-		$this->serverContainer->method('get')
-			->with('\OCA\Talk\Share\Helper\ShareAPIController')
-			->willReturn($helper);
 
 		$this->shareManager->method('createShare')
 			->with($this->callback(function (IShare $share) use ($path) {
@@ -2772,13 +2765,8 @@ class ShareAPIControllerTest extends TestCase {
 			->with('spreed')
 			->willReturn(true);
 
-		// This is not possible anymore with PHPUnit 10+
-		// as `setMethods` was removed and now real reflection is used, thus the class needs to exist.
-		// $helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
-		$helper = $this->getMockBuilder(\stdClass::class)
-			->addMethods(['createShare'])
-			->getMock();
-		$helper->method('createShare')
+		$this->mockTalkController()
+			->method('createShare')
 			->with(
 				$share,
 				'recipientRoom',
@@ -2789,10 +2777,6 @@ class ShareAPIControllerTest extends TestCase {
 					throw new OCSNotFoundException('Exception thrown by the helper');
 				}
 			);
-
-		$this->serverContainer->method('get')
-			->with('\OCA\Talk\Share\Helper\ShareAPIController')
-			->willReturn($helper);
 
 		$this->shareManager->expects($this->never())->method('createShare');
 
@@ -4941,6 +4925,7 @@ class ShareAPIControllerTest extends TestCase {
 			$expects['attributes'] = \json_encode($shareParams['attributes']);
 		}
 		if (isset($shareParams['node'])) {
+			/** @var Node&MockObject */
 			$node = $this->createMock($shareParams['node']['class']);
 
 			$node->method('getMimeType')->willReturn($shareParams['node']['mimeType']);
@@ -5214,22 +5199,13 @@ class ShareAPIControllerTest extends TestCase {
 				->with('spreed')
 				->willReturn(true);
 
-			// This is not possible anymore with PHPUnit 10+
-			// as `setMethods` was removed and now real reflection is used, thus the class needs to exist.
-			// $helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
-			$helper = $this->getMockBuilder(\stdClass::class)
-				->addMethods(['formatShare', 'canAccessShare'])
-				->getMock();
-			$helper->method('formatShare')
+			$helper = $this->mockTalkController();
+			$helper ->method('formatShare')
 				->with($share)
 				->willReturn($formatShareByHelper);
 			$helper->method('canAccessShare')
 				->with($share)
 				->willReturn(true);
-
-			$this->serverContainer->method('get')
-				->with('\OCA\Talk\Share\Helper\ShareAPIController')
-				->willReturn($helper);
 		}
 
 		$result = $this->invokePrivate($this->ocs, 'formatShare', [$share]);
@@ -5646,5 +5622,22 @@ class ShareAPIControllerTest extends TestCase {
 		$share->expects($this->once())->method('setHideDownload')->with(false);
 
 		$this->invokePrivate($ocs, 'checkInheritedAttributes', [$share]);
+	}
+
+	/**
+	 * Helper to allow testing Talk integration even if Talk
+	 * is not available during tests.
+	 */
+	private function mockTalkController(): MockObject {
+		if (class_exists(\OCA\Talk\Share\Helper\ShareAPIController::class)) {
+			$helper = $this->createMock(\OCA\Talk\Share\Helper\ShareAPIController::class);
+		} else {
+			$helper = $this->createMock(InternalTalkShareAPIController::class);
+		}
+
+		$this->serverContainer->method('get')
+			->with(\OCA\Talk\Share\Helper\ShareAPIController::class)
+			->willReturn($helper);
+		return $helper;
 	}
 }

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1471,12 +1471,6 @@
       <code><![CDATA[Circles]]></code>
       <code><![CDATA[Circles]]></code>
     </UndefinedClass>
-    <UndefinedDocblockClass>
-      <code><![CDATA[$this->getRoomShareHelper()]]></code>
-      <code><![CDATA[$this->getRoomShareHelper()]]></code>
-      <code><![CDATA[$this->getRoomShareHelper()]]></code>
-      <code><![CDATA[\OCA\Talk\Share\Helper\ShareAPIController]]></code>
-    </UndefinedDocblockClass>
   </file>
   <file src="apps/files_sharing/lib/Controller/ShareController.php">
     <DeprecatedClass>

--- a/build/stubs/oca_talk_share_helper_shareapicontroller.php
+++ b/build/stubs/oca_talk_share_helper_shareapicontroller.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Talk\Share\Helper;
+
+/**
+ * Helper of OCA\Files_Sharing\Controller\ShareAPIController for room shares.
+ *
+ * The methods of this class are called from the ShareAPIController to perform
+ * actions or checks specific to room shares.
+ */
+class ShareAPIController
+{
+    public function __construct(protected string $userId, protected \OCA\Talk\Manager $manager, protected \OCA\Talk\Service\ParticipantService $participantService, protected \OCP\AppFramework\Utility\ITimeFactory $timeFactory, protected \OCP\IL10N $l, protected \OCP\IURLGenerator $urlGenerator)
+    {
+    }
+    /**
+     * Formats the specific fields of a room share for OCS output.
+     *
+     * The returned fields override those set by the main ShareAPIController.
+     */
+    public function formatShare(\OCP\Share\IShare $share): array
+    {
+    }
+    /**
+     * Prepares the given share to be passed to OC\Share20\Manager::createShare.
+     *
+     * @throws OCSNotFoundException
+     */
+    public function createShare(\OCP\Share\IShare $share, string $shareWith, int $permissions, string $expireDate): void
+    {
+    }
+    /**
+     * Returns whether the given user can access the given room share or not.
+     *
+     * A user can access a room share only if they are a participant of the room.
+     */
+    public function canAccessShare(\OCP\Share\IShare $share, string $user): bool
+    {
+    }
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -97,6 +97,7 @@
 		<file name="3rdparty/sabre/uri/lib/functions.php" />
 		<file name="build/stubs/app_api.php" />
 		<file name="build/stubs/php-polyfill.php" />
+		<file name="build/stubs/oca_talk_share_helper_shareapicontroller.php" />
 	</stubs>
 	<issueHandlers>
 		<LessSpecificReturnStatement errorLevel="error"/>


### PR DESCRIPTION
## Summary

Preparation for next PHPUnit version.
`addMethods` was removed so we need to replace all places.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
