### PR TITLE
test(integration): Add an integration test with the guests app

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -73,8 +73,10 @@ jobs:
           - 'sharing_features'
           - 'theming_features'
           - 'videoverification_features'
+          - 'guests_features'
 
         php-versions: ['8.4']
+        guests-versions: ['main']
         spreed-versions: ['main']
         activity-versions: ['master']
 
@@ -110,6 +112,15 @@ jobs:
           repository: nextcloud/spreed
           path: apps/spreed
           ref: ${{ matrix.spreed-versions }}
+
+      - name: Checkout Guests app
+        if: ${{ matrix.test-suite == 'guests_features' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: nextcloud/guests
+          path: apps/guests
+          ref: ${{ matrix.guests-versions }}
 
       - name: Checkout Activity app
         if: ${{ matrix.test-suite == 'sharing_features' }}

--- a/build/integration/config/behat.yml
+++ b/build/integration/config/behat.yml
@@ -193,6 +193,17 @@ default:
               - admin
             regular_user_password: 123456
         - TalkContext
+    guests:
+      paths:
+        - "%paths.base%/../guests_features"
+      contexts:
+        - GuestsContext
+        - SharingContext:
+            baseUrl: http://localhost:8080/ocs/
+            admin:
+              - admin
+              - admin
+            regular_user_password: 123456
     setup:
       paths:
         - "%paths.base%/../setup_features"

--- a/build/integration/features/bootstrap/GuestsContext.php
+++ b/build/integration/features/bootstrap/GuestsContext.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+use Behat\Behat\Context\Context;
+
+class GuestsContext implements Context {
+	public const TEST_PASSWORD = '123456';
+	protected static $lastStdOut = null;
+	protected static $lastCode = null;
+
+	#[\Behat\Hook\BeforeScenario('@Guests')]
+	#[\Behat\Hook\BeforeFeature('@Guests')]
+	public static function skipTestsIfGuestsIsNotInstalled() {
+		if (!self::isGuestsInstalled()) {
+			throw new Exception('Guests needs to be installed to run features or scenarios tagged with @Guests');
+		}
+	}
+
+	#[\Behat\Hook\AfterScenario('@Guests')]
+	public static function disableGuests() {
+		self::runOcc(['app:disable', 'guests']);
+	}
+
+	private static function isGuestsInstalled(): bool {
+		self::runOcc(['app:list']);
+		return strpos(self::$lastStdOut, 'guests') !== false;
+	}
+
+	private static function runOcc(array $args, array $env = []): int {
+		// Based on "runOcc" from CommandLine trait (which can not be used due
+		// to not being static and being already used in other sibling
+		// contexts).
+		$args = array_map(function ($arg) {
+			return escapeshellarg($arg);
+		}, $args);
+		$args[] = '--no-ansi --no-warnings';
+		$args = implode(' ', $args);
+
+		$descriptor = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+		$process = proc_open('php console.php ' . $args, $descriptor, $pipes, $ocPath = '../..', $env);
+		self::$lastStdOut = stream_get_contents($pipes[1]);
+		self::$lastCode = proc_close($process);
+
+		return self::$lastCode;
+	}
+
+	#[\Behat\Step\Given('/^user "([^"]*)" is a guest account user$/')]
+	public function createGuestUser(string $email): void {
+		self::runOcc([
+			'user:delete',
+			$email,
+		]);
+
+		$lastCode = self::runOcc([
+			'config:app:set',
+			'guests',
+			'hash_user_ids',
+			'--value=false',
+			'--type=boolean',
+		]);
+		\PHPUnit\Framework\Assert::assertEquals(0, $lastCode);
+
+		$lastCode = self::runOcc([
+			'guests:add',
+			// creator user
+			'admin',
+			// email
+			$email,
+			'--display-name',
+			$email . '-displayname',
+			'--password-from-env',
+		], [
+			'OC_PASS' => self::TEST_PASSWORD,
+		]);
+		\PHPUnit\Framework\Assert::assertEquals(0, $lastCode, 'Guest creation succeeded for ' . $email);
+	}
+
+}

--- a/build/integration/guests_features/guest-filesystem.feature
+++ b/build/integration/guests_features/guest-filesystem.feature
@@ -1,0 +1,25 @@
+@Guests
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+Feature: guests app
+  Background:
+    Given using api version "1"
+    Given using old dav path
+    Given invoking occ with "app:enable --force guests"
+    Given the command was successful
+    And user "user-guest@example.com" is a guest account user
+
+  Scenario: Receive a share as a guests app user
+    And user "user-guest@example.com" should see following elements
+      | / |
+    Given user "user0" exists
+    And As an "user0"
+    When creating a share with
+      | path | welcome.txt |
+      | shareType | 0 |
+      | shareWith | user-guest@example.com |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "user-guest@example.com" should see following elements
+      | / |
+      | /welcome.txt |


### PR DESCRIPTION
It has quite nasty overwrites in place for appconfig and storages which break too often and can otherwise only be noticed by low privileged users.

The idea is that server developers are made aware

- Last breakage: https://github.com/nextcloud/server/pull/59511
- :red_circle: CI run with this test before the guests app fix: https://github.com/nextcloud/server/actions/runs/24284119381/job/70910539845?pr=59588#step:12:54
- Fix in: https://github.com/nextcloud/guests/pull/1529
- :green_circle: CI run with this test after the guests app fix



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
