### PR TITLE
fix(file-search): use default limit to search query if not provided on request body

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -343,6 +343,7 @@ class FileSearchBackend implements ISearchBackend {
 		}, $query->orderBy);
 
 		$limit = $query->limit;
+		$maxResults = $limit->maxResults !== 0 ? (int)$limit->maxResults : 100;
 		$offset = $limit->firstResult;
 
 		$limitHome = false;
@@ -370,7 +371,7 @@ class FileSearchBackend implements ISearchBackend {
 
 		return new SearchQuery(
 			$operators,
-			(int)$limit->maxResults,
+			$maxResults,
 			$offset,
 			$orders,
 			$this->user,

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -97,7 +97,7 @@ class FileSearchBackendTest extends TestCase {
 					'name',
 					'foo'
 				),
-				0,
+				100,
 				0,
 				[],
 				$this->user
@@ -126,7 +126,7 @@ class FileSearchBackendTest extends TestCase {
 					'mimetype',
 					'foo'
 				),
-				0,
+				100,
 				0,
 				[],
 				$this->user
@@ -155,7 +155,7 @@ class FileSearchBackendTest extends TestCase {
 					'size',
 					10
 				),
-				0,
+				100,
 				0,
 				[],
 				$this->user
@@ -184,7 +184,7 @@ class FileSearchBackendTest extends TestCase {
 					'mtime',
 					10
 				),
-				0,
+				100,
 				0,
 				[],
 				$this->user
@@ -213,7 +213,7 @@ class FileSearchBackendTest extends TestCase {
 					'mimetype',
 					FileInfo::MIMETYPE_FOLDER
 				),
-				0,
+				100,
 				0,
 				[],
 				$this->user


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Sets a default limit for file search requests that don't include `<d:limit>` and `<d:nresults>` props. Without this, unlimited searches on large storages could exhaust PHP memory. Falls back to 100 results when no limit is specified.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
