### PR TITLE
fix(controller): Add default range to $limit parameter

### DIFF
--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -26,6 +26,9 @@ use Psr\Log\LoggerInterface;
  * Class to dispatch the request to the middleware dispatcher
  */
 class Dispatcher {
+	public const DEFAULT_MIN = 1;
+	public const DEFAULT_MAX = 500;
+
 	/**
 	 * @param Http $protocol the http protocol with contains all status headers
 	 * @param MiddlewareDispatcher $middlewareDispatcher the dispatcher which
@@ -149,7 +152,7 @@ class Dispatcher {
 				$value = false;
 			} elseif ($value !== null && \in_array($type, $types, true)) {
 				settype($value, $type);
-				$this->ensureParameterValueSatisfiesRange($param, $value);
+				$this->ensureParameterValueSatisfiesRange($param, $value, $default);
 			} elseif ($value === null && $type !== null && $this->appContainer->has($type)) {
 				$value = $this->appContainer->get($type);
 			}
@@ -193,7 +196,7 @@ class Dispatcher {
 	 * @psalm-param mixed $value
 	 * @throws ParameterOutOfRangeException
 	 */
-	private function ensureParameterValueSatisfiesRange(string $param, $value): void {
+	private function ensureParameterValueSatisfiesRange(string $param, $value, $default): void {
 		$rangeInfo = $this->reflector->getRange($param);
 		if ($rangeInfo) {
 			if ($value < $rangeInfo['min'] || $value > $rangeInfo['max']) {
@@ -202,6 +205,15 @@ class Dispatcher {
 					$value,
 					$rangeInfo['min'],
 					$rangeInfo['max'],
+				);
+			}
+		} elseif ($param === 'limit') {
+			if ($value !== $default && ($value < self::DEFAULT_MIN || $value > self::DEFAULT_MAX)) {
+				throw new ParameterOutOfRangeException(
+					$param,
+					$value,
+					self::DEFAULT_MIN,
+					self::DEFAULT_MAX,
 				);
 			}
 		}

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -549,18 +549,34 @@ class DispatcherTest extends \Test\TestCase {
 			[7, 14, 5, true],
 			[7, 14, 10, false],
 			[-14, -7, -10, false],
+			[null, null, -1, false],
+
+			// $limit comes with default limits of self::DEFAULT_MIN (1) <= $limit <= self::DEFAULT_MAX (500)
+			[null, null, -1, true, 'limit'],
+			[null, null, -1, false, 'limit', -1],
+			[null, null, 0, true, 'limit'],
+			[null, null, 0, true, 'limit', -1],
+			[null, null, 1, false, 'limit'],
+			[null, null, 500, false, 'limit'],
+			[null, null, 501, true, 'limit'],
 		];
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('rangeDataProvider')]
-	public function testEnsureParameterValueSatisfiesRange(int $min, int $max, int $input, bool $throw): void {
+	public function testEnsureParameterValueSatisfiesRange(?int $min, ?int $max, int $input, bool $throw, string $param = 'myArgument', ?int $default = null): void {
 		$this->reflector = $this->createMock(ControllerMethodReflector::class);
-		$this->reflector->expects($this->any())
-			->method('getRange')
-			->willReturn([
-				'min' => $min,
-				'max' => $max,
-			]);
+		if ($min === null && $max === null) {
+			$this->reflector->expects($this->any())
+				->method('getRange')
+				->willReturn(null);
+		} else {
+			$this->reflector->expects($this->any())
+				->method('getRange')
+				->willReturn([
+					'min' => $min,
+					'max' => $max,
+				]);
+		}
 
 		$this->dispatcher = new Dispatcher(
 			$this->http,
@@ -578,7 +594,7 @@ class DispatcherTest extends \Test\TestCase {
 			$this->expectException(ParameterOutOfRangeException::class);
 		}
 
-		$this->invokePrivate($this->dispatcher, 'ensureParameterValueSatisfiesRange', ['myArgument', $input]);
+		self::invokePrivate($this->dispatcher, 'ensureParameterValueSatisfiesRange', [$param, $input, $default]);
 		if (!$throw) {
 			// do not mark this test risky
 			$this->assertTrue(true);


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
