### PR TITLE
fix(snowflake): fix wrong documentation about serverId

### DIFF
--- a/apps/settings/lib/SetupChecks/ServerIdConfig.php
+++ b/apps/settings/lib/SetupChecks/ServerIdConfig.php
@@ -40,14 +40,16 @@ final class ServerIdConfig implements ISetupCheck {
 
 		if ($serverid === PHP_INT_MIN) {
 			return SetupResult::info(
-				$this->l10n->t('Server identifier isn’t configured. It is recommended if your Nextcloud instance is running on several PHP servers. Add a server ID in your configuration.'),
+				$this->l10n->t(
+					'Server identifier isn’t configured. It is recommended if your Nextcloud instance is running on several PHP servers. Add a server ID in your configuration.',
+				),
 				$linkToDoc,
 			);
 		}
 
-		if ($serverid < 0 || $serverid > 1023) {
+		if ($serverid < 0 || $serverid > 511) {
 			return SetupResult::error(
-				$this->l10n->t('"%d" is not a valid server identifier. It must be between 0 and 1023.', [$serverid]),
+				$this->l10n->t('"%d" is not a valid server identifier. It must be between 0 and 511.', [$serverid]),
 				$linkToDoc,
 			);
 		}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -50,7 +50,7 @@ $CONFIG = [
 	 * It is useful when your Nextcloud instance is using different PHP servers.
 	 * Once it's set it shouldn't be changed.
 	 *
-	 * Value must be an integer, comprised between 0 and 1023.
+	 * Value must be an integer, comprised between 0 and 511.
 	 *
 	 * When config.php is shared between different servers, this value should be overriden with "NC_serverid=<int>" on each server.
 	 * Note that it must be overriden for CLI and for your webserver.

--- a/lib/private/Snowflake/SnowflakeDecoder.php
+++ b/lib/private/Snowflake/SnowflakeDecoder.php
@@ -28,7 +28,7 @@ final class SnowflakeDecoder implements ISnowflakeDecoder {
 			throw new \Exception('Invalid Snowflake ID: ' . $snowflakeId);
 		}
 
-		/** @var array{seconds: positive-int, milliseconds: int<0,999>, serverId: int<0, 1023>, sequenceId: int<0,4095>, isCli: bool} $data */
+		/** @var array{seconds: positive-int, milliseconds: int<0,999>, serverId: int<0, 511>, sequenceId: int<0,4095>, isCli: bool} $data */
 		$data = PHP_INT_SIZE === 8
 			? $this->decode64bits((int)$snowflakeId)
 			: $this->decode32bits($snowflakeId);

--- a/lib/public/Snowflake/ISnowflakeGenerator.php
+++ b/lib/public/Snowflake/ISnowflakeGenerator.php
@@ -16,17 +16,16 @@ use OCP\AppFramework\Attribute\Consumable;
  *
  * Customized version of Snowflake IDs for Nextcloud:
  *   1 bit : Unused, always 0, avoid issue with PHP signed integers.
- *	31 bits: Timestamp from 2025-10-01. Allows to store a bit more than 68 years. Allows to find creation time.
- *	10 bits: Milliseconds (between 0 and 999)
- *	 9 bits: Server ID, identify server which generated the ID (between 0 and 1023)
- *	 1 bit : CLI or Web (0 or 1)
- *	12 bits: Sequence ID, usually a serial number of objects created in the same number on same server (between 0 and 4095)
+ *  31 bits: Timestamp from 2025-10-01. Allows to store a bit more than 68 years. Allows to find creation time.
+ *  10 bits: Milliseconds (between 0 and 999)
+ *   9 bits: Server ID, identify server which generated the ID (between 0 and 511)
+ *   1 bit : CLI or Web (0 or 1)
+ *  12 bits: Sequence ID, usually a serial number of objects created in the same number on same server (between 0 and 4095)
  *
  * @since 33.0.0
  */
 #[Consumable(since: '33.0.0')]
 interface ISnowflakeGenerator {
-
 	/**
 	 * Offset applied on timestamps to keep it short
 	 * Start from 2025-10-01 at 00:00:00

--- a/lib/public/Snowflake/Snowflake.php
+++ b/lib/public/Snowflake/Snowflake.php
@@ -19,7 +19,7 @@ use OCP\AppFramework\Attribute\Consumable;
 #[Consumable(since: '33.0.0')]
 final readonly class Snowflake {
 	/**
-	 * @psalm-param int<0,1023> $serverId
+	 * @psalm-param int<0,511> $serverId
 	 * @psalm-param int<0,4095> $sequenceId
 	 * @psalm-param non-negative-int $seconds
 	 * @psalm-param int<0,999> $milliseconds
@@ -36,7 +36,7 @@ final readonly class Snowflake {
 	}
 
 	/**
-	 * @psalm-return int<0,1023>
+	 * @psalm-return int<0,511>
 	 * @since 33.0.0
 	 */
 	public function getServerId(): int {

--- a/tests/lib/Snowflake/GeneratorTest.php
+++ b/tests/lib/Snowflake/GeneratorTest.php
@@ -29,18 +29,15 @@ class GeneratorTest extends TestCase {
 	private ISequence&MockObject $sequence;
 
 	#[\Override]
-	public function setUp():void {
+	public function setUp(): void {
 		$this->decoder = new SnowflakeDecoder();
 
 		$this->config = $this->createMock(IConfig::class);
-		$this->config->method('getSystemValueInt')
-			->with('serverid')
-			->willReturn(42);
+		$this->config->method('getSystemValueInt')->with('serverid')->willReturn(42);
 
 		$this->sequence = $this->createMock(ISequence::class);
 		$this->sequence->method('isAvailable')->willReturn(true);
 		$this->sequence->method('nextId')->willReturn(421);
-
 	}
 
 	public function testGenerator(): void {
@@ -54,7 +51,7 @@ class GeneratorTest extends TestCase {
 
 		// Check serverId
 		$this->assertGreaterThanOrEqual(0, $data->getServerId());
-		$this->assertLessThanOrEqual(1023, $data->getServerId());
+		$this->assertLessThanOrEqual(511, $data->getServerId());
 
 		// Check sequenceId
 		$this->assertGreaterThanOrEqual(0, $data->getSequenceId());
@@ -76,7 +73,7 @@ class GeneratorTest extends TestCase {
 		$generator = new SnowflakeGenerator($timeFactory, $this->config, $this->sequence);
 		$data = $this->decoder->decode($generator->nextId());
 
-		$this->assertEquals($expectedSeconds, ($data->getCreatedAt()->format('U') - ISnowflakeGenerator::TS_OFFSET));
+		$this->assertEquals($expectedSeconds, $data->getCreatedAt()->format('U') - ISnowflakeGenerator::TS_OFFSET);
 		$this->assertEquals($expectedMilliseconds, (int)$data->getCreatedAt()->format('v'));
 		$this->assertEquals(42, $data->getServerId());
 	}


### PR DESCRIPTION
## Summary

Maximum value of a server ID is 511 (9 bits) and not 1023.

Tests are correct: https://github.com/nextcloud/server/blob/master/tests/lib/Snowflake/DecoderTest.php#L46-L47

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
