### PR TITLE
test(cypress): defer ResizeObserver callbacks to next frame

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -13,3 +13,16 @@ import 'core-js/actual/promise/with-resolvers.js'
 // @see https://github.com/cypress-io/cypress/issues/20341
 Cypress.on('uncaught:exception', (err) => !err.message.includes('ResizeObserver loop limit exceeded'))
 Cypress.on('uncaught:exception', (err) => !err.message.includes('ResizeObserver loop completed with undelivered notifications'))
+
+// Defer ResizeObserver callbacks one frame to break floating UI sync loops
+// that otherwise tank the renderer and trigger Electron's unresponsive kill.
+Cypress.on('window:before:load', (win) => {
+	const Original = win.ResizeObserver
+	win.ResizeObserver = class extends Original {
+		constructor(callback: ResizeObserverCallback) {
+			super((entries, observer) => {
+				win.requestAnimationFrame(() => callback(entries, observer))
+			})
+		}
+	}
+})


### PR DESCRIPTION
## Summary

`users_manager.cy.ts` has been crashing the Electron renderer on CI repeatedly. Heap snapshots ruled out OOM (dialog mount only adds ~2 MB to JS heap). A local Cypress pre-crash video shows `ResizeObserver loop completed with undelivered notifications` firing several times when the edit dialog and the Manager NcSelect open.

The loop seems to come from Floating UI's `autoUpdate` (used by `NcSelect` for popper positioning): each resize triggers a position recalc, which changes layout, which triggers another resize. We already suppress this as an uncaught exception in `cypress/support/e2e.ts`, but suppression only helps if the renderer survives. On slower CI CPUs the loop tanks the main thread until Electron's page unresponsive watchdog kills the renderer outright. Cypress then reports a generic renderer crashed with boilerplate advice about `experimentalMemoryManagement` and `numTestsKeptInMemory` (red herring, neither helped).

This patches `ResizeObserver` so callbacks fire on the next animation frame, breaking the synchronous loop. Workaround in the test harness, not a real fix. The proper fix belongs upstream in `@nextcloud/vue` and will be filed separately.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
