### PR TITLE
fix: track time spent in recursive markOrRun calls

### DIFF
--- a/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
+++ b/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
@@ -43,9 +43,11 @@ class SharesUpdatedListener implements IEventListener {
 	private float $cutOffMarkTime;
 
 	/**
-	 * The total amount of time we've spent so far processing updates
+	 * Timestamp marking the first time this listener was triggered, used to
+	 * determine if we should update the share date immediately or just mark the
+	 * users for refresh.
 	 */
-	private float $updatedTime = 0.0;
+	private ?float $firstRun = null;
 	private bool $inUpdate = false;
 
 	public function __construct(
@@ -134,14 +136,15 @@ class SharesUpdatedListener implements IEventListener {
 	}
 
 	private function markOrRun(IUser $user, callable $callback): void {
-		$start = floatval($this->clock->now()->format('U.u'));
-		if ($this->cutOffMarkTime === -1.0 || $this->updatedTime < $this->cutOffMarkTime) {
+		$now = floatval($this->clock->now()->format('U.u'));
+		$this->firstRun ??= $now;
+		$elapsed = $now - $this->firstRun;
+
+		if ($this->cutOffMarkTime === -1.0 && $elapsed < $this->cutOffMarkTime) {
 			$callback();
 		} else {
 			$this->markUserForRefresh($user);
 		}
-		$end = floatval($this->clock->now()->format('U.u'));
-		$this->updatedTime += $end - $start;
 	}
 
 	private function updateOrMarkUser(IUser $user): void {

--- a/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
+++ b/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
@@ -43,9 +43,11 @@ class SharesUpdatedListener implements IEventListener {
 	private float $cutOffMarkTime;
 
 	/**
-	 * The total amount of time we've spent so far processing updates
+	 * Timestamp marking the first time this listener was triggered, used to
+	 * determine if we should update the share date immediately or just mark the
+	 * users for refresh.
 	 */
-	private float $updatedTime = 0.0;
+	private ?float $firstRun = null;
 
 	public function __construct(
 		private readonly IManager $shareManager,
@@ -128,14 +130,15 @@ class SharesUpdatedListener implements IEventListener {
 	}
 
 	private function markOrRun(IUser $user, callable $callback): void {
-		$start = floatval($this->clock->now()->format('U.u'));
-		if ($this->cutOffMarkTime === -1.0 || $this->updatedTime < $this->cutOffMarkTime) {
+		$now = (float)$this->clock->now()->format('U.u');
+		$this->firstRun ??= $now;
+		$elapsed = $now - $this->firstRun;
+
+		if ($this->cutOffMarkTime === -1.0 || $elapsed < $this->cutOffMarkTime) {
 			$callback();
 		} else {
 			$this->markUserForRefresh($user);
 		}
-		$end = floatval($this->clock->now()->format('U.u'));
-		$this->updatedTime += $end - $start;
 	}
 
 	private function updateOrMarkUser(IUser $user): void {

--- a/apps/files_sharing/tests/SharesUpdatedListenerTest.php
+++ b/apps/files_sharing/tests/SharesUpdatedListenerTest.php
@@ -39,6 +39,8 @@ class SharesUpdatedListenerTest extends \Test\TestCase {
 	private LoggerInterface&MockObject $logger;
 	private $clockFn;
 
+	private int $time = 0;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -50,7 +52,7 @@ class SharesUpdatedListenerTest extends \Test\TestCase {
 		$this->userConfig = new MockUserConfig();
 		$this->clock = $this->createMock(ClockInterface::class);
 		$this->clockFn = function () {
-			return new \DateTimeImmutable('@0');
+			return new \DateTimeImmutable("@{$this->time}");
 		};
 		$this->clock->method('now')
 			->willReturnCallback(function () {
@@ -159,6 +161,36 @@ class SharesUpdatedListenerTest extends \Test\TestCase {
 			[1.1, 2],
 			[-1, 2],
 		];
+	}
+
+	public function testCutoffSpansMultipleHandleInvocations(): void {
+		$share = $this->createMock(IShare::class);
+		$user1 = $this->createUser('user1', '');
+
+		$this->manager->method('getUsersForShare')
+			->willReturn([$user1]);
+
+		$event = new ShareCreatedEvent($share);
+		$this->sharesUpdatedListener->setCutOffMarkTime(4);
+
+		// First handle at t=0: firstRun=0, elapsed=0 < 0.5 → callback runs
+		$this->shareRecipientUpdater
+			->expects($this->exactly(2))
+			->method('updateForAddedShare');
+
+		$this->assertFalse(
+			$this->userConfig->getValueBool($user1->getUID(), 'files_sharing', ConfigLexicon::USER_NEEDS_SHARE_REFRESH)
+		);
+
+		$this->sharesUpdatedListener->handle($event);
+		$this->time = 1;
+		$this->sharesUpdatedListener->handle($event);
+		$this->time = 4;
+		$this->sharesUpdatedListener->handle($event);
+
+		$this->assertTrue(
+			$this->userConfig->getValueBool($user1->getUID(), 'files_sharing', ConfigLexicon::USER_NEEDS_SHARE_REFRESH)
+		);
 	}
 
 	#[DataProvider('shareMarkAfterTimeProvider')]


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The callback executed by `SharesUpdatedListener::markOrRun` may emit events that are handled by the same event listener. In an unfortunate chain, if A causes B which causes C ... etc, and all are handled by this listener, the execution will not stop even after the elapsed time is greater than the cutoff time, as the elapsed time is only updated after the callback finishes.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
