### PR TITLE
fix: split large Content-Security-Policy headers over multiple HTTP headers

### DIFF
--- a/lib/private/AppFramework/Http/Output.php
+++ b/lib/private/AppFramework/Http/Output.php
@@ -47,6 +47,34 @@ class Output implements IOutput {
 	 */
 	#[\Override]
 	public function setHeader($header) {
+		// Apache mod_proxy_fcgi parses FCGI response headers with a buffer
+		// hardcoded at HUGE_STRING_LEN (8192 bytes in httpd.h); 7800 leaves
+		// a safety margin for the status line and surrounding header bytes.
+		$maxLen = 7800;
+		if (strlen($header) > $maxLen) {
+			foreach (['Content-Security-Policy:', 'Feature-Policy:'] as $prefix) {
+				if (str_starts_with($header, $prefix)) {
+					$value = ltrim(substr($header, strlen($prefix)));
+					$directives = array_filter(array_map(trim(...), explode(';', $value)));
+					$segment = '';
+					$first = true;
+					foreach ($directives as $directive) {
+						$candidate = $segment === '' ? $directive : $segment . ';' . $directive;
+						if (strlen($prefix . ' ' . $candidate . ';') > $maxLen && $segment !== '') {
+							header($prefix . ' ' . $segment . ';', $first);
+							$first = false;
+							$segment = $directive;
+						} else {
+							$segment = $candidate;
+						}
+					}
+					if ($segment !== '') {
+						header($prefix . ' ' . $segment . ';', $first);
+					}
+					return;
+				}
+			}
+		}
 		header($header);
 	}
 


### PR DESCRIPTION
## Summary

When the `Content-Security-Policy` header exceeds 7800 bytes, split it into multiple `header()` calls. Apache `mod_proxy_fcgi` otherwise fails with `AH01070 Error parsing script headers` and returns HTTP 500 because
`HUGE_STRING_LEN` is hardcoded at 8192 bytes in `httpd.h` and is used to parse FCGI response headers. Raising this limit by recompiling Apache does not fix the issue (other related FCGI buffer limits sit at the same value).

The split is performed only between directives, never inside one. Per CSP Level 3 §3.1, multiple CSP headers are enforced as the intersection of the conveyed policies, so behavior is unchanged for compliant clients.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
