### PR TITLE
fix: Remove SAB entries if backend does not match

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -201,7 +201,10 @@ class SyncService extends ASyncService {
 			$vCard = Reader::read($card['carddata']);
 			$uid = $vCard->UID->getValue();
 			// load backend and see if user exists
-			if (!$this->userManager->userExists($uid)) {
+			$user = $this->userManager->get($uid);
+
+			// If the user does not exist
+			if ($user === null || self::getCardUri($user) !== $card['uri']) {
 				$this->deleteUser($card['uri']);
 			}
 		}

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -367,6 +367,44 @@ END:VCARD';
 		$ss->deleteUser($user);
 	}
 
+	public function testSyncInstance(): void {
+		/** @var CardDavBackend | MockObject $backend */
+		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder(LoggerInterface::class)->disableOriginalConstructor()->getMock();
+
+		$backend->expects($this->exactly(1))->method('deleteCard');
+
+		$backend->method('getCards')->willReturn([
+			[
+				'carddata' => "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 3.4.8//EN\r\nUID:test-user\r\nFN:test-user\r\nN:test-user;;;;\r\nEND:VCARD\r\n\r\n",
+				'uri' => 'Database:test-user.vcf',
+			],
+			[
+				'carddata' => "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 3.4.8//EN\r\nUID:test-user\r\nFN:test-user\r\nN:test-user;;;;\r\nEND:VCARD\r\n\r\n",
+				'uri' => 'LDAP:test-user.vcf',
+			],
+		]
+		);
+
+		$backend->method('getAddressBooksByUri')
+			->with('principals/system/system', 'system')
+			->willReturn(['id' => -1]);
+
+		$userManager = $this->createMock(IUserManager::class);
+		$dbConnection = $this->createMock(IDBConnection::class);
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$user->method('getUID')->willReturn('test-user');
+		$userManager->method('get')->willReturn($user);
+
+		$converter = $this->createMock(Converter::class);
+		$clientService = $this->createMock(IClientService::class);
+		$config = $this->createMock(IConfig::class);
+
+		$ss = new SyncService($clientService, $config, $backend, $userManager, $dbConnection, $logger, $converter);
+		$ss->syncInstance();
+	}
+
 	public function testDeleteAddressbookWhenAccessRevoked(): void {
 		$this->expectException(ClientExceptionInterface::class);
 


### PR DESCRIPTION
## Summary

In some scenarios you might end up with cards of a user with different backends (e.g. when you moved from Database to LDAP). While we cleanup non-existent users with `occ dav:sync-system-addressbook`, we leave duplicates of the same UIDs.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
