### PR TITLE
fix(settings): Don't register invalid routes

### DIFF
--- a/apps/settings/appinfo/routes.php
+++ b/apps/settings/appinfo/routes.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 return [
-	'resources' => [
-		'AuthSettings' => ['url' => '/settings/personal/authtokens' , 'root' => ''],
-	],
 	'routes' => [
 		['name' => 'AuthorizedGroup#saveSettings', 'url' => '/settings/authorizedgroups/saveSettings', 'verb' => 'POST'],
 
+		['name' => 'AuthSettings#create', 'url' => '/settings/personal/authtokens', 'verb' => 'POST' , 'root' => ''],
+		['name' => 'AuthSettings#update', 'url' => '/settings/personal/authtokens/{id}', 'verb' => 'PUT' , 'root' => ''],
+		['name' => 'AuthSettings#destroy', 'url' => '/settings/personal/authtokens/{id}', 'verb' => 'DELETE' , 'root' => ''],
 		['name' => 'AuthSettings#wipe', 'url' => '/settings/personal/authtokens/wipe/{id}', 'verb' => 'POST' , 'root' => ''],
 
 		['name' => 'MailSettings#setMailSettings', 'url' => '/settings/admin/mailsettings', 'verb' => 'POST' , 'root' => ''],


### PR DESCRIPTION
### Before
```
| settings.authsettings.create                              | POST                   | /settings/personal/authtokens                                                         |
| settings.authsettings.destroy                             | DELETE                 | /settings/personal/authtokens/{id}                                                    |
| settings.authsettings.index                               | GET                    | /settings/personal/authtokens                                                         |
| settings.authsettings.show                                | GET                    | /settings/personal/authtokens/{id}                                                    |
| settings.authsettings.update                              | PUT                    | /settings/personal/authtokens/{id}                                                    |
| settings.authsettings.wipe                                | POST                   | /settings/personal/authtokens/wipe/{id}                                               |
```
:boom: https://github.com/nextcloud/server/blob/5d0d0c17e5ecf108506506606be53dfa8bc7586a/apps/settings/lib/Controller/AuthSettingsController.php#L38 does not have index or show methods

Resulting in log spam on invalid requests:
```
GET /settings/personal/authtokens/foobar

> Method OCA\Settings\Controller\AuthSettingsController::show() does not exist 
```

### After
```
| settings.authsettings.create                              | POST                   | /settings/personal/authtokens                                                         |
| settings.authsettings.destroy                             | DELETE                 | /settings/personal/authtokens/{id}                                                    |
| settings.authsettings.update                              | PUT                    | /settings/personal/authtokens/{id}                                                    |
| settings.authsettings.wipe                                | POST                   | /settings/personal/authtokens/wipe/{id}                                               |
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
