### PR TITLE
ci(workflows): send new issue notifications to app maintainers by app label

### DIFF
--- a/.github/workflows/notify-owners.yml
+++ b/.github/workflows/notify-owners.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Notify maintainers based on issue labels
+
+on:
+  issues:
+      types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest-low
+    steps:
+        - uses: jenschelkopf/issue-label-notification-action@f7d2363e5efa18b8aeea671ca8093e183ae8f218 # v1.3
+          with:
+             recipients: |
+                  feature: admin audit=@luka-nextcloud @samin-z
+                  feature: caldav=@hamza221 @SebastianKrupinski
+                  feature: carddav=@hamza221 @SebastianKrupinski
+                  feature: comments=@edward-ly @marcelklehr
+                  feature: contacts=@kesselb @SebastianKrupinski
+                  feature: dashboard=@julien-nc @juliusknorr
+                  feature: dav=@hamza221 @SebastianKrupinski
+                  feature: encryption (server-side)=@come-nc @icewind1991
+                  feature: federation=@nfebe
+                  feature: files=@skjnldsv @artonge
+                  feature: files_reminders=@skjnldsv @nfebe
+                  feature: ldap=@come-nc @blizzz
+                  feature: profile=@pringelmann @Altahrim
+                  feature: settings=@hweihwang
+                  feature: status=@Antreesy @nickvergessen
+                  feature: tags=@Antreesy @marcelklehr
+                  feature: theming=@skjnldsv @juliusknorr
+                  feature: webhooks=@janepie @julien-nc
+                  feature: workflows=@blizzz @juliusknorr


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Whenever a new issue for a particular app in this repository is created, this new workflow will send a GitHub notification to the appropriate app maintainer(s) by posting a comment in the issue mentioning them.

The current list of eligible apps only includes those for which a corresponding label already exists, but I am open to suggestions regarding what the final list should contain.

cc @DaphneMuller @janepie 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
