### PR TITLE
Let devs choose the handler for http requests

### DIFF
--- a/lib/private/Http/Client/ClientService.php
+++ b/lib/private/Http/Client/ClientService.php
@@ -41,9 +41,9 @@ class ClientService implements IClientService {
 	}
 
 	#[\Override]
-	public function newClient(): IClient {
-		$handler = new CurlHandler();
-		$stack = HandlerStack::create($handler);
+	public function newClient(?callable $handler = null): IClient {
+		$clientHandler = $handler ?? new CurlHandler();
+		$stack = HandlerStack::create($clientHandler);
 		if ($this->config->getSystemValueBool('dns_pinning', true)) {
 			$stack->push($this->dnsPinMiddleware->addDnsPinning());
 		}

--- a/lib/public/Http/Client/IClientService.php
+++ b/lib/public/Http/Client/IClientService.php
@@ -16,8 +16,10 @@ namespace OCP\Http\Client;
  */
 interface IClientService {
 	/**
+	 * @param ?callable $handler Handler that overrides the default CurlHandler
 	 * @return IClient
 	 * @since 8.1.0
+	 * @since 35.0.0 Added $handler optional param
 	 */
-	public function newClient(): IClient;
+	public function newClient(?callable $handler = null): IClient;
 }


### PR DESCRIPTION
So they can choose a stream handler for example.

## Summary

When using the `'stream' => true` request option with IClient, the response body is a resource but its content is written all at once when the request is done.
This happens because the use of the `CurlHandler` is hardcoded in https://github.com/nextcloud/server/blob/fb67d5d/lib/private/Http/Client/ClientService.php#L44
The Curlhandler makes a blocking call to `curl_exec` which executes the request synchronously.

To allow progressive streamed responses, we need:
* to use HTTP 1/*
* to allow guzzle to use the StreamHandler

This is just a PoC. I have no idea if it's the right thing to do.
Wdyt?


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
