### PR TITLE
fix(user): invalidate folder ETag when quota changes

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -2257,6 +2257,7 @@ return array(
     'OC\\User\\LazyUser' => $baseDir . '/lib/private/User/LazyUser.php',
     'OC\\User\\Listeners\\BeforeUserDeletedListener' => $baseDir . '/lib/private/User/Listeners/BeforeUserDeletedListener.php',
     'OC\\User\\Listeners\\UserChangedListener' => $baseDir . '/lib/private/User/Listeners/UserChangedListener.php',
+    'OC\\User\\Listeners\\UserQuotaChangedListener' => $baseDir . '/lib/private/User/Listeners/UserQuotaChangedListener.php',
     'OC\\User\\LoginException' => $baseDir . '/lib/private/User/LoginException.php',
     'OC\\User\\Manager' => $baseDir . '/lib/private/User/Manager.php',
     'OC\\User\\NoUserException' => $baseDir . '/lib/private/User/NoUserException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -2298,6 +2298,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\User\\LazyUser' => __DIR__ . '/../../..' . '/lib/private/User/LazyUser.php',
         'OC\\User\\Listeners\\BeforeUserDeletedListener' => __DIR__ . '/../../..' . '/lib/private/User/Listeners/BeforeUserDeletedListener.php',
         'OC\\User\\Listeners\\UserChangedListener' => __DIR__ . '/../../..' . '/lib/private/User/Listeners/UserChangedListener.php',
+        'OC\\User\\Listeners\\UserQuotaChangedListener' => __DIR__ . '/../../..' . '/lib/private/User/Listeners/UserQuotaChangedListener.php',
         'OC\\User\\LoginException' => __DIR__ . '/../../..' . '/lib/private/User/LoginException.php',
         'OC\\User\\Manager' => __DIR__ . '/../../..' . '/lib/private/User/Manager.php',
         'OC\\User\\NoUserException' => __DIR__ . '/../../..' . '/lib/private/User/NoUserException.php',

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -157,6 +157,7 @@ use OC\User\AvailabilityCoordinator;
 use OC\User\DisplayNameCache;
 use OC\User\Listeners\BeforeUserDeletedListener;
 use OC\User\Listeners\UserChangedListener;
+use OC\User\Listeners\UserQuotaChangedListener;
 use OC\User\Session;
 use OC\User\User;
 use OCA\Theming\ImageManager;
@@ -1342,6 +1343,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$eventDispatcher->addServiceListener(LoginFailed::class, LoginFailedListener::class);
 		$eventDispatcher->addServiceListener(PostLoginEvent::class, UserLoggedInListener::class);
 		$eventDispatcher->addServiceListener(UserChangedEvent::class, UserChangedListener::class);
+		$eventDispatcher->addServiceListener(UserChangedEvent::class, UserQuotaChangedListener::class);
 		$eventDispatcher->addServiceListener(BeforeUserDeletedEvent::class, BeforeUserDeletedListener::class);
 
 		FilesMetadataManager::loadListeners($eventDispatcher);

--- a/lib/private/User/Listeners/UserQuotaChangedListener.php
+++ b/lib/private/User/Listeners/UserQuotaChangedListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\User\Listeners;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\IRootFolder;
+use OCP\User\Events\UserChangedEvent;
+
+/**
+ * @template-implements IEventListener<UserChangedEvent>
+ */
+class UserQuotaChangedListener implements IEventListener {
+	public function __construct(
+		private IRootFolder $rootFolder,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof UserChangedEvent) {
+			return;
+		}
+
+		if ($event->getFeature() !== 'quota') {
+			return;
+		}
+
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($event->getUser()->getUID());
+			$userFolder->getStorage()->getCache()->update(
+				$userFolder->getId(),
+				['etag' => uniqid()]
+			);
+		} catch (\Throwable) {
+			// Non-fatal: best-effort ETag invalidation.
+			// Stale quota corrects itself on the client's next full sync.
+		}
+	}
+}

--- a/lib/private/User/Listeners/UserQuotaChangedListener.php
+++ b/lib/private/User/Listeners/UserQuotaChangedListener.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\User\Listeners;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\IRootFolder;
+use OCP\User\Events\UserChangedEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @template-implements IEventListener<UserChangedEvent>
+ */
+class UserQuotaChangedListener implements IEventListener {
+	public function __construct(
+		private IRootFolder $rootFolder,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!$event instanceof UserChangedEvent) {
+			return;
+		}
+
+		if ($event->getFeature() !== 'quota') {
+			return;
+		}
+
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($event->getUser()->getUID());
+			$userFolder->getStorage()->getCache()->update(
+				$userFolder->getId(),
+				['etag' => uniqid()]
+			);
+		} catch (\Throwable $e) {
+			// Non-fatal: best-effort ETag invalidation.
+			// Stale quota corrects itself on the client's next full sync.
+			$this->logger->warning('Failed to invalidate user root etag after quota change', [
+				'user' => $event->getUser()->getUID(),
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/tests/lib/User/Listeners/UserQuotaChangedListenerIntegrationTest.php
+++ b/tests/lib/User/Listeners/UserQuotaChangedListenerIntegrationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\User\Listeners;
+
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
+use Test\TestCase;
+
+/**
+ * End-to-end coverage for the quota change etag invalidation: unlike the
+ * mock-based unit test this proves the listener is actually registered in
+ * the server container, by going through the real setQuota() event chain.
+ */
+#[Group('DB')]
+class UserQuotaChangedListenerIntegrationTest extends TestCase {
+	private const TEST_USER = 'quota_etag_listener_test_user';
+
+	#[\Override]
+	protected function tearDown(): void {
+		Server::get(IUserManager::class)->get(self::TEST_USER)?->delete();
+		parent::tearDown();
+	}
+
+	public function testSetQuotaInvalidatesUserRootEtag(): void {
+		$userManager = Server::get(IUserManager::class);
+		$userManager->get(self::TEST_USER)?->delete();
+		$user = $userManager->createUser(self::TEST_USER, 'correct-Horse-battery1!');
+		$this->assertNotFalse($user);
+
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_USER);
+		$cache = $userFolder->getStorage()->getCache();
+		$etagBefore = $cache->get($userFolder->getInternalPath())->getEtag();
+
+		$user->setQuota('5 GB');
+
+		$etagAfter = $cache->get($userFolder->getInternalPath())->getEtag();
+		$this->assertNotEquals(
+			$etagBefore,
+			$etagAfter,
+			'User root etag must change when the quota changes so clients re-fetch quota-available-bytes',
+		);
+	}
+}

--- a/tests/lib/User/Listeners/UserQuotaChangedListenerTest.php
+++ b/tests/lib/User/Listeners/UserQuotaChangedListenerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace Test\User\Listeners;
+
+use OC\User\Listeners\UserQuotaChangedListener;
+use OCP\EventDispatcher\Event;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Storage\IStorage;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class UserQuotaChangedListenerTest extends TestCase {
+	private IRootFolder&MockObject $rootFolder;
+	private UserQuotaChangedListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->listener = new UserQuotaChangedListener($this->rootFolder);
+	}
+
+	public function testIgnoresNonUserChangedEvent(): void {
+		$this->rootFolder->expects($this->never())->method('getUserFolder');
+		$this->listener->handle($this->createMock(Event::class));
+	}
+
+	public function testIgnoresNonQuotaFeature(): void {
+		$user = $this->createMock(IUser::class);
+		$event = new UserChangedEvent($user, 'displayName', 'Alice', 'Bob');
+
+		$this->rootFolder->expects($this->never())->method('getUserFolder');
+		$this->listener->handle($event);
+	}
+
+	public function testInvalidatesEtagOnQuotaChange(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$cache = $this->createMock(ICache::class);
+		$cache->expects($this->once())
+			->method('update')
+			->with($this->isInt(), $this->callback(
+				fn (array $data) => isset($data['etag']) && $data['etag'] !== ''
+			));
+
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('getCache')->willReturn($cache);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getStorage')->willReturn($storage);
+		$userFolder->method('getId')->willReturn(42);
+
+		$this->rootFolder->method('getUserFolder')->with('alice')->willReturn($userFolder);
+
+		$event = new UserChangedEvent($user, 'quota', '5 GB', '1 GB');
+		$this->listener->handle($event);
+	}
+
+	public function testSwallowsExceptionGracefully(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$this->rootFolder->method('getUserFolder')
+			->willThrowException(new \Exception('Storage unavailable'));
+
+		// Should not throw
+		$event = new UserChangedEvent($user, 'quota', '5 GB', '1 GB');
+		$this->listener->handle($event);
+		$this->addToAssertionCount(1);
+	}
+}

--- a/tests/lib/User/Listeners/UserQuotaChangedListenerTest.php
+++ b/tests/lib/User/Listeners/UserQuotaChangedListenerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\User\Listeners;
+
+use OC\User\Listeners\UserQuotaChangedListener;
+use OCP\EventDispatcher\Event;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Storage\IStorage;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class UserQuotaChangedListenerTest extends TestCase {
+	private IRootFolder&MockObject $rootFolder;
+	private LoggerInterface&MockObject $logger;
+	private UserQuotaChangedListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->listener = new UserQuotaChangedListener($this->rootFolder, $this->logger);
+	}
+
+	public function testIgnoresNonUserChangedEvent(): void {
+		$this->rootFolder->expects($this->never())->method('getUserFolder');
+		$this->listener->handle($this->createMock(Event::class));
+	}
+
+	public function testIgnoresNonQuotaFeature(): void {
+		$user = $this->createMock(IUser::class);
+		$event = new UserChangedEvent($user, 'displayName', 'Alice', 'Bob');
+
+		$this->rootFolder->expects($this->never())->method('getUserFolder');
+		$this->listener->handle($event);
+	}
+
+	public function testInvalidatesEtagOnQuotaChange(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$cache = $this->createMock(ICache::class);
+		$cache->expects($this->once())
+			->method('update')
+			->with($this->isInt(), $this->callback(
+				fn (array $data) => isset($data['etag']) && $data['etag'] !== ''
+			));
+
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('getCache')->willReturn($cache);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getStorage')->willReturn($storage);
+		$userFolder->method('getId')->willReturn(42);
+
+		$this->rootFolder->method('getUserFolder')->with('alice')->willReturn($userFolder);
+
+		$event = new UserChangedEvent($user, 'quota', '5 GB', '1 GB');
+		$this->listener->handle($event);
+	}
+
+	public function testSwallowsExceptionButLogsWarning(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$this->rootFolder->method('getUserFolder')
+			->willThrowException(new \Exception('Storage unavailable'));
+
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with($this->isString(), $this->callback(
+				fn (array $context) => $context['user'] === 'alice' && $context['exception'] instanceof \Exception
+			));
+
+		// Must not throw
+		$event = new UserChangedEvent($user, 'quota', '5 GB', '1 GB');
+		$this->listener->handle($event);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/51977
* Resolves https://github.com/nextcloud/server/issues/52875
* Related to https://github.com/nextcloud/server/issues/13604
* Related to https://github.com/nextcloud/desktop/issues/4580
* TeamFolders PR: https://github.com/nextcloud/groupfolders/pull/4539

## Summary

When an admin changes a user's quota (via the admin UI, provisioning API, or CLI), desktop sync clients continue using the stale `quota-available-bytes` value from their last PROPFIND until the etag of the user's home folder changes.

This PR invalidates the etag entry whenever `setQuota()` persists a new quota value, forcing clients to re-fetch on their next sync cycle.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
