### PR TITLE
feat(app-licenses): Add further compatible licenses for apps to use

### DIFF
--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -381,14 +381,30 @@
     <xs:simpleType name="licence">
         <xs:restriction base="xs:string">
             <!-- Requires Nextcloud minVersion >= 31 -->
+            <xs:enumeration value="0BSD"/>
             <xs:enumeration value="AGPL-3.0-only"/>
             <xs:enumeration value="AGPL-3.0-or-later"/>
             <xs:enumeration value="Apache-2.0"/>
+            <xs:enumeration value="BSD-2-Clause"/>
+            <xs:enumeration value="BSD-3-Clause"/>
+            <xs:enumeration value="BSD-3-Clause-Clear"/>
             <xs:enumeration value="CC0-1.0"/>
+            <xs:enumeration value="EUPL-1.2"/>
+            <xs:enumeration value="FSFAP"/>
+            <xs:enumeration value="GPL-2.0-or-later"/>
             <xs:enumeration value="GPL-3.0-only"/>
             <xs:enumeration value="GPL-3.0-or-later"/>
+            <xs:enumeration value="LGPL-2.1-only"/>
+            <xs:enumeration value="LGPL-2.1-or-later"/>
+            <xs:enumeration value="LGPL-3.0-only"/>
+            <xs:enumeration value="LGPL-3.0-or-later"/>
             <xs:enumeration value="MIT"/>
             <xs:enumeration value="MPL-2.0"/>
+            <xs:enumeration value="OLDAP-2.7"/>
+            <xs:enumeration value="PDDL-1.0"/>
+            <xs:enumeration value="SAX-PD"/>
+            <xs:enumeration value="Unlicense"/>
+            <xs:enumeration value="X11"/>
 
             <!-- Deprecated -->
             <xs:enumeration value="agpl"/>

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -377,14 +377,30 @@
     <xs:simpleType name="licence">
         <xs:restriction base="xs:string">
             <!-- Requires Nextcloud minVersion >= 31 -->
+            <xs:enumeration value="0BSD"/>
             <xs:enumeration value="AGPL-3.0-only"/>
             <xs:enumeration value="AGPL-3.0-or-later"/>
             <xs:enumeration value="Apache-2.0"/>
+            <xs:enumeration value="BSD-2-Clause"/>
+            <xs:enumeration value="BSD-3-Clause"/>
+            <xs:enumeration value="BSD-3-Clause-Clear"/>
             <xs:enumeration value="CC0-1.0"/>
+            <xs:enumeration value="EUPL-1.2"/>
+            <xs:enumeration value="FSFAP"/>
+            <xs:enumeration value="GPL-2.0-or-later"/>
             <xs:enumeration value="GPL-3.0-only"/>
             <xs:enumeration value="GPL-3.0-or-later"/>
+            <xs:enumeration value="LGPL-2.1-only"/>
+            <xs:enumeration value="LGPL-2.1-or-later"/>
+            <xs:enumeration value="LGPL-3.0-only"/>
+            <xs:enumeration value="LGPL-3.0-or-later"/>
             <xs:enumeration value="MIT"/>
             <xs:enumeration value="MPL-2.0"/>
+            <xs:enumeration value="OLDAP-2.7"/>
+            <xs:enumeration value="PDDL-1.0"/>
+            <xs:enumeration value="SAX-PD"/>
+            <xs:enumeration value="Unlicense"/>
+            <xs:enumeration value="X11"/>
 
             <!-- Deprecated -->
             <xs:enumeration value="agpl"/>


### PR DESCRIPTION
Resolves https://github.com/nextcloud/appstore/issues/1710

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/appstore/issues/1710 and 
* is the companion to https://github.com/nextcloud/appstore/pull/1754

## Summary
Adds further feasible licenses aligned between @AndyScherzinger and @schiessle

Documentation happens in/via https://github.com/nextcloud/appstore/pull/1754 in the app store docs

## TODO

- [ ] merge

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
