### PR TITLE
Quota wrapper fixes

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -621,6 +621,9 @@ class File extends Node implements IFile {
 		if ($e instanceof NotFoundException) {
 			throw new NotFound($this->l10n->t('File not found: %1$s', [$e->getMessage()]), 0, $e);
 		}
+		if ($e instanceof Files\NotEnoughSpaceException) {
+			throw new EntityTooLarge($this->l10n->t('Insufficient space'), 0, $e);
+		}
 
 		throw new \Sabre\DAV\Exception($e->getMessage(), 0, $e);
 	}

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -11,6 +11,8 @@ use OC\Files\Filesystem;
 use OC\SystemConfig;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
+use OCP\Files\GenericFileException;
+use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\Storage\IStorage;
 
 class Quota extends Wrapper {
@@ -213,5 +215,32 @@ class Quota extends Wrapper {
 
 	public function enableQuota(bool $enabled): void {
 		$this->enabled = $enabled;
+	}
+
+	#[\Override]
+	public function writeStream(string $path, $stream, ?int $size = null): int {
+		if (!$this->hasQuota()) {
+			return parent::writeStream($path, $stream, $size);
+		}
+
+		$free = $this->free_space($path);
+		if ($this->shouldApplyQuota($path) && $free == 0) {
+			throw new NotEnoughSpaceException();
+		}
+
+		if ($size !== null) {
+			if ($size < $free) {
+				return parent::writeStream($path, $stream, $size);
+			} else {
+				throw new NotEnoughSpaceException();
+			}
+		} else {
+			// force fallback through `fopen` to handle the quota
+			try {
+				return parent::writeStreamFallback($path, $stream);
+			} catch (GenericFileException) {
+				throw new NotEnoughSpaceException();
+			}
+		}
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -120,19 +120,20 @@ class Quota extends Wrapper {
 
 	#[\Override]
 	public function fopen(string $path, string $mode) {
-		if (!$this->hasQuota()) {
+		if (!$this->hasQuota() || $this->isPartFile($path)) {
 			return $this->getWrapperStorage()->fopen($path, $mode);
 		}
-		$source = $this->getWrapperStorage()->fopen($path, $mode);
 
-		// don't apply quota for part files
-		if (!$this->isPartFile($path)) {
-			$free = $this->free_space($path);
-			if ($source && (is_int($free) || is_float($free)) && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
-				// only apply quota for files, not metadata, trash or others
-				if ($this->shouldApplyQuota($path)) {
-					return \OC\Files\Stream\Quota::wrap($source, $free);
-				}
+		$free = $this->free_space($path);
+		if ($this->shouldApplyQuota($path) && $free == 0) {
+			return false;
+		}
+
+		$source = $this->getWrapperStorage()->fopen($path, $mode);
+		if ($source && (is_int($free) || is_float($free)) && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
+			// only apply quota for files, not metadata, trash or others
+			if ($this->shouldApplyQuota($path)) {
+				return \OC\Files\Stream\Quota::wrap($source, $free);
 			}
 		}
 

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -392,6 +392,13 @@ class Wrapper implements Storage, ILockingStorage, IWriteStreamStorage {
 			return $storage->writeStream($path, $stream, $size);
 		}
 
+		return $this->writeStreamFallback($path, $stream);
+	}
+
+	/**
+	 * @param resource $stream
+	 */
+	protected function writeStreamFallback(string $path, $stream): int {
 		$target = $this->fopen($path, 'w');
 		if ($target === false) {
 			throw new GenericFileException('Failed to open ' . $path);

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -235,4 +235,25 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$fh = $instance->fopen('files/test.txt', 'w');
 		$this->assertFalse($fh);
 	}
+
+	public function testNoWriteStreamQuota(): void {
+		$instance = $this->getLimitedStorage(5.0);
+		$stream = fopen('php://temp', 'w+');
+		fwrite($stream, 'foo');
+		rewind($stream);
+		$instance->writeStream('files/test.txt', $stream);
+
+		$stream = fopen('php://temp', 'w+');
+		fwrite($stream, 'foobar');
+		rewind($stream);
+		$this->expectException(Files\NotEnoughSpaceException::class);
+		$instance->writeStream('files/test.txt', $stream);
+	}
+
+	public function testNoWriteStreamQuotaZero(): void {
+		$instance = $this->getLimitedStorage(0.0);
+		$stream = fopen('php://temp', 'w+');
+		$this->expectException(Files\NotEnoughSpaceException::class);
+		$instance->writeStream('files/test.txt', $stream);
+	}
 }

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -229,4 +229,10 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$instance = $this->getLimitedStorage(0.0);
 		$this->assertFalse($instance->touch('foobar'));
 	}
+
+	public function testNoFopenQuotaZero(): void {
+		$instance = $this->getLimitedStorage(0.0);
+		$fh = $instance->fopen('files/test.txt', 'w');
+		$this->assertFalse($fh);
+	}
 }


### PR DESCRIPTION
- Block creating empty files trough `fopen`
- Apply quota on `writeStream`

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
