### PR TITLE
fix(testing): Fix fake provider reverting strings with emojis

### DIFF
--- a/apps/testing/lib/Provider/FakeTranslationProvider.php
+++ b/apps/testing/lib/Provider/FakeTranslationProvider.php
@@ -25,6 +25,14 @@ class FakeTranslationProvider implements ITranslationProvider {
 	}
 
 	public function translate(?string $fromLanguage, string $toLanguage, string $text): string {
-		return strrev($text);
+		return $this->mb_strrev($text);
+	}
+
+	protected function mb_strrev(string $str): string {
+		$r = '';
+		for ($i = mb_strlen($str); $i >= 0; $i--) {
+			$r .= mb_substr($str, $i, 1);
+		}
+		return $r;
 	}
 }


### PR DESCRIPTION
Before | After
---|---
<img width="1221" height="595" alt="image" src="https://github.com/user-attachments/assets/951d98ac-0b46-47f8-b80d-c8ab2d96e99a" /> | <img width="1381" height="558" alt="Bildschirmfoto vom 2026-04-10 15-51-25" src="https://github.com/user-attachments/assets/0e0b78c1-bad6-4a75-95e1-d626e7e1bd71" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
