### PR TITLE
Fix/57375 zero quota external storage folder delete

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -100,7 +100,11 @@ class Quota extends Wrapper {
 			return $this->getWrapperStorage()->file_put_contents($path, $data);
 		}
 		$free = $this->free_space($path);
-		if ($free < 0 || strlen($data) < $free) {
+		// Only apply quota for files under the user's "files/" tree.
+		// Writes to metadata locations (files_trashbin/, files_versions/, ...)
+		// must not be blocked, otherwise features like the trashbin break
+		// for users whose quota happens to be exhausted (notably quota=0).
+		if ($free < 0 || !$this->shouldApplyQuota($path) || strlen($data) < $free) {
 			return $this->getWrapperStorage()->file_put_contents($path, $data);
 		} else {
 			return false;
@@ -113,7 +117,7 @@ class Quota extends Wrapper {
 			return $this->getWrapperStorage()->copy($source, $target);
 		}
 		$free = $this->free_space($target);
-		if ($free < 0 || $this->getSize($source) < $free) {
+		if ($free < 0 || !$this->shouldApplyQuota($target) || $this->getSize($source) < $free) {
 			return $this->getWrapperStorage()->copy($source, $target);
 		} else {
 			return false;
@@ -167,7 +171,12 @@ class Quota extends Wrapper {
 			return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
 		$free = $this->free_space($targetInternalPath);
-		if ($free < 0 || $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
+		// Skip the quota check when the target lives outside of "files/"
+		// (e.g. files_trashbin/, files_versions/). This is essential so that
+		// the trashbin can store deleted items even when the user's quota is
+		// fully consumed: otherwise DELETE operations on external mounts fail
+		// with HTTP 403 because the move-to-trash copy returns false.
+		if ($free < 0 || !$this->shouldApplyQuota($targetInternalPath) || $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
 			return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		} else {
 			return false;
@@ -180,7 +189,7 @@ class Quota extends Wrapper {
 			return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
 		$free = $this->free_space($targetInternalPath);
-		if ($free < 0 || $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
+		if ($free < 0 || !$this->shouldApplyQuota($targetInternalPath) || $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
 			return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		} else {
 			return false;
@@ -206,7 +215,9 @@ class Quota extends Wrapper {
 			return $this->getWrapperStorage()->touch($path, $mtime);
 		}
 		$free = $this->free_space($path);
-		if ($free == 0) {
+		// Same rule as the other write paths: only block when the target is
+		// actually under the user-quota controlled "files/" tree.
+		if ($free == 0 && $this->shouldApplyQuota($path)) {
 			return false;
 		}
 
@@ -219,12 +230,12 @@ class Quota extends Wrapper {
 
 	#[\Override]
 	public function writeStream(string $path, $stream, ?int $size = null): int {
-		if (!$this->hasQuota()) {
+		if (!$this->hasQuota() || !$this->shouldApplyQuota($path)) {
 			return parent::writeStream($path, $stream, $size);
 		}
 
 		$free = $this->free_space($path);
-		if ($this->shouldApplyQuota($path) && $free == 0) {
+		if ($free == 0) {
 			throw new NotEnoughSpaceException();
 		}
 

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -225,9 +225,13 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($instance->mkdir('cache'));
 	}
 
-	public function testNoTouchQuotaZero(): void {
+	public function testTouchBlockedUnderFilesWhenQuotaIsZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
-		$this->assertFalse($instance->touch('foobar'));
+		// touch is blocked only for paths under files/ (user quota area)
+		$this->assertFalse($instance->touch('files/foobar'));
+		// touch outside files/ (trashbin, versions, ...) must remain allowed
+		$this->assertTrue($instance->mkdir('files_trashbin'));
+		$this->assertTrue($instance->touch('files_trashbin/foobar'));
 	}
 
 	public function testNoFopenQuotaZero(): void {
@@ -255,5 +259,48 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$stream = fopen('php://temp', 'w+');
 		$this->expectException(Files\NotEnoughSpaceException::class);
 		$instance->writeStream('files/test.txt', $stream);
+	}
+
+	/**
+	 * writeStream outside of files/ (trashbin, versions, ...) must succeed
+	 * even when the user quota is exhausted.
+	 */
+	public function testWriteStreamAllowedOutsideFilesWhenQuotaIsZero(): void {
+		$instance = $this->getLimitedStorage(0.0);
+		$this->assertTrue($instance->mkdir('files_trashbin'));
+		$stream = fopen('php://temp', 'w+');
+		fwrite($stream, 'foo');
+		rewind($stream);
+		$this->assertEquals(3, $instance->writeStream('files_trashbin/test.txt', $stream));
+	}
+
+	/**
+	 * Writes under "files/" must still be blocked when quota is 0, but writes
+	 * outside that prefix (trashbin metadata, versions, ...) must not be
+	 * blocked, otherwise features like the trashbin break for users whose
+	 * quota happens to be exhausted (notably quota=0).
+	 */
+	public function testFilePutContentsBlockedUnderFilesWhenQuotaIsZero(): void {
+		$instance = $this->getLimitedStorage(0.0);
+		$this->assertFalse($instance->file_put_contents('files/foo', 'x'));
+		$this->assertTrue($instance->mkdir('files_trashbin'));
+		$this->assertNotFalse($instance->file_put_contents('files_trashbin/foo.json', '{}'));
+	}
+
+	/**
+	 * Copying from another storage (e.g. an external SMB mount) into the
+	 * trashbin must succeed even when the quota is exhausted: this is what
+	 * happens on every DELETE when files_trashbin is enabled. Conversely,
+	 * copying into "files/" must still be blocked.
+	 */
+	public function testCopyFromStorageAllowedToTrashbinWhenQuotaIsZero(): void {
+		$source = new Local(['datadir' => $this->tmpDir]);
+		$source->file_put_contents('source.txt', 'hello');
+
+		$instance = $this->getLimitedStorage(0.0);
+		$this->assertTrue($instance->mkdir('files_trashbin'));
+		$this->assertTrue($instance->copyFromStorage($source, 'source.txt', 'files_trashbin/source.txt'));
+
+		$this->assertFalse($instance->copyFromStorage($source, 'source.txt', 'files/source.txt'));
 	}
 }


### PR DESCRIPTION
* Resolves: #57375

## Summary

Users with **quota set to 0** (intentionally, so nothing is stored under their home `files/` except structure / external mounts) hit incorrect WebDAV failures:

1. **MKCOL / uploads / moves** could fail with `507 Insufficient Storage` because `QuotaPlugin` treated directory creation like a fixed byte write (4096) against `free_space == 0`, and the home `Quota` wrapper blocked `mkdir` when quota was exhausted.

2. With **`files_trashbin` enabled**, **DELETE** on items on external storage could return **403 Forbidden** (`Directory::delete` → `rmdir` false) because `Quota::copyFromStorage` / related write paths did not honor `shouldApplyQuota()` — writes under `files_trashbin/` were incorrectly subject to the same `free_space == 0` gate as real user files under `files/`.

This PR aligns quota enforcement with the existing intent of `shouldApplyQuota()` (only paths under `files/` count toward user quota):

- **`QuotaPlugin`**: skip pre-quota checks for directory creation (`MKCOL`); empty dirs do not consume user quota bytes.
- **`Quota` wrapper**: allow `mkdir` when quota is exactly `0` for empty directories; delegate real file blocking to `fopen` / `file_put_contents` / etc.
- **`Quota` wrapper**: apply `shouldApplyQuota()` to `copyFromStorage`, `moveFromStorage`, `copy`, `file_put_contents`, and `touch` so trashbin / versions / metadata paths are not blocked when home quota is `0`.

Unit tests updated in `tests/lib/Files/Storage/Wrapper/QuotaTest.php` and `apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php`.

## TODO

- [ ] CI green

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI