### PR TITLE
[Bug]: Email settings endpoint returns HTTP 400 with port parameter t…

### DIFF
--- a/apps/settings/lib/Controller/MailSettingsController.php
+++ b/apps/settings/lib/Controller/MailSettingsController.php
@@ -57,11 +57,12 @@ class MailSettingsController extends Controller {
 		string $mail_smtpsecure,
 		string $mail_smtphost,
 		?bool $mail_smtpauth,
-		string $mail_smtpport,
+		string|int $mail_smtpport,
 		string $mail_sendmailmode,
 		?bool $mail_noverify = null,
 	): DataResponse {
 		$mail_smtpauth = $mail_smtpauth == '1';
+		$mail_smtpport = (string)$mail_smtpport;
 
 		$configs = [
 			'mail_domain' => $mail_domain,


### PR DESCRIPTION
…ype mismatch

Affected Version: 33.0.3+
Issue: POST /settings/admin/mailsettings returns HTTP 400 for all users
Root Cause: Vue admin frontend sends port as numeric JSON ("mail_smtpport": 587), but controller declares string $mail_smtpport. AppFramework doesn't auto-cast int→string, causing TypeError.
Workaround: Use occ config:system:set CLI instead

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
