### PR TITLE
Feat: Better reporting if something is wrong with taskprocessing

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -138,6 +138,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\SystemIs64bit' => $baseDir . '/../lib/SetupChecks/SystemIs64bit.php',
     'OCA\\Settings\\SetupChecks\\TaskProcessingPickupSpeed' => $baseDir . '/../lib/SetupChecks/TaskProcessingPickupSpeed.php',
     'OCA\\Settings\\SetupChecks\\TaskProcessingSuccessRate' => $baseDir . '/../lib/SetupChecks/TaskProcessingSuccessRate.php',
+    'OCA\\Settings\\SetupChecks\\TaskProcessingWorkerIsRunning' => $baseDir . '/../lib/SetupChecks/TaskProcessingWorkerIsRunning.php',
     'OCA\\Settings\\SetupChecks\\TempSpaceAvailable' => $baseDir . '/../lib/SetupChecks/TempSpaceAvailable.php',
     'OCA\\Settings\\SetupChecks\\TransactionIsolation' => $baseDir . '/../lib/SetupChecks/TransactionIsolation.php',
     'OCA\\Settings\\SetupChecks\\TwoFactorConfiguration' => $baseDir . '/../lib/SetupChecks/TwoFactorConfiguration.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -153,6 +153,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\SystemIs64bit' => __DIR__ . '/..' . '/../lib/SetupChecks/SystemIs64bit.php',
         'OCA\\Settings\\SetupChecks\\TaskProcessingPickupSpeed' => __DIR__ . '/..' . '/../lib/SetupChecks/TaskProcessingPickupSpeed.php',
         'OCA\\Settings\\SetupChecks\\TaskProcessingSuccessRate' => __DIR__ . '/..' . '/../lib/SetupChecks/TaskProcessingSuccessRate.php',
+        'OCA\\Settings\\SetupChecks\\TaskProcessingWorkerIsRunning' => __DIR__ . '/..' . '/../lib/SetupChecks/TaskProcessingWorkerIsRunning.php',
         'OCA\\Settings\\SetupChecks\\TempSpaceAvailable' => __DIR__ . '/..' . '/../lib/SetupChecks/TempSpaceAvailable.php',
         'OCA\\Settings\\SetupChecks\\TransactionIsolation' => __DIR__ . '/..' . '/../lib/SetupChecks/TransactionIsolation.php',
         'OCA\\Settings\\SetupChecks\\TwoFactorConfiguration' => __DIR__ . '/..' . '/../lib/SetupChecks/TwoFactorConfiguration.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -73,6 +73,8 @@ use OCA\Settings\SetupChecks\ServerIdConfig;
 use OCA\Settings\SetupChecks\SupportedDatabase;
 use OCA\Settings\SetupChecks\SystemIs64bit;
 use OCA\Settings\SetupChecks\TaskProcessingPickupSpeed;
+use OCA\Settings\SetupChecks\TaskProcessingSuccessRate;
+use OCA\Settings\SetupChecks\TaskProcessingWorkerIsRunning;
 use OCA\Settings\SetupChecks\TempSpaceAvailable;
 use OCA\Settings\SetupChecks\TransactionIsolation;
 use OCA\Settings\SetupChecks\TwoFactorConfiguration;
@@ -211,6 +213,8 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(SupportedDatabase::class);
 		$context->registerSetupCheck(SystemIs64bit::class);
 		$context->registerSetupCheck(TaskProcessingPickupSpeed::class);
+		$context->registerSetupCheck(TaskProcessingSuccessRate::class);
+		$context->registerSetupCheck(TaskProcessingWorkerIsRunning::class);
 		$context->registerSetupCheck(TempSpaceAvailable::class);
 		$context->registerSetupCheck(TransactionIsolation::class);
 		$context->registerSetupCheck(TwoFactorConfiguration::class);

--- a/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingPickupSpeed.php
@@ -16,7 +16,7 @@ use OCP\SetupCheck\SetupResult;
 use OCP\TaskProcessing\IManager;
 
 class TaskProcessingPickupSpeed implements ISetupCheck {
-	public const MAX_SLOW_PERCENTAGE = 0.2;
+	public const MAX_SLOW_PERCENTAGE = 0.1;
 
 	public const MAX_DAYS = 14;
 

--- a/apps/settings/lib/SetupChecks/TaskProcessingSuccessRate.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingSuccessRate.php
@@ -17,7 +17,7 @@ use OCP\TaskProcessing\IManager;
 use OCP\TaskProcessing\Task;
 
 class TaskProcessingSuccessRate implements ISetupCheck {
-	public const MAX_FAILURE_PERCENTAGE = 0.2;
+	public const MAX_FAILURE_PERCENTAGE = 0.1;
 
 	public const MAX_DAYS = 14;
 
@@ -33,7 +33,7 @@ class TaskProcessingSuccessRate implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Task Processing pickup speed');
+		return $this->l10n->t('Task Processing success rate');
 	}
 
 	public function run(): SetupResult {

--- a/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
@@ -52,7 +52,7 @@ class TaskProcessingWorkerIsRunning implements ISetupCheck {
 			);
 		}
 		$lastIteration = (int)$this->appConfig->getValueString('core', 'taskprocessing_worker_last_iteration', lazy: true);
-		if ($lastIteration > $this->timeFactory->now()->getTimestamp() - 60 * self::IS_RUNNING_IN_LAST_X_MINUTES) {
+		if ($lastIteration > $this->timeFactory->now()->getTimestamp() - (60 * self::IS_RUNNING_IN_LAST_X_MINUTES)) {
 			return SetupResult::success(
 				$this->l10n->n('The Task Processing worker has run in the last minute.', 'The Task Processing worker has run in the last %n minute.', self::IS_RUNNING_IN_LAST_X_MINUTES)
 			);

--- a/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
@@ -29,14 +29,17 @@ class TaskProcessingWorkerIsRunning implements ISetupCheck {
 	) {
 	}
 
+	#[\Override]
 	public function getCategory(): string {
 		return 'ai';
 	}
 
+	#[\Override]
 	public function getName(): string {
 		return $this->l10n->t('Task Processing worker status');
 	}
 
+	#[\Override]
 	public function run(): SetupResult {
 		$lastNDays = self::HAS_TASKS_IN_LAST_X_DAYS;
 		$tasks = $this->taskProcessingManager->getTasks(userId: '', scheduleAfter: $this->timeFactory->now()->getTimestamp() - (60 * 60 * 24 * $lastNDays));

--- a/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
@@ -54,11 +54,18 @@ class TaskProcessingWorkerIsRunning implements ISetupCheck {
 		$lastIteration = (int)$this->appConfig->getValueString('core', 'taskprocessing_worker_last_iteration', lazy: true);
 		if ($lastIteration > $this->timeFactory->now()->getTimestamp() - (60 * self::IS_RUNNING_IN_LAST_X_MINUTES)) {
 			return SetupResult::success(
-				$this->l10n->n('The Task Processing worker has run in the last minute.', 'The Task Processing worker has run in the last %n minute.', self::IS_RUNNING_IN_LAST_X_MINUTES)
+				$this->l10n->n('The Task Processing worker has run in the last minute.', 'The Task Processing worker has run in the last %n minutes.', self::IS_RUNNING_IN_LAST_X_MINUTES)
 			);
 		}
+
+		if ($lastIteration > 0) {
+			return SetupResult::warning(
+				$this->l10n->t('The Task Processing worker does not seem to be running. The last run was at %s.', [date('Y-m-d H:i:s', $lastIteration)])
+			);
+		}
+
 		return SetupResult::warning(
-			$this->l10n->t('The Task Processing worker does not seem to be running. The last run was at %s.', [date('Y-m-d H:i:s', (int)$this->appConfig->getValueString('core', 'taskprocessing_worker_last_iteration'))])
+			$this->l10n->t('The Task Processing worker does not seem to be running. It seems it has never run so far.')
 		);
 	}
 }

--- a/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
@@ -51,7 +51,7 @@ class TaskProcessingWorkerIsRunning implements ISetupCheck {
 				)
 			);
 		}
-		$lastIteration = (int)$this->appConfig->getValueString('core', 'taskprocessing_worker_last_iteration', lazy: true);
+		$lastIteration = (int)$this->appConfig->getValueString('core', 'ai.taskprocessing_worker_last_iteration', lazy: true);
 		if ($lastIteration > $this->timeFactory->now()->getTimestamp() - (60 * self::IS_RUNNING_IN_LAST_X_MINUTES)) {
 			return SetupResult::success(
 				$this->l10n->n('The Task Processing worker has run in the last minute.', 'The Task Processing worker has run in the last %n minutes.', self::IS_RUNNING_IN_LAST_X_MINUTES)

--- a/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
+++ b/apps/settings/lib/SetupChecks/TaskProcessingWorkerIsRunning.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+use OCP\TaskProcessing\IManager;
+
+class TaskProcessingWorkerIsRunning implements ISetupCheck {
+
+	public const HAS_TASKS_IN_LAST_X_DAYS = 7;
+	public const IS_RUNNING_IN_LAST_X_MINUTES = 5;
+
+	public function __construct(
+		private readonly IL10N $l10n,
+		private readonly IManager $taskProcessingManager,
+		private readonly ITimeFactory $timeFactory,
+		private readonly IAppConfig $appConfig,
+	) {
+	}
+
+	public function getCategory(): string {
+		return 'ai';
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Task Processing worker status');
+	}
+
+	public function run(): SetupResult {
+		$lastNDays = self::HAS_TASKS_IN_LAST_X_DAYS;
+		$tasks = $this->taskProcessingManager->getTasks(userId: '', scheduleAfter: $this->timeFactory->now()->getTimestamp() - (60 * 60 * 24 * $lastNDays));
+		$taskCount = count($tasks);
+		if ($taskCount === 0) {
+			// In case taskprocessing is not used at all
+			return SetupResult::success(
+				$this->l10n->n(
+					'No scheduled tasks in the last day.',
+					'No scheduled tasks in the last %n days.',
+					$lastNDays
+				)
+			);
+		}
+		$lastIteration = (int)$this->appConfig->getValueString('core', 'taskprocessing_worker_last_iteration', lazy: true);
+		if ($lastIteration > $this->timeFactory->now()->getTimestamp() - 60 * self::IS_RUNNING_IN_LAST_X_MINUTES) {
+			return SetupResult::success(
+				$this->l10n->n('The Task Processing worker has run in the last minute.', 'The Task Processing worker has run in the last %n minute.', self::IS_RUNNING_IN_LAST_X_MINUTES)
+			);
+		}
+		return SetupResult::warning(
+			$this->l10n->t('The Task Processing worker does not seem to be running. The last run was at %s.', [date('Y-m-d H:i:s', (int)$this->appConfig->getValueString('core', 'taskprocessing_worker_last_iteration'))])
+		);
+	}
+}

--- a/apps/settings/tests/SetupChecks/TaskProcessingPickupSpeedTest.php
+++ b/apps/settings/tests/SetupChecks/TaskProcessingPickupSpeedTest.php
@@ -43,8 +43,8 @@ class TaskProcessingPickupSpeedTest extends TestCase {
 		for ($i = 0; $i < 100; $i++) {
 			$task = new Task('test', ['test' => 'test'], 'settings', 'user' . $i);
 			$task->setStartedAt(0);
-			if ($i < 15) {
-				$task->setScheduledAt(60 * 5); // 15% get 5mins
+			if ($i < 5) {
+				$task->setScheduledAt(60 * 5); // 5% get 5mins
 			} else {
 				$task->setScheduledAt(60); // the rest gets 1min
 			}

--- a/apps/settings/tests/SetupChecks/TaskProcessingSuccessRateTest.php
+++ b/apps/settings/tests/SetupChecks/TaskProcessingSuccessRateTest.php
@@ -44,8 +44,8 @@ class TaskProcessingSuccessRateTest extends TestCase {
 			$task = new Task('test', ['test' => 'test'], 'settings', 'user' . $i);
 			$task->setStartedAt(0);
 			$task->setEndedAt(1);
-			if ($i < 15) {
-				$task->setStatus(Task::STATUS_FAILED); // 15% get status FAILED
+			if ($i < 5) {
+				$task->setStatus(Task::STATUS_FAILED); // 5% get status FAILED
 			} else {
 				$task->setStatus(Task::STATUS_SUCCESSFUL);
 			}

--- a/apps/settings/tests/SetupChecks/TaskProcessingWorkerIsRunningTest.php
+++ b/apps/settings/tests/SetupChecks/TaskProcessingWorkerIsRunningTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 namespace OCA\Settings\Tests;
@@ -53,7 +53,7 @@ class TaskProcessingWorkerIsRunningTest extends TestCase {
 			$tasks[] = $task;
 		}
 		$this->taskProcessingManager->method('getTasks')->willReturn($tasks);
-
+		$this->timeFactory->method('now')->willReturn(new \DateTimeImmutable());
 		$this->appConfig->method('getValueString')->willReturn((string)$this->timeFactory->now()->getTimestamp());
 
 		$this->assertEquals(SetupResult::SUCCESS, $this->check->run()->getSeverity());
@@ -70,7 +70,7 @@ class TaskProcessingWorkerIsRunningTest extends TestCase {
 			$tasks[] = $task;
 		}
 		$this->taskProcessingManager->method('getTasks')->willReturn($tasks);
-
+		$this->timeFactory->method('now')->willReturn(new \DateTimeImmutable());
 		$this->appConfig->method('getValueString')->willReturn((string)($this->timeFactory->now()->getTimestamp() - 60 * 10));
 
 		$this->assertEquals(SetupResult::WARNING, $this->check->run()->getSeverity());

--- a/apps/settings/tests/SetupChecks/TaskProcessingWorkerIsRunningTest.php
+++ b/apps/settings/tests/SetupChecks/TaskProcessingWorkerIsRunningTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Settings\Tests;
+
+use OCA\Settings\SetupChecks\TaskProcessingWorkerIsRunning;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\SetupCheck\SetupResult;
+use OCP\TaskProcessing\IManager;
+use OCP\TaskProcessing\Task;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class TaskProcessingWorkerIsRunningTest extends TestCase {
+	private IL10N&MockObject $l10n;
+	private ITimeFactory&MockObject $timeFactory;
+	private IManager&MockObject $taskProcessingManager;
+	private IAppConfig&MockObject $appConfig;
+
+	private TaskProcessingWorkerIsRunning $check;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->timeFactory = $this->getMockBuilder(ITimeFactory::class)->getMock();
+		$this->taskProcessingManager = $this->getMockBuilder(IManager::class)->getMock();
+		$this->appConfig = $this->getMockBuilder(IAppConfig::class)->getMock();
+
+		$this->check = new TaskProcessingWorkerIsRunning(
+			$this->l10n,
+			$this->taskProcessingManager,
+			$this->timeFactory,
+			$this->appConfig
+		);
+	}
+
+	public function testPass(): void {
+		$tasks = [];
+		for ($i = 0; $i < 10; $i++) {
+			$task = new Task('test', ['test' => 'test'], 'settings', 'user' . $i);
+			$task->setStartedAt($this->timeFactory->now()->getTimestamp());
+			$task->setScheduledAt($this->timeFactory->now()->getTimestamp());
+			$task->setEndedAt($this->timeFactory->now()->getTimestamp());
+			$task->setStatus(Task::STATUS_SUCCESSFUL);
+			$tasks[] = $task;
+		}
+		$this->taskProcessingManager->method('getTasks')->willReturn($tasks);
+
+		$this->appConfig->method('getValueString')->willReturn((string)$this->timeFactory->now()->getTimestamp());
+
+		$this->assertEquals(SetupResult::SUCCESS, $this->check->run()->getSeverity());
+	}
+
+	public function testFail(): void {
+		$tasks = [];
+		for ($i = 0; $i < 10; $i++) {
+			$task = new Task('test', ['test' => 'test'], 'settings', 'user' . $i);
+			$task->setStartedAt($this->timeFactory->now()->getTimestamp());
+			$task->setScheduledAt($this->timeFactory->now()->getTimestamp());
+			$task->setEndedAt($this->timeFactory->now()->getTimestamp());
+			$task->setStatus(Task::STATUS_SUCCESSFUL);
+			$tasks[] = $task;
+		}
+		$this->taskProcessingManager->method('getTasks')->willReturn($tasks);
+
+		$this->appConfig->method('getValueString')->willReturn((string)($this->timeFactory->now()->getTimestamp() - 60 * 10));
+
+		$this->assertEquals(SetupResult::WARNING, $this->check->run()->getSeverity());
+	}
+}

--- a/core/Command/TaskProcessing/WorkerCommand.php
+++ b/core/Command/TaskProcessing/WorkerCommand.php
@@ -93,7 +93,7 @@ class WorkerCommand extends Base {
 			}
 
 			if ($lastConfigStorageTime < $this->timeFactory->now()->getTimestamp() - 60) {
-				$this->appConfig->setValueString('core', 'taskprocessing_worker_last_iteration', (string)$this->timeFactory->now()->getTimestamp(), lazy: true);
+				$this->appConfig->setValueString('core', 'ai.taskprocessing_worker_last_iteration', (string)$this->timeFactory->now()->getTimestamp(), lazy: true);
 				$lastConfigStorageTime = $this->timeFactory->now()->getTimestamp();
 			}
 			$processedTask = $this->processNextTask($output, $taskTypes);

--- a/core/Command/TaskProcessing/WorkerCommand.php
+++ b/core/Command/TaskProcessing/WorkerCommand.php
@@ -10,6 +10,7 @@ namespace OC\Core\Command\TaskProcessing;
 
 use OC\Core\Command\Base;
 use OC\Core\Command\InterruptedException;
+use OCP\IAppConfig;
 use OCP\TaskProcessing\Exception\Exception;
 use OCP\TaskProcessing\Exception\NotFoundException;
 use OCP\TaskProcessing\IManager;
@@ -23,6 +24,7 @@ class WorkerCommand extends Base {
 	public function __construct(
 		private readonly IManager $taskProcessingManager,
 		private readonly LoggerInterface $logger,
+		private readonly IAppConfig $appConfig,
 	) {
 		parent::__construct();
 	}
@@ -87,6 +89,7 @@ class WorkerCommand extends Base {
 				break;
 			}
 
+			$this->appConfig->setValueString('core', 'taskprocessing_worker_last_iteration', (string)time(), lazy: true);
 			$processedTask = $this->processNextTask($output, $taskTypes);
 
 			if ($once) {

--- a/core/Command/TaskProcessing/WorkerCommand.php
+++ b/core/Command/TaskProcessing/WorkerCommand.php
@@ -10,6 +10,7 @@ namespace OC\Core\Command\TaskProcessing;
 
 use OC\Core\Command\Base;
 use OC\Core\Command\InterruptedException;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;
 use OCP\TaskProcessing\Exception\Exception;
 use OCP\TaskProcessing\Exception\NotFoundException;
@@ -25,6 +26,7 @@ class WorkerCommand extends Base {
 		private readonly IManager $taskProcessingManager,
 		private readonly LoggerInterface $logger,
 		private readonly IAppConfig $appConfig,
+		private readonly ITimeFactory $timeFactory,
 	) {
 		parent::__construct();
 	}
@@ -63,12 +65,13 @@ class WorkerCommand extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$startTime = time();
+		$startTime = $this->timeFactory->now()->getTimestamp();
 		$timeout = (int)$input->getOption('timeout');
 		$interval = (int)$input->getOption('interval');
 		$once = $input->getOption('once') === true;
 		/** @var list<string> $taskTypes */
 		$taskTypes = $input->getOption('taskTypes');
+		$lastConfigStorageTime = 0;
 
 		if ($timeout > 0) {
 			$output->writeln('<info>Task processing worker will stop after ' . $timeout . ' seconds</info>');
@@ -76,7 +79,7 @@ class WorkerCommand extends Base {
 
 		while (true) {
 			// Stop if timeout exceeded
-			if ($timeout > 0 && ($startTime + $timeout) < time()) {
+			if ($timeout > 0 && ($startTime + $timeout) < $this->timeFactory->now()->getTimestamp()) {
 				$output->writeln('Timeout reached, exiting...', OutputInterface::VERBOSITY_VERBOSE);
 				break;
 			}
@@ -84,12 +87,15 @@ class WorkerCommand extends Base {
 			// Handle SIGTERM/SIGINT gracefully
 			try {
 				$this->abortIfInterrupted();
-			} catch (InterruptedException $e) {
+			} catch (InterruptedException) {
 				$output->writeln('<info>Task processing worker stopped</info>');
 				break;
 			}
 
-			$this->appConfig->setValueString('core', 'taskprocessing_worker_last_iteration', (string)time(), lazy: true);
+			if ($lastConfigStorageTime < $this->timeFactory->now()->getTimestamp() - 60) {
+				$this->appConfig->setValueString('core', 'taskprocessing_worker_last_iteration', (string)$this->timeFactory->now()->getTimestamp(), lazy: true);
+				$lastConfigStorageTime = $this->timeFactory->now()->getTimestamp();
+			}
 			$processedTask = $this->processNextTask($output, $taskTypes);
 
 			if ($once) {

--- a/tests/Core/Command/TaskProcessing/WorkerCommandTest.php
+++ b/tests/Core/Command/TaskProcessing/WorkerCommandTest.php
@@ -37,7 +37,7 @@ class WorkerCommandTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->timeFactory->method('now')->willReturnCallback(fn() => new \DateTimeImmutable());
+		$this->timeFactory->method('now')->willReturnCallback(fn () => new \DateTimeImmutable());
 		$this->command = new WorkerCommand($this->manager, $this->logger, $this->appConfig, $this->timeFactory);
 	}
 

--- a/tests/Core/Command/TaskProcessing/WorkerCommandTest.php
+++ b/tests/Core/Command/TaskProcessing/WorkerCommandTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Tests\Core\Command\TaskProcessing;
 
 use OC\Core\Command\TaskProcessing\WorkerCommand;
+use OCP\IAppConfig;
 use OCP\TaskProcessing\Exception\Exception;
 use OCP\TaskProcessing\Exception\NotFoundException;
 use OCP\TaskProcessing\IManager;
@@ -24,6 +25,7 @@ use Test\TestCase;
 class WorkerCommandTest extends TestCase {
 	private IManager&MockObject $manager;
 	private LoggerInterface&MockObject $logger;
+	private IAppConfig&MockObject $appConfig;
 	private WorkerCommand $command;
 
 	protected function setUp(): void {
@@ -31,7 +33,8 @@ class WorkerCommandTest extends TestCase {
 
 		$this->manager = $this->createMock(IManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->command = new WorkerCommand($this->manager, $this->logger);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->command = new WorkerCommand($this->manager, $this->logger, $this->appConfig);
 	}
 
 	/**

--- a/tests/Core/Command/TaskProcessing/WorkerCommandTest.php
+++ b/tests/Core/Command/TaskProcessing/WorkerCommandTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Tests\Core\Command\TaskProcessing;
 
 use OC\Core\Command\TaskProcessing\WorkerCommand;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;
 use OCP\TaskProcessing\Exception\Exception;
 use OCP\TaskProcessing\Exception\NotFoundException;
@@ -26,6 +27,7 @@ class WorkerCommandTest extends TestCase {
 	private IManager&MockObject $manager;
 	private LoggerInterface&MockObject $logger;
 	private IAppConfig&MockObject $appConfig;
+	private ITimeFactory&MockObject $timeFactory;
 	private WorkerCommand $command;
 
 	protected function setUp(): void {
@@ -34,7 +36,9 @@ class WorkerCommandTest extends TestCase {
 		$this->manager = $this->createMock(IManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
-		$this->command = new WorkerCommand($this->manager, $this->logger, $this->appConfig);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->method('now')->willReturnCallback(fn() => new \DateTimeImmutable());
+		$this->command = new WorkerCommand($this->manager, $this->logger, $this->appConfig, $this->timeFactory);
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
It turns out that the occ taskprocessing:worker command does not run when the instance is in maintenance mode and then usually just stops (after a few failed restarts). This adds a setup check to make the admin aware that the worker is not running, iff there have been scheduled tasks in the last 7 days (to make sure we don't warn if the feature is not used).
The second commit increases the sensitivity threshold for the other taskprocessing setup checks from 20% to 10% to make them warn earlier.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
