### PR TITLE
fix(systemtags): Include leading slash in unified search tag link

### DIFF
--- a/apps/systemtags/lib/Search/TagSearchProvider.php
+++ b/apps/systemtags/lib/Search/TagSearchProvider.php
@@ -102,7 +102,7 @@ class TagSearchProvider implements IProvider {
 			$thumbnailUrl = '';
 			$link = $this->urlGenerator->linkToRoute('files.view.indexView', [
 				'view' => 'tags',
-			]) . '?dir=' . $tag->getId();
+			]) . '?dir=/' . $tag->getId();
 			$searchResultEntry = new SearchResultEntry(
 				$thumbnailUrl,
 				$this->l10n->t('All tagged %s …', [$tag->getName()]),


### PR DESCRIPTION
Tag results from unified search opened the tags view with a directory path missing its leading slash, which the view rejected with "Invalid tag ID". Tag links now match the path convention used elsewhere so the tag opens correctly and lists the files associated with it.

