### PR TITLE
Allow insertIgnoreConflict to work with sharding and use it for filecache.

### DIFF
--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -129,4 +129,8 @@ class Adapter {
 			throw $e;
 		}
 	}
+
+	public function getInsertIgnoreSqlTransformer(): ?callable {
+		return null;
+	}
 }

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -111,12 +111,15 @@ class Adapter {
 	/**
 	 * @throws \OCP\DB\Exception
 	 */
-	public function insertIgnoreConflict(string $table, array $values) : int {
+	public function insertIgnoreConflict(string $table, array $values, array $hintShardKey = []) : int {
 		try {
 			$builder = $this->conn->getQueryBuilder();
 			$builder->insert($table);
 			foreach ($values as $key => $value) {
 				$builder->setValue($key, $builder->createNamedParameter($value));
+			}
+			if (isset($hintShardKey['column'], $hintShardKey['value'])) {
+				$builder->hintShardKey($hintShardKey['column'], $hintShardKey['value'], $hintShardKey['overwrite'] ?? false);
 			}
 			return $builder->executeStatement();
 		} catch (DbalException $e) {

--- a/lib/private/DB/AdapterMySQL.php
+++ b/lib/private/DB/AdapterMySQL.php
@@ -36,12 +36,15 @@ class AdapterMySQL extends Adapter {
 		return $this->collation;
 	}
 
-	public function insertIgnoreConflict(string $table, array $values): int {
+	public function insertIgnoreConflict(string $table, array $values, array $hintShardKey = []): int {
 		$builder = $this->conn->getQueryBuilder();
 		$builder->insert($table);
-		$updates = [];
 		foreach ($values as $key => $value) {
 			$builder->setValue($key, $builder->createNamedParameter($value));
+		}
+
+		if (isset($hintShardKey['column'], $hintShardKey['value'])) {
+			$builder->hintShardKey($hintShardKey['column'], $hintShardKey['value'], $hintShardKey['overwrite'] ?? false);
 		}
 
 		/*

--- a/lib/private/DB/AdapterMySQL.php
+++ b/lib/private/DB/AdapterMySQL.php
@@ -47,23 +47,22 @@ class AdapterMySQL extends Adapter {
 			$builder->hintShardKey($hintShardKey['column'], $hintShardKey['value'], $hintShardKey['overwrite'] ?? false);
 		}
 
-		/*
-		 * We can't use ON DUPLICATE KEY UPDATE here because Nextcloud use the CLIENT_FOUND_ROWS flag
-		 * With this flag the MySQL returns the number of selected rows
-		 * instead of the number of affected/modified rows
-		 * It's impossible to change this behaviour at runtime or for a single query
-		 * Then, the result is 1 if a row is inserted and also 1 if a row is updated with same or different values
-		 *
-		 * With INSERT IGNORE, the result is 1 when a row is inserted, 0 otherwise
-		 *
-		 * Risk: it can also ignore other errors like type mismatch or truncated data…
-		 */
-		$res = $this->conn->executeStatement(
-			preg_replace('/^INSERT/i', 'INSERT IGNORE', $builder->getSQL()),
-			$builder->getParameters(),
-			$builder->getParameterTypes()
-		);
+		$builder->ignoreConflictsOnInsert();
+		return $builder->executeStatement();
+	}
 
-		return $res;
+	/**
+	 * We can't use ON DUPLICATE KEY UPDATE here because Nextcloud use the CLIENT_FOUND_ROWS flag
+	 * With this flag the MySQL returns the number of selected rows
+	 * instead of the number of affected/modified rows
+	 * It's impossible to change this behaviour at runtime or for a single query
+	 * Then, the result is 1 if a row is inserted and also 1 if a row is updated with same or different values
+	 *
+	 * With INSERT IGNORE, the result is 1 when a row is inserted, 0 otherwise
+	 *
+	 * Risk: it can also ignore other errors like type mismatch or truncated data…
+	 */
+	public function getInsertIgnoreSqlTransformer(): callable {
+		return fn (string $sql) => preg_replace('/^INSERT/i', 'INSERT IGNORE', $sql);
 	}
 }

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -23,13 +23,16 @@ class AdapterPgSql extends Adapter {
 		return $statement;
 	}
 
-	public function insertIgnoreConflict(string $table, array $values) : int {
+	public function insertIgnoreConflict(string $table, array $values, array $hintShardKey = []) : int {
 		// "upsert" is only available since PgSQL 9.5, but the generic way
 		// would leave error logs in the DB.
 		$builder = $this->conn->getQueryBuilder();
 		$builder->insert($table);
 		foreach ($values as $key => $value) {
 			$builder->setValue($key, $builder->createNamedParameter($value));
+		}
+		if (isset($hintShardKey['column'], $hintShardKey['value'])) {
+			$builder->hintShardKey($hintShardKey['column'], $hintShardKey['value'], $hintShardKey['overwrite'] ?? false);
 		}
 		$queryString = $builder->getSQL() . ' ON CONFLICT DO NOTHING';
 		return $this->conn->executeUpdate($queryString, $builder->getParameters(), $builder->getParameterTypes());

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -34,7 +34,11 @@ class AdapterPgSql extends Adapter {
 		if (isset($hintShardKey['column'], $hintShardKey['value'])) {
 			$builder->hintShardKey($hintShardKey['column'], $hintShardKey['value'], $hintShardKey['overwrite'] ?? false);
 		}
-		$queryString = $builder->getSQL() . ' ON CONFLICT DO NOTHING';
-		return $this->conn->executeUpdate($queryString, $builder->getParameters(), $builder->getParameterTypes());
+		$builder->ignoreConflictsOnInsert();
+		return $builder->executeStatement();
+	}
+
+	public function getInsertIgnoreSqlTransformer(): callable {
+		return fn (string $sql) => $sql . ' ON CONFLICT DO NOTHING';
 	}
 }

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -88,10 +88,11 @@ class AdapterSqlite extends Adapter {
 			$builder->hintShardKey($hintShardKey['column'], $hintShardKey['value'], $hintShardKey['overwrite'] ?? false);
 		}
 
-		return $this->conn->executeStatement(
-			$builder->getSQL() . ' ON CONFLICT DO NOTHING',
-			$builder->getParameters(),
-			$builder->getParameterTypes()
-		);
+		$builder->ignoreConflictsOnInsert();
+		return $builder->executeStatement();
+	}
+
+	public function getInsertIgnoreSqlTransformer(): callable {
+		return fn (string $sql) => $sql . ' ON CONFLICT DO NOTHING';
 	}
 }

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -77,12 +77,15 @@ class AdapterSqlite extends Adapter {
 		}
 	}
 
-	public function insertIgnoreConflict(string $table, array $values): int {
+	public function insertIgnoreConflict(string $table, array $values, array $hintShardKey = []): int {
 		$builder = $this->conn->getQueryBuilder();
 		$builder->insert($table);
-		$updates = [];
 		foreach ($values as $key => $value) {
 			$builder->setValue($key, $builder->createNamedParameter($value));
+		}
+
+		if (isset($hintShardKey['column'], $hintShardKey['value'])) {
+			$builder->hintShardKey($hintShardKey['column'], $hintShardKey['value'], $hintShardKey['overwrite'] ?? false);
 		}
 
 		return $this->conn->executeStatement(

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -961,4 +961,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	public function getCrossShardMoveHelper(): CrossShardMoveHelper {
 		return new CrossShardMoveHelper($this->shardConnectionManager);
 	}
+
+	public function getInsertIgnoreSqlTransformer(): ?callable {
+		return $this->adapter->getInsertIgnoreSqlTransformer();
+	}
 }

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -548,9 +548,9 @@ class Connection extends PrimaryReadReplicaConnection {
 		}
 	}
 
-	public function insertIgnoreConflict(string $table, array $values) : int {
+	public function insertIgnoreConflict(string $table, array $values, array $hintShardKey = []) : int {
 		try {
-			return $this->adapter->insertIgnoreConflict($table, $values);
+			return $this->adapter->insertIgnoreConflict($table, $values, $hintShardKey);
 		} catch (\Exception $e) {
 			$this->logDatabaseException($e);
 			throw $e;

--- a/lib/private/DB/ConnectionAdapter.php
+++ b/lib/private/DB/ConnectionAdapter.php
@@ -89,9 +89,9 @@ class ConnectionAdapter implements IDBConnection {
 		}
 	}
 
-	public function insertIgnoreConflict(string $table, array $values): int {
+	public function insertIgnoreConflict(string $table, array $values, array $hintShardKey = []): int {
 		try {
-			return $this->inner->insertIgnoreConflict($table, $values);
+			return $this->inner->insertIgnoreConflict($table, $values, $hintShardKey);
 		} catch (Exception $e) {
 			throw DbalException::wrap($e);
 		}

--- a/lib/private/DB/ConnectionAdapter.php
+++ b/lib/private/DB/ConnectionAdapter.php
@@ -265,4 +265,8 @@ class ConnectionAdapter implements IDBConnection {
 	public function getCrossShardMoveHelper(): CrossShardMoveHelper {
 		return $this->inner->getCrossShardMoveHelper();
 	}
+
+	public function getInsertIgnoreSqlTransformer(): ?callable {
+		return $this->inner->getInsertIgnoreSqlTransformer();
+	}
 }

--- a/lib/private/DB/QueryBuilder/ExtendedQueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExtendedQueryBuilder.php
@@ -47,6 +47,11 @@ abstract class ExtendedQueryBuilder extends TypedQueryBuilder {
 		return $this->builder->getState();
 	}
 
+	public function ignoreConflictsOnInsert(): self {
+		$this->builder->ignoreConflictsOnInsert();
+		return $this;
+	}
+
 	public function getSQL() {
 		return $this->builder->getSQL();
 	}

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -39,6 +39,7 @@ class QueryBuilder extends TypedQueryBuilder {
 	private bool $nonEmptyWhere = false;
 	protected ?string $lastInsertedTable = null;
 	private array $selectedColumns = [];
+	private bool $insertIgnoreConflicts = false;
 
 	/**
 	 * Initializes a new QueryBuilder.
@@ -275,6 +276,13 @@ class QueryBuilder extends TypedQueryBuilder {
 		);
 	}
 
+	public function ignoreConflictsOnInsert(): self {
+		if ($this->getType() !== \Doctrine\DBAL\Query\QueryBuilder::INSERT) {
+			throw new \LogicException('ignoreConflictsOnInsert() can only be used on INSERT queries');
+		}
+		$this->insertIgnoreConflicts = true;
+		return $this;
+	}
 
 	/**
 	 * Gets the complete SQL string formed by the current specifications of this QueryBuilder.
@@ -289,7 +297,11 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @return string The SQL query string.
 	 */
 	public function getSQL() {
-		return $this->queryBuilder->getSQL();
+		$sql = $this->queryBuilder->getSQL();
+		if ($this->insertIgnoreConflicts && $this->connection->getInsertIgnoreSqlTransformer() !== null) {
+			return ($this->connection->getInsertIgnoreSqlTransformer())($sql);
+		}
+		return $sql;
 	}
 
 	/**

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -394,21 +394,8 @@ class Cache implements ICache {
 		}
 
 		if (count($extensionValues)) {
-			try {
-				$query = $this->getQueryBuilder();
-				$query->insert('filecache_extended');
-				$query->hintShardKey('storage', $this->getNumericStorageId());
-
-				$query->setValue('fileid', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT));
-				foreach ($extensionValues as $column => $value) {
-					$query->setValue($column, $query->createNamedParameter($value));
-				}
-
-				$query->executeStatement();
-			} catch (Exception $e) {
-				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-					throw $e;
-				}
+			$insertCount = $this->connection->insertIgnoreConflict('filecache_extended', array_merge(['fileid' => $id], $extensionValues), ['column' => 'storage', 'value' => $this->getNumericStorageId()]);
+			if ($insertCount === 0) {
 				$query = $this->getQueryBuilder();
 				$query->update('filecache_extended')
 					->whereFileId($id)

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -217,6 +217,14 @@ interface IQueryBuilder {
 	public function executeStatement(?IDBConnection $connection = null): int;
 
 	/**
+	 * Set to ignore conflicts on insert
+	 *
+	 * @since 34.0.0
+	 * @return self
+	 */
+	public function ignoreConflictsOnInsert(): self;
+
+	/**
 	 * Gets the complete SQL string formed by the current specifications of this QueryBuilder.
 	 *
 	 * <code>

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -168,10 +168,12 @@ interface IDBConnection {
 	 *
 	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
 	 * @param array $values data that should be inserted into the table  (column name => value)
+	 * @param array{column: string, value: mixed, overwrite?: bool}|array{} $hintShardKey An array representing the shard key to hint
 	 * @return int number of inserted rows
+	 * @since 34.0.0 Parameter $hintShardKey was added
 	 * @since 16.0.0
 	 */
-	public function insertIgnoreConflict(string $table, array $values) : int;
+	public function insertIgnoreConflict(string $table, array $values, array $hintShardKey = []) : int;
 
 	/**
 	 * Insert or update a row value


### PR DESCRIPTION
* Resolves: #19494

## Summary
Replaces #48564

As we added `hintShardKey` to the query since #48564 was opened, it can't be resolved directly through use of `insertIgnoreConflict` anymore. To set `hintShardKey` anyway, I've added an extra optional 3rd parameter to do that.

As the `insertIgnoreConflict` methods in the database adapters use the connection directly to alter the produced SQL, bypassing the `QueryBuilder` and therefore the `ShardedQueryBuilder` when sharding is activated, I added a `ignoreConflictsOnInsert` method to `IQueryBuilder` we can use to tell the QB to apply a callable provided by the DB adapters to alter the produced SQL in this specific case.

In `OC\Files\Cache\Cache`, I'm bypassing the `CacheQueryBuilder` and using `insertIgnoreConflict` directly on the connection. **It's possible this is very wrong, please advise**.

## TODO

- [ ] Verify that bypassing `CacheQueryBuilder` in this case is fine
- [x] Check it actually works
- [ ] See what kind of tests can be added for that

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
