### PR TITLE
fix: use proper index when deleting mounts

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -522,7 +522,7 @@ class UserMountCache implements IUserMountCache {
 	public function removeMount(string $mountPoint): void {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('mounts')
-			->where($query->expr()->eq('mount_point', $query->createNamedParameter($mountPoint)));
+			->where($query->expr()->eq('mount_point_hash', $query->createNamedParameter(hash('xxh128', $mountPoint))));
 		$query->executeStatement();
 	}
 


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/server/pull/57760 for easier reviews.

Select by path hash instead of full path.