### PR TITLE
feat(user_ldap): Add option to check all seen users

### DIFF
--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -11,7 +11,6 @@ use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_Proxy;
-use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -58,6 +57,19 @@ class CheckUser extends Command {
 				InputOption::VALUE_NONE,
 				'sync all seen users instead of only one'
 			)
+			->addOption(
+				'limit',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'limit the number of user to process for --all-seen-users'
+			)
+			->addOption(
+				'offset',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'offset to apply for --all-seen-users',
+				0
+			)
 		;
 	}
 
@@ -70,18 +82,20 @@ class CheckUser extends Command {
 			if ($uid !== null) {
 				return $this->checkUser($input, $output, $uid);
 			} elseif ($input->getOption('all-seen-users')) {
-				$this->userManager->callForSeenUsers(
-					function (IUser $user) use ($input, $output): true {
-						try {
-							$output->writeln('<info>Checking ' . $user->getUID() . '…</info>', OutputInterface::VERBOSITY_VERBOSE);
-							$this->checkUser($input, $output, $user->getUID());
-						} catch (\Exception $e) {
-							$output->writeln('<error> ' . $user->getUID() . ': ' . $e->getMessage() . '</error>');
-						}
-						/* Always continue */
-						return true;
+				$offset = (int)$input->getOption('offset');
+				$limit = $input->getOption('limit');
+				if ($limit !== null) {
+					$limit = (int)$limit;
+				}
+				$userIterator = $this->userManager->getSeenUsers($offset, $limit);
+				foreach ($userIterator as $user) {
+					try {
+						$output->writeln('<info>Checking ' . $user->getUID() . '…</info>', OutputInterface::VERBOSITY_VERBOSE);
+						$this->checkUser($input, $output, $user->getUID());
+					} catch (\Exception $e) {
+						$output->writeln('<error> ' . $user->getUID() . ': ' . $e->getMessage() . '</error>');
 					}
-				);
+				}
 				$output->writeln('<info>Finished checking all seen users.</info>', OutputInterface::VERBOSITY_VERBOSE);
 				return self::SUCCESS;
 			} else {

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -11,6 +11,8 @@ use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_Proxy;
+use OCP\IUser;
+use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,6 +25,7 @@ class CheckUser extends Command {
 		protected Helper $helper,
 		protected DeletedUsersIndex $dui,
 		protected UserMapping $mapping,
+		protected IUserManager $userManager,
 	) {
 		parent::__construct();
 	}
@@ -34,7 +37,7 @@ class CheckUser extends Command {
 			->setDescription('checks whether a user exists on LDAP.')
 			->addArgument(
 				'ocName',
-				InputArgument::REQUIRED,
+				InputArgument::OPTIONAL,
 				'the user name as used in Nextcloud, or the LDAP DN'
 			)
 			->addOption(
@@ -49,6 +52,12 @@ class CheckUser extends Command {
 				InputOption::VALUE_NONE,
 				'syncs values from LDAP'
 			)
+			->addOption(
+				'all-seen-users',
+				null,
+				InputOption::VALUE_NONE,
+				'sync all seen users instead of only one'
+			)
 		;
 	}
 
@@ -57,35 +66,59 @@ class CheckUser extends Command {
 		try {
 			$this->assertAllowed($input->getOption('force'));
 			$uid = $input->getArgument('ocName');
-			if ($this->backend->getLDAPAccess($uid)->stringResemblesDN($uid)) {
-				$username = $this->backend->dn2UserName($uid);
-				if ($username !== false) {
-					$uid = $username;
-				}
-			}
-			$wasMapped = $this->userWasMapped($uid);
-			$exists = $this->backend->userExistsOnLDAP($uid, true);
-			if ($exists === true) {
-				$output->writeln('The user is still available on LDAP.');
-				if ($input->getOption('update')) {
-					$this->updateUser($uid, $output);
-				}
-				return self::SUCCESS;
-			}
 
-			if ($wasMapped) {
-				$this->dui->markUser($uid);
-				$output->writeln('The user does not exists on LDAP anymore.');
-				$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
-					. $uid . '"');
+			if ($uid !== null) {
+				return $this->checkUser($input, $output, $uid);
+			} elseif ($input->getOption('all-seen-users')) {
+				$this->userManager->callForSeenUsers(
+					function (IUser $user) use ($input, $output): true {
+						try {
+							$output->writeln('<info>Checking ' . $user->getUID() . '…</info>', OutputInterface::VERBOSITY_VERBOSE);
+							$this->checkUser($input, $output, $user->getUID());
+						} catch (\Exception $e) {
+							$output->writeln('<error> ' . $user->getUID() . ': ' . $e->getMessage() . '</error>');
+						}
+						/* Always continue */
+						return true;
+					}
+				);
+				$output->writeln('<info>Finished checking all seen users.</info>', OutputInterface::VERBOSITY_VERBOSE);
 				return self::SUCCESS;
+			} else {
+				throw new \InvalidArgumentException('Either a user name or --all-seen-users is required');
 			}
-
-			throw new \Exception('The given user is not a recognized LDAP user.');
 		} catch (\Exception $e) {
 			$output->writeln('<error>' . $e->getMessage() . '</error>');
 			return self::FAILURE;
 		}
+	}
+
+	private function checkUser(InputInterface $input, OutputInterface $output, string $uid): int {
+		if ($this->backend->getLDAPAccess($uid)->stringResemblesDN($uid)) {
+			$username = $this->backend->dn2UserName($uid);
+			if ($username !== false) {
+				$uid = $username;
+			}
+		}
+		$wasMapped = $this->userWasMapped($uid);
+		$exists = $this->backend->userExistsOnLDAP($uid, true);
+		if ($exists === true) {
+			$output->writeln('The user is still available on LDAP.');
+			if ($input->getOption('update')) {
+				$this->updateUser($uid, $output);
+			}
+			return self::SUCCESS;
+		}
+
+		if ($wasMapped) {
+			$this->dui->markUser($uid);
+			$output->writeln('The user does not exists on LDAP anymore.');
+			$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
+				. $uid . '"');
+			return self::SUCCESS;
+		}
+
+		throw new \Exception('The given user is not a recognized LDAP user.');
 	}
 
 	/**

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -11,6 +11,8 @@ use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_Proxy;
+use OCP\IUser;
+use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,6 +25,7 @@ class CheckUser extends Command {
 		protected Helper $helper,
 		protected DeletedUsersIndex $dui,
 		protected UserMapping $mapping,
+		protected IUserManager $userManager,
 	) {
 		parent::__construct();
 	}
@@ -33,7 +36,7 @@ class CheckUser extends Command {
 			->setDescription('checks whether a user exists on LDAP.')
 			->addArgument(
 				'ocName',
-				InputArgument::REQUIRED,
+				InputArgument::OPTIONAL,
 				'the user name as used in Nextcloud, or the LDAP DN'
 			)
 			->addOption(
@@ -48,6 +51,12 @@ class CheckUser extends Command {
 				InputOption::VALUE_NONE,
 				'syncs values from LDAP'
 			)
+			->addOption(
+				'all-seen-users',
+				null,
+				InputOption::VALUE_NONE,
+				'sync all seen users instead of only one'
+			)
 		;
 	}
 
@@ -55,35 +64,59 @@ class CheckUser extends Command {
 		try {
 			$this->assertAllowed($input->getOption('force'));
 			$uid = $input->getArgument('ocName');
-			if ($this->backend->getLDAPAccess($uid)->stringResemblesDN($uid)) {
-				$username = $this->backend->dn2UserName($uid);
-				if ($username !== false) {
-					$uid = $username;
-				}
-			}
-			$wasMapped = $this->userWasMapped($uid);
-			$exists = $this->backend->userExistsOnLDAP($uid, true);
-			if ($exists === true) {
-				$output->writeln('The user is still available on LDAP.');
-				if ($input->getOption('update')) {
-					$this->updateUser($uid, $output);
-				}
-				return self::SUCCESS;
-			}
 
-			if ($wasMapped) {
-				$this->dui->markUser($uid);
-				$output->writeln('The user does not exists on LDAP anymore.');
-				$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
-					. $uid . '"');
+			if ($uid !== null) {
+				return $this->checkUser($input, $output, $uid);
+			} elseif ($input->getOption('all-seen-users')) {
+				$this->userManager->callForSeenUsers(
+					function (IUser $user) use ($input, $output): true {
+						try {
+							$output->writeln('<info>Checking ' . $user->getUID() . '…</info>', OutputInterface::VERBOSITY_VERBOSE);
+							$this->checkUser($input, $output, $user->getUID());
+						} catch (\Exception $e) {
+							$output->writeln('<error> ' . $user->getUID() . ': ' . $e->getMessage() . '</error>');
+						}
+						/* Always continue */
+						return true;
+					}
+				);
+				$output->writeln('<info>Finished checking all seen users.</info>', OutputInterface::VERBOSITY_VERBOSE);
 				return self::SUCCESS;
+			} else {
+				throw new \InvalidArgumentException('Either a user name or --all-seen-users is required');
 			}
-
-			throw new \Exception('The given user is not a recognized LDAP user.');
 		} catch (\Exception $e) {
 			$output->writeln('<error>' . $e->getMessage() . '</error>');
 			return self::FAILURE;
 		}
+	}
+
+	private function checkUser(InputInterface $input, OutputInterface $output, string $uid): int {
+		if ($this->backend->getLDAPAccess($uid)->stringResemblesDN($uid)) {
+			$username = $this->backend->dn2UserName($uid);
+			if ($username !== false) {
+				$uid = $username;
+			}
+		}
+		$wasMapped = $this->userWasMapped($uid);
+		$exists = $this->backend->userExistsOnLDAP($uid, true);
+		if ($exists === true) {
+			$output->writeln('The user is still available on LDAP.');
+			if ($input->getOption('update')) {
+				$this->updateUser($uid, $output);
+			}
+			return self::SUCCESS;
+		}
+
+		if ($wasMapped) {
+			$this->dui->markUser($uid);
+			$output->writeln('The user does not exists on LDAP anymore.');
+			$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
+				. $uid . '"');
+			return self::SUCCESS;
+		}
+
+		throw new \Exception('The given user is not a recognized LDAP user.');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This can be useful in some situations to sync all seen users with --update
- [x] Add a limit

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
