### PR TITLE
fix(accounts): enforce per-property scope restrictions via API

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -119,6 +119,30 @@ class AccountManager implements IAccountManager {
 			throw new InvalidArgumentException('scope');
 		}
 
+		// Properties that are local-only must not be set to FEDERATED or PUBLISHED scope.
+		if (
+			in_array($property->getName(), self::UNPUBLISHED_PROPERTIES, true)
+			&& in_array($property->getScope(), [self::SCOPE_FEDERATED, self::SCOPE_PUBLISHED], true)
+		) {
+			if ($throwOnData) {
+				throw new InvalidArgumentException('scope');
+			} else {
+				$property->setScope(self::SCOPE_LOCAL);
+			}
+		}
+
+		// PUBLISHED scope requires the lookup server upload to be enabled by the admin.
+		if ($property->getScope() === self::SCOPE_PUBLISHED) {
+			$lookupServerUploadEnabled = $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'no') === 'yes';
+			if (!$lookupServerUploadEnabled) {
+				if ($throwOnData) {
+					throw new InvalidArgumentException('scope');
+				} else {
+					$property->setScope(self::SCOPE_LOCAL);
+				}
+			}
+		}
+
 		if (
 			$property->getScope() === self::SCOPE_PRIVATE
 			&& in_array($property->getName(), [self::PROPERTY_DISPLAYNAME, self::PROPERTY_EMAIL])

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -114,8 +114,8 @@ class AccountManager implements IAccountManager {
 		}
 	}
 
-	protected function testPropertyScope(IAccountProperty $property, array $allowedScopes, bool $throwOnData): void {
-		if ($throwOnData && !in_array($property->getScope(), $allowedScopes, true)) {
+	protected function testPropertyScope(IAccountProperty $property, array $allowedScopes): void {
+		if (!in_array($property->getScope(), $allowedScopes, true)) {
 			throw new InvalidArgumentException('scope');
 		}
 
@@ -124,22 +124,14 @@ class AccountManager implements IAccountManager {
 			in_array($property->getName(), self::UNPUBLISHED_PROPERTIES, true)
 			&& in_array($property->getScope(), [self::SCOPE_FEDERATED, self::SCOPE_PUBLISHED], true)
 		) {
-			if ($throwOnData) {
-				throw new InvalidArgumentException('scope');
-			} else {
-				$property->setScope(self::SCOPE_LOCAL);
-			}
+			throw new InvalidArgumentException('scope');
 		}
 
 		// PUBLISHED scope requires the lookup server upload to be enabled by the admin.
 		if ($property->getScope() === self::SCOPE_PUBLISHED) {
 			$lookupServerUploadEnabled = $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'no') === 'yes';
 			if (!$lookupServerUploadEnabled) {
-				if ($throwOnData) {
-					throw new InvalidArgumentException('scope');
-				} else {
-					$property->setScope(self::SCOPE_LOCAL);
-				}
+				throw new InvalidArgumentException('scope');
 			}
 		}
 
@@ -147,13 +139,8 @@ class AccountManager implements IAccountManager {
 			$property->getScope() === self::SCOPE_PRIVATE
 			&& in_array($property->getName(), [self::PROPERTY_DISPLAYNAME, self::PROPERTY_EMAIL])
 		) {
-			if ($throwOnData) {
-				// v2-private is not available for these fields
-				throw new InvalidArgumentException('scope');
-			} else {
-				// default to local
-				$property->setScope(self::SCOPE_LOCAL);
-			}
+			// v2-private is not available for these fields
+			throw new InvalidArgumentException('scope');
 		} else {
 			// migrate scope values to the new format
 			// invalid scopes are mapped to a default value
@@ -899,7 +886,7 @@ class AccountManager implements IAccountManager {
 		}
 
 		foreach ($account->getAllProperties() as $property) {
-			$this->testPropertyScope($property, self::ALLOWED_SCOPES, true);
+			$this->testPropertyScope($property, self::ALLOWED_SCOPES);
 		}
 
 		$oldData = $this->getUser($account->getUser(), false);

--- a/lib/public/Accounts/IAccountManager.php
+++ b/lib/public/Accounts/IAccountManager.php
@@ -147,6 +147,21 @@ interface IAccountManager {
 	public const PROPERTY_PRONOUNS = 'pronouns';
 
 	/**
+	 * Properties that are only visible within the local instance and must not be
+	 * published to the global lookup server or shared via federation.
+	 * This matches the frontend's UNPUBLISHED_READABLE_PROPERTIES constant.
+	 *
+	 * @since 32.0.0
+	 */
+	public const UNPUBLISHED_PROPERTIES = [
+		self::PROPERTY_BIOGRAPHY,
+		self::PROPERTY_BIRTHDATE,
+		self::PROPERTY_HEADLINE,
+		self::PROPERTY_ORGANISATION,
+		self::PROPERTY_ROLE,
+	];
+
+	/**
 	 * The list of allowed properties
 	 *
 	 * @since 25.0.0

--- a/lib/public/Accounts/IAccountManager.php
+++ b/lib/public/Accounts/IAccountManager.php
@@ -151,7 +151,7 @@ interface IAccountManager {
 	 * published to the global lookup server or shared via federation.
 	 * This matches the frontend's UNPUBLISHED_READABLE_PROPERTIES constant.
 	 *
-	 * @since 32.0.0
+	 * @since 34.0.0
 	 */
 	public const UNPUBLISHED_PROPERTIES = [
 		self::PROPERTY_BIOGRAPHY,

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -1062,4 +1062,59 @@ class AccountManagerTest extends TestCase {
 			$this->assertEquals($expectedResultScopeValue, $resultScope, "The result scope doesn't follow the value set into the config or defaults correctly.");
 		}
 	}
+
+	public static function dataUpdateAccountRejectsInvalidScopeForUnpublishedProperty(): array {
+		$cases = [];
+		foreach (IAccountManager::UNPUBLISHED_PROPERTIES as $property) {
+			$cases[] = [$property, IAccountManager::SCOPE_FEDERATED];
+			$cases[] = [$property, IAccountManager::SCOPE_PUBLISHED];
+		}
+		return $cases;
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateAccountRejectsInvalidScopeForUnpublishedProperty')]
+	public function testUpdateAccountRejectsInvalidScopeForUnpublishedProperty(string $property, string $scope): void {
+		$user = $this->createMock(IUser::class);
+		$account = new Account($user);
+		$account->setProperty($property, 'some value', $scope, IAccountManager::NOT_VERIFIED);
+
+		$manager = $this->getInstance(['getUser', 'updateUser']);
+		$manager->method('getUser')->with($user, false)->willReturn([]);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('scope');
+		$manager->updateAccount($account);
+	}
+
+	public function testUpdateAccountRejectsPublishedScopeWhenLookupServerDisabled(): void {
+		$user = $this->createMock(IUser::class);
+		$account = new Account($user);
+		$account->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::NOT_VERIFIED);
+
+		$manager = $this->getInstance(['getUser', 'updateUser']);
+		$manager->method('getUser')->with($user, false)->willReturn([]);
+		$this->config->method('getAppValue')
+			->with('files_sharing', 'lookupServerUploadEnabled', 'no')
+			->willReturn('no');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('scope');
+		$manager->updateAccount($account);
+	}
+
+	public function testUpdateAccountAllowsPublishedScopeWhenLookupServerEnabled(): void {
+		$user = $this->createMock(IUser::class);
+		$account = new Account($user);
+		$account->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::NOT_VERIFIED);
+
+		$manager = $this->getInstance(['getUser', 'updateUser']);
+		$manager->method('getUser')->with($user, false)->willReturn([]);
+		$this->config->method('getSystemValueString')->willReturn('');
+		$this->config->method('getAppValue')
+			->with('files_sharing', 'lookupServerUploadEnabled', 'no')
+			->willReturn('yes');
+		$manager->expects($this->once())->method('updateUser');
+
+		$manager->updateAccount($account);
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #59225 — the `PUT /ocs/v2.php/cloud/users/<uid>` API accepted any valid scope value for any profile property, allowing users to bypass the visibility restrictions enforced by the frontend UI (e.g. setting `websiteScope=v2-published` on an instance where the admin has disabled lookup server upload).

- Adds `IAccountManager::UNPUBLISHED_PROPERTIES` constant listing the profile fields that must never be federated or published (biography, birthdate, headline, organisation, role) — mirrors the frontend's `UNPUBLISHED_READABLE_PROPERTIES`
- `testPropertyScope` now rejects `SCOPE_FEDERATED`/`SCOPE_PUBLISHED` for those properties
- `testPropertyScope` now rejects `SCOPE_PUBLISHED` for all properties unless the admin has enabled lookup server upload (`files_sharing.lookupServerUploadEnabled`)

## Test plan

- [ ] `NOCOVERAGE=1 ./autotest.sh sqlite tests/lib/Accounts/AccountManagerTest.php` — all 63 tests pass including 3 new ones
- [ ] Manually: `PUT /ocs/v2.php/cloud/users/<uid>` with `biographyScope=v2-federated` → expect HTTP 400 `Invalid scope`
- [ ] Manually: `PUT /ocs/v2.php/cloud/users/<uid>` with `websiteScope=v2-published` on an instance with lookup server upload disabled → expect HTTP 400 `Invalid scope`
- [ ] Manually: same request with lookup server upload enabled → expect success

🤖 Generated with [Claude Code](https://claude.com/claude-code)