### PR TITLE
fix: fix LazyUserFolder::getMountPoint

### DIFF
--- a/lib/private/Files/Node/LazyUserFolder.php
+++ b/lib/private/Files/Node/LazyUserFolder.php
@@ -70,7 +70,7 @@ class LazyUserFolder extends LazyFolder {
 		if ($this->folder !== null) {
 			return $this->folder->getMountPoint();
 		}
-		$mountPoint = $this->mountManager->find('/' . $this->user->getUID());
+		$mountPoint = $this->mountManager->find($this->path);
 		if (is_null($mountPoint)) {
 			throw new \Exception('No mountpoint for user folder');
 		}


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/server/pull/57760 for easier reviews.

Find the mountpoint for the actual user folder (`/$uid/files`) instead of just `/$uid`.

- While these are usually the same, they aren't always.
- Finding the mounts for `/$uid` triggers a full fs setup for the user, while `/$uid/files` does a proper for-path setup.