### PR TITLE
fix: add proper ACLs for trashbin proxys

### DIFF
--- a/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObject.php
+++ b/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObject.php
@@ -105,7 +105,17 @@ class DeletedCalendarObject implements IACL, ICalendarObject, IRestorable {
 			],
 			[
 				'privilege' => '{DAV:}unbind', // For moving and deletion
-				'principal' => '{DAV:}owner',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}all',
+				'principal' => $this->getOwner() . '/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner() . '/calendar-proxy-read',
 				'protected' => true,
 			],
 		];

--- a/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObjectsCollection.php
+++ b/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObjectsCollection.php
@@ -137,9 +137,24 @@ class DeletedCalendarObjectsCollection implements ICalendarObjectContainer, IACL
 			],
 			[
 				'privilege' => '{DAV:}unbind',
-				'principal' => '{DAV:}owner',
+				'principal' => $this->getOwner(),
 				'protected' => true,
-			]
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner() . '/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}unbind',
+				'principal' => $this->getOwner() . '/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner() . '/calendar-proxy-read',
+				'protected' => true,
+			],
 		];
 	}
 }

--- a/apps/dav/lib/CalDAV/Trashbin/TrashbinHome.php
+++ b/apps/dav/lib/CalDAV/Trashbin/TrashbinHome.php
@@ -38,6 +38,28 @@ class TrashbinHome implements IACL, ICollection, IProperties {
 	}
 
 	#[\Override]
+	public function getACL(): array {
+		$ownerPrincipal = $this->principalInfo['uri'];
+		return [
+			[
+				'privilege' => '{DAV:}all',
+				'principal' => $ownerPrincipal,
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}all',
+				'principal' => $ownerPrincipal . '/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $ownerPrincipal . '/calendar-proxy-read',
+				'protected' => true,
+			],
+		];
+	}
+
+	#[\Override]
 	public function createFile($name, $data = null) {
 		throw new Forbidden('Permission denied to create files in the trashbin');
 	}


### PR DESCRIPTION
* Resolves: #42051

## Summary
Add proper ACLs for proxys 

## How I tested 

1.  Delegate User1 calendar to admin

```
curl -X PROPPATCH 'http://nextcloud.local/remote.php/dav/principals/users/user2/calendar-proxy-write' \
  -u 'user2:user2' \
  -H 'Content-Type: application/xml' \
  -b 'XDEBUG_SESSION=PHPSTORM' \
  --data-binary @- <<'EOF'
<?xml version="1.0" encoding="utf-8" ?>
<D:propertyupdate xmlns:D="DAV:">
	<D:set>
		<D:prop>
			<D:group-member-set>
				<D:href>/remote.php/dav/principals/users/admin</D:href>
			</D:group-member-set>
		</D:prop>
	</D:set>
</D:propertyupdate>
```

2. enable delegation on the client
<img width="524" height="495" alt="image" src="https://github.com/user-attachments/assets/e380b0d2-235f-4e8c-a629-0667462d47d5" />


3. Connect admin to an external client that supports delegation  (Apple calendar) 
<img width="671" height="78" alt="image" src="https://github.com/user-attachments/assets/18add973-bc6b-431c-ac7d-3b6b7bc08275" />

4. apply patch 
<img width="217" height="263" alt="image" src="https://github.com/user-attachments/assets/8b0aa1d7-18f1-4396-b23f-bdaea3d23197" />



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
