### PR TITLE
fix(Util): `getScripts` also need to reorder core translations

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -168,16 +168,27 @@ class Util {
 		// Flatten array and remove duplicates
 		$sortedScripts = array_merge([self::$scriptsInit], $sortedScripts);
 		$sortedScripts = array_merge(...array_values($sortedScripts));
+		$sortedScripts = array_unique($sortedScripts);
 
-		// Override core-common and core-main order
-		if (in_array('core/js/main', $sortedScripts)) {
-			array_unshift($sortedScripts, 'core/js/main');
-		}
-		if (in_array('core/js/common', $sortedScripts)) {
-			array_unshift($sortedScripts, 'core/js/common');
-		}
+		usort($sortedScripts, fn (string $a, string $b) => self::scriptOrderValue($b) <=> self::scriptOrderValue($a));
+		return $sortedScripts;
+	}
 
-		return array_unique($sortedScripts);
+	/**
+	 * Gets a numeric value based on the script name.
+	 * This is used to ensure that the global state is initialized before all other scripts.
+	 *
+	 * @param string $name - The script name
+	 * @since 34.0.0
+	 */
+	private static function scriptOrderValue(string $name): int {
+		return match($name) {
+			'core/js/common' => 3,
+			'core/js/main' => 2,
+			default => str_starts_with($name, 'core/l10n/')
+				? 1 // core translations have to be loaded directly after core-main
+				: 0, // other scripts should preserve their current order
+		};
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/59501

## Summary
Currently `core-common` and `core-main` are prepended to the scripts, as they provide the global state. But the script ordering logic does not know about this and might sort core translations after they are used.

Meaning we need to register core translations as soon as the global scope is initialized (so that `OC.L10N.register` is available).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
