### PR TITLE
Restore missing apps on upgrade

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -23,6 +23,7 @@ use OC\Repair\Events\RepairInfoEvent;
 use OC\Repair\Events\RepairStartEvent;
 use OC\Repair\Events\RepairStepEvent;
 use OC\Repair\Events\RepairWarningEvent;
+use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -391,6 +392,8 @@ class Updater extends BasicEmitter {
 				$this->emit('\OC\Updater', 'checkAppStoreApp', [$app]);
 
 				if (isset($previousEnableStates[$app])) {
+					$this->restoreMissingAppStoreApp($app);
+
 					if (!empty($previousEnableStates[$app]) && is_array($previousEnableStates[$app])) {
 						$this->appManager->enableAppForGroups($app, $previousEnableStates[$app]);
 					} elseif ($previousEnableStates[$app] === 'yes') {
@@ -402,6 +405,17 @@ class Updater extends BasicEmitter {
 					'exception' => $ex,
 				]);
 			}
+		}
+	}
+
+	private function restoreMissingAppStoreApp(string $appId): void {
+		try {
+			$this->appManager->getAppPath($appId, true);
+		} catch (AppPathNotFoundException) {
+			// the app was not found locally but we know it was previously enabled
+			// so we automatically download it from the appstore and run its missing migrations
+			$this->installer->downloadApp($appId);
+			$this->installer->installApp($appId);
 		}
 	}
 

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -11,6 +11,7 @@ namespace Test;
 use OC\Installer;
 use OC\IntegrityCheck\Checker;
 use OC\Updater;
+use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use OCP\IConfig;
@@ -106,5 +107,37 @@ class UpdaterTest extends TestCase {
 			->willReturn($vendor);
 
 		$this->assertSame($result, $this->updater->isUpgradePossible($oldVersion, $newVersion, $allowedVersions));
+	}
+
+	public function testUpgradeAppStoreAppsRestoresMissingAutoDisabledAppBeforeEnabling(): void {
+		$this->installer->expects($this->once())
+			->method('isUpdateAvailable')
+			->with('mailroundcube')
+			->willReturn(false);
+
+		$this->installer->expects($this->once())
+			->method('downloadApp')
+			->with('mailroundcube');
+
+		$this->installer->expects($this->once())
+			->method('installApp')
+			->with('mailroundcube');
+
+		$this->appManager->expects($this->once())
+			->method('getAppPath')
+			->with('mailroundcube', true)
+			->willThrowException(new AppPathNotFoundException('missing'));
+
+		$this->appManager->expects($this->once())
+			->method('enableApp')
+			->with('mailroundcube');
+
+		$this->appManager->expects($this->never())
+			->method('enableAppForGroups');
+
+		self::invokePrivate($this->updater, 'upgradeAppStoreApps', [
+			['mailroundcube'],
+			['mailroundcube' => 'yes'],
+		]);
 	}
 }


### PR DESCRIPTION
## Summary

When updating Nextcloud, if an app folder is missing, Nextcloud used to download the app again but now it does not.

This makes sure an app that was previously enabled and cannot be found on the filesystem while updating NC will get downloaded and enabled.

This issue was introduced by https://github.com/nextcloud/server/pull/53895 which was included in NC 32. So we need to backport to 33 and 32.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
