### PR TITLE
fix(files_sharing): validate empty file parameter in PublicPreviewController

### DIFF
--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -122,11 +122,18 @@ class PublicPreviewController extends PublicShareController {
 		try {
 			$node = $share->getNode();
 			if ($node instanceof Folder) {
+				if ($file === '') {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
 				$file = $node->get($file);
 			} else {
 				$file = $node;
 			}
+		} catch (NotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
 
+		try {
 			$f = $this->previewManager->getPreview($file, $x, $y, !$a);
 			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
 			$response->cacheFor($cacheForSeconds);

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -227,6 +227,98 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->assertEquals($expected, $res);
 	}
 
+	public function testPreviewFolderEmptyFile(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$res = $this->controller->getPreview('token', '', 10, 10);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderInvalidFileWithMimeFallback(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$folder->method('get')
+			->with($this->equalTo('notexist.png'))
+			->willThrowException(new NotFoundException());
+
+		$res = $this->controller->getPreview('token', 'notexist.png', 10, 10, true, true);
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderValidFileNoPreviewWithMimeFallback(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$file = $this->createMock(File::class);
+		$folder->method('get')
+			->with($this->equalTo('file'))
+			->willReturn($file);
+
+		$this->previewManager->method('getPreview')
+			->with($this->equalTo($file), 10, 10, false)
+			->willThrowException(new NotFoundException());
+
+		$file->method('getMimeType')
+			->willReturn('image/png');
+
+		$mimeIconProvider = $this->createMock(IMimeIconProvider::class);
+		$mimeIconProvider->method('getMimeIconUrl')
+			->with('image/png')
+			->willReturn('/core/img/filetypes/image.svg');
+
+		$controller = new PublicPreviewController(
+			'files_sharing',
+			$this->request,
+			$this->shareManager,
+			$this->createMock(ISession::class),
+			$this->previewManager,
+			$mimeIconProvider,
+		);
+
+		$res = $controller->getPreview('token', 'file', 10, 10, true, true);
+		$this->assertInstanceOf(\OCP\AppFramework\Http\RedirectResponse::class, $res);
+	}
+
 	public function testPreviewFolderInvalidFile(): void {
 		$share = $this->createMock(IShare::class);
 		$this->shareManager->method('getShareByToken')


### PR DESCRIPTION
Fixes #59229

## Summary

The `getPreview()` method in `PublicPreviewController` had two input validation issues
that caused internal server errors:

**Case A:** When requesting a public preview for a folder share without a `file` parameter,
`$node->get('')` returns the Folder itself. `getPreview()` then crashes because it expects
a `File` instance, not a `Folder`.

**Case B:** When requesting a non-existent file with `mimeFallback=true`, the `NotFoundException`
from `$node->get($file)` falls into the catch block where `$file->getMimeType()` is called.
At that point `$file` is still the original string parameter, not a Node object, causing a
fatal error.

## Changes

- Add early return with `400 Bad Request` when `$file` is empty on folder shares
- Split the try-catch into two blocks: one for node resolution, one for preview generation
- This ensures `$file` is always a valid Node object when `mimeFallback` code executes

## Test plan

- [x] Added `testPreviewFolderEmptyFile` — empty file parameter returns 400
- [x] Added `testPreviewFolderInvalidFileWithMimeFallback` — non-existent file with mimeFallback returns 404
- [x] Added `testPreviewFolderValidFileNoPreviewWithMimeFallback` — valid file, no preview, mimeFallback redirects to mime icon
- [x] Existing tests still pass (no regressions)