### PR TITLE
fix(apps): filter autoloading registration by app type in loadApps

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -256,7 +256,7 @@ class AppManager implements IAppManager {
 		// Add each apps' folder as allowed class path
 		foreach ($apps as $app) {
 			// If the app is already loaded then autoloading it makes no sense
-			if (!$this->isAppLoaded($app)) {
+			if (!$this->isAppLoaded($app) && ($types === [] || $this->isType($app, $types))) {
 				try {
 					$path = $this->getAppPath($app);
 					\OC_App::registerAutoloading($app, $path);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Make `loadApps(array $types = [])` apply the `$types` filter consistently to both code paths.

Previously, the initial autoloader-registration loop ignored `$types` and touched all enabled apps, while the later `loadApp()` loop only loaded matching app types. Since `loadApp()` already handles autoloader registration itself, this broad pre-registration was inconsistent with the method contract and appears redundant for filtered loads. PHP CI also passed with the `$types` filter applied.

### Context

I couldn’t find evidence that `loadApps()` must pre-register autoloaders for non-target app types; `loadApp()` and `Coordinator` already register autoloading per app. At best, this looks like historical baggage rather than part of the documented contract.

To stay conservative in case there are hidden cross-app assumptions (that aren't already addressed in other ways), this change only applies the `$types` filter to the first loop for now, rather than removing that loop entirely.

### Testing

- PHP CI passed with the `$types` filter applied to the autoloader-registration loop.

### Notes

* This appears safe for both `IBootstrap` and non-`IBootstrap` apps.
* Possible follow-up: remove the remaining redundant pre-registration loop entirely.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
