### PR TITLE
fix(s3): improve error on move/copy operations when bucket quota exceeded

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -8,6 +8,7 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use Aws\S3\Exception\S3Exception;
 use OC\Files\Utils\PathHelper;
 use OC\Files\View;
 use OCA\DAV\AppInfo\Application;
@@ -455,7 +456,7 @@ class Directory extends Node implements
 			if (!$renameOkay) {
 				throw new \Sabre\DAV\Exception\Forbidden('');
 			}
-		} catch (StorageNotAvailableException $e) {
+		} catch (StorageNotAvailableException|S3Exception $e) {
 			throw new ServiceUnavailable($e->getMessage(), $e->getCode(), $e);
 		} catch (ForbiddenException $ex) {
 			throw new Forbidden($ex->getMessage(), $ex->getRetry(), $ex);

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -8,6 +8,7 @@
 
 namespace OC\Files\Storage;
 
+use Aws\S3\Exception\S3Exception;
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\CacheDependencies;
 use OC\Files\Cache\Propagator;
@@ -563,6 +564,9 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 				try {
 					$this->writeStream($targetInternalPath, $source);
 					$result = true;
+				} catch (S3Exception $e) {
+					Server::get(LoggerInterface::class)->warning('Failed to copy stream to storage', ['exception' => $e]);
+					throw $e;
 				} catch (\Exception $e) {
 					Server::get(LoggerInterface::class)->warning('Failed to copy stream to storage', ['exception' => $e]);
 				}


### PR DESCRIPTION
Fixes: #58801

## Screenshots

Before | After
--- | ---
<img width="450" height="75" alt="image" src="https://github.com/user-attachments/assets/2e344af6-41f2-45e8-bacb-1510c449146f" /> | <img width="511" height="75" alt="image" src="https://github.com/user-attachments/assets/4e06c204-12e3-49af-af37-b5b98c8470ea" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Screenshots before/after for front-end changes
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] AI was used to understand the context, but code changes were done on my own and verified by stepping through with the debugger
