### PR TITLE
fix(core): remove duplicate MySQL user prefix

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -142,8 +142,8 @@ class MySQL extends AbstractDatabase {
 
 			//we don't have a dbuser specified in config
 			if ($this->dbUser !== $oldUser) {
-				//add prefix to the admin username to prevent collisions
-				$adminUser = substr('oc_' . $username, 0, 16);
+				//cap to 16 characters
+				$adminUser = substr($username, 0, 16);
 
 				$i = 1;
 				while (true) {
@@ -169,7 +169,7 @@ class MySQL extends AbstractDatabase {
 					} else {
 						//repeat with different username
 						$length = strlen((string)$i);
-						$adminUser = substr('oc_' . $username, 0, 16 - $length) . $i;
+						$adminUser = substr($username, 0, 16 - $length) . $i;
 						$i++;
 					}
 				}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

PR #53212 implemented a hardcoded database username, instead of deriving it from the Nextcloud admin username, to be able to setup Nextcloud without admin user.

However, it used `oc_admin`, while the MySQL database setup adds `oc_` again in the dedicated `createSpecificUser()` function, resulting in `oc_oc_admin`. In case of PostgreSQL, this was done in `setupDatabase()`, replaced with the hardcoded username.

I kept the 16 characters limit, not sure whether this is still needed. The function is actually called only internally, only in this very script, so it should never see any other value than `oc_admin`. Let me know if I should remove the 0-16 substring, along with the confusing `$adminUser` variable (since this user is neither the database admin, nor the Nextcloud admin).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
