### PR TITLE
fix(zip): Fix warning when downloading Zip file

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
@@ -91,10 +91,11 @@ class ZipFolderPlugin extends ServerPlugin {
 	 * It is possible to filter / limit the files that should be downloaded,
 	 * either by passing (multiple) `X-NC-Files: the-file` headers
 	 * or by setting a `files=JSON_ARRAY_OF_FILES` URL query.
-	 *
-	 * @return false|null
 	 */
-	public function handleDownload(Request $request, Response $response): ?bool {
+	public function handleDownload(Request $request, Response $response): ?false {
+		if ($request->getHeader('X-Sabre-Original-Method') === 'HEAD') {
+			return null;
+		}
 		$node = $this->tree->getNodeForPath($request->getPath());
 		if (!($node instanceof Directory)) {
 			// only handle directories
@@ -183,11 +184,12 @@ class ZipFolderPlugin extends ServerPlugin {
 	}
 
 	/**
-	 * Tell sabre/dav not to trigger it's own response sending logic as the handleDownload will have already send the response
-	 *
-	 * @return false|null
+	 * Tell sabre/dav not to trigger its own response sending logic as the handleDownload will have already sent the response
 	 */
-	public function afterDownload(Request $request, Response $response): ?bool {
+	public function afterDownload(Request $request, Response $response): ?false {
+		if ($request->getHeader('X-Sabre-Original-Method') === 'HEAD') {
+			return null;
+		}
 		$node = $this->tree->getNodeForPath($request->getPath());
 		if (!($node instanceof Directory)) {
 			// only handle directories


### PR DESCRIPTION
* Resolves: #55833

## Summary

The HEAD request, create a GET subrequest which is not compatible with the ZIP plugin since the ZIP plugin is directly streaming the content to php://output, so we were sending the content in a HEAD request and creating the ZIP twice and this was creating various warning in logs too.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
