### PR TITLE
debt(users): Make User object constructor argument mandatory

### DIFF
--- a/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
@@ -7,16 +7,16 @@
  */
 namespace OCA\Files_External\Tests\Controller;
 
-use OC\User\User;
 use OCA\Files_External\Controller\GlobalStoragesController;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\GlobalStoragesService;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class GlobalStoragesControllerTest extends StoragesControllerTestCase {
@@ -33,9 +33,9 @@ class GlobalStoragesControllerTest extends StoragesControllerTestCase {
 
 	private function createController(bool $allowCreateLocal = true): GlobalStoragesController {
 		$session = $this->createMock(IUserSession::class);
+		$userManager = Server::get(IUserManager::class);
 		$session->method('getUser')
-			->willReturn(new User('test', null, $this->createMock(IEventDispatcher::class)));
-
+			->willReturn($userManager->getUserObject('test', null, false));
 		$config = $this->createMock(IConfig::class);
 		$config->method('getSystemValue')
 			->with('files_external_allow_create_new_local', true)

--- a/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
@@ -7,16 +7,17 @@
  */
 namespace OCA\Files_External\Tests\Controller;
 
-use OC\User\User;
 use OCA\Files_External\Controller\GlobalStoragesController;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\GlobalStoragesService;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
+use OCP\UserInterface;
 use Psr\Log\LoggerInterface;
 
 class GlobalStoragesControllerTest extends StoragesControllerTestCase {
@@ -33,9 +34,10 @@ class GlobalStoragesControllerTest extends StoragesControllerTestCase {
 
 	private function createController(bool $allowCreateLocal = true): GlobalStoragesController {
 		$session = $this->createMock(IUserSession::class);
+		$userManager = Server::get(IUserManager::class);
+		$userBackend = $this->getMockBuilder(UserInterface::class)->getMock();
 		$session->method('getUser')
-			->willReturn(new User('test', null, $this->createMock(IEventDispatcher::class)));
-
+			->willReturn($userManager->getUserObject('test', $userBackend));
 		$config = $this->createMock(IConfig::class);
 		$config->method('getSystemValue')
 			->with('files_external_allow_create_new_local', true)

--- a/apps/files_external/tests/Controller/UserStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/UserStoragesControllerTest.php
@@ -8,28 +8,22 @@ declare(strict_types=1);
  */
 namespace OCA\Files_External\Tests\Controller;
 
-use OC\User\User;
 use OCA\Files_External\Controller\UserStoragesController;
 use OCA\Files_External\Lib\Storage\SMB;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\AppFramework\Http;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class UserStoragesControllerTest extends StoragesControllerTestCase {
-
-	/**
-	 * @var array
-	 */
-	private array $oldAllowedBackends;
-
 	protected function setUp(): void {
 		parent::setUp();
 		$this->service = $this->createMock(UserStoragesService::class);
@@ -42,9 +36,9 @@ class UserStoragesControllerTest extends StoragesControllerTestCase {
 
 	private function createController(bool $allowCreateLocal = true) {
 		$session = $this->createMock(IUserSession::class);
+		$userManager = Server::get(IUserManager::class);
 		$session->method('getUser')
-			->willReturn(new User('test', null, $this->createMock(IEventDispatcher::class)));
-
+			->willReturn($userManager->getUserObject('test', null, false));
 		$config = $this->createMock(IConfig::class);
 		$config->method('getSystemValue')
 			->with('files_external_allow_create_new_local', true)

--- a/apps/files_external/tests/Controller/UserStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/UserStoragesControllerTest.php
@@ -8,19 +8,20 @@ declare(strict_types=1);
  */
 namespace OCA\Files_External\Tests\Controller;
 
-use OC\User\User;
 use OCA\Files_External\Controller\UserStoragesController;
 use OCA\Files_External\Lib\Storage\SMB;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\AppFramework\Http;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
+use OCP\UserInterface;
 use Psr\Log\LoggerInterface;
 
 class UserStoragesControllerTest extends StoragesControllerTestCase {
@@ -42,9 +43,10 @@ class UserStoragesControllerTest extends StoragesControllerTestCase {
 
 	private function createController(bool $allowCreateLocal = true) {
 		$session = $this->createMock(IUserSession::class);
+		$userManager = Server::get(IUserManager::class);
+		$userBackend = $this->getMockBuilder(UserInterface::class)->getMock();
 		$session->method('getUser')
-			->willReturn(new User('test', null, $this->createMock(IEventDispatcher::class)));
-
+			->willReturn($userManager->getUserObject('test', $userBackend));
 		$config = $this->createMock(IConfig::class);
 		$config->method('getSystemValue')
 			->with('files_external_allow_create_new_local', true)

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -12,9 +12,9 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroupManager;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -37,8 +37,9 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 
 		$this->globalStoragesService = $this->service;
 
-		$this->user = new User(self::USER_ID, null, Server::get(IEventDispatcher::class));
-		/** @var IUserSession&MockObject $userSession */
+		$userManager = Server::get(IUserManager::class);
+		$this->user = $userManager->getUserObject(self::USER_ID, null, false);
+
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession
 			->expects($this->any())

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -12,11 +12,12 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroupManager;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
+use OCP\UserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
 
@@ -37,8 +38,10 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 
 		$this->globalStoragesService = $this->service;
 
-		$this->user = new User(self::USER_ID, null, Server::get(IEventDispatcher::class));
-		/** @var IUserSession&MockObject $userSession */
+		$userManager = Server::get(IUserManager::class);
+		$userBackend = $this->getMockBuilder(UserInterface::class)->getMock();
+		$this->user = $userManager->getUserObject(self::USER_ID, $userBackend);
+
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession
 			->expects($this->any())

--- a/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php
+++ b/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php
@@ -10,12 +10,9 @@ namespace OC\User\BackgroundJobs;
 
 use OC\User\Manager;
 use OC\User\PartiallyDeletedUsersBackend;
-use OC\User\User;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
-use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class CleanupDeletedUsers extends TimedJob {
@@ -48,13 +45,7 @@ class CleanupDeletedUsers extends TimedJob {
 			}
 
 			try {
-				$user = new User(
-					$userId,
-					$backend,
-					Server::get(IEventDispatcher::class),
-					$this->userManager,
-					$this->config,
-				);
+				$user = $this->userManager->getUserObject($userId, $backend, false);
 				$user->delete();
 				$this->logger->info('Cleaned up deleted user {userId}', ['userId' => $userId]);
 			} catch (\Throwable $error) {

--- a/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php
+++ b/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php
@@ -10,12 +10,9 @@ namespace OC\User\BackgroundJobs;
 
 use OC\User\Manager;
 use OC\User\PartiallyDeletedUsersBackend;
-use OC\User\User;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
-use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class CleanupDeletedUsers extends TimedJob {
@@ -47,13 +44,7 @@ class CleanupDeletedUsers extends TimedJob {
 			}
 
 			try {
-				$user = new User(
-					$userId,
-					$backend,
-					Server::get(IEventDispatcher::class),
-					$this->userManager,
-					$this->config,
-				);
+				$user = $this->userManager->getUserObject($userId, $backend, false);
 				$user->delete();
 				$this->logger->info('Cleaned up deleted user {userId}', ['userId' => $userId]);
 			} catch (\Throwable $error) {

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -19,6 +19,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\IUserManager;
@@ -112,12 +113,6 @@ class Manager extends PublicEmitter implements IUserManager {
 		$this->backends = [];
 	}
 
-	/**
-	 * get a user by user id
-	 *
-	 * @param string $uid
-	 * @return User|null Either the user or null if the specified user does not exist
-	 */
 	#[\Override]
 	public function get($uid) {
 		if (is_null($uid) || $uid === '' || $uid === false) {
@@ -160,15 +155,8 @@ class Manager extends PublicEmitter implements IUserManager {
 		return $this->displayNameCache->getDisplayName($uid);
 	}
 
-	/**
-	 * get or construct the user object
-	 *
-	 * @param string $uid
-	 * @param UserInterface $backend
-	 * @param bool $cacheUser If false the newly created user object will not be cached
-	 * @return User
-	 */
-	public function getUserObject($uid, $backend, $cacheUser = true) {
+	#[\Override]
+	public function getUserObject(string $uid, ?UserInterface $backend = null, bool $cacheUser = true): IUser {
 		if ($backend instanceof IGetRealUIDBackend) {
 			$uid = $backend->getRealUID($uid);
 		}
@@ -177,10 +165,20 @@ class Manager extends PublicEmitter implements IUserManager {
 			return $this->cachedUsers[$uid];
 		}
 
-		$user = new User($uid, $backend, $this->eventDispatcher, $this, $this->config);
+		$user = new User(
+			$uid,
+			$backend,
+			$this->eventDispatcher,
+			$this,
+			$this->config,
+			// DI injection is not used here as IURLGenerator needs IUserSession which needs IUserManager.
+			Server::get(IURLGenerator::class),
+		);
+
 		if ($cacheUser) {
 			$this->cachedUsers[$uid] = $user;
 		}
+
 		return $user;
 	}
 
@@ -390,7 +388,6 @@ class Manager extends PublicEmitter implements IUserManager {
 	#[\Override]
 	public function createUser($uid, $password): IUser|false {
 		// DI injection is not used here as IRegistry needs the user manager itself for user count and thus it would create a cyclic dependency
-		/** @var IAssertion $assertion */
 		$assertion = Server::get(IAssertion::class);
 		$assertion->createUserIsLegit();
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -19,6 +19,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\IUserManager;
@@ -108,12 +109,6 @@ class Manager extends PublicEmitter implements IUserManager {
 		$this->backends = [];
 	}
 
-	/**
-	 * get a user by user id
-	 *
-	 * @param string $uid
-	 * @return User|null Either the user or null if the specified user does not exist
-	 */
 	public function get($uid) {
 		if (is_null($uid) || $uid === '' || $uid === false) {
 			return null;
@@ -154,15 +149,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		return $this->displayNameCache->getDisplayName($uid);
 	}
 
-	/**
-	 * get or construct the user object
-	 *
-	 * @param string $uid
-	 * @param UserInterface $backend
-	 * @param bool $cacheUser If false the newly created user object will not be cached
-	 * @return User
-	 */
-	public function getUserObject($uid, $backend, $cacheUser = true) {
+	public function getUserObject(string $uid, UserInterface $backend, bool $cacheUser = true): IUser {
 		if ($backend instanceof IGetRealUIDBackend) {
 			$uid = $backend->getRealUID($uid);
 		}
@@ -171,10 +158,20 @@ class Manager extends PublicEmitter implements IUserManager {
 			return $this->cachedUsers[$uid];
 		}
 
-		$user = new User($uid, $backend, $this->eventDispatcher, $this, $this->config);
+		$user = new User(
+			$uid,
+			$backend,
+			$this->eventDispatcher,
+			$this,
+			$this->config,
+			// DI injection is not used here as IURLGenerator needs IUserSession which needs IUserManager.
+			Server::get(IURLGenerator::class),
+		);
+
 		if ($cacheUser) {
 			$this->cachedUsers[$uid] = $user;
 		}
+
 		return $user;
 	}
 
@@ -377,7 +374,6 @@ class Manager extends PublicEmitter implements IUserManager {
 	 */
 	public function createUser($uid, $password): IUser|false {
 		// DI injection is not used here as IRegistry needs the user manager itself for user count and thus it would create a cyclic dependency
-		/** @var IAssertion $assertion */
 		$assertion = Server::get(IAssertion::class);
 		$assertion->createUserIsLegit();
 

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -50,8 +50,6 @@ use function json_encode;
 class User implements IUser {
 	private const CONFIG_KEY_MANAGERS = 'manager';
 
-	private IConfig $config;
-	private IURLGenerator $urlGenerator;
 	protected ?IAccountManager $accountManager = null;
 
 	private ?string $displayName = null;
@@ -63,15 +61,13 @@ class User implements IUser {
 	private ?IAvatarManager $avatarManager = null;
 
 	public function __construct(
-		private string $uid,
-		private ?UserInterface $backend,
-		private IEventDispatcher $dispatcher,
-		private Emitter|Manager|null $emitter = null,
-		?IConfig $config = null,
-		$urlGenerator = null,
+		private readonly string $uid,
+		private readonly ?UserInterface $backend,
+		private readonly IEventDispatcher $dispatcher,
+		private readonly Emitter|Manager $emitter,
+		private readonly IConfig $config,
+		private readonly IURLGenerator $urlGenerator,
 	) {
-		$this->config = $config ?? Server::get(IConfig::class);
-		$this->urlGenerator = $urlGenerator ?? Server::get(IURLGenerator::class);
 	}
 
 	#[\Override]
@@ -251,10 +247,8 @@ class User implements IUser {
 			return false;
 		}
 
-		if ($this->emitter) {
-			/** @deprecated 21.0.0 use BeforeUserDeletedEvent event with the IEventDispatcher instead */
-			$this->emitter->emit('\OC\User', 'preDelete', [$this]);
-		}
+		/** @deprecated 21.0.0 use BeforeUserDeletedEvent event with the IEventDispatcher instead */
+		$this->emitter->emit('\OC\User', 'preDelete', [$this]);
 		$this->dispatcher->dispatchTyped(new BeforeUserDeletedEvent($this));
 
 		// Set delete flag on the user - this is needed to ensure that the user data is removed if there happen any exception in the backend
@@ -315,10 +309,8 @@ class User implements IUser {
 			throw $e;
 		}
 
-		if ($this->emitter !== null) {
-			/** @deprecated 21.0.0 use UserDeletedEvent event with the IEventDispatcher instead */
-			$this->emitter->emit('\OC\User', 'postDelete', [$this]);
-		}
+		/** @deprecated 21.0.0 use UserDeletedEvent event with the IEventDispatcher instead */
+		$this->emitter->emit('\OC\User', 'postDelete', [$this]);
 		$this->dispatcher->dispatchTyped(new UserDeletedEvent($this));
 
 		// Finally we can unset the delete flag and all other states
@@ -336,9 +328,7 @@ class User implements IUser {
 	#[\Override]
 	public function setPassword($password, $recoveryPassword = null): bool {
 		$this->dispatcher->dispatchTyped(new BeforePasswordUpdatedEvent($this, $password, $recoveryPassword));
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);
-		}
+		$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);
 		if ($this->backend->implementsActions(Backend::SET_PASSWORD)) {
 			/** @var ISetPasswordBackend $backend */
 			$backend = $this->backend;
@@ -346,9 +336,7 @@ class User implements IUser {
 
 			if ($result !== false) {
 				$this->dispatcher->dispatchTyped(new PasswordUpdatedEvent($this, $password, $recoveryPassword));
-				if ($this->emitter) {
-					$this->emitter->emit('\OC\User', 'postSetPassword', [$this, $password, $recoveryPassword]);
-				}
+				$this->emitter->emit('\OC\User', 'postSetPassword', [$this, $password, $recoveryPassword]);
 			}
 
 			return !($result === false);
@@ -676,8 +664,6 @@ class User implements IUser {
 
 	public function triggerChange($feature, $value = null, $oldValue = null): void {
 		$this->dispatcher->dispatchTyped(new UserChangedEvent($this, $feature, $value, $oldValue));
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\User', 'changeUser', [$this, $feature, $value, $oldValue]);
-		}
+		$this->emitter->emit('\OC\User', 'changeUser', [$this, $feature, $value, $oldValue]);
 	}
 }

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -50,8 +50,6 @@ use function json_encode;
 class User implements IUser {
 	private const CONFIG_KEY_MANAGERS = 'manager';
 
-	private IConfig $config;
-	private IURLGenerator $urlGenerator;
 	protected ?IAccountManager $accountManager = null;
 
 	private ?string $displayName = null;
@@ -63,15 +61,13 @@ class User implements IUser {
 	private ?IAvatarManager $avatarManager = null;
 
 	public function __construct(
-		private string $uid,
-		private ?UserInterface $backend,
-		private IEventDispatcher $dispatcher,
-		private Emitter|Manager|null $emitter = null,
-		?IConfig $config = null,
-		$urlGenerator = null,
+		private readonly string $uid,
+		private readonly ?UserInterface $backend,
+		private readonly IEventDispatcher $dispatcher,
+		private readonly Emitter|Manager $emitter,
+		private readonly IConfig $config,
+		private readonly IURLGenerator $urlGenerator,
 	) {
-		$this->config = $config ?? Server::get(IConfig::class);
-		$this->urlGenerator = $urlGenerator ?? Server::get(IURLGenerator::class);
 	}
 
 	public function getUID(): string {
@@ -241,10 +237,8 @@ class User implements IUser {
 			return false;
 		}
 
-		if ($this->emitter) {
-			/** @deprecated 21.0.0 use BeforeUserDeletedEvent event with the IEventDispatcher instead */
-			$this->emitter->emit('\OC\User', 'preDelete', [$this]);
-		}
+		/** @deprecated 21.0.0 use BeforeUserDeletedEvent event with the IEventDispatcher instead */
+		$this->emitter->emit('\OC\User', 'preDelete', [$this]);
 		$this->dispatcher->dispatchTyped(new BeforeUserDeletedEvent($this));
 
 		// Set delete flag on the user - this is needed to ensure that the user data is removed if there happen any exception in the backend
@@ -305,10 +299,8 @@ class User implements IUser {
 			throw $e;
 		}
 
-		if ($this->emitter !== null) {
-			/** @deprecated 21.0.0 use UserDeletedEvent event with the IEventDispatcher instead */
-			$this->emitter->emit('\OC\User', 'postDelete', [$this]);
-		}
+		/** @deprecated 21.0.0 use UserDeletedEvent event with the IEventDispatcher instead */
+		$this->emitter->emit('\OC\User', 'postDelete', [$this]);
 		$this->dispatcher->dispatchTyped(new UserDeletedEvent($this));
 
 		// Finally we can unset the delete flag and all other states
@@ -325,9 +317,7 @@ class User implements IUser {
 	 */
 	public function setPassword($password, $recoveryPassword = null): bool {
 		$this->dispatcher->dispatchTyped(new BeforePasswordUpdatedEvent($this, $password, $recoveryPassword));
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);
-		}
+		$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);
 		if ($this->backend->implementsActions(Backend::SET_PASSWORD)) {
 			/** @var ISetPasswordBackend $backend */
 			$backend = $this->backend;
@@ -335,9 +325,7 @@ class User implements IUser {
 
 			if ($result !== false) {
 				$this->dispatcher->dispatchTyped(new PasswordUpdatedEvent($this, $password, $recoveryPassword));
-				if ($this->emitter) {
-					$this->emitter->emit('\OC\User', 'postSetPassword', [$this, $password, $recoveryPassword]);
-				}
+				$this->emitter->emit('\OC\User', 'postSetPassword', [$this, $password, $recoveryPassword]);
 			}
 
 			return !($result === false);
@@ -643,8 +631,6 @@ class User implements IUser {
 
 	public function triggerChange($feature, $value = null, $oldValue = null): void {
 		$this->dispatcher->dispatchTyped(new UserChangedEvent($this, $feature, $value, $oldValue));
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\User', 'changeUser', [$this, $feature, $value, $oldValue]);
-		}
+		$this->emitter->emit('\OC\User', 'changeUser', [$this, $feature, $value, $oldValue]);
 	}
 }

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -266,4 +266,10 @@ interface IUserManager {
 	 * @since 33.0.0
 	 */
 	public function getExistingUser(string $userId, ?string $displayName = null): IUser;
+
+	/**
+	 * Get or construct the user object
+	 * @since 34.0.0
+	 */
+	public function getUserObject(string $uid, ?UserInterface $backend = null, bool $cacheUser = true): IUser;
 }

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -266,4 +266,9 @@ interface IUserManager {
 	 * @since 33.0.0
 	 */
 	public function getExistingUser(string $userId, ?string $displayName = null): IUser;
+
+	/**
+	 * Get or construct the user object
+	 */
+	public function getUserObject(string $uid, UserInterface $backend, bool $cacheUser = true): IUser;
 }

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -14,8 +14,6 @@ use OC\Files\Cache\Wrapper\CacheJail;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Temporary;
-use OC\User\User;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchComparison;
 use OCP\IDBConnection;
@@ -379,9 +377,8 @@ class CacheTest extends \Test\TestCase {
 
 	public function testSearchQueryByTag(): void {
 		$userId = static::getUniqueID('user');
-		Server::get(IUserManager::class)->createUser($userId, $userId);
+		$user = Server::get(IUserManager::class)->createUser($userId, $userId);
 		static::loginAsUser($userId);
-		$user = new User($userId, null, Server::get(IEventDispatcher::class));
 
 		$file1 = 'folder';
 		$file2 = 'folder/foobar';

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -14,8 +14,6 @@ use OC\Files\Cache\Wrapper\CacheJail;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Temporary;
-use OC\User\User;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchComparison;
 use OCP\IDBConnection;
@@ -376,9 +374,8 @@ class CacheTest extends \Test\TestCase {
 
 	public function testSearchQueryByTag(): void {
 		$userId = static::getUniqueID('user');
-		Server::get(IUserManager::class)->createUser($userId, $userId);
+		$user = Server::get(IUserManager::class)->createUser($userId, $userId);
 		static::loginAsUser($userId);
-		$user = new User($userId, null, Server::get(IEventDispatcher::class));
 
 		$file1 = 'folder';
 		$file2 = 'folder/foobar';

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -14,10 +14,11 @@ use OC\Files\Cache\Wrapper\CacheWrapper;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Jail;
-use OC\User\User;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchComparison;
+use OCP\IUserManager;
+use OCP\Server;
+use OCP\UserInterface;
 use Test\Files\Cache\CacheTest;
 
 /**
@@ -94,7 +95,9 @@ class CacheJailTest extends CacheTest {
 		$this->sourceCache->put($file1, $data1);
 		$this->sourceCache->put($file2, $data1);
 
-		$user = new User('foo', null, $this->createMock(IEventDispatcher::class));
+		$userManager = Server::get(IUserManager::class);
+		$userBackend = $this->getMockBuilder(UserInterface::class)->getMock();
+		$user = $userManager->getUserObject('foo', $userBackend, false);
 		$query = new SearchQuery(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'name', 'foobar'), 10, 0, [], $user);
 		$result = $this->cache->searchQuery($query);
 

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -14,10 +14,11 @@ use OC\Files\Cache\Wrapper\CacheWrapper;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Jail;
-use OC\User\User;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchComparison;
+use OCP\IUserManager;
+use OCP\Server;
+use OCP\UserInterface;
 use Test\Files\Cache\CacheTest;
 
 /**
@@ -93,7 +94,9 @@ class CacheJailTest extends CacheTest {
 		$this->sourceCache->put($file1, $data1);
 		$this->sourceCache->put($file2, $data1);
 
-		$user = new User('foo', null, $this->createMock(IEventDispatcher::class));
+		$userManager = Server::get(IUserManager::class);
+		$userBackend = $this->getMockBuilder(UserInterface::class)->getMock();
+		$user = $userManager->getUserObject('foo', $userBackend);
 		$query = new SearchQuery(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'name', 'foobar'), 10, 0, [], $user);
 		$result = $this->cache->searchQuery($query);
 

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -45,10 +45,10 @@ class GroupTest extends \Test\TestCase {
 	 * @return \OC\User\Manager
 	 */
 	protected function getUserManager() {
-		$userManager = $this->getMockBuilder('\OC\User\Manager')
+		$userManager = $this->getMockBuilder(\OC\User\Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$backend = $this->getMockBuilder('\OC\User\Backend')
+		$backend = $this->getMockBuilder(\OC\User\Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user1 = $this->newUser('user1', $backend);
@@ -60,6 +60,13 @@ class GroupTest extends \Test\TestCase {
 				['user1', $user1],
 				['user2', $user2],
 				['user3', $user3]
+			]);
+		$userManager->expects($this->any())
+			->method('getUserObject')
+			->willReturnMap([
+				['user1', null, false, $user1],
+				['user2', null, false, $user2],
+				['user3', null, false, $user3]
 			]);
 		return $userManager;
 	}
@@ -308,7 +315,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', null, false)]);
 
 		$users = $group->searchUsers('2');
 
@@ -330,11 +337,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', null, false)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', null, false)]);
 
 		$users = $group->searchUsers('2');
 
@@ -353,7 +360,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 1, 1)
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', null, false)]);
 
 		$users = $group->searchUsers('user', 1, 1);
 
@@ -375,11 +382,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', null, false)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user1' => new User('user1', null, $this->dispatcher)]);
+			->willReturn(['user1' => $userManager->getUserObject('user1', null, false)]);
 
 		$users = $group->searchUsers('user', 2, 1);
 

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -14,15 +14,18 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\BeforeGroupChangedEvent;
 use OCP\Group\Events\GroupChangedEvent;
 use OCP\IUser;
+use OCP\UserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class GroupTest extends \Test\TestCase {
 	/** @var IEventDispatcher|MockObject */
 	protected $dispatcher;
+	protected UserInterface&MockObject $userBackend;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->userBackend = $this->createMock(UserInterface::class);
 	}
 
 	/**
@@ -307,7 +310,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', $this->userBackend)]);
 
 		$users = $group->searchUsers('2');
 
@@ -329,11 +332,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', $this->userBackend)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', $this->userBackend)]);
 
 		$users = $group->searchUsers('2');
 
@@ -352,7 +355,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 1, 1)
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', $this->userBackend)]);
 
 		$users = $group->searchUsers('user', 1, 1);
 
@@ -374,11 +377,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user2' => new User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => $userManager->getUserObject('user2', $this->userBackend)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user1' => new User('user1', null, $this->dispatcher)]);
+			->willReturn(['user1' => $userManager->getUserObject('user1', $this->userBackend)]);
 
 		$users = $group->searchUsers('user', 2, 1);
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -21,7 +21,9 @@ use OCP\Group\Backend\ISearchableGroupBackend;
 use OCP\GroupInterface;
 use OCP\ICacheFactory;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Security\Ip\IRemoteAddress;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -811,7 +813,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('testgroup', '', 1, 0)
-			->willReturn([new User('user2', null, $this->dispatcher)]);
+			->willReturn([Server::get(IUserManager::class)->getUserObject('user2', null, false)]);
 
 		$this->userManager->expects($this->never())->method('get');
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -22,6 +22,7 @@ use OCP\GroupInterface;
 use OCP\ICacheFactory;
 use OCP\IUser;
 use OCP\Security\Ip\IRemoteAddress;
+use OCP\UserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -807,10 +808,12 @@ class ManagerTest extends TestCase {
 			->with('testgroup')
 			->willReturn(true);
 
+		$userBackend = $this->createMock(UserInterface::class);
+
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('testgroup', '', 1, 0)
-			->willReturn([new User('user2', null, $this->dispatcher)]);
+			->willReturn([$this->userManager->getUserObject('user2', $userBackend)]);
 
 		$this->userManager->expects($this->never())->method('get');
 

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -8,18 +8,27 @@
 
 namespace Test\Traits;
 
+use OC\User\Manager;
 use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
-use OCP\UserInterface;
 
 class DummyUser extends User {
 	public function __construct(
 		private string $uid,
 	) {
-		parent::__construct($this->uid, null, Server::get(IEventDispatcher::class));
+		parent::__construct(
+			$this->uid,
+			null,
+			Server::get(IEventDispatcher::class),
+			Server::get(Manager::class),
+			Server::get(IConfig::class),
+			Server::get(IURLGenerator::class),
+		);
 	}
 
 	#[\Override]

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -9,11 +9,12 @@
 namespace Test\User;
 
 use OC\User\Database;
-use OC\User\User;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
+use OCP\IUserManager;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -122,8 +123,9 @@ class DatabaseTest extends Backend {
 		$user2 = $this->getUser();
 		$this->backend->createUser($user2, 'pass1');
 
-		$user1Obj = new User($user1, $this->backend, $this->createMock(IEventDispatcher::class));
-		$user2Obj = new User($user2, $this->backend, $this->createMock(IEventDispatcher::class));
+		$userManager = Server::get(IUserManager::class);
+		$user1Obj = $userManager->getUserObject($user1, $this->backend);
+		$user2Obj = $userManager->getUserObject($user2, $this->backend);
 		$emailAddr1 = "$user1@nextcloud.com";
 		$emailAddr2 = "$user2@nextcloud.com";
 

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -9,11 +9,12 @@
 namespace Test\User;
 
 use OC\User\Database;
-use OC\User\User;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
+use OCP\IUserManager;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -118,8 +119,9 @@ class DatabaseTest extends Backend {
 		$user2 = $this->getUser();
 		$this->backend->createUser($user2, 'pass1');
 
-		$user1Obj = new User($user1, $this->backend, $this->createMock(IEventDispatcher::class));
-		$user2Obj = new User($user2, $this->backend, $this->createMock(IEventDispatcher::class));
+		$userManager = Server::get(IUserManager::class);
+		$user1Obj = $userManager->getUserObject($user1, $this->backend);
+		$user2Obj = $userManager->getUserObject($user2, $this->backend);
 		$emailAddr1 = "$user1@nextcloud.com";
 		$emailAddr2 = "$user2@nextcloud.com";
 

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -21,7 +21,6 @@ use OC\Session\Memory;
 use OC\User\LoginException;
 use OC\User\Manager;
 use OC\User\Session;
-use OC\User\User;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -31,9 +30,11 @@ use OCP\IRequest;
 use OCP\IRequestId;
 use OCP\ISession;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Lockdown\ILockdownManager;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ISecureRandom;
+use OCP\Server;
 use OCP\User\Events\PostLoginEvent;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -125,7 +126,7 @@ class SessionTest extends \Test\TestCase {
 				'getUser'
 			])
 			->getMock();
-		$user = new User('sepp', null, $this->createMock(IEventDispatcher::class));
+		$user = Server::get(IUserManager::class)->getUserObject('sepp', null, false);
 		$userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($isLoggedIn ? $user : null);
@@ -907,9 +908,11 @@ class SessionTest extends \Test\TestCase {
 	}
 
 	public function testActiveUserAfterSetSession(): void {
+		$userManager = Server::get(IUserManager::class);
+
 		$users = [
-			'foo' => new User('foo', null, $this->createMock(IEventDispatcher::class)),
-			'bar' => new User('bar', null, $this->createMock(IEventDispatcher::class))
+			'foo' => $userManager->getUserObject('foo', null, false),
+			'bar' => $userManager->getUserObject('bar', null, false),
 		];
 
 		$manager = $this->getMockBuilder(Manager::class)

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -30,11 +30,16 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IRequestId;
 use OCP\ISession;
+use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Lockdown\ILockdownManager;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ISecureRandom;
+use OCP\Server;
+use OCP\Support\Subscription\IAssertion;
 use OCP\User\Events\PostLoginEvent;
+use OCP\UserInterface;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -124,7 +129,7 @@ class SessionTest extends \Test\TestCase {
 				'getUser'
 			])
 			->getMock();
-		$user = new User('sepp', null, $this->createMock(IEventDispatcher::class));
+		$manager->getUserObject('sepp', null, null, null, null, $this->config);
 		$userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($isLoggedIn ? $user : null);
@@ -906,9 +911,12 @@ class SessionTest extends \Test\TestCase {
 	}
 
 	public function testActiveUserAfterSetSession(): void {
+		$userManager = Server::get(IUserManager::class);
+		$userBackend = $this->getMockBuilder(UserInterface::class)->getMock();
+
 		$users = [
-			'foo' => new User('foo', null, $this->createMock(IEventDispatcher::class)),
-			'bar' => new User('bar', null, $this->createMock(IEventDispatcher::class))
+			'foo' => $userManager->getUserObject('foo', $userBackend),
+			'bar' => $userManager->getUserObject('bar', $userBackend),
 		];
 
 		$manager = $this->getMockBuilder(Manager::class)

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -10,8 +10,10 @@ namespace Test\User;
 
 use OC\AllConfig;
 use OC\Files\Mount\ObjectHomeMountProvider;
+use OC\Hooks\Emitter;
 use OC\Hooks\PublicEmitter;
 use OC\User\Database;
+use OC\User\Manager;
 use OC\User\User;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -23,6 +25,7 @@ use OCP\IUser;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\Server;
+use OCP\UserInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -38,6 +41,24 @@ class UserTest extends TestCase {
 		$this->dispatcher = Server::get(IEventDispatcher::class);
 	}
 
+	private function createUserObject(
+		string $uid,
+		?UserInterface $backend = null,
+		?IEventDispatcher $dispatcher = null,
+		?Emitter $emitter = null,
+		?IConfig $config = null,
+		?IURLGenerator $urlGenerator = null,
+	): User {
+		return new User(
+			$uid,
+			$backend,
+			$dispatcher ?? $this->dispatcher,
+			$emitter ?? $this->createMock(Manager::class),
+			$config ?? Server::get(IConfig::class),
+			$urlGenerator ?? Server::get(IURLGenerator::class),
+		);
+	}
+
 	public function testDisplayName(): void {
 		$backend = $this->createMock(\OC\User\Backend::class);
 		$backend->expects($this->once())
@@ -50,7 +71,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('Foo', $user->getDisplayName());
 	}
 
@@ -69,7 +90,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
@@ -83,7 +104,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
@@ -99,7 +120,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_PASSWORD);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->setPassword('bar', ''));
 	}
 
@@ -112,7 +133,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->setPassword('bar', ''));
 	}
 
@@ -133,7 +154,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->canChangeAvatar());
 	}
 
@@ -154,7 +175,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->canChangeAvatar());
 	}
 
@@ -167,7 +188,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->canChangeAvatar());
 	}
 
@@ -179,7 +200,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->delete());
 	}
 
@@ -212,7 +233,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->delete());
 	}
 
@@ -227,14 +248,14 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::GET_HOME);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('/home/foo', $user->getHome());
 	}
 
 	public function testGetBackendClassName(): void {
-		$user = new User('foo', new \Test\Util\User\Dummy(), $this->dispatcher);
+		$user = $this->createUserObject('foo', new \Test\Util\User\Dummy(), $this->dispatcher);
 		$this->assertEquals('Dummy', $user->getBackendClassName());
-		$user = new User('foo', new Database(), $this->dispatcher);
+		$user = $this->createUserObject('foo', new Database(), $this->dispatcher);
 		$this->assertEquals('Database', $user->getBackendClassName());
 	}
 
@@ -258,7 +279,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo('datadirectory'))
 			->willReturn('arbitrary/path');
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $allConfig);
+		$user = $this->createUserObject('foo', $backend, null, null, $allConfig);
 		$this->assertEquals('arbitrary/path/foo', $user->getHome());
 	}
 
@@ -269,7 +290,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_PASSWORD);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->canChangePassword());
 	}
 
@@ -280,7 +301,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->canChangePassword());
 	}
 
@@ -296,7 +317,7 @@ class UserTest extends TestCase {
 			->with('allow_user_to_change_display_name')
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$this->assertTrue($user->canChangeDisplayName());
 	}
 
@@ -307,7 +328,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->canChangeDisplayName());
 	}
 
@@ -323,7 +344,7 @@ class UserTest extends TestCase {
 			->with('foo', 'Foo')
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->createMock(IEventDispatcher::class));
+		$user = $this->createUserObject('foo', $backend, $this->createMock(IEventDispatcher::class));
 		$this->assertTrue($user->setDisplayName('Foo'));
 		$this->assertEquals('Foo', $user->getDisplayName());
 	}
@@ -338,7 +359,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_DISPLAYNAME);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->setDisplayName(' '));
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
@@ -353,7 +374,7 @@ class UserTest extends TestCase {
 		$backend->expects($this->never())
 			->method('setDisplayName');
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->setDisplayName('Foo'));
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
@@ -382,7 +403,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_PASSWORD);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter);
+		$user = $this->createUserObject('foo', $backend, null, $emitter);
 
 		$user->setPassword('bar', '');
 		$this->assertEquals(2, $hooksCalled);
@@ -417,7 +438,7 @@ class UserTest extends TestCase {
 			->willReturnArgument(1);
 
 		$emitter = new PublicEmitter();
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 
 		$hook = function (IUser $user) use ($test, &$hooksCalled): void {
 			$hooksCalled++;
@@ -514,7 +535,7 @@ class UserTest extends TestCase {
 
 		$user = $this->getMockBuilder(User::class)
 			->onlyMethods(['getHome'])
-			->setConstructorArgs(['foo', $backend, $this->dispatcher, null, $config])
+			->setConstructorArgs(['foo', $backend, $this->dispatcher, $this->createMock(Manager::class), $config, Server::get(IURLGenerator::class)])
 			->getMock();
 
 		$user->expects(self::atLeastOnce())
@@ -548,7 +569,7 @@ class UserTest extends TestCase {
 		$urlGenerator->method('getAbsoluteURL')
 			->withAnyParameters()
 			->willReturn($absoluteUrl);
-		$user = new User('foo', $backend, $this->dispatcher, null, null, $urlGenerator);
+		$user = $this->createUserObject('foo', $backend, null, null, null, $urlGenerator);
 		$this->assertEquals($cloudId, $user->getCloudId());
 	}
 
@@ -577,7 +598,7 @@ class UserTest extends TestCase {
 				'email'
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setSystemEMailAddress('');
 	}
 
@@ -607,7 +628,7 @@ class UserTest extends TestCase {
 				'foo@bar.com'
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setSystemEMailAddress('foo@bar.com');
 	}
 
@@ -630,7 +651,7 @@ class UserTest extends TestCase {
 		$config->expects($this->any())
 			->method('setUserValue');
 
-		$user = new User('foo', $backend, $dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, $dispatcher, $emitter, $config);
 		$user->setSystemEMailAddress('foo@bar.com');
 	}
 
@@ -660,7 +681,7 @@ class UserTest extends TestCase {
 				'23 TB'
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setQuota('23 TB');
 	}
 
@@ -674,7 +695,7 @@ class UserTest extends TestCase {
 			->method('emit');
 
 		$config = $this->createMock(IConfig::class);
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 
 		$userValueMap = [
 			['foo', 'files', 'quota', 'default', 'default'],
@@ -702,7 +723,7 @@ class UserTest extends TestCase {
 			->method('emit');
 
 		$config = $this->createMock(IConfig::class);
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 
 		$userValueMap = [
 			['foo', 'files', 'quota', 'default', 'default'],
@@ -739,7 +760,7 @@ class UserTest extends TestCase {
 		$config->expects($this->never())
 			->method('setUserValue');
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setQuota('23 TB');
 	}
 
@@ -756,7 +777,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$this->assertSame(42, $user->getLastLogin());
 	}
 
@@ -780,7 +801,7 @@ class UserTest extends TestCase {
 				fn ($user, $app, $key, $default) => ($key === 'enabled' ? 'false' : $default)
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$user->setEnabled(true);
 	}
 
@@ -802,8 +823,9 @@ class UserTest extends TestCase {
 				'foo',
 				$backend,
 				$this->dispatcher,
-				null,
+				$this->createMock(Manager::class),
 				$config,
+				Server::get(IURLGenerator::class),
 			])
 			->onlyMethods(['isEnabled', 'triggerChange'])
 			->getMock();
@@ -833,8 +855,9 @@ class UserTest extends TestCase {
 				'foo',
 				$backend,
 				$this->dispatcher,
-				null,
+				$this->createMock(Manager::class),
 				$config,
+				Server::get(IURLGenerator::class),
 			])
 			->onlyMethods(['isEnabled', 'triggerChange'])
 			->getMock();
@@ -861,7 +884,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$this->assertSame('foo@bar.com', $user->getEMailAddress());
 	}
 }

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -10,8 +10,10 @@ namespace Test\User;
 
 use OC\AllConfig;
 use OC\Files\Mount\ObjectHomeMountProvider;
+use OC\Hooks\Emitter;
 use OC\Hooks\PublicEmitter;
 use OC\User\Database;
+use OC\User\Manager;
 use OC\User\User;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -23,6 +25,7 @@ use OCP\IUser;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\Server;
+use OCP\UserInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -37,6 +40,24 @@ class UserTest extends TestCase {
 		$this->dispatcher = Server::get(IEventDispatcher::class);
 	}
 
+	private function createUserObject(
+		string $uid,
+		?UserInterface $backend = null,
+		?IEventDispatcher $dispatcher = null,
+		?Emitter $emitter = null,
+		?IConfig $config = null,
+		?IURLGenerator $urlGenerator = null,
+	): User {
+		return new User(
+			$uid,
+			$backend,
+			$dispatcher ?? $this->dispatcher,
+			$emitter ?? $this->createMock(Manager::class),
+			$config ?? Server::get(IConfig::class),
+			$urlGenerator ?? Server::get(IURLGenerator::class),
+		);
+	}
+
 	public function testDisplayName(): void {
 		$backend = $this->createMock(\OC\User\Backend::class);
 		$backend->expects($this->once())
@@ -49,7 +70,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('Foo', $user->getDisplayName());
 	}
 
@@ -68,7 +89,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
@@ -82,7 +103,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo(\OC\User\Backend::GET_DISPLAYNAME))
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
@@ -98,7 +119,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_PASSWORD);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->setPassword('bar', ''));
 	}
 
@@ -111,7 +132,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->setPassword('bar', ''));
 	}
 
@@ -132,7 +153,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->canChangeAvatar());
 	}
 
@@ -153,7 +174,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->canChangeAvatar());
 	}
 
@@ -166,7 +187,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->canChangeAvatar());
 	}
 
@@ -178,7 +199,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->delete());
 	}
 
@@ -211,7 +232,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->delete());
 	}
 
@@ -226,14 +247,14 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::GET_HOME);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertEquals('/home/foo', $user->getHome());
 	}
 
 	public function testGetBackendClassName(): void {
-		$user = new User('foo', new \Test\Util\User\Dummy(), $this->dispatcher);
+		$user = $this->createUserObject('foo', new \Test\Util\User\Dummy(), $this->dispatcher);
 		$this->assertEquals('Dummy', $user->getBackendClassName());
-		$user = new User('foo', new Database(), $this->dispatcher);
+		$user = $this->createUserObject('foo', new Database, $this->dispatcher);
 		$this->assertEquals('Database', $user->getBackendClassName());
 	}
 
@@ -257,7 +278,7 @@ class UserTest extends TestCase {
 			->with($this->equalTo('datadirectory'))
 			->willReturn('arbitrary/path');
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $allConfig);
+		$user = $this->createUserObject('foo', $backend, null, null, $allConfig);
 		$this->assertEquals('arbitrary/path/foo', $user->getHome());
 	}
 
@@ -268,7 +289,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_PASSWORD);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->canChangePassword());
 	}
 
@@ -279,7 +300,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->canChangePassword());
 	}
 
@@ -295,7 +316,7 @@ class UserTest extends TestCase {
 			->with('allow_user_to_change_display_name')
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$this->assertTrue($user->canChangeDisplayName());
 	}
 
@@ -306,7 +327,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->canChangeDisplayName());
 	}
 
@@ -322,7 +343,7 @@ class UserTest extends TestCase {
 			->with('foo', 'Foo')
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->createMock(IEventDispatcher::class));
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertTrue($user->setDisplayName('Foo'));
 		$this->assertEquals('Foo', $user->getDisplayName());
 	}
@@ -337,7 +358,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_DISPLAYNAME);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->setDisplayName(' '));
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
@@ -352,7 +373,7 @@ class UserTest extends TestCase {
 		$backend->expects($this->never())
 			->method('setDisplayName');
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = $this->createUserObject('foo', $backend);
 		$this->assertFalse($user->setDisplayName('Foo'));
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
@@ -381,7 +402,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->willReturnCallback(static fn (int $actions): bool => $actions === \OC\User\Backend::SET_PASSWORD);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter);
+		$user = $this->createUserObject('foo', $backend, null, $emitter);
 
 		$user->setPassword('bar', '');
 		$this->assertEquals(2, $hooksCalled);
@@ -416,7 +437,7 @@ class UserTest extends TestCase {
 			->willReturnArgument(1);
 
 		$emitter = new PublicEmitter();
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 
 		$hook = function (IUser $user) use ($test, &$hooksCalled): void {
 			$hooksCalled++;
@@ -547,7 +568,7 @@ class UserTest extends TestCase {
 		$urlGenerator->method('getAbsoluteURL')
 			->withAnyParameters()
 			->willReturn($absoluteUrl);
-		$user = new User('foo', $backend, $this->dispatcher, null, null, $urlGenerator);
+		$user = $this->createUserObject('foo', $backend, null, null, null, $urlGenerator);
 		$this->assertEquals($cloudId, $user->getCloudId());
 	}
 
@@ -576,7 +597,7 @@ class UserTest extends TestCase {
 				'email'
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setSystemEMailAddress('');
 	}
 
@@ -606,7 +627,7 @@ class UserTest extends TestCase {
 				'foo@bar.com'
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setSystemEMailAddress('foo@bar.com');
 	}
 
@@ -629,7 +650,7 @@ class UserTest extends TestCase {
 		$config->expects($this->any())
 			->method('setUserValue');
 
-		$user = new User('foo', $backend, $dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, $dispatcher, $emitter, $config);
 		$user->setSystemEMailAddress('foo@bar.com');
 	}
 
@@ -659,7 +680,7 @@ class UserTest extends TestCase {
 				'23 TB'
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setQuota('23 TB');
 	}
 
@@ -673,7 +694,7 @@ class UserTest extends TestCase {
 			->method('emit');
 
 		$config = $this->createMock(IConfig::class);
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 
 		$userValueMap = [
 			['foo', 'files', 'quota', 'default', 'default'],
@@ -701,7 +722,7 @@ class UserTest extends TestCase {
 			->method('emit');
 
 		$config = $this->createMock(IConfig::class);
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 
 		$userValueMap = [
 			['foo', 'files', 'quota', 'default', 'default'],
@@ -738,7 +759,7 @@ class UserTest extends TestCase {
 		$config->expects($this->never())
 			->method('setUserValue');
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = $this->createUserObject('foo', $backend, null, $emitter, $config);
 		$user->setQuota('23 TB');
 	}
 
@@ -755,7 +776,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$this->assertSame(42, $user->getLastLogin());
 	}
 
@@ -779,7 +800,7 @@ class UserTest extends TestCase {
 				fn ($user, $app, $key, $default) => ($key === 'enabled' ? 'false' : $default)
 			);
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$user->setEnabled(true);
 	}
 
@@ -860,7 +881,7 @@ class UserTest extends TestCase {
 				}
 			});
 
-		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$user = $this->createUserObject('foo', $backend, null, null, $config);
 		$this->assertSame('foo@bar.com', $user->getEMailAddress());
 	}
 }


### PR DESCRIPTION
We already have a factory method to build `User` objects, so let's use it and stop with the conditional arguments and properties. This will make adding new constructor arguments easier in the future.

One nitpick is that I kept the `$backend` argument optional, the reason being that in Collectives and Groupfolders, we are creating a dummy user without a backend because the files_versions API needs one.

Adaptations in apps:
- https://github.com/nextcloud/groupfolders/pull/4601
- https://github.com/nextcloud/collectives/pull/2456