### PR TITLE
fix(files_external): S3 folder mtime updated on every read-only access

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -344,7 +344,9 @@ class AmazonS3 extends Common {
 			if ($cacheEntry instanceof CacheEntry) {
 				$data['storage_mtime'] = $cacheEntry->getStorageMTime();
 			} elseif (!$this->isRoot($path) && $directoryMarker = $this->headObject($path . '/')) {
-				$data['storage_mtime'] = strtotime($directoryMarker['LastModified']);
+				if (isset($directoryMarker['LastModified'])) {
+					$data['storage_mtime'] = strtotime($directoryMarker['LastModified']);
+				}
 			}
 		}
 		return $data;
@@ -673,12 +675,14 @@ class AmazonS3 extends Common {
 	}
 
 	private function objectToMetaData(array $object): array {
+		$mtime = isset($object['LastModified']) ? strtotime($object['LastModified']) : time();
+		$etag = isset($object['ETag']) ? trim($object['ETag'], '"') : '';
 		return [
 			'name' => basename($object['Key']),
 			'mimetype' => $this->mimeDetector->detectPath($object['Key']),
-			'mtime' => strtotime($object['LastModified']),
-			'storage_mtime' => strtotime($object['LastModified']),
-			'etag' => trim($object['ETag'], '"'),
+			'mtime' => $mtime,
+			'storage_mtime' => $mtime,
+			'etag' => $etag,
 			'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE,
 			'size' => (int)($object['Size'] ?? $object['ContentLength']),
 		];

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -331,6 +331,26 @@ class AmazonS3 extends Common {
 	}
 
 	#[\Override]
+	public function getMetaData(string $path): ?array {
+		$data = parent::getMetaData($path);
+		if ($data !== null && $data['mimetype'] === FileInfo::MIMETYPE_FOLDER) {
+			// Common::getMetaData sets storage_mtime = mtime, but for S3 virtual directories
+			// mtime may have been updated by mtime propagation while storage_mtime should
+			// reflect the actual last storage change. Without this override the scanner sees
+			// data['storage_mtime'] != cacheData['storage_mtime'] and re-writes the cache,
+			// causing View::getCacheEntry to trigger propagateChange on every read.
+			$path = $this->normalizePath($path);
+			$cacheEntry = $this->getCache()->get($this->getCachePath($path));
+			if ($cacheEntry instanceof CacheEntry) {
+				$data['storage_mtime'] = $cacheEntry->getStorageMTime();
+			} elseif (!$this->isRoot($path) && $directoryMarker = $this->headObject($path . '/')) {
+				$data['storage_mtime'] = strtotime($directoryMarker['LastModified']);
+			}
+		}
+		return $data;
+	}
+
+	#[\Override]
 	public function is_dir(string $path): bool {
 		$path = $this->normalizePath($path);
 

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -71,6 +71,11 @@ class AmazonS3 extends Common {
 		return $path === '.';
 	}
 
+	private function getCachePath(string $path): string {
+		// normalizePath() converts '' to '.' for S3 object keys, but filecache stores the root as ''
+		return $this->isRoot($path) ? '' : $path;
+	}
+
 	private function cleanKey(string $path): string {
 		if ($this->isRoot($path)) {
 			return '/';
@@ -666,7 +671,7 @@ class AmazonS3 extends Common {
 		if ($this->versioningEnabled() && !$this->doesDirectoryExist($path)) {
 			return null;
 		}
-		$cacheEntry = $this->getCache()->get($path);
+		$cacheEntry = $this->getCache()->get($this->getCachePath($path));
 		if ($cacheEntry instanceof CacheEntry) {
 			return $cacheEntry->getData();
 		} else {

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -65,4 +65,30 @@ class Amazons3Test extends \Test\Files\Storage\Storage {
 		);
 	}
 
+	/**
+	 * Regression test: Common::getMetaData sets storage_mtime = mtime, but for S3 virtual
+	 * directories mtime may have been bumped by propagation while storage_mtime should stay
+	 * stable. The override restores storage_mtime from the cache entry so the scanner does
+	 * not see a spurious mismatch and re-write the cache on every scan.
+	 */
+	public function testGetMetaDataDirectoryPreservesStorageMtimeSeparateFromMtime(): void {
+		$this->instance->getScanner()->scan('', Scanner::SCAN_SHALLOW);
+
+		$cachedRoot = $this->instance->getCache()->get('');
+		$this->assertNotFalse($cachedRoot, 'Root entry must exist in cache after scan');
+
+		// Simulate propagation bumping mtime without touching storage_mtime
+		$originalStorageMtime = $cachedRoot['storage_mtime'];
+		$this->instance->getCache()->update($cachedRoot->getId(), [
+			'mtime' => $originalStorageMtime + 9999,
+		]);
+
+		$meta = $this->instance->getMetaData('');
+		$this->assertNotNull($meta, 'getMetaData(\'\') must return data');
+		$this->assertEquals(
+			$originalStorageMtime,
+			$meta['storage_mtime'],
+			'getMetaData must return storage_mtime from cache, not the propagated mtime'
+		);
+	}
 }

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Files_External\Tests\Storage;
 
+use OC\Files\Cache\Scanner;
 use OCA\Files_External\Lib\Storage\AmazonS3;
 
 /**
@@ -39,7 +40,29 @@ class Amazons3Test extends \Test\Files\Storage\Storage {
 		parent::tearDown();
 	}
 
-	public function testStat(): void {
-		$this->markTestSkipped('S3 doesn\'t update the parents folder mtime');
+	/**
+	 * Regression test for the '.' vs '' root path mismatch in getDirectoryMetaData.
+	 *
+	 * normalizePath('') returns '.' for S3 object keys, but the filecache stores the
+	 * storage root under the key ''. Before the fix, getCache()->get('.') returned false,
+	 * causing getDirectoryMetaData to return a fabricated time() on every call, which
+	 * made getCacheEntry always see a changed storage_mtime and fire propagateChange.
+	 */
+	public function testStatRootPreservesStorageMtimeFromCache(): void {
+		$this->instance->getScanner()->scan('', Scanner::SCAN_SHALLOW);
+
+		$cachedRoot = $this->instance->getCache()->get('');
+		$this->assertNotFalse($cachedRoot, 'Root entry must exist in cache after scan');
+
+		$cachedStorageMtime = $cachedRoot['storage_mtime'];
+
+		$stat = $this->instance->stat('');
+		$this->assertNotFalse($stat, 'stat(\'\') must return data');
+		$this->assertEquals(
+			$cachedStorageMtime,
+			$stat['storage_mtime'],
+			'stat(\'\') must return storage_mtime from the cache entry, not a fabricated time()'
+		);
 	}
+
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1410,9 +1410,17 @@ class View {
 				$data = $cache->get($internalPath);
 			} elseif (!Scanner::isPartialFile($internalPath) && $watcher->needsUpdate($internalPath, $data)) {
 				$this->lockFile($relativePath, ILockingProvider::LOCK_SHARED);
+				$cacheDataBefore = $data instanceof CacheEntry ? $data->getData() : false;
 				$watcher->update($internalPath, $data);
-				$storage->getPropagator()->propagateChange($internalPath, time());
 				$data = $cache->get($internalPath);
+				$cacheDataAfter = $data instanceof CacheEntry ? $data->getData() : false;
+
+				// Only propagate mtime change to parent folders if the scanner actually changed the cached metadata,
+				// to avoid updating folder mtimes on every read for backends that conservatively report directories as updated (e.g. S3)
+				if ($cacheDataAfter !== $cacheDataBefore) {
+					$storage->getPropagator()->propagateChange($internalPath, time());
+					$data = $cache->get($internalPath);
+				}
 				$this->unlockFile($relativePath, ILockingProvider::LOCK_SHARED);
 			}
 		} catch (LockedException $e) {

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -81,6 +81,16 @@ class TemporaryNoLocal extends Temporary {
 	}
 }
 
+/**
+ * Storage that always reports hasUpdated() = true for any path, simulating the
+ * behavior of Amazon S3 external storage (which has no real directory objects).
+ */
+class TemporaryAlwaysUpdated extends Temporary {
+	public function hasUpdated(string $path, int $time): bool {
+		return true;
+	}
+}
+
 class TestEventHandler {
 	public function umount() {
 	}
@@ -441,6 +451,45 @@ class ViewTest extends \Test\TestCase {
 
 		$cachedData = $rootView->getFileInfo('foo.txt');
 		$this->assertEquals(3, $cachedData['size']);
+	}
+
+	/**
+	 * Regression test for View::getCacheEntry unconditionally calling propagateChange
+	 * when the watcher reports needsUpdate = true, regardless of whether the scanner
+	 * found any actual storage change.
+	 *
+	 * Backends like Amazon S3 always return hasUpdated() = true for directory paths
+	 * because S3 has no real directory objects. Before the fix, every getFileInfo()
+	 * call on a folder fired propagateChange(path, time()), stamping all ancestor
+	 * folders in the filecache with the current request timestamp.
+	 *
+	 * After the fix, propagateChange is only called when watcher->update() actually
+	 * changes the cached metadata for the path.
+	 */
+	public function testWatcherDoesNotPropagateWhenStorageMtimeUnchanged(): void {
+		$storage = $this->getTestStorage(true, TemporaryAlwaysUpdated::class);
+		Filesystem::mount($storage, [], '/');
+		$storage->getWatcher()->setPolicy(Watcher::CHECK_ALWAYS);
+
+		$rootView = new View('');
+
+		// Note the root mtime right after the initial scan.
+		$rootMtimeBefore = $storage->getCache()->get('')['mtime'];
+
+		// Access a subfolder. The watcher will fire (hasUpdated always returns true),
+		// but the scanner leaves the cached metadata for 'folder' unchanged.
+		// getCacheEntry must therefore NOT call propagateChange('folder', time()),
+		// which would update the root entry's mtime to the current timestamp.
+		$rootView->getFileInfo('folder');
+
+		// Read the root mtime directly from the cache to avoid triggering another watcher cycle.
+		$rootMtimeAfter = $storage->getCache()->get('')['mtime'];
+
+		$this->assertEquals(
+			$rootMtimeBefore,
+			$rootMtimeAfter,
+			'Root folder mtime must not be updated when the watcher fires but cached metadata has not changed'
+		);
 	}
 
 	public function testCopyBetweenStorageNoCross(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #

### Summary

 The `mtime` (and `storage_mtime`) of an S3 external storage root folder was updated
 on every `occ files:scan` / `occ files_external:scan` run and on every folder browse
 — even when nothing on S3 had changed.

### AI findings

Compiled into HTML file here: [s3-mtime-propagation.html](https://github.com/user-attachments/files/28155401/s3-mtime-propagation.html)

### How to reproduce

- Connect an S3 external storage and populate it (tested with rustfs S3)
- Create a public share, verify folder mtimes are not updated
- Reload the page, see 'Modified' date updated
- From a public link, access share, read the folder content, download the file
- Alternative: run `occ files:scan` or `occ files_external:scan` for the folder
- See 'Modified' date updated on root
---

 ## Root causes (3, fixed independently)

 **1. Wrong filecache key for the storage root** (`AmazonS3#getDirectoryMetaData`)

 `normalizePath('')` returns `'.'` for S3 object keys, but the filecache stores the
 storage root under the key `''`. `getDirectoryMetaData()` was calling
 `getCache()->get('.')` which looks up by `md5('.')`, never matching the root entry
 stored at `md5('')`.

 The cache miss caused `getDirectoryMetaData` to return synthetic data with `time()`
 as `mtime`/`storage_mtime` and `uniqid()` as `etag` on every call. The scanner then
 saw a `storage_mtime` mismatch and wrote the fabricated timestamps back to the cache
 on every scan run, regardless of whether any S3 content had changed.

 Fix: introduce `getCachePath()` to translate the normalized root path `'.'` back to
 `''` before any filecache lookup.

 **2. `Common::getMetaData` clobbers `storage_mtime`** (`AmazonS3#getMetaData`)

 `Common::getMetaData()` always sets `storage_mtime = mtime` before returning. For S3
 virtual directories `mtime` can be bumped by child propagation while `storage_mtime`
 should remain the actual last S3 change. When the scanner later calls `getMetaData()`
 it compares `data['storage_mtime']` against `cacheData['storage_mtime']`; if they
 differ it writes the value back, triggering `View::getCacheEntry` to fire
 `propagateChange` on every read even when nothing on S3 changed.

 Fix: override `getMetaData()` to restore `storage_mtime` from the live cache entry
 after the parent call.

 **3. `propagateChange()` fired unconditionally after watcher update** (`View#getCacheEntry`)

 S3's `hasUpdated()` always returns `true` for directories (S3 has no cheap global
 change-detection mechanism). `getCacheEntry()` called `watcher->update()` and then
 unconditionally called `propagateChange()` whenever the watcher reported a change,
 meaning every folder browse bumped the parent `mtime` chain.

 Fix: snapshot the cache entry before `watcher->update()` and compare it with the
 entry after. `propagateChange()` is only invoked when at least one metadata field
 (`mtime`, `storage_mtime`, `size`, or `etag`) actually changed.

---




Before | After
-- | --
<img width="488" height="89" alt="image" src="https://github.com/user-attachments/assets/fae151dc-ae6c-4f0d-aeb8-74294c3ef67b" /> | <img width="486" height="88" alt="image" src="https://github.com/user-attachments/assets/9fa8d5b7-0766-4ef9-b51a-6692922906cf" />


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
