### PR TITLE
fix(zip): suppress sabre/dav response only if stream was actually sent

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
@@ -38,6 +38,12 @@ class ZipFolderPlugin extends ServerPlugin {
 	 */
 	private ?Server $server = null;
 
+	/**
+	 * Whether handleDownload has fully streamed an archive for the current request.
+	 * Used by afterDownload to decide whether to suppress sabre/dav's own response logic.
+	 */
+	private bool $streamed = false;
+
 	public function __construct(
 		private Tree $tree,
 		private LoggerInterface $logger,
@@ -180,6 +186,8 @@ class ZipFolderPlugin extends ServerPlugin {
 			$this->streamNode($streamer, $node, $rootPath);
 		}
 		$streamer->finalize();
+		$this->streamed = true; // archive fully streamed
+
 		return false;
 	}
 
@@ -190,12 +198,11 @@ class ZipFolderPlugin extends ServerPlugin {
 		if ($request->getHeader('X-Sabre-Original-Method') === 'HEAD') {
 			return null;
 		}
-		$node = $this->tree->getNodeForPath($request->getPath());
-		if (!($node instanceof Directory)) {
-			// only handle directories
+
+		if (!$this->streamed) {
 			return null;
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`afterDownload` currently returns `false` (suppressing sabre/dav's own response logic) for any GET request targeting a Directory node, regardless of whether `handleDownload` actually streamed an archive.

This means a GET on a folder without an `Accept: zip` or `Accept: tar` header causes `handleDownload` to correctly bail out with null, but `afterDownload` then silently swallows sabre/dav's response, resulting in an empty reply to the client instead of the expected.

The fix: suppress sabre/dav response only if stream was actually sent.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
