### PR TITLE
fix: Increase limit for share/unshare requests per hour

### DIFF
--- a/apps/dav/lib/DAV/Security/RateLimiting.php
+++ b/apps/dav/lib/DAV/Security/RateLimiting.php
@@ -34,7 +34,7 @@ class RateLimiting {
 		}
 
 		$identifier = 'share-addressbook-or-calendar';
-		$userLimit = $this->config->getValueInt('dav', 'rateLimitShareAddressbookOrCalendar', 20);
+		$userLimit = $this->config->getValueInt('dav', 'rateLimitShareAddressbookOrCalendar', 100);
 		$userPeriod = $this->config->getValueInt('dav', 'rateLimitPeriodShareAddressbookOrCalendar', 3600);
 
 		try {

--- a/apps/dav/tests/unit/DAV/Security/RateLimitingTest.php
+++ b/apps/dav/tests/unit/DAV/Security/RateLimitingTest.php
@@ -24,7 +24,6 @@ class RateLimitingTest extends TestCase {
 	private IAppConfig&MockObject $config;
 	private ILimiter&MockObject $limiter;
 	private RateLimiting $rateLimiting;
-	private string $userId = 'user123';
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -86,7 +85,7 @@ class RateLimitingTest extends TestCase {
 			->method('registerUserRequest')
 			->with(
 				'share-addressbook-or-calendar',
-				20,
+				100,
 				3600,
 				$user,
 			)


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolve https://github.com/nextcloud/server/issues/60338

## Summary

The current rate limit allows 20 share/unshare/can edit requests per hour per user. 

If one want's to re-organize calendars or addressbooks 20 can be bit tight, hence changing the default to 100. 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
