### PR TITLE
fix: remove wrongly used system address book flag

### DIFF
--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -47,11 +47,6 @@ class ContactsManager {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function setupSystemContactsProvider(IManager $cm, ?string $userId, IURLGenerator $urlGenerator) {
-		$systemAddressBookExposed = $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED);
-		if (!$systemAddressBookExposed) {
-			return;
-		}
-
 		$addressBooks = $this->backend->getAddressBooksForUser('principals/system/system');
 		$this->register($cm, $addressBooks, $urlGenerator, $userId);
 	}

--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -8,8 +8,6 @@
 
 namespace OCA\DAV\CardDAV;
 
-use OCA\DAV\AppInfo\Application;
-use OCA\DAV\ConfigLexicon;
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Contacts\IManager;
 use OCP\IAppConfig;
@@ -48,11 +46,6 @@ class ContactsManager {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function setupSystemContactsProvider(IManager $cm, ?string $userId, IURLGenerator $urlGenerator) {
-		$systemAddressBookExposed = $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::SYSTEM_ADDRESSBOOK_EXPOSED);
-		if (!$systemAddressBookExposed) {
-			return;
-		}
-
 		$addressBooks = $this->backend->getAddressBooksForUser('principals/system/system');
 		$this->register($cm, $addressBooks, $urlGenerator, $userId);
 	}

--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -10,7 +10,6 @@ namespace OCA\DAV\CardDAV;
 
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Contacts\IManager;
-use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -25,7 +24,6 @@ class ContactsManager {
 		private CardDavBackend $backend,
 		private IL10N $l10n,
 		private PropertyMapper $propertyMapper,
-		private IAppConfig $appConfig,
 	) {
 	}
 

--- a/apps/dav/lib/Settings/Admin/SystemAddressBookSettings.php
+++ b/apps/dav/lib/Settings/Admin/SystemAddressBookSettings.php
@@ -27,12 +27,12 @@ class SystemAddressBookSettings implements IDeclarativeSettingsForm {
 			'section_id' => 'groupware',
 			'storage_type' => DeclarativeSettingsTypes::STORAGE_TYPE_EXTERNAL,
 			'title' => $this->l->t('System Address Book'),
-			'description' => $this->l->t('The system address book contains contact information for all users in your instance.'),
+			'description' => $this->l->t('The system address book contains contact information for all users in your instance. The system address book is required for the searching and auto-completion of users.'),
 
 			'fields' => [
 				[
 					'id' => 'system_addressbook_enabled',
-					'title' => $this->l->t('Enable System Address Book'),
+					'title' => $this->l->t('Enable System Address Book in DAV clients'),
 					'type' => DeclarativeSettingsTypes::CHECKBOX,
 					'default' => false,
 					'options' => [],

--- a/apps/dav/lib/Settings/Admin/SystemAddressBookSettings.php
+++ b/apps/dav/lib/Settings/Admin/SystemAddressBookSettings.php
@@ -28,12 +28,12 @@ class SystemAddressBookSettings implements IDeclarativeSettingsForm {
 			'section_id' => 'groupware',
 			'storage_type' => DeclarativeSettingsTypes::STORAGE_TYPE_EXTERNAL,
 			'title' => $this->l->t('System Address Book'),
-			'description' => $this->l->t('The system address book contains contact information for all users in your instance.'),
+			'description' => $this->l->t('The system address book contains contact information for all users in your instance. The system address book is required for the searching and auto-completion of users.'),
 
 			'fields' => [
 				[
 					'id' => 'system_addressbook_enabled',
-					'title' => $this->l->t('Enable System Address Book'),
+					'title' => $this->l->t('Enable System Address Book in DAV clients'),
 					'type' => DeclarativeSettingsTypes::CHECKBOX,
 					'default' => false,
 					'options' => [],

--- a/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
+++ b/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
@@ -13,31 +13,66 @@ use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Contacts\IManager;
-use OCP\IAppConfig;
+use OCP\IAddressBook;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ContactsManagerTest extends TestCase {
-	public function test(): void {
-		/** @var IManager&MockObject $cm */
-		$cm = $this->createMock(IManager::class);
-		$cm->expects($this->exactly(1))->method('registerAddressBook');
-		/** @var IURLGenerator&MockObject $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var CardDavBackend&MockObject $backEnd */
-		$backEnd = $this->createMock(CardDavBackend::class);
-		$backEnd->method('getAddressBooksForUser')->willReturn([
-			['{DAV:}displayname' => 'Test address book', 'uri' => 'default'],
-		]);
-		$propertyMapper = $this->createMock(PropertyMapper::class);
-		/** @var IAppConfig&MockObject $appConfig */
-		$appConfig = $this->createMock(IAppConfig::class);
+	private IManager&MockObject $contactsManager;
+	private IURLGenerator&MockObject $urlGenerator;
+	private CardDavBackend&MockObject $backend;
+	private PropertyMapper&MockObject $propertyMapper;
+	private IL10N&MockObject $l10n;
+	private ContactsManager $manager;
 
-		/** @var IL10N&MockObject $l */
-		$l = $this->createMock(IL10N::class);
-		$app = new ContactsManager($backEnd, $l, $propertyMapper, $appConfig);
-		$app->setupContactsProvider($cm, 'user01', $urlGenerator);
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->contactsManager = $this->createMock(IManager::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->backend = $this->createMock(CardDavBackend::class);
+		$this->propertyMapper = $this->createMock(PropertyMapper::class);
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->backend->method('getAddressBooksForUser')
+			->willReturnCallback(static fn (string $principalUri): array => match ($principalUri) {
+				'principals/users/user01' => [
+					['id' => 1, 'uri' => 'default', 'principaluri' => $principalUri, '{DAV:}displayname' => 'Test address book'],
+				],
+				'principals/system/system' => [
+					['id' => 2, 'uri' => 'system', 'principaluri' => $principalUri, '{DAV:}displayname' => 'System address book'],
+				],
+				default => [],
+			});
+
+		$this->manager = new ContactsManager($this->backend, $this->l10n, $this->propertyMapper);
+	}
+
+	public function testSetupContactsProvider(): void {
+		$registered = [];
+		$this->contactsManager->expects($this->exactly(2))
+			->method('registerAddressBook')
+			->willReturnCallback(function (IAddressBook $addressBook) use (&$registered): void {
+				$registered[] = $addressBook->getUri();
+			});
+
+		$this->manager->setupContactsProvider($this->contactsManager, 'user01', $this->urlGenerator);
+
+		$this->assertEquals(['default', 'system'], $registered);
+	}
+
+	public function testSetupSystemContactsProvider(): void {
+		$registered = [];
+		$this->contactsManager->expects($this->exactly(1))
+			->method('registerAddressBook')
+			->willReturnCallback(function (IAddressBook $addressBook) use (&$registered): void {
+				$registered[] = $addressBook->getUri();
+			});
+
+		$this->manager->setupSystemContactsProvider($this->contactsManager, 'user01', $this->urlGenerator);
+
+		$this->assertEquals(['system'], $registered);
 	}
 }

--- a/build/integration/features/bootstrap/FeatureContext.php
+++ b/build/integration/features/bootstrap/FeatureContext.php
@@ -29,5 +29,6 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->deleteServerConfig('bruteforcesettings', 'apply_allowlist_to_ratelimit');
 		$this->deleteServerConfig('core', 'shareapi_exclude_groups');
 		$this->deleteServerConfig('core', 'shareapi_exclude_groups_list');
+		$this->deleteServerConfig('dav', 'system_addressbook_exposed');
 	}
 }

--- a/build/integration/features/contacts-menu.feature
+++ b/build/integration/features/contacts-menu.feature
@@ -359,18 +359,20 @@ Feature: contacts-menu
     # Disabled because it regularly fails on drone:
     # Then the list of searched contacts has "0" contacts
 
-  Scenario: users cannot list other users from the system address book
-    Given user "user0" exists
-    And user "user1" exists
-    And invoking occ with "config:app:set dav system_addressbook_exposed --value false"
-    And Logging in using web as "user1"
-    And searching for contacts matching with ""
-    Then the list of searched contacts has "1" contacts
-    And invoking occ with "config:app:delete dav system_addressbook_exposed"
-
+  # The example contact of the personal address book is listed next to "user0" of the system address book
   Scenario: users can list other users from the system address book
     Given user "user0" exists
     And user "user1" exists
+    And Logging in using web as "user1"
+    And searching for contacts matching with ""
+    Then the list of searched contacts has "2" contacts
+
+  # Exposing the system address book is only about DAV clients, user searching and
+  # auto-completion keep working when it is disabled
+  Scenario: users can list other users from the system address book when it is not exposed to DAV clients
+    Given user "user0" exists
+    And user "user1" exists
+    And invoking occ with "config:app:set dav system_addressbook_exposed --value false"
     And Logging in using web as "user1"
     And searching for contacts matching with ""
     Then the list of searched contacts has "2" contacts


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
## Summary

* Resolves: # Client Ticket
* Related:  https://github.com/nextcloud/server/pull/63392

- Removed flag that disables system address book in contacts manager
- Updated wording in Groupware Address book toggle UI toggle 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
