### PR TITLE
fix(TaskProcessing): Normalize file ID before getting node

### DIFF
--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -1633,9 +1633,16 @@ class Manager implements IManager {
 	 * @throws ValidationException
 	 */
 	private function validateFileId(mixed $id): File {
-		$node = $this->rootFolder->getFirstNodeById($id);
+		if (is_int($fileId)) {
+			$normalizedFileId = $fileId;
+		} elseif (is_string($fileId) && ctype_digit($fileId)) {
+			$normalizedFileId = (int)$fileId;
+		} else {
+			throw new \InvalidArgumentException('File ID must be an integer: ' . $id);
+		}
+		$node = $this->rootFolder->getFirstNodeById($normalizedFileId);
 		if ($node === null) {
-			$node = $this->rootFolder->getFirstNodeByIdInPath($id, '/' . $this->rootFolder->getAppDataDirectoryName() . '/');
+			$node = $this->rootFolder->getFirstNodeByIdInPath($normalizedFileId, '/' . $this->rootFolder->getAppDataDirectoryName() . '/');
 			if ($node === null) {
 				throw new ValidationException('Could not find file ' . $id);
 			} elseif (!$node instanceof File) {

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -1633,10 +1633,10 @@ class Manager implements IManager {
 	 * @throws ValidationException
 	 */
 	private function validateFileId(mixed $id): File {
-		if (is_int($fileId)) {
-			$normalizedFileId = $fileId;
-		} elseif (is_string($fileId) && ctype_digit($fileId)) {
-			$normalizedFileId = (int)$fileId;
+		if (is_int($id)) {
+			$normalizedFileId = $id;
+		} elseif (is_string($id) && ctype_digit($id)) {
+			$normalizedFileId = (int)$id;
 		} else {
 			throw new \InvalidArgumentException('File ID must be an integer: ' . $id);
 		}


### PR DESCRIPTION
## Summary
`getFirstNodeById` will throw if it gets anything other than an int.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
