### PR TITLE
test: Add integration test to confirm a user can not add themselves t…

### DIFF
--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -487,9 +487,24 @@ Feature: provisioning
     Given As an "admin"
     And user "brand-new-user" exists
     And group "new-group" exists
+    And group "other-group" exists
     When sending "POST" to "/cloud/users/brand-new-user/subadmins" with
       | groupid | new-group |
     Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+
+    # Ensure self promotion is not possible
+    Given As an "brand-new-user"
+    When sending "POST" to "/cloud/users/brand-new-user/groups" with
+      | groupid | admin |
+    Then the OCS status code should be "104"
+    And the HTTP status code should be "200"
+
+    # Ensure self adding to other groups is not possible
+    Given As an "brand-new-user"
+    When sending "POST" to "/cloud/users/brand-new-user/groups" with
+      | groupid | other-group |
+    Then the OCS status code should be "104"
     And the HTTP status code should be "200"
 
   Scenario: get users using a subadmin
@@ -793,7 +808,7 @@ Feature: provisioning
     Then the HTTP status code should be "200"
     And user "subadmin" is disabled
 
-  Scenario: Admin user cannot disable himself
+  Scenario: Admin user cannot disable themself
     Given As an "admin"
     And user "another-admin" exists
     And user "another-admin" belongs to group "admin"
@@ -804,7 +819,7 @@ Feature: provisioning
     And As an "admin"
     And user "another-admin" is enabled
 
-  Scenario:Admin user cannot enable himself
+  Scenario: Admin user cannot enable themself
     Given As an "admin"
     And user "another-admin" exists
     And user "another-admin" belongs to group "admin"
@@ -837,7 +852,7 @@ Feature: provisioning
     And As an "admin"
     And user "user2" is disabled
 
-  Scenario: Subadmin should not be able to disable himself
+  Scenario: Subadmin should not be able to disable themself
     Given As an "admin"
     And user "subadmin" exists
     And group "new-group" exists
@@ -850,7 +865,7 @@ Feature: provisioning
     And As an "admin"
     And user "subadmin" is enabled
 
-  Scenario: Subadmin should not be able to enable himself
+  Scenario: Subadmin should not be able to enable themself
     Given As an "admin"
     And user "subadmin" exists
     And group "new-group" exists


### PR DESCRIPTION
…o another group

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
