### PR TITLE
fix(occ): set GID before UID to ensure success

### DIFF
--- a/occ
+++ b/occ
@@ -8,26 +8,37 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-/**
- * Drop privileges when run as root
- */
-function dropPrivileges(): void {
-	if (posix_getuid() !== 0) {
-		return;
-	}
-
-	$configPath = __DIR__ . '/config/config.php';
-	$uid = @fileowner($configPath);
-	if ($uid === false) {
-		return;
-	}
-	$info = posix_getpwuid($uid);
-	if ($info === false) {
-		return;
-	}
-	posix_setuid($uid);
-	posix_setgid($info['gid']);
+if (posix_getuid() === 0) {
+	switchToConfigFileOwner();
 }
 
-dropPrivileges();
 require_once __DIR__ . '/console.php';
+
+/**
+ * Attempt to switch process identity to match the config file when run as root.
+ *
+ * This is a convenience for the operator to allow `occ` to run without manual
+ * user switching. It drops primary root privileges but is not a true sandbox.
+ *
+ * Note: Best-effort only. Will not change privileges if config file owner has
+ * no passwd entry. Does not clear environment variables nor supplementary groups.
+ * Failures are ignored here as downstream checks validate the final UID state.
+ */
+function switchToConfigFileOwner(): void {
+	$configPath = __DIR__ . '/config/config.php';
+	$targetUid = @fileowner($configPath);
+
+	if ($targetUid === false) {
+		return;
+	}
+
+	$ownerInfo = posix_getpwuid($targetUid);
+	if ($ownerInfo === false) {
+		return;
+	}
+
+	$targetGid = $ownerInfo['gid'];
+
+	posix_setgid($targetGid);
+	posix_setuid($targetUid);
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The previous implementation attempted to set GID after dropping root UID, which would fail (silently) and made the `posix_setgid()` call effectively a no-op. This swaps the order to set the target GID first.

Also refactored for clarity:
- Renamed `dropPrivileges` to `switchToConfigFileOwner` for clearer intent
- Update docblock to explicitly state best-effort limitations
- Use more descriptive variable names
- Re-organized for readability

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
