### PR TITLE
fix(comments): Add an action to comment notification that dismisses it

### DIFF
--- a/apps/comments/lib/Controller/NotificationsController.php
+++ b/apps/comments/lib/Controller/NotificationsController.php
@@ -80,7 +80,10 @@ class NotificationsController extends Controller {
 
 			$url = $this->urlGenerator->linkToRouteAbsolute(
 				'files.viewcontroller.showFile',
-				[ 'fileid' => $comment->getObjectId() ]
+				[
+					'fileid' => $comment->getObjectId(),
+					'opendetails' => 'true',
+				]
 			);
 
 			return new RedirectResponse($url);

--- a/apps/comments/lib/Notification/Notifier.php
+++ b/apps/comments/lib/Notification/Notifier.php
@@ -15,6 +15,7 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
+use OCP\Notification\IAction;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\Notification\UnknownNotificationException;
@@ -118,14 +119,23 @@ class Notifier implements INotifier {
 						'name' => $displayName,
 					];
 				}
+
+				$commentLink = $this->url->linkToRouteAbsolute(
+					'comments.Notifications.view',
+					['id' => $comment->getId()],
+				);
+
 				[$message, $messageParameters] = $this->commentToRichMessage($comment);
 				$notification->setRichSubject($subject, $subjectParameters)
 					->setRichMessage($message, $messageParameters)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath('core', 'actions/comment.svg')))
-					->setLink($this->url->linkToRouteAbsolute(
-						'comments.Notifications.view',
-						['id' => $comment->getId()])
-					);
+					->setLink($commentLink);
+
+				$action = $notification->createAction();
+				$action->setLink($commentLink, IAction::TYPE_WEB);
+				$action->setPrimary(true);
+				$action->setParsedLabel($l->t('Go to file'));
+				$notification->addParsedAction($action);
 
 				return $notification;
 				break;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Ref https://github.com/nextcloud/activity/issues/2531

## Summary

- Sibling PR for https://github.com/nextcloud/activity/pull/2532
- Both should be done
  - Activity PR is for when a user enables "Push" for "Comments on files"
  - This PR is for "mention notifications" which work natively

Before | After
---|---
<img width="542" height="302" alt="grafik" src="https://github.com/user-attachments/assets/dc3febb0-2f5a-45a4-9d44-d8cf55f42d9a" /> | <img width="540" height="372" alt="grafik" src="https://github.com/user-attachments/assets/c809d655-5ed1-4154-bd52-d8bd3657de4d" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
