### PR TITLE
Refactor(index.php): entrypoint error handling and improve fatal fallback messaging

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,8 +23,7 @@ use Psr\Log\LoggerInterface;
  * Respond with JSON for non-HTML requests, otherwise render an HTML page.
  * If a template name is provided, render it instead of the default error page template.
  */
-function respondWithHtmlOrJsonError(int $statusCode, string $message, ?string $templateName = null): never
-{
+function respondWithHtmlOrJsonError(int $statusCode, string $message, ?string $templateName = null): never {
 	$request = Server::get(IRequest::class);
 
 	// TODO: consider parsing the Accept header properly instead of checking for "html".

--- a/index.php
+++ b/index.php
@@ -19,90 +19,101 @@ use OCP\Server;
 use OCP\Template\ITemplateManager;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Respond with JSON for non-HTML requests, otherwise render an HTML page.
+ * If a template name is provided, render it instead of the default error page template.
+ */
+function respondWithHtmlOrJsonError(int $statusCode, string $message, ?string $templateName = null): never
+{
+	$request = Server::get(IRequest::class);
+
+	// TODO: consider parsing the Accept header properly instead of checking for "html".
+	if (stripos($request->getHeader('Accept'), 'html') === false) {
+		http_response_code($statusCode);
+		header('Content-Type: application/json; charset=utf-8');
+		echo json_encode(['message' => $message]);
+		exit();
+	}
+
+	$templateManager = Server::get(ITemplateManager::class);
+
+	if ($templateName !== null) {
+		// Guest pages do not set the HTTP status code; do it here.
+		http_response_code($statusCode);
+		$templateManager->printGuestPage('core', $templateName);
+		exit();
+	}
+
+	$templateManager->printErrorPage($message, $message, $statusCode);
+}
+
+// Main entrypoint
+// TODO: consider whether other error paths should also support a non-HTML response (e.g. ServiceUnavailableException, Exception, HintException).
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
+	$logger = Server::get(LoggerInterface::class);
+	$templateManager = Server::get(ITemplateManager::class);
+
 	OC::handleRequest();
 } catch (ServiceUnavailableException $ex) {
-	Server::get(LoggerInterface::class)->error($ex->getMessage(), [
-		'app' => 'index',
-		'exception' => $ex,
-	]);
+	// Server-side failure: log it because it may require admin attention.
+	$logger->error($ex->getMessage(), ['app' => 'index', 'exception' => $ex]);
 
-	//show the user a detailed error page
-	Server::get(ITemplateManager::class)->printExceptionErrorPage($ex, 503);
+	$templateManager->printExceptionErrorPage($ex, 503);
 } catch (HintException $ex) {
 	try {
-		Server::get(ITemplateManager::class)->printErrorPage($ex->getMessage(), $ex->getHint(), 503);
+		// Expected client-side failure; return an appropriate response without logging.
+		$templateManager->printErrorPage($ex->getMessage(), $ex->getHint(), 503);
 	} catch (Exception $ex2) {
 		try {
-			Server::get(LoggerInterface::class)->error($ex->getMessage(), [
-				'app' => 'index',
-				'exception' => $ex,
-			]);
-			Server::get(LoggerInterface::class)->error($ex2->getMessage(), [
-				'app' => 'index',
-				'exception' => $ex2,
-			]);
+			// Error-page rendering failed; log both failures if possible before falling back again.
+			$logger->error($ex->getMessage(), ['app' => 'index', 'exception' => $ex]);
+			$logger->error($ex2->getMessage(), ['app' => 'index', 'exception' => $ex2]);
 		} catch (Throwable $e) {
-			// no way to log it properly - but to avoid a white page of death we try harder and ignore this one here
+			// Logging failed as well, so avoid a white page of death and continue to the last resort.
 		}
 
-		//show the user a detailed error page
-		Server::get(ITemplateManager::class)->printExceptionErrorPage($ex, 500);
+		// Last resort: try the exception-based error page after the direct template render failed.
+		$templateManager->printExceptionErrorPage($ex, 500);
 	}
 } catch (LoginException $ex) {
-	$request = Server::get(IRequest::class);
-	/**
-	 * Routes with the @CORS annotation and other API endpoints should
-	 * not return a webpage, so we only print the error page when html is accepted,
-	 * otherwise we reply with a JSON array like the SecurityMiddleware would do.
-	 */
-	if (stripos($request->getHeader('Accept'), 'html') === false) {
-		http_response_code(401);
-		header('Content-Type: application/json; charset=utf-8');
-		echo json_encode(['message' => $ex->getMessage()]);
-		exit();
-	}
-	Server::get(ITemplateManager::class)->printErrorPage($ex->getMessage(), $ex->getMessage(), 401);
+	// Expected client-side failure; return an appropriate response without logging.
+	respondWithHtmlOrJsonError(401, $ex->getMessage());
 } catch (MaxDelayReached $ex) {
-	$request = Server::get(IRequest::class);
-	/**
-	 * Routes with the @CORS annotation and other API endpoints should
-	 * not return a webpage, so we only print the error page when html is accepted,
-	 * otherwise we reply with a JSON array like the BruteForceMiddleware would do.
-	 */
-	if (stripos($request->getHeader('Accept'), 'html') === false) {
-		http_response_code(429);
-		header('Content-Type: application/json; charset=utf-8');
-		echo json_encode(['message' => $ex->getMessage()]);
-		exit();
-	}
-	http_response_code(429);
-	Server::get(ITemplateManager::class)->printGuestPage('core', '429');
+	// Expected client-side failure; return an appropriate response without logging.
+	respondWithHtmlOrJsonError(429, $ex->getMessage(), '429');
 } catch (Exception $ex) {
-	Server::get(LoggerInterface::class)->error($ex->getMessage(), [
-		'app' => 'index',
-		'exception' => $ex,
-	]);
+	// Server-side failure: log it because it may require admin attention.
+	$logger->error($ex->getMessage(), ['app' => 'index', 'exception' => $ex]);
 
-	//show the user a detailed error page
-	Server::get(ITemplateManager::class)->printExceptionErrorPage($ex, 500);
+	$templateManager->printExceptionErrorPage($ex, 500);
 } catch (Error $ex) {
 	try {
-		Server::get(LoggerInterface::class)->error($ex->getMessage(), [
-			'app' => 'index',
-			'exception' => $ex,
-		]);
+		// Fatal-error handling path: try to log the original error before rendering the fallback page.
+		$logger->error($ex->getMessage(), ['app' => 'index', 'exception' => $ex]);
 	} catch (Error $e) {
+		// Last resort: even logging failed, so emit a plain-text response and rethrow for the webserver log.
 		http_response_code(500);
 		header('Content-Type: text/plain; charset=utf-8');
+
+		$timestamp = gmdate('Y-m-d H:i:s \U\T\C');
+
 		print("Internal Server Error\n\n");
-		print("The server encountered an internal error and was unable to complete your request.\n");
-		print("Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.\n");
-		print("More details can be found in the webserver log.\n");
+		print("The server encountered an error and could not complete your request.\n");
+		print("If this continues, please contact the administrator and provide the timestamp below\n");
+		print("along with a brief description of what you were trying to do.\n\n");
+
+		print("----------------------------------------\n");
+		print("Error timestamp: {$timestamp}\n");
+		print("----------------------------------------\n\n");
+
+		print("For administrators: check the application and webserver logs for details.\n");
 
 		throw $ex;
 	}
-	Server::get(ITemplateManager::class)->printExceptionErrorPage($ex, 500);
+
+	// Logging succeeded, so attempt the detailed exception page.
+	$templateManager->printExceptionErrorPage($ex, 500);
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This changeset refactors `index.php` error handling to make the different failure paths easier to follow and more consistent.

### What changed

- Centralized the non-HTML error response logic for `LoginException` and `MaxDelayReached`
- Reworked inline comments to better describe:
  - expected client-side failures
  - server-side failures that may require admin attention
  - the nested fallback tiers used when error rendering itself fails
- Improved the final plain-text fatal-error fallback with clearer user guidance
- Added a timestamp to the fatal fallback output to help with support correlation when a request ID is unavailable
- Preserved the original fatal error propagation with `throw $ex;`

### Notes

- The observable behavior for the main exception paths remains the same
- The fatal-error fallback text has been updated for clarity
- The non-HTML response handling is centralized in a helper for readability and consistency

### Follow-up considerations

We should consider:

- whether some of the other error code paths should have non-HTML/JSON response handling (didn't change that since it would be a material behavior change)
- making the `Accept` header check more robust to avoid false positives, including exact string matching as well as proper handling of quality factors (`q=`)

## TODO

- [ ] Possibly update tests (only if some check the actual text output)
- [ ] Test test test

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
