### PR TITLE
fix(SetupChecks): maintenance window length is 4h (not 6h)

### DIFF
--- a/apps/settings/lib/SetupChecks/MaintenanceWindowStart.php
+++ b/apps/settings/lib/SetupChecks/MaintenanceWindowStart.php
@@ -41,7 +41,7 @@ class MaintenanceWindowStart implements ISetupCheck {
 		}
 
 		$startValue = (int)$configValue;
-		$endValue = ($startValue + 6) % 24;
+		$endValue = ($startValue + 4) % 24;
 		return SetupResult::success(
 			str_replace(
 				['{start}', '{end}'],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

https://github.com/nextcloud/server/blob/521e61828fbeb87f3385aea2ca6ea74ac335414c/core/Service/CronService.php#L138

(Or we increase the implementation to 6 to match; I have no strong opinions either way).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
