### PR TITLE
fix(user_status): make setUserStatus() idempotent for concurrent duplicate requests

### DIFF
--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -284,7 +284,18 @@ class StatusService {
 
 		if ($createBackup) {
 			if ($this->backupCurrentStatus($userId) === false) {
-				return null; // Already a status set automatically => abort.
+				// A backup already exists, meaning another automated status is active.
+				// If the active status already carries the same messageId, this is a
+				// duplicate/concurrent request for the same event — treat it as success.
+				try {
+					$currentStatus = $this->mapper->findByUserId($userId);
+					if ($currentStatus->getMessageId() === $messageId) {
+						return $currentStatus;
+					}
+				} catch (DoesNotExistException) {
+					// No active status row exists, fall through to abort
+				}
+				return null; // A different automated status is active => abort.
 			}
 
 			// If we just created the backup

--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -285,7 +285,18 @@ class StatusService {
 
 		if ($createBackup) {
 			if ($this->backupCurrentStatus($userId) === false) {
-				return null; // Already a status set automatically => abort.
+				// A backup already exists, meaning another automated status is active.
+				// If the active status already carries the same messageId, this is a
+				// duplicate/concurrent request for the same event — treat it as success.
+				try {
+					$currentStatus = $this->mapper->findByUserId($userId);
+					if ($currentStatus->getMessageId() === $messageId) {
+						return $currentStatus;
+					}
+				} catch (DoesNotExistException) {
+					// No active status row exists, fall through to abort
+				}
+				return null; // A different automated status is active => abort.
 			}
 
 			// If we just created the backup

--- a/apps/user_status/tests/Unit/Service/StatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/StatusServiceTest.php
@@ -802,7 +802,7 @@ class StatusServiceTest extends TestCase {
 		$previous->setUserId('john');
 		$previous->setIsBackup(false);
 
-		$this->mapper->expects($this->once())
+		$this->mapper->expects($this->exactly($expectedUpdateShortcut ? 1 : 2))
 			->method('findByUserId')
 			->with('john')
 			->willReturn($previous);
@@ -824,5 +824,37 @@ class StatusServiceTest extends TestCase {
 			->willReturn(true);
 
 		$this->service->setUserStatus('john', IUserStatus::DND, $messageId, true);
+	}
+
+	public function testSetUserStatusIdempotentOnConcurrentDuplicateRequest(): void {
+		$existing = new UserStatus();
+		$existing->setId(1);
+		$existing->setStatus(IUserStatus::DND);
+		$existing->setStatusTimestamp(1337);
+		$existing->setIsUserDefined(true);
+		$existing->setMessageId(IUserStatus::MESSAGE_CALL);
+		$existing->setUserId('john');
+		$existing->setIsBackup(false);
+
+		$this->mapper->expects($this->exactly(2))
+			->method('findByUserId')
+			->with('john')
+			->willReturn($existing);
+
+		/** @var MockObject&Exception $exception */
+		$exception = $this->createMock(Exception::class);
+		$exception->method('getReason')->willReturn(Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION);
+		$this->mapper->expects($this->once())
+			->method('createBackupStatus')
+			->willThrowException($exception);
+
+		$this->predefinedStatusService->expects($this->once())
+			->method('isValidId')
+			->with(IUserStatus::MESSAGE_CALL)
+			->willReturn(true);
+
+		// Active status already has MESSAGE_CALL — concurrent duplicate request should succeed
+		$result = $this->service->setUserStatus('john', IUserStatus::DND, IUserStatus::MESSAGE_CALL, true);
+		$this->assertSame($existing, $result);
 	}
 }

--- a/apps/user_status/tests/Unit/Service/StatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/StatusServiceTest.php
@@ -803,7 +803,7 @@ class StatusServiceTest extends TestCase {
 		$previous->setUserId('john');
 		$previous->setIsBackup(false);
 
-		$this->mapper->expects($this->once())
+		$this->mapper->expects($this->exactly($expectedUpdateShortcut ? 1 : 2))
 			->method('findByUserId')
 			->with('john')
 			->willReturn($previous);
@@ -825,5 +825,37 @@ class StatusServiceTest extends TestCase {
 			->willReturn(true);
 
 		$this->service->setUserStatus('john', IUserStatus::DND, $messageId, true);
+	}
+
+	public function testSetUserStatusIdempotentOnConcurrentDuplicateRequest(): void {
+		$existing = new UserStatus();
+		$existing->setId(1);
+		$existing->setStatus(IUserStatus::DND);
+		$existing->setStatusTimestamp(1337);
+		$existing->setIsUserDefined(true);
+		$existing->setMessageId(IUserStatus::MESSAGE_CALL);
+		$existing->setUserId('john');
+		$existing->setIsBackup(false);
+
+		$this->mapper->expects($this->exactly(2))
+			->method('findByUserId')
+			->with('john')
+			->willReturn($existing);
+
+		/** @var MockObject&Exception $exception */
+		$exception = $this->createMock(Exception::class);
+		$exception->method('getReason')->willReturn(Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION);
+		$this->mapper->expects($this->once())
+			->method('createBackupStatus')
+			->willThrowException($exception);
+
+		$this->predefinedStatusService->expects($this->once())
+			->method('isValidId')
+			->with(IUserStatus::MESSAGE_CALL)
+			->willReturn(true);
+
+		// Active status already has MESSAGE_CALL — concurrent duplicate request should succeed
+		$result = $this->service->setUserStatus('john', IUserStatus::DND, IUserStatus::MESSAGE_CALL, true);
+		$this->assertSame($existing, $result);
 	}
 }


### PR DESCRIPTION
## Summary

When two automated events of the same type fire simultaneously (e.g. a calendar webhook is delivered twice, or two Talk clients both trigger a call status at the same time), both requests race through setUserStatus().

The first request succeeds: it creates a backup of the user's previous status and sets the new automated status. The second request finds the backup slot already occupied (unique constraint on user_id), so backupCurrentStatus() returns false. Previously this caused setUserStatus() to return null, which the caller interpreted as a failure even though the desired status was already correctly set by the first request.

Fix: after backupCurrentStatus() returns false, re-read the current active status row. If it already carries the same messageId that we were trying to set, the operation is effectively complete — return the existing status instead of null. If it carries a different messageId (a higher-priority automated status is active), we still return null to abort as before.

This also covers the meeting-with-call scenario: if a calendar BUSY status is active and a Talk call starts, the call correctly overrides it via the priority shortcut path. If the calendar fires a duplicate webhook while the call is already active, the re-read finds MESSAGE_CALL ≠ MESSAGE_CALENDAR_BUSY and correctly aborts rather than overriding the ongoing call.

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
