### PR TITLE
fix(navigation): Fix default app icon

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -355,7 +355,7 @@ class NavigationManager implements INavigationManager {
 					$icon = $this->appManager->getAppIcon($app);
 				}
 				if ($icon === null) {
-					$icon = $this->urlGenerator->imagePath('core', 'default-app-icon');
+					$icon = $this->urlGenerator->imagePath('core', 'places/default-app-icon.svg');
 				}
 
 				$this->add(array_merge([


### PR DESCRIPTION
### Before
<img width="1097" height="708" alt="grafik" src="https://github.com/user-attachments/assets/79904c5a-67e7-49ca-b714-2a7070a4c0c3" />

```
Type: RuntimeException
Code: 0
Message: image not found: image:default-app-icon webroot: serverroot:…/server
File: …/server/lib/private/URLGenerator.php
Line: 235
```

### After
:gear: is shown:

<img width="562" height="75" alt="Bildschirmfoto vom 2026-04-27 10-51-09" src="https://github.com/user-attachments/assets/d4b40c92-c4ce-477f-91e7-ebb54e2f0cd8" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
