### PR TITLE
refactor: Add strict property/parameter typing to OCP\HintException

### DIFF
--- a/lib/public/HintException.php
+++ b/lib/public/HintException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -7,31 +9,29 @@
 namespace OCP;
 
 /**
- * Class HintException
- *
  * An Exception class with the intention to be presented to the end user
  *
- * @package OCP
  * @since 23.0.0
  */
 class HintException extends \Exception {
-	private $hint;
-
 	/**
 	 * HintException constructor.
 	 *
 	 * @since 23.0.0
-	 * @param string $message The error message. It will be not revealed to the
-	 *                        the user (unless the hint is empty) and thus
-	 *                        should be not translated.
-	 * @param string $hint A useful message that is presented to the end
-	 *                     user. It should be translated, but must not
-	 *                     contain sensitive data.
+	 * @param string $message The error message. It is not intended to be shown
+	 *                        to the end user unless the hint is empty, and
+	 *                        therefore should not be translated.
+	 * @param string $hint A useful message presented to the end user. It should
+	 *                     be translated, but must not contain sensitive data.
 	 * @param int $code
 	 * @param \Exception|null $previous
 	 */
-	public function __construct($message, $hint = '', $code = 0, ?\Exception $previous = null) {
-		$this->hint = $hint;
+	public function __construct(
+		string $message,
+		private string $hint = '',
+		int $code = 0,
+		?\Exception $previous = null,
+	) {
 		parent::__construct($message, $code, $previous);
 	}
 
@@ -40,7 +40,6 @@ class HintException extends \Exception {
 	 * code, the message and the hint.
 	 *
 	 * @since 23.0.0
-	 * @return string
 	 */
 	public function __toString(): string {
 		return self::class . ": [{$this->code}]: {$this->message} ({$this->hint})\n";
@@ -52,12 +51,8 @@ class HintException extends \Exception {
 	 * instead.
 	 *
 	 * @since 23.0.0
-	 * @return string
 	 */
 	public function getHint(): string {
-		if (empty($this->hint)) {
-			return $this->message;
-		}
-		return $this->hint;
+		return $this->hint !== '' ? $this->hint : $this->message;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Changes:

* Added `declare(strict_types=1)`
* Typed constructor params:
* Typed property with constructor property promotion
* Simplified `getHint()` to a direct string check

Why:

* Stronger static analysis
* Clearer public API contract
* Less boilerplate
* Same runtime behavior for valid callers

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (yes, but manually reviewed)
