### PR TITLE
Fix app name not translated in the title of public pages

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -163,6 +163,8 @@ class TemplateLayout {
 				$page->assign('appid', $appId);
 				$page->assign('bodyid', 'body-public');
 
+				$this->initialState->provideInitialState('core', 'apps', array_values($this->navigationManager->getAll()));
+
 				// Set logo link target
 				$logoUrl = $this->config->getSystemValueString('logo_url', '');
 				$page->assign('logoUrl', $logoUrl);

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -163,7 +163,7 @@ class TemplateLayout {
 				$page->assign('appid', $appId);
 				$page->assign('bodyid', 'body-public');
 
-				$this->initialState->provideInitialState('core', 'apps', array_values($this->navigationManager->getAll()));
+				$this->initialState->provideInitialState('core', 'apps', [$this->navigationManager->get($appId)]);
 
 				// Set logo link target
 				$logoUrl = $this->config->getSystemValueString('logo_url', '');


### PR DESCRIPTION
@nextcloud/vue automatically [adds the localized app name to the page title if a page heading but not an explicit page title is given](https://github.com/nextcloud-libraries/nextcloud-vue/blob/86ccdc621637e1270dde3d15b80e047d010bfba7/src/components/NcAppContent/NcAppContent.vue#L353-L355). The localized app name [is expected to be provided in the `core->apps` initial state](https://github.com/nextcloud-libraries/nextcloud-vue/blob/1a80caa6738a8fbb52ce6570787fc1c7da475fc8/src/utils/appName.ts#L38-L41), but [that was set only when rendering a page as a registered user](https://github.com/nextcloud/server/blob/521bb9432e2c7028db9e7a60763b848899d60a2e/lib/private/TemplateLayout.php#L84). In public pages that data was not provided, so the title contained the app ID rather than the localized app name.

## How to test

- Configure your browser to show pages in German
- Create a link share
- In a private window, open the link to the public share

### Result with this pull request

The title of the page is `Öffentliche Dateifreigabe - Dateien - Nextcloud`

### Result without this pull request

The title of the page is `Öffentliche Dateifreigabe - files - Nextcloud`
