### PR TITLE
[stable33] test(cypress): restore dashboard after app-limit test

### DIFF
--- a/cypress/e2e/settings/apps.cy.ts
+++ b/cypress/e2e/settings/apps.cy.ts
@@ -9,6 +9,15 @@ import { handlePasswordConfirmation } from './usersUtils.ts'
 const admin = new User('admin', 'admin')
 
 describe('Settings: App management', { testIsolation: true }, () => {
+	after(() => {
+		// 'Limit app usage to group' deselects the admin group without untoggling
+		// the group-limit switch, leaving Dashboard with an empty allow-list and
+		// hiding it from non-admin users. Re-enabling rewrites the app's `enabled`
+		// flag back to `yes`, which restores the `/` redirect to dashboard for
+		// subsequent specs.
+		cy.runOccCommand('app:enable dashboard')
+	})
+
 	beforeEach(() => {
 		// disable QA if already enabled
 		cy.runOccCommand('app:disable -n testing')


### PR DESCRIPTION
## Summary

The `Limit app usage to group` test deselects the admin group without untoggling the group-limit switch, leaving Dashboard with an empty allow-list and hiding it from non-admin users. Subsequent specs (e.g. `a11y-color-contrast.cy.ts`) then redirect past Dashboard to Files, which uses `#content-vue` instead of `#content`, and break.

`app:enable dashboard` in `after()` clears the limit.

Stable33-only - master's appstore split rewrote this test with a proper save flow that doesn't leave the bad state behind.
