### PR TITLE
fix(http-client): detect brotli support via libcurl, not PHP extension

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -88,7 +88,7 @@ class Client implements IClient {
 		$headers = $options[RequestOptions::HEADERS] ?? [];
 		if (!isset($headers['Accept-Encoding'])) {
 			$acceptEnc = 'gzip';
-			if ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) {
+			if (((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) === CURL_VERSION_BROTLI) {
 				$acceptEnc = 'br, ' . $acceptEnc;
 			}
 			$options[RequestOptions::HEADERS] = $headers; // ensure headers are present

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -88,7 +88,7 @@ class Client implements IClient {
 		$headers = $options[RequestOptions::HEADERS] ?? [];
 		if (!isset($headers['Accept-Encoding'])) {
 			$acceptEnc = 'gzip';
-			if (function_exists('brotli_uncompress')) {
+			if ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) {
 				$acceptEnc = 'br, ' . $acceptEnc;
 			}
 			$options[RequestOptions::HEADERS] = $headers; // ensure headers are present

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -288,7 +288,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
+		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 		$this->defaultRequestOptions = [
 			'verify' => '/my/path.crt',
 			'proxy' => [
@@ -495,7 +495,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
+		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 
 		$this->assertEquals([
 			'verify' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',
@@ -553,7 +553,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
+		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
@@ -615,7 +615,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = function_exists('brotli_uncompress') ? 'br, gzip' : 'gzip';
+		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
@@ -680,11 +680,12 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
+		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
 			'headers' => [
 				'User-Agent' => $userAgent,
-				'Accept-Encoding' => 'gzip',
+				'Accept-Encoding' => $acceptEnc,
 			],
 			'timeout' => 30,
 			'nextcloud' => [

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -288,7 +288,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
+		$acceptEnc = (((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) === CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 		$this->defaultRequestOptions = [
 			'verify' => '/my/path.crt',
 			'proxy' => [
@@ -495,7 +495,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
+		$acceptEnc = (((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) === CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 
 		$this->assertEquals([
 			'verify' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',
@@ -553,7 +553,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
+		$acceptEnc = (((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) === CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
@@ -615,7 +615,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
+		$acceptEnc = (((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) === CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
@@ -680,7 +680,7 @@ class ClientTest extends \Test\TestCase {
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');
 
-		$acceptEnc = ((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
+		$acceptEnc = (((curl_version()['features'] ?? 0) & CURL_VERSION_BROTLI) === CURL_VERSION_BROTLI) ? 'br, gzip' : 'gzip';
 		$this->assertEquals([
 			'verify' => '/my/path.crt',
 			'headers' => [


### PR DESCRIPTION
- Fixes a regression introduced in #55433.

## Summary

`function_exists('brotli_uncompress')` checks the wrong layer.
In Guzzle's curl handler, `CURLOPT_ENCODING` is set to `''` which instructs libcurl to decompress all encodings it was compiled with. **All decompression happens inside libcurl.** The PHP `brotli_uncompress()` function is never called in this pipeline.

The wrong check creates two silent failure modes:
- PHP extension present, libcurl compiled **without** brotli →  server sends `Content-Encoding: br`, libcurl passes compressed bytes  through, application receives garbled data
- PHP extension absent, libcurl compiled **with** brotli →  brotli is never advertised in `Accept-Encoding` despite full support

The correct signal is `CURL_VERSION_BROTLI` in `curl_version()['features']`, which reflects whether this libcurl binary was compiled with `libbrotlidec`.
This is also how the Nextcloud **News app** (`FetcherConfig.php`) detects brotli support.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
