### PR TITLE
feat(TaskProcessing): add TextToTextReformatParagraphs task type

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -949,6 +949,7 @@ return array(
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextFormalization' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextHeadline' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextProofread' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextProofread.php',
+    'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformatParagraphs' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformulation' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextSimplification' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextSimplification.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextSummary' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextSummary.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -990,6 +990,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextFormalization' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextHeadline' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextProofread' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextProofread.php',
+        'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformatParagraphs' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformulation' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextSimplification' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextSimplification.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextSummary' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextSummary.php',

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -84,6 +84,7 @@ use OCP\TaskProcessing\TaskTypes\TextToTextChatWithTools;
 use OCP\TaskProcessing\TaskTypes\TextToTextFormalization;
 use OCP\TaskProcessing\TaskTypes\TextToTextHeadline;
 use OCP\TaskProcessing\TaskTypes\TextToTextProofread;
+use OCP\TaskProcessing\TaskTypes\TextToTextReformatParagraphs;
 use OCP\TaskProcessing\TaskTypes\TextToTextReformulation;
 use OCP\TaskProcessing\TaskTypes\TextToTextSimplification;
 use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
@@ -689,6 +690,7 @@ class Manager implements IManager {
 			TextToTextChatWithTools::ID => Server::get(TextToTextChatWithTools::class),
 			ContextAgentInteraction::ID => Server::get(ContextAgentInteraction::class),
 			TextToTextProofread::ID => Server::get(TextToTextProofread::class),
+			TextToTextReformatParagraphs::ID => Server::get(TextToTextReformatParagraphs::class),
 			TextToSpeech::ID => Server::get(TextToSpeech::class),
 			AudioToAudioChat::ID => Server::get(AudioToAudioChat::class),
 			ContextAgentAudioInteraction::ID => Server::get(ContextAgentAudioInteraction::class),

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\TaskProcessing\TaskTypes;
+
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\ShapeDescriptor;
+
+/**
+ * This is the task processing task type for reformatting text into paragraphs
+ * @since 34.0.0
+ */
+class TextToTextReformatParagraphs implements ITaskType {
+	/**
+	 * @since 34.0.0
+	 */
+	public const ID = 'core:text2text:reformatparagraphs';
+
+	private IL10N $l;
+
+	/**
+	 * @param IFactory $l10nFactory
+	 * @since 34.0.0
+	 */
+	public function __construct(
+		IFactory $l10nFactory,
+	) {
+		$this->l = $l10nFactory->get('lib');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 34.0.0
+	 */
+	#[\Override]
+	public function getName(): string {
+		return $this->l->t('Reformat paragraphs');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 34.0.0
+	 */
+	#[\Override]
+	public function getDescription(): string {
+		return $this->l->t('Reformats a text into multiple paragraphs separated by topic');
+	}
+
+	/**
+	 * @return string
+	 * @since 34.0.0
+	 */
+	#[\Override]
+	public function getId(): string {
+		return self::ID;
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 34.0.0
+	 */
+	#[\Override]
+	public function getInputShape(): array {
+		return [
+			'input' => new ShapeDescriptor(
+				$this->l->t('Text'),
+				$this->l->t('The text to reformat'),
+				EShapeType::Text
+			),
+		];
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 34.0.0
+	 */
+	#[\Override]
+	public function getOutputShape(): array {
+		return [
+			'output' => new ShapeDescriptor(
+				$this->l->t('Reformatted text'),
+				$this->l->t('The reformatted text with paragraphs separated by topic'),
+				EShapeType::Text
+			),
+		];
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

A new task that is meant to reformat large blobs of text into paragraphs specifically to beautify text responses from whisper.

## TODO

- [ ] Implement in providers.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
