### PR TITLE
feat: Implement PSR-18 ClientInterface in IClient

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -19,6 +19,8 @@ use OCP\ICertificateManager;
 use OCP\IConfig;
 use OCP\Security\IRemoteHostValidator;
 use OCP\ServerVersion;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use function parse_url;
 
@@ -475,6 +477,11 @@ class Client implements IClient {
 		$response = $this->client->request($method, $uri, $this->buildRequestOptions($options));
 		$isStream = isset($options['stream']) && $options['stream'];
 		return new Response($response, $isStream);
+	}
+
+	public function sendRequest(RequestInterface $request): ResponseInterface {
+		$this->preventLocalAddress((string)$request->getUri(), []);
+		return $this->client->sendRequest($request);
 	}
 
 	protected function wrapGuzzlePromise(PromiseInterface $promise): IPromise {

--- a/lib/public/Http/Client/IClient.php
+++ b/lib/public/Http/Client/IClient.php
@@ -8,12 +8,16 @@ declare(strict_types=1);
  */
 namespace OCP\Http\Client;
 
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Interface IClient
  *
  * @since 8.1.0
  */
-interface IClient {
+interface IClient extends ClientInterface {
 
 	/**
 	 * Default request timeout for requests
@@ -267,6 +271,18 @@ interface IClient {
 	 * @since 29.0.0
 	 */
 	public function request(string $method, string $uri, array $options = []): IResponse;
+
+	/**
+	 * Sends a PSR-7 request and returns a PSR-7 response, part of the PSR-18 interface.
+	 *
+	 * @param RequestInterface $request PSR-7 request interface
+	 *
+	 * @return ResponseInterface PSR-7 response interface
+	 *
+	 * @throws \Psr\Http\Client\ClientExceptionInterface If an error happens while processing the request.
+	 * @since 34.0.0
+	 */
+	public function sendRequest(RequestInterface $request): ResponseInterface;
 
 	/**
 	 * Sends an asynchronous GET request


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/documentation/issues/2196

## Summary

This makes sure the `IClient` is compliant with PSR-18. This means that any PSR-18 client could be dropped in as a backing client in the future, and it also means that any library using PSR-18 to communicate with a HTTP client can use `IClient`

## TODO

- [ ] Make sure all CI works

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
