### PR TITLE
fix(http-client): guard HTTP/2 defaults against unsupported libcurl builds

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -21,6 +21,7 @@ use OCP\Security\IRemoteHostValidator;
 use OCP\ServerVersion;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use function parse_url;
 
@@ -41,30 +42,53 @@ class Client implements IClient {
 	}
 
 	private function buildRequestOptions(array $options): array {
-		$proxy = $this->getProxyUri();
-
 		$defaults = [
 			RequestOptions::VERIFY => $this->getCertBundle(),
 			RequestOptions::TIMEOUT => IClient::DEFAULT_REQUEST_TIMEOUT,
 			// Prefer HTTP/2 globally (PSR-7 request version)
 			RequestOptions::VERSION => '2.0',
+			'curl' => [
+				\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_2TLS,
+			],
 		];
-		$defaults['curl'][\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2TLS;
 
-		$options['nextcloud']['allow_local_address'] = $this->isLocalAddressAllowed($options);
-		if ($options['nextcloud']['allow_local_address'] === false) {
-			$onRedirectFunction = function (
-				\Psr\Http\Message\RequestInterface $request,
-				\Psr\Http\Message\ResponseInterface $response,
-				\Psr\Http\Message\UriInterface $uri,
-			) use ($options): void {
-				$this->preventLocalAddress($uri->__toString(), $options);
-			};
+		$this->applyLocalAddressProtection($defaults, $options);
+		$this->applyProxyOption($defaults);
 
-			$defaults[RequestOptions::ALLOW_REDIRECTS] = [
-				'on_redirect' => $onRedirectFunction
-			];
+		$options = array_merge($defaults, $options);
+		$options[RequestOptions::HEADERS] ??= [];
+
+		$this->ensureDefaultUserAgent($options);
+		$this->ensureDefaultAcceptEncoding($options);
+		$this->normalizeLegacySaveToOption($options);
+
+		return $options;
+	}
+
+	/**
+	 * Propagate local-address policy into request options and validate redirect targets.
+	 */
+	private function applyLocalAddressProtection(array &$defaults, array &$options): void {
+		$allowLocalAddress = $this->isLocalAddressAllowed($options);
+		$options['nextcloud']['allow_local_address'] = $allowLocalAddress;
+
+		if ($allowLocalAddress) {
+			return;
 		}
+
+		$defaults[RequestOptions::ALLOW_REDIRECTS] = [
+			'on_redirect' => function (
+				RequestInterface $_request,
+				ResponseInterface $_response,
+				UriInterface $uri,
+			) use ($options): void {
+				$this->preventLocalAddress((string)$uri, $options);
+			},
+		];
+	}
+
+	private function applyProxyOption(array &$defaults): void {
+		$proxy = $this->getProxyUri();
 
 		// Only add RequestOptions::PROXY if Nextcloud is explicitly
 		// configured to use a proxy. This is needed in order not to override
@@ -72,36 +96,46 @@ class Client implements IClient {
 		if ($proxy !== null) {
 			$defaults[RequestOptions::PROXY] = $proxy;
 		}
+	}
 
-		$options = array_merge($defaults, $options);
-
-		if (!isset($options[RequestOptions::HEADERS]['User-Agent'])) {
-			$userAgent = 'Nextcloud-Server-Crawler/' . $this->serverVersion->getVersionString();
-			$overwriteCliUrl = $this->config->getSystemValueString('overwrite.cli.url');
-			if ($this->config->getSystemValueBool('http_client_add_user_agent_url') && !empty($overwriteCliUrl)) {
-				$userAgent .= '; +' . rtrim($overwriteCliUrl, '/');
-			}
-			$options[RequestOptions::HEADERS]['User-Agent'] = $userAgent;
+	private function ensureDefaultUserAgent(array &$options): void {
+		if (isset($options[RequestOptions::HEADERS]['User-Agent'])) {
+			return;
 		}
 
-		// Ensure headers array exists and set Accept-Encoding only if not present
-		$headers = $options[RequestOptions::HEADERS] ?? [];
-		if (!isset($headers['Accept-Encoding'])) {
-			$acceptEnc = 'gzip';
-			if (function_exists('brotli_uncompress')) {
-				$acceptEnc = 'br, ' . $acceptEnc;
-			}
-			$options[RequestOptions::HEADERS] = $headers; // ensure headers are present
-			$options[RequestOptions::HEADERS]['Accept-Encoding'] = $acceptEnc;
+		$userAgent = 'Nextcloud-Server-Crawler/' . $this->serverVersion->getVersionString();
+		$overwriteCliUrl = $this->config->getSystemValueString('overwrite.cli.url');
+		$addUrl = !empty($overwriteCliUrl) && $this->config->getSystemValueBool('http_client_add_user_agent_url', false);
+
+		// Optionally append the instance URL to the crawler user agent.
+		if ($addUrl) {
+			$userAgent .= '; +' . rtrim($overwriteCliUrl, '/');
 		}
 
-		// Fallback for save_to
-		if (isset($options['save_to'])) {
-			$options['sink'] = $options['save_to'];
-			unset($options['save_to']);
+		$options[RequestOptions::HEADERS]['User-Agent'] = $userAgent;
+	}
+
+	private function ensureDefaultAcceptEncoding(array &$options): void {
+		if (isset($options[RequestOptions::HEADERS]['Accept-Encoding'])) {
+			return;
 		}
 
-		return $options;
+		$acceptEncoding = 'gzip';
+		if (function_exists('brotli_uncompress')) {
+			$acceptEncoding = 'br, ' . $acceptEncoding;
+		}
+
+		$options[RequestOptions::HEADERS]['Accept-Encoding'] = $acceptEncoding;
+	}
+
+	private function normalizeLegacySaveToOption(array &$options): void {
+		if (!isset($options['save_to'])) {
+			return;
+		}
+
+		// Support legacy 'save_to' by mapping it to Guzzle's 'sink'.
+		$options['sink'] = $options['save_to'];
+		unset($options['save_to']);
 	}
 
 	private function getCertBundle(): string {
@@ -155,7 +189,7 @@ class Client implements IClient {
 		return $proxy;
 	}
 
-	private function isLocalAddressAllowed(array $options) : bool {
+	private function isLocalAddressAllowed(array $options): bool {
 		if (($options['nextcloud']['allow_local_address'] ?? false)
 			|| $this->config->getSystemValueBool('allow_local_remote_servers', false)) {
 			return true;

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -45,13 +45,9 @@ class Client implements IClient {
 		$defaults = [
 			RequestOptions::VERIFY => $this->getCertBundle(),
 			RequestOptions::TIMEOUT => IClient::DEFAULT_REQUEST_TIMEOUT,
-			// Prefer HTTP/2 globally (PSR-7 request version)
-			RequestOptions::VERSION => '2.0',
-			'curl' => [
-				\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_2TLS,
-			],
 		];
 
+		$this->applyHttp2Defaults($defaults);
 		$this->applyLocalAddressProtection($defaults, $options);
 		$this->applyProxyOption($defaults);
 
@@ -136,6 +132,35 @@ class Client implements IClient {
 		// Support legacy 'save_to' by mapping it to Guzzle's 'sink'.
 		$options['sink'] = $options['save_to'];
 		unset($options['save_to']);
+	}
+
+	private function applyHttp2Defaults(array &$defaults): void {
+		if (!$this->supportsHttp2()) {
+			return;
+		}
+
+		// Prefer HTTP/2 when supported by the local libcurl build.
+		$defaults[RequestOptions::VERSION] = '2.0';
+
+		if (\defined('CURL_HTTP_VERSION_2TLS')) {
+			$defaults['curl'][\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2TLS;
+			return;
+		}
+
+		if (\defined('CURL_HTTP_VERSION_2_0')) {
+			$defaults['curl'][\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2_0;
+		}
+	}
+
+	private function supportsHttp2(): bool {
+		if (!\function_exists('curl_version') || !\defined('CURL_VERSION_HTTP2')) {
+			return false;
+		}
+
+		$curlVersion = \curl_version();
+		$features = $curlVersion['features'] ?? 0;
+
+		return ($features & \CURL_VERSION_HTTP2) === \CURL_VERSION_HTTP2;
 	}
 
 	private function getCertBundle(): string {

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -152,7 +152,7 @@ class Client implements IClient {
 		}
 	}
 
-	private function supportsHttp2(): bool {
+	protected function supportsHttp2(): bool {
 		if (!\function_exists('curl_version') || !\defined('CURL_VERSION_HTTP2')) {
 			return false;
 		}

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -770,7 +770,7 @@ class ClientTest extends \Test\TestCase {
 
 		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
 
-		$this->assertEquals([
+		$expected = [
 			'verify' => '/my/path.crt',
 			'headers' => [
 				'User-Agent' => $userAgent,

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -51,14 +51,37 @@ class ClientTest extends \Test\TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->serverVersion = $this->createMock(ServerVersion::class);
 
-		$this->client = new Client(
-			$this->config,
-			$this->certificateManager,
-			$this->guzzleClient,
-			$this->remoteHostValidator,
-			$this->logger,
-			$this->serverVersion,
-		);
+		$this->client = $this->newClientWithHttp2Support(true);
+	}
+
+	private function newClientWithHttp2Support(bool $supportsHttp2): Client {
+		$client = $this->getMockBuilder(Client::class)
+			->setConstructorArgs([
+				$this->config,
+				$this->certificateManager,
+				$this->guzzleClient,
+				$this->remoteHostValidator,
+				$this->logger,
+				$this->serverVersion,
+			])
+			->onlyMethods(['supportsHttp2'])
+			->getMock();
+
+		$client->method('supportsHttp2')
+			->willReturn($supportsHttp2);
+
+		return $client;
+	}
+
+	private function addExpectedHttp2Options(array $options): array {
+		$options['version'] = '2.0';
+		$options['curl'] = [
+			\CURLOPT_HTTP_VERSION => \defined('CURL_HTTP_VERSION_2TLS')
+				? \CURL_HTTP_VERSION_2TLS
+				: \CURL_HTTP_VERSION_2_0,
+		];
+
+		return $options;
 	}
 
 	public function testGetProxyUri(): void {
@@ -257,7 +280,9 @@ class ClientTest extends \Test\TestCase {
 		$this->client->delete($uri);
 	}
 
-	private function setUpDefaultRequestOptions(): void {
+	private function setUpDefaultRequestOptions(bool $supportsHttp2 = true): void {
+		$this->client = $this->newClientWithHttp2Support($supportsHttp2);
+
 		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
@@ -288,6 +313,7 @@ class ClientTest extends \Test\TestCase {
 			->willReturn('123.45.6');
 
 		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
+
 		$this->defaultRequestOptions = [
 			'verify' => '/my/path.crt',
 			'proxy' => [
@@ -298,17 +324,16 @@ class ClientTest extends \Test\TestCase {
 
 				'User-Agent' => 'Nextcloud-Server-Crawler/123.45.6',
 				'Accept-Encoding' => $acceptEnc,
-
 			],
 			'timeout' => 30,
 			'nextcloud' => [
 				'allow_local_address' => true,
 			],
-			'version' => '2.0',
-			'curl' => [
-				\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_2TLS,
-			],
 		];
+
+		if ($supportsHttp2) {
+			$this->defaultRequestOptions = $this->addExpectedHttp2Options($this->defaultRequestOptions);
+		}
 	}
 
 	public function testGet(): void {
@@ -468,6 +493,8 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	public function testSetDefaultOptionsWithNotInstalled(): void {
+		$this->client = $this->newClientWithHttp2Support(true);
+
 		$this->config
 			->expects($this->exactly(3))
 			->method('getSystemValueBool')
@@ -483,6 +510,7 @@ class ClientTest extends \Test\TestCase {
 				['proxy', '', ''],
 				['overwrite.cli.url', '', ''],
 			]);
+
 		$this->certificateManager
 			->expects($this->never())
 			->method('listCertificates');
@@ -496,7 +524,7 @@ class ClientTest extends \Test\TestCase {
 
 		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
 
-		$this->assertEquals([
+		$expected = [
 			'verify' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',
 			'headers' => [
 				'User-Agent' => 'Nextcloud-Server-Crawler/123.45.6',
@@ -514,14 +542,16 @@ class ClientTest extends \Test\TestCase {
 				): void {
 				},
 			],
-			'version' => '2.0',
-			'curl' => [
-				\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_2TLS,
-			],
-		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
+		];
+		
+		$expected = $this->addExpectedHttp2Options($expected);
+
+		$this->assertEquals($expected, self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
 	}
 
 	public function testSetDefaultOptionsWithProxy(): void {
+		$this->client = $this->newClientWithHttp2Support(true);
+
 		$this->config
 			->expects($this->exactly(3))
 			->method('getSystemValueBool')
@@ -543,6 +573,7 @@ class ClientTest extends \Test\TestCase {
 				['proxyuserpwd', '', ''],
 				['overwrite.cli.url', '', ''],
 			]);
+
 		$this->certificateManager
 			->expects($this->once())
 			->method('getAbsoluteBundlePath')
@@ -554,7 +585,7 @@ class ClientTest extends \Test\TestCase {
 
 		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
 
-		$this->assertEquals([
+		$expected = [
 			'verify' => '/my/path.crt',
 			'proxy' => [
 				'http' => 'foo',
@@ -576,14 +607,16 @@ class ClientTest extends \Test\TestCase {
 				): void {
 				},
 			],
-			'version' => '2.0',
-			'curl' => [
-				\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_2TLS,
-			],
-		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
+		];
+
+		$expected = $this->addExpectedHttp2Options($expected);
+
+		$this->assertEquals($expected, self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
 	}
 
 	public function testSetDefaultOptionsWithProxyAndExclude(): void {
+		$this->client = $this->newClientWithHttp2Support(true);
+
 		$this->config
 			->expects($this->exactly(3))
 			->method('getSystemValueBool')
@@ -605,6 +638,7 @@ class ClientTest extends \Test\TestCase {
 				['proxyuserpwd', '', ''],
 				['overwrite.cli.url', '', ''],
 			]);
+
 		$this->certificateManager
 			->expects($this->once())
 			->method('getAbsoluteBundlePath')
@@ -616,7 +650,7 @@ class ClientTest extends \Test\TestCase {
 
 		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
 
-		$this->assertEquals([
+		$expected = [
 			'verify' => '/my/path.crt',
 			'proxy' => [
 				'http' => 'foo',
@@ -639,11 +673,63 @@ class ClientTest extends \Test\TestCase {
 				): void {
 				},
 			],
-			'version' => '2.0',
-			'curl' => [
-				\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_2TLS,
+		];
+
+		$expected = $this->addExpectedHttp2Options($expected);
+
+		$this->assertEquals($expected, self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
+	}
+
+	public function testSetDefaultOptionsWithoutHttp2Support(): void {
+		$this->client = $this->newClientWithHttp2Support(false);
+
+		$this->config
+			->expects($this->exactly(3))
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['installed', false, true],
+				['allow_local_remote_servers', false, false],
+				['http_client_add_user_agent_url', false, false],
+			]);
+		$this->config
+			->expects($this->exactly(2))
+			->method('getSystemValueString')
+			->willReturnMap([
+				['proxy', '', ''],
+				['overwrite.cli.url', '', ''],
+			]);
+
+		$this->certificateManager
+			->expects($this->once())
+			->method('getAbsoluteBundlePath')
+			->willReturn('/my/path.crt');
+
+		$this->serverVersion->method('getVersionString')
+			->willReturn('123.45.6');
+
+		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
+
+		$expected = [
+			'verify' => '/my/path.crt',
+			'headers' => [
+				'User-Agent' => 'Nextcloud-Server-Crawler/123.45.6',
+				'Accept-Encoding' => $acceptEnc,
 			],
-		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
+			'timeout' => 30,
+			'nextcloud' => [
+				'allow_local_address' => false,
+			],
+			'allow_redirects' => [
+				'on_redirect' => function (
+					\Psr\Http\Message\RequestInterface $request,
+					\Psr\Http\Message\ResponseInterface $response,
+					\Psr\Http\Message\UriInterface $uri,
+				): void {
+				},
+			],
+		];
+
+		$this->assertEquals($expected, self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
 	}
 
 	public static function dataForTestSetServerUrlInUserAgent(): array {
@@ -655,6 +741,8 @@ class ClientTest extends \Test\TestCase {
 
 	#[DataProvider('dataForTestSetServerUrlInUserAgent')]
 	public function testSetServerUrlInUserAgent(string $url, string $userAgent): void {
+		$this->client = $this->newClientWithHttp2Support(true);
+
 		$this->config
 			->expects($this->exactly(3))
 			->method('getSystemValueBool')
@@ -670,6 +758,7 @@ class ClientTest extends \Test\TestCase {
 				['proxy', '', ''],
 				['overwrite.cli.url', '', $url],
 			]);
+
 		$this->certificateManager
 			->expects($this->once())
 			->method('getAbsoluteBundlePath')
@@ -679,11 +768,13 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
+		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
+
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
 			'headers' => [
 				'User-Agent' => $userAgent,
-				'Accept-Encoding' => 'gzip',
+				'Accept-Encoding' => $acceptEnc,
 			],
 			'timeout' => 30,
 			'nextcloud' => [
@@ -697,10 +788,10 @@ class ClientTest extends \Test\TestCase {
 				): void {
 				},
 			],
-			'version' => '2.0',
-			'curl' => [
-				\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_2TLS,
-			],
-		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
+		];
+
+		$expected = $this->addExpectedHttp2Options($expected);
+
+		$this->assertEquals($expected, self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
 	}
 }

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -496,7 +496,6 @@ class ClientTest extends \Test\TestCase {
 		$this->client = $this->newClientWithHttp2Support(true);
 
 		$this->config
-			->expects($this->exactly(3))
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['installed', false, false],
@@ -553,7 +552,6 @@ class ClientTest extends \Test\TestCase {
 		$this->client = $this->newClientWithHttp2Support(true);
 
 		$this->config
-			->expects($this->exactly(3))
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['installed', false, true],
@@ -618,7 +616,6 @@ class ClientTest extends \Test\TestCase {
 		$this->client = $this->newClientWithHttp2Support(true);
 
 		$this->config
-			->expects($this->exactly(3))
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['installed', false, true],
@@ -684,7 +681,6 @@ class ClientTest extends \Test\TestCase {
 		$this->client = $this->newClientWithHttp2Support(false);
 
 		$this->config
-			->expects($this->exactly(3))
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['installed', false, true],
@@ -744,7 +740,6 @@ class ClientTest extends \Test\TestCase {
 		$this->client = $this->newClientWithHttp2Support(true);
 
 		$this->config
-			->expects($this->exactly(3))
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['installed', false, true],

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -543,7 +543,7 @@ class ClientTest extends \Test\TestCase {
 				},
 			],
 		];
-		
+
 		$expected = $this->addExpectedHttp2Options($expected);
 
 		$this->assertEquals($expected, self::invokePrivate($this->client, 'buildRequestOptions', [[]]));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #58528 <!-- related github issue -->

## Summary

Only enable HTTP/2 defaults when local libcurl supports HTTP/2. Also refactors `buildRequestOptions()` into smaller helpers.

### Motivation

Improve readability of the request option setup and fix #58528, where HTTP/2 defaults can break setups with libcurl builds that do not support HTTP/2.

### What changed

- extract request option setup into smaller private helpers
- simplify proxy, header, redirect, and legacy option handling
- only set `RequestOptions::VERSION` and curl HTTP/2 options when libcurl supports HTTP/2
- update `ClientTest` to cover both HTTP/2-supported and unsupported cases deterministically

### Related

- #55433

### Notes

- First commit is purely refactor
- Second commit is the fix for #58528 
- Balance of commits are test additions/revisions followed by tidying/fixup

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
