### PR TITLE
perf: swap around root_id and mount_path_hash in index

### DIFF
--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -121,7 +121,6 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['storage_id'], 'mounts_storage_index');
 			$table->addIndex(['root_id'], 'mounts_root_index');
 			$table->addIndex(['mount_id'], 'mounts_mount_id_index');
-			$table->addIndex(['user_id', 'root_id', 'mount_point'], 'mounts_user_root_path_index', [], ['lengths' => [null, null, 128]]);
 		} else {
 			$table = $schema->getTable('mounts');
 			if (!$table->hasColumn('mount_id')) {

--- a/core/Migrations/Version33000Date20251209123503.php
+++ b/core/Migrations/Version33000Date20251209123503.php
@@ -39,10 +39,6 @@ class Version33000Date20251209123503 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 32, // xxh128
 			]);
-			if ($table->hasIndex('mounts_user_root_path_index')) {
-				$table->dropIndex('mounts_user_root_path_index');
-			}
-			$table->addUniqueIndex(['user_id', 'root_id', 'mount_point_hash'], 'mounts_user_root_path_index');
 			return $schema;
 		}
 

--- a/core/Migrations/Version34000Date20260415161745.php
+++ b/core/Migrations/Version34000Date20260415161745.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\DropIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+#[AddIndex(table: 'mounts', type: IndexType::UNIQUE)]
+#[DropIndex(table: 'mounts', type: IndexType::UNIQUE)]
+class Version34000Date20260415161745 extends SimpleMigrationStep {
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$changed = false;
+		if ($schema->hasTable('mounts')) {
+			$table = $schema->getTable('mounts');
+
+			if ($table->hasIndex('mounts_user_root_path_index')) {
+				$table->dropIndex('mounts_user_root_path_index');
+				$changed = true;
+			}
+			if (!$table->hasIndex('mounts_user_path_root_index')) {
+				$table->addUniqueIndex(['user_id', 'mount_point_hash', 'root_id'], 'mounts_user_path_root_index');
+				$changed = true;
+			}
+		}
+
+		return $changed ? $schema : null;
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1595,6 +1595,7 @@ return array(
     'OC\\Core\\Migrations\\Version33000Date20251209123503' => $baseDir . '/core/Migrations/Version33000Date20251209123503.php',
     'OC\\Core\\Migrations\\Version33000Date20260126120000' => $baseDir . '/core/Migrations/Version33000Date20260126120000.php',
     'OC\\Core\\Migrations\\Version34000Date20260318095645' => $baseDir . '/core/Migrations/Version34000Date20260318095645.php',
+    'OC\\Core\\Migrations\\Version34000Date20260415161745' => $baseDir . '/core/Migrations/Version34000Date20260415161745.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\ResponseDefinitions' => $baseDir . '/core/ResponseDefinitions.php',
     'OC\\Core\\Service\\CronService' => $baseDir . '/core/Service/CronService.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1636,6 +1636,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version33000Date20251209123503' => __DIR__ . '/../../..' . '/core/Migrations/Version33000Date20251209123503.php',
         'OC\\Core\\Migrations\\Version33000Date20260126120000' => __DIR__ . '/../../..' . '/core/Migrations/Version33000Date20260126120000.php',
         'OC\\Core\\Migrations\\Version34000Date20260318095645' => __DIR__ . '/../../..' . '/core/Migrations/Version34000Date20260318095645.php',
+        'OC\\Core\\Migrations\\Version34000Date20260415161745' => __DIR__ . '/../../..' . '/core/Migrations/Version34000Date20260415161745.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\ResponseDefinitions' => __DIR__ . '/../../..' . '/core/ResponseDefinitions.php',
         'OC\\Core\\Service\\CronService' => __DIR__ . '/../../..' . '/core/Service/CronService.php',


### PR DESCRIPTION
There is currently no place (outside of tests) where we filter by just the user and root_id, but there are places (and more with https://github.com/nextcloud/server/pull/59649) where we filter by just user and mountpoint.

By moving the two columns around in the index we ensure that the index can be better used for those queries.