### PR TITLE
fix(files_external): set size to -1 for root entry

### DIFF
--- a/apps/files_external/lib/Service/MountCacheService.php
+++ b/apps/files_external/lib/Service/MountCacheService.php
@@ -119,7 +119,7 @@ class MountCacheService implements IEventListener {
 		$data = [
 			'path' => '',
 			'path_hash' => md5(''),
-			'size' => 0,
+			'size' => -1,
 			'unencrypted_size' => 0,
 			'mtime' => 0,
 			'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE,


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Sets the fake root folder's size to `-1` so it gets scanned by the scanner. Before the changes below, scanning happened because there would be no cache entry for the directory, which triggered the first scan. Since with the newer changes a fake root is created with size 0, this does no longer happen.

https://github.com/nextcloud/server/blob/d8e8703796abb20487e2c4edf6b18b9deaf161a1/apps/files_external/lib/Service/MountCacheService.php#L117-L134

## TODO

- [ ] 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
