### PR TITLE
Add support for PKCE in oauth2

### DIFF
--- a/apps/oauth2/appinfo/info.xml
+++ b/apps/oauth2/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>OAuth 2.0</name>
 	<summary>Allows OAuth2 compatible authentication from other web applications.</summary>
 	<description>The OAuth2 app allows administrators to configure the built-in authentication workflow to also allow OAuth2 compatible authentication from other web applications.</description>
-	<version>1.22.0</version>
+	<version>1.23.0</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>OAuth2</namespace>

--- a/apps/oauth2/appinfo/info.xml
+++ b/apps/oauth2/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>OAuth 2.0</name>
 	<summary>Allows OAuth2 compatible authentication from other web applications.</summary>
 	<description>The OAuth2 app allows administrators to configure the built-in authentication workflow to also allow OAuth2 compatible authentication from other web applications.</description>
-	<version>2.0.0-dev.0</version>
+	<version>2.0.0-dev.1</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>OAuth2</namespace>

--- a/apps/oauth2/composer/composer/autoload_classmap.php
+++ b/apps/oauth2/composer/composer/autoload_classmap.php
@@ -25,5 +25,6 @@ return array(
     'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => $baseDir . '/../lib/Migration/Version011602Date20230613160650.php',
     'OCA\\OAuth2\\Migration\\Version011603Date20230620111039' => $baseDir . '/../lib/Migration/Version011603Date20230620111039.php',
     'OCA\\OAuth2\\Migration\\Version011901Date20240829164356' => $baseDir . '/../lib/Migration/Version011901Date20240829164356.php',
+    'OCA\\OAuth2\\Migration\\Version012300Date20250423141506' => $baseDir . '/../lib/Migration/Version012300Date20250423141506.php',
     'OCA\\OAuth2\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',
 );

--- a/apps/oauth2/composer/composer/autoload_classmap.php
+++ b/apps/oauth2/composer/composer/autoload_classmap.php
@@ -27,6 +27,7 @@ return array(
     'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => $baseDir . '/../lib/Migration/Version011602Date20230613160650.php',
     'OCA\\OAuth2\\Migration\\Version011603Date20230620111039' => $baseDir . '/../lib/Migration/Version011603Date20230620111039.php',
     'OCA\\OAuth2\\Migration\\Version011901Date20240829164356' => $baseDir . '/../lib/Migration/Version011901Date20240829164356.php',
+    'OCA\\OAuth2\\Migration\\Version012300Date20250423141506' => $baseDir . '/../lib/Migration/Version012300Date20250423141506.php',
     'OCA\\OAuth2\\Service\\ClientService' => $baseDir . '/../lib/Service/ClientService.php',
     'OCA\\OAuth2\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',
 );

--- a/apps/oauth2/composer/composer/autoload_static.php
+++ b/apps/oauth2/composer/composer/autoload_static.php
@@ -40,6 +40,7 @@ class ComposerStaticInitOAuth2
         'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => __DIR__ . '/..' . '/../lib/Migration/Version011602Date20230613160650.php',
         'OCA\\OAuth2\\Migration\\Version011603Date20230620111039' => __DIR__ . '/..' . '/../lib/Migration/Version011603Date20230620111039.php',
         'OCA\\OAuth2\\Migration\\Version011901Date20240829164356' => __DIR__ . '/..' . '/../lib/Migration/Version011901Date20240829164356.php',
+        'OCA\\OAuth2\\Migration\\Version012300Date20250423141506' => __DIR__ . '/..' . '/../lib/Migration/Version012300Date20250423141506.php',
         'OCA\\OAuth2\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',
     );
 

--- a/apps/oauth2/composer/composer/autoload_static.php
+++ b/apps/oauth2/composer/composer/autoload_static.php
@@ -42,6 +42,7 @@ class ComposerStaticInitOAuth2
         'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => __DIR__ . '/..' . '/../lib/Migration/Version011602Date20230613160650.php',
         'OCA\\OAuth2\\Migration\\Version011603Date20230620111039' => __DIR__ . '/..' . '/../lib/Migration/Version011603Date20230620111039.php',
         'OCA\\OAuth2\\Migration\\Version011901Date20240829164356' => __DIR__ . '/..' . '/../lib/Migration/Version011901Date20240829164356.php',
+        'OCA\\OAuth2\\Migration\\Version012300Date20250423141506' => __DIR__ . '/..' . '/../lib/Migration/Version012300Date20250423141506.php',
         'OCA\\OAuth2\\Service\\ClientService' => __DIR__ . '/..' . '/../lib/Service/ClientService.php',
         'OCA\\OAuth2\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',
     );

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -29,6 +29,8 @@ use OCP\Security\ISecureRandom;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 class LoginRedirectorController extends Controller {
+	private const PKCE_STRING_PATTERN = '/^[A-Za-z0-9._~-]{43,128}$/';
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
@@ -58,8 +60,8 @@ class LoginRedirectorController extends Controller {
 	 * @param string $state State of the flow
 	 * @param string $response_type Response type for the flow
 	 * @param string $redirect_uri URI to redirect to after the flow (is only used for legacy ownCloud clients)
-	 * @param string $code_challenge PKCE code challenge (optional)
-	 * @param string $code_challenge_method PKCE code challenge method "S256" or "plain" (optional)
+	 * @param string $code_challenge PKCE code challenge (optional, RFC 7636 format)
+	 * @param string $code_challenge_method PKCE code challenge method. Only "S256" is supported. If omitted, RFC 7636 defaults to "plain", which is rejected.
 	 * @return TemplateResponse<Http::STATUS_OK, array{}>|RedirectResponse<Http::STATUS_SEE_OTHER, array{}>
 	 *
 	 * 200: Client not found
@@ -89,18 +91,21 @@ class LoginRedirectorController extends Controller {
 			return new RedirectResponse($url);
 		}
 
-		if ($code_challenge_method !== '' && $code_challenge_method !== 'S256' && $code_challenge_method !== 'plain') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge_method&state=' . \urlencode($state);
-			return new RedirectResponse($url);
-		}
-
-		if ($code_challenge !== '' && $code_challenge_method === '') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge_method+required&state=' . \urlencode($state);
-			return new RedirectResponse($url);
-		}
-
 		if ($code_challenge === '' && $code_challenge_method !== '') {
 			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge+required&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		if ($code_challenge !== '' && preg_match(self::PKCE_STRING_PATTERN, $code_challenge) !== 1) {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		$effectiveCodeChallengeMethod = $code_challenge_method === '' && $code_challenge !== ''
+			? 'plain'
+			: $code_challenge_method;
+		if ($effectiveCodeChallengeMethod !== '' && $effectiveCodeChallengeMethod !== 'S256') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Transform+algorithm+not+supported&state=' . \urlencode($state);
 			return new RedirectResponse($url);
 		}
 
@@ -113,7 +118,7 @@ class LoginRedirectorController extends Controller {
 
 		$this->session->set('oauth.state', $state);
 		$this->session->set('oauth.code_challenge', $code_challenge);
-		$this->session->set('oauth.code_challenge_method', $code_challenge_method);
+		$this->session->set('oauth.code_challenge_method', $effectiveCodeChallengeMethod);
 
 		if (in_array($client->getName(), $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -58,6 +58,8 @@ class LoginRedirectorController extends Controller {
 	 * @param string $state State of the flow
 	 * @param string $response_type Response type for the flow
 	 * @param string $redirect_uri URI to redirect to after the flow (is only used for legacy ownCloud clients)
+	 * @param string $code_challenge PKCE code challenge (optional)
+	 * @param string $code_challenge_method PKCE code challenge method "S256" or "plain" (optional)
 	 * @return TemplateResponse<Http::STATUS_OK, array{}>|RedirectResponse<Http::STATUS_SEE_OTHER, array{}>
 	 *
 	 * 200: Client not found
@@ -69,7 +71,9 @@ class LoginRedirectorController extends Controller {
 	public function authorize($client_id,
 		$state,
 		$response_type,
-		string $redirect_uri = ''): TemplateResponse|RedirectResponse {
+		string $redirect_uri = '',
+		string $code_challenge = '',
+		string $code_challenge_method = ''): TemplateResponse|RedirectResponse {
 		try {
 			$client = $this->clientMapper->getByIdentifier($client_id);
 		} catch (ClientNotFoundException $e) {
@@ -85,6 +89,21 @@ class LoginRedirectorController extends Controller {
 			return new RedirectResponse($url);
 		}
 
+		if ($code_challenge_method !== '' && $code_challenge_method !== 'S256' && $code_challenge_method !== 'plain') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge_method&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		if ($code_challenge !== '' && $code_challenge_method === '') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge_method+required&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		if ($code_challenge === '' && $code_challenge_method !== '') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge+required&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
 		$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);
 
 		$providedRedirectUri = '';
@@ -93,6 +112,8 @@ class LoginRedirectorController extends Controller {
 		}
 
 		$this->session->set('oauth.state', $state);
+		$this->session->set('oauth.code_challenge', $code_challenge);
+		$this->session->set('oauth.code_challenge_method', $code_challenge_method);
 
 		if (in_array($client->getName(), $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -30,6 +30,7 @@ use OCP\Security\ISecureRandom;
 #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 class LoginRedirectorController extends Controller {
 	private const PKCE_STRING_PATTERN = '/^[A-Za-z0-9._~-]{43,128}$/';
+	private const LEGACY_LOCALHOST_REDIRECT_PATTERN = '/^http:\/\/localhost:[0-9]+$/';
 
 	/**
 	 * @param string $appName
@@ -51,6 +52,41 @@ class LoginRedirectorController extends Controller {
 		private IConfig $config,
 	) {
 		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * @return RedirectResponse<Http::STATUS_SEE_OTHER, array{}>
+	 */
+	private function buildErrorRedirectResponse(
+		string $registeredRedirectUri,
+		string $providedRedirectUri,
+		string $error,
+		string $state,
+		?string $errorDescription = null,
+	): RedirectResponse {
+		$redirectUri = $registeredRedirectUri;
+		$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);
+		if ($enableOcClients && $redirectUri === 'http://localhost:*' && preg_match(self::LEGACY_LOCALHOST_REDIRECT_PATTERN, $providedRedirectUri) === 1) {
+			$redirectUri = $providedRedirectUri;
+		}
+
+		$fragment = '';
+		$fragmentPosition = strpos($redirectUri, '#');
+		if ($fragmentPosition !== false) {
+			$fragment = substr($redirectUri, $fragmentPosition);
+			$redirectUri = substr($redirectUri, 0, $fragmentPosition);
+		}
+
+		$params = [
+			'error' => $error,
+		];
+		if ($errorDescription !== null) {
+			$params['error_description'] = $errorDescription;
+		}
+		$params['state'] = $state;
+
+		$separator = str_contains($redirectUri, '?') ? '&' : '?';
+		return new RedirectResponse($redirectUri . $separator . http_build_query($params) . $fragment);
 	}
 
 	/**
@@ -86,27 +122,22 @@ class LoginRedirectorController extends Controller {
 		}
 
 		if ($response_type !== 'code') {
-			//Fail
-			$url = $client->getRedirectUri() . '?error=unsupported_response_type&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'unsupported_response_type', $state);
 		}
 
 		if ($code_challenge === '' && $code_challenge_method !== '') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge+required&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'invalid_request', $state, 'code_challenge required');
 		}
 
 		if ($code_challenge !== '' && preg_match(self::PKCE_STRING_PATTERN, $code_challenge) !== 1) {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'invalid_request', $state, 'Invalid code_challenge');
 		}
 
 		$effectiveCodeChallengeMethod = $code_challenge_method === '' && $code_challenge !== ''
 			? 'plain'
 			: $code_challenge_method;
 		if ($effectiveCodeChallengeMethod !== '' && $effectiveCodeChallengeMethod !== 'S256') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Transform+algorithm+not+supported&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'invalid_request', $state, 'Transform algorithm not supported');
 		}
 
 		$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -51,6 +51,8 @@ class LoginRedirectorController extends Controller {
 	 * @param string $state State of the flow
 	 * @param string $response_type Response type for the flow
 	 * @param string $redirect_uri URI to redirect to after the flow (is only used for legacy ownCloud clients)
+	 * @param string $code_challenge PKCE code challenge (optional)
+	 * @param string $code_challenge_method PKCE code challenge method "S256" or "plain" (optional)
 	 * @return TemplateResponse<Http::STATUS_OK, array{}>|RedirectResponse<Http::STATUS_SEE_OTHER, array{}>
 	 *
 	 * 200: Client not found
@@ -60,7 +62,12 @@ class LoginRedirectorController extends Controller {
 	#[NoCSRFRequired]
 	#[UseSession]
 	public function authorize(
-		string $client_id, string $state, string $response_type, string $redirect_uri = '',
+		string $client_id,
+		string $state,
+		string $response_type,
+		string $redirect_uri = '',
+		string $code_challenge = '',
+		string $code_challenge_method = '',
 	): TemplateResponse|RedirectResponse {
 		try {
 			$client = $this->clientMapper->getByIdentifier($client_id);
@@ -77,6 +84,21 @@ class LoginRedirectorController extends Controller {
 			return new RedirectResponse($url);
 		}
 
+		if ($code_challenge_method !== '' && $code_challenge_method !== 'S256' && $code_challenge_method !== 'plain') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge_method&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		if ($code_challenge !== '' && $code_challenge_method === '') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge_method+required&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		if ($code_challenge === '' && $code_challenge_method !== '') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge+required&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
 		$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);
 
 		$providedRedirectUri = '';
@@ -85,6 +107,8 @@ class LoginRedirectorController extends Controller {
 		}
 
 		$this->session->set('oauth.state', $state);
+		$this->session->set('oauth.code_challenge', $code_challenge);
+		$this->session->set('oauth.code_challenge_method', $code_challenge_method);
 
 		if (in_array($client->getName(), $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -31,6 +31,8 @@ use OCP\Security\ISecureRandom;
 #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 class LoginRedirectorController extends Controller {
 	private const PKCE_STRING_PATTERN = '/^[A-Za-z0-9._~-]{43,128}$/';
+	private const LEGACY_LOCALHOST_REDIRECT_PATTERN = '/^http:\/\/localhost:[0-9]+$/';
+
 	public function __construct(
 		string $appName,
 		IRequest $request,
@@ -43,6 +45,41 @@ class LoginRedirectorController extends Controller {
 		private readonly IConfig $config,
 	) {
 		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * @return RedirectResponse<Http::STATUS_SEE_OTHER, array{}>
+	 */
+	private function buildErrorRedirectResponse(
+		string $registeredRedirectUri,
+		string $providedRedirectUri,
+		string $error,
+		string $state,
+		?string $errorDescription = null,
+	): RedirectResponse {
+		$redirectUri = $registeredRedirectUri;
+		$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);
+		if ($enableOcClients && $redirectUri === 'http://localhost:*' && preg_match(self::LEGACY_LOCALHOST_REDIRECT_PATTERN, $providedRedirectUri) === 1) {
+			$redirectUri = $providedRedirectUri;
+		}
+
+		$fragment = '';
+		$fragmentPosition = strpos($redirectUri, '#');
+		if ($fragmentPosition !== false) {
+			$fragment = substr($redirectUri, $fragmentPosition);
+			$redirectUri = substr($redirectUri, 0, $fragmentPosition);
+		}
+
+		$params = [
+			'error' => $error,
+		];
+		if ($errorDescription !== null) {
+			$params['error_description'] = $errorDescription;
+		}
+		$params['state'] = $state;
+
+		$separator = str_contains($redirectUri, '?') ? '&' : '?';
+		return new RedirectResponse($redirectUri . $separator . http_build_query($params) . $fragment);
 	}
 
 	/**
@@ -80,27 +117,22 @@ class LoginRedirectorController extends Controller {
 		}
 
 		if ($response_type !== 'code') {
-			//Fail
-			$url = $client->getRedirectUri() . '?error=unsupported_response_type&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'unsupported_response_type', $state);
 		}
 
 		if ($code_challenge === '' && $code_challenge_method !== '') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge+required&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'invalid_request', $state, 'code_challenge required');
 		}
 
 		if ($code_challenge !== '' && preg_match(self::PKCE_STRING_PATTERN, $code_challenge) !== 1) {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'invalid_request', $state, 'Invalid code_challenge');
 		}
 
 		$effectiveCodeChallengeMethod = $code_challenge_method === '' && $code_challenge !== ''
 			? 'plain'
 			: $code_challenge_method;
 		if ($effectiveCodeChallengeMethod !== '' && $effectiveCodeChallengeMethod !== 'S256') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Transform+algorithm+not+supported&state=' . \urlencode($state);
-			return new RedirectResponse($url);
+			return $this->buildErrorRedirectResponse($client->getRedirectUri(), $redirect_uri, 'invalid_request', $state, 'Transform algorithm not supported');
 		}
 
 		$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -30,6 +30,7 @@ use OCP\Security\ISecureRandom;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 class LoginRedirectorController extends Controller {
+	private const PKCE_STRING_PATTERN = '/^[A-Za-z0-9._~-]{43,128}$/';
 	public function __construct(
 		string $appName,
 		IRequest $request,
@@ -51,8 +52,8 @@ class LoginRedirectorController extends Controller {
 	 * @param string $state State of the flow
 	 * @param string $response_type Response type for the flow
 	 * @param string $redirect_uri URI to redirect to after the flow (is only used for legacy ownCloud clients)
-	 * @param string $code_challenge PKCE code challenge (optional)
-	 * @param string $code_challenge_method PKCE code challenge method "S256" or "plain" (optional)
+	 * @param string $code_challenge PKCE code challenge (optional, RFC 7636 format)
+	 * @param string $code_challenge_method PKCE code challenge method. Only "S256" is supported. If omitted, RFC 7636 defaults to "plain", which is rejected.
 	 * @return TemplateResponse<Http::STATUS_OK, array{}>|RedirectResponse<Http::STATUS_SEE_OTHER, array{}>
 	 *
 	 * 200: Client not found
@@ -84,18 +85,21 @@ class LoginRedirectorController extends Controller {
 			return new RedirectResponse($url);
 		}
 
-		if ($code_challenge_method !== '' && $code_challenge_method !== 'S256' && $code_challenge_method !== 'plain') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge_method&state=' . \urlencode($state);
-			return new RedirectResponse($url);
-		}
-
-		if ($code_challenge !== '' && $code_challenge_method === '') {
-			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge_method+required&state=' . \urlencode($state);
-			return new RedirectResponse($url);
-		}
-
 		if ($code_challenge === '' && $code_challenge_method !== '') {
 			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=code_challenge+required&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		if ($code_challenge !== '' && preg_match(self::PKCE_STRING_PATTERN, $code_challenge) !== 1) {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Invalid+code_challenge&state=' . \urlencode($state);
+			return new RedirectResponse($url);
+		}
+
+		$effectiveCodeChallengeMethod = $code_challenge_method === '' && $code_challenge !== ''
+			? 'plain'
+			: $code_challenge_method;
+		if ($effectiveCodeChallengeMethod !== '' && $effectiveCodeChallengeMethod !== 'S256') {
+			$url = $client->getRedirectUri() . '?error=invalid_request&error_description=Transform+algorithm+not+supported&state=' . \urlencode($state);
 			return new RedirectResponse($url);
 		}
 
@@ -108,7 +112,7 @@ class LoginRedirectorController extends Controller {
 
 		$this->session->set('oauth.state', $state);
 		$this->session->set('oauth.code_challenge', $code_challenge);
-		$this->session->set('oauth.code_challenge_method', $code_challenge_method);
+		$this->session->set('oauth.code_challenge_method', $effectiveCodeChallengeMethod);
 
 		if (in_array($client->getName(), $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -61,6 +61,7 @@ class OauthApiController extends Controller {
 	 * @param ?string $refresh_token Refresh token
 	 * @param ?string $client_id Client ID
 	 * @param ?string $client_secret Client secret
+	 * @param ?string $code_verifier PKCE code verifier (required if code_challenge was provided)
 	 * @throws Exception
 	 * @return JSONResponse<Http::STATUS_OK, array{access_token: string, token_type: string, expires_in: int, refresh_token: string, user_id: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *
@@ -73,6 +74,7 @@ class OauthApiController extends Controller {
 	public function getToken(
 		string $grant_type, ?string $code, ?string $refresh_token,
 		?string $client_id, ?string $client_secret,
+		?string $code_verifier = null,
 	): JSONResponse {
 
 		// We only handle two types
@@ -123,6 +125,38 @@ class OauthApiController extends Controller {
 				$expiredSince = $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER - $codeCreatedAt;
 				$response->throttle(['invalid_request' => 'authorization_code_expired', 'expired_since' => $expiredSince]);
 				return $response;
+			}
+
+			// verify PKCE code_verifier if code_challenge was provided
+			$hashedCodeChallenge = $accessToken->getHashedCodeChallenge();
+			if ($hashedCodeChallenge !== null && $hashedCodeChallenge !== '') {
+				if ($code_verifier === null || $code_verifier === '') {
+					$response = new JSONResponse([
+						'error' => 'invalid_request',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_request' => 'code_verifier_required']);
+					return $response;
+				}
+
+				$codeChallengeMethod = $accessToken->getCodeChallengeMethod();
+				if ($codeChallengeMethod === 'S256') {
+					$expectedHash = rtrim(strtr(base64_encode(hash('sha256', $code_verifier, true)), '+/', '-_'), '=');
+					if (!hash_equals($hashedCodeChallenge, $expectedHash)) {
+						$response = new JSONResponse([
+							'error' => 'invalid_grant',
+						], Http::STATUS_BAD_REQUEST);
+						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
+						return $response;
+					}
+				} else {
+					if (!hash_equals($hashedCodeChallenge, $code_verifier)) {
+						$response = new JSONResponse([
+							'error' => 'invalid_grant',
+						], Http::STATUS_BAD_REQUEST);
+						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
+						return $response;
+					}
+				}
 			}
 		}
 

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -35,6 +35,7 @@ use Psr\Log\LoggerInterface;
 class OauthApiController extends Controller {
 	// the authorization code expires after 10 minutes
 	public const AUTHORIZATION_CODE_EXPIRES_AFTER = 10 * 60;
+	private const PKCE_STRING_PATTERN = '/^[A-Za-z0-9._~-]{43,128}$/';
 
 	public function __construct(
 		string $appName,
@@ -61,7 +62,7 @@ class OauthApiController extends Controller {
 	 * @param ?string $refresh_token Refresh token
 	 * @param ?string $client_id Client ID
 	 * @param ?string $client_secret Client secret
-	 * @param ?string $code_verifier PKCE code verifier (required if code_challenge was provided)
+	 * @param ?string $code_verifier PKCE code verifier in RFC 7636 format (required if code_challenge was provided)
 	 * @throws Exception
 	 * @return JSONResponse<Http::STATUS_OK, array{access_token: string, token_type: string, expires_in: int, refresh_token: string, user_id: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *
@@ -138,24 +139,30 @@ class OauthApiController extends Controller {
 					return $response;
 				}
 
+				if (preg_match(self::PKCE_STRING_PATTERN, $code_verifier) !== 1) {
+					$response = new JSONResponse([
+						'error' => 'invalid_grant',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_grant' => 'invalid_code_verifier']);
+					return $response;
+				}
+
 				$codeChallengeMethod = $accessToken->getCodeChallengeMethod();
-				if ($codeChallengeMethod === 'S256') {
-					$expectedHash = rtrim(strtr(base64_encode(hash('sha256', $code_verifier, true)), '+/', '-_'), '=');
-					if (!hash_equals($hashedCodeChallenge, $expectedHash)) {
-						$response = new JSONResponse([
-							'error' => 'invalid_grant',
-						], Http::STATUS_BAD_REQUEST);
-						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
-						return $response;
-					}
-				} else {
-					if (!hash_equals($hashedCodeChallenge, $code_verifier)) {
-						$response = new JSONResponse([
-							'error' => 'invalid_grant',
-						], Http::STATUS_BAD_REQUEST);
-						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
-						return $response;
-					}
+				if ($codeChallengeMethod !== 'S256') {
+					$response = new JSONResponse([
+						'error' => 'invalid_grant',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_grant' => 'unsupported_code_challenge_method']);
+					return $response;
+				}
+
+				$expectedHash = rtrim(strtr(base64_encode(hash('sha256', $code_verifier, true)), '+/', '-_'), '=');
+				if (!hash_equals($hashedCodeChallenge, $expectedHash)) {
+					$response = new JSONResponse([
+						'error' => 'invalid_grant',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
+					return $response;
 				}
 			}
 		}

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -73,6 +73,7 @@ class OauthApiController extends Controller {
 	 * @param ?string $refresh_token Refresh token
 	 * @param ?string $client_id Client ID
 	 * @param ?string $client_secret Client secret
+	 * @param ?string $code_verifier PKCE code verifier (required if code_challenge was provided)
 	 * @throws Exception
 	 * @return JSONResponse<Http::STATUS_OK, array{access_token: string, token_type: string, expires_in: int, refresh_token: string, user_id: string, "x.nc-gss.secondary_url"?: ?string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *
@@ -85,6 +86,7 @@ class OauthApiController extends Controller {
 	public function getToken(
 		string $grant_type, ?string $code, ?string $refresh_token,
 		?string $client_id, ?string $client_secret,
+		?string $code_verifier = null,
 	): JSONResponse {
 
 		// We only handle two types
@@ -135,6 +137,38 @@ class OauthApiController extends Controller {
 				$expiredSince = $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER - $codeCreatedAt;
 				$response->throttle(['invalid_request' => 'authorization_code_expired', 'expired_since' => $expiredSince]);
 				return $response;
+			}
+
+			// verify PKCE code_verifier if code_challenge was provided
+			$hashedCodeChallenge = $accessToken->getHashedCodeChallenge();
+			if ($hashedCodeChallenge !== null && $hashedCodeChallenge !== '') {
+				if ($code_verifier === null || $code_verifier === '') {
+					$response = new JSONResponse([
+						'error' => 'invalid_request',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_request' => 'code_verifier_required']);
+					return $response;
+				}
+
+				$codeChallengeMethod = $accessToken->getCodeChallengeMethod();
+				if ($codeChallengeMethod === 'S256') {
+					$expectedHash = rtrim(strtr(base64_encode(hash('sha256', $code_verifier, true)), '+/', '-_'), '=');
+					if (!hash_equals($hashedCodeChallenge, $expectedHash)) {
+						$response = new JSONResponse([
+							'error' => 'invalid_grant',
+						], Http::STATUS_BAD_REQUEST);
+						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
+						return $response;
+					}
+				} else {
+					if (!hash_equals($hashedCodeChallenge, $code_verifier)) {
+						$response = new JSONResponse([
+							'error' => 'invalid_grant',
+						], Http::STATUS_BAD_REQUEST);
+						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
+						return $response;
+					}
+				}
 			}
 		}
 

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -43,6 +43,7 @@ use Psr\Log\LoggerInterface;
 class OauthApiController extends Controller {
 	// the authorization code expires after 10 minutes
 	public const AUTHORIZATION_CODE_EXPIRES_AFTER = 10 * 60;
+	private const PKCE_STRING_PATTERN = '/^[A-Za-z0-9._~-]{43,128}$/';
 
 	public function __construct(
 		string $appName,
@@ -73,7 +74,7 @@ class OauthApiController extends Controller {
 	 * @param ?string $refresh_token Refresh token
 	 * @param ?string $client_id Client ID
 	 * @param ?string $client_secret Client secret
-	 * @param ?string $code_verifier PKCE code verifier (required if code_challenge was provided)
+	 * @param ?string $code_verifier PKCE code verifier in RFC 7636 format (required if code_challenge was provided)
 	 * @throws Exception
 	 * @return JSONResponse<Http::STATUS_OK, array{access_token: string, token_type: string, expires_in: int, refresh_token: string, user_id: string, "x.nc-gss.secondary_url"?: ?string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *
@@ -150,24 +151,30 @@ class OauthApiController extends Controller {
 					return $response;
 				}
 
+				if (preg_match(self::PKCE_STRING_PATTERN, $code_verifier) !== 1) {
+					$response = new JSONResponse([
+						'error' => 'invalid_grant',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_grant' => 'invalid_code_verifier']);
+					return $response;
+				}
+
 				$codeChallengeMethod = $accessToken->getCodeChallengeMethod();
-				if ($codeChallengeMethod === 'S256') {
-					$expectedHash = rtrim(strtr(base64_encode(hash('sha256', $code_verifier, true)), '+/', '-_'), '=');
-					if (!hash_equals($hashedCodeChallenge, $expectedHash)) {
-						$response = new JSONResponse([
-							'error' => 'invalid_grant',
-						], Http::STATUS_BAD_REQUEST);
-						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
-						return $response;
-					}
-				} else {
-					if (!hash_equals($hashedCodeChallenge, $code_verifier)) {
-						$response = new JSONResponse([
-							'error' => 'invalid_grant',
-						], Http::STATUS_BAD_REQUEST);
-						$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
-						return $response;
-					}
+				if ($codeChallengeMethod !== 'S256') {
+					$response = new JSONResponse([
+						'error' => 'invalid_grant',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_grant' => 'unsupported_code_challenge_method']);
+					return $response;
+				}
+
+				$expectedHash = rtrim(strtr(base64_encode(hash('sha256', $code_verifier, true)), '+/', '-_'), '=');
+				if (!hash_equals($hashedCodeChallenge, $expectedHash)) {
+					$response = new JSONResponse([
+						'error' => 'invalid_grant',
+					], Http::STATUS_BAD_REQUEST);
+					$response->throttle(['invalid_grant' => 'pkce_verification_failed']);
+					return $response;
 				}
 			}
 		}

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -24,6 +24,10 @@ use OCP\DB\Types;
  * @method void setCodeCreatedAt(int $createdAt)
  * @method int getTokenCount()
  * @method void setTokenCount(int $tokenCount)
+ * @method string|null getHashedCodeChallenge()
+ * @method void setHashedCodeChallenge(?string $hashedCodeChallenge)
+ * @method string|null getCodeChallengeMethod()
+ * @method void setCodeChallengeMethod(?string $codeChallengeMethod)
  */
 class AccessToken extends Entity {
 	/** @var int */
@@ -38,14 +42,20 @@ class AccessToken extends Entity {
 	protected $codeCreatedAt;
 	/** @var int */
 	protected $tokenCount;
+	/** @var string|null */
+	protected $hashedCodeChallenge;
+	/** @var string|null */
+	protected $codeChallengeMethod;
 
 	public function __construct() {
 		$this->addType('id', Types::INTEGER);
 		$this->addType('tokenId', Types::INTEGER);
 		$this->addType('clientId', Types::INTEGER);
-		$this->addType('hashedCode', 'string');
-		$this->addType('encryptedToken', 'string');
+		$this->addType('hashedCode', Types::STRING);
+		$this->addType('encryptedToken', Types::STRING);
 		$this->addType('codeCreatedAt', Types::INTEGER);
 		$this->addType('tokenCount', Types::INTEGER);
+		$this->addType('hashedCodeChallenge', Types::STRING);
+		$this->addType('codeChallengeMethod', Types::STRING);
 	}
 }

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -25,6 +25,10 @@ use OCP\DB\Types;
  * @method void setCodeCreatedAt(int $createdAt)
  * @method int getTokenCount()
  * @method void setTokenCount(int $tokenCount)
+ * @method string|null getHashedCodeChallenge()
+ * @method void setHashedCodeChallenge(?string $hashedCodeChallenge)
+ * @method string|null getCodeChallengeMethod()
+ * @method void setCodeChallengeMethod(?string $codeChallengeMethod)
  */
 class AccessToken extends Entity {
 	/** @var int */
@@ -39,14 +43,20 @@ class AccessToken extends Entity {
 	protected $codeCreatedAt;
 	/** @var int */
 	protected $tokenCount;
+	/** @var string|null */
+	protected $hashedCodeChallenge;
+	/** @var string|null */
+	protected $codeChallengeMethod;
 
 	public function __construct() {
 		$this->addType('id', Types::INTEGER);
 		$this->addType('tokenId', Types::INTEGER);
 		$this->addType('clientId', Types::INTEGER);
-		$this->addType('hashedCode', 'string');
-		$this->addType('encryptedToken', 'string');
+		$this->addType('hashedCode', Types::STRING);
+		$this->addType('encryptedToken', Types::STRING);
 		$this->addType('codeCreatedAt', Types::INTEGER);
 		$this->addType('tokenCount', Types::INTEGER);
+		$this->addType('hashedCodeChallenge', Types::STRING);
+		$this->addType('codeChallengeMethod', Types::STRING);
 	}
 }

--- a/apps/oauth2/lib/Migration/Version012300Date20250423141506.php
+++ b/apps/oauth2/lib/Migration/Version012300Date20250423141506.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\OAuth2\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version012300Date20250423141506 extends SimpleMigrationStep {
+
+	public function __construct(
+	) {
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('oauth2_access_tokens')) {
+			$table = $schema->getTable('oauth2_access_tokens');
+			$dbChanged = false;
+			if (!$table->hasColumn('hashed_code_challenge')) {
+				$table->addColumn('hashed_code_challenge', Types::STRING, [
+					'notnull' => false,
+					'length' => 128,
+				]);
+				$dbChanged = true;
+			}
+			if (!$table->hasColumn('code_challenge_method')) {
+				$table->addColumn('code_challenge_method', Types::STRING, [
+					'notnull' => false,
+					'length' => 10,
+				]);
+				$dbChanged = true;
+			}
+			if ($dbChanged) {
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+}

--- a/apps/oauth2/openapi.json
+++ b/apps/oauth2/openapi.json
@@ -74,6 +74,24 @@
                             "type": "string",
                             "default": ""
                         }
+                    },
+                    {
+                        "name": "code_challenge",
+                        "in": "query",
+                        "description": "PKCE code challenge (optional)",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    {
+                        "name": "code_challenge_method",
+                        "in": "query",
+                        "description": "PKCE code challenge method \"S256\" or \"plain\" (optional)",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
                     }
                 ],
                 "responses": {
@@ -153,6 +171,12 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Client secret"
+                                    },
+                                    "code_verifier": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "PKCE code verifier (required if code_challenge was provided)"
                                     }
                                 }
                             }

--- a/apps/oauth2/openapi.json
+++ b/apps/oauth2/openapi.json
@@ -78,7 +78,7 @@
                     {
                         "name": "code_challenge",
                         "in": "query",
-                        "description": "PKCE code challenge (optional)",
+                        "description": "PKCE code challenge (optional, RFC 7636 format)",
                         "schema": {
                             "type": "string",
                             "default": ""
@@ -87,7 +87,7 @@
                     {
                         "name": "code_challenge_method",
                         "in": "query",
-                        "description": "PKCE code challenge method \"S256\" or \"plain\" (optional)",
+                        "description": "PKCE code challenge method. Only \"S256\" is supported. If omitted, RFC 7636 defaults to \"plain\", which is rejected.",
                         "schema": {
                             "type": "string",
                             "default": ""
@@ -176,7 +176,7 @@
                                         "type": "string",
                                         "nullable": true,
                                         "default": null,
-                                        "description": "PKCE code verifier (required if code_challenge was provided)"
+                                        "description": "PKCE code verifier in RFC 7636 format (required if code_challenge was provided)"
                                     }
                                 }
                             }

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -165,6 +165,23 @@ class LoginRedirectorControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'wrongcode'));
 	}
 
+	public function testAuthorizeRejectsCodeChallengeMethodWithoutChallenge(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+
+		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=code_challenge+required&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', '', 'S256'));
+	}
+
 	public function testAuthorizeWithLegacyOcClient(): void {
 		$client = new Client();
 		$client->setClientIdentifier('MyClientIdentifier');

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -176,6 +176,28 @@ class LoginRedirectorControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'wrongcode'));
 	}
 
+	public function testAuthorizeWrongResponseTypePreservesExistingQuery(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar?hello=world');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('oauth2.enable_oc_clients', false)
+			->willReturn(false);
+
+		$expected = new RedirectResponse('http://foo.bar?hello=world&error=unsupported_response_type&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'wrongcode'));
+	}
+
 	public function testAuthorizeRejectsCodeChallengeMethodWithoutChallenge(): void {
 		$client = new Client();
 		$client->setClientIdentifier('MyClientIdentifier');
@@ -207,8 +229,36 @@ class LoginRedirectorControllerTest extends TestCase {
 			->method('set');
 
 		$codeChallenge = str_repeat('a', 43);
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('oauth2.enable_oc_clients', false)
+			->willReturn(false);
 		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Transform+algorithm+not+supported&state=MyState');
 		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', $codeChallenge));
+	}
+
+	public function testAuthorizeRejectsPkceWithoutMethodForLegacyOcClientUsingProvidedRedirectUri(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://localhost:*');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('oauth2.enable_oc_clients', false)
+			->willReturn(true);
+
+		$codeChallenge = str_repeat('a', 43);
+		$expected = new RedirectResponse('http://localhost:30000?error=invalid_request&error_description=Transform+algorithm+not+supported&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', 'http://localhost:30000', $codeChallenge));
 	}
 
 	public function testAuthorizeRejectsUnsupportedCodeChallengeMethod(): void {
@@ -225,6 +275,11 @@ class LoginRedirectorControllerTest extends TestCase {
 			->method('set');
 
 		$codeChallenge = str_repeat('a', 43);
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('oauth2.enable_oc_clients', false)
+			->willReturn(false);
 		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Transform+algorithm+not+supported&state=MyState');
 		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', $codeChallenge, 'plain'));
 	}
@@ -241,6 +296,11 @@ class LoginRedirectorControllerTest extends TestCase {
 		$this->session
 			->expects($this->never())
 			->method('set');
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('oauth2.enable_oc_clients', false)
+			->willReturn(false);
 
 		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Invalid+code_challenge&state=MyState');
 		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', 'short', 'S256'));

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -70,9 +70,18 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects($this->once())
+			->expects($this->exactly(3))
 			->method('set')
-			->with('oauth.state', 'MyState');
+			->willReturnCallback(function (string $key, string $value): void {
+				switch ([$key, $value]) {
+					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
+						break;
+					default:
+						throw new LogicException();
+				}
+			});
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')
@@ -104,11 +113,13 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects(static::exactly(2))
+			->expects(static::exactly(4))
 			->method('set')
 			->willReturnCallback(function (string $key, string $value): void {
 				switch ([$key, $value]) {
 					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
 					case [ClientFlowLoginController::STATE_NAME, 'MyStateToken']:
 						/* Expected */
 						break;
@@ -182,6 +193,59 @@ class LoginRedirectorControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', '', 'S256'));
 	}
 
+	public function testAuthorizeRejectsPkceWithoutMethodBecausePlainIsUnsupported(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+
+		$codeChallenge = str_repeat('a', 43);
+		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Transform+algorithm+not+supported&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', $codeChallenge));
+	}
+
+	public function testAuthorizeRejectsUnsupportedCodeChallengeMethod(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+
+		$codeChallenge = str_repeat('a', 43);
+		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Transform+algorithm+not+supported&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', $codeChallenge, 'plain'));
+	}
+
+	public function testAuthorizeRejectsInvalidCodeChallengeFormat(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+
+		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Invalid+code_challenge&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', 'short', 'S256'));
+	}
+
 	public function testAuthorizeWithLegacyOcClient(): void {
 		$client = new Client();
 		$client->setClientIdentifier('MyClientIdentifier');
@@ -192,9 +256,18 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects($this->once())
+			->expects($this->exactly(3))
 			->method('set')
-			->with('oauth.state', 'MyState');
+			->willReturnCallback(function (string $key, string $value): void {
+				switch ([$key, $value]) {
+					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
+						break;
+					default:
+						throw new LogicException();
+				}
+			});
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')
@@ -225,9 +298,18 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects($this->once())
+			->expects($this->exactly(3))
 			->method('set')
-			->with('oauth.state', 'MyState');
+			->willReturnCallback(function (string $key, string $value): void {
+				switch ([$key, $value]) {
+					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
+						break;
+					default:
+						throw new LogicException();
+				}
+			});
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -71,9 +71,18 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects($this->once())
+			->expects($this->exactly(3))
 			->method('set')
-			->with('oauth.state', 'MyState');
+			->willReturnCallback(function (string $key, string $value): void {
+				switch ([$key, $value]) {
+					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
+						break;
+					default:
+						throw new LogicException();
+				}
+			});
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')
@@ -105,11 +114,13 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects(static::exactly(2))
+			->expects(static::exactly(4))
 			->method('set')
 			->willReturnCallback(function (string $key, string $value): void {
 				switch ([$key, $value]) {
 					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
 					case [ClientFlowLoginController::STATE_NAME, 'MyStateToken']:
 						/* Expected */
 						break;
@@ -182,6 +193,59 @@ class LoginRedirectorControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', '', 'S256'));
 	}
 
+	public function testAuthorizeRejectsPkceWithoutMethodBecausePlainIsUnsupported(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+
+		$codeChallenge = str_repeat('a', 43);
+		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Transform+algorithm+not+supported&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', $codeChallenge));
+	}
+
+	public function testAuthorizeRejectsUnsupportedCodeChallengeMethod(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+
+		$codeChallenge = str_repeat('a', 43);
+		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Transform+algorithm+not+supported&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', $codeChallenge, 'plain'));
+	}
+
+	public function testAuthorizeRejectsInvalidCodeChallengeFormat(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyClientIdentifier');
+		$client->setRedirectUri('http://foo.bar');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientId')
+			->willReturn($client);
+		$this->session
+			->expects($this->never())
+			->method('set');
+
+		$expected = new RedirectResponse('http://foo.bar?error=invalid_request&error_description=Invalid+code_challenge&state=MyState');
+		$this->assertEquals($expected, $this->loginRedirectorController->authorize('MyClientId', 'MyState', 'code', '', 'short', 'S256'));
+	}
+
 	public function testAuthorizeWithLegacyOcClient(): void {
 		$client = new Client();
 		$client->setClientIdentifier('MyClientIdentifier');
@@ -192,9 +256,18 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects($this->once())
+			->expects($this->exactly(3))
 			->method('set')
-			->with('oauth.state', 'MyState');
+			->willReturnCallback(function (string $key, string $value): void {
+				switch ([$key, $value]) {
+					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
+						break;
+					default:
+						throw new LogicException();
+				}
+			});
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')
@@ -225,9 +298,18 @@ class LoginRedirectorControllerTest extends TestCase {
 			->with('MyClientId')
 			->willReturn($client);
 		$this->session
-			->expects($this->once())
+			->expects($this->exactly(3))
 			->method('set')
-			->with('oauth.state', 'MyState');
+			->willReturnCallback(function (string $key, string $value): void {
+				switch ([$key, $value]) {
+					case ['oauth.state', 'MyState']:
+					case ['oauth.code_challenge', '']:
+					case ['oauth.code_challenge_method', '']:
+						break;
+					default:
+						throw new LogicException();
+				}
+			});
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -200,12 +200,13 @@ class OauthApiControllerTest extends TestCase {
 			'error' => 'invalid_request',
 		], Http::STATUS_BAD_REQUEST);
 		$expected->throttle(['invalid_request' => 'code_verifier_required']);
+		$codeChallenge = str_repeat('a', 43);
 
 		$accessToken = new AccessToken();
 		$accessToken->setClientId(42);
 		$accessToken->setCodeCreatedAt(100);
-		$accessToken->setHashedCodeChallenge('challenge');
-		$accessToken->setCodeChallengeMethod('plain');
+		$accessToken->setHashedCodeChallenge($codeChallenge);
+		$accessToken->setCodeChallengeMethod('S256');
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
@@ -218,17 +219,18 @@ class OauthApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null));
 	}
 
-	public function testGetTokenPkcePlainVerifierMismatch(): void {
+	public function testGetTokenPkceRejectsInvalidVerifierFormat(): void {
 		$expected = new JSONResponse([
 			'error' => 'invalid_grant',
 		], Http::STATUS_BAD_REQUEST);
-		$expected->throttle(['invalid_grant' => 'pkce_verification_failed']);
+		$expected->throttle(['invalid_grant' => 'invalid_code_verifier']);
+		$codeChallenge = str_repeat('a', 43);
 
 		$accessToken = new AccessToken();
 		$accessToken->setClientId(42);
 		$accessToken->setCodeCreatedAt(100);
-		$accessToken->setHashedCodeChallenge('expected-verifier');
-		$accessToken->setCodeChallengeMethod('plain');
+		$accessToken->setHashedCodeChallenge($codeChallenge);
+		$accessToken->setCodeChallengeMethod('S256');
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
@@ -238,7 +240,7 @@ class OauthApiControllerTest extends TestCase {
 		$this->timeFactory->method('now')
 			->willReturn($dateNow);
 
-		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'short'));
 	}
 
 	public function testGetTokenPkceS256VerifierMismatch(): void {
@@ -261,14 +263,38 @@ class OauthApiControllerTest extends TestCase {
 		$this->timeFactory->method('now')
 			->willReturn($dateNow);
 
-		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, str_repeat('b', 43)));
+	}
+
+	public function testGetTokenPkceRejectsUnsupportedStoredMethod(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_grant',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_grant' => 'unsupported_code_challenge_method']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge(str_repeat('a', 43));
+		$accessToken->setCodeChallengeMethod('plain');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, str_repeat('a', 43)));
 	}
 
 	public function testGetTokenPkceS256VerifierMatch(): void {
-		$codeVerifier = 'verifier-value';
+		$codeVerifier = str_repeat('a', 43);
 		$codeChallenge = rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
 
 		$accessToken = new AccessToken();
+		$accessToken->setId(21);
 		$accessToken->setClientId(42);
 		$accessToken->setTokenId(1337);
 		$accessToken->setEncryptedToken('encryptedToken');
@@ -291,9 +317,21 @@ class OauthApiControllerTest extends TestCase {
 			->with(42)
 			->willReturn($client);
 
+		$this->db->expects($this->once())
+			->method('beginTransaction');
+
+		$this->db->expects($this->once())
+			->method('commit');
+
+		$this->db->expects($this->never())
+			->method('rollBack');
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateToken');
+
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validcode')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -336,13 +374,14 @@ class OauthApiControllerTest extends TestCase {
 			->willReturn('newEncryptedToken');
 
 		$this->accessTokenMapper->expects($this->once())
-			->method('update')
+			->method('rotateToken')
 			->with(
-				$this->callback(function (AccessToken $token) {
-					return $token->getHashedCode() === hash('sha512', 'random128')
-						&& $token->getEncryptedToken() === 'newEncryptedToken';
-				})
-			);
+				21,
+				'validcode',
+				'random128',
+				'newEncryptedToken',
+				true,
+			)->willReturn(1);
 
 		$expected = new JSONResponse([
 			'access_token' => 'random72',
@@ -471,7 +510,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -510,7 +549,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -620,7 +659,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -733,7 +772,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -848,7 +887,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -195,6 +195,177 @@ class OauthApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null));
 	}
 
+	public function testGetTokenPkceRequiresVerifier(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_request',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_request' => 'code_verifier_required']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge('challenge');
+		$accessToken->setCodeChallengeMethod('plain');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null));
+	}
+
+	public function testGetTokenPkcePlainVerifierMismatch(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_grant',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_grant' => 'pkce_verification_failed']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge('expected-verifier');
+		$accessToken->setCodeChallengeMethod('plain');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+	}
+
+	public function testGetTokenPkceS256VerifierMismatch(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_grant',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_grant' => 'pkce_verification_failed']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge('expected-challenge');
+		$accessToken->setCodeChallengeMethod('S256');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+	}
+
+	public function testGetTokenPkceS256VerifierMatch(): void {
+		$codeVerifier = 'verifier-value';
+		$codeChallenge = rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setTokenId(1337);
+		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge($codeChallenge);
+		$accessToken->setCodeChallengeMethod('S256');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$client = new Client();
+		$client->setClientIdentifier('clientId');
+		$client->setSecret(bin2hex('hashedClientSecret'));
+		$this->clientMapper->method('getByUid')
+			->with(42)
+			->willReturn($client);
+
+		$this->crypto
+			->method('decrypt')
+			->with('encryptedToken')
+			->willReturn('decryptedToken');
+
+		$this->crypto
+			->method('calculateHMAC')
+			->with('clientSecret')
+			->willReturn('hashedClientSecret');
+
+		$appToken = new PublicKeyToken();
+		$appToken->setUid('userId');
+		$this->tokenProvider->method('getTokenById')
+			->with(1337)
+			->willThrowException(new ExpiredTokenException($appToken));
+
+		$this->secureRandom->method('generate')
+			->willReturnCallback(function ($len) {
+				return 'random' . $len;
+			});
+
+		$this->tokenProvider->expects($this->once())
+			->method('rotate')
+			->with(
+				$appToken,
+				'decryptedToken',
+				'random72'
+			)->willReturn($appToken);
+
+		$this->time->method('getTime')
+			->willReturn(1000);
+
+		$this->tokenProvider->expects($this->once())
+			->method('updateToken')
+			->with(
+				$this->callback(function (PublicKeyToken $token) {
+					return $token->getExpires() === 4600;
+				})
+			);
+
+		$this->crypto->method('encrypt')
+			->with('random72', 'random128')
+			->willReturn('newEncryptedToken');
+
+		$this->accessTokenMapper->expects($this->once())
+			->method('update')
+			->with(
+				$this->callback(function (AccessToken $token) {
+					return $token->getHashedCode() === hash('sha512', 'random128')
+						&& $token->getEncryptedToken() === 'newEncryptedToken';
+				})
+			);
+
+		$expected = new JSONResponse([
+			'access_token' => 'random72',
+			'token_type' => 'Bearer',
+			'expires_in' => 3600,
+			'refresh_token' => 'random128',
+			'user_id' => 'userId',
+		]);
+
+		$this->request->method('getRemoteAddress')
+			->willReturn('1.2.3.4');
+
+		$this->throttler->expects($this->once())
+			->method('resetDelay')
+			->with(
+				'1.2.3.4',
+				'login',
+				['user' => 'userId']
+			);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, 'clientId', 'clientSecret', $codeVerifier));
+	}
+
 	public function testRefreshTokenInvalidRefreshToken(): void {
 		$expected = new JSONResponse([
 			'error' => 'invalid_request',

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -210,12 +210,13 @@ class OauthApiControllerTest extends TestCase {
 			'error' => 'invalid_request',
 		], Http::STATUS_BAD_REQUEST);
 		$expected->throttle(['invalid_request' => 'code_verifier_required']);
+		$codeChallenge = str_repeat('a', 43);
 
 		$accessToken = new AccessToken();
 		$accessToken->setClientId(42);
 		$accessToken->setCodeCreatedAt(100);
-		$accessToken->setHashedCodeChallenge('challenge');
-		$accessToken->setCodeChallengeMethod('plain');
+		$accessToken->setHashedCodeChallenge($codeChallenge);
+		$accessToken->setCodeChallengeMethod('S256');
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
@@ -228,17 +229,18 @@ class OauthApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null));
 	}
 
-	public function testGetTokenPkcePlainVerifierMismatch(): void {
+	public function testGetTokenPkceRejectsInvalidVerifierFormat(): void {
 		$expected = new JSONResponse([
 			'error' => 'invalid_grant',
 		], Http::STATUS_BAD_REQUEST);
-		$expected->throttle(['invalid_grant' => 'pkce_verification_failed']);
+		$expected->throttle(['invalid_grant' => 'invalid_code_verifier']);
+		$codeChallenge = str_repeat('a', 43);
 
 		$accessToken = new AccessToken();
 		$accessToken->setClientId(42);
 		$accessToken->setCodeCreatedAt(100);
-		$accessToken->setHashedCodeChallenge('expected-verifier');
-		$accessToken->setCodeChallengeMethod('plain');
+		$accessToken->setHashedCodeChallenge($codeChallenge);
+		$accessToken->setCodeChallengeMethod('S256');
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
@@ -248,7 +250,7 @@ class OauthApiControllerTest extends TestCase {
 		$this->timeFactory->method('now')
 			->willReturn($dateNow);
 
-		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'short'));
 	}
 
 	public function testGetTokenPkceS256VerifierMismatch(): void {
@@ -271,14 +273,38 @@ class OauthApiControllerTest extends TestCase {
 		$this->timeFactory->method('now')
 			->willReturn($dateNow);
 
-		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, str_repeat('b', 43)));
+	}
+
+	public function testGetTokenPkceRejectsUnsupportedStoredMethod(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_grant',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_grant' => 'unsupported_code_challenge_method']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge(str_repeat('a', 43));
+		$accessToken->setCodeChallengeMethod('plain');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, str_repeat('a', 43)));
 	}
 
 	public function testGetTokenPkceS256VerifierMatch(): void {
-		$codeVerifier = 'verifier-value';
+		$codeVerifier = str_repeat('a', 43);
 		$codeChallenge = rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
 
 		$accessToken = new AccessToken();
+		$accessToken->setId(21);
 		$accessToken->setClientId(42);
 		$accessToken->setTokenId(1337);
 		$accessToken->setEncryptedToken('encryptedToken');
@@ -301,9 +327,21 @@ class OauthApiControllerTest extends TestCase {
 			->with(42)
 			->willReturn($client);
 
+		$this->db->expects($this->once())
+			->method('beginTransaction');
+
+		$this->db->expects($this->once())
+			->method('commit');
+
+		$this->db->expects($this->never())
+			->method('rollBack');
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateToken');
+
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validcode')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -346,13 +384,14 @@ class OauthApiControllerTest extends TestCase {
 			->willReturn('newEncryptedToken');
 
 		$this->accessTokenMapper->expects($this->once())
-			->method('update')
+			->method('rotateToken')
 			->with(
-				$this->callback(function (AccessToken $token) {
-					return $token->getHashedCode() === hash('sha512', 'random128')
-						&& $token->getEncryptedToken() === 'newEncryptedToken';
-				})
-			);
+				21,
+				'validcode',
+				'random128',
+				'newEncryptedToken',
+				true,
+			)->willReturn(1);
 
 		$expected = new JSONResponse([
 			'access_token' => 'random72',
@@ -481,7 +520,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -520,7 +559,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -630,7 +669,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -743,7 +782,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto
@@ -858,7 +897,7 @@ class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('decrypt')
-			->with('encryptedToken')
+			->with('encryptedToken', 'validrefresh')
 			->willReturn('decryptedToken');
 
 		$this->crypto

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -205,6 +205,177 @@ class OauthApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null));
 	}
 
+	public function testGetTokenPkceRequiresVerifier(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_request',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_request' => 'code_verifier_required']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge('challenge');
+		$accessToken->setCodeChallengeMethod('plain');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null));
+	}
+
+	public function testGetTokenPkcePlainVerifierMismatch(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_grant',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_grant' => 'pkce_verification_failed']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge('expected-verifier');
+		$accessToken->setCodeChallengeMethod('plain');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+	}
+
+	public function testGetTokenPkceS256VerifierMismatch(): void {
+		$expected = new JSONResponse([
+			'error' => 'invalid_grant',
+		], Http::STATUS_BAD_REQUEST);
+		$expected->throttle(['invalid_grant' => 'pkce_verification_failed']);
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge('expected-challenge');
+		$accessToken->setCodeChallengeMethod('S256');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, null, null, 'wrong-verifier'));
+	}
+
+	public function testGetTokenPkceS256VerifierMatch(): void {
+		$codeVerifier = 'verifier-value';
+		$codeChallenge = rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
+
+		$accessToken = new AccessToken();
+		$accessToken->setClientId(42);
+		$accessToken->setTokenId(1337);
+		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->setCodeCreatedAt(100);
+		$accessToken->setHashedCodeChallenge($codeChallenge);
+		$accessToken->setCodeChallengeMethod('S256');
+
+		$this->accessTokenMapper->method('getByCode')
+			->with('validcode')
+			->willReturn($accessToken);
+
+		$dateNow = (new \DateTimeImmutable())->setTimestamp(101);
+		$this->timeFactory->method('now')
+			->willReturn($dateNow);
+
+		$client = new Client();
+		$client->setClientIdentifier('clientId');
+		$client->setSecret(bin2hex('hashedClientSecret'));
+		$this->clientMapper->method('getByUid')
+			->with(42)
+			->willReturn($client);
+
+		$this->crypto
+			->method('decrypt')
+			->with('encryptedToken')
+			->willReturn('decryptedToken');
+
+		$this->crypto
+			->method('calculateHMAC')
+			->with('clientSecret')
+			->willReturn('hashedClientSecret');
+
+		$appToken = new PublicKeyToken();
+		$appToken->setUid('userId');
+		$this->tokenProvider->method('getTokenById')
+			->with(1337)
+			->willThrowException(new ExpiredTokenException($appToken));
+
+		$this->secureRandom->method('generate')
+			->willReturnCallback(function ($len) {
+				return 'random' . $len;
+			});
+
+		$this->tokenProvider->expects($this->once())
+			->method('rotate')
+			->with(
+				$appToken,
+				'decryptedToken',
+				'random72'
+			)->willReturn($appToken);
+
+		$this->time->method('getTime')
+			->willReturn(1000);
+
+		$this->tokenProvider->expects($this->once())
+			->method('updateToken')
+			->with(
+				$this->callback(function (PublicKeyToken $token) {
+					return $token->getExpires() === 4600;
+				})
+			);
+
+		$this->crypto->method('encrypt')
+			->with('random72', 'random128')
+			->willReturn('newEncryptedToken');
+
+		$this->accessTokenMapper->expects($this->once())
+			->method('update')
+			->with(
+				$this->callback(function (AccessToken $token) {
+					return $token->getHashedCode() === hash('sha512', 'random128')
+						&& $token->getEncryptedToken() === 'newEncryptedToken';
+				})
+			);
+
+		$expected = new JSONResponse([
+			'access_token' => 'random72',
+			'token_type' => 'Bearer',
+			'expires_in' => 3600,
+			'refresh_token' => 'random128',
+			'user_id' => 'userId',
+		]);
+
+		$this->request->method('getRemoteAddress')
+			->willReturn('1.2.3.4');
+
+		$this->throttler->expects($this->once())
+			->method('resetDelay')
+			->with(
+				'1.2.3.4',
+				'login',
+				['user' => 'userId']
+			);
+
+		$this->assertEquals($expected, $this->oauthApiController->getToken('authorization_code', 'validcode', null, 'clientId', 'clientSecret', $codeVerifier));
+	}
+
 	public function testRefreshTokenInvalidRefreshToken(): void {
 		$expected = new JSONResponse([
 			'error' => 'invalid_request',

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -324,6 +324,13 @@ class ClientFlowLoginController extends Controller {
 				$redirectUri = $providedRedirectUri;
 			}
 
+			$fragment = '';
+			$fragmentPosition = strpos($redirectUri, '#');
+			if ($fragmentPosition !== false) {
+				$fragment = substr($redirectUri, $fragmentPosition);
+				$redirectUri = substr($redirectUri, 0, $fragmentPosition);
+			}
+
 			if (parse_url($redirectUri, PHP_URL_QUERY)) {
 				$redirectUri .= '&';
 			} else {
@@ -335,6 +342,7 @@ class ClientFlowLoginController extends Controller {
 				urlencode($this->session->get('oauth.state')),
 				urlencode($code)
 			);
+			$redirectUri .= $fragment;
 			$this->session->remove('oauth.state');
 		} else {
 			$redirectUri = 'nc://login/server:' . $this->getServerPath() . '&user:' . urlencode($loginName) . '&password:' . urlencode($token);

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -297,7 +297,18 @@ class ClientFlowLoginController extends Controller {
 			$accessToken->setHashedCode(hash('sha512', $code));
 			$accessToken->setTokenId($generatedToken->getId());
 			$accessToken->setCodeCreatedAt($this->timeFactory->now()->getTimestamp());
+
+			$codeChallenge = $this->session->get('oauth.code_challenge');
+			$codeChallengeMethod = $this->session->get('oauth.code_challenge_method');
+			if ($codeChallenge !== null && $codeChallenge !== '') {
+				$accessToken->setHashedCodeChallenge($codeChallenge);
+				$accessToken->setCodeChallengeMethod($codeChallengeMethod);
+			}
+
 			$this->accessTokenMapper->insert($accessToken);
+
+			$this->session->remove('oauth.code_challenge');
+			$this->session->remove('oauth.code_challenge_method');
 
 			$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);
 

--- a/openapi.json
+++ b/openapi.json
@@ -27715,7 +27715,7 @@
                     {
                         "name": "code_challenge",
                         "in": "query",
-                        "description": "PKCE code challenge (optional)",
+                        "description": "PKCE code challenge (optional, RFC 7636 format)",
                         "schema": {
                             "type": "string",
                             "default": ""
@@ -27724,7 +27724,7 @@
                     {
                         "name": "code_challenge_method",
                         "in": "query",
-                        "description": "PKCE code challenge method \"S256\" or \"plain\" (optional)",
+                        "description": "PKCE code challenge method. Only \"S256\" is supported. If omitted, RFC 7636 defaults to \"plain\", which is rejected.",
                         "schema": {
                             "type": "string",
                             "default": ""
@@ -27813,7 +27813,7 @@
                                         "type": "string",
                                         "nullable": true,
                                         "default": null,
-                                        "description": "PKCE code verifier (required if code_challenge was provided)"
+                                        "description": "PKCE code verifier in RFC 7636 format (required if code_challenge was provided)"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -27711,6 +27711,24 @@
                             "type": "string",
                             "default": ""
                         }
+                    },
+                    {
+                        "name": "code_challenge",
+                        "in": "query",
+                        "description": "PKCE code challenge (optional)",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    {
+                        "name": "code_challenge_method",
+                        "in": "query",
+                        "description": "PKCE code challenge method \"S256\" or \"plain\" (optional)",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
                     }
                 ],
                 "responses": {
@@ -27790,6 +27808,12 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Client secret"
+                                    },
+                                    "code_verifier": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "PKCE code verifier (required if code_challenge was provided)"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -30213,6 +30213,24 @@
                             "type": "string",
                             "default": ""
                         }
+                    },
+                    {
+                        "name": "code_challenge",
+                        "in": "query",
+                        "description": "PKCE code challenge (optional)",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    {
+                        "name": "code_challenge_method",
+                        "in": "query",
+                        "description": "PKCE code challenge method \"S256\" or \"plain\" (optional)",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
                     }
                 ],
                 "responses": {
@@ -30292,6 +30310,12 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Client secret"
+                                    },
+                                    "code_verifier": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "PKCE code verifier (required if code_challenge was provided)"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -30217,7 +30217,7 @@
                     {
                         "name": "code_challenge",
                         "in": "query",
-                        "description": "PKCE code challenge (optional)",
+                        "description": "PKCE code challenge (optional, RFC 7636 format)",
                         "schema": {
                             "type": "string",
                             "default": ""
@@ -30226,7 +30226,7 @@
                     {
                         "name": "code_challenge_method",
                         "in": "query",
-                        "description": "PKCE code challenge method \"S256\" or \"plain\" (optional)",
+                        "description": "PKCE code challenge method. Only \"S256\" is supported. If omitted, RFC 7636 defaults to \"plain\", which is rejected.",
                         "schema": {
                             "type": "string",
                             "default": ""
@@ -30315,7 +30315,7 @@
                                         "type": "string",
                                         "nullable": true,
                                         "default": null,
-                                        "description": "PKCE code verifier (required if code_challenge was provided)"
+                                        "description": "PKCE code verifier in RFC 7636 format (required if code_challenge was provided)"
                                     }
                                 }
                             }

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -434,6 +434,8 @@ class ClientFlowLoginControllerTest extends TestCase {
 			]);
 		$calls = [
 			'client.flow.state.token',
+			'oauth.code_challenge',
+			'oauth.code_challenge_method',
 			'oauth.state',
 		];
 		$this->session
@@ -507,12 +509,13 @@ class ClientFlowLoginControllerTest extends TestCase {
 	}
 
 	public function testGeneratePasswordWithPasswordForOauthClientStoresPkceChallenge(): void {
+		$codeChallenge = str_repeat('a', 43);
 		$this->session
 			->method('get')
 			->willReturnMap([
 				['client.flow.state.token', 'MyStateToken'],
 				['oauth.state', 'MyOauthState'],
-				['oauth.code_challenge', 'PkceChallenge'],
+				['oauth.code_challenge', $codeChallenge],
 				['oauth.code_challenge_method', 'S256'],
 			]);
 		$calls = [
@@ -598,7 +601,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->expects($this->once())
 			->method('insert')
 			->with($this->callback(function (AccessToken $accessToken) {
-				return $accessToken->getHashedCodeChallenge() === 'PkceChallenge'
+				return $accessToken->getHashedCodeChallenge() === str_repeat('a', 43)
 					&& $accessToken->getCodeChallengeMethod() === 'S256'
 					&& $accessToken->getHashedCode() === hash('sha512', 'MyAccessCode');
 			}));

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -14,8 +14,8 @@ use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Core\Controller\ClientFlowLoginController;
-use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\AccessToken;
+use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCP\AppFramework\Http;
@@ -423,6 +423,8 @@ class ClientFlowLoginControllerTest extends TestCase {
 	 * @testWith
 	 * ["https://example.com/redirect.php", "https://example.com/redirect.php?state=MyOauthState&code=MyAccessCode"]
 	 * ["https://example.com/redirect.php?hello=world", "https://example.com/redirect.php?hello=world&state=MyOauthState&code=MyAccessCode"]
+	 * ["https://example.com/redirect.php#target", "https://example.com/redirect.php?state=MyOauthState&code=MyAccessCode#target"]
+	 * ["https://example.com/redirect.php?hello=world#target", "https://example.com/redirect.php?hello=world&state=MyOauthState&code=MyAccessCode#target"]
 	 *
 	 */
 	public function testGeneratePasswordWithPasswordForOauthClient($redirectUri, $redirectUrl): void {

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -15,6 +15,7 @@ use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Core\Controller\ClientFlowLoginController;
 use OCA\OAuth2\Db\AccessTokenMapper;
+use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCP\AppFramework\Http;
@@ -502,6 +503,115 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->method('dispatchTyped');
 
 		$expected = new RedirectResponse($redirectUrl);
+		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken', 'MyClientIdentifier'));
+	}
+
+	public function testGeneratePasswordWithPasswordForOauthClientStoresPkceChallenge(): void {
+		$this->session
+			->method('get')
+			->willReturnMap([
+				['client.flow.state.token', 'MyStateToken'],
+				['oauth.state', 'MyOauthState'],
+				['oauth.code_challenge', 'PkceChallenge'],
+				['oauth.code_challenge_method', 'S256'],
+			]);
+		$calls = [
+			'client.flow.state.token',
+			'oauth.code_challenge',
+			'oauth.code_challenge_method',
+			'oauth.state',
+		];
+		$this->session
+			->method('remove')
+			->willReturnCallback(function ($key) use (&$calls): void {
+				$expected = array_shift($calls);
+				$this->assertEquals($expected, $key);
+			});
+		$this->session
+			->expects($this->once())
+			->method('getId')
+			->willReturn('SessionId');
+		$myToken = $this->createMock(IToken::class);
+		$myToken
+			->expects($this->once())
+			->method('getLoginName')
+			->willReturn('MyLoginName');
+		$this->tokenProvider
+			->expects($this->once())
+			->method('getToken')
+			->with('SessionId')
+			->willReturn($myToken);
+		$this->tokenProvider
+			->expects($this->once())
+			->method('getPassword')
+			->with($myToken, 'SessionId')
+			->willReturn('MyPassword');
+		$this->random
+			->method('generate')
+			->willReturnMap([
+				[72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS, 'MyGeneratedToken'],
+				[128, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS, 'MyAccessCode'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user
+			->expects($this->once())
+			->method('getUID')
+			->willReturn('MyUid');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$token = $this->createMock(IToken::class);
+		$token->method('getId')->willReturn(123);
+		$this->tokenProvider
+			->expects($this->once())
+			->method('generateToken')
+			->with(
+				'MyGeneratedToken',
+				'MyUid',
+				'MyLoginName',
+				'MyPassword',
+				'My OAuth client',
+				IToken::PERMANENT_TOKEN,
+				IToken::DO_NOT_REMEMBER
+			)
+			->willReturn($token);
+		$client = new Client();
+		$client->setId(42);
+		$client->setName('My OAuth client');
+		$client->setRedirectUri('https://example.com/redirect.php');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientIdentifier')
+			->willReturn($client);
+		$this->crypto
+			->expects($this->once())
+			->method('encrypt')
+			->with('MyGeneratedToken', 'MyAccessCode')
+			->willReturn('EncryptedToken');
+		$this->timeFactory
+			->expects($this->once())
+			->method('now')
+			->willReturn((new \DateTimeImmutable())->setTimestamp(100));
+		$this->accessTokenMapper
+			->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (AccessToken $accessToken) {
+				return $accessToken->getHashedCodeChallenge() === 'PkceChallenge'
+					&& $accessToken->getCodeChallengeMethod() === 'S256'
+					&& $accessToken->getHashedCode() === hash('sha512', 'MyAccessCode');
+			}));
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('oauth2.enable_oc_clients', false)
+			->willReturn(false);
+
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped');
+
+		$expected = new RedirectResponse('https://example.com/redirect.php?state=MyOauthState&code=MyAccessCode');
 		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken', 'MyClientIdentifier'));
 	}
 

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -15,6 +15,7 @@ use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Core\Controller\ClientFlowLoginController;
 use OCA\OAuth2\Db\AccessTokenMapper;
+use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCP\AppFramework\Http;
@@ -503,6 +504,115 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->method('dispatchTyped');
 
 		$expected = new RedirectResponse($redirectUrl);
+		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken', 'MyClientIdentifier'));
+	}
+
+	public function testGeneratePasswordWithPasswordForOauthClientStoresPkceChallenge(): void {
+		$this->session
+			->method('get')
+			->willReturnMap([
+				['client.flow.state.token', 'MyStateToken'],
+				['oauth.state', 'MyOauthState'],
+				['oauth.code_challenge', 'PkceChallenge'],
+				['oauth.code_challenge_method', 'S256'],
+			]);
+		$calls = [
+			'client.flow.state.token',
+			'oauth.code_challenge',
+			'oauth.code_challenge_method',
+			'oauth.state',
+		];
+		$this->session
+			->method('remove')
+			->willReturnCallback(function ($key) use (&$calls): void {
+				$expected = array_shift($calls);
+				$this->assertEquals($expected, $key);
+			});
+		$this->session
+			->expects($this->once())
+			->method('getId')
+			->willReturn('SessionId');
+		$myToken = $this->createMock(IToken::class);
+		$myToken
+			->expects($this->once())
+			->method('getLoginName')
+			->willReturn('MyLoginName');
+		$this->tokenProvider
+			->expects($this->once())
+			->method('getToken')
+			->with('SessionId')
+			->willReturn($myToken);
+		$this->tokenProvider
+			->expects($this->once())
+			->method('getPassword')
+			->with($myToken, 'SessionId')
+			->willReturn('MyPassword');
+		$this->random
+			->method('generate')
+			->willReturnMap([
+				[72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS, 'MyGeneratedToken'],
+				[128, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS, 'MyAccessCode'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user
+			->expects($this->once())
+			->method('getUID')
+			->willReturn('MyUid');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$token = $this->createMock(IToken::class);
+		$token->method('getId')->willReturn(123);
+		$this->tokenProvider
+			->expects($this->once())
+			->method('generateToken')
+			->with(
+				'MyGeneratedToken',
+				'MyUid',
+				'MyLoginName',
+				'MyPassword',
+				'My OAuth client',
+				IToken::PERMANENT_TOKEN,
+				IToken::DO_NOT_REMEMBER
+			)
+			->willReturn($token);
+		$client = new Client();
+		$client->setId(42);
+		$client->setName('My OAuth client');
+		$client->setRedirectUri('https://example.com/redirect.php');
+		$this->clientMapper
+			->expects($this->once())
+			->method('getByIdentifier')
+			->with('MyClientIdentifier')
+			->willReturn($client);
+		$this->crypto
+			->expects($this->once())
+			->method('encrypt')
+			->with('MyGeneratedToken', 'MyAccessCode')
+			->willReturn('EncryptedToken');
+		$this->timeFactory
+			->expects($this->once())
+			->method('now')
+			->willReturn((new \DateTimeImmutable())->setTimestamp(100));
+		$this->accessTokenMapper
+			->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (AccessToken $accessToken) {
+				return $accessToken->getHashedCodeChallenge() === 'PkceChallenge'
+					&& $accessToken->getCodeChallengeMethod() === 'S256'
+					&& $accessToken->getHashedCode() === hash('sha512', 'MyAccessCode');
+			}));
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('oauth2.enable_oc_clients', false)
+			->willReturn(false);
+
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped');
+
+		$expected = new RedirectResponse('https://example.com/redirect.php?state=MyOauthState&code=MyAccessCode');
 		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken', 'MyClientIdentifier'));
 	}
 

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -14,8 +14,8 @@ use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Core\Controller\ClientFlowLoginController;
-use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\AccessToken;
+use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCP\AppFramework\Http;
@@ -424,6 +424,8 @@ class ClientFlowLoginControllerTest extends TestCase {
 	 * @testWith
 	 * ["https://example.com/redirect.php", "https://example.com/redirect.php?state=MyOauthState&code=MyAccessCode"]
 	 * ["https://example.com/redirect.php?hello=world", "https://example.com/redirect.php?hello=world&state=MyOauthState&code=MyAccessCode"]
+	 * ["https://example.com/redirect.php#target", "https://example.com/redirect.php?state=MyOauthState&code=MyAccessCode#target"]
+	 * ["https://example.com/redirect.php?hello=world#target", "https://example.com/redirect.php?hello=world&state=MyOauthState&code=MyAccessCode#target"]
 	 *
 	 */
 	public function testGeneratePasswordWithPasswordForOauthClient($redirectUri, $redirectUrl): void {

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -435,6 +435,8 @@ class ClientFlowLoginControllerTest extends TestCase {
 			]);
 		$calls = [
 			'client.flow.state.token',
+			'oauth.code_challenge',
+			'oauth.code_challenge_method',
 			'oauth.state',
 		];
 		$this->session
@@ -508,12 +510,13 @@ class ClientFlowLoginControllerTest extends TestCase {
 	}
 
 	public function testGeneratePasswordWithPasswordForOauthClientStoresPkceChallenge(): void {
+		$codeChallenge = str_repeat('a', 43);
 		$this->session
 			->method('get')
 			->willReturnMap([
 				['client.flow.state.token', 'MyStateToken'],
 				['oauth.state', 'MyOauthState'],
-				['oauth.code_challenge', 'PkceChallenge'],
+				['oauth.code_challenge', $codeChallenge],
 				['oauth.code_challenge_method', 'S256'],
 			]);
 		$calls = [
@@ -599,7 +602,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->expects($this->once())
 			->method('insert')
 			->with($this->callback(function (AccessToken $accessToken) {
-				return $accessToken->getHashedCodeChallenge() === 'PkceChallenge'
+				return $accessToken->getHashedCodeChallenge() === str_repeat('a', 43)
 					&& $accessToken->getCodeChallengeMethod() === 'S256'
 					&& $accessToken->getHashedCode() === hash('sha512', 'MyAccessCode');
 			}));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #12881

## Summary

* Support optional `code_challenge` and `code_challenge_method` params in the authorize endpoint
* Implement PKCE support as described in [the RFC](https://datatracker.ietf.org/doc/html/rfc7636#section-4)
* When using PKCE, only allow the `S256` method (do no support `plain`)
* Fix preservation of the query params and fragments in the redirect URL

## TODO

- [x] test with a real client: This script was used for testing: [pkce_test.sh](https://github.com/user-attachments/files/31138087/pkce_test.sh) . It takes the base URL, client ID and client secret as input, generates the code challenge, guides the user to browse the authorize page and log in, then takes the oauth code as input (the user gets it in the redirect URI) and performs a bunch of test requests (testing errors and successes).
- [ ] adjust server documentation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
