### PR TITLE
fix(UserConfig): cast getTypedValue() result to string in getValueBool()

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3566,6 +3566,11 @@
       <code><![CDATA[$CONFIG]]></code>
     </UndefinedVariable>
   </file>
+  <file src="lib/private/Config/UserConfig.php">
+    <RedundantCast>
+      <code><![CDATA[(string)$this->getTypedValue($userId, $app, $key, $default ? 'true' : 'false', $lazy, ValueType::BOOL)]]></code>
+    </RedundantCast>
+  </file>
   <file src="lib/private/Console/Application.php">
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -705,7 +705,11 @@ class UserConfig implements IUserConfig {
 		bool $default = false,
 		bool $lazy = false,
 	): bool {
-		$b = strtolower($this->getTypedValue($userId, $app, $key, $default ? 'true' : 'false', $lazy, ValueType::BOOL));
+		// The explicit (string) cast guards against a PHP OPcache bug where values passed
+		// by reference across function boundaries can have their type corrupted (e.g. bool
+		// returned as int). Affects PHP 8.x with OPcache enabled; fixed upstream in
+		// https://github.com/php/php-src/pull/21973. Keep until minimum PHP version is bumped.
+		$b = strtolower((string)$this->getTypedValue($userId, $app, $key, $default ? 'true' : 'false', $lazy, ValueType::BOOL));
 		return in_array($b, ['1', 'true', 'yes', 'on']);
 	}
 


### PR DESCRIPTION
* Resolves: #59629

## Summary

PHP 8.4 made passing non-strings to `strtolower()` a fatal `TypeError`. `UserConfig::getValueBool()` calls `strtolower()` directly on the return value of `getTypedValue()`, which can return a non-string under certain conditions. The `(string)` cast prevents the TypeError regardless of what `getTypedValue()` returns.

Verified in production on NC 33.0.2 / PHP 8.4 — LDAP users were getting 500 errors on every authenticated request.

## TODO

- [ ] Investigate the root cause of why `getTypedValue()` returns a non-string (see discussion in #59629)

## Checklist

- [ ] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable — backport to stable33 needed
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI