### PR TITLE
chore: Remove long-time deprecated things from workflowengine

### DIFF
--- a/apps/workflowengine/lib/Service/RuleMatcher.php
+++ b/apps/workflowengine/lib/Service/RuleMatcher.php
@@ -88,11 +88,8 @@ class RuleMatcher implements IRuleMatcher {
 		if (!$this->operation) {
 			throw new RuntimeException('Operation is not set');
 		}
-		return $this->getMatchingOperations(get_class($this->operation), $returnFirstMatchingOperationOnly);
-	}
-
-	public function getMatchingOperations(string $class, bool $returnFirstMatchingOperationOnly = true): array {
-		$scopes[] = new ScopeContext(IManager::SCOPE_ADMIN);
+		$class = get_class($this->operation);
+		$scopes = [new ScopeContext(IManager::SCOPE_ADMIN)];
 		$user = $this->session->getUser();
 		if ($user !== null && $this->manager->isUserScopeEnabled()) {
 			$scopes[] = new ScopeContext(IManager::SCOPE_USER, $user->getUID());
@@ -111,7 +108,6 @@ class RuleMatcher implements IRuleMatcher {
 		}
 
 		if ($this->entity instanceof IEntity) {
-			/** @var ScopeContext[] $additionalScopes */
 			$additionalScopes = $this->manager->getAllConfiguredScopesForOperation($class);
 			foreach ($additionalScopes as $hash => $scopeCandidate) {
 				if ($scopeCandidate->getScope() !== IManager::SCOPE_USER || in_array($scopeCandidate, $scopes)) {

--- a/apps/workflowengine/lib/Settings/ASettings.php
+++ b/apps/workflowengine/lib/Settings/ASettings.php
@@ -37,11 +37,6 @@ abstract class ASettings implements ISettings {
 	abstract public function getScope(): int;
 
 	public function getForm(): TemplateResponse {
-		// @deprecated in 20.0.0: retire this one in favor of the typed event
-		$this->eventDispatcher->dispatch(
-			'OCP\WorkflowEngine::loadAdditionalSettingScripts',
-			new LoadSettingsScriptsEvent()
-		);
 		$this->eventDispatcher->dispatchTyped(new LoadSettingsScriptsEvent());
 
 		$entities = $this->manager->getEntitiesList();

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2657,11 +2657,6 @@
       <code><![CDATA[getSubject]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/workflowengine/lib/Settings/ASettings.php">
-    <DeprecatedMethod>
-      <code><![CDATA[dispatch]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php">
     <DeprecatedClass>
       <code><![CDATA[Files::rmdirr($dir)]]></code>

--- a/lib/public/WorkflowEngine/IRuleMatcher.php
+++ b/lib/public/WorkflowEngine/IRuleMatcher.php
@@ -18,16 +18,6 @@ use RuntimeException;
  */
 interface IRuleMatcher extends IFileCheck {
 	/**
-	 * This method is left for backwards compatibility and easier porting of
-	 * apps. Please use 'getFlows' instead (and setOperation if you implement
-	 * an IComplexOperation).
-	 *
-	 * @since 18.0.0
-	 * @deprecated 18.0.0
-	 */
-	public function getMatchingOperations(string $class, bool $returnFirstMatchingOperationOnly = true): array;
-
-	/**
 	 * @throws RuntimeException
 	 * @since 18.0.0
 	 */


### PR DESCRIPTION
## Summary

Remove deprecated event since 20 and method since 18 :broom: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
