### PR TITLE
fix(webhook-listeners): hour lifetime of tokens

### DIFF
--- a/apps/webhook_listeners/lib/Db/EphemeralTokenMapper.php
+++ b/apps/webhook_listeners/lib/Db/EphemeralTokenMapper.php
@@ -25,7 +25,7 @@ use Psr\Log\LoggerInterface;
 
 class EphemeralTokenMapper extends QBMapper {
 	public const TABLE_NAME = 'webhook_tokens';
-	public const TOKEN_LIFETIME = 1 * 1 * 60; // one hour in seconds
+	public const TOKEN_LIFETIME = 1 * 60 * 60; // one hour in seconds
 
 	public function __construct(
 		IDBConnection $db,


### PR DESCRIPTION
Token lifetime should be an hour, there was a 60 missing


## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
