### PR TITLE
Fix: missing early fail for basic auth without credentials

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -81,6 +81,9 @@ class Auth extends AbstractBasic {
 			$this->session->close();
 			return true;
 		} else {
+			if ($username === '' || $password === '') {
+				return false;
+			}
 			try {
 				if ($this->userSession->logClientIn($username, $password, $this->request, $this->throttler)) {
 					$this->session->set(self::DAV_AUTHENTICATED, $this->userSession->getUser()->getUID());

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -206,6 +206,14 @@ class AuthTest extends TestCase {
 		self::invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']);
 	}
 
+	public function testValidateUserPassReturnsFalseWithEmptyUsernameAndPassword(): void {
+		$this->userSession
+			->expects($this->never())
+			->method('logClientIn');
+
+		$this->assertFalse(self::invokePrivate($this->auth, 'validateUserPass', ['', '']));
+	}
+
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGet(): void {
 		$request = $this->createMock(RequestInterface::class);
 		$response = $this->createMock(ResponseInterface::class);


### PR DESCRIPTION
Fixes nextcloud/server#59849

Make "validateUserPass" method of OCA\DAV\Connector\Sabre\Auth class return false if empty username and password have been passed to it

* Resolves: #59849

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
