### PR TITLE
feat(ContactsInteraction): Allow write-properties to support sort favorites feature

### DIFF
--- a/apps/contactsinteraction/lib/Card.php
+++ b/apps/contactsinteraction/lib/Card.php
@@ -44,6 +44,11 @@ class Card implements ICard, IACL {
 				'principal' => $this->getOwner(),
 				'protected' => true,
 			],
+			[
+				'privilege' => '{DAV:}write-properties',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Right now, the automatically added `Recently contacted` address book only allows read requests. That's insufficient for the favorite contacts feature, as we need to allow `write-properties` here as well. There are no additional changes necessary, as the properties are automatically being written to the `oc_properties` table.

Refs https://github.com/nextcloud/contacts/issues/105

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
