### PR TITLE
fix: correct typo 'occured' to 'occurred' in SetupCheckManager

### DIFF
--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -34,7 +34,7 @@ class SetupCheckManager implements ISetupCheckManager {
 			try {
 				$setupResult = $setupCheckObject->run();
 			} catch (\Throwable $t) {
-				$setupResult = SetupResult::error("An exception occured while running the setup check:\n$t");
+				$setupResult = SetupResult::error("An exception occurred while running the setup check:\n$t");
 				$this->logger->error('Exception running check ' . get_class($setupCheckObject) . ': ' . $t->getMessage(), ['exception' => $t]);
 			}
 			$setupResult->setName($setupCheckObject->getName());


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # (leave blank - this is a typo fix)

## Summary
Fixed a typo in SetupCheckManager.php where 'occured' 
was misspelled and should be 'occurred'.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
