### PR TITLE
feat: mail manager integration to ShareByMailProvider

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -39,6 +39,8 @@ use OCP\Share\IShare;
 use OCP\Share\IShareProviderWithNotification;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
+use OCP\Mail\Provider\IManager as IMailManager;
+use OCP\IAppConfig;
 
 /**
  * Class ShareByMail
@@ -58,6 +60,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 
 	public function __construct(
 		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IDBConnection $dbConnection,
 		private ISecureRandom $secureRandom,
 		private IUserManager $userManager,
@@ -70,6 +73,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		private SettingsManager $settingsManager,
 		private Defaults $defaults,
 		private IHasher $hasher,
+		private IMailManager $mailManager,
 		private IEventDispatcher $eventDispatcher,
 		private IShareManager $shareManager,
 		private IEmailValidator $emailValidator,
@@ -327,6 +331,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		$shareWith = $share->getSharedWith();
 
 		$initiatorUser = $this->userManager->get($initiator);
+		$initiatorEmail = ($initiatorUser instanceof IUser) ? $initiatorUser->getEMailAddress() : null;
 		$initiatorDisplayName = ($initiatorUser instanceof IUser) ? $initiatorUser->getDisplayName() : $initiator;
 		$message = $this->mailer->createMessage();
 
@@ -386,7 +391,17 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				]
 			);
 		}
-		$message->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$fromAddress = Util::getDefaultEmailAddress(user_part: $instanceName);
+		$mailProvidersEnabled = $this->appConfig->getValueBool('core', 'mail_providers_enabled');
+		if ($mailProvidersEnabled && $this->mailManager->has()) {
+			if ($initiatorEmail !== null) {
+				$service = $this->mailManager->findServiceByAddress($initiator, $initiatorEmail);
+				if ($service !== null) {
+					$fromAddress = $service->getPrimaryAddress()->getAddress();
+				}
+			}
+		}
+		$message->setFrom([$fromAddress => $senderName]);
 
 		// The "Reply-To" is set to the sharer if an mail address is configured
 		// also the default footer contains a "Do not reply" which needs to be adjusted.


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This PR lets the user use initiator's email as sender if mail providers enabled

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
