### PR TITLE
fix(setup-check): 'occured' -> 'occurred' in SetupCheckManager error message

### DIFF
--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -33,7 +33,7 @@ class SetupCheckManager implements ISetupCheckManager {
 			try {
 				$setupResult = $setupCheckObject->run();
 			} catch (\Throwable $t) {
-				$setupResult = SetupResult::error("An exception occured while running the setup check:\n$t");
+				$setupResult = SetupResult::error("An exception occurred while running the setup check:\n$t");
 				$this->logger->error('Exception running check ' . get_class($setupCheckObject) . ': ' . $t->getMessage(), ['exception' => $t]);
 			}
 			$setupResult->setName($setupCheckObject->getName());


### PR DESCRIPTION
Error message in `lib/private/SetupCheck/SetupCheckManager.php` line 36 reads 'An exception occured while running the setup check'. This error message is surfaced to admins when a setup check throws. Fixed to 'occurred'. String-literal-only change.