### PR TITLE
ci(CodeQL): only run on relevant JS/TS and workflow changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,37 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "master", "stable*" ]
+    paths: &codeql_paths
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/codeql-config.yml'
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/npm-shrinkwrap.json'
+      - '**/pnpm-lock.yaml'
+      - '**/yarn.lock'
+      - '**/tsconfig*.json'
+      - '**/jsconfig*.json'
+      - '**/.eslintrc'
+      - '**/.eslintrc.*'
+      - '**/eslint.config.*'
+      - '**/babel.config.*'
+      - '**/webpack.config.*'
+      - '**/vite.config.*'
+      - '**/vitest.config.*'
+      - '**/jest.config.*'
+      - '**/rollup.config.*'
+      - '**/postcss.config.*'
+      - '**/tailwind.config.*'
   pull_request:
     branches: [ "master", "stable*" ]
+    paths: *codeql_paths
   schedule:
     - cron: '28 18 * * 1'
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Only run the CodeQL workflow for changes relevant to the analyzers configured here:
- GitHub Actions
- JavaScript / TypeScript

PHP is covered by other tooling, so there is no need to run this workflow on unrelated PHP-only changes; in additional the weekly scheduled run remains unfiltered so even anything somehow missed will still ultimately get analyzed.

### Changes

Add `paths` filters for `push` and `pull_request` triggers, while keeping the scheduled run unchanged.

### Benefit

This reduces unnecessary CI runs and noise on unrelated PRs.

## TODO

- [ ] Confirm required status and/or wrap 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
