### PR TITLE
feat(theming): Introduce font weight variables

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -70,6 +70,12 @@
   --font-face: system-ui, -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --default-font-size: 15px;
   --font-size-small: 13px;
+  /* Default text font weight */
+  --font-weight-default: 400;
+  /* Font weight for interactive elements */
+  --font-weight-element: 500;
+  /* Weight for titles and headings */
+  --font-weight-heading: 600;
   /* 1.5 x font-size for accessibility */
   --default-line-height: 1.5;
   --animation-quick: 100ms;

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -194,6 +194,12 @@ class DefaultTheme implements ITheme {
 			'--font-face' => "system-ui, -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
 			'--default-font-size' => '15px',
 			'--font-size-small' => '13px',
+			// Default text font weight
+			'--font-weight-default' => '400',
+			// Font weight for interactive elements
+			'--font-weight-element' => '500',
+			// Weight for titles and headings
+			'--font-weight-heading' => '600',
 			// 1.5 * font-size for accessibility
 			'--default-line-height' => '1.5',
 


### PR DESCRIPTION
## Summary

Counterpart of https://github.com/nextcloud-libraries/nextcloud-vue/pull/8469

@ShGKme

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
