### PR TITLE
feat(auth): Add IAlternativeLoginProvider

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -168,6 +168,7 @@ return array(
     'OCP\\Authentication\\Exceptions\\PasswordUnavailableException' => $baseDir . '/lib/public/Authentication/Exceptions/PasswordUnavailableException.php',
     'OCP\\Authentication\\Exceptions\\WipeTokenException' => $baseDir . '/lib/public/Authentication/Exceptions/WipeTokenException.php',
     'OCP\\Authentication\\IAlternativeLogin' => $baseDir . '/lib/public/Authentication/IAlternativeLogin.php',
+    'OCP\\Authentication\\IAlternativeLoginProvider' => $baseDir . '/lib/public/Authentication/IAlternativeLoginProvider.php',
     'OCP\\Authentication\\IApacheBackend' => $baseDir . '/lib/public/Authentication/IApacheBackend.php',
     'OCP\\Authentication\\IProvideUserSecretBackend' => $baseDir . '/lib/public/Authentication/IProvideUserSecretBackend.php',
     'OCP\\Authentication\\LoginCredentials\\ICredentials' => $baseDir . '/lib/public/Authentication/LoginCredentials/ICredentials.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -209,6 +209,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Authentication\\Exceptions\\PasswordUnavailableException' => __DIR__ . '/../../..' . '/lib/public/Authentication/Exceptions/PasswordUnavailableException.php',
         'OCP\\Authentication\\Exceptions\\WipeTokenException' => __DIR__ . '/../../..' . '/lib/public/Authentication/Exceptions/WipeTokenException.php',
         'OCP\\Authentication\\IAlternativeLogin' => __DIR__ . '/../../..' . '/lib/public/Authentication/IAlternativeLogin.php',
+        'OCP\\Authentication\\IAlternativeLoginProvider' => __DIR__ . '/../../..' . '/lib/public/Authentication/IAlternativeLoginProvider.php',
         'OCP\\Authentication\\IApacheBackend' => __DIR__ . '/../../..' . '/lib/public/Authentication/IApacheBackend.php',
         'OCP\\Authentication\\IProvideUserSecretBackend' => __DIR__ . '/../../..' . '/lib/public/Authentication/IProvideUserSecretBackend.php',
         'OCP\\Authentication\\LoginCredentials\\ICredentials' => __DIR__ . '/../../..' . '/lib/public/Authentication/LoginCredentials/ICredentials.php',

--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Services\InitialStateProvider;
 use OCP\Authentication\IAlternativeLogin;
+use OCP\Authentication\IAlternativeLoginProvider;
 use OCP\Calendar\ICalendarProvider;
 use OCP\Calendar\Resource\IBackend as IResourceBackend;
 use OCP\Calendar\Room\IBackend as IRoomBackend;
@@ -44,6 +45,7 @@ use OCP\Teams\ITeamResourceProvider;
 use OCP\TextProcessing\IProvider as ITextProcessingProvider;
 use OCP\Translation\ITranslationProvider;
 use OCP\UserMigration\IMigrator as IUserMigrator;
+use Override;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
@@ -94,6 +96,9 @@ class RegistrationContext {
 
 	/** @var ServiceRegistration<IAlternativeLogin>[] */
 	private $alternativeLogins = [];
+
+	/** @var ServiceRegistration<IAlternativeLoginProvider>[] */
+	private array $alternativeLoginProviders = [];
 
 	/** @var ServiceRegistration<InitialStateProvider>[] */
 	private $initialStates = [];
@@ -246,6 +251,14 @@ class RegistrationContext {
 
 			public function registerAlternativeLogin(string $class): void {
 				$this->context->registerAlternativeLogin(
+					$this->appId,
+					$class
+				);
+			}
+
+			#[Override]
+			public function registerAlternativeLoginProvider(string $class): void {
+				$this->context->registerAlternativeLoginProvider(
 					$this->appId,
 					$class
 				);
@@ -493,6 +506,10 @@ class RegistrationContext {
 
 	public function registerAlternativeLogin(string $appId, string $class): void {
 		$this->alternativeLogins[] = new ServiceRegistration($appId, $class);
+	}
+
+	public function registerAlternativeLoginProvider(string $appId, string $class): void {
+		$this->alternativeLoginProviders[] = new ServiceRegistration($appId, $class);
 	}
 
 	public function registerInitialState(string $appId, string $class): void {
@@ -826,6 +843,13 @@ class RegistrationContext {
 	 */
 	public function getAlternativeLogins(): array {
 		return $this->alternativeLogins;
+	}
+
+	/**
+	 * @return ServiceRegistration<IAlternativeLoginProvider>[]
+	 */
+	public function getAlternativeLoginProviders(): array {
+		return $this->alternativeLoginProviders;
 	}
 
 	/**

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -19,6 +19,7 @@ use OC\SystemConfig;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\Authentication\IAlternativeLogin;
+use OCP\Authentication\IAlternativeLoginProvider;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
@@ -41,6 +42,8 @@ use function OCP\Log\logger;
  * upgrading and removing apps.
  */
 class OC_App {
+
+	/** @var list<array{name: string, href: string, class: string}> */
 	private static array $altLogin = [];
 	private static array $alreadyRegistered = [];
 	public const supportedApp = 300;
@@ -300,11 +303,54 @@ class OC_App {
 	}
 
 	/**
-	 * @return array
+	 * @return list<array{name: string, href: string, class: string}>
 	 */
 	public static function getAlternativeLogIns(): array {
 		/** @var Coordinator $bootstrapCoordinator */
 		$bootstrapCoordinator = Server::get(Coordinator::class);
+
+		foreach ($bootstrapCoordinator->getRegistrationContext()->getAlternativeLoginProviders() as $registration) {
+			if (!in_array(IAlternativeLoginProvider::class, class_implements($registration->getService()), true)) {
+				Server::get(LoggerInterface::class)->error('Alternative login option {option} does not implement {interface} and is therefore ignored.', [
+					'option' => $registration->getService(),
+					'interface' => IAlternativeLoginProvider::class,
+					'app' => $registration->getAppId(),
+				]);
+				continue;
+			}
+
+			try {
+				/** @var IAlternativeLoginProvider $provider */
+				$provider = Server::get($registration->getService());
+			} catch (ContainerExceptionInterface $e) {
+				Server::get(LoggerInterface::class)->error('Alternative login option {option} can not be initialized.',
+					[
+						'exception' => $e,
+						'option' => $registration->getService(),
+						'app' => $registration->getAppId(),
+					]);
+				continue;
+			}
+
+			foreach ($provider->getAlternativeLogins() as $alternativeLogin) {
+				try {
+					$alternativeLogin->load();
+
+					self::$altLogin[] = [
+						'name' => $alternativeLogin->getLabel(),
+						'href' => $alternativeLogin->getLink(),
+						'class' => $alternativeLogin->getClass(),
+					];
+				} catch (Throwable $e) {
+					Server::get(LoggerInterface::class)->error('Alternative login option {option} had an error while loading.',
+						[
+							'exception' => $e,
+							'option' => $registration->getService(),
+							'app' => $registration->getAppId(),
+						]);
+				}
+			}
+		}
 
 		foreach ($bootstrapCoordinator->getRegistrationContext()->getAlternativeLogins() as $registration) {
 			if (!in_array(IAlternativeLogin::class, class_implements($registration->getService()), true)) {

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -161,8 +161,20 @@ interface IRegistrationContext {
 	 * @return void
 	 *
 	 * @since 20.0.0
+	 * @deprecated 34.0.0 Use registerAlternativeLoginProvider instead.
 	 */
 	public function registerAlternativeLogin(string $class): void;
+
+	/**
+	 * Register an alternative login options provider
+	 *
+	 * It is allowed to register more than one option per app.
+	 *
+	 * @param class-string<\OCP\Authentication\IAlternativeLoginProvider> $class
+	 *
+	 * @since 34.0.0
+	 */
+	public function registerAlternativeLoginProvider(string $class): void;
 
 	/**
 	 * Register an initialstate provider

--- a/lib/public/Authentication/IAlternativeLoginProvider.php
+++ b/lib/public/Authentication/IAlternativeLoginProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Authentication;
+
+/**
+ * Provider exposing one or multiple IAlternativeLogin.
+ *
+ * @since 34.0.0
+ */
+interface IAlternativeLoginProvider {
+	/**
+	 * @return list<IAlternativeLogin>
+	 * @since 34.0.0
+	 */
+	public function getAlternativeLogins(): array;
+}


### PR DESCRIPTION
IAlternativeLogin has a fatal flaw in that it is not possible to register multiple alternative login dynamically but only statically.

IAlternativeLoginProvider fixes this limitation as the provider can then provider multiple IAlternativeLogin.


## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
