### PR TITLE
perf: delay loading storage info in Cache untill needed

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -61,7 +61,7 @@ class Cache implements ICache {
 	 */
 	protected array $partial = [];
 	protected string $storageId;
-	protected Storage $storageCache;
+	protected ?Storage $storageCache = null;
 	protected IMimeTypeLoader $mimetypeLoader;
 	protected IDBConnection $connection;
 	protected SystemConfig $systemConfig;
@@ -69,6 +69,7 @@ class Cache implements ICache {
 	protected QuerySearchHelper $querySearchHelper;
 	protected IEventDispatcher $eventDispatcher;
 	protected IFilesMetadataManager $metadataManager;
+	private CacheDependencies $cacheDependencies;
 
 	public function __construct(
 		private IStorage $storage,
@@ -83,7 +84,7 @@ class Cache implements ICache {
 		if (!$dependencies) {
 			$dependencies = Server::get(CacheDependencies::class);
 		}
-		$this->storageCache = new Storage($this->storage, true, $dependencies->getConnection());
+		$this->cacheDependencies = $dependencies;
 		$this->mimetypeLoader = $dependencies->getMimeTypeLoader();
 		$this->connection = $dependencies->getConnection();
 		$this->systemConfig = $dependencies->getSystemConfig();
@@ -101,6 +102,9 @@ class Cache implements ICache {
 	}
 
 	public function getStorageCache(): Storage {
+		if (!$this->storageCache) {
+			$this->storageCache = new Storage($this->storage, true, $this->cacheDependencies->getConnection());
+		}
 		return $this->storageCache;
 	}
 
@@ -111,7 +115,7 @@ class Cache implements ICache {
 	 */
 	#[\Override]
 	public function getNumericStorageId() {
-		return $this->storageCache->getNumericId();
+		return $this->getStorageCache()->getNumericId();
 	}
 
 	/**


### PR DESCRIPTION
Saves a query when creating the cache if we end up not needing the storage info.

Together with https://github.com/nextcloud/server/pull/59900 this removes N queries for groupfolders (with per-groupfolder storage).

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
