### PR TITLE
chore: fix strict psalm and rector

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -28,6 +28,7 @@ use OCP\Lock\LockedException;
 use OCP\PreConditionNotMetException;
 use OCP\Server;
 use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IAttributes;
 use OCP\Share\IManager;
 use RuntimeException;
 use Sabre\DAV\Exception;
@@ -297,7 +298,7 @@ abstract class Node implements INode {
 		$attributes = [];
 		if ($storage->instanceOfStorage(ISharedStorage::class)) {
 			$attributes = $storage->getShare()->getAttributes();
-			if ($attributes === null) {
+			if (!$attributes instanceof IAttributes) {
 				return [];
 			}
 

--- a/build/rector-strict.php
+++ b/build/rector-strict.php
@@ -25,6 +25,10 @@ return (require __DIR__ . '/rector-shared.php')
 		$nextcloudDir . '/lib/private/DB/QueryBuilder/TypedQueryBuilder.php',
 		$nextcloudDir . '/lib/public/DB/QueryBuilder/ITypedQueryBuilder.php',
 	])
+	->withAutoloadPaths([
+		// ensure rector properly autoload the public interfaces
+		$nextcloudDir . '/lib/public',
+	])
 	->withPreparedSets(
 		deadCode: true,
 		codeQuality: true,

--- a/psalm-strict.xml
+++ b/psalm-strict.xml
@@ -45,6 +45,9 @@
 	<extraFiles>
 		<directory name="apps/dav/lib"/>
 		<directory name="apps/settings/lib"/>
+		<!-- As long as the files are not in the projectFiles list, we need to include them here to make psalm aware of our interfaces -->
+		<directory name="lib/private"/>
+		<directory name="lib/public"/>
 		<directory name="3rdparty"/>
 	</extraFiles>
 	<stubs>

--- a/psalm-strict.xml
+++ b/psalm-strict.xml
@@ -15,6 +15,9 @@
 	findUnusedVariablesAndParams="true"
 	phpVersion="8.2"
 >
+	<plugins>
+		<pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+	</plugins>
 	<projectFiles>
 		<file name="core/BackgroundJobs/ExpirePreviewsJob.php"/>
 		<file name="lib/public/IContainer.php"/>

--- a/psalm-strict.xml
+++ b/psalm-strict.xml
@@ -37,7 +37,6 @@
 		<file name="lib/public/Share/IShareHelper.php"/>
 		<ignoreFiles>
 			<directory name="apps/**/composer"/>
-			<directory name="apps/**/tests"/>
 			<directory name="lib/composer"/>
 			<directory name="lib/l10n"/>
 			<directory name="3rdparty"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -20,6 +20,7 @@
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />
 		<plugin filename="build/psalm/AttributeNamedParameters.php" />
 		<plugin filename="build/psalm/LogicalOperatorChecker.php" />
+		<pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
 	</plugins>
 	<projectFiles>
 		<directory name="apps/admin_audit"/>

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,7 +1,4 @@
 {
-	"require": {
-		"vimeo/psalm": "^6.16"
-	},
 	"config": {
 		"platform": {
 			"php": "8.2.27"
@@ -9,5 +6,9 @@
 		"allow-plugins": {
 			"composer/package-versions-deprecated": true
 		}
+	},
+	"require": {
+		"psalm/plugin-phpunit": "^0.19.7",
+		"vimeo/psalm": "^6.16"
 	}
 }

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7591b157e86a8c10c3360618317e822c",
+    "content-hash": "305efadf319961c090d8cd0b425471b1",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1914,6 +1914,64 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.19.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": ">=8.1",
+                "vimeo/psalm": "dev-master || ^6.10.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.20.0",
+                "phpspec/prophecy-phpunit": "<2.3.0",
+                "phpunit/phpunit": "<8.5.1"
+            },
+            "require-dev": {
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.7"
+            },
+            "time": "2025-03-31T18:49:55+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
- split from #59997 

## Summary
- As cherry picked psalm changes to also cover tests and make use of the phpunit plugin.
- Fix the strict rector rules to properly autoload OCP otherwise it does not know about those interface¹
- Fix the strict psalm rules for the same reason to make them aware of our OC and OCP code
- Apply the changes and committed the results 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
