### PR TITLE
[stable32] fix(settings): do not show admin section container if empty

### DIFF
--- a/apps/settings/templates/settings/frame.php
+++ b/apps/settings/templates/settings/frame.php
@@ -40,30 +40,29 @@ style('settings', 'settings');
 
 	<?php if (!empty($_['forms']['admin'])): ?>
 		<div id="app-navigation-caption-administration" class="app-navigation-caption"><?php p($l->t('Administration')); ?></div>
+		<nav class="app-navigation-administration" aria-labelledby="app-navigation-caption-administration">
+			<ul>
+				<?php foreach ($_['forms']['admin'] as $form) {
+					if (isset($form['anchor'])) {
+						$anchor = \OCP\Server::get(\OCP\IURLGenerator::class)->linkToRoute('settings.AdminSettings.index', ['section' => $form['anchor']]);
+						$class = 'nav-icon-' . $form['anchor'];
+						$sectionName = $form['section-name']; ?>
+						<li <?php print_unescaped($form['active'] ? ' class="active"' : ''); ?> data-section-id="<?php print_unescaped($form['anchor']); ?>" data-section-type="admin">
+							<a href="<?php p($anchor); ?>"<?php print_unescaped($form['active'] ? ' aria-current="page"' : ''); ?>>
+								<?php if (!empty($form['icon'])) { ?>
+									<img alt="" src="<?php print_unescaped($form['icon']); ?>">
+									<span><?php p($form['section-name']); ?></span>
+								<?php } else { ?>
+									<span class="no-icon"><?php p($form['section-name']); ?></span>
+								<?php } ?>
+							</a>
+						</li>
+						<?php
+					}
+				} ?>
+			</ul>
+		</nav>
 	<?php endif; ?>
-	<nav class="app-navigation-administration" aria-labelledby="app-navigation-caption-administration">
-		<ul>
-			<?php foreach ($_['forms']['admin'] as $form) {
-				if (isset($form['anchor'])) {
-					$anchor = \OCP\Server::get(\OCP\IURLGenerator::class)->linkToRoute('settings.AdminSettings.index', ['section' => $form['anchor']]);
-					$class = 'nav-icon-' . $form['anchor'];
-					$sectionName = $form['section-name']; ?>
-					<li <?php print_unescaped($form['active'] ? ' class="active"' : ''); ?> data-section-id="<?php print_unescaped($form['anchor']); ?>" data-section-type="admin">
-						<a href="<?php p($anchor); ?>"<?php print_unescaped($form['active'] ? ' aria-current="page"' : ''); ?>>
-							<?php if (!empty($form['icon'])) { ?>
-								<img alt="" src="<?php print_unescaped($form['icon']); ?>">
-								<span><?php p($form['section-name']); ?></span>
-							<?php } else { ?>
-								<span class="no-icon"><?php p($form['section-name']); ?></span>
-							<?php } ?>
-						</a>
-					</li>
-					<?php
-				}
-			}
-?>
-		</ul>
-	</nav>
 </div>
 <main id="app-content" <?php if (!empty($_['activeSectionId'])) { ?> data-active-section-id="<?php print_unescaped($_['activeSectionId']) ?>" <?php } if (!empty($_['activeSectionType'])) { ?> data-active-section-type="<?php print_unescaped($_['activeSectionType']) ?>" <?php } ?>>
 	<?php print_unescaped($_['content']); ?>


### PR DESCRIPTION
- fixes https://github.com/nextcloud/server/issues/59337

Already fixed for Nextcloud 34+ but here we need to fix the legacy navigation as well.
The problem is that empty `<ul>` elements are not allowed, lists always require at least one list item for accessibility. Ref: https://www.w3.org/TR/wai-aria-1.2/#mustContain

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
