### PR TITLE
refactor(appstore): cleanup page controller

### DIFF
--- a/apps/appstore/lib/Controller/PageController.php
+++ b/apps/appstore/lib/Controller/PageController.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace OCA\Appstore\Controller;
 
-use OC\App\AppManager;
 use OC\App\AppStore\Bundles\BundleFetcher;
 use OC\Installer;
 use OCA\AppAPI\Service\ExAppsPageService;
 use OCA\Appstore\AppInfo\Application;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
@@ -37,7 +37,7 @@ final class PageController extends Controller {
 		private readonly IL10N $l10n,
 		private readonly IConfig $config,
 		private readonly Installer $installer,
-		private readonly AppManager $appManager,
+		private readonly IAppManager $appManager,
 		private readonly IURLGenerator $urlGenerator,
 		private readonly IInitialState $initialState,
 		private readonly BundleFetcher $bundleFetcher,
@@ -56,7 +56,7 @@ final class PageController extends Controller {
 		$this->initialState->provideInitialState('appstoreEnabled', $this->config->getSystemValueBool('appstoreenabled', true));
 		$this->initialState->provideInitialState('appstoreBundles', $this->getBundles());
 		$this->initialState->provideInitialState('appstoreDeveloperDocs', $this->urlGenerator->linkToDocs('developer-manual'));
-		$this->initialState->provideInitialState('appstoreUpdateCount', count($this->getAppsWithUpdates()));
+		$this->initialState->provideInitialState('appstoreUpdateCount', $this->getUpdatesCount());
 
 		if ($this->appManager->isEnabledForAnyone('app_api')) {
 			try {
@@ -81,19 +81,9 @@ final class PageController extends Controller {
 		return $templateResponse;
 	}
 
-
-	private function getAppsWithUpdates(): array {
-		$appClass = new \OC_App();
-		$apps = $appClass->listAllApps();
-		/** @var array{id: string, ...} $app */
-		foreach ($apps as $key => $app) {
-			$newVersion = $this->installer->isUpdateAvailable($app['id']);
-			if ($newVersion === false) {
-				unset($apps[$key]);
-			}
-		}
-
-		return $apps;
+	private function getUpdatesCount(): int {
+		$apps = $this->appManager->getEnabledApps();
+		return array_reduce($apps, fn (int $carry, string $app): int => $carry + ($this->installer->isUpdateAvailable($app) !== false ? 1 : 0), 0);
 	}
 
 	/**

--- a/apps/appstore/tests/Controller/PageControllerTest.php
+++ b/apps/appstore/tests/Controller/PageControllerTest.php
@@ -7,10 +7,10 @@ declare(strict_types=1);
  */
 namespace OCA\Appstore\Tests\Controller;
 
-use OC\App\AppManager;
 use OC\App\AppStore\Bundles\BundleFetcher;
 use OC\Installer;
 use OCA\Appstore\Controller\PageController;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -32,7 +32,7 @@ final class PageControllerTest extends TestCase {
 
 	private INavigationManager&MockObject $navigationManager;
 
-	private AppManager&MockObject $appManager;
+	private IAppManager&MockObject $appManager;
 
 	private BundleFetcher&MockObject $bundleFetcher;
 
@@ -55,7 +55,7 @@ final class PageControllerTest extends TestCase {
 			->willReturnArgument(0);
 		$this->config = $this->createMock(IConfig::class);
 		$this->navigationManager = $this->createMock(INavigationManager::class);
-		$this->appManager = $this->createMock(AppManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
 		$this->bundleFetcher = $this->createMock(BundleFetcher::class);
 		$this->installer = $this->createMock(Installer::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);


### PR DESCRIPTION
## Summary
1. use IAppManager instead of AppManager
2. reduce functions to only filter whats needed (update count vs apps with updates).
3. do not use legacy OC_App

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
