### PR TITLE
docs(lock): clarify ILockManager API documentation

### DIFF
--- a/lib/private/Files/Lock/LockManager.php
+++ b/lib/private/Files/Lock/LockManager.php
@@ -21,7 +21,7 @@ class LockManager implements ILockManager {
 	private ?LockContext $lockInScope = null;
 
 	public function registerLockProvider(ILockProvider $lockProvider): void {
-		if ($this->lockProvider) {
+		if ($this->lockProvider || $this->lockProviderClass) {
 			throw new PreConditionNotMetException('There is already a registered lock provider');
 		}
 

--- a/lib/public/Files/Lock/ILockManager.php
+++ b/lib/public/Files/Lock/ILockManager.php
@@ -12,47 +12,54 @@ namespace OCP\Files\Lock;
 use OCP\PreConditionNotMetException;
 
 /**
- * Manage app integrations with files_lock with collaborative editors
+ * Manage app integrations with the files_lock app and collaborative editors.
  *
- * The OCP parts are mainly for exposing the ability to lock/unlock for apps and
- * to give the files_lock app a way to register and then be triggered by the apps
- * while the actual locking implementation is kept in the LockProvider and DAV
- * plugin from files_lock app.
+ * This public API exposes locking operations to apps and allows a lock provider
+ * from files_lock to be registered. The actual locking implementation remains
+ * in the provider and the DAV plugin of the files_lock app.
  *
  * @since 24.0.0
  */
 interface ILockManager extends ILockProvider {
 	/**
-	 * @throws PreConditionNotMetException if there is already a lock provider registered
+	 * Register the lock provider implementation.
+	 *
+	 * @throws PreConditionNotMetException if a lock provider is already registered
 	 * @since 24.0.0
 	 * @deprecated 30.0.0 Use registerLazyLockProvider
 	 */
 	public function registerLockProvider(ILockProvider $lockProvider): void;
 
 	/**
-	 * @param string $lockProviderClass
-	 * @return void
+	 * Register a lock provider class for lazy resolution from the server container.
+	 *
+	 * @throws PreConditionNotMetException if a lock provider is already registered
 	 * @since 30.0.0
 	 */
 	public function registerLazyLockProvider(string $lockProviderClass): void;
 
 	/**
-	 * @return bool
+	 * Check whether a lock provider is currently available.
+	 *
 	 * @since 24.0.0
 	 */
 	public function isLockProviderAvailable(): bool;
 
 	/**
-	 * Run within the scope of a given lock condition
+	 * Run a callback within the scope of the given lock context.
 	 *
-	 * The callback will also be executed if no lock provider is present
+	 * The callback is also executed if no lock provider is available.
 	 *
+	 * @throws PreConditionNotMetException if another lock scope is already active
 	 * @since 24.0.0
 	 */
 	public function runInScope(LockContext $lock, callable $callback): void;
 
 	/**
-	 * @throws NoLockProviderException if there is no lock provider available
+	 * Get the lock context currently active in this scope.
+	 *
+	 * Returns null if no lock scope is active.
+	 *
 	 * @since 24.0.0
 	 */
 	public function getLockInScope(): ?LockContext;

--- a/lib/public/Files/Lock/ILockManager.php
+++ b/lib/public/Files/Lock/ILockManager.php
@@ -41,6 +41,8 @@ interface ILockManager extends ILockProvider {
 	/**
 	 * Check whether a lock provider is currently available.
 	 *
+	 * If a provider class was registered lazily, this may attempt to resolve it.
+	 *
 	 * @since 24.0.0
 	 */
 	public function isLockProviderAvailable(): bool;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Improve the `ILockManager` documentation and also fix a presumed bug in the underlying `registerLockProvider()` implementation.

### Changes

- improve the interface-level description for `ILockManager`
- document `registerLazyLockProvider()` throwing `PreConditionNotMetException` when a provider is already registered
- document `runInScope()` throwing `PreConditionNotMetException` when a scope is already active
- fix `getLockInScope()` docs to reflect that it returns `null` when no scope is active instead of throwing
- clarify that `isLockProviderAvailable()` checks current availability and may attempt lazy provider resolution
- **Implementation fix:** align `registerLockProvider()` behavior with the documented single-provider registration contract by also rejecting previously registered lazy providers

### Notes

This change is intended to improve API clarity and keep the public interface documentation in sync with the implementation. No functional behavior changes are intended beyond the consistency fix in `registerLockProvider()`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
