### PR TITLE
fix(updater): Make "maintenance mode kept active" more obvious

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -140,7 +140,7 @@ class Upgrade extends Command {
 				$output->writeln('<info>Turned off maintenance mode</info>');
 			});
 			$updater->listen('\OC\Updater', 'maintenanceActive', function () use ($output): void {
-				$output->writeln('<info>Maintenance mode is kept active</info>');
+				$output->writeln('<comment>Maintenance mode is kept active</comment>');
 			});
 			$updater->listen('\OC\Updater', 'updateEnd',
 				function ($success) use ($output, $self): void {

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -82,7 +82,7 @@ if (Util::needUpgrade()) {
 		$eventSource->send('success', $l->t('Turned off maintenance mode'));
 	});
 	$updater->listen('\OC\Updater', 'maintenanceActive', function () use ($eventSource, $l): void {
-		$eventSource->send('success', $l->t('Maintenance mode is kept active'));
+		$eventSource->send('notice', $l->t('Maintenance mode is kept active'));
 	});
 	$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use ($eventSource, $l): void {
 		$eventSource->send('success', $l->t('Updating database schema'));


### PR DESCRIPTION
Before | After
---|---
<img width="498" height="335" alt="Bildschirmfoto vom 2026-04-09 09-14-25" src="https://github.com/user-attachments/assets/121296ad-2c9a-4fba-951f-93cca17c1608" /> | <img width="621" height="336" alt="Bildschirmfoto vom 2026-04-09 09-16-06" src="https://github.com/user-attachments/assets/8eed7182-be3e-4438-8142-398ba4b17e87" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
