### PR TITLE
chore(i18n): Remove space in word1/word2

### DIFF
--- a/apps/files_external/lib/Lib/Backend/FTP.php
+++ b/apps/files_external/lib/Lib/Backend/FTP.php
@@ -23,7 +23,7 @@ class FTP extends Backend {
 			->setIdentifier('ftp')
 			->addIdentifierAlias('\OC\Files\Storage\FTP') // legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\FTP')
-			->setText($l->t('FTP / FTPS'))
+			->setText($l->t('FTP/FTPS'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				(new DefinitionParameter('port', $l->t('Port')))

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -30,7 +30,7 @@ class SMB extends Backend {
 			->setIdentifier('smb')
 			->addIdentifierAlias('\OC\Files\Storage\SMB')// legacy compat
 			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
-			->setText($l->t('SMB / CIFS (Windows network share)'))
+			->setText($l->t('SMB/CIFS (Windows network share)'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				new DefinitionParameter('share', $l->t('Share')),

--- a/apps/files_external/lib/Lib/Backend/SMB_OC.php
+++ b/apps/files_external/lib/Lib/Backend/SMB_OC.php
@@ -28,7 +28,7 @@ class SMB_OC extends Backend {
 		$this
 			->setIdentifier('\OC\Files\Storage\SMB_OC')
 			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
-			->setText($l->t('SMB / CIFS using Nextcloud login'))
+			->setText($l->t('SMB/CIFS using Nextcloud login'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
 				(new DefinitionParameter('username_as_share', $l->t('Login as share')))


### PR DESCRIPTION
Summary of Slash Usage Rules
Standard rule:
→ No spaces around the slash when connecting single words
→ FTP/FTPS
Technical documentation (e.g., Microsoft):
→ Slash is commonly used
→ No spaces → FTP/FTPS
Technical documentation (e.g., Google):
→ Prefer writing it out for clarity → FTP or FTPS
→ If a slash is used → no spaces → FTP/FTPS
General typography (e.g., University of Chicago Press / Oxford style):
→ No spaces when the slash connects single terms
→ Spaces may be used only when separating longer phrases