### PR TITLE
fix(Files/Cache): align `MoveFromCacheTrait` fallback validation with `Cache::moveFromCache`

### DIFF
--- a/lib/private/Files/Cache/MoveFromCacheTrait.php
+++ b/lib/private/Files/Cache/MoveFromCacheTrait.php
@@ -11,34 +11,41 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 
 /**
- * Fallback implementation for moveFromCache
+ * Generic fallback implementation for moving cache entries.
+ *
+ * This fallback copies the source entry to the target path and then removes
+ * it from the source cache.
+ *
+ * It is intended for cache implementations that do not provide a specialized
+ * in-place move operation.
  */
 trait MoveFromCacheTrait {
-	/**
-	 * store meta data for a file or folder
-	 *
-	 * @param string $file
-	 * @param array $data
-	 *
-	 * @return int file id
-	 * @throws \RuntimeException
-	 */
+
 	abstract public function put($file, array $data);
 
 	abstract public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int;
 
 	/**
-	 * Move a file or folder in the cache
+	 * Move a file or folder in the cache.
+	 *
+	 * This fallback performs the move as a copy-then-delete, so it does not
+	 * preserve the original cache entry identity and may result in a new file id
+	 * at the destination.
 	 *
 	 * @param ICache $sourceCache
 	 * @param string $sourcePath
 	 * @param string $targetPath
+	 * @throws \RuntimeException if the source entry cannot be copied
 	 */
 	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {
 		$sourceEntry = $sourceCache->get($sourcePath);
 
-		$this->copyFromCache($sourceCache, $sourceEntry, $targetPath);
+		if (!$sourceEntry) {
+			throw new \RuntimeException('Source path not found in cache: ' . $sourcePath);
+		}
 
+		$this->copyFromCache($sourceCache, $sourceEntry, $targetPath);
+		// non-atomic; failed removals can leave duplicates
 		$sourceCache->remove($sourcePath);
 	}
 }

--- a/lib/private/Files/Cache/MoveFromCacheTrait.php
+++ b/lib/private/Files/Cache/MoveFromCacheTrait.php
@@ -35,7 +35,7 @@ trait MoveFromCacheTrait {
 	 * @param ICache $sourceCache
 	 * @param string $sourcePath
 	 * @param string $targetPath
-	 * @throws \RuntimeException if the source entry cannot be copied
+	 * @throws \RuntimeException if the source path cannot be found in cache
 	 */
 	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {
 		$sourceEntry = $sourceCache->get($sourcePath);


### PR DESCRIPTION

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Validate the source cache entry in `MoveFromCacheTrait::moveFromCache()` before attempting the fallback copy-then-delete move.

### Why

The fallback path should fail consistently when the source entry does not exist, rather than relying on a less specific downstream failure. This also keeps the trait behavior aligned with `Cache::moveFromCache()`.

### Behavior change

Low risk:

* If the source path is missing, this `moveFromCache()` now throws a clearer `RuntimeException` immediately.
* This matches the validation already performed by `Cache::moveFromCache()`.
* The observable behavior is unchanged for callers that already depended on an exception; only the failure location and message are improved.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
