### PR TITLE
perf(appstore): optimize apps.json processing and reuse stale cache on refresh failure

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -90,7 +90,10 @@ class AppFetcher extends Fetcher {
 				}
 
 				try {
-					$rawPlatformVersionSpec = (string)$release['rawPlatformVersionSpec'];
+					$rawPlatformVersionSpec = $release['rawPlatformVersionSpec'] ?? null;
+					if ($rawPlatformVersionSpec === null) {
+						continue; // no spec; treat as incompatible, skip
+					}
 					if (!isset($platformSpecCache[$rawPlatformVersionSpec])) {
 						$serverVersion = $versionParser->getVersion($rawPlatformVersionSpec);
 						$platformSpecCache[$rawPlatformVersionSpec] = [
@@ -106,8 +109,7 @@ class AppFetcher extends Fetcher {
 
 					$isPhpCompatible = true;
 
-					$rawPhpVersionSpec = (string)($release['rawPhpVersionSpec'] ?? '*');
-
+					$rawPhpVersionSpec = $release['rawPhpVersionSpec'] ?? '*';
 					if ($rawPhpVersionSpec !== '*') {
 						if (!isset($phpSpecCache[$rawPhpVersionSpec])) {
 							$phpVersion = $versionParser->getVersion($rawPhpVersionSpec);
@@ -174,12 +176,6 @@ class AppFetcher extends Fetcher {
 
 		// If the admin specified a allow list, filter apps from the appstore
 		$allowList = $this->config->getSystemValue('appsallowlist');
-		if (is_array($allowList) && $this->registry->delegateHasValidSubscription()) {
-			$allowSet = array_flip($allowList);
-			return array_values(array_filter($apps, static function ($app) use ($allowSet) {
-				return isset($allowSet[$app['id']]);
-			}));
-		}
 		if (is_array($allowList) && $this->registry->delegateHasValidSubscription()) {
 			$allowSet = array_flip($allowList);
 			return array_filter($apps, static function ($app) use ($allowSet) {

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -60,80 +60,93 @@ class AppFetcher extends Fetcher {
 			return [];
 		}
 
-		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
-		$allowNightly = $allowUnstable || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
+		$channel = $this->getChannel();
+		$allowPreReleases = $allowUnstable || $channel === 'beta' || $channel === 'daily' || $channel === 'git';
+		$allowNightly = $allowUnstable || $channel === 'daily' || $channel === 'git';
+
+		$versionParser = new VersionParser();
+		$ncVersion = $this->getVersion();
+		$currentPhpVersion = PHP_VERSION;
+		$ignoreMaxVersion = $this->ignoreMaxVersion;
+
+		/** @var array<string, array{0: string, 1: string}> $platformSpecCache */
+		$platformSpecCache = [];
+		/** @var array<string, array{0: string, 1: string}> $phpSpecCache */
+		$phpSpecCache = [];
 
 		foreach ($response['data'] as $dataKey => $app) {
-			$releases = [];
+			$bestRelease = null;
 
-			// Filter all compatible releases
+			// Filter compatible releases
 			foreach ($app['releases'] as $release) {
-				// Exclude all nightly and pre-releases if required
-				if (($allowNightly || $release['isNightly'] === false)
-					&& ($allowPreReleases || !str_contains($release['version'], '-'))) {
-					// Exclude all versions not compatible with the current version
-					try {
-						$versionParser = new VersionParser();
-						$serverVersion = $versionParser->getVersion($release['rawPlatformVersionSpec']);
-						$ncVersion = $this->getVersion();
-						$minServerVersion = $serverVersion->getMinimumVersion();
-						$maxServerVersion = $serverVersion->getMaximumVersion();
-						$minFulfilled = $this->compareVersion->isCompatible($ncVersion, $minServerVersion, '>=');
-						$maxFulfilled = $maxServerVersion !== ''
-							&& $this->compareVersion->isCompatible($ncVersion, $maxServerVersion, '<=');
-						$isPhpCompatible = true;
-						if (($release['rawPhpVersionSpec'] ?? '*') !== '*') {
-							$phpVersion = $versionParser->getVersion($release['rawPhpVersionSpec']);
-							$minPhpVersion = $phpVersion->getMinimumVersion();
-							$maxPhpVersion = $phpVersion->getMaximumVersion();
-							$minPhpFulfilled = $minPhpVersion === '' || $this->compareVersion->isCompatible(
-								PHP_VERSION,
-								$minPhpVersion,
-								'>='
-							);
-							$maxPhpFulfilled = $maxPhpVersion === '' || $this->compareVersion->isCompatible(
-								PHP_VERSION,
-								$maxPhpVersion,
-								'<='
-							);
+				// Exclude nightly builds
+				if (($release['isNightly'] ?? false) !== false && !$allowNightly) {
+					continue;
+				}
 
-							$isPhpCompatible = $minPhpFulfilled && $maxPhpFulfilled;
-						}
-						if ($minFulfilled && ($this->ignoreMaxVersion || $maxFulfilled) && $isPhpCompatible) {
-							$releases[] = $release;
-						}
-					} catch (\InvalidArgumentException $e) {
-						$this->logger->warning($e->getMessage(), [
-							'exception' => $e,
-						]);
+				// Exclude pre-releases
+				if (str_contains($release['version'], '-') && !$allowPreReleases)) {
+					continue;
+				}
+
+				try {
+					$rawPlatformVersionSpec = (string)$release['rawPlatformVersionSpec'];
+					if (!isset($platformSpecCache[$rawPlatformVersionSpec])) {
+						$serverVersion = $versionParser->getVersion($rawPlatformVersionSpec);
+						$platformSpecCache[$rawPlatformVersionSpec] = [
+							$serverVersion->getMinimumVersion(),
+							$serverVersion->getMaximumVersion(),
+						];
 					}
+
+					[$minServerVersion, $maxServerVersion] = $platformSpecCache[$rawPlatformVersionSpec];
+
+					$minFulfilled = $this->compareVersion->isCompatible($ncVersion, $minServerVersion, '>=');
+					$maxFulfilled = $maxServerVersion !== '' && $this->compareVersion->isCompatible($ncVersion, $maxServerVersion, '<=');
+
+					$isPhpCompatible = true;
+
+					$rawPhpVersionSpec = (string)($release['rawPhpVersionSpec'] ?? '*');
+
+					if ($rawPhpVersionSpec !== '*') {
+						if (!isset($phpSpecCache[$rawPhpVersionSpec])) {
+							$phpVersion = $versionParser->getVersion($rawPhpVersionSpec);
+							$phpSpecCache[$rawPhpVersionSpec] = [
+								$phpVersion->getMinimumVersion(),
+								$phpVersion->getMaximumVersion(),
+							];
+						}
+		
+						[$minPhpVersion, $maxPhpVersion] = $phpSpecCache[$rawPhpVersionSpec];
+
+						$minPhpFulfilled = $minPhpVersion === '' || $this->compareVersion->isCompatible($currentPhpVersion, $minPhpVersion, '>=');
+						$maxPhpFulfilled = $maxPhpVersion === '' || $this->compareVersion->isCompatible($currentPhpVersion, $maxPhpVersion, '<=');
+						
+						$isPhpCompatible = $minPhpFulfilled && $maxPhpFulfilled;
+					}
+
+					$isCompatible = $minFulfilled && ($ignoreMaxVersion || $maxFulfilled) && $isPhpCompatible;
+
+					if (!$isCompatible) {
+						continue;
+					}
+
+					$betterRelease = $bestRelease === null || version_compare((string)$release['version'], (string)$bestRelease['version'], '>');
+					if ($betterRelease) {
+						$bestRelease = $release;
+					}
+				} catch (\InvalidArgumentException $e) {
+					$this->logger->warning($e->getMessage(), [ 'exception' => $e, ]);
 				}
 			}
 
-			if (empty($releases)) {
+			if ($bestRelease === null) {
 				// Remove apps that don't have a matching release
 				$response['data'][$dataKey] = [];
 				continue;
 			}
 
-			// Get the highest version
-			$versions = [];
-			foreach ($releases as $release) {
-				$versions[] = $release['version'];
-			}
-			usort($versions, function ($version1, $version2) {
-				return version_compare($version1, $version2);
-			});
-			$versions = array_reverse($versions);
-			if (isset($versions[0])) {
-				$highestVersion = $versions[0];
-				foreach ($releases as $release) {
-					if ((string)$release['version'] === (string)$highestVersion) {
-						$response['data'][$dataKey]['releases'] = [$release];
-						break;
-					}
-				}
-			}
+			$response['data'][$dataKey]['releases'] = [$bestRelease];
 		}
 
 		$response['data'] = array_values(array_filter($response['data']));

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -85,7 +85,7 @@ class AppFetcher extends Fetcher {
 				}
 
 				// Exclude pre-releases
-				if (str_contains($release['version'], '-') && !$allowPreReleases)) {
+				if (str_contains($release['version'], '-') && !$allowPreReleases) {
 					continue;
 				}
 

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -80,7 +80,7 @@ class AppFetcher extends Fetcher {
 			// Filter compatible releases
 			foreach ($app['releases'] as $release) {
 				// Exclude nightly builds
-				if (($release['isNightly'] ?? false) !== false && !$allowNightly) {
+				if ($release['isNightly'] !== false && !$allowNightly) {
 					continue;
 				}
 

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -171,12 +171,13 @@ class AppFetcher extends Fetcher {
 		if (empty($apps)) {
 			return [];
 		}
-		$allowList = $this->config->getSystemValue('appsallowlist');
 
 		// If the admin specified a allow list, filter apps from the appstore
+		$allowList = $this->config->getSystemValue('appsallowlist');
 		if (is_array($allowList) && $this->registry->delegateHasValidSubscription()) {
-			return array_filter($apps, function ($app) use ($allowList) {
-				return in_array($app['id'], $allowList);
+			$allowSet = array_flip($allowList);
+			return array_filter($apps, static function ($app) use ($allowSet) {
+				return isset($allowSet[$app['id']]);
 			});
 		}
 

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -176,6 +176,12 @@ class AppFetcher extends Fetcher {
 		$allowList = $this->config->getSystemValue('appsallowlist');
 		if (is_array($allowList) && $this->registry->delegateHasValidSubscription()) {
 			$allowSet = array_flip($allowList);
+			return array_values(array_filter($apps, static function ($app) use ($allowSet) {
+				return isset($allowSet[$app['id']]);
+			}));
+		}
+		if (is_array($allowList) && $this->registry->delegateHasValidSubscription()) {
+			$allowSet = array_flip($allowList);
 			return array_filter($apps, static function ($app) use ($allowSet) {
 				return isset($allowSet[$app['id']]);
 			});

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -175,7 +175,7 @@ abstract class Fetcher {
 			$responseJson = $this->fetch($ETag, $content, $allowUnstable);
 
 			if (empty($responseJson) || empty($responseJson['data'])) {
-				return [];
+				return is_array($cachedData) ? $cachedData : [];
 			}
 
 			$file->putContent(json_encode($responseJson));

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -134,6 +134,7 @@ abstract class Fetcher {
 
 		$ETag = '';
 		$content = '';
+		$cachedData = null;
 
 		try {
 			// File does already exists
@@ -141,6 +142,10 @@ abstract class Fetcher {
 			$jsonBlob = json_decode($file->getContent(), true);
 
 			if (is_array($jsonBlob)) {
+				if (isset($jsonBlob['data']) && is_array($jsonBlob['data'])) {
+					$cachedData = $jsonBlob['data'];
+				}
+
 				// No caching when the version has been updated
 				if (isset($jsonBlob['ncversion']) && $jsonBlob['ncversion'] === $this->getVersion()) {
 					// If the timestamp is older than 3600 seconds request the files new
@@ -177,13 +182,10 @@ abstract class Fetcher {
 			return $responseJson['data'];
 		} catch (ConnectException $e) {
 			$this->logger->warning('Could not connect to appstore: ' . $e->getMessage(), ['app' => 'appstoreFetcher']);
-			return [];
+			return is_array($cachedData) ? $cachedData : [];
 		} catch (\Exception $e) {
-			$this->logger->warning($e->getMessage(), [
-				'exception' => $e,
-				'app' => 'appstoreFetcher',
-			]);
-			return [];
+			$this->logger->warning($e->getMessage(), ['exception' => $e, 'app' => 'appstoreFetcher',]);
+			return is_array($cachedData) ? $cachedData : [];
 		}
 	}
 

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -174,7 +174,7 @@ abstract class Fetcher {
 			}
 
 			$file->putContent(json_encode($responseJson));
-			return json_decode($file->getContent(), true)['data'];
+			return $responseJson['data'];
 		} catch (ConnectException $e) {
 			$this->logger->warning('Could not connect to appstore: ' . $e->getMessage(), ['app' => 'appstoreFetcher']);
 			return [];

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -2250,4 +2250,97 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 		$this->assertEquals(count($apps), 1);
 		$this->assertEquals($apps[0]['id'], 'contacts');
 	}
+
+	public function testGetKeepsHighestCompatibleReleaseOnly(): void {
+		$this->config->method('getSystemValueString')
+			->willReturnCallback(function ($key, $default) {
+				if ($key === 'version') {
+					return '30.0.0';
+				} elseif ($key === 'appstoreurl' && $default === 'https://apps.nextcloud.com/api/v1') {
+					return 'https://custom.appsstore.endpoint/api/v1';
+				}
+				return $default;
+			});
+		$this->config->method('getSystemValueBool')
+			->willReturnArgument(1);
+
+		$file = $this->createMock(ISimpleFile::class);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder
+			->expects($this->once())
+			->method('getFile')
+			->with('apps.json')
+			->willThrowException(new NotFoundException());
+		$folder
+			->expects($this->once())
+			->method('newFile')
+			->with('apps.json')
+			->willReturn($file);
+		$this->appData
+			->expects($this->once())
+			->method('getFolder')
+			->with('/')
+			->willReturn($folder);
+
+		$client = $this->createMock(IClient::class);
+		$this->clientService
+			->expects($this->once())
+			->method('newClient')
+			->willReturn($client);
+
+		$response = $this->createMock(IResponse::class);
+		$client
+			->expects($this->once())
+			->method('get')
+			->with('https://custom.appsstore.endpoint/api/v1/apps.json')
+			->willReturn($response);
+
+		$response
+			->expects($this->once())
+			->method('getBody')
+			->willReturn(json_encode([
+				[
+					'id' => 'testapp',
+					'releases' => [
+						[
+							'version' => '1.0.0',
+							'isNightly' => false,
+							'rawPhpVersionSpec' => '*',
+							'rawPlatformVersionSpec' => '>=30 <=30',
+						],
+						[
+							'version' => '1.5.0',
+							'isNightly' => false,
+							'rawPhpVersionSpec' => '*',
+							'rawPlatformVersionSpec' => '>=30 <=30',
+						],
+						[
+							'version' => '2.0.0',
+							'isNightly' => false,
+							'rawPhpVersionSpec' => '*',
+							'rawPlatformVersionSpec' => '>=31 <=31',
+						],
+					],
+				],
+			], JSON_THROW_ON_ERROR));
+		$response->method('getHeader')
+			->with($this->equalTo('ETag'))
+			->willReturn('"myETag"');
+
+		$this->timeFactory
+			->expects($this->once())
+			->method('getTime')
+			->willReturn(1234);
+
+		$file
+			->expects($this->once())
+			->method('putContent');
+
+		$result = $this->fetcher->get();
+
+		$this->assertCount(1, $result);
+		$this->assertSame('testapp', $result[0]['id']);
+		$this->assertCount(1, $result[0]['releases']);
+		$this->assertSame('1.5.0', $result[0]['releases'][0]['version']);
+	}
 }

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -465,9 +465,9 @@ abstract class FetcherBase extends TestCase {
 			->willReturn('{"timestamp":1200,"data":[{"id":"MyApp"}],"ncversion":"11.0.0.2","ETag":"\"myETag\""}');
 
 		$this->timeFactory
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('getTime')
-			->willReturn(4801);
+			->willReturnOnConsecutiveCalls(4801, 4801);
 
 		$expected = [
 			[

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -149,9 +149,8 @@ abstract class FetcherBase extends TestCase {
 			->method('putContent')
 			->with($fileData);
 		$file
-			->expects($this->once())
-			->method('getContent')
-			->willReturn($fileData);
+			->expects($this->never())
+			->method('getContent');
 		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')
@@ -199,12 +198,9 @@ abstract class FetcherBase extends TestCase {
 			->method('putContent')
 			->with($fileData);
 		$file
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getContent')
-			->willReturnOnConsecutiveCalls(
-				'{"timestamp":1200,"data":{"MyApp":{"id":"MyApp"}},"ncversion":"11.0.0.2"}',
-				$fileData
-			);
+			->willReturn('{"timestamp":1200,"data":{"MyApp":{"id":"MyApp"}},"ncversion":"11.0.0.2"}');
 		$this->timeFactory
 			->expects($this->exactly(2))
 			->method('getTime')
@@ -275,12 +271,9 @@ abstract class FetcherBase extends TestCase {
 			->method('putContent')
 			->with($fileData);
 		$file
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getContent')
-			->willReturnOnConsecutiveCalls(
-				'{"timestamp":1200,"data":{"MyApp":{"id":"MyApp"}}',
-				$fileData
-			);
+			->willReturn('{"timestamp":1200,"data":{"MyApp":{"id":"MyApp"}}');
 		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')
@@ -348,12 +341,9 @@ abstract class FetcherBase extends TestCase {
 			->method('putContent')
 			->with($fileData);
 		$file
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getContent')
-			->willReturnOnConsecutiveCalls(
-				'{"timestamp":1200,"data":{"MyApp":{"id":"MyApp"}},"ncversion":"11.0.0.1"',
-				$fileData
-			);
+			->willReturn('{"timestamp":1200,"data":{"MyApp":{"id":"MyApp"}},"ncversion":"11.0.0.1"');
 		$this->timeFactory
 			->method('getTime')
 			->willReturn(1201);
@@ -388,9 +378,14 @@ abstract class FetcherBase extends TestCase {
 		$this->assertSame($expected, $this->fetcher->get());
 	}
 
-	public function testGetWithExceptionInClient(): void {
+	public function testGetWithExceptionInClientReturnsStaleCachedData(): void {
 		$this->config->method('getSystemValueString')
-			->willReturnArgument(1);
+			->willReturnCallback(function ($key, $default) {
+				if ($key === 'version') {
+					return '11.0.0.2';
+				}
+				return $default;
+			});
 		$this->config->method('getSystemValueBool')
 			->willReturnArgument(1);
 
@@ -409,7 +404,13 @@ abstract class FetcherBase extends TestCase {
 		$file
 			->expects($this->once())
 			->method('getContent')
-			->willReturn('{"timestamp":1200,"data":{"MyApp":{"id":"MyApp"}}}');
+			->willReturn('{"timestamp":1200,"data":[{"id":"MyApp"}],"ncversion":"11.0.0.2","ETag":"\"myETag\""}');
+
+		$this->timeFactory
+			->expects($this->once())
+			->method('getTime')
+			->willReturn(4801);
+
 		$client = $this->createMock(IClient::class);
 		$this->clientService
 			->expects($this->once())
@@ -419,9 +420,144 @@ abstract class FetcherBase extends TestCase {
 			->expects($this->once())
 			->method('get')
 			->with($this->endpoint)
-			->willThrowException(new \Exception());
+			->willThrowException(new \Exception('refresh failed'));
 
-		$this->assertSame([], $this->fetcher->get());
+		$expected = [
+			[
+				'id' => 'MyApp',
+			],
+		];
+
+		$this->assertSame($expected, $this->fetcher->get());
+	}
+
+	public function testGetReturnsStaleCachedDataWhenRefreshReturnsEmptyResult(): void {
+		$this->config->method('getSystemValueString')
+			->willReturnCallback(function ($key, $default) {
+				if ($key === 'version') {
+					return '11.0.0.2';
+				}
+				return $default;
+			});
+		$this->config->method('getSystemValueBool')
+			->willReturnArgument(1);
+
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['settings', 'appstore-fetcher-lastFailure', '0', '4800'],
+			]);
+
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->appData
+			->expects($this->once())
+			->method('getFolder')
+			->with('/')
+			->willReturn($folder);
+		$folder
+			->expects($this->once())
+			->method('getFile')
+			->with($this->fileName)
+			->willReturn($file);
+		$file
+			->expects($this->once())
+			->method('getContent')
+			->willReturn('{"timestamp":1200,"data":[{"id":"MyApp"}],"ncversion":"11.0.0.2","ETag":"\"myETag\""}');
+
+		$this->timeFactory
+			->expects($this->once())
+			->method('getTime')
+			->willReturn(4801);
+
+		$expected = [
+			[
+				'id' => 'MyApp',
+			],
+		];
+
+		$this->assertSame($expected, $this->fetcher->get());
+	}
+
+	public function testGetReturnsFreshDataWithoutReadingBackWrittenCache(): void {
+		$this->config
+			->method('getSystemValueString')
+			->willReturnCallback(function ($var, $default) {
+				if ($var === 'appstoreurl') {
+					return 'https://apps.nextcloud.com/api/v1';
+				} elseif ($var === 'version') {
+					return '11.0.0.2';
+				}
+				return $default;
+			});
+		$this->config->method('getSystemValueBool')
+			->willReturnArgument(1);
+
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->appData
+			->expects($this->once())
+			->method('getFolder')
+			->with('/')
+			->willReturn($folder);
+		$folder
+			->expects($this->once())
+			->method('getFile')
+			->with($this->fileName)
+			->willThrowException(new NotFoundException());
+		$folder
+			->expects($this->once())
+			->method('newFile')
+			->with($this->fileName)
+			->willReturn($file);
+
+		$client = $this->createMock(IClient::class);
+		$this->clientService
+			->expects($this->once())
+			->method('newClient')
+			->willReturn($client);
+
+		$response = $this->createMock(IResponse::class);
+		$client
+			->expects($this->once())
+			->method('get')
+			->with($this->endpoint)
+			->willReturn($response);
+
+		$response
+			->expects($this->once())
+			->method('getBody')
+			->willReturn('[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}]');
+		$response
+			->method('getHeader')
+			->with($this->equalTo('ETag'))
+			->willReturn('"myETag"');
+
+		$fileData = '{"data":[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}],"timestamp":1502,"ncversion":"11.0.0.2","ETag":"\"myETag\""}';
+		$file
+			->expects($this->once())
+			->method('putContent')
+			->with($fileData);
+
+		$file
+			->expects($this->never())
+			->method('getContent');
+
+		$this->timeFactory
+			->expects($this->once())
+			->method('getTime')
+			->willReturn(1502);
+
+		$expected = [
+			[
+				'id' => 'MyNewApp',
+				'foo' => 'foo',
+			],
+			[
+				'id' => 'bar',
+			],
+		];
+
+		$this->assertSame($expected, $this->fetcher->get());
 	}
 
 	public function testGetMatchingETag(): void {
@@ -462,12 +598,9 @@ abstract class FetcherBase extends TestCase {
 			->method('putContent')
 			->with($newData);
 		$file
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getContent')
-			->willReturnOnConsecutiveCalls(
-				$origData,
-				$newData,
-			);
+			->willReturn($origData);
 		$this->timeFactory
 			->expects($this->exactly(2))
 			->method('getTime')
@@ -545,12 +678,9 @@ abstract class FetcherBase extends TestCase {
 			->method('putContent')
 			->with($fileData);
 		$file
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getContent')
-			->willReturnOnConsecutiveCalls(
-				'{"data":[{"id":"MyOldApp","abc":"def"}],"timestamp":1200,"ncversion":"11.0.0.2","ETag":"\"myETag\""}',
-				$fileData,
-			);
+			->willReturn('{"data":[{"id":"MyOldApp","abc":"def"}],"timestamp":1200,"ncversion":"11.0.0.2","ETag":"\"myETag\""}');
 		$this->timeFactory
 			->expects($this->exactly(2))
 			->method('getTime')
@@ -636,12 +766,9 @@ abstract class FetcherBase extends TestCase {
 			->method('putContent')
 			->with($fileData);
 		$file
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getContent')
-			->willReturnOnConsecutiveCalls(
-				'{"data":[{"id":"MyOldApp","abc":"def"}],"timestamp":1200,"ncversion":"11.0.0.2","ETag":"\"myETag\""}',
-				$fileData
-			);
+			->willReturn('{"data":[{"id":"MyOldApp","abc":"def"}],"timestamp":1200,"ncversion":"11.0.0.2","ETag":"\"myETag\""}');
 		$client = $this->createMock(IClient::class);
 		$this->clientService
 			->expects($this->once())


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Improve appstore refresh performance and resilience by reducing work in the hot path, avoiding unnecessary cache I/O, and reusing stale cached data when refresh fails.

### Changes

* refactor `AppFetcher::fetch()` to:
  - reuse a single `VersionParser`
  - memoize parsed platform/PHP version specs
  - select the best compatible release in a single pass
  - avoid temporary arrays and per-app sorting
* clean up `Fetcher::get()` to:
  - return processed data directly after writing cache content
  - avoid immediately re-reading and decoding the just-written cache file
  - return stale cached data instead of `[]` when a refresh fails and a previous cache exists
* tests
  - adjust to anticipate stale caching response behavior change
  - adjust to no longer expect reading data back from storage immediately after writing it
  - expand appfetcher coverage to include "highest compatible version wins"

### Why

The appstore feed is large (~27 MB raw in local benchmarking), while the processed cache is much smaller (~3.4 MB). Most of the hot-path CPU cost comes from filtering and selecting compatible releases for each app. On refresh failures, serving the last known good cache is also more resilient than returning an empty app list.

### Benchmarks

Local benchmarks on a real `apps.json` showed:
- `AppFetcher` processing: ~1.4x faster
- end-to-end local refresh path: ~1.09x–1.11x faster
- Note: the end-to-end number is dominated by HTTP + JSON decode, which this PR doesn't change.

### Notes

This change is intended to be behavior-preserving on successful refreshes and does not change the persisted cache format.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
