### PR TITLE
feat: add config header and tests.

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -16,6 +16,23 @@ use OCP\Util;
  */
 class Config {
 	public const ENV_PREFIX = 'NC_';
+	public const CONF_WARNING = "
+/*
+ * WARNING
+ *
+ * This file gets modified by automatic processes and all lines that are not
+ * active code (ie. comments) are lost during that process.
+ *
+ * If you want to document things with comments or use constants add your settings
+ * in a '<NAME>.config.php' file which will be included and rendered into this file.
+ *
+ * Example:
+ *   <?php
+ *   \$CONFIG = [];
+ *
+ * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
+ */
+";
 
 	protected array $cache = [];
 	protected array $envCache = [];
@@ -268,25 +285,9 @@ class Config {
 		}
 
 		// Create a php file ...
-		$content = "<?php
-
-/*
- * WARNING
- *
- * This file gets modified by automatic processes and all lines that are not
- * active code (ie. comments) are lost during that process.
- *
- * If you want to document things with comments or use constants add your settings
- * in a '<NAME>.config.php' file which will be included and rendered into this file.
- *
- * Example:
- *   <?php
- *   \$CONFIG = [];
- *
- * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
- */
-
-\$CONFIG = ";
+		$content = "<?php\n";
+		$content .= self::CONF_WARNING;
+		$content .= '$CONFIG = ';
 		$content .= var_export(self::trustSystemConfig($this->cache), true);
 		$content .= ";\n";
 

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -268,8 +268,25 @@ class Config {
 		}
 
 		// Create a php file ...
-		$content = "<?php\n";
-		$content .= '$CONFIG = ';
+		$content = "<?php
+
+/*
+ * WARNING
+ *
+ * This file gets modified by automatic processes and all lines that are not
+ * active code (ie. comments) are lost during that process.
+ *
+ * If you want to document things with comments or use constants add your settings
+ * in a '<NAME>.config.php' file which will be included and rendered into this file.
+ *
+ * Example:
+ *   <?php
+ *   \$CONFIG = [];
+ *
+ * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
+ */
+
+\$CONFIG = ";
 		$content .= var_export(self::trustSystemConfig($this->cache), true);
 		$content .= ";\n";
 

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -97,25 +97,8 @@ class ConfigTest extends TestCase {
 		$this->assertSame('moo', $config->getValue('foo'));
 
 		$content = file_get_contents($this->configFile);
-		$expected = "<?php
-
-/*
- * WARNING
- *
- * This file gets modified by automatic processes and all lines that are not
- * active code (ie. comments) are lost during that process.
- *
- * If you want to document things with comments or use constants add your settings
- * in a '<NAME>.config.php' file which will be included and rendered into this file.
- *
- * Example:
- *   <?php
- *   \$CONFIG = [];
- *
- * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
- */
-
-";
+		$expected = "<?php\n";
+		$expected .= \OC\Config::CONF_WARNING;
 		$expected .= "\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertEquals($expected, $content);
@@ -127,25 +110,8 @@ class ConfigTest extends TestCase {
 
 		$content = file_get_contents($this->configFile);
 
-		$expected = "<?php
-
-/*
- * WARNING
- *
- * This file gets modified by automatic processes and all lines that are not
- * active code (ie. comments) are lost during that process.
- *
- * If you want to document things with comments or use constants add your settings
- * in a '<NAME>.config.php' file which will be included and rendered into this file.
- *
- * Example:
- *   <?php
- *   \$CONFIG = [];
- *
- * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
- */
-
-";
+		$expected = "<?php\n";
+		$expected .= \OC\Config::CONF_WARNING;
 		$expected .= "\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'bar' => 'red',\n  'apps' => \n "
 			. " array (\n    0 => 'files',\n    1 => 'gallery',\n  ),\n);\n";
@@ -177,25 +143,8 @@ class ConfigTest extends TestCase {
 		$this->assertSame(null, $config->getValue('not_exists'));
 
 		$content = file_get_contents($this->configFile);
-		$expected = "<?php
-
-/*
- * WARNING
- *
- * This file gets modified by automatic processes and all lines that are not
- * active code (ie. comments) are lost during that process.
- *
- * If you want to document things with comments or use constants add your settings
- * in a '<NAME>.config.php' file which will be included and rendered into this file.
- *
- * Example:
- *   <?php
- *   \$CONFIG = [];
- *
- * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
- */
-
-";
+		$expected = "<?php\n";
+		$expected .= \OC\Config::CONF_WARNING;
 		$expected .= "\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n);\n";
 		$this->assertEquals($expected, $content);
@@ -207,25 +156,8 @@ class ConfigTest extends TestCase {
 		$this->assertSame('this_was_clearly_not_set_before', $config->getValue('foo', 'this_was_clearly_not_set_before'));
 		$content = file_get_contents($this->configFile);
 
-		$expected = "<?php
-
-/*
- * WARNING
- *
- * This file gets modified by automatic processes and all lines that are not
- * active code (ie. comments) are lost during that process.
- *
- * If you want to document things with comments or use constants add your settings
- * in a '<NAME>.config.php' file which will be included and rendered into this file.
- *
- * Example:
- *   <?php
- *   \$CONFIG = [];
- *
- * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
- */
-
-";
+		$expected = "<?php\n";
+		$expected .= \OC\Config::CONF_WARNING;
 		$expected .= "\$CONFIG = array (\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertEquals($expected, $content);
@@ -246,25 +178,8 @@ class ConfigTest extends TestCase {
 
 		// Write a new value to the config
 		$config->setValue('CoolWebsites', ['demo.owncloud.org', 'owncloud.org', 'owncloud.com']);
-		$expected = "<?php
-
-/*
- * WARNING
- *
- * This file gets modified by automatic processes and all lines that are not
- * active code (ie. comments) are lost during that process.
- *
- * If you want to document things with comments or use constants add your settings
- * in a '<NAME>.config.php' file which will be included and rendered into this file.
- *
- * Example:
- *   <?php
- *   \$CONFIG = [];
- *
- * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
- */
-
-";
+		$expected = "<?php\n";
+		$expected .= \OC\Config::CONF_WARNING;
 		$expected .= "\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'php53' => 'totallyOutdated',\n  'CoolWebsites' => \n  array (\n  "
 			. "  0 => 'demo.owncloud.org',\n    1 => 'owncloud.org',\n    2 => 'owncloud.com',\n  ),\n);\n";

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -97,7 +97,26 @@ class ConfigTest extends TestCase {
 		$this->assertSame('moo', $config->getValue('foo'));
 
 		$content = file_get_contents($this->configFile);
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
+		$expected = "<?php
+
+/*
+ * WARNING
+ *
+ * This file gets modified by automatic processes and all lines that are not
+ * active code (ie. comments) are lost during that process.
+ *
+ * If you want to document things with comments or use constants add your settings
+ * in a '<NAME>.config.php' file which will be included and rendered into this file.
+ *
+ * Example:
+ *   <?php
+ *   \$CONFIG = [];
+ *
+ * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
+ */
+
+";
+		$expected .= "\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertEquals($expected, $content);
 
@@ -108,7 +127,26 @@ class ConfigTest extends TestCase {
 
 		$content = file_get_contents($this->configFile);
 
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
+		$expected = "<?php
+
+/*
+ * WARNING
+ *
+ * This file gets modified by automatic processes and all lines that are not
+ * active code (ie. comments) are lost during that process.
+ *
+ * If you want to document things with comments or use constants add your settings
+ * in a '<NAME>.config.php' file which will be included and rendered into this file.
+ *
+ * Example:
+ *   <?php
+ *   \$CONFIG = [];
+ *
+ * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
+ */
+
+";
+		$expected .= "\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'bar' => 'red',\n  'apps' => \n "
 			. " array (\n    0 => 'files',\n    1 => 'gallery',\n  ),\n);\n";
 		$this->assertEquals($expected, $content);
@@ -139,7 +177,26 @@ class ConfigTest extends TestCase {
 		$this->assertSame(null, $config->getValue('not_exists'));
 
 		$content = file_get_contents($this->configFile);
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
+		$expected = "<?php
+
+/*
+ * WARNING
+ *
+ * This file gets modified by automatic processes and all lines that are not
+ * active code (ie. comments) are lost during that process.
+ *
+ * If you want to document things with comments or use constants add your settings
+ * in a '<NAME>.config.php' file which will be included and rendered into this file.
+ *
+ * Example:
+ *   <?php
+ *   \$CONFIG = [];
+ *
+ * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
+ */
+
+";
+		$expected .= "\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n);\n";
 		$this->assertEquals($expected, $content);
 	}
@@ -150,7 +207,26 @@ class ConfigTest extends TestCase {
 		$this->assertSame('this_was_clearly_not_set_before', $config->getValue('foo', 'this_was_clearly_not_set_before'));
 		$content = file_get_contents($this->configFile);
 
-		$expected = "<?php\n\$CONFIG = array (\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
+		$expected = "<?php
+
+/*
+ * WARNING
+ *
+ * This file gets modified by automatic processes and all lines that are not
+ * active code (ie. comments) are lost during that process.
+ *
+ * If you want to document things with comments or use constants add your settings
+ * in a '<NAME>.config.php' file which will be included and rendered into this file.
+ *
+ * Example:
+ *   <?php
+ *   \$CONFIG = [];
+ *
+ * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
+ */
+
+";
+		$expected .= "\$CONFIG = array (\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertEquals($expected, $content);
 	}
@@ -170,7 +246,26 @@ class ConfigTest extends TestCase {
 
 		// Write a new value to the config
 		$config->setValue('CoolWebsites', ['demo.owncloud.org', 'owncloud.org', 'owncloud.com']);
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
+		$expected = "<?php
+
+/*
+ * WARNING
+ *
+ * This file gets modified by automatic processes and all lines that are not
+ * active code (ie. comments) are lost during that process.
+ *
+ * If you want to document things with comments or use constants add your settings
+ * in a '<NAME>.config.php' file which will be included and rendered into this file.
+ *
+ * Example:
+ *   <?php
+ *   \$CONFIG = [];
+ *
+ * See also: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files
+ */
+
+";
+		$expected .= "\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  "
 			. "  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'php53' => 'totallyOutdated',\n  'CoolWebsites' => \n  array (\n  "
 			. "  0 => 'demo.owncloud.org',\n    1 => 'owncloud.org',\n    2 => 'owncloud.com',\n  ),\n);\n";
 		$this->assertEquals($expected, file_get_contents($this->configFile));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #55171 (implements part of the suggested fix)
* Second attempt after #58886

## Summary
`config.php` is re-rendered by nextcloud regularly removing comments and rendering constants into their values, nextcloud supports using multiple config files and renders their content into the main config.php without modifying the external files.
This PR adds a header to `config.php` warning the admin/user of this and suggesting the use of the multiple config files mechanism.

## TODO

- [ ] In the future adding a footer that lists the files that were rendered into `config.php` in the order that they were included will probably help admins troubleshoot if a config variable is doubled up by mistake.
- [ ] Expand documentation more at https://docs.nextcloud.com/server/33/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-merged-configuration-files with examples
- [ ] Add example/suggestion to use separate file for DB configuration https://docs.nextcloud.com/server/33/admin_manual/configuration_database/linux_database_configuration.html#ssl-for-mysql-database

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~Screenshots before/after for front-end changes~
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] ~[Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)~
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] ~The content of this PR was partly or fully generated using AI~