### PR TITLE
fix(user_ldap): fix lastLogin reading wrong appid and configkey

### DIFF
--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -164,7 +164,7 @@ class OfflineUser {
 		$this->foundDeleted = $this->userConfig->getValueInt($this->ocName, 'user_ldap', 'foundDeleted');
 		$this->extStorageHome = $this->userConfig->getValueString($this->ocName, 'user_ldap', 'extStorageHome');
 		$this->email = $this->userConfig->getValueString($this->ocName, 'user_ldap', 'email');
-		$this->lastLogin = $this->userConfig->getValueInt($this->ocName, 'user_ldap', 'email');
+		$this->lastLogin = $this->userConfig->getValueInt($this->ocName, 'login', 'lastLogin');
 	}
 
 	/**


### PR DESCRIPTION
Fixes #58421

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #58421

## Summary

`fetchDetails()` in `OfflineUser` was using the wrong appid (`user_ldap`) and key (`email`) when reading `lastLogin` via `getValueInt()`. The value is stored under appid `login` with key `lastLogin` (as written by `User::updateLastLoginTimestamp()`), so this always returned 0 for offline LDAP users.

## TODO

- [x] One-line fix

## Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation (manuals or wiki) has been updated or is not required
- [x] Backports requested where applicable
- [x] Labels added where applicable
- [x] Milestone added for target branch/version

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
