### PR TITLE
fix: avoid checking share validity during mount updates

### DIFF
--- a/apps/files_sharing/lib/ShareRecipientUpdater.php
+++ b/apps/files_sharing/lib/ShareRecipientUpdater.php
@@ -89,7 +89,7 @@ class ShareRecipientUpdater {
 	 */
 	public function updateForDeletedShare(IUser $user, IShare $share): void {
 		try {
-			$userShare = $this->shareManager->getShareById($share->getFullId(), $user->getUID());
+			$userShare = $this->shareManager->getShareById($share->getFullId(), $user->getUID(), false);
 			$this->userMountCache->removeMount($this->getMountPointFromTarget($user, $userShare->getTarget()), $user);
 		} catch (ShareNotFound) {
 			// user doesn't actually have access to the share


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
