### PR TITLE
fix(user_status): stabilise the user_status

### DIFF
--- a/apps/user_status/lib/Db/UserStatusMapper.php
+++ b/apps/user_status/lib/Db/UserStatusMapper.php
@@ -36,7 +36,8 @@ class UserStatusMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb
 			->select('*')
-			->from($this->tableName);
+			->from($this->tableName)
+			->where($qb->expr()->eq('is_backup', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)));
 
 		if ($limit !== null) {
 			$qb->setMaxResults($limit);
@@ -68,7 +69,7 @@ class UserStatusMapper extends QBMapper {
 					$qb->expr()->isNotNull('custom_icon'),
 					$qb->expr()->isNotNull('custom_message'),
 				),
-				$qb->expr()->notLike('user_id', $qb->createNamedParameter($this->db->escapeLikeParameter('_') . '%'))
+				$qb->expr()->eq('is_backup', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL))
 			));
 
 		if ($limit !== null) {
@@ -125,7 +126,8 @@ class UserStatusMapper extends QBMapper {
 			->andWhere($qb->expr()->orX(
 				$qb->expr()->eq('is_user_defined', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
 				$qb->expr()->eq('status', $qb->createNamedParameter(IUserStatus::ONLINE))
-			));
+			))
+			->andWhere($qb->expr()->eq('is_backup', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)));
 
 		$qb->executeStatement();
 	}
@@ -139,7 +141,8 @@ class UserStatusMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
 			->where($qb->expr()->isNotNull('clear_at'))
-			->andWhere($qb->expr()->lte('clear_at', $qb->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT)));
+			->andWhere($qb->expr()->lte('clear_at', $qb->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('is_backup', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)));
 
 		$qb->executeStatement();
 	}

--- a/apps/user_status/lib/Listener/UserDeletedListener.php
+++ b/apps/user_status/lib/Listener/UserDeletedListener.php
@@ -43,5 +43,6 @@ class UserDeletedListener implements IEventListener {
 
 		$user = $event->getUser();
 		$this->service->removeUserStatus($user->getUID());
+		$this->service->removeBackupUserStatus($user->getUID());
 	}
 }

--- a/apps/user_status/lib/Listener/UserDeletedListener.php
+++ b/apps/user_status/lib/Listener/UserDeletedListener.php
@@ -44,5 +44,6 @@ class UserDeletedListener implements IEventListener {
 
 		$user = $event->getUser();
 		$this->service->removeUserStatus($user->getUID());
+		$this->service->removeBackupUserStatus($user->getUID());
 	}
 }

--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -284,6 +284,7 @@ class StatusService {
 
 		if ($createBackup) {
 			if ($this->backupCurrentStatus($userId) === false) {
+				$this->logger->debug('Automated status change aborted for user ' . $userId . ': backup already exists (another automated status is active)', ['app' => 'user_status']);
 				return null; // Already a status set automatically => abort.
 			}
 
@@ -516,6 +517,7 @@ class StatusService {
 			return true;
 		} catch (Exception $ex) {
 			if ($ex->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				$this->logger->debug('Backup status already exists for user ' . $userId . ', skipping backup creation', ['app' => 'user_status']);
 				return false;
 			}
 			throw $ex;
@@ -533,7 +535,7 @@ class StatusService {
 
 		$deleted = $this->mapper->deleteCurrentStatusToRestoreBackup($userId, $messageId);
 		if (!$deleted) {
-			// Another status is set automatically or no status, do nothing
+			$this->logger->debug('Status revert skipped for user ' . $userId . ': current status does not match messageId "' . $messageId . '" (user may have changed status manually)', ['app' => 'user_status']);
 			return null;
 		}
 
@@ -589,10 +591,10 @@ class StatusService {
 		try {
 			return $this->mapper->insert($userStatus);
 		} catch (Exception $e) {
-			// Ignore if a parallel request already set the status
 			if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 				throw $e;
 			}
+			$this->logger->debug('Concurrent insert conflict for user ' . $userStatus->getUserId() . ': status was already set by a parallel request', ['app' => 'user_status']);
 		}
 		return $userStatus;
 	}

--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -285,6 +285,7 @@ class StatusService {
 
 		if ($createBackup) {
 			if ($this->backupCurrentStatus($userId) === false) {
+				$this->logger->debug('Automated status change aborted for user ' . $userId . ': backup already exists (another automated status is active)', ['app' => 'user_status']);
 				return null; // Already a status set automatically => abort.
 			}
 
@@ -517,6 +518,7 @@ class StatusService {
 			return true;
 		} catch (Exception $ex) {
 			if ($ex->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				$this->logger->debug('Backup status already exists for user ' . $userId . ', skipping backup creation', ['app' => 'user_status']);
 				return false;
 			}
 			throw $ex;
@@ -534,7 +536,7 @@ class StatusService {
 
 		$deleted = $this->mapper->deleteCurrentStatusToRestoreBackup($userId, $messageId);
 		if (!$deleted) {
-			// Another status is set automatically or no status, do nothing
+			$this->logger->debug('Status revert skipped for user ' . $userId . ': current status does not match messageId "' . $messageId . '" (user may have changed status manually)', ['app' => 'user_status']);
 			return null;
 		}
 
@@ -590,10 +592,10 @@ class StatusService {
 		try {
 			return $this->mapper->insert($userStatus);
 		} catch (Exception $e) {
-			// Ignore if a parallel request already set the status
 			if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 				throw $e;
 			}
+			$this->logger->debug('Concurrent insert conflict for user ' . $userStatus->getUserId() . ': status was already set by a parallel request', ['app' => 'user_status']);
 		}
 		return $userStatus;
 	}

--- a/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
+++ b/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
@@ -47,6 +47,24 @@ class UserStatusMapperTest extends TestCase {
 		$this->assertEquals('user2', $offsetResults[0]->getUserId());
 	}
 
+	public function testFindAllExcludesBackups(): void {
+		$this->insertSampleStatuses();
+
+		$backup = new UserStatus();
+		$backup->setUserId('_backupuser');
+		$backup->setStatus('dnd');
+		$backup->setStatusTimestamp(5000);
+		$backup->setIsUserDefined(true);
+		$backup->setIsBackup(true);
+		$this->mapper->insert($backup);
+
+		$allResults = $this->mapper->findAll();
+		$this->assertCount(3, $allResults);
+
+		$userIds = array_map(fn ($s) => $s->getUserId(), $allResults);
+		$this->assertNotContains('_backupuser', $userIds);
+	}
+
 	public function testFindAllRecent(): void {
 		$this->insertSampleStatuses();
 
@@ -54,6 +72,26 @@ class UserStatusMapperTest extends TestCase {
 		$this->assertCount(2, $allResults);
 		$this->assertEquals('user2', $allResults[0]->getUserId());
 		$this->assertEquals('user1', $allResults[1]->getUserId());
+	}
+
+	public function testFindAllRecentExcludesBackups(): void {
+		$this->insertSampleStatuses();
+
+		$backup = new UserStatus();
+		$backup->setUserId('_backupuser');
+		$backup->setStatus('dnd');
+		$backup->setStatusTimestamp(7000);
+		$backup->setStatusMessageTimestamp(7000);
+		$backup->setIsUserDefined(true);
+		$backup->setIsBackup(true);
+		$backup->setCustomMessage('Backed up status');
+		$this->mapper->insert($backup);
+
+		$allResults = $this->mapper->findAllRecent(10, 0);
+		$this->assertCount(2, $allResults);
+
+		$userIds = array_map(fn ($s) => $s->getUserId(), $allResults);
+		$this->assertNotContains('_backupuser', $userIds);
 	}
 
 	public function testGetFind(): void {
@@ -188,6 +226,43 @@ class UserStatusMapperTest extends TestCase {
 
 		$this->expectException(DoesNotExistException::class);
 		$this->mapper->findByUserId('user1');
+	}
+
+	public function testClearOlderThanClearAtPreservesBackups(): void {
+		$backup = new UserStatus();
+		$backup->setUserId('_user1');
+		$backup->setStatus('dnd');
+		$backup->setStatusTimestamp(5000);
+		$backup->setIsUserDefined(true);
+		$backup->setIsBackup(true);
+		$backup->setClearAt(50000);
+		$this->mapper->insert($backup);
+
+		$this->mapper->clearOlderThanClearAt(55000);
+
+		// Backup should survive cleanup despite having expired clear_at
+		$backupStatus = $this->mapper->findByUserId('user1', true);
+		$this->assertEquals('_user1', $backupStatus->getUserId());
+		$this->assertEquals('dnd', $backupStatus->getStatus());
+		$this->assertTrue($backupStatus->getIsBackup());
+	}
+
+	public function testClearStatusesOlderThanPreservesBackups(): void {
+		$backup = new UserStatus();
+		$backup->setUserId('_user1');
+		$backup->setStatus('online');
+		$backup->setStatusTimestamp(1000);
+		$backup->setIsUserDefined(false);
+		$backup->setIsBackup(true);
+		$this->mapper->insert($backup);
+
+		$this->mapper->clearStatusesOlderThan(5000, 8000);
+
+		// Backup should survive cleanup despite old timestamp
+		$backupStatus = $this->mapper->findByUserId('user1', true);
+		$this->assertEquals('online', $backupStatus->getStatus());
+		$this->assertFalse($backupStatus->getIsUserDefined());
+		$this->assertEquals(1000, $backupStatus->getStatusTimestamp());
 	}
 
 	private function insertSampleStatuses(): void {

--- a/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
+++ b/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
@@ -48,6 +48,24 @@ class UserStatusMapperTest extends TestCase {
 		$this->assertEquals('user2', $offsetResults[0]->getUserId());
 	}
 
+	public function testFindAllExcludesBackups(): void {
+		$this->insertSampleStatuses();
+
+		$backup = new UserStatus();
+		$backup->setUserId('_backupuser');
+		$backup->setStatus('dnd');
+		$backup->setStatusTimestamp(5000);
+		$backup->setIsUserDefined(true);
+		$backup->setIsBackup(true);
+		$this->mapper->insert($backup);
+
+		$allResults = $this->mapper->findAll();
+		$this->assertCount(3, $allResults);
+
+		$userIds = array_map(fn ($s) => $s->getUserId(), $allResults);
+		$this->assertNotContains('_backupuser', $userIds);
+	}
+
 	public function testFindAllRecent(): void {
 		$this->insertSampleStatuses();
 
@@ -55,6 +73,26 @@ class UserStatusMapperTest extends TestCase {
 		$this->assertCount(2, $allResults);
 		$this->assertEquals('user2', $allResults[0]->getUserId());
 		$this->assertEquals('user1', $allResults[1]->getUserId());
+	}
+
+	public function testFindAllRecentExcludesBackups(): void {
+		$this->insertSampleStatuses();
+
+		$backup = new UserStatus();
+		$backup->setUserId('_backupuser');
+		$backup->setStatus('dnd');
+		$backup->setStatusTimestamp(7000);
+		$backup->setStatusMessageTimestamp(7000);
+		$backup->setIsUserDefined(true);
+		$backup->setIsBackup(true);
+		$backup->setCustomMessage('Backed up status');
+		$this->mapper->insert($backup);
+
+		$allResults = $this->mapper->findAllRecent(10, 0);
+		$this->assertCount(2, $allResults);
+
+		$userIds = array_map(fn ($s) => $s->getUserId(), $allResults);
+		$this->assertNotContains('_backupuser', $userIds);
 	}
 
 	public function testGetFind(): void {
@@ -189,6 +227,43 @@ class UserStatusMapperTest extends TestCase {
 
 		$this->expectException(DoesNotExistException::class);
 		$this->mapper->findByUserId('user1');
+	}
+
+	public function testClearOlderThanClearAtPreservesBackups(): void {
+		$backup = new UserStatus();
+		$backup->setUserId('_user1');
+		$backup->setStatus('dnd');
+		$backup->setStatusTimestamp(5000);
+		$backup->setIsUserDefined(true);
+		$backup->setIsBackup(true);
+		$backup->setClearAt(50000);
+		$this->mapper->insert($backup);
+
+		$this->mapper->clearOlderThanClearAt(55000);
+
+		// Backup should survive cleanup despite having expired clear_at
+		$backupStatus = $this->mapper->findByUserId('user1', true);
+		$this->assertEquals('_user1', $backupStatus->getUserId());
+		$this->assertEquals('dnd', $backupStatus->getStatus());
+		$this->assertTrue($backupStatus->getIsBackup());
+	}
+
+	public function testClearStatusesOlderThanPreservesBackups(): void {
+		$backup = new UserStatus();
+		$backup->setUserId('_user1');
+		$backup->setStatus('online');
+		$backup->setStatusTimestamp(1000);
+		$backup->setIsUserDefined(false);
+		$backup->setIsBackup(true);
+		$this->mapper->insert($backup);
+
+		$this->mapper->clearStatusesOlderThan(5000, 8000);
+
+		// Backup should survive cleanup despite old timestamp
+		$backupStatus = $this->mapper->findByUserId('user1', true);
+		$this->assertEquals('online', $backupStatus->getStatus());
+		$this->assertFalse($backupStatus->getIsUserDefined());
+		$this->assertEquals(1000, $backupStatus->getStatusTimestamp());
 	}
 
 	private function insertSampleStatuses(): void {

--- a/apps/user_status/tests/Unit/Listener/UserDeletedListenerTest.php
+++ b/apps/user_status/tests/Unit/Listener/UserDeletedListenerTest.php
@@ -28,12 +28,15 @@ class UserDeletedListenerTest extends TestCase {
 
 	public function testHandleWithCorrectEvent(): void {
 		$user = $this->createMock(IUser::class);
-		$user->expects($this->once())
-			->method('getUID')
+		$user->method('getUID')
 			->willReturn('john.doe');
 
 		$this->service->expects($this->once())
 			->method('removeUserStatus')
+			->with('john.doe');
+
+		$this->service->expects($this->once())
+			->method('removeBackupUserStatus')
 			->with('john.doe');
 
 		$event = new UserDeletedEvent($user);

--- a/apps/user_status/tests/Unit/Listener/UserDeletedListenerTest.php
+++ b/apps/user_status/tests/Unit/Listener/UserDeletedListenerTest.php
@@ -29,12 +29,15 @@ class UserDeletedListenerTest extends TestCase {
 
 	public function testHandleWithCorrectEvent(): void {
 		$user = $this->createMock(IUser::class);
-		$user->expects($this->once())
-			->method('getUID')
+		$user->method('getUID')
 			->willReturn('john.doe');
 
 		$this->service->expects($this->once())
 			->method('removeUserStatus')
+			->with('john.doe');
+
+		$this->service->expects($this->once())
+			->method('removeBackupUserStatus')
 			->with('john.doe');
 
 		$event = new UserDeletedEvent($user);


### PR DESCRIPTION
The `user_status` backup mechanism (saves/restores status during calls, calendar events, OOO) had several bugs causing unreliable status restoration.                                                      
                                                                                                                                                                                                             
  ### Bugs fixed                                                                                                                                                                                             
                                                                        
  **1. Background job actively destroys backups** (most critical)                                                                                                                                            
  - `clearOlderThanClearAt()` deleted backup rows with expired `clear_at`
  - `clearStatusesOlderThan()` overwrote backup statuses to OFFLINE                                                                                                                                          
  - Both ran every 60s, corrupting saved statuses before they could be restored
  - **Fix:** Added `is_backup=false` filter to both queries                                                                                                                                                  
   
  **2. Backup rows leaked into user-facing queries**                                                                                                                                                         
  - `findAll()` returned backup rows (prefixed `_userId`) to callers    
  - `findAllRecent()` filtered via slow `LIKE '_%'` instead of `is_backup` column
  - **Fix:** Added `is_backup=false` to `findAll()`, replaced `LIKE` with `is_backup` check in `findAllRecent()`                                                                                             
   
  **3. User deletion orphaned backups**                                                                                                                                                                      
  - `UserDeletedListener` only removed active status, leaving backup rows forever
  - **Fix:** Also call `removeBackupUserStatus()`                                                                                                                                                            
                                                                        
  **4. Silent failures with no logging**
  - Backup conflicts, aborted status changes, failed reverts — all returned `null`/`false` with zero logging
  - **Fix:** Added `debug` logging to 4 silent failure paths in `StatusService`                                                                                                                              
   
  ### Tests added                                                                                                                                                                                            
  - 4 new mapper tests (backups excluded from queries, backups survive cleanup)
  - 1 updated listener test (backup removal on user deletion)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
