### PR TITLE
feat(theming): Increase blur radius

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -5,7 +5,7 @@
   --color-main-background-rgb: 255,255,255;
   --color-main-background-translucent: rgba(var(--color-main-background-rgb), .97);
   --color-main-background-blur: rgba(var(--color-main-background-rgb), .8);
-  --filter-background-blur: blur(25px);
+  --filter-background-blur: blur(50px);
   --gradient-main-background: var(--color-main-background) 0%, var(--color-main-background-translucent) 85%, transparent 100%;
   --color-background-hover: #f5f5f5;
   /** Can be used e.g. to colorize selected table rows */

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -125,7 +125,7 @@ class DefaultTheme implements ITheme {
 			'--color-main-background-rgb' => $colorMainBackgroundRGB,
 			'--color-main-background-translucent' => 'rgba(var(--color-main-background-rgb), .97)',
 			'--color-main-background-blur' => 'rgba(var(--color-main-background-rgb), .8)',
-			'--filter-background-blur' => $workingBlur ? 'blur(25px)' : 'none',
+			'--filter-background-blur' => $workingBlur ? 'blur(50px)' : 'none',
 
 			// to use like this: background-image: linear-gradient(0, var('--gradient-main-background));
 			'--gradient-main-background' => 'var(--color-main-background) 0%, var(--color-main-background-translucent) 85%, transparent 100%',


### PR DESCRIPTION
## Summary

25px is a bit small for large surfaces

Also discussed with @jancborchardt

| Before | After |
|--------|--------|
| <img width="307" height="417" alt="image" src="https://github.com/user-attachments/assets/f5a09172-683e-4582-8a6f-75f84ef9d703" /> | <img width="307" height="417" alt="image" src="https://github.com/user-attachments/assets/1b1e4e70-7ea8-4a7f-98d9-b14145463d72" /> |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
