### PR TITLE
fix(workflowengine): remove non existing script loading

### DIFF
--- a/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
+++ b/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
@@ -18,7 +18,6 @@ use OCP\WorkflowEngine\Events\LoadSettingsScriptsEvent;
 /** @template-implements IEventListener<LoadSettingsScriptsEvent> */
 class LoadAdditionalSettingsScriptsListener implements IEventListener {
 	public function handle(Event $event): void {
-		Util::addScript('core', 'systemtags');
 		Util::addScript(Application::APP_ID, 'workflowengine');
 	}
 }


### PR DESCRIPTION
- resolves https://github.com/nextcloud/server/issues/59385

The script does not exist anymore, so remove it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
