### PR TITLE
chore: Increase page load timeout for oracle setup tests

### DIFF
--- a/cypress/e2e/core/setup.ts
+++ b/cypress/e2e/core/setup.ts
@@ -88,6 +88,7 @@ describe('Can install Nextcloud', { testIsolation: true, retries: 0 }, () => {
 	})
 
 	it('Oracle', () => {
+		Cypress.config('pageLoadTimeout', 100000)
 		cy.runCommand('cp /var/www/html/tests/databases-all-config.php /var/www/html/config/config.php')
 		cy.visit('/')
 		cy.get('[data-cy-setup-form]').should('be.visible')


### PR DESCRIPTION
## Summary

Fix this kind of failures:
<img width="990" height="601" alt="Copie d&#39;écran_20260430_180738" src="https://github.com/user-attachments/assets/6c3244b2-45b4-496d-9c5b-9f5286db937e" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
