### PR TITLE
fix(SimpleFile): Catch exception and call `checkFile()` to sanitize broken `appdata` folder

### DIFF
--- a/lib/private/Files/Node/File.php
+++ b/lib/private/Files/Node/File.php
@@ -9,6 +9,7 @@ namespace OC\Files\Node;
 
 use OCP\Constants;
 use OCP\Files\GenericFileException;
+use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Lock\LockedException;
 
@@ -35,7 +36,7 @@ class File extends Node implements \OCP\Files\File {
 		if ($this->checkPermissions(Constants::PERMISSION_READ)) {
 			$content = $this->view->file_get_contents($this->path);
 			if ($content === false) {
-				throw new GenericFileException();
+				throw new GenericFileException('file_get_contents failed');
 			}
 			return $content;
 		} else {
@@ -66,6 +67,7 @@ class File extends Node implements \OCP\Files\File {
 	/**
 	 * @param string $mode
 	 * @return resource|false
+	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 * @throws LockedException
 	 */

--- a/lib/private/Files/SimpleFS/SimpleFile.php
+++ b/lib/private/Files/SimpleFS/SimpleFile.php
@@ -54,27 +54,25 @@ class SimpleFile implements ISimpleFile {
 	/**
 	 * Get the content
 	 *
-	 * @throws GenericFileException
 	 * @throws LockedException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
 	#[\Override]
-	public function getContent(): string {
-		$result = $this->file->getContent();
-
-		if ($result === false) {
+	public function getContent(): string|bool {
+		try {
+			return $this->file->getContent();
+		} catch (GenericFileException) {
 			$this->checkFile();
 		}
 
-		return $result;
+		return false;
 	}
 
 	/**
 	 * Overwrite the file
 	 *
 	 * @param string|resource $data
-	 * @throws GenericFileException
 	 * @throws LockedException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
@@ -83,7 +81,7 @@ class SimpleFile implements ISimpleFile {
 	public function putContent($data): void {
 		try {
 			$this->file->putContent($data);
-		} catch (NotFoundException $e) {
+		} catch (GenericFileException) {
 			$this->checkFile();
 		}
 	}

--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -58,7 +58,7 @@ interface ISimpleFile {
 	 * @throws NotPermittedException
 	 * @since 11.0.0
 	 */
-	public function getContent(): string;
+	public function getContent(): string|bool;
 
 	/**
 	 * Overwrite the file

--- a/tests/lib/Files/SimpleFS/SimpleFileTest.php
+++ b/tests/lib/Files/SimpleFS/SimpleFileTest.php
@@ -10,6 +10,7 @@ namespace Test\File\SimpleFS;
 use OC\Files\SimpleFS\SimpleFile;
 use OCP\Files\File;
 use OCP\Files\Folder;
+use OCP\Files\GenericFileException;
 use OCP\Files\NotFoundException;
 
 class SimpleFileTest extends \Test\TestCase {
@@ -92,7 +93,7 @@ class SimpleFileTest extends \Test\TestCase {
 
 	public function testGetContentInvalidAppData(): void {
 		$this->file->method('getContent')
-			->willReturn(false);
+			->willThrowException(new GenericFileException());
 		$this->file->method('stat')->willReturn(false);
 
 		$parent = $this->createMock(Folder::class);
@@ -107,6 +108,20 @@ class SimpleFileTest extends \Test\TestCase {
 		$this->expectException(NotFoundException::class);
 
 		$this->simpleFile->getContent();
+	}
+
+	public function testGetContentReturnsFalseOnFailure(): void {
+		$this->file->expects($this->once())
+			->method('getContent')
+			->willThrowException(new GenericFileException());
+
+		// We don't want to test the `checkFile()`
+		// method, so, just return an empty array.
+		$this->file->method('stat')->willReturn([]);
+
+		$result = $this->simpleFile->getContent();
+
+		$this->assertFalse($result);
 	}
 
 	public function testRead(): void {


### PR DESCRIPTION
* Resolves: #56510 

## Summary

During analyzing of #56510, I realized that broken `appdata` folders are not handled correctly since version 27 ([this commit to be precise](https://github.com/nextcloud/server/commit/546d94c3ec5b0cb06cc284dead0da98ee346fc81)).

The issue here is that folders and their files can be listed in the `oc_filecache` database table, but not exist on filesystem anymore. If that is the case, our wrappers still work correctly as they always prefer the file cache... Until it comes to **really** read or write to the file system. And here our own `putContent()` and `getContent()` methods don't follow the same scheme as their `put_file_contents()` and `get_file_contents()` counterparts as we throw an exception instead of returning `false`.

This change isn't considered on all calls... I can only speak for the preview generation, as that's what I try to fix. The introduction of the `oc_previews` table fixed the issue there, which means only Nextcloud 32 and older are affected by this bug. But a quick look through the code tells me that there are still a lot more cases that expect `false` in case of an error, while others already catch an `NotFoundException` (that's only being thrown when there's no hit against the file cache or method calls like `checkPermission()` fail... Ohh lord...).

Anyway... With this change, the preview generation will restore the correct `appdata` structure and starts to generate previews instead of being broken until someone runs `occ preview:cleanup` manually.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
