### PR TITLE
fix(profile): clean up 404 profile template

### DIFF
--- a/apps/profile/templates/404-profile.php
+++ b/apps/profile/templates/404-profile.php
@@ -3,11 +3,14 @@
  * SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 /** @var array $_ */
 /** @var \OCP\IL10N $l */
 /** @var \OCP\Defaults $theme */
+
 // @codeCoverageIgnoreStart
-if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
+if (!isset($_)) {
+	// Standalone access is not supported; redirect to the root.
 	require_once '../../../lib/base.php';
 
 	$urlGenerator = \OCP\Server::get(\OCP\IURLGenerator::class);
@@ -15,16 +18,22 @@ if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
 	exit;
 }
 // @codeCoverageIgnoreEnd
+
+$urlGenerator = \OCP\Server::get(\OCP\IURLGenerator::class);
+$backUrl = $urlGenerator->linkTo('', 'index.php');
 ?>
-<?php if (isset($_['content'])) : ?>
-	<?php print_unescaped($_['content']) ?>
-<?php else : ?>
+
+<?php if (isset($_['content'])): ?>
+	<?php print_unescaped($_['content']); ?>
+<?php else: ?>
 	<div class="body-login-container update">
 		<div class="icon-big icon-error"></div>
 		<h2><?php p($l->t('Profile not found')); ?></h2>
-		<p class="infogroup"><?php p($l->t('The profile does not exist.')); ?></p>
-		<p><a class="button primary" href="<?php p(\OCP\Server::get(\OCP\IURLGenerator::class)->linkTo('', 'index.php')) ?>">
+		<p class="infogroup"><?php p($l->t('The profile does not exist or is unavailable.')); ?></p>
+		<p>
+			<a class="button primary" href="<?php p($backUrl); ?>">
 				<?php p($l->t('Back to %s', [$theme->getName()])); ?>
-			</a></p>
+			</a>
+		</p>
 	</div>
 <?php endif; ?>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Make messaging more consistent with [the generic 404.php template](https://github.com/nextcloud/server/blob/1219c8e152e43324bafd2132b12d2590ea78e6d2/core/templates/404.php#L26).

Refactor (clarity/modernize).

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
