### PR TITLE
fix(files_sharing): Drop trailing '?' from public download redirect URL

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -401,7 +401,9 @@ class ShareController extends AuthPublicShareController {
 		}
 
 		$davUrl = '/public.php/dav/files/' . $token . $davPath;
-		$davUrl .= '?' . http_build_query($params);
+		if (!empty($params)) {
+			$davUrl .= '?' . http_build_query($params);
+		}
 		return new RedirectResponse($this->urlGenerator->getAbsoluteURL($davUrl));
 	}
 }


### PR DESCRIPTION
Public share download links now redirect to the public DAV endpoint cleanly when no additional query parameters are present. Previously the redirect always appended a trailing '?' to the target URL, which caused an Internal Server Error for clients that called the legacy download endpoint without query parameters (e.g. the Thunderbird FileLink extension). Links shared before this change are resolvable again.

