### PR TITLE
fix(auth): clarify token_auth_enforced semantics and add auth token revoke occ command

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -400,9 +400,16 @@ $CONFIG = [
 	'auto_logout' => false,
 
 	/**
-	 * Enforce token authentication for clients, which blocks requests using the user
-	 * password for enhanced security. Users need to generate tokens in personal settings
-	 * which can be used as passwords on their clients.
+	 * Enforce token authentication for client logins.
+	 *
+	 * When enabled, new client authentication attempts using the user's account
+	 * password are rejected and clients must use an app password or other valid
+	 * token instead.
+	 *
+	 * This setting does not automatically revoke already existing browser sessions,
+	 * remember-me logins, or previously issued tokens. To fully enforce the policy
+	 * for existing authenticated sessions, those sessions/tokens must be invalidated
+	 * separately.
 	 *
 	 * Defaults to ``false``
 	 */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -409,7 +409,8 @@ $CONFIG = [
 	 * This setting does not automatically revoke already existing browser sessions,
 	 * remember-me logins, or previously issued tokens. To fully enforce the policy
 	 * for existing authenticated sessions, those sessions/tokens must be invalidated
-	 * separately.
+	 * separately. Use ``occ user:auth-tokens:revoke`` if you want to invalidate 
+	 * existing sessions after enabling this policy.
 	 *
 	 * Defaults to ``false``
 	 */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -409,7 +409,8 @@ $CONFIG = [
 	 * This setting does not automatically revoke existing browser sessions,
 	 * remember-me logins, or previously issued tokens. To fully enforce this
 	 * policy for already authenticated sessions, invalidate those sessions or
-	 * tokens separately, for example with ``occ user:auth-tokens:revoke``.
+	 * tokens separately, for example with
+	 * ``occ user:auth-tokens:revoke --sessions``.
 	 *
 	 * Defaults to ``false``
 	 */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -403,14 +403,13 @@ $CONFIG = [
 	 * Enforce token authentication for client logins.
 	 *
 	 * When enabled, new client authentication attempts using the user's account
-	 * password are rejected and clients must use an app password or other valid
+	 * password are rejected and clients must use an app password or another valid
 	 * token instead.
 	 *
-	 * This setting does not automatically revoke already existing browser sessions,
-	 * remember-me logins, or previously issued tokens. To fully enforce the policy
-	 * for existing authenticated sessions, those sessions/tokens must be invalidated
-	 * separately. Use ``occ user:auth-tokens:revoke`` if you want to invalidate 
-	 * existing sessions after enabling this policy.
+	 * This setting does not automatically revoke existing browser sessions,
+	 * remember-me logins, or previously issued tokens. To fully enforce this
+	 * policy for already authenticated sessions, invalidate those sessions or
+	 * tokens separately, for example with ``occ user:auth-tokens:revoke``.
 	 *
 	 * Defaults to ``false``
 	 */

--- a/core/Command/User/AuthTokens/Revoke.php
+++ b/core/Command/User/AuthTokens/Revoke.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Command\User\AuthTokens;
+
+use OC\Authentication\Token\IProvider;
+use OC\Authentication\Token\PublicKeyTokenMapper;
+use OC\Core\Command\Base;
+use OCP\Authentication\Token\IToken;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class Revoke extends Base {
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IProvider $tokenProvider,
+		protected PublicKeyTokenMapper $mapper,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+
+		$this
+			->setName('user:auth-tokens:revoke')
+			->setDescription('Revoke authentication tokens by class/type')
+			->addArgument(
+				'uid',
+				InputArgument::OPTIONAL,
+				'ID of the user to revoke tokens for'
+			)
+			->addOption(
+				'all-users',
+				null,
+				InputOption::VALUE_NONE,
+				'Revoke tokens for all users'
+			)
+			->addOption(
+				'browser-sessions',
+				null,
+				InputOption::VALUE_NONE,
+				'Revoke browser session tokens (temporary, non-remembered)'
+			)
+			->addOption(
+				'remembered-sessions',
+				null,
+				InputOption::VALUE_NONE,
+				'Revoke remembered browser session tokens (temporary, remembered)'
+			)
+			->addOption(
+				'non-app-passwords',
+				null,
+				InputOption::VALUE_NONE,
+				'Revoke all tokens except permanent app passwords (includes session, remembered, one-time, and wipe tokens)'
+			)
+			->addOption(
+				'all',
+				null,
+				InputOption::VALUE_NONE,
+				'Revoke all tokens including app passwords'
+			)
+			->addOption(
+				'dry-run',
+				null,
+				InputOption::VALUE_NONE,
+				'Show which tokens would be revoked without deleting them'
+			)
+			->addOption(
+				'force',
+				'f',
+				InputOption::VALUE_NONE,
+				'Skip confirmation prompt'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$uid = $input->getArgument('uid');
+		$allUsers = (bool)$input->getOption('all-users');
+
+		$modes = [
+			'browser-sessions' => (bool)$input->getOption('browser-sessions'),
+			'remembered-sessions' => (bool)$input->getOption('remembered-sessions'),
+			'non-app-passwords' => (bool)$input->getOption('non-app-passwords'),
+			'all' => (bool)$input->getOption('all'),
+		];
+
+		$selectedModes = array_filter($modes);
+		if (count($selectedModes) !== 1) {
+			throw new RuntimeException('Specify exactly one of --browser-sessions, --remembered-sessions, --non-app-passwords, or --all.');
+		}
+
+		if ($allUsers && $uid !== null) {
+			throw new RuntimeException('Do not provide <uid> together with --all-users.');
+		}
+
+		if (!$allUsers && (!is_string($uid) || $uid === '')) {
+			throw new RuntimeException('Specify <uid> or use --all-users.');
+		}
+
+		$dryRun = (bool)$input->getOption('dry-run');
+		$force = (bool)$input->getOption('force');
+
+		// Confirm destructive operations unless --force or --dry-run is set
+		if (!$dryRun && !$force && $input->isInteractive()) {
+			$modeName = array_key_first($selectedModes);
+			$scope = $allUsers ? 'ALL users' : "user '$uid'";
+			$message = "<question>This will revoke all --{$modeName} tokens for {$scope}. Continue? [y/N]</question> ";
+
+			/** @var QuestionHelper $helper */
+			$helper = $this->getHelper('question');
+			$question = new ConfirmationQuestion($message, false);
+			if (!$helper->ask($input, $output, $question)) {
+				$output->writeln('Aborted.');
+				return Command::SUCCESS;
+			}
+		}
+
+		$revoked = 0;
+
+		if ($allUsers) {
+			if (!$dryRun) {
+				// Use bulk deletion for --all-users when possible to avoid
+				// iterating every user and their tokens individually
+				$bulkCount = $this->bulkRevoke($modes, $output);
+				if ($bulkCount !== null) {
+					$output->writeln("<info>Revoked {$bulkCount} token(s).</info>");
+					return Command::SUCCESS;
+				}
+			}
+
+			// Fall back to per-user iteration for dry-run (needs token details)
+			// or if bulk deletion is not applicable
+			$this->userManager->callForAllUsers(function (IUser $user) use ($output, $dryRun, $modes, &$revoked): void {
+				$revoked += $this->revokeForUser($user->getUID(), $modes, $output, $dryRun);
+			});
+		} else {
+			$user = $this->userManager->get($uid);
+			if ($user === null) {
+				$output->writeln('<error>user not found</error>');
+				return Command::FAILURE;
+			}
+			$revoked = $this->revokeForUser($user->getUID(), $modes, $output, $dryRun);
+		}
+
+		if ($dryRun) {
+			$output->writeln("<info>Dry run complete. {$revoked} token(s) would be revoked.</info>");
+		} else {
+			$output->writeln("<info>Revoked {$revoked} token(s).</info>");
+		}
+
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Attempt a bulk DELETE query for --all-users instead of per-user iteration.
+	 *
+	 * @return int|null Number of deleted rows, or null if the mode doesn't
+	 *                  support bulk deletion (caller should fall back to per-user)
+	 */
+	private function bulkRevoke(array $modes, OutputInterface $output): ?int {
+		// Build type/remember constraints for a single bulk query
+		if ($modes['browser-sessions']) {
+			return $this->mapper->invalidateByTypeAndRemember(
+				IToken::TEMPORARY_TOKEN,
+				IToken::DO_NOT_REMEMBER
+			);
+		}
+
+		if ($modes['remembered-sessions']) {
+			return $this->mapper->invalidateByTypeAndRemember(
+				IToken::TEMPORARY_TOKEN,
+				IToken::REMEMBER
+			);
+		}
+
+		if ($modes['non-app-passwords']) {
+			return $this->mapper->invalidateAllExceptType(IToken::PERMANENT_TOKEN);
+		}
+
+		if ($modes['all']) {
+			return $this->mapper->invalidateAllTokens();
+		}
+
+		return null;
+	}
+
+	private function revokeForUser(string $uid, array $modes, OutputInterface $output, bool $dryRun): int {
+		$tokens = $this->tokenProvider->getTokenByUser($uid);
+		$count = 0;
+
+		foreach ($tokens as $token) {
+			if (!$this->matchesSelection($token, $modes)) {
+				continue;
+			}
+
+			$count++;
+
+			if ($output->isVerbose()) {
+				$output->writeln(sprintf(
+					'%s token %d for user %s (type=%s remember=%s name=%s)',
+					$dryRun ? 'Would revoke' : 'Revoking',
+					$token->getId(),
+					$uid,
+					self::formatTokenType($token->getType()),
+					(string)$token->getRemember(),
+					$token->getName()
+				));
+			}
+
+			if (!$dryRun) {
+				$this->tokenProvider->invalidateTokenById($uid, $token->getId());
+			}
+		}
+
+		return $count;
+	}
+
+	private function matchesSelection(IToken $token, array $modes): bool {
+		if ($modes['all']) {
+			return true;
+		}
+
+		$type = $token->getType();
+
+		if ($modes['browser-sessions']) {
+			return $type === IToken::TEMPORARY_TOKEN
+				&& $token->getRemember() === IToken::DO_NOT_REMEMBER;
+		}
+
+		if ($modes['remembered-sessions']) {
+			return $type === IToken::TEMPORARY_TOKEN
+				&& $token->getRemember() === IToken::REMEMBER;
+		}
+
+		if ($modes['non-app-passwords']) {
+			// Includes TEMPORARY_TOKEN, WIPE_TOKEN, and ONETIME_TOKEN
+			return $type !== IToken::PERMANENT_TOKEN;
+		}
+
+		return false;
+	}
+
+	private static function formatTokenType(int $type): string {
+		return match ($type) {
+			IToken::TEMPORARY_TOKEN => 'temporary',
+			IToken::PERMANENT_TOKEN => 'permanent',
+			IToken::WIPE_TOKEN => 'wipe',
+			IToken::ONETIME_TOKEN => 'onetime',
+			default => (string)$type,
+		};
+	}
+}

--- a/core/Command/User/AuthTokens/Revoke.php
+++ b/core/Command/User/AuthTokens/Revoke.php
@@ -51,22 +51,22 @@ class Revoke extends Base {
 				'Revoke tokens for all users'
 			)
 			->addOption(
-				'browser-sessions',
+				'sessions',
 				null,
 				InputOption::VALUE_NONE,
-				'Revoke browser session tokens (temporary, non-remembered)'
+				'Revoke all session tokens, including remembered sessions'
 			)
 			->addOption(
 				'remembered-sessions',
 				null,
 				InputOption::VALUE_NONE,
-				'Revoke remembered browser session tokens (temporary, remembered)'
+				'Revoke remembered session tokens only'
 			)
 			->addOption(
-				'non-app-passwords',
+				'all-except-app-passwords',
 				null,
 				InputOption::VALUE_NONE,
-				'Revoke all tokens except permanent app passwords (includes session, remembered, one-time, and wipe tokens)'
+				'Revoke all tokens except permanent app passwords'
 			)
 			->addOption(
 				'all',
@@ -93,15 +93,15 @@ class Revoke extends Base {
 		$allUsers = (bool)$input->getOption('all-users');
 
 		$modes = [
-			'browser-sessions' => (bool)$input->getOption('browser-sessions'),
+			'sessions' => (bool)$input->getOption('sessions'),
 			'remembered-sessions' => (bool)$input->getOption('remembered-sessions'),
-			'non-app-passwords' => (bool)$input->getOption('non-app-passwords'),
+			'all-except-app-passwords' => (bool)$input->getOption('all-except-app-passwords'),
 			'all' => (bool)$input->getOption('all'),
 		];
 
 		$selectedModes = array_filter($modes);
 		if (count($selectedModes) !== 1) {
-			throw new RuntimeException('Specify exactly one of --browser-sessions, --remembered-sessions, --non-app-passwords, or --all.');
+			throw new RuntimeException('Specify exactly one of --sessions, --remembered-sessions, --all-except-app-passwords, or --all.');
 		}
 
 		if ($allUsers && $uid !== null) {
@@ -115,11 +115,12 @@ class Revoke extends Base {
 		$dryRun = (bool)$input->getOption('dry-run');
 		$force = (bool)$input->getOption('force');
 
-		// Confirm destructive operations unless --force or --dry-run is set
+		// For bulk destructive operations, ask for confirmation unless this is
+		// a dry-run or the caller explicitly requested non-interactive behavior.
 		if (!$dryRun && !$force && $input->isInteractive()) {
 			$modeName = array_key_first($selectedModes);
 			$scope = $allUsers ? 'ALL users' : "user '$uid'";
-			$message = "<question>This will revoke all --{$modeName} tokens for {$scope}. Continue? [y/N]</question> ";
+			$message = "<question>This will revoke all {$modeName} tokens for {$scope}. Continue? [y/N]</question> ";
 
 			/** @var QuestionHelper $helper */
 			$helper = $this->getHelper('question');
@@ -134,17 +135,17 @@ class Revoke extends Base {
 
 		if ($allUsers) {
 			if (!$dryRun) {
-				// Use bulk deletion for --all-users when possible to avoid
-				// iterating every user and their tokens individually
-				$bulkCount = $this->bulkRevoke($modes, $output);
+				// Prefer a single bulk DELETE for all-users operations where the
+				// selected revoke mode maps cleanly to SQL predicates.
+				$bulkCount = $this->bulkRevoke($modes);
 				if ($bulkCount !== null) {
 					$output->writeln("<info>Revoked {$bulkCount} token(s).</info>");
 					return Command::SUCCESS;
 				}
 			}
 
-			// Fall back to per-user iteration for dry-run (needs token details)
-			// or if bulk deletion is not applicable
+			// Dry-run needs to enumerate tokens to report matches, and any mode
+			// not handled by bulkRevoke() falls back to per-user evaluation.
 			$this->userManager->callForAllUsers(function (IUser $user) use ($output, $dryRun, $modes, &$revoked): void {
 				$revoked += $this->revokeForUser($user->getUID(), $modes, $output, $dryRun);
 			});
@@ -167,18 +168,12 @@ class Revoke extends Base {
 	}
 
 	/**
-	 * Attempt a bulk DELETE query for --all-users instead of per-user iteration.
-	 *
-	 * @return int|null Number of deleted rows, or null if the mode doesn't
-	 *                  support bulk deletion (caller should fall back to per-user)
+	 * @return int|null Number of deleted rows, or null if caller should fall back
+	 *                  to per-user iteration
 	 */
-	private function bulkRevoke(array $modes, OutputInterface $output): ?int {
-		// Build type/remember constraints for a single bulk query
-		if ($modes['browser-sessions']) {
-			return $this->mapper->invalidateByTypeAndRemember(
-				IToken::TEMPORARY_TOKEN,
-				IToken::DO_NOT_REMEMBER
-			);
+	private function bulkRevoke(array $modes): ?int {
+		if ($modes['sessions']) {
+			return $this->mapper->invalidateByType(IToken::TEMPORARY_TOKEN);
 		}
 
 		if ($modes['remembered-sessions']) {
@@ -188,7 +183,7 @@ class Revoke extends Base {
 			);
 		}
 
-		if ($modes['non-app-passwords']) {
+		if ($modes['all-except-app-passwords']) {
 			return $this->mapper->invalidateAllExceptType(IToken::PERMANENT_TOKEN);
 		}
 
@@ -237,9 +232,9 @@ class Revoke extends Base {
 
 		$type = $token->getType();
 
-		if ($modes['browser-sessions']) {
-			return $type === IToken::TEMPORARY_TOKEN
-				&& $token->getRemember() === IToken::DO_NOT_REMEMBER;
+		if ($modes['sessions']) {
+			// "sessions" means all temporary tokens, including remembered sessions.
+			return $type === IToken::TEMPORARY_TOKEN;
 		}
 
 		if ($modes['remembered-sessions']) {
@@ -247,8 +242,8 @@ class Revoke extends Base {
 				&& $token->getRemember() === IToken::REMEMBER;
 		}
 
-		if ($modes['non-app-passwords']) {
-			// Includes TEMPORARY_TOKEN, WIPE_TOKEN, and ONETIME_TOKEN
+		if ($modes['all-except-app-passwords']) {
+			// Preserve permanent app passwords, revoke every other token type.
 			return $type !== IToken::PERMANENT_TOKEN;
 		}
 

--- a/core/Command/User/AuthTokens/Revoke.php
+++ b/core/Command/User/AuthTokens/Revoke.php
@@ -178,7 +178,8 @@ class Revoke extends Base {
 	 *    a short TTL (TOKEN_CACHE_TTL = 10s) and will self-heal quickly.
 	 *  - Dispatching events per-token would require loading every row first,
 	 *    negating the performance benefit of the bulk path.
-	 *  - We already do this (presumably acceptably) elsewhere.
+	 *  - Bulk token invalidation already follows this pattern elsewhere in 
+	 *    the codebase.
 	 *
 	 * @return int|null Number of deleted rows, or null if the caller should
 	 *                  fall back to per-user iteration.

--- a/core/Command/User/AuthTokens/Revoke.php
+++ b/core/Command/User/AuthTokens/Revoke.php
@@ -168,8 +168,20 @@ class Revoke extends Base {
 	}
 
 	/**
-	 * @return int|null Number of deleted rows, or null if caller should fall back
-	 *                  to per-user iteration
+	 * Attempt a bulk DELETE for --all-users instead of per-user iteration.
+	 *
+	 * This operates directly on the mapper for performance (single SQL DELETE
+	 * per mode). The trade-off is that TokenInvalidatedEvent is not dispatched
+	 * for individual tokens. This is acceptable because:
+	 *
+	 *  - The event is primarily consumed by the token cache layer, which uses
+	 *    a short TTL (TOKEN_CACHE_TTL = 10s) and will self-heal quickly.
+	 *  - Dispatching events per-token would require loading every row first,
+	 *    negating the performance benefit of the bulk path.
+	 *	- We already do this (presumably acceptably) elsewhere.
+	 *
+	 * @return int|null Number of deleted rows, or null if the caller should
+	 *                  fall back to per-user iteration.
 	 */
 	private function bulkRevoke(array $modes): ?int {
 		if ($modes['sessions']) {

--- a/core/Command/User/AuthTokens/Revoke.php
+++ b/core/Command/User/AuthTokens/Revoke.php
@@ -178,7 +178,7 @@ class Revoke extends Base {
 	 *    a short TTL (TOKEN_CACHE_TTL = 10s) and will self-heal quickly.
 	 *  - Dispatching events per-token would require loading every row first,
 	 *    negating the performance benefit of the bulk path.
-	 *	- We already do this (presumably acceptably) elsewhere.
+	 *  - We already do this (presumably acceptably) elsewhere.
 	 *
 	 * @return int|null Number of deleted rows, or null if the caller should
 	 *                  fall back to per-user iteration.

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -226,6 +226,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\User\AuthTokens\Add::class));
 	$application->add(Server::get(Command\User\AuthTokens\ListCommand::class));
 	$application->add(Server::get(Command\User\AuthTokens\Delete::class));
+	$application->add(Server::get(Command\User\AuthTokens\Revoke::class));
 	$application->add(Server::get(Verify::class));
 	$application->add(Server::get(Welcome::class));
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1435,6 +1435,7 @@ return array(
     'OC\\Core\\Command\\User\\AuthTokens\\Add' => $baseDir . '/core/Command/User/AuthTokens/Add.php',
     'OC\\Core\\Command\\User\\AuthTokens\\Delete' => $baseDir . '/core/Command/User/AuthTokens/Delete.php',
     'OC\\Core\\Command\\User\\AuthTokens\\ListCommand' => $baseDir . '/core/Command/User/AuthTokens/ListCommand.php',
+	'OC\\Core\\Command\\User\\AuthTokens\\ListCommand' => $baseDir . '/core/Command/User/AuthTokens/Revoke.php',
     'OC\\Core\\Command\\User\\ClearGeneratedAvatarCacheCommand' => $baseDir . '/core/Command/User/ClearGeneratedAvatarCacheCommand.php',
     'OC\\Core\\Command\\User\\Delete' => $baseDir . '/core/Command/User/Delete.php',
     'OC\\Core\\Command\\User\\Disable' => $baseDir . '/core/Command/User/Disable.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1435,7 +1435,7 @@ return array(
     'OC\\Core\\Command\\User\\AuthTokens\\Add' => $baseDir . '/core/Command/User/AuthTokens/Add.php',
     'OC\\Core\\Command\\User\\AuthTokens\\Delete' => $baseDir . '/core/Command/User/AuthTokens/Delete.php',
     'OC\\Core\\Command\\User\\AuthTokens\\ListCommand' => $baseDir . '/core/Command/User/AuthTokens/ListCommand.php',
-	'OC\\Core\\Command\\User\\AuthTokens\\ListCommand' => $baseDir . '/core/Command/User/AuthTokens/Revoke.php',
+	'OC\\Core\\Command\\User\\AuthTokens\\Revoke' => $baseDir . '/core/Command/User/AuthTokens/Revoke.php',
     'OC\\Core\\Command\\User\\ClearGeneratedAvatarCacheCommand' => $baseDir . '/core/Command/User/ClearGeneratedAvatarCacheCommand.php',
     'OC\\Core\\Command\\User\\Delete' => $baseDir . '/core/Command/User/Delete.php',
     'OC\\Core\\Command\\User\\Disable' => $baseDir . '/core/Command/User/Disable.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1476,6 +1476,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\User\\AuthTokens\\Add' => __DIR__ . '/../../..' . '/core/Command/User/AuthTokens/Add.php',
         'OC\\Core\\Command\\User\\AuthTokens\\Delete' => __DIR__ . '/../../..' . '/core/Command/User/AuthTokens/Delete.php',
         'OC\\Core\\Command\\User\\AuthTokens\\ListCommand' => __DIR__ . '/../../..' . '/core/Command/User/AuthTokens/ListCommand.php',
+		'OC\\Core\\Command\\User\\AuthTokens\\Revoke' => __DIR__ . '/../../..' . '/core/Command/User/AuthTokens/Revoke.php',
         'OC\\Core\\Command\\User\\ClearGeneratedAvatarCacheCommand' => __DIR__ . '/../../..' . '/core/Command/User/ClearGeneratedAvatarCacheCommand.php',
         'OC\\Core\\Command\\User\\Delete' => __DIR__ . '/../../..' . '/core/Command/User/Delete.php',
         'OC\\Core\\Command\\User\\Disable' => __DIR__ . '/../../..' . '/core/Command/User/Disable.php',

--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -62,6 +62,19 @@ class PublicKeyTokenMapper extends QBMapper {
 	}
 
 	/**
+	 * Delete all tokens of a given type.
+	 *
+	 * @return int Number of deleted rows
+	 */
+	public function invalidateByType(int $type): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->tableName)
+			->where($qb->expr()->eq('type', $qb->createNamedParameter($type, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
+		return $qb->executeStatement();
+	}
+
+	/**
 	 * Delete all tokens of a given type and remember value.
 	 *
 	 * @return int Number of deleted rows

--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -62,6 +62,45 @@ class PublicKeyTokenMapper extends QBMapper {
 	}
 
 	/**
+	 * Delete all tokens of a given type and remember value.
+	 *
+	 * @return int Number of deleted rows
+	 */
+	public function invalidateByTypeAndRemember(int $type, int $remember): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->tableName)
+			->where($qb->expr()->eq('type', $qb->createNamedParameter($type, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('remember', $qb->createNamedParameter($remember, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * Delete all tokens except those of a given type.
+	 *
+	 * @return int Number of deleted rows
+	 */
+	public function invalidateAllExceptType(int $exceptType): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->tableName)
+			->where($qb->expr()->neq('type', $qb->createNamedParameter($exceptType, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * Delete all tokens.
+	 *
+	 * @return int Number of deleted rows
+	 */
+	public function invalidateAllTokens(): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->tableName)
+			->where($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
+		return $qb->executeStatement();
+	}
+
+	/**
 	 * Get the user UID for the given token
 	 *
 	 * @throws DoesNotExistException

--- a/tests/Core/Command/User/AuthTokens/RevokeTest.php
+++ b/tests/Core/Command/User/AuthTokens/RevokeTest.php
@@ -205,4 +205,103 @@ class RevokeTest extends TestCase {
 
 		self::assertSame(0, $result);
 	}
+
+	public function testAllUsersBulkRevokeSessionsUsesBulkPath(): void {
+		$this->input->method('getArgument')
+			->with('uid')
+			->willReturn(null);
+
+		$this->input->method('getOption')
+			->willReturnCallback(function (string $option) {
+				return match ($option) {
+					'all-users' => true,
+					'sessions' => true,
+					'remembered-sessions' => false,
+					'all-except-app-passwords' => false,
+					'all' => false,
+					'dry-run' => false,
+					'force' => true,
+					default => throw new \InvalidArgumentException("Unexpected option $option"),
+				};
+			});
+
+		// Bulk path should call the mapper directly, not iterate users
+		$this->mapper->expects($this->once())
+			->method('invalidateByType')
+			->with(IToken::TEMPORARY_TOKEN)
+			->willReturn(5);
+
+		$this->userManager->expects($this->never())
+			->method('callForAllUsers');
+
+		$this->tokenProvider->expects($this->never())
+			->method('getTokenByUser');
+
+		$this->output->method('isVerbose')->willReturn(false);
+		$this->output->expects($this->once())
+			->method('writeln')
+			->with('<info>Revoked 5 token(s).</info>');
+
+		$result = self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
+
+		self::assertSame(0, $result);
+	}
+
+	public function testAllUsersDryRunFallsBackToPerUserIteration(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$tempToken = $this->createConfiguredMock(IToken::class, [
+			'getId' => 101,
+			'getType' => IToken::TEMPORARY_TOKEN,
+			'getRemember' => IToken::DO_NOT_REMEMBER,
+			'getName' => 'Firefox',
+		]);
+
+		$this->input->method('getArgument')
+			->with('uid')
+			->willReturn(null);
+
+		$this->input->method('getOption')
+			->willReturnCallback(function (string $option) {
+				return match ($option) {
+					'all-users' => true,
+					'sessions' => true,
+					'remembered-sessions' => false,
+					'all-except-app-passwords' => false,
+					'all' => false,
+					'dry-run' => true,
+					'force' => true,
+					default => throw new \InvalidArgumentException("Unexpected option $option"),
+				};
+			});
+
+		// Bulk mapper methods should NOT be called in dry-run
+		$this->mapper->expects($this->never())
+			->method('invalidateByType');
+
+		// Should fall back to per-user iteration
+		$this->userManager->expects($this->once())
+			->method('callForAllUsers')
+			->willReturnCallback(function (\Closure $callback) use ($user): void {
+				$callback($user);
+			});
+
+		$this->tokenProvider->expects($this->once())
+			->method('getTokenByUser')
+			->with('alice')
+			->willReturn([$tempToken]);
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateTokenById');
+
+		$this->output->method('isVerbose')->willReturn(false);
+		$this->output->expects($this->once())
+			->method('writeln')
+			->with('<info>Dry run complete. 1 token(s) would be revoked.</info>');
+
+		$result = self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
+
+		self::assertSame(0, $result);
+	}
 }

--- a/tests/Core/Command/User/AuthTokens/RevokeTest.php
+++ b/tests/Core/Command/User/AuthTokens/RevokeTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Tests\Core\Command\User\AuthTokens;
+
+use OC\Authentication\Token\IProvider;
+use OC\Authentication\Token\PublicKeyTokenMapper;
+use OC\Core\Command\User\AuthTokens\Revoke;
+use OCP\Authentication\Token\IToken;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Test\TestCase;
+
+class RevokeTest extends TestCase {
+	protected IUserManager&MockObject $userManager;
+	protected IProvider&MockObject $tokenProvider;
+	protected PublicKeyTokenMapper&MockObject $mapper;
+	protected InputInterface&MockObject $input;
+	protected OutputInterface&MockObject $output;
+	protected Revoke $command;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->mapper = $this->createMock(PublicKeyTokenMapper::class);
+		$this->input = $this->createMock(InputInterface::class);
+		$this->output = $this->createMock(OutputInterface::class);
+
+		$this->command = new Revoke(
+			$this->userManager,
+			$this->tokenProvider,
+			$this->mapper,
+		);
+	}
+
+	public function testExecuteFailsWithoutMode(): void {
+		$this->input->method('getArgument')
+			->with('uid')
+			->willReturn('alice');
+
+		$this->input->method('getOption')
+			->willReturnCallback(function (string $option) {
+				return match ($option) {
+					'all-users',
+					'sessions',
+					'remembered-sessions',
+					'all-except-app-passwords',
+					'all',
+					'dry-run',
+					'force' => false,
+					default => throw new \InvalidArgumentException("Unexpected option $option"),
+				};
+			});
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Specify exactly one of --sessions, --remembered-sessions, --all-except-app-passwords, or --all.');
+
+		self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
+	}
+
+	public function testSessionsRevokesOnlyTemporaryTokens(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$tempToken = $this->createConfiguredMock(IToken::class, [
+			'getId' => 101,
+			'getType' => IToken::TEMPORARY_TOKEN,
+			'getRemember' => IToken::DO_NOT_REMEMBER,
+			'getName' => 'Firefox',
+		]);
+
+		$rememberedTempToken = $this->createConfiguredMock(IToken::class, [
+			'getId' => 102,
+			'getType' => IToken::TEMPORARY_TOKEN,
+			'getRemember' => IToken::REMEMBER,
+			'getName' => 'Remembered browser',
+		]);
+
+		$permanentToken = $this->createConfiguredMock(IToken::class, [
+			'getId' => 201,
+			'getType' => IToken::PERMANENT_TOKEN,
+			'getRemember' => IToken::DO_NOT_REMEMBER,
+			'getName' => 'Desktop client',
+		]);
+
+		$this->input->method('getArgument')
+			->with('uid')
+			->willReturn('alice');
+
+		$this->input->method('getOption')
+			->willReturnCallback(function (string $option) {
+				return match ($option) {
+					'all-users' => false,
+					'sessions' => true,
+					'remembered-sessions' => false,
+					'all-except-app-passwords' => false,
+					'all' => false,
+					'dry-run' => false,
+					'force' => true,
+					default => throw new \InvalidArgumentException("Unexpected option $option"),
+				};
+			});
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('alice')
+			->willReturn($user);
+
+		$this->tokenProvider->expects($this->once())
+			->method('getTokenByUser')
+			->with('alice')
+			->willReturn([$tempToken, $rememberedTempToken, $permanentToken]);
+
+		$this->tokenProvider->expects($this->exactly(2))
+			->method('invalidateTokenById')
+			->willReturnCallback(function (string $uid, int $id): void {
+				self::assertSame('alice', $uid);
+				self::assertContains($id, [101, 102]);
+			});
+
+		$this->output->method('isVerbose')->willReturn(false);
+		$this->output->expects($this->once())
+			->method('writeln')
+			->with('<info>Revoked 2 token(s).</info>');
+
+		$result = self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
+
+		self::assertSame(0, $result);
+	}
+
+	public function testAllExceptAppPasswordsDryRunDoesNotRevoke(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$tempToken = $this->createConfiguredMock(IToken::class, [
+			'getId' => 101,
+			'getType' => IToken::TEMPORARY_TOKEN,
+			'getRemember' => IToken::DO_NOT_REMEMBER,
+			'getName' => 'Firefox',
+		]);
+
+		$wipeToken = $this->createConfiguredMock(IToken::class, [
+			'getId' => 301,
+			'getType' => IToken::WIPE_TOKEN,
+			'getRemember' => IToken::DO_NOT_REMEMBER,
+			'getName' => 'Remote wipe',
+		]);
+
+		$permanentToken = $this->createConfiguredMock(IToken::class, [
+			'getId' => 201,
+			'getType' => IToken::PERMANENT_TOKEN,
+			'getRemember' => IToken::DO_NOT_REMEMBER,
+			'getName' => 'Desktop client',
+		]);
+
+		$this->input->method('getArgument')
+			->with('uid')
+			->willReturn('alice');
+
+		$this->input->method('getOption')
+			->willReturnCallback(function (string $option) {
+				return match ($option) {
+					'all-users' => false,
+					'sessions' => false,
+					'remembered-sessions' => false,
+					'all-except-app-passwords' => true,
+					'all' => false,
+					'dry-run' => true,
+					'force' => true,
+					default => throw new \InvalidArgumentException("Unexpected option $option"),
+				};
+			});
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('alice')
+			->willReturn($user);
+
+		$this->tokenProvider->expects($this->once())
+			->method('getTokenByUser')
+			->with('alice')
+			->willReturn([$tempToken, $wipeToken, $permanentToken]);
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateTokenById');
+
+		$this->output->method('isVerbose')->willReturn(false);
+		$this->output->expects($this->once())
+			->method('writeln')
+			->with('<info>Dry run complete. 2 token(s) would be revoked.</info>');
+
+		$result = self::invokePrivate($this->command, 'execute', [$this->input, $this->output]);
+
+		self::assertSame(0, $result);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #50279 <!-- related github issue -->

## Summary

~~Clarify the documented behavior of `token_auth_enforced` and~~ add a new `occ` command to revoke existing auth tokens/sessions when admins want to enforce the policy on already-authenticated users.

Changes:

* ~~update `config/config.sample.php` to clarify that `token_auth_enforced`:~~
  - ~~blocks new client logins using the account password~~
  - ~~does **not** automatically revoke existing sessions/tokens~~
  - can be paired with `occ user:auth-tokens:revoke --sessions`
* add `occ user:auth-tokens:revoke` with mode flags:
  - `--sessions`: all temporary session tokens (including remembered)
  - `--remembered-sessions`: remembered session tokens only
  - `--all-except-app-passwords`: everything except permanent app passwords
  - `--all`: everything including app passwords
  - supports single-user and `--all-users`
  - supports `--dry-run` and `--force`
* add bulk mapper helpers for efficient all-users revocation
* add PHPUnit tests for command validation, per-user revoke behavior, and bulk path routing

Motivation:

The previous documentation suggested immediate full enforcement for all client access. In practice, `token_auth_enforced` is only checked in `logClientIn()`, so already-issued sessions/tokens are not re-checked against it. Existing `TEMPORARY_TOKEN` entries can therefore remain valid as long as clients keep using them, since each request refreshes `last_activity` and prevents age-based cleanup.

This change makes that behavior explicit and provides admins with a supported way to revoke existing auth state if they want full enforcement after enabling the setting.

Notes:

* No change to runtime semantics of `token_auth_enforced`; this adds an explicit admin action instead of introducing implicit mass logout on config toggle.
* Existing `user:auth-tokens:delete` is token-id/uid/date oriented. The new `revoke` command is policy-oriented and targets token classes directly, which fits the "enabled `token_auth_enforced` and need to clean up" admin workflow.
* For `--all-users` in non-dry-run mode, revocation uses bulk SQL deletes instead of per-token `invalidateTokenById()`. This intentionally skips per-token `TokenInvalidatedEvent` dispatch for performance. The token cache is short-lived (`TOKEN_CACHE_TTL` / 10s), and similar bulk invalidation patterns already exist elsewhere in the code base (e.g. `invalidateOld()` and `deleteTempToken()` in `PublicKeyTokenMapper`).

## TODO

- [ ] Test test test

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
