### PR TITLE
docs(group): clarify group listing API docs

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -1072,18 +1072,13 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 	}
 
 	/**
-	 * get a list of all groups using a paged search
+	 * Get groups via LDAP search.
 	 *
-	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
-	 * @return array with group names
+	 * Uses a paged search when available to override server-side search limits.
+	 * Active Directory has a default limit of 1000 results.
 	 *
-	 * Returns a list with all groups
-	 * Uses a paged search if available to override a
-	 * server side search limit.
-	 * (active directory has a limit of 1000 by default)
 	 * @throws Exception
+	 * @throws ServerNotAvailableException
 	 */
 	#[\Override]
 	public function getGroups($search = '', $limit = -1, $offset = 0) {

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -240,13 +240,7 @@ class Database extends ABackend implements
 	}
 
 	/**
-	 * get a list of all groups
-	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
-	 * @return array an array of group names
-	 *
-	 * Returns a list with all groups
+	 * Search for groups by gid or display name.
 	 */
 	#[\Override]
 	public function getGroups(string $search = '', int $limit = -1, int $offset = 0) {

--- a/lib/public/GroupInterface.php
+++ b/lib/public/GroupInterface.php
@@ -95,15 +95,15 @@ interface GroupInterface {
 	public function getUserGroups($uid);
 
 	/**
-	 * @brief Get a list of all groups
+	 * Get a list of groups matching the search criteria.
 	 *
-	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
-	 * @return array an array of group names
+	 * An empty search returns all groups.
+	 *
+	 * @param string $search Search term used to filter group names
+	 * @param int $limit Maximum number of results to return, or -1 for no limit
+	 * @param int $offset Offset for paginated results
+	 * @return list<string> An array of group names
 	 * @since 4.5.0
-	 *
-	 * Returns a list with all groups
 	 */
 	public function getGroups(string $search = '', int $limit = -1, int $offset = 0);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Clarifies the public `GroupInterface::getGroups()` documentation to describe search/pagination behavior more accurately, and removes/trims redundant implementation docblocks in private group backends.

Arose while looking at nextcloud/guests#1465, where I discovered its implementation doesn't even use the `$search` criteria currently (fixing that there now separately).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
