### PR TITLE
fix: load core translations on public sharing pages

### DIFF
--- a/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
+++ b/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
@@ -44,6 +44,7 @@ class PublicTemplateResponse extends TemplateResponse {
 		array $headers = [],
 	) {
 		parent::__construct($appName, $templateName, $params, 'public', $status, $headers);
+		\OCP\Util::addTranslations('core');
 		\OCP\Util::addScript('core', 'public-page-menu');
 		\OCP\Util::addScript('core', 'public-page-user-menu');
 


### PR DESCRIPTION
## Summary

Public sharing pages do not load core translations (`core/l10n/<lang>.js`), causing strings like "Set public name", "Change public name", "You are currently not identified.", and "User menu" to always appear in English regardless of the configured language.

## Root Cause

In `PublicTemplateResponse.php`, the constructor calls `\OCP\Util::addScript('core', ...)` to load JavaScript bundles (`public-page-menu`, `public-page-user-menu`). These bundles use runtime `t("core", ...)` calls that depend on loaded translations.

However, core translations are never loaded because:
1. `Util::addScript()` in `lib/public/Util.php` **skips** `addTranslations()` when `$application === 'core'` (line ~159-161)
2. `PublicTemplateResponse` never explicitly calls `addTranslations('core')`

As a result, `core/l10n/<lang>.js` is never included on public sharing pages, and all `t("core", ...)` calls fall back to English.

## Fix

Add `\OCP\Util::addTranslations('core')` before the `addScript` calls in `PublicTemplateResponse.php`.

This is a one-line change that ensures core translation files are loaded on public pages, making all runtime translation calls in the public page JavaScript bundles work correctly.

## Testing

1. Set `'force_language' => 'tr'` (or any non-English language) in `config/config.php`
2. Create a public share link for any file/folder
3. Open the link in an incognito window
4. **Before fix:** "Set public name", "You are currently not identified." appear in English
5. **After fix:** These strings appear in the configured language

## Affected Pages

All public sharing pages rendered via `PublicTemplateResponse` (file shares, folder shares, etc.)

Fixes https://github.com/nextcloud/server/issues/59501