### PR TITLE
fix(tests): Fix encryption test isolation between test runs

### DIFF
--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -27,6 +27,7 @@ use OC\User\Session;
 use OCP\Command\IBus;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\IRootFolder;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
@@ -194,6 +195,22 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 			if (method_exists($this, $methodName)) {
 				call_user_func([$this, $methodName]);
 			}
+		}
+
+		// Clean up encryption state to prevent test pollution
+		// This ensures encryption_enabled is reset after each test, preventing
+		// MultiKeyEncryptException failures in subsequent tests when encryption
+		// is left enabled but user keys don't exist
+		try {
+			$appConfig = Server::get(IAppConfig::class);
+			$currentValue = $appConfig->getValueBool('core', 'encryption_enabled', false);
+			if ($currentValue) {
+				$appConfig->setValueBool('core', 'encryption_enabled', false);
+				$appConfig->deleteKey('core', 'default_encryption_module');
+				$appConfig->deleteKey('encryption', 'useMasterKey');
+			}
+		} catch (\Throwable $e) {
+			// Ignore - may be called before bootstrap completes
 		}
 	}
 


### PR DESCRIPTION
## Summary

Add global encryption teardown to TestCase base class so encryption state does not leak between test suites regardless of which tests ran earlier.

Spawned from #57279

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [X] The content of this PR was partly or fully generated using AI
