### PR TITLE
test(user): add valid username coverage for Manager::createUser

### DIFF
--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -332,6 +332,50 @@ class ManagerTest extends TestCase {
 		$manager->createUser($uid, $password);
 	}
 
+	public static function dataCreateUserValid(): array {
+		return [
+			['foo', 'bar'],
+			['Foo', 'bar'],
+			['FOO', 'bar'],
+			['123', 'bar'],
+			['foo bar', 'bar'],
+			['foo_bar', 'bar'],
+			['foo.bar', 'bar'],
+			['foo@bar', 'bar'],
+			["foo-bar", 'bar'],
+			["foo'bar", 'bar'],
+			['a', 'bar'],
+			['test' . str_repeat('a', 59), 'bar'], // 63 chars total, still valid
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateUserValid')]
+	public function testCreateUserValid(string $uid, string $password): void {
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->willReturn(true);
+
+		$backend->expects($this->once())
+			->method('createUser')
+			->with($this->equalTo($uid), $this->equalTo($password))
+			->willReturn(true);
+
+		$backend->expects($this->once())
+			->method('userExists')
+			->with($this->equalTo($uid))
+			->willReturn(false);
+
+		$backend->expects($this->never())
+			->method('loginName2UserName');
+
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager->registerBackend($backend);
+
+		$user = $manager->createUser($uid, $password);
+		$this->assertEquals($uid, $user->getUID());
+	}
+
 	public function testCreateUserSingleBackendNotExists(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->any())


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Add explicit positive coverage for valid usernames in `ManagerTest`, complementing the existing invalid-username cases.

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
