### PR TITLE
chore: Cleanup setAppTypes and move it to AppManager

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -1043,6 +1043,27 @@ class AppManager implements IAppManager {
 	}
 
 	/**
+	 * Read app types from info.xml and cache them in the database
+	 */
+	public function setAppTypes(string $app, array $appData): void {
+		if (isset($appData['types'])) {
+			$appTypes = implode(',', $appData['types']);
+		} else {
+			$appTypes = '';
+			$appData['types'] = [];
+		}
+
+		$this->config->setAppValue($app, 'types', $appTypes);
+
+		if ($this->hasProtectedAppType($appData['types'])) {
+			$enabled = $this->config->getAppValue($app, 'enabled', 'yes');
+			if ($enabled !== 'yes' && $enabled !== 'no') {
+				$this->config->setAppValue($app, 'enabled', 'yes');
+			}
+		}
+	}
+
+	/**
 	 * Run upgrade tasks for an app after the code has already been updated
 	 *
 	 * @throws AppPathNotFoundException if app folder can't be found
@@ -1099,7 +1120,7 @@ class AppManager implements IAppManager {
 			$this->config->setAppValue('core', 'public_' . $name, $appId . '/' . $path);
 		}
 
-		\OC_App::setAppTypes($appId);
+		$this->setAppTypes($appId, $appData);
 
 		$version = $this->getAppVersion($appId);
 		$this->config->setAppValue($appId, 'installed_version', $version);

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OC;
 
 use Doctrine\DBAL\Exception\TableExistsException;
+use OC\App\AppManager;
 use OC\App\AppStore\AppNotFoundException;
 use OC\App\AppStore\Bundles\Bundle;
 use OC\App\AppStore\Fetcher\AppFetcher;
@@ -19,7 +20,6 @@ use OC\DB\Connection;
 use OC\DB\MigrationService;
 use OC\Files\FilenameValidator;
 use OCP\App\AppPathNotFoundException;
-use OCP\App\IAppManager;
 use OCP\BackgroundJob\IJobList;
 use OCP\Files;
 use OCP\HintException;
@@ -46,7 +46,7 @@ class Installer {
 		private ITempManager $tempManager,
 		private LoggerInterface $logger,
 		private IConfig $config,
-		private IAppManager $appManager,
+		private AppManager $appManager,
 		private IFactory $l10nFactory,
 		private bool $isCLI,
 	) {
@@ -583,7 +583,7 @@ class Installer {
 			$this->config->setAppValue('core', 'public_' . $name, $info['id'] . '/' . $path);
 		}
 
-		\OC_App::setAppTypes($info['id']);
+		$this->appManager->setAppTypes($info['id'], $info);
 
 		return $info['id'];
 	}

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -137,34 +137,6 @@ class OC_App {
 	}
 
 	/**
-	 * read app types from info.xml and cache them in the database
-	 */
-	public static function setAppTypes(string $app): void {
-		$appManager = Server::get(IAppManager::class);
-		$appData = $appManager->getAppInfo($app);
-		if (!is_array($appData)) {
-			return;
-		}
-
-		if (isset($appData['types'])) {
-			$appTypes = implode(',', $appData['types']);
-		} else {
-			$appTypes = '';
-			$appData['types'] = [];
-		}
-
-		$config = Server::get(IConfig::class);
-		$config->setAppValue($app, 'types', $appTypes);
-
-		if ($appManager->hasProtectedAppType($appData['types'])) {
-			$enabled = $config->getAppValue($app, 'enabled', 'yes');
-			if ($enabled !== 'yes' && $enabled !== 'no') {
-				$config->setAppValue($app, 'enabled', 'yes');
-			}
-		}
-	}
-
-	/**
 	 * Returns apps enabled for the current user.
 	 *
 	 * @param bool $forceRefresh whether to refresh the cache

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use OC\App\AppManager;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\Archive\ZIP;
 use OC\Installer;
@@ -30,17 +31,12 @@ use Psr\Log\LoggerInterface;
 class InstallerTest extends TestCase {
 	private static $appid = 'testapp';
 	private $appstore;
-	/** @var AppFetcher|\PHPUnit\Framework\MockObject\MockObject */
-	private $appFetcher;
-	/** @var IClientService|\PHPUnit\Framework\MockObject\MockObject */
-	private $clientService;
-	/** @var ITempManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $tempManager;
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	private $logger;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-	private IAppManager&MockObject $appManager;
+	private AppFetcher&MockObject $appFetcher;
+	private IClientService&MockObject $clientService;
+	private ITempManager&MockObject $tempManager;
+	private LoggerInterface&MockObject $logger;
+	private IConfig&MockObject $config;
+	private AppManager&MockObject $appManager;
 	private IFactory&MockObject $l10nFactory;
 
 	protected function setUp(): void {
@@ -51,7 +47,7 @@ class InstallerTest extends TestCase {
 		$this->tempManager = $this->createMock(ITempManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->config = $this->createMock(IConfig::class);
-		$this->appManager = $this->createMock(IAppManager::class);
+		$this->appManager = $this->createMock(AppManager::class);
 		$this->l10nFactory = $this->createMock(IFactory::class);
 
 		$config = Server::get(IConfig::class);


### PR DESCRIPTION
## Summary

Move this internal method to AppManager, take the opportunity to clean it up.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
