### PR TITLE
perf: don't fetch child mounts when getting node parent

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -279,7 +279,7 @@ class Node implements INode {
 
 			// Manually fetch the parent if the current node doesn't have a file info yet
 			try {
-				$fileInfo = $this->getFileInfo();
+				$fileInfo = $this->getFileInfo(false);
 			} catch (NotFoundException) {
 				$this->parent = $this->root->get($newPath);
 				/** @var \OCP\Files\Folder $this->parent */


### PR DESCRIPTION
No need to do all that work just to get the parent id.