### PR TITLE
fix(user_status): clean up orphaned backup statuses in background job

### DIFF
--- a/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
+++ b/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
@@ -43,5 +43,6 @@ class ClearOldStatusesBackgroundJob extends TimedJob {
 
 		$this->mapper->clearOlderThanClearAt($now);
 		$this->mapper->clearStatusesOlderThan($now - StatusService::INVALIDATE_STATUS_THRESHOLD, $now);
+		$this->mapper->cleanOrphanedBackups($now - 86400);
 	}
 }

--- a/apps/user_status/lib/Db/UserStatusMapper.php
+++ b/apps/user_status/lib/Db/UserStatusMapper.php
@@ -185,6 +185,14 @@ class UserStatusMapper extends QBMapper {
 		return $qb->executeStatement() > 0;
 	}
 
+	public function cleanOrphanedBackups(int $olderThan): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->tableName)
+			->where($qb->expr()->eq('is_backup', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->lte('status_timestamp', $qb->createNamedParameter($olderThan, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+
 	public function restoreBackupStatuses(array $ids): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->update($this->tableName)

--- a/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
+++ b/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
@@ -329,4 +329,58 @@ class UserStatusMapperTest extends TestCase {
 		$this->assertEquals(true, $user3Status->getIsBackup());
 		$this->assertEquals('Vacationing', $user3Status->getCustomMessage());
 	}
+
+	public function testCleanOrphanedBackups(): void {
+		// Recent backup — should survive
+		$recentBackup = new UserStatus();
+		$recentBackup->setUserId('_user1');
+		$recentBackup->setStatus('dnd');
+		$recentBackup->setStatusTimestamp(9000);
+		$recentBackup->setIsUserDefined(true);
+		$recentBackup->setIsBackup(true);
+		$this->mapper->insert($recentBackup);
+
+		// Old backup — should be deleted
+		$oldBackup = new UserStatus();
+		$oldBackup->setUserId('_user2');
+		$oldBackup->setStatus('away');
+		$oldBackup->setStatusTimestamp(1000);
+		$oldBackup->setIsUserDefined(false);
+		$oldBackup->setIsBackup(true);
+		$this->mapper->insert($oldBackup);
+
+		// Active (non-backup) status with old timestamp — must not be deleted
+		$activeStatus = new UserStatus();
+		$activeStatus->setUserId('user3');
+		$activeStatus->setStatus('online');
+		$activeStatus->setStatusTimestamp(1000);
+		$activeStatus->setIsUserDefined(true);
+		$activeStatus->setIsBackup(false);
+		$this->mapper->insert($activeStatus);
+
+		$this->mapper->cleanOrphanedBackups(5000);
+
+		// Recent backup survives
+		$surviving = $this->mapper->findByUserId('user1', true);
+		$this->assertEquals('_user1', $surviving->getUserId());
+
+		// Old backup is gone
+		$this->expectException(DoesNotExistException::class);
+		$this->mapper->findByUserId('user2', true);
+	}
+
+	public function testCleanOrphanedBackupsDoesNotTouchActiveStatuses(): void {
+		$activeStatus = new UserStatus();
+		$activeStatus->setUserId('user1');
+		$activeStatus->setStatus('online');
+		$activeStatus->setStatusTimestamp(1000);
+		$activeStatus->setIsUserDefined(true);
+		$activeStatus->setIsBackup(false);
+		$this->mapper->insert($activeStatus);
+
+		$this->mapper->cleanOrphanedBackups(5000);
+
+		$found = $this->mapper->findByUserId('user1', false);
+		$this->assertEquals('user1', $found->getUserId());
+	}
 }


### PR DESCRIPTION
Backup rows that were never restored (e.g. because the user manually changed their status during a call) would accumulate indefinitely. The background job now deletes backup rows older than 24 hours.

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
