### PR TITLE
fix(files_external): Allow editing authentication mechanism on saved mounts

### DIFF
--- a/apps/files_external/src/components/AddExternalStorageDialog/AddExternalStorageDialog.vue
+++ b/apps/files_external/src/components/AddExternalStorageDialog/AddExternalStorageDialog.vue
@@ -106,7 +106,7 @@ watch(authMechanisms, () => {
 		<NcSelect
 			v-model="authMechanism"
 			:options="authMechanisms"
-			:disabled="!internalStorage.backend || authMechanisms.length <= 1 || !!(internalStorage.id && internalStorage.authMechanism)"
+			:disabled="!internalStorage.backend || authMechanisms.length <= 1"
 			:inputLabel="t('files_external', 'Authentication')"
 			label="name"
 			required />


### PR DESCRIPTION
Restores the pre-33 behaviour where admins can change the authentication mechanism of an existing external storage mount through the settings UI. After the External Storage settings rewrite the dropdown was locked read-only for any mount with an id, leaving the value configured at creation time as the only one ever shown. Backend type stays locked because changing it would invalidate the mount; authentication mechanism is independent and was always meant to remain editable.

