### PR TITLE
fix(AppStore/Fetcher): catch GenericFileException when reading cache file in Fetcher

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -171,12 +171,13 @@ abstract class Fetcher {
 			// File does not already exist
 			$file = $rootFolder->newFile($this->fileName);
 		} catch (GenericFileException $e) {
-			$this->logger->warning('Could not read appstore cache file, it will be refreshed', ['app' => 'appstoreFetcher', 'exception' => $e]);
 			try {
 				$file->delete();
-			} catch (\Exception $deleteException) {
+			} catch (\Exception) {
+				$this->logger->error('Could not read appstore cache file', ['app' => 'appstoreFetcher', 'exception' => $e]);
 				return [];
 			}
+			$this->logger->warning('Could not read appstore cache file, it will be refreshed', ['app' => 'appstoreFetcher', 'exception' => $e]);
 			$file = $rootFolder->newFile($this->fileName);
 		}
 

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Exception\ServerException;
 use OC\Files\AppData\Factory;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\GenericFileException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Http\Client\IClientService;
@@ -167,7 +168,15 @@ abstract class Fetcher {
 				}
 			}
 		} catch (NotFoundException $e) {
-			// File does not already exists
+			// File does not already exist
+			$file = $rootFolder->newFile($this->fileName);
+		} catch (GenericFileException $e) {
+			$this->logger->warning('Could not read appstore cache file, it will be refreshed', ['app' => 'appstoreFetcher', 'exception' => $e]);
+			try {
+				$file->delete();
+			} catch (\Exception $deleteException) {
+				return [];
+			}
 			$file = $rootFolder->newFile($this->fileName);
 		}
 

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -13,6 +13,7 @@ use OC\App\AppStore\Fetcher\Fetcher;
 use OC\Files\AppData\AppData;
 use OC\Files\AppData\Factory;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\GenericFileException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -672,6 +673,89 @@ abstract class FetcherBase extends TestCase {
 			->expects($this->once())
 			->method('getTime')
 			->willReturn(1501);
+
+		$expected = [
+			[
+				'id' => 'MyNewApp',
+				'foo' => 'foo',
+			],
+			[
+				'id' => 'bar',
+			],
+		];
+		$this->assertSame($expected, $this->fetcher->get());
+	}
+
+	public function testGetWithUnreadableCacheFileRecreatesAndFetches(): void {
+		$this->config
+			->method('getSystemValueString')
+			->willReturnCallback(function ($var, $default) {
+				if ($var === 'appstoreurl') {
+					return 'https://apps.nextcloud.com/api/v1';
+				} elseif ($var === 'version') {
+					return '11.0.0.2';
+				}
+				return $default;
+			});
+		$this->config->method('getSystemValueBool')
+			->willReturnArgument(1);
+
+		$folder = $this->createMock(ISimpleFolder::class);
+		$corruptedFile = $this->createMock(ISimpleFile::class);
+		$freshFile = $this->createMock(ISimpleFile::class);
+		$this->appData
+			->expects($this->once())
+			->method('getFolder')
+			->with('/')
+			->willReturn($folder);
+		$folder
+			->expects($this->once())
+			->method('getFile')
+			->with($this->fileName)
+			->willReturn($corruptedFile);
+		$corruptedFile
+			->expects($this->once())
+			->method('getContent')
+			->willThrowException(new GenericFileException());
+		$corruptedFile
+			->expects($this->once())
+			->method('delete');
+		$folder
+			->expects($this->once())
+			->method('newFile')
+			->with($this->fileName)
+			->willReturn($freshFile);
+		$client = $this->createMock(IClient::class);
+		$this->clientService
+			->expects($this->once())
+			->method('newClient')
+			->willReturn($client);
+		$response = $this->createMock(IResponse::class);
+		$client
+			->expects($this->once())
+			->method('get')
+			->with($this->endpoint)
+			->willReturn($response);
+		$response
+			->expects($this->once())
+			->method('getBody')
+			->willReturn('[{"id":"MyNewApp", "foo": "foo"}, {"id":"bar"}]');
+		$response->method('getHeader')
+			->with($this->equalTo('ETag'))
+			->willReturn('"myETag"');
+		$fileData = '{"data":[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}],"timestamp":1502,"ncversion":"11.0.0.2","ETag":"\"myETag\""}';
+		$freshFile
+			->expects($this->once())
+			->method('putContent')
+			->with($fileData);
+		$freshFile
+			->expects($this->once())
+			->method('getContent')
+			->willReturn($fileData);
+		$this->timeFactory
+			->expects($this->once())
+			->method('getTime')
+			->willReturn(1502);
 
 		$expected = [
 			[

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -698,7 +698,7 @@ abstract class FetcherBase extends TestCase {
 				return $default;
 			});
 		$this->config->method('getSystemValueBool')
-			->willReturnArgument(1);
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$corruptedFile = $this->createMock(ISimpleFile::class);
@@ -725,6 +725,7 @@ abstract class FetcherBase extends TestCase {
 			->method('newFile')
 			->with($this->fileName)
 			->willReturn($freshFile);
+
 		$client = $this->createMock(IClient::class);
 		$this->clientService
 			->expects($this->once())
@@ -743,6 +744,7 @@ abstract class FetcherBase extends TestCase {
 		$response->method('getHeader')
 			->with($this->equalTo('ETag'))
 			->willReturn('"myETag"');
+
 		$fileData = '{"data":[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}],"timestamp":1502,"ncversion":"11.0.0.2","ETag":"\"myETag\""}';
 		$freshFile
 			->expects($this->once())


### PR DESCRIPTION
## Summary

When the appstore cache file exists but `file_get_contents` returns `false`, `OC\Files\Node\File::getContent()` throws a `GenericFileException`. This exception was not caught by `Fetcher::get()`, which only caught `NotFoundException`, causing the entire apps settings page to crash with an unhandled exception.

**Fix:** catch `GenericFileException` alongside `NotFoundException`, log a warning, recreate the cache file, and proceed to fetch fresh data from the appstore — same recovery path as when the file is absent.

## Test plan

- [x] Added unit test `testGetWithUnreadableCacheFileRecreatesAndFetches` in `FetcherBase` that mocks `getContent()` throwing `GenericFileException` and asserts the fetcher recovers and returns fresh data
- [x] All existing fetcher tests still pass (35/35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)