### PR TITLE
docs(lock): clarify LockContext docs and modernize implementation

### DIFF
--- a/apps/dav/lib/Migration/Version1039Date20260408000000.php
+++ b/apps/dav/lib/Migration/Version1039Date20260408000000.php
@@ -22,6 +22,7 @@ use OCP\Migration\SimpleMigrationStep;
 #[AddColumn(table: 'calendars', name: 'default_alarm_pday', type: ColumnType::INTEGER)]
 #[AddColumn(table: 'calendars', name: 'default_alarm_fday', type: ColumnType::INTEGER)]
 class Version1039Date20260408000000 extends SimpleMigrationStep {
+	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();

--- a/lib/public/Files/Lock/LockContext.php
+++ b/lib/public/Files/Lock/LockContext.php
@@ -12,32 +12,25 @@ namespace OCP\Files\Lock;
 use OCP\Files\Node;
 
 /**
- * Structure to identify a specific lock context to request or
- * describe a lock with the affected node and ownership information
+ * Value object describing the context in which a lock is requested or evaluated.
  *
- * This is used to match a lock/unlock request or file operation to existing locks
+ * A lock context identifies the affected node together with the lock owner type
+ * and owner identifier, so lock-aware operations can be matched against existing locks.
  *
  * @since 24.0.0
  */
 final class LockContext {
-	private Node $node;
-	private int $type;
-	private string $owner;
-
 	/**
-	 * @param Node $node Node that is owned by the lock
-	 * @param int $type Type of the lock owner
-	 * @param string $owner Unique identifier for the lock owner based on the type
+	 * @param Node $node Node the lock context applies to
+	 * @param ILock::TYPE_* $type Lock owner type
+	 * @param string $owner Owner identifier for the given type - e.g. a user id, app id, or lock token
 	 * @since 24.0.0
 	 */
 	public function __construct(
-		Node $node,
-		int $type,
-		string $owner,
+		private readonly Node $node,
+		private readonly int $type,
+		private readonly string $owner,
 	) {
-		$this->node = $node;
-		$this->type = $type;
-		$this->owner = $owner;
 	}
 
 	/**
@@ -48,7 +41,9 @@ final class LockContext {
 	}
 
 	/**
-	 * @return int
+	 * Returns the lock owner type.
+	 *
+	 * @return ILock::TYPE_*
 	 * @since 24.0.0
 	 */
 	public function getType(): int {
@@ -56,7 +51,10 @@ final class LockContext {
 	}
 
 	/**
-	 * @return string user id / app id / lock token depending on the type
+	 * Returns the owner identifier for the current lock type.
+	 *
+	 * For example, this may be a user id, app id, or lock token.
+	 *
 	 * @since 24.0.0
 	 */
 	public function getOwner(): string {
@@ -64,19 +62,19 @@ final class LockContext {
 	}
 
 	/**
+	 * Returns a human-readable representation for logging and debugging.
+	 *
+	 * Not guaranteed to be a stable machine-readable contract.
+	 *
 	 * @since 24.0.0
 	 */
 	public function __toString(): string {
-		$typeString = 'unknown';
-		if ($this->type === ILock::TYPE_USER) {
-			$typeString = 'ILock::TYPE_USER';
-		}
-		if ($this->type === ILock::TYPE_APP) {
-			$typeString = 'ILock::TYPE_APP';
-		}
-		if ($this->type === ILock::TYPE_TOKEN) {
-			$typeString = 'ILock::TYPE_TOKEN';
-		}
-		return "$typeString  $this->owner " . $this->getNode()->getId();
+		$typeString = match ($this->type) {
+			ILock::TYPE_USER => 'ILock::TYPE_USER',
+			ILock::TYPE_APP => 'ILock::TYPE_APP',
+			ILock::TYPE_TOKEN => 'ILock::TYPE_TOKEN',
+			default => 'unknown',
+		};
+		return sprintf('%s %s %d', $typeString, $this->owner, $this->node->getId());
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Improve `LockContext` documentation and make the implementation more concise.

## Changes

- clarify the class docblock and constructor parameter docs
- document `getType()`, `getOwner()`, and `__toString()` more clearly
- switch to constructor property promotion
- mark properties as `readonly`
- simplify `__toString()` using `match` and `sprintf()`

## Notes

This is a documentation/cleanup change only and is not intended to change lock behavior.[^1]

[^1]: Technically I did drop an extra space in the `__toString()` output.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
