### PR TITLE
feat(cron): prevent pending transactions forgotten by a job

### DIFF
--- a/core/Service/CronService.php
+++ b/core/Service/CronService.php
@@ -13,6 +13,7 @@ namespace OC\Core\Service;
 
 use OC;
 use OC\Authentication\LoginCredentials\Store;
+use OC\DB\Connection;
 use OC\Security\CSRF\TokenStorage\SessionStorage;
 use OC\Session\CryptoWrapper;
 use OC\Session\Memory;
@@ -38,6 +39,7 @@ class CronService {
 		private readonly IAppManager $appManager,
 		private readonly ISession $session,
 		private readonly Session $userSession,
+		private readonly Connection $connection,
 		private readonly CryptoWrapper $cryptoWrapper,
 		private readonly Store $store,
 		private readonly SessionStorage $sessionStorage,
@@ -210,6 +212,12 @@ class CronService {
 			// clean up after unclean jobs
 			$this->setupManager->tearDown();
 			$this->tempManager->clean();
+			if ($this->connection->inTransaction()) {
+				$this->connection->rollBack();
+				$message = 'Cron job left a transaction opened after executing job ' . $jobDetails . '. The transaction was rolled back.';
+				$this->logger->warning($message, ['app' => 'cron']);
+				$this->verboseOutput($message);
+			}
 
 			$this->verboseOutput('Job ' . $jobDetails . ' done in ' . ($timeAfter - $timeBefore) . ' seconds');
 


### PR DESCRIPTION
## Summary
A job can forget to close its transaction so all following jobs will operate in a transaction.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
