### PR TITLE
[stable33] build(deps): bump phpseclib/phpseclib from 2.0.47 to 2.0.52

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1440,7 +1440,6 @@
       <code><![CDATA[encrypt]]></code>
       <code><![CDATA[setIV]]></code>
       <code><![CDATA[setIV]]></code>
-      <code><![CDATA[setKey]]></code>
     </InternalMethod>
   </file>
   <file src="apps/files_external/lib/Service/BackendService.php">


### PR DESCRIPTION
- [x] https://github.com/nextcloud/3rdparty/pull/2363

| Prod Packages       | Operation | Base   | Target |
|---------------------|-----------|--------|--------|
| phpseclib/phpseclib | Upgraded  | 2.0.47 | 2.0.52 |

