### PR TITLE
refactor(preview): remove deprecated `PreviewManager::registerProvider` API

### DIFF
--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -107,7 +107,7 @@ class PreviewManager implements IPreview {
 	 * @param string $mimeTypeRegex Regex with the mime types that are supported by this provider
 	 * @param ProviderClosure $callable
 	 */
-	public function registerProvider(string $mimeTypeRegex, Closure $callable): void {
+	private function registerProviderClosure(string $mimeTypeRegex, Closure $callable): void {
 		if (!$this->enablePreviews) {
 			return;
 		}
@@ -293,7 +293,7 @@ class PreviewManager implements IPreview {
 	 */
 	protected function registerCoreProvider(string $class, string $mimeType, array $options = []): void {
 		if (in_array(trim($class, '\\'), $this->getEnabledDefaultProvider())) {
-			$this->registerProvider($mimeType, function () use ($class, $options) {
+			$this->registerProviderClosure($mimeType, function () use ($class, $options): IProviderV2 {
 				return new $class($options);
 			});
 		}
@@ -419,7 +419,7 @@ class PreviewManager implements IPreview {
 			}
 			$this->loadedBootstrapProviders[$key] = null;
 
-			$this->registerProvider($provider->getMimeTypeRegex(), function () use ($provider): IProviderV2|false {
+			$this->registerProviderClosure($provider->getMimeTypeRegex(), function () use ($provider): IProviderV2|false {
 				try {
 					return $this->container->get($provider->getService());
 				} catch (NotFoundExceptionInterface) {

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -294,6 +294,7 @@ class PreviewManager implements IPreview {
 	protected function registerCoreProvider(string $class, string $mimeType, array $options = []): void {
 		if (in_array(trim($class, '\\'), $this->getEnabledDefaultProvider())) {
 			$this->registerProviderClosure($mimeType, function () use ($class, $options): IProviderV2 {
+				/** @var IProviderV2 $class */
 				return new $class($options);
 			});
 		}

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -107,8 +107,7 @@ class PreviewManager implements IPreview {
 	 * @param string $mimeTypeRegex Regex with the mime types that are supported by this provider
 	 * @param ProviderClosure $callable
 	 */
-	#[\Override]
-	public function registerProvider(string $mimeTypeRegex, Closure $callable): void {
+	private function registerProviderClosure(string $mimeTypeRegex, Closure $callable): void {
 		if (!$this->enablePreviews) {
 			return;
 		}
@@ -300,7 +299,7 @@ class PreviewManager implements IPreview {
 	 */
 	protected function registerCoreProvider(string $class, string $mimeType, array $options = []): void {
 		if (in_array(trim($class, '\\'), $this->getEnabledDefaultProvider())) {
-			$this->registerProvider($mimeType, function () use ($class, $options) {
+			$this->registerProviderClosure($mimeType, function () use ($class, $options): IProviderV2 {
 				return new $class($options);
 			});
 		}
@@ -426,7 +425,7 @@ class PreviewManager implements IPreview {
 			}
 			$this->loadedBootstrapProviders[$key] = null;
 
-			$this->registerProvider($provider->getMimeTypeRegex(), function () use ($provider): IProviderV2|false {
+			$this->registerProviderClosure($provider->getMimeTypeRegex(), function () use ($provider): IProviderV2|false {
 				try {
 					return $this->container->get($provider->getService());
 				} catch (NotFoundExceptionInterface) {

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -300,6 +300,7 @@ class PreviewManager implements IPreview {
 	protected function registerCoreProvider(string $class, string $mimeType, array $options = []): void {
 		if (in_array(trim($class, '\\'), $this->getEnabledDefaultProvider())) {
 			$this->registerProviderClosure($mimeType, function () use ($class, $options): IProviderV2 {
+				/** @var IProviderV2 $class */
 				return new $class($options);
 			});
 		}

--- a/lib/public/IPreview.php
+++ b/lib/public/IPreview.php
@@ -5,8 +5,6 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal Nextcloud classes
 
 namespace OCP;
 
@@ -34,19 +32,6 @@ interface IPreview {
 	 * @since 11.0.0
 	 */
 	public const MODE_COVER = 'cover';
-
-	/**
-	 * In order to improve lazy loading a closure can be registered which will be
-	 * called in case preview providers are actually requested
-	 *
-	 * @param string $mimeTypeRegex Regex with the mime types that are supported by this provider
-	 * @param ProviderClosure $callable
-	 * @since 8.1.0
-	 * @see \OCP\AppFramework\Bootstrap\IRegistrationContext::registerPreviewProvider
-	 *
-	 * @deprecated 23.0.0 Register your provider via the IRegistrationContext when booting the app
-	 */
-	public function registerProvider(string $mimeTypeRegex, Closure $callable): void;
 
 	/**
 	 * Get all providers


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

:broom: 

## Summary

* remove the deprecated public `PreviewManager::registerProvider()` API
  - deprecated since v23 via #23171 
* replace it with a private internal helper for provider registration
* update internal core and bootstrap provider registration to use the new helper
* add an explicit return type to the core provider closure for consistency with bootstrap provider registration

Notes:

* keeps the existing provider registration behavior unchanged
* reduces public API surface

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI