### PR TITLE
docs(config): clarify overwrite.cli.url description

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -739,12 +739,19 @@ $CONFIG = [
 	'overwritecondaddr' => '',
 
 	/**
-	 * Use this configuration parameter to specify the base URL for any URLs which
-	 * are generated within Nextcloud using any kind of command line tools (cron or
-	 * occ). The value should contain the full base URL:
+	 * Set the canonical base URL Nextcloud should use when generating URLs outside
+	 * a normal web request, such as in background jobs or at the command-line.
+	 * The value should be the full base URL including the web root, for example:
 	 * ``https://www.example.com/nextcloud``
-	 * Please make sure to set the value to the URL that your users mainly use to access this Nextcloud.
-	 * Otherwise, there might be problems with the URL generation via cron.
+	 *
+	 * In most setups, this should match the URL your users normally use to access
+	 * Nextcloud. If it is incorrect, URL generation may be wrong in cron jobs,
+	 * ``occ``, notifications, and similar contexts.
+	 *
+	 * NOTE: During installation, Nextcloud seeds this value from the installer’s
+	 * current access context. If it was not preseeded (for example, via
+	 * ``autoconfig.php``), the inferred value may not match the public URL that
+	 * users normally use to access Nextcloud and may need adjustment.
 	 *
 	 * Defaults to ``''`` (empty string)
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Clarify the `overwrite.cli.url` description in `config/config.sample.php` so it better reflects how Nextcloud uses the value during CLI and background execution.

The updated text:
- explains that the setting is used when generating URLs outside a normal web request
- calls out common contexts like background jobs, `occ`, and notifications
- notes that installation seeds the value from the installer’s current access context when it is not already preseeded
- warns that the inferred value may not match the public URL users actually use and thus may need manual adjustment

## Notes

This is a documentation-only change. No runtime behavior is changed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
