### PR TITLE
docs: Adjust since for forUpdate & ConflictResolutionMode

### DIFF
--- a/lib/public/DB/QueryBuilder/ConflictResolutionMode.php
+++ b/lib/public/DB/QueryBuilder/ConflictResolutionMode.php
@@ -12,19 +12,19 @@ namespace OCP\DB\QueryBuilder;
 /**
  * Conflict resolution mode for "FOR UPDATE" select queries.
  *
- * @since 34.0.0
+ * @since 33.0.0
  */
 enum ConflictResolutionMode {
 	/**
 	 * Wait for the row to be unlocked.
 	 *
-	 * @since 34.0.0
+	 * @since 33.0.0
 	 */
 	case Ordinary;
 	/**
 	 * Skip the row if it is locked.
 	 *
-	 * @since 34.0.0
+	 * @since 33.0.0
 	 */
 	case SkipLocked;
 }

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -1098,7 +1098,7 @@ interface IQueryBuilder {
 	 * Locks the queried rows for a subsequent update.
 	 *
 	 * @return $this
-	 * @since 34.0.0
+	 * @since 33.0.0
 	 */
 	public function forUpdate(ConflictResolutionMode $conflictResolutionMode = ConflictResolutionMode::Ordinary): self;
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Spotted while backporting https://github.com/nextcloud/server/pull/59940.

The api made it into 33.0.0 (https://github.com/nextcloud/server/pull/58198) and hence should say since 33 ;)

 Applied to the backport for 59940 already, hence no backport needed. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
