### PR TITLE
[stable33] test(cypress): restore dashboard after app-limit test

### DIFF
--- a/cypress/e2e/theming/a11y-color-contrast.cy.ts
+++ b/cypress/e2e/theming/a11y-color-contrast.cy.ts
@@ -121,7 +121,11 @@ describe('Accessibility of Nextcloud theming colors', () => {
 					// set user theme
 					cy.runOccCommand(`user:setting -- '${$user.userId}' theming enabled-themes '[\\"${theme}\\"]'`)
 					cy.login($user)
-					cy.visit('/')
+					// Visit the dashboard explicitly: the test injects elements into `#content`,
+					// which only exists when the user layout wraps an app like Dashboard.
+					// `cy.visit('/')` would follow the system default app redirect, which can land
+					// on Files (using `#content-vue`) and break the `#content` query below.
+					cy.visit('/apps/dashboard')
 					cy.injectAxe({ axeCorePath: 'node_modules/axe-core/axe.min.js' })
 				})
 			})


### PR DESCRIPTION
## Summary

The `Limit app usage to group` test deselects the admin group without untoggling the group-limit switch, leaving Dashboard with an empty allow-list and hiding it from non-admin users. Subsequent specs (e.g. `a11y-color-contrast.cy.ts`) then redirect past Dashboard to Files, which uses `#content-vue` instead of `#content`, and break.

`app:enable dashboard` in `after()` clears the limit.

Stable33-only - master's appstore split rewrote this test with a proper save flow that doesn't leave the bad state behind.
