### PR TITLE
Wrap oauth2 token rotation in a transaction

### DIFF
--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -184,21 +184,9 @@ class OauthApiController extends Controller {
 		$redeemedThrottleReason = $grant_type === 'authorization_code'
 			? 'authorization_code_already_redeemed'
 			: 'refresh_token_already_redeemed';
-		$tokenRotated = false;
 
 		$this->db->beginTransaction();
 		try {
-			$appToken = $this->tokenProvider->rotate(
-				$appToken,
-				$decryptedToken,
-				$newToken
-			);
-			$tokenRotated = true;
-
-			// Expiration is in 1 hour again
-			$appToken->setExpires($this->time->getTime() + 3600);
-			$this->tokenProvider->updateToken($appToken);
-
 			$updatedRows = $this->accessTokenMapper->rotateToken(
 				$accessToken->getId(),
 				$code,
@@ -209,8 +197,6 @@ class OauthApiController extends Controller {
 
 			if ($updatedRows !== 1) {
 				$this->db->rollBack();
-				// tokenProvider->rotate() updates the auth token cache, so we have to clear the new token on rollback
-				$this->tokenProvider->invalidateToken($newToken);
 				$response = new JSONResponse([
 					'error' => 'invalid_request',
 				], Http::STATUS_BAD_REQUEST);
@@ -218,16 +204,24 @@ class OauthApiController extends Controller {
 				return $response;
 			}
 
+			$appToken = $this->tokenProvider->rotate(
+				$appToken,
+				$decryptedToken,
+				$newToken
+			);
+
+			// Expiration is in 1 hour again
+			$appToken->setExpires($this->time->getTime() + 3600);
+			$this->tokenProvider->updateToken($appToken);
+
 			$this->db->commit();
 		} catch (\Throwable $e) {
 			if ($this->db->inTransaction()) {
 				$this->db->rollBack();
 			}
-
-			if ($tokenRotated) {
-				// tokenProvider->rotate() updates the auth token cache, so we have to clear the new token on rollback
-				$this->tokenProvider->invalidateToken($newToken);
-			}
+			// rotate() and updateToken() write the auth token to the cache,
+			// so if we are past rotate() we must invalidate the new token
+			$this->tokenProvider->invalidateToken($newToken);
 
 			throw $e;
 		}

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -24,6 +24,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\DB\Exception;
+use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ICrypto;
@@ -47,6 +48,7 @@ class OauthApiController extends Controller {
 		private LoggerInterface $logger,
 		private IThrottler $throttler,
 		private ITimeFactory $timeFactory,
+		private IDBConnection $db,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -177,27 +179,55 @@ class OauthApiController extends Controller {
 
 		// Rotate the apptoken (so the old one becomes invalid basically)
 		$newToken = $this->secureRandom->generate(72, ISecureRandom::CHAR_ALPHANUMERIC);
-
-		$appToken = $this->tokenProvider->rotate(
-			$appToken,
-			$decryptedToken,
-			$newToken
-		);
-
-		// Expiration is in 1 hour again
-		$appToken->setExpires($this->time->getTime() + 3600);
-		$this->tokenProvider->updateToken($appToken);
-
-		// Generate a new refresh token and encrypt the new apptoken in the DB
 		$newCode = $this->secureRandom->generate(128, ISecureRandom::CHAR_ALPHANUMERIC);
-		$accessToken->setHashedCode(hash('sha512', $newCode));
-		$accessToken->setEncryptedToken($this->crypto->encrypt($newToken, $newCode));
-		// increase the number of delivered oauth token
-		// this helps with cleaning up DB access token when authorization code has expired
-		// and it never delivered any oauth token
-		$tokenCount = $accessToken->getTokenCount();
-		$accessToken->setTokenCount($tokenCount + 1);
-		$this->accessTokenMapper->update($accessToken);
+		$newEncryptedToken = $this->crypto->encrypt($newToken, $newCode);
+		$tokenRotated = false;
+
+		$this->db->beginTransaction();
+		try {
+			$appToken = $this->tokenProvider->rotate(
+				$appToken,
+				$decryptedToken,
+				$newToken
+			);
+			$tokenRotated = true;
+
+			// Expiration is in 1 hour again
+			$appToken->setExpires($this->time->getTime() + 3600);
+			$this->tokenProvider->updateToken($appToken);
+
+			$updatedRows = $this->accessTokenMapper->rotateToken(
+				$accessToken->getId(),
+				$code,
+				$newCode,
+				$newEncryptedToken,
+				$grant_type === 'authorization_code',
+			);
+
+			if ($updatedRows !== 1) {
+				$this->db->rollBack();
+				// tokenProvider->rotate() updates the auth token cache, so we have to clear the new token on rollback
+				$this->tokenProvider->invalidateToken($newToken);
+				$response = new JSONResponse([
+					'error' => 'invalid_request',
+				], Http::STATUS_BAD_REQUEST);
+				$response->throttle(['invalid_request' => 'token already redeemed']);
+				return $response;
+			}
+
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			if ($this->db->inTransaction()) {
+				$this->db->rollBack();
+			}
+
+			if ($tokenRotated) {
+				// tokenProvider->rotate() updates the auth token cache, so we have to clear the new token on rollback
+				$this->tokenProvider->invalidateToken($newToken);
+			}
+
+			throw $e;
+		}
 
 		$this->throttler->resetDelay($this->request->getRemoteAddress(), 'login', ['user' => $appToken->getUID()]);
 

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -181,6 +181,9 @@ class OauthApiController extends Controller {
 		$newToken = $this->secureRandom->generate(72, ISecureRandom::CHAR_ALPHANUMERIC);
 		$newCode = $this->secureRandom->generate(128, ISecureRandom::CHAR_ALPHANUMERIC);
 		$newEncryptedToken = $this->crypto->encrypt($newToken, $newCode);
+		$redeemedThrottleReason = $grant_type === 'authorization_code'
+			? 'authorization_code_already_redeemed'
+			: 'refresh_token_already_redeemed';
 		$tokenRotated = false;
 
 		$this->db->beginTransaction();
@@ -211,7 +214,7 @@ class OauthApiController extends Controller {
 				$response = new JSONResponse([
 					'error' => 'invalid_request',
 				], Http::STATUS_BAD_REQUEST);
-				$response->throttle(['invalid_request' => 'token already redeemed']);
+				$response->throttle(['invalid_request' => $redeemedThrottleReason]);
 				return $response;
 			}
 

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -82,4 +82,31 @@ class AccessTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->lt('code_created_at', $qb->createNamedParameter($maxTokenCreationTs, IQueryBuilder::PARAM_INT)));
 		$qb->executeStatement();
 	}
+
+	/**
+	 * Rotate an access token only if it still matches the caller's previously-read state.
+	 *
+	 * @param int $id
+	 * @param string $oldCode
+	 * @param string $newCode
+	 * @param string $encryptedToken
+	 * @param bool $expectAuthorizationCodeState Require the token to still be unused
+	 * @return int Number of updated rows
+	 */
+	public function rotateToken(int $id, string $oldCode, string $newCode, string $encryptedToken, bool $expectAuthorizationCodeState): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb
+			->update($this->tableName)
+			->set('hashed_code', $qb->createNamedParameter(hash('sha512', $newCode)))
+			->set('encrypted_token', $qb->createNamedParameter($encryptedToken))
+			->set('token_count', $qb->createFunction('token_count + 1'))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('hashed_code', $qb->createNamedParameter(hash('sha512', $oldCode))));
+
+		if ($expectAuthorizationCodeState) {
+			$qb->andWhere($qb->expr()->eq('token_count', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+		}
+
+		return $qb->executeStatement();
+	}
 }

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -696,20 +696,14 @@ class OauthApiControllerTest extends TestCase {
 				return 'random' . $len;
 			});
 
-		$this->tokenProvider->expects($this->once())
-			->method('rotate')
-			->with(
-				$appToken,
-				'decryptedToken',
-				'random72'
-			)->willReturn($appToken);
+		$this->tokenProvider->expects($this->never())
+			->method('rotate');
 
 		$this->time->method('getTime')
 			->willReturn(1000);
 
-		$this->tokenProvider->expects($this->once())
-			->method('updateToken')
-			->with($this->isInstanceOf(PublicKeyToken::class));
+		$this->tokenProvider->expects($this->never())
+			->method('updateToken');
 
 		$this->crypto->method('encrypt')
 			->with('random72', 'random128')
@@ -721,16 +715,11 @@ class OauthApiControllerTest extends TestCase {
 		$this->db->expects($this->never())
 			->method('commit');
 
-		$this->db->expects($this->exactly(2))
-			->method('inTransaction')
-			->willReturnOnConsecutiveCalls(true, false);
-
 		$this->db->expects($this->once())
 			->method('rollBack');
 
-		$this->tokenProvider->expects($this->once())
-			->method('invalidateToken')
-			->with('random72');
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateToken');
 
 		$this->accessTokenMapper->expects($this->once())
 			->method('rotateToken')

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -656,7 +656,7 @@ class OauthApiControllerTest extends TestCase {
 		$expected = new JSONResponse([
 			'error' => 'invalid_request',
 		], Http::STATUS_BAD_REQUEST);
-		$expected->throttle(['invalid_request' => 'token already redeemed']);
+		$expected->throttle(['invalid_request' => 'refresh_token_already_redeemed']);
 
 		$accessToken = new AccessToken();
 		$accessToken->setId(21);

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -20,6 +20,7 @@ use OCA\OAuth2\Exceptions\ClientNotFoundException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ICrypto;
@@ -53,6 +54,8 @@ class OauthApiControllerTest extends TestCase {
 	private $logger;
 	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
+	/** @var IDBConnection|\PHPUnit\Framework\MockObject\MockObject */
+	private $db;
 	/** @var OauthApiController */
 	private $oauthApiController;
 
@@ -69,6 +72,7 @@ class OauthApiControllerTest extends TestCase {
 		$this->throttler = $this->createMock(IThrottler::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->db = $this->createMock(IDBConnection::class);
 
 		$this->oauthApiController = new OauthApiController(
 			'oauth2',
@@ -81,7 +85,8 @@ class OauthApiControllerTest extends TestCase {
 			$this->time,
 			$this->logger,
 			$this->throttler,
-			$this->timeFactory
+			$this->timeFactory,
+			$this->db,
 		);
 	}
 
@@ -316,6 +321,7 @@ class OauthApiControllerTest extends TestCase {
 
 	public function testRefreshTokenValidAppToken(): void {
 		$accessToken = new AccessToken();
+		$accessToken->setId(21);
 		$accessToken->setClientId(42);
 		$accessToken->setTokenId(1337);
 		$accessToken->setEncryptedToken('encryptedToken');
@@ -367,6 +373,18 @@ class OauthApiControllerTest extends TestCase {
 		$this->time->method('getTime')
 			->willReturn(1000);
 
+		$this->db->expects($this->once())
+			->method('beginTransaction');
+
+		$this->db->expects($this->once())
+			->method('commit');
+
+		$this->db->expects($this->never())
+			->method('rollBack');
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateToken');
+
 		$this->tokenProvider->expects($this->once())
 			->method('updateToken')
 			->with(
@@ -380,13 +398,14 @@ class OauthApiControllerTest extends TestCase {
 			->willReturn('newEncryptedToken');
 
 		$this->accessTokenMapper->expects($this->once())
-			->method('update')
+			->method('rotateToken')
 			->with(
-				$this->callback(function (AccessToken $token) {
-					return $token->getHashedCode() === hash('sha512', 'random128')
-						&& $token->getEncryptedToken() === 'newEncryptedToken';
-				})
-			);
+				21,
+				'validrefresh',
+				'random128',
+				'newEncryptedToken',
+				false,
+			)->willReturn(1);
 
 		$expected = new JSONResponse([
 			'access_token' => 'random72',
@@ -412,6 +431,7 @@ class OauthApiControllerTest extends TestCase {
 
 	public function testRefreshTokenValidAppTokenBasicAuth(): void {
 		$accessToken = new AccessToken();
+		$accessToken->setId(21);
 		$accessToken->setClientId(42);
 		$accessToken->setTokenId(1337);
 		$accessToken->setEncryptedToken('encryptedToken');
@@ -463,6 +483,18 @@ class OauthApiControllerTest extends TestCase {
 		$this->time->method('getTime')
 			->willReturn(1000);
 
+		$this->db->expects($this->once())
+			->method('beginTransaction');
+
+		$this->db->expects($this->once())
+			->method('commit');
+
+		$this->db->expects($this->never())
+			->method('rollBack');
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateToken');
+
 		$this->tokenProvider->expects($this->once())
 			->method('updateToken')
 			->with(
@@ -476,13 +508,14 @@ class OauthApiControllerTest extends TestCase {
 			->willReturn('newEncryptedToken');
 
 		$this->accessTokenMapper->expects($this->once())
-			->method('update')
+			->method('rotateToken')
 			->with(
-				$this->callback(function (AccessToken $token) {
-					return $token->getHashedCode() === hash('sha512', 'random128')
-						&& $token->getEncryptedToken() === 'newEncryptedToken';
-				})
-			);
+				21,
+				'validrefresh',
+				'random128',
+				'newEncryptedToken',
+				false,
+			)->willReturn(1);
 
 		$expected = new JSONResponse([
 			'access_token' => 'random72',
@@ -511,6 +544,7 @@ class OauthApiControllerTest extends TestCase {
 
 	public function testRefreshTokenExpiredAppToken(): void {
 		$accessToken = new AccessToken();
+		$accessToken->setId(21);
 		$accessToken->setClientId(42);
 		$accessToken->setTokenId(1337);
 		$accessToken->setEncryptedToken('encryptedToken');
@@ -562,6 +596,18 @@ class OauthApiControllerTest extends TestCase {
 		$this->time->method('getTime')
 			->willReturn(1000);
 
+		$this->db->expects($this->once())
+			->method('beginTransaction');
+
+		$this->db->expects($this->once())
+			->method('commit');
+
+		$this->db->expects($this->never())
+			->method('rollBack');
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateToken');
+
 		$this->tokenProvider->expects($this->once())
 			->method('updateToken')
 			->with(
@@ -575,13 +621,14 @@ class OauthApiControllerTest extends TestCase {
 			->willReturn('newEncryptedToken');
 
 		$this->accessTokenMapper->expects($this->once())
-			->method('update')
+			->method('rotateToken')
 			->with(
-				$this->callback(function (AccessToken $token) {
-					return $token->getHashedCode() === hash('sha512', 'random128')
-						&& $token->getEncryptedToken() === 'newEncryptedToken';
-				})
-			);
+				21,
+				'validrefresh',
+				'random128',
+				'newEncryptedToken',
+				false,
+			)->willReturn(1);
 
 		$expected = new JSONResponse([
 			'access_token' => 'random72',
@@ -601,6 +648,102 @@ class OauthApiControllerTest extends TestCase {
 				'login',
 				['user' => 'userId']
 			);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('refresh_token', null, 'validrefresh', 'clientId', 'clientSecret'));
+	}
+
+	public function testRefreshTokenRedeemedConcurrently(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_request',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_request' => 'token already redeemed']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setId(21);
+		$accessToken->setClientId(42);
+		$accessToken->setTokenId(1337);
+		$accessToken->setEncryptedToken('encryptedToken');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validrefresh')
+			->willReturn($accessToken);
+
+		$client = new Client();
+		$client->setClientIdentifier('clientId');
+		$client->setSecret(bin2hex('hashedClientSecret'));
+		$this->clientMapper->method('getByUid')
+			->with(42)
+			->willReturn($client);
+
+		$this->crypto
+			->method('decrypt')
+			->with('encryptedToken')
+			->willReturn('decryptedToken');
+
+		$this->crypto
+			->method('calculateHMAC')
+			->with('clientSecret')
+			->willReturn('hashedClientSecret');
+
+		$appToken = new PublicKeyToken();
+		$appToken->setUid('userId');
+		$this->tokenProvider->method('getTokenById')
+			->with(1337)
+			->willReturn($appToken);
+
+		$this->secureRandom->method('generate')
+			->willReturnCallback(function ($len) {
+				return 'random' . $len;
+			});
+
+		$this->tokenProvider->expects($this->once())
+			->method('rotate')
+			->with(
+				$appToken,
+				'decryptedToken',
+				'random72'
+			)->willReturn($appToken);
+
+		$this->time->method('getTime')
+			->willReturn(1000);
+
+		$this->tokenProvider->expects($this->once())
+			->method('updateToken')
+			->with($this->isInstanceOf(PublicKeyToken::class));
+
+		$this->crypto->method('encrypt')
+			->with('random72', 'random128')
+			->willReturn('newEncryptedToken');
+
+		$this->db->expects($this->once())
+			->method('beginTransaction');
+
+		$this->db->expects($this->never())
+			->method('commit');
+
+		$this->db->expects($this->exactly(2))
+			->method('inTransaction')
+			->willReturnOnConsecutiveCalls(true, false);
+
+		$this->db->expects($this->once())
+			->method('rollBack');
+
+		$this->tokenProvider->expects($this->once())
+			->method('invalidateToken')
+			->with('random72');
+
+		$this->accessTokenMapper->expects($this->once())
+			->method('rotateToken')
+			->with(
+				21,
+				'validrefresh',
+				'random128',
+				'newEncryptedToken',
+				false,
+			)->willReturn(0);
+
+		$this->throttler->expects($this->never())
+			->method('resetDelay');
 
 		$this->assertEquals($expected, $this->oauthApiController->getToken('refresh_token', null, 'validrefresh', 'clientId', 'clientSecret'));
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Wrap the token rotation in a transaction, only rotate if the access token hasn't been modified since we have read it.
If the access token has been modified, we invalidate the authentication token if needed and we rollback the db changes.

This logic applies to a code (when generating the first access token) or a refresh token (when refreshing an access token).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
