### PR TITLE
fix(LocalPreviewStorage): Use correct regex to detect files in nested directory format

### DIFF
--- a/lib/private/Preview/Storage/LocalPreviewStorage.php
+++ b/lib/private/Preview/Storage/LocalPreviewStorage.php
@@ -281,7 +281,7 @@ class LocalPreviewStorage implements IPreviewStorage {
 
 				// Move old flat preview to new nested directory format.
 				$dirName = str_replace($this->getPreviewRootFolder(), '', $item['filePath']);
-				if (preg_match('/[0-9a-e]\/[0-9a-e]\/[0-9a-e]\/[0-9a-e]\/[0-9a-e]\/[0-9a-e]\/[0-9a-e]\/[0-9]+/', $dirName) !== 1) {
+				if (preg_match('/([[:xdigit:]]\/){7}[0-9]+/', $dirName) !== 1) {
 					$previewPath = $this->constructPath($preview);
 					$this->createParentFiles($previewPath);
 					$ok = rename($item['realPath'], $previewPath);


### PR DESCRIPTION
## Summary

The `LocalPreviewStorage` didn't detected files in the nested directory format correctly. The regex didn't included the letter `f`, which can occur in hexadecimal md5 hashes as well. May fix [the issue from this comment](https://github.com/nextcloud/server/issues/56510#issuecomment-4239240010).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
