### PR TITLE
perf(files): use bounded favorite searches in dashboard widget and activity helper

### DIFF
--- a/apps/files/lib/Activity/Helper.php
+++ b/apps/files/lib/Activity/Helper.php
@@ -7,18 +7,26 @@
  */
 namespace OCA\Files\Activity;
 
+use OC\Files\Search\SearchBinaryOperator;
+use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchOrder;
+use OC\Files\Search\SearchQuery;
+use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
-use OCP\ITagManager;
+use OCP\Files\Search\ISearchBinaryOperator;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOrder;
+use OCP\IUserManager;
 
 class Helper {
 	/** If a user has a lot of favorites the query might get too slow and long */
 	public const FAVORITE_LIMIT = 50;
 
 	public function __construct(
-		protected ITagManager $tagManager,
 		protected IRootFolder $rootFolder,
+		protected IUserManager $userManager,
 	) {
 	}
 
@@ -32,29 +40,40 @@ class Helper {
 	 * @throws \RuntimeException when too many or no favorites where found
 	 */
 	public function getFavoriteNodes(string $user, bool $foldersOnly = false): array {
-		$tags = $this->tagManager->load('files', [], false, $user);
-		$favorites = $tags->getFavorites();
-
-		if (empty($favorites)) {
+		$userObject = $this->userManager->get($user);
+		if ($userObject === null) {
 			throw new \RuntimeException('No favorites', 1);
-		} elseif (isset($favorites[self::FAVORITE_LIMIT])) {
-			throw new \RuntimeException('Too many favorites', 2);
 		}
 
-		// Can not DI because the user is not known on instantiation
 		$userFolder = $this->rootFolder->getUserFolder($user);
-		$favoriteNodes = [];
-		foreach ($favorites as $favorite) {
-			$node = $userFolder->getFirstNodeById($favorite);
-			if ($node) {
-				if (!$foldersOnly || $node instanceof Folder) {
-					$favoriteNodes[] = $node;
-				}
-			}
+
+		$operator = new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'favorite', true);
+		if ($foldersOnly) {
+			$operator = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+				$operator,
+				new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'mimetype', FileInfo::MIMETYPE_FOLDER),
+			]);
 		}
+
+		$favoriteNodes = $userFolder->search(new SearchQuery(
+			$operator,
+			self::FAVORITE_LIMIT + 1,
+			0,
+			[
+				new SearchOrder(ISearchOrder::DIRECTION_DESCENDING, 'mtime'),
+			],
+			$userObject,
+		));
 
 		if (empty($favoriteNodes)) {
 			throw new \RuntimeException('No favorites', 1);
+		} elseif (isset($favoriteNodes[self::FAVORITE_LIMIT])) {
+			throw new \RuntimeException('Too many favorites', 2);
+		}
+
+		if ($foldersOnly) {
+			/** @var Folder[] $favoriteNodes */
+			return $favoriteNodes;
 		}
 
 		return $favoriteNodes;

--- a/apps/files/lib/Dashboard/FavoriteWidget.php
+++ b/apps/files/lib/Dashboard/FavoriteWidget.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 namespace OCA\Files\Dashboard;
 
 use OCA\Files\AppInfo\Application;
+use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchOrder;
+use OC\Files\Search\SearchQuery;
 use OCP\Dashboard\IAPIWidgetV2;
 use OCP\Dashboard\IButtonWidget;
 use OCP\Dashboard\IIconWidget;
@@ -21,9 +24,10 @@ use OCP\Dashboard\Model\WidgetOptions;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOrder;
 use OCP\IL10N;
 use OCP\IPreview;
-use OCP\ITagManager;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 
@@ -34,7 +38,6 @@ class FavoriteWidget implements IIconWidget, IAPIWidgetV2, IButtonWidget, IOptio
 		private readonly IURLGenerator $urlGenerator,
 		private readonly IMimeTypeDetector $mimeTypeDetector,
 		private readonly IUserManager $userManager,
-		private readonly ITagManager $tagManager,
 		private readonly IRootFolder $rootFolder,
 		private readonly IPreview $previewManager,
 	) {
@@ -71,50 +74,51 @@ class FavoriteWidget implements IIconWidget, IAPIWidgetV2, IButtonWidget, IOptio
 
 	public function getItems(string $userId, int $limit = 7): array {
 		$user = $this->userManager->get($userId);
-
 		if (!$user) {
 			return [];
 		}
-		$tags = $this->tagManager->load('files', [], false, $userId);
-		$favorites = $tags->getFavorites();
-		if (empty($favorites)) {
-			return [];
-		}
-		$favoriteNodes = [];
-		$userFolder = $this->rootFolder->getUserFolder($userId);
-		$count = 0;
-		foreach ($favorites as $favorite) {
-			$node = $userFolder->getFirstNodeById($favorite);
-			if ($node) {
-				$url = $this->urlGenerator->linkToRouteAbsolute(
-					'files.view.showFile', ['fileid' => $node->getId()]
-				);
-				if ($node instanceof File) {
-					$icon = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', [
-						'x' => 256,
-						'y' => 256,
-						'fileId' => $node->getId(),
-						'c' => $node->getEtag(),
-						'mimeFallback' => true,
-					]);
-				} else {
-					$icon = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'filetypes/folder.svg'));
-				}
-				$favoriteNodes[] = new WidgetItem(
-					$node->getName(),
-					'',
-					$url,
-					$icon,
-					(string)$node->getCreationTime()
-				);
-				$count++;
-				if ($count >= $limit) {
-					break;
-				}
-			}
-		}
 
-		return $favoriteNodes;
+		$userFolder = $this->rootFolder->getUserFolder($userId);
+		$folderIcon = $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->imagePath('core', 'filetypes/folder.svg')
+		);
+
+		$favoriteNodes = $userFolder->search(new SearchQuery(
+			new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'favorite', true),
+			$limit,
+			0,
+			[
+				new SearchOrder(ISearchOrder::DIRECTION_DESCENDING, 'mtime'),
+			],
+			$user,
+		));
+
+		return array_map(function ($node) use ($folderIcon) {
+			$url = $this->urlGenerator->linkToRouteAbsolute(
+				'files.view.showFile',
+				['fileid' => $node->getId()]
+			);
+
+			if ($node instanceof File) {
+				$icon = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', [
+					'x' => 256,
+					'y' => 256,
+					'fileId' => $node->getId(),
+					'c' => $node->getEtag(),
+					'mimeFallback' => true,
+				]);
+			} else {
+				$icon = $folderIcon;
+			}
+
+			return new WidgetItem(
+				$node->getName(),
+				'',
+				$url,
+				$icon,
+				(string)$node->getCreationTime()
+			);
+		}, $favoriteNodes);
 	}
 
 	public function getItemsV2(string $userId, ?string $since = null, int $limit = 7): WidgetItems {

--- a/apps/files/lib/Dashboard/FavoriteWidget.php
+++ b/apps/files/lib/Dashboard/FavoriteWidget.php
@@ -22,12 +22,10 @@ use OCP\Dashboard\Model\WidgetItem;
 use OCP\Dashboard\Model\WidgetItems;
 use OCP\Dashboard\Model\WidgetOptions;
 use OCP\Files\File;
-use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOrder;
 use OCP\IL10N;
-use OCP\IPreview;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 
@@ -36,10 +34,8 @@ class FavoriteWidget implements IIconWidget, IAPIWidgetV2, IButtonWidget, IOptio
 	public function __construct(
 		private readonly IL10N $l10n,
 		private readonly IURLGenerator $urlGenerator,
-		private readonly IMimeTypeDetector $mimeTypeDetector,
 		private readonly IUserManager $userManager,
 		private readonly IRootFolder $rootFolder,
-		private readonly IPreview $previewManager,
 	) {
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Replace favorites ID lookup + per-node resolution with bounded file search queries in the Favorites widget and the activity helper.

### What Changes

Previously these code paths:

* loaded favorite file IDs via tags
* resolved nodes one-by-one with `getFirstNodeById()`
* applied limits in PHP 

This PR switches them to use the existing files search stack directly with:

* `favorite = true`
* explicit `limit` / `offset`
* explicit ordering (`mtime DESC`)

### Why

This keeps the work bounded at the query layer and avoids repeated node lookups for small UI surfaces like the dashboard widget and favorites-based activity filtering.

Profiler traces on the dashboard widget showed the old implementation producing repeated filecache lookups per favorite, while the refactored implementation produces a single bounded query.

### Notes

* `Activity\Helper` preserves the existing `FAVORITE_LIMIT` behavior by querying `FAVORITE_LIMIT + 1` and still throwing `"Too many favorites"` if exceeded.
* This also makes favorite ordering deterministic. Previously the order from `getFavorites()` / `getIdsForTag()` was effectively unspecified.

### Folow-up

* A future cleanup could add a shared files-layer helper/API for favorite-node searches so this query construction does not need to be repeated at call sites.
* There may be some opportunity to reduce queries elsewhere in the Activity look-ups used for the UI. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI