### PR TITLE
[stable32] Fix reenabling system address book

### DIFF
--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -21,6 +21,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Server;
+use OCP\Util;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Sabre\CardDAV\Backend;
@@ -53,7 +54,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 	 */
 	public function getChildren() {
 		if ($this->l10n === null) {
-			$this->l10n = \OC::$server->getL10N('dav');
+			$this->l10n = Util::getL10N('dav');
 		}
 		if ($this->config === null) {
 			$this->config = Server::get(IConfig::class);

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -45,6 +45,9 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 		private ?IGroupManager $groupManager,
 	) {
 		parent::__construct($carddavBackend, $principalUri);
+
+		$this->l10n = Util::getL10N('dav');
+		$this->config = Server::get(IConfig::class);
 	}
 
 	/**
@@ -53,13 +56,6 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 	 * @return IAddressBook[]
 	 */
 	public function getChildren() {
-		if ($this->l10n === null) {
-			$this->l10n = Util::getL10N('dav');
-		}
-		if ($this->config === null) {
-			$this->config = Server::get(IConfig::class);
-		}
-
 		/** @var string|array $principal */
 		$principal = $this->principalUri;
 		$addressBooks = $this->carddavBackend->getAddressBooksForUser($this->principalUri);

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -14,6 +14,7 @@ use OCA\DAV\CardDAV\Integration\ExternalAddressBook;
 use OCA\DAV\CardDAV\Integration\IAddressBookProvider;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\QueryException;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -37,6 +38,9 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 	/** @var IConfig */
 	protected $config;
 
+	/** @var IAppConfig */
+	protected $appConfig;
+
 	public function __construct(
 		Backend\BackendInterface $carddavBackend,
 		string $principalUri,
@@ -48,6 +52,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 
 		$this->l10n = Util::getL10N('dav');
 		$this->config = Server::get(IConfig::class);
+		$this->appConfig = Server::get(IAppConfig::class);
 	}
 
 	/**
@@ -61,7 +66,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 		$addressBooks = $this->carddavBackend->getAddressBooksForUser($this->principalUri);
 		// add the system address book
 		$systemAddressBook = null;
-		$systemAddressBookExposed = $this->config->getAppValue('dav', 'system_addressbook_exposed', 'yes') === 'yes';
+		$systemAddressBookExposed = $this->appConfig->getValueBool('dav', 'system_addressbook_exposed', true);
 		if ($systemAddressBookExposed && is_string($principal) && $principal !== 'principals/system/system' && $this->carddavBackend instanceof CardDavBackend) {
 			$systemAddressBook = $this->carddavBackend->getAddressBooksByUri('principals/system/system', 'system');
 			if ($systemAddressBook !== null) {

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -592,9 +592,6 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CardDAV/UserAddressBooks.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$this->principalUri]]></code>
       <code><![CDATA[$this->principalUri]]></code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -594,7 +594,6 @@
   <file src="apps/dav/lib/CardDAV/UserAddressBooks.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getL10N]]></code>
     </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$this->principalUri]]></code>


### PR DESCRIPTION
Fixes #57329

When `system_addressbook_exposed` is set through the administration settings [it is set as a boolean value in `IAppConfig`](https://github.com/nextcloud/server/blob/5981b7eb512aa411f51cad541d01c5c6e93476f0/apps/dav/lib/Listener/DavAdminSettingsListener.php#L59) which, in the end, stores it as `0` or `1`. However, when read from `IConfig` in `UserAddressBooks` it was strictly compared against `"yes"`, so even if explicitly enabled the comparison always failed and the system address book was always seen as disabled. To solve that now the comparison is made against a boolean value in `IAppConfig`, which is also consistent with [other places where the value is got](https://github.com/nextcloud/server/blob/dd1ad9abeba4bb7d92d7ebdf52ac0fda495029e4/apps/dav/lib/CardDAV/ContactsManager.php#L48).

Note that the problem does not happen in _stable33_ and later because in those versions [`getValueBool` is used being already since `system_addressbook_exposed` was registered in the lexicon](https://github.com/nextcloud/server/pull/55657/commits/e976a1323fc3aa23d82a8e055e16387bd6288f0d#diff-0ceb8b82b21f915d51279848e4e3140252fec9a09bf895ca101c0110176f985dR66)

Due to that besides the fix itself a couple of minor refactorings were added to make the code more similar to _stable33_ for consistency.

## How to reproduce

- Enable the Contacts app
- Open the Groupware administration settings
- Disable the system address book
- Enable the system address book again
- Open the Contacts app
- Open its settings
- Check the available address books

### Result with this pull request

The system address book is available

### Result without this pull request

The system address book is not available
