### PR TITLE
feat(ocp): expose whether talk is enabled for user

### DIFF
--- a/lib/private/Talk/Broker.php
+++ b/lib/private/Talk/Broker.php
@@ -91,4 +91,20 @@ class Broker implements IBroker {
 
 		$this->backend->deleteConversation($id);
 	}
+
+	public function isDisabledForUser(): bool {
+		if (!$this->hasBackend()) {
+			return true;
+		}
+
+		return $this->backend->isDisabledForUser();
+	}
+
+	public function isNotAllowedToCreateConversations(): bool {
+		if (!$this->hasBackend()) {
+			return true;
+		}
+
+		return $this->backend->isNotAllowedToCreateConversations();
+	}
 }

--- a/lib/private/Talk/Broker.php
+++ b/lib/private/Talk/Broker.php
@@ -92,19 +92,19 @@ class Broker implements IBroker {
 		$this->backend->deleteConversation($id);
 	}
 
-	public function isDisabledForUser(): bool {
-		if (!$this->hasBackend()) {
-			return true;
+	public function isAllowedToCreateConversations(): bool {
+		if (!$this->isEnabledForUser()) {
+			return false;
 		}
 
-		return $this->backend->isDisabledForUser();
+		return $this->backend->isAllowedToCreateConversations();
 	}
 
-	public function isNotAllowedToCreateConversations(): bool {
+	public function isEnabledForUser(): bool {
 		if (!$this->hasBackend()) {
-			return true;
+			return false;
 		}
 
-		return $this->backend->isNotAllowedToCreateConversations();
+		return $this->backend->isEnabledForUser();
 	}
 }

--- a/lib/public/Talk/IBroker.php
+++ b/lib/public/Talk/IBroker.php
@@ -67,26 +67,22 @@ interface IBroker {
 	public function deleteConversation(string $id): void;
 
 	/**
-	 * Check if the logged in user is not allowed to create conversations,
-	 * respecting the per-group restrictions configured in Talk admin settings
-	 * (allowed_groups).
+	 * Check if the logged-in user is allowed to create conversations
 	 *
-	 * Returns false when Talk is not available at all.
+	 * Also returns false when no backend is available
 	 *
 	 * @return bool
 	 * @since 34.0.0
 	 */
-	public function isNotAllowedToCreateConversations(): bool;
+	public function isAllowedToCreateConversations(): bool;
 
 	/**
-	 * Check if Talk is disabled for the logged in user, respecting the
-	 * per-group restriction configured in Talk admin settings
-	 * (start_conversations).
+	 * Check if the Talk backend is enabled for the logged-in user
 	 *
-	 * Returns false when Talk is not available at all.
+	 * Also returns false when no backend is available
 	 *
 	 * @return bool
 	 * @since 34.0.0
 	 */
-	public function isDisabledForUser(): bool;
+	public function isEnabledForUser(): bool;
 }

--- a/lib/public/Talk/IBroker.php
+++ b/lib/public/Talk/IBroker.php
@@ -65,4 +65,28 @@ interface IBroker {
 	 * @since 26.0.0
 	 */
 	public function deleteConversation(string $id): void;
+
+	/**
+	 * Check if the logged in user is not allowed to create conversations,
+	 * respecting the per-group restrictions configured in Talk admin settings
+	 * (allowed_groups).
+	 *
+	 * Returns false when Talk is not available at all.
+	 *
+	 * @return bool
+	 * @since 34.0.0
+	 */
+	public function isNotAllowedToCreateConversations(): bool;
+
+	/**
+	 * Check if Talk is disabled for the logged in user, respecting the
+	 * per-group restriction configured in Talk admin settings
+	 * (start_conversations).
+	 *
+	 * Returns false when Talk is not available at all.
+	 *
+	 * @return bool
+	 * @since 34.0.0
+	 */
+	public function isDisabledForUser(): bool;
 }

--- a/lib/public/Talk/ITalkBackend.php
+++ b/lib/public/Talk/ITalkBackend.php
@@ -44,26 +44,20 @@ interface ITalkBackend {
 	public function deleteConversation(string $id): void;
 
 	/**
-	 * Check if the logged in user is not allowed to create conversations,
-	 * respecting the per-group restrictions configured in Talk admin settings
-	 * (allowed_groups).
+	 * Check if the logged-in user is allowed to create conversations
 	 *
-	 * Returns false when Talk is not available at all.
+	 * Also returns false when no backend is enabled for the user
 	 *
 	 * @return bool
 	 * @since 34.0.0
 	 */
-	public function isNotAllowedToCreateConversations(): bool;
+	public function isAllowedToCreateConversations(): bool;
 
 	/**
-	 * Check if Talk is disabled for the logged in user, respecting the
-	 * per-group restriction configured in Talk admin settings
-	 * (start_conversations).
-	 *
-	 * Returns false when Talk is not available at all.
+	 * Check if the Talk backend is enabled for the logged-in user
 	 *
 	 * @return bool
 	 * @since 34.0.0
 	 */
-	public function isDisabledForUser(): bool;
+	public function isEnabledForUser(): bool;
 }

--- a/lib/public/Talk/ITalkBackend.php
+++ b/lib/public/Talk/ITalkBackend.php
@@ -42,4 +42,28 @@ interface ITalkBackend {
 	 * @since 26.0.0
 	 */
 	public function deleteConversation(string $id): void;
+
+	/**
+	 * Check if the logged in user is not allowed to create conversations,
+	 * respecting the per-group restrictions configured in Talk admin settings
+	 * (allowed_groups).
+	 *
+	 * Returns false when Talk is not available at all.
+	 *
+	 * @return bool
+	 * @since 34.0.0
+	 */
+	public function isNotAllowedToCreateConversations(): bool;
+
+	/**
+	 * Check if Talk is disabled for the logged in user, respecting the
+	 * per-group restriction configured in Talk admin settings
+	 * (start_conversations).
+	 *
+	 * Returns false when Talk is not available at all.
+	 *
+	 * @return bool
+	 * @since 34.0.0
+	 */
+	public function isDisabledForUser(): bool;
 }

--- a/tests/lib/Talk/BrokerTest.php
+++ b/tests/lib/Talk/BrokerTest.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\QueryException;
 use OCP\IServerContainer;
 use OCP\Talk\IConversationOptions;
 use OCP\Talk\ITalkBackend;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Test\TestCase;
@@ -51,7 +52,7 @@ class BrokerTest extends TestCase {
 	}
 
 	public function testHasNoBackend(): void {
-		$this->coordinator->expects(self::once())
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($this->createMock(RegistrationContext::class));
 
@@ -63,16 +64,16 @@ class BrokerTest extends TestCase {
 	public function testHasFaultyBackend(): void {
 		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
 		$registrationContext = $this->createMock(RegistrationContext::class);
-		$this->coordinator->expects(self::once())
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($registrationContext);
-		$registrationContext->expects(self::once())
+		$registrationContext->expects($this->once())
 			->method('getTalkBackendRegistration')
 			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
-		$this->container->expects(self::once())
+		$this->container->expects($this->once())
 			->method('get')
 			->willThrowException(new QueryException());
-		$this->logger->expects(self::once())
+		$this->logger->expects($this->once())
 			->method('error');
 
 		self::assertFalse(
@@ -83,14 +84,14 @@ class BrokerTest extends TestCase {
 	public function testHasBackend(): void {
 		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
 		$registrationContext = $this->createMock(RegistrationContext::class);
-		$this->coordinator->expects(self::once())
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($registrationContext);
-		$registrationContext->expects(self::once())
+		$registrationContext->expects($this->once())
 			->method('getTalkBackendRegistration')
 			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
 		$talkService = $this->createMock(ITalkBackend::class);
-		$this->container->expects(self::once())
+		$this->container->expects($this->once())
 			->method('get')
 			->with($fakeTalkServiceClass)
 			->willReturn($talkService);
@@ -110,19 +111,19 @@ class BrokerTest extends TestCase {
 	public function testCreateConversation(): void {
 		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
 		$registrationContext = $this->createMock(RegistrationContext::class);
-		$this->coordinator->expects(self::once())
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($registrationContext);
-		$registrationContext->expects(self::once())
+		$registrationContext->expects($this->once())
 			->method('getTalkBackendRegistration')
 			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
 		$talkService = $this->createMock(ITalkBackend::class);
-		$this->container->expects(self::once())
+		$this->container->expects($this->once())
 			->method('get')
 			->with($fakeTalkServiceClass)
 			->willReturn($talkService);
 		$options = $this->createMock(IConversationOptions::class);
-		$talkService->expects(self::once())
+		$talkService->expects($this->once())
 			->method('createConversation')
 			->with('Watercooler', [], $options);
 
@@ -133,91 +134,115 @@ class BrokerTest extends TestCase {
 		);
 	}
 
-	public function testIsDisabledForUserNoBackend(): void {
-		$this->coordinator->expects(self::once())
+	public function testIsEnabledForUserNoBackend(): void {
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($this->createMock(RegistrationContext::class));
 
-		self::assertTrue(
-			$this->broker->isDisabledForUser()
+		self::assertFalse(
+			$this->broker->isEnabledForUser()
 		);
 	}
 
-	public static function dataIsDisabledForUser(): array {
+	public static function dataIsEnabledForUser(): array {
 		return [
 			[true],
 			[false],
 		];
 	}
 
-	/**
-	 * @dataProvider dataIsDisabledForUser
-	 */
-	public function testIsDisabledForUser(bool $disabled): void {
+	#[DataProvider('dataIsEnabledForUser')]
+	public function testIsEnabledForUser(bool $enabled): void {
 		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
 		$registrationContext = $this->createMock(RegistrationContext::class);
-		$this->coordinator->expects(self::once())
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($registrationContext);
-		$registrationContext->expects(self::once())
+		$registrationContext->expects($this->once())
 			->method('getTalkBackendRegistration')
 			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
 		$talkService = $this->createMock(ITalkBackend::class);
-		$this->container->expects(self::once())
+		$this->container->expects($this->once())
 			->method('get')
 			->with($fakeTalkServiceClass)
 			->willReturn($talkService);
-		$talkService->expects(self::once())
-			->method('isDisabledForUser')
-			->willReturn($disabled);
+		$talkService->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn($enabled);
 
 		self::assertSame(
-			$disabled,
-			$this->broker->isDisabledForUser()
+			$enabled,
+			$this->broker->isEnabledForUser()
 		);
 	}
 
-	public function testIsNotAllowedToCreateConversationsNoBackend(): void {
-		$this->coordinator->expects(self::once())
+	public function testIsAllowedToCreateConversationsNoBackend(): void {
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($this->createMock(RegistrationContext::class));
 
-		self::assertTrue(
-			$this->broker->isNotAllowedToCreateConversations()
+		self::assertFalse(
+			$this->broker->isAllowedToCreateConversations()
 		);
 	}
 
-	public static function dataIsNotAllowedToCreateConversations(): array {
+	public function testIsAllowedToCreateConversationsBackendDisabled(): void {
+		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
+		$registrationContext = $this->createMock(RegistrationContext::class);
+		$this->coordinator->expects($this->once())
+			->method('getRegistrationContext')
+			->willReturn($registrationContext);
+		$registrationContext->expects($this->once())
+			->method('getTalkBackendRegistration')
+			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
+		$talkService = $this->createMock(ITalkBackend::class);
+		$this->container->expects($this->once())
+			->method('get')
+			->with($fakeTalkServiceClass)
+			->willReturn($talkService);
+		$talkService->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(false);
+		$talkService->expects($this->never())
+			->method('isAllowedToCreateConversations');
+
+		self::assertFalse(
+			$this->broker->isAllowedToCreateConversations()
+		);
+	}
+
+	public static function dataIsAllowedToCreateConversations(): array {
 		return [
 			[true],
 			[false],
 		];
 	}
 
-	/**
-	 * @dataProvider dataIsNotAllowedToCreateConversations
-	 */
-	public function testIsNotAllowedToCreateConversations(bool $notAllowed): void {
+	#[DataProvider('dataIsAllowedToCreateConversations')]
+	public function testIsAllowedToCreateConversations(bool $allowed): void {
 		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
 		$registrationContext = $this->createMock(RegistrationContext::class);
-		$this->coordinator->expects(self::once())
+		$this->coordinator->expects($this->once())
 			->method('getRegistrationContext')
 			->willReturn($registrationContext);
-		$registrationContext->expects(self::once())
+		$registrationContext->expects($this->once())
 			->method('getTalkBackendRegistration')
 			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
 		$talkService = $this->createMock(ITalkBackend::class);
-		$this->container->expects(self::once())
+		$this->container->expects($this->once())
 			->method('get')
 			->with($fakeTalkServiceClass)
 			->willReturn($talkService);
-		$talkService->expects(self::once())
-			->method('isNotAllowedToCreateConversations')
-			->willReturn($notAllowed);
+		$talkService->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(true);
+		$talkService->expects($this->once())
+			->method('isAllowedToCreateConversations')
+			->willReturn($allowed);
 
 		self::assertSame(
-			$notAllowed,
-			$this->broker->isNotAllowedToCreateConversations()
+			$allowed,
+			$this->broker->isAllowedToCreateConversations()
 		);
 	}
 }

--- a/tests/lib/Talk/BrokerTest.php
+++ b/tests/lib/Talk/BrokerTest.php
@@ -132,4 +132,92 @@ class BrokerTest extends TestCase {
 			$options
 		);
 	}
+
+	public function testIsDisabledForUserNoBackend(): void {
+		$this->coordinator->expects(self::once())
+			->method('getRegistrationContext')
+			->willReturn($this->createMock(RegistrationContext::class));
+
+		self::assertTrue(
+			$this->broker->isDisabledForUser()
+		);
+	}
+
+	public static function dataIsDisabledForUser(): array {
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsDisabledForUser
+	 */
+	public function testIsDisabledForUser(bool $disabled): void {
+		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
+		$registrationContext = $this->createMock(RegistrationContext::class);
+		$this->coordinator->expects(self::once())
+			->method('getRegistrationContext')
+			->willReturn($registrationContext);
+		$registrationContext->expects(self::once())
+			->method('getTalkBackendRegistration')
+			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
+		$talkService = $this->createMock(ITalkBackend::class);
+		$this->container->expects(self::once())
+			->method('get')
+			->with($fakeTalkServiceClass)
+			->willReturn($talkService);
+		$talkService->expects(self::once())
+			->method('isDisabledForUser')
+			->willReturn($disabled);
+
+		self::assertSame(
+			$disabled,
+			$this->broker->isDisabledForUser()
+		);
+	}
+
+	public function testIsNotAllowedToCreateConversationsNoBackend(): void {
+		$this->coordinator->expects(self::once())
+			->method('getRegistrationContext')
+			->willReturn($this->createMock(RegistrationContext::class));
+
+		self::assertTrue(
+			$this->broker->isNotAllowedToCreateConversations()
+		);
+	}
+
+	public static function dataIsNotAllowedToCreateConversations(): array {
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsNotAllowedToCreateConversations
+	 */
+	public function testIsNotAllowedToCreateConversations(bool $notAllowed): void {
+		$fakeTalkServiceClass = '\\OCA\\Spreed\\TalkBackend';
+		$registrationContext = $this->createMock(RegistrationContext::class);
+		$this->coordinator->expects(self::once())
+			->method('getRegistrationContext')
+			->willReturn($registrationContext);
+		$registrationContext->expects(self::once())
+			->method('getTalkBackendRegistration')
+			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
+		$talkService = $this->createMock(ITalkBackend::class);
+		$this->container->expects(self::once())
+			->method('get')
+			->with($fakeTalkServiceClass)
+			->willReturn($talkService);
+		$talkService->expects(self::once())
+			->method('isNotAllowedToCreateConversations')
+			->willReturn($notAllowed);
+
+		self::assertSame(
+			$notAllowed,
+			$this->broker->isNotAllowedToCreateConversations()
+		);
+	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
Expose the Talk app admin settings `start_conversations` and `allowed_groups` through OCP

For https://github.com/nextcloud/calendar/pull/8216

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (Tests were AI generated) 
