### PR TITLE
fix(weather_status): load translations when injecting dashboard widget script

### DIFF
--- a/apps/weather_status/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/apps/weather_status/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -35,5 +35,6 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		}
 
 		Util::addScript('weather_status', 'weather-status');
+		Util::addTranslations('weather_status');
 	}
 }


### PR DESCRIPTION
## Summary

- The `BeforeTemplateRenderedListener` injected the `weather-status` script into the dashboard page but never called `Util::addTranslations('weather_status')`
- This meant all `t('weather_status', ...)` calls in the weather widget fell back to raw English source strings, breaking localisation for all non-English users
- Fix: add `Util::addTranslations('weather_status')` alongside the existing `addScript` call

Needs backport to stable32.

Fixes https://github.com/nextcloud/server/issues/60179

## Test plan

- [ ] Set your Nextcloud language to a non-English locale
- [ ] Open the dashboard with the weather status widget active
- [ ] Verify weather widget strings (e.g. "Detect location", "Set custom address", "Favorites") are now translated

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>