### PR TITLE
chore: remove redundant ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
 		"ext-dom": "*",
 		"ext-fileinfo": "*",
 		"ext-gd": "*",
-		"ext-json": "*",
 		"ext-libxml": "*",
 		"ext-mbstring": "*",
 		"ext-openssl": "*",
@@ -86,7 +85,7 @@
 		"test:db": "@composer run test -- --group DB --group SLOWDB",
 		"test:files_external": "phpunit --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration tests/phpunit-autotest-external.xml",
 		"rector": "rector --config=build/rector.php && composer cs:fix",
-		"rector:strict": "rector --config=build/rector-strict.php && composer cs:fix",
+"rector:strict": "rector --config=build/rector-strict.php && composer cs:fix",
 		"openapi": "./build/openapi-checker.sh"
 	},
 	"extra": {


### PR DESCRIPTION
ext-json has been bundled with PHP since PHP 8.0.
Since Nextcloud requires PHP ^8.2, this requirement is redundant.

Fixes #58354

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
ext-json has been bundled with PHP since PHP 8.0.
Since Nextcloud requires PHP ^8.2, this explicit 
requirement is redundant and can be safely removed.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
