### PR TITLE
test(files): make SearchBuilderTest independent of shared filecache state

### DIFF
--- a/tests/lib/Files/Cache/SearchBuilderTest.php
+++ b/tests/lib/Files/Cache/SearchBuilderTest.php
@@ -40,6 +40,7 @@ class SearchBuilderTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->cleanupStorage();
 		$this->builder = Server::get(IDBConnection::class)->getQueryBuilder();
 		$this->mimetypeLoader = $this->createMock(IMimeTypeLoader::class);
 		$this->filesMetadataManager = $this->createMock(IFilesMetadataManager::class);
@@ -67,7 +68,7 @@ class SearchBuilderTest extends TestCase {
 			]);
 
 		$this->searchBuilder = new SearchBuilder($this->mimetypeLoader, $this->filesMetadataManager);
-		$this->numericStorageId = 10000;
+		$this->numericStorageId = random_int(1000000, PHP_INT_MAX);
 
 		$this->builder->select(['fileid'])
 			->from('filecache', 'file') // alias needed for QuerySearchHelper#getOperatorFieldAndValue
@@ -76,19 +77,19 @@ class SearchBuilderTest extends TestCase {
 
 	protected function tearDown(): void {
 		parent::tearDown();
+		$this->cleanupStorage();
+	}
 
+	private function cleanupStorage(): void {
 		$builder = Server::get(IDBConnection::class)->getQueryBuilder();
-
 		$builder->delete('filecache')
 			->where($builder->expr()->eq('storage', $builder->createNamedParameter($this->numericStorageId, IQueryBuilder::PARAM_INT)));
-
 		$builder->executeStatement();
 	}
 
 	private function addCacheEntry(array $data) {
 		$data['storage'] = $this->numericStorageId;
 		$data['etag'] = 'unimportant';
-		$data['storage_mtime'] = $data['mtime'];
 		if (!isset($data['path'])) {
 			$data['path'] = 'random/' . $this->getUniqueID();
 		}
@@ -96,6 +97,7 @@ class SearchBuilderTest extends TestCase {
 		if (!isset($data['mtime'])) {
 			$data['mtime'] = 100;
 		}
+		$data['storage_mtime'] = $data['mtime'];
 		if (!isset($data['size'])) {
 			$data['size'] = 100;
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Make `SearchBuilderTest` less flaky by removing its dependence on a fixed `storage` id in `filecache`.

### Changes

- use a unique `numericStorageId` per test run instead of `10000`
- defensively clean matching `filecache` rows in `setUp()`
- fix `addCacheEntry()` so `storage_mtime` is assigned after defaulting `mtime`

### Why

This DB test currently inserts/searches rows in `filecache` using a hard-coded `storage = 10000` and only cleans up in `tearDown()`. If stale rows exist for that storage, the assertions can pick up unrelated `fileid`s and fail nondeterministically in CI.

Using a unique storage id makes the test self-isolating, and the `storage_mtime` change fixes a small helper bug where `mtime` could be read before default initialization.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
