### PR TITLE
feat: allow setting custom login-name for occ generated app password

### DIFF
--- a/core/Command/User/AuthTokens/Add.php
+++ b/core/Command/User/AuthTokens/Add.php
@@ -55,6 +55,12 @@ class Add extends Command {
 				InputOption::VALUE_REQUIRED,
 				'Name for the app password, defaults to "cli".'
 			)
+			->addOption(
+				'login-name',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Optional login-name, defaults to UID'
+			)
 		;
 	}
 
@@ -89,13 +95,15 @@ class Add extends Command {
 			$output->writeln('<info>No password provided. The generated app password will therefore have limited capabilities. Any operation that requires the login password will fail.</info>');
 		}
 
+		$loginName = $input->getOption('login-name') ?? $user->getUID();
+
 		$tokenName = $input->getOption('name') ?: 'cli';
 
 		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 		$generatedToken = $this->tokenProvider->generateToken(
 			$token,
 			$user->getUID(),
-			$user->getUID(),
+			$loginName,
 			$password,
 			$tokenName,
 			IToken::PERMANENT_TOKEN,


### PR DESCRIPTION
## Summary

added the option to set the login_name for auth-tokens created with occ

For example, this can be helpful if you want to automatically integrate CalDAV and CardDAV resources in Thunderbird. See: [https://help.nextcloud.com/t/use-mailaddress-instead-of-userid-with-app-password/243247](https://help.nextcloud.com/t/use-mailaddress-instead-of-userid-with-app-password/243247)

## Example
occ user:add-app-password testuser --login-name=testuser@domain.tld


