### PR TITLE
fix(teams-api): adjust resource filtering

### DIFF
--- a/core/Controller/TeamsApiController.php
+++ b/core/Controller/TeamsApiController.php
@@ -66,7 +66,8 @@ class TeamsApiController extends OCSController {
 	public function listTeams(string $providerId, string $resourceId): DataResponse {
 		/** @psalm-suppress PossiblyNullArgument The route is limited to logged-in users */
 		$teams = $this->teamManager->getTeamsForResource($providerId, $resourceId, $this->userId);
-		$sharesPerTeams = $this->teamManager->getSharedWithList(array_map(static fn (Team $team): string => $team->getId(), $teams), $this->userId);
+		$teamIds = array_map(static fn (Team $team): string => $team->getId(), $teams);
+		$sharesPerTeams = $this->teamManager->getSharedWithList($teamIds, $this->userId, $resourceId);
 		$listTeams = array_values(array_map(static function (Team $team) use ($sharesPerTeams) {
 			$response = $team->jsonSerialize();
 			$response['resources'] = array_map(static fn (TeamResource $resource) => $resource->jsonSerialize(), $sharesPerTeams[$team->getId()] ?? []);

--- a/lib/private/Teams/TeamManager.php
+++ b/lib/private/Teams/TeamManager.php
@@ -84,7 +84,7 @@ class TeamManager implements ITeamManager {
 		return array_values($resources);
 	}
 
-	public function getSharedWithList(array $teams, string $userId): array {
+	public function getSharedWithList(array $teams, string $userId, string $resourceId): array {
 		if (!$this->hasTeamSupport()) {
 			return [];
 		}
@@ -92,7 +92,7 @@ class TeamManager implements ITeamManager {
 		$resources = [];
 		foreach ($this->getProviders() as $provider) {
 			if (method_exists($provider, 'getSharedWithList')) {
-				$resources[] = $provider->getSharedWithList($teams, $userId);
+				$resources[] = $provider->getSharedWithList($teams, $resourceId);
 			} else {
 				foreach ($teams as $team) {
 					$resources[] = [$team => $provider->getSharedWith($team)];

--- a/lib/public/Teams/ITeamManager.php
+++ b/lib/public/Teams/ITeamManager.php
@@ -42,12 +42,13 @@ interface ITeamManager {
 	public function getTeamsForResource(string $providerId, string $resourceId, string $userId): array;
 
 	/**
-	 * @param string[] $teams
-	 * @return array<string, list<TeamResource>>
+	 * Returns all team resources for the given teams, user and resource
 	 *
+	 * @return array<string, list<TeamResource>>
 	 * @since 33.0.0
+	 * @since 34.0.0 Added $resourceId param
 	 */
-	public function getSharedWithList(array $teams, string $userId): array;
+	public function getSharedWithList(array $teams, string $userId, string $resourceId): array;
 
 	/**
 	 * Returns all teams that a given user is a member of


### PR DESCRIPTION
* Resolves: #
* Related to: https://github.com/nextcloud/circles/pull/2458

## Summary

Adjust resource filtering on teams API.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI