### PR TITLE
refactor(provisioning): do not use legacy `OC_App` class

### DIFF
--- a/apps/provisioning_api/lib/Controller/AppsController.php
+++ b/apps/provisioning_api/lib/Controller/AppsController.php
@@ -10,7 +10,6 @@ namespace OCA\Provisioning_API\Controller;
 
 use OC\App\AppStore\AppNotFoundException;
 use OC\Installer;
-use OC_App;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
@@ -46,35 +45,31 @@ class AppsController extends OCSController {
 	/**
 	 * Get a list of installed apps
 	 *
-	 * @param ?string $filter Filter for enabled or disabled apps
+	 * @param 'enabled'|'disabled'|null $filter Filter for enabled or disabled apps
 	 * @return DataResponse<Http::STATUS_OK, array{apps: list<string>}, array{}>
 	 * @throws OCSException
 	 *
 	 * 200: Installed apps returned
 	 */
 	public function getApps(?string $filter = null): DataResponse {
-		$apps = (new OC_App())->listAllApps();
-		/** @var list<string> $list */
-		$list = [];
-		foreach ($apps as $app) {
-			$list[] = $app['id'];
-		}
-		if ($filter) {
-			switch ($filter) {
-				case 'enabled':
-					return new DataResponse(['apps' => \OC_App::getEnabledApps()]);
-					break;
-				case 'disabled':
-					$enabled = OC_App::getEnabledApps();
-					return new DataResponse(['apps' => array_values(array_diff($list, $enabled))]);
-					break;
-				default:
-					// Invalid filter variable
-					throw new OCSException('', 101);
+		if ($filter !== null) {
+			$enabledApps = $this->appManager->getEnabledApps();
+			if ($filter === 'enabled') {
+				return new DataResponse(['apps' => $enabledApps]);
+			} elseif ($filter === 'disabled') {
+				$allApps = $this->appManager->getAllAppsInAppsFolders();
+				$coreApps = $this->appManager->getAlwaysEnabledApps();
+				$disabledApps = array_diff($allApps, $enabledApps, $coreApps);
+				return new DataResponse(['apps' => array_values($disabledApps)]);
+			} else {
+				throw new OCSException('Invalid filter', 101);
 			}
-		} else {
-			return new DataResponse(['apps' => $list]);
 		}
+
+		$allApps = $this->appManager->getAllAppsInAppsFolders();
+		$coreApps = $this->appManager->getAlwaysEnabledApps();
+		$apps = array_diff($allApps, $coreApps);
+		return new DataResponse(['apps' => array_values($apps)]);
 	}
 
 	/**

--- a/apps/provisioning_api/openapi-administration.json
+++ b/apps/provisioning_api/openapi-administration.json
@@ -390,7 +390,11 @@
                         "schema": {
                             "type": "string",
                             "nullable": true,
-                            "default": null
+                            "default": null,
+                            "enum": [
+                                "enabled",
+                                "disabled"
+                            ]
                         }
                     },
                     {

--- a/apps/provisioning_api/openapi-full.json
+++ b/apps/provisioning_api/openapi-full.json
@@ -437,7 +437,11 @@
                         "schema": {
                             "type": "string",
                             "nullable": true,
-                            "default": null
+                            "default": null,
+                            "enum": [
+                                "enabled",
+                                "disabled"
+                            ]
                         }
                     },
                     {

--- a/openapi.json
+++ b/openapi.json
@@ -27887,7 +27887,11 @@
                         "schema": {
                             "type": "string",
                             "nullable": true,
-                            "default": null
+                            "default": null,
+                            "enum": [
+                                "enabled",
+                                "disabled"
+                            ]
                         }
                     },
                     {


### PR DESCRIPTION
## Summary

`OC_App` is legacy and deprecated so instead use the app manager especially as only the app ids were queried here.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
