### PR TITLE
[stable29] build(deps): bump phpseclib/phpseclib to 2.0.52, symfony/process to 5…

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -880,7 +880,6 @@
       <code><![CDATA[encrypt]]></code>
       <code><![CDATA[setIV]]></code>
       <code><![CDATA[setIV]]></code>
-      <code><![CDATA[setKey]]></code>
     </InternalMethod>
     <TooManyArguments>
       <code><![CDATA[test]]></code>


### PR DESCRIPTION
….4.51

- [x] https://github.com/nextcloud/3rdparty/pull/2369

| Prod Packages       | Operation | Base    | Target  |
|---------------------|-----------|---------|---------|
| phpseclib/phpseclib | Upgraded  | 2.0.47  | 2.0.52  |
| symfony/process     | Upgraded  | v5.4.47 | v5.4.51 |

- And patches from https://github.com/advisories/GHSA-27qh-8cxx-2cr5