### PR TITLE
fix(settings): Fix admin delegation for hidden sections

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -338,6 +338,7 @@ class Manager implements IManager {
 	#[\Override]
 	public function getAdminDelegatedSettings(): array {
 		$sections = $this->getAdminSections();
+		$sections[self::SETTINGS_DELEGATION] = $this->getSections(self::SETTINGS_DELEGATION);
 		$settings = [];
 		foreach ($sections as $sectionPriority) {
 			foreach ($sectionPriority as $section) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/58851
* Follow-up of: https://github.com/nextcloud/server/pull/55261

## Summary

Webhooks and users did not appear anymore in admin delegation because only admin sections were considered and not the new delegation sections.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
