### PR TITLE
fix(dav): adjust password session check on legacy dav auth

### DIFF
--- a/apps/dav/lib/Connector/LegacyPublicAuth.php
+++ b/apps/dav/lib/Connector/LegacyPublicAuth.php
@@ -16,6 +16,7 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use Sabre\DAV\Auth\Backend\AbstractBasic;
+use Sabre\DAV\Exception\NotAuthenticated;
 
 /**
  * Class PublicAuth
@@ -69,22 +70,29 @@ class LegacyPublicAuth extends AbstractBasic {
 			if ($share->getShareType() === IShare::TYPE_LINK
 				|| $share->getShareType() === IShare::TYPE_EMAIL
 				|| $share->getShareType() === IShare::TYPE_CIRCLE) {
+				// Validate password if provided
 				if ($this->shareManager->checkPassword($share, $password)) {
-					return true;
-				} elseif ($this->session->exists(PublicAuth::DAV_AUTHENTICATED)
-					&& $this->session->get(PublicAuth::DAV_AUTHENTICATED) === $share->getId()) {
-					return true;
-				} else {
-					if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
-						// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
-						http_response_code(401);
-						header('WWW-Authenticate: DummyBasic realm="' . $this->realm . '"');
-						throw new \Sabre\DAV\Exception\NotAuthenticated('Cannot authenticate over ajax calls');
+					// If not set, set authenticated session cookie
+					if (!$this->isShareInSession($share)) {
+						$this->addShareToSession($share);
 					}
-
-					$this->throttler->registerAttempt(self::BRUTEFORCE_ACTION, $this->request->getRemoteAddress());
-					return false;
+					return true;
 				}
+
+				// We are already authenticated for this share in the session
+				if ($this->isShareInSession($share)) {
+					return true;
+				}
+
+				if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
+					// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
+					http_response_code(401);
+					header('WWW-Authenticate: DummyBasic realm="' . $this->realm . '"');
+					throw new NotAuthenticated('Cannot authenticate over ajax calls');
+				}
+
+				$this->throttler->registerAttempt(self::BRUTEFORCE_ACTION, $this->request->getRemoteAddress());
+				return false;
 			} elseif ($share->getShareType() === IShare::TYPE_REMOTE) {
 				return true;
 			} else {
@@ -93,6 +101,29 @@ class LegacyPublicAuth extends AbstractBasic {
 			}
 		}
 		return true;
+	}
+
+	private function addShareToSession(IShare $share): void {
+		$allowedShareIds = $this->session->get(PublicAuth::DAV_AUTHENTICATED) ?? [];
+		if (!is_array($allowedShareIds)) {
+			$allowedShareIds = [];
+		}
+
+		$allowedShareIds[] = $share->getId();
+		$this->session->set(PublicAuth::DAV_AUTHENTICATED, $allowedShareIds);
+	}
+
+	private function isShareInSession(IShare $share): bool {
+		if (!$this->session->exists(PublicAuth::DAV_AUTHENTICATED)) {
+			return false;
+		}
+
+		$allowedShareIds = $this->session->get(PublicAuth::DAV_AUTHENTICATED);
+		if (!is_array($allowedShareIds)) {
+			return false;
+		}
+
+		return in_array($share->getId(), $allowedShareIds);
 	}
 
 	public function getShare(): IShare {

--- a/apps/dav/lib/Connector/LegacyPublicAuth.php
+++ b/apps/dav/lib/Connector/LegacyPublicAuth.php
@@ -17,6 +17,7 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use Sabre\DAV\Auth\Backend\AbstractBasic;
+use Sabre\DAV\Exception\NotAuthenticated;
 
 /**
  * Class PublicAuth
@@ -71,22 +72,29 @@ class LegacyPublicAuth extends AbstractBasic {
 			if ($share->getShareType() === IShare::TYPE_LINK
 				|| $share->getShareType() === IShare::TYPE_EMAIL
 				|| $share->getShareType() === IShare::TYPE_CIRCLE) {
+				// Validate password if provided
 				if ($this->shareManager->checkPassword($share, $password)) {
-					return true;
-				} elseif ($this->session->exists(PublicAuth::DAV_AUTHENTICATED)
-					&& $this->session->get(PublicAuth::DAV_AUTHENTICATED) === $share->getId()) {
-					return true;
-				} else {
-					if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
-						// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
-						http_response_code(401);
-						header('WWW-Authenticate: DummyBasic realm="' . $this->realm . '"');
-						throw new \Sabre\DAV\Exception\NotAuthenticated('Cannot authenticate over ajax calls');
+					// If not set, set authenticated session cookie
+					if (!$this->isShareInSession($share)) {
+						$this->addShareToSession($share);
 					}
-
-					$this->throttler->registerAttempt(self::BRUTEFORCE_ACTION, $this->request->getRemoteAddress());
-					return false;
+					return true;
 				}
+
+				// We are already authenticated for this share in the session
+				if ($this->isShareInSession($share)) {
+					return true;
+				}
+
+				if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
+					// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
+					http_response_code(401);
+					header('WWW-Authenticate: DummyBasic realm="' . $this->realm . '"');
+					throw new NotAuthenticated('Cannot authenticate over ajax calls');
+				}
+
+				$this->throttler->registerAttempt(self::BRUTEFORCE_ACTION, $this->request->getRemoteAddress());
+				return false;
 			} elseif ($share->getShareType() === IShare::TYPE_REMOTE) {
 				return true;
 			} else {
@@ -95,6 +103,29 @@ class LegacyPublicAuth extends AbstractBasic {
 			}
 		}
 		return true;
+	}
+
+	private function addShareToSession(IShare $share): void {
+		$allowedShareIds = $this->session->get(PublicAuth::DAV_AUTHENTICATED) ?? [];
+		if (!is_array($allowedShareIds)) {
+			$allowedShareIds = [];
+		}
+
+		$allowedShareIds[] = $share->getId();
+		$this->session->set(PublicAuth::DAV_AUTHENTICATED, $allowedShareIds);
+	}
+
+	private function isShareInSession(IShare $share): bool {
+		if (!$this->session->exists(PublicAuth::DAV_AUTHENTICATED)) {
+			return false;
+		}
+
+		$allowedShareIds = $this->session->get(PublicAuth::DAV_AUTHENTICATED);
+		if (!is_array($allowedShareIds)) {
+			return false;
+		}
+
+		return in_array($share->getId(), $allowedShareIds);
 	}
 
 	public function getShare(): IShare {

--- a/apps/dav/lib/Connector/LegacyPublicAuth.php
+++ b/apps/dav/lib/Connector/LegacyPublicAuth.php
@@ -125,7 +125,7 @@ class LegacyPublicAuth extends AbstractBasic {
 			return false;
 		}
 
-		return in_array($share->getId(), $allowedShareIds);
+		return in_array($share->getId(), $allowedShareIds, true);
 	}
 
 	public function getShare(): IShare {

--- a/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
@@ -168,7 +168,7 @@ class LegacyPublicAuthTest extends TestCase {
 			)->willReturn(false);
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
-		$this->session->method('get')->with('public_link_authenticated')->willReturn('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['42']);
 
 		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
 
@@ -192,7 +192,7 @@ class LegacyPublicAuthTest extends TestCase {
 			)->willReturn(false);
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
-		$this->session->method('get')->with('public_link_authenticated')->willReturn('43');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['43']);
 
 		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
 
@@ -217,7 +217,7 @@ class LegacyPublicAuthTest extends TestCase {
 			)->willReturn(false);
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
-		$this->session->method('get')->with('public_link_authenticated')->willReturn('43');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['43']);
 
 		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
 

--- a/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
@@ -174,7 +174,7 @@ class LegacyPublicAuthTest extends TestCase {
 			)->willReturn(false);
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
-		$this->session->method('get')->with('public_link_authenticated')->willReturn('42');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['42']);
 
 		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
 
@@ -199,7 +199,7 @@ class LegacyPublicAuthTest extends TestCase {
 			)->willReturn(false);
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
-		$this->session->method('get')->with('public_link_authenticated')->willReturn('43');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['43']);
 
 		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
 
@@ -224,7 +224,7 @@ class LegacyPublicAuthTest extends TestCase {
 			)->willReturn(false);
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
-		$this->session->method('get')->with('public_link_authenticated')->willReturn('43');
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['43']);
 
 		$result = $this->invokePrivate($this->auth, 'validateUserPass', ['username', 'password']);
 


### PR DESCRIPTION
Follow-up https://github.com/nextcloud/server/pull/55955/

## Summary
We adjusted the session to store multiple granted public shares, so you could open a few tabs and not get logge dout the previous ones.
But I did not migrate the legacy auth middleware. It seems it's still used in older versions, maybe we plan the removal of the old dav v1 entrypoint


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
