### PR TITLE
fix: chunk storage ids when preload storage info

### DIFF
--- a/apps/dav/lib/Migration/Version1039Date20260408000000.php
+++ b/apps/dav/lib/Migration/Version1039Date20260408000000.php
@@ -22,6 +22,7 @@ use OCP\Migration\SimpleMigrationStep;
 #[AddColumn(table: 'calendars', name: 'default_alarm_pday', type: ColumnType::INTEGER)]
 #[AddColumn(table: 'calendars', name: 'default_alarm_fday', type: ColumnType::INTEGER)]
 class Version1039Date20260408000000 extends SimpleMigrationStep {
+	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();

--- a/lib/private/Files/Cache/StorageGlobal.php
+++ b/lib/private/Files/Cache/StorageGlobal.php
@@ -42,21 +42,23 @@ class StorageGlobal {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->select(['id', 'numeric_id', 'available', 'last_checked'])
 			->from('storages')
-			->where($builder->expr()->in('id', $builder->createNamedParameter(array_values($storageIds), IQueryBuilder::PARAM_STR_ARRAY)));
+			->where($builder->expr()->in('id', $builder->createParameter('ids'), IQueryBuilder::PARAM_STR_ARRAY));
 
-		$result = $query->executeQuery();
-		while (($row = $result->fetch()) !== false) {
-			$normalizedRow = [
-				'id' => (string)$row['id'],
-				'numeric_id' => (int)$row['numeric_id'],
-				'available' => (bool)$row['available'],
-				'last_checked' => (int)$row['last_checked'],
-			];
+		foreach (array_chunk($storageIds, 1000) as $chunk) {
+			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 
-			$this->cache[$normalizedRow['id']] = $normalizedRow;
+			$result = $query->executeQuery();
+			while (($row = $result->fetch()) !== false) {
+				$normalizedRow = [
+					'id' => (string)$row['id'],
+					'numeric_id' => (int)$row['numeric_id'],
+					'available' => (bool)$row['available'],
+					'last_checked' => (int)$row['last_checked'],
+				];
+
+				$this->cache[$normalizedRow['id']] = $normalizedRow;
+			}
 		}
-
-		$result->closeCursor();
 	}
 
 	/**

--- a/lib/private/Files/Cache/StorageGlobal.php
+++ b/lib/private/Files/Cache/StorageGlobal.php
@@ -41,21 +41,23 @@ class StorageGlobal {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->select(['id', 'numeric_id', 'available', 'last_checked'])
 			->from('storages')
-			->where($builder->expr()->in('id', $builder->createNamedParameter(array_values($storageIds), IQueryBuilder::PARAM_STR_ARRAY)));
+			->where($builder->expr()->in('id', $builder->createParameter('ids'), IQueryBuilder::PARAM_STR_ARRAY));
 
-		$result = $query->executeQuery();
-		while (($row = $result->fetch()) !== false) {
-			$normalizedRow = [
-				'id' => (string)$row['id'],
-				'numeric_id' => (int)$row['numeric_id'],
-				'available' => (bool)$row['available'],
-				'last_checked' => (int)$row['last_checked'],
-			];
+		foreach(array_chunk($storageIds, 1000) as $chunk) {
+			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 
-			$this->cache[$normalizedRow['id']] = $normalizedRow;
+			$result = $query->executeQuery();
+			while (($row = $result->fetch()) !== false) {
+				$normalizedRow = [
+					'id' => (string)$row['id'],
+					'numeric_id' => (int)$row['numeric_id'],
+					'available' => (bool)$row['available'],
+					'last_checked' => (int)$row['last_checked'],
+				];
+
+				$this->cache[$normalizedRow['id']] = $normalizedRow;
+			}
 		}
-
-		$result->closeCursor();
 	}
 
 	/**


### PR DESCRIPTION
Currently this method is only used for external storage, so we're unlikely to hit the 1K limit, but might as well ensure it doesn't break in the future.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
