### PR TITLE
fix(repair): restrict unserialize() in RemoveBrokenProperties

### DIFF
--- a/lib/private/Repair/RemoveBrokenProperties.php
+++ b/lib/private/Repair/RemoveBrokenProperties.php
@@ -37,7 +37,7 @@ class RemoveBrokenProperties implements IRepairStep {
 		$brokenIds = [];
 		while ($entry = $result->fetch()) {
 			if (!empty($entry['propertyvalue'])) {
-				$object = @unserialize(str_replace('\x00', chr(0), $entry['propertyvalue']));
+				$object = @unserialize(str_replace('\x00', chr(0), $entry['propertyvalue']), ['allowed_classes' => false]);
 				if ($object === false) {
 					$brokenIds[] = $entry['id'];
 				}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- N/A — no existing issue -->

## Summary
`RemoveBrokenProperties::run()` calls `unserialize()` on the `propertyvalue` column without restricting `allowed_classes`. The result is only compared against `false` to identify broken rows, so no class instantiation is needed. As written though, magic methods (`__wakeup`/`__destruct`) on any class referenced by the serialized payload still execute.

The runtime decoder for the same column already restricts deserialization. See `apps/dav/lib/DAV/CustomPropertiesBackend.php:675-678`, which passes `['allowed_classes' => self::ALLOWED_SERIALIZED_CLASSES]`. This change applies the same hardening to the repair step. It uses `['allowed_classes' => false]` since the unserialized value is never used, only its truthiness is checked.

No behavior change for valid or broken rows.

Found while testing an in-development static analysis tool I'm building against open-source PHP codebases.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
