### PR TITLE
[stable33] chore: Remove incorrect resource typing in ILDAPProvider

### DIFF
--- a/lib/public/LDAP/ILDAPProvider.php
+++ b/lib/public/LDAP/ILDAPProvider.php
@@ -56,7 +56,7 @@ interface ILDAPProvider {
 	/**
 	 * Return a new LDAP connection resource for the specified user.
 	 * @param string $uid user id
-	 * @return \LDAP\Connection|resource
+	 * @return \LDAP\Connection
 	 * @since 11.0.0
 	 */
 	public function getLDAPConnection($uid);
@@ -64,7 +64,7 @@ interface ILDAPProvider {
 	/**
 	 * Return a new LDAP connection resource for the specified group.
 	 * @param string $gid group id
-	 * @return \LDAP\Connection|resource
+	 * @return \LDAP\Connection
 	 * @since 13.0.0
 	 */
 	public function getGroupLDAPConnection($gid);


### PR DESCRIPTION
## Summary

Subset of https://github.com/nextcloud/server/pull/59379 for stable33.
Removes the resource typing which is not possible with PHP>=8.1.
Helps applications to have clean typing through nextcloud/ocp.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
