### PR TITLE
docs(CertificateManager/ICertificateManager): clarify API

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2980,13 +2980,19 @@ $CONFIG = [
 	'enable_lazy_objects' => true,
 
 	/**
-	 * Change the default certificates bundle used for trusting certificates.
+	 * Override the default CA bundle used by Nextcloud to verify TLS certificates.
 	 *
-	 * Nextcloud ships its own up-to-date certificates bundle, but in certain cases admins may wish to specify a different bundle, for example the one shipped by their distro.
+	 * By default, Nextcloud uses its shipped CA bundle. You may instead configure a
+	 * bundle provided by your operating-system distribution or organization, such as
+	 * ``/etc/ssl/certs/ca-certificates.crt`` on Debian-derived systems.
 	 *
-	 * Defaults to `\OC::$SERVERROOT . '/resources/config/ca-bundle.crt'`.
+	 * The value must be the path to a readable local CA-bundle file. Nextcloud uses
+	 * this bundle directly when no certificates have been uploaded, and includes it
+	 * when generating a bundle containing uploaded certificates.
+	 *
+	 * Defaults to ``resources/config/ca-bundle.crt`` inside the Nextcloud installation directory.
 	 */
-	'default_certificates_bundle_path' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',
+	'default_certificates_bundle_path' => '/etc/ssl/certs/ca-certificates.crt',
 
 	/**
 	 * OpenMetrics skipped exporters

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -16,7 +16,15 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 /**
- * Manage trusted certificates for users
+ * Manage trusted certificates and the effective CA bundle used by Nextcloud.
+ *
+ * Uploaded PEM certificates are merged with the shipped default CA bundle to
+ * produce the effective bundle consumed by HTTP clients and external storage
+ * integrations.
+ *
+ * The uploaded certificates and generated bundle are stored under the
+ * files_external path for historical reasons, maintaining compatibility
+ * with pre-existing deployments.
  */
 class CertificateManager implements ICertificateManager {
 	private ?string $bundlePath = null;
@@ -30,7 +38,7 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * Returns all certificates trusted by the user
+	 * Return the certificates stored in the internal upload area.
 	 *
 	 * @return ICertificate[]
 	 */
@@ -67,6 +75,9 @@ class CertificateManager implements ICertificateManager {
 		return $result;
 	}
 
+	/**
+	 * Check whether any uploaded certificates are present.
+	 */
 	private function hasCertificates(): bool {
 		if (!$this->config->getSystemValueBool('installed', false)) {
 			return false;
@@ -91,9 +102,14 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * create the certificate bundle of all trusted certificated
+	 * Rebuild the generated effected certificate bundle from:
+	 * - uploaded certificates
+	 * - the shipped default CA bundle
+	 * - the current system CA bundle, if present and different from the target
+	 *
+	 * The bundle is written atomically to /files_external/rootcerts.crt.
 	 */
-	public function createCertificateBundle(): void {
+	private function createCertificateBundle(): void {
 		$path = $this->getPathToCertificates();
 		$certs = $this->listCertificates();
 
@@ -143,11 +159,12 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * Save the certificate and re-generate the certificate bundle
+	 * Store a certificate and regenerate the effective bundle.
 	 *
-	 * @param string $certificate the certificate data
-	 * @param string $name the filename for the certificate
-	 * @throws \Exception If the certificate could not get added
+	 * @param string $certificate Certificate data in PEM format
+	 * @param string $name File name to store the certificate under
+	 * @return ICertificate
+	 * @throws \Exception If the certificate cannot be stored or the bundle cannot be rebuilt
 	 */
 	#[\Override]
 	public function addCertificate(string $certificate, string $name): ICertificate {
@@ -172,7 +189,10 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * Remove the certificate and re-generate the certificate bundle
+	 * Remove a stored certificate and regenerate the effective bundle.
+	 *
+	 * @param string $name File name of the certificate to remove
+	 * @return bool False if the path is invalid, true otherwise
 	 */
 	#[\Override]
 	public function removeCertificate(string $name): bool {
@@ -193,7 +213,7 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * Get the path to the certificate bundle
+	 * Get the relative path to the generated certificate bundle.
 	 */
 	#[\Override]
 	public function getCertificateBundle(): string {
@@ -201,8 +221,15 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * Get the full local path to the certificate bundle
-	 * @throws \Exception when getting bundle path fails
+	 * Get the local filesystem path to the effective certificate bundle.
+	 *
+	 * Returns the generated bundle when uploaded certificates exist, otherwise
+	 * falls back to the shipped default CA bundle.
+	 *
+	 * If resolving the generated bundle fails, the default bundle is returned as
+	 * a safe fallback.
+	 *
+	 * @throws \Exception If unable to retrieve/confirm the bundle path for any reason.
 	 */
 	#[\Override]
 	public function getAbsoluteBundlePath(): string {
@@ -230,12 +257,19 @@ class CertificateManager implements ICertificateManager {
 		}
 	}
 
+	/**
+	 * Get the base path used to store uploaded certificates and the generated bundle.
+	 *
+	 * Kept under the files_external namespace for compatibility with existing
+	 * deployments.
+	 */
 	private function getPathToCertificates(): string {
 		return '/files_external/';
 	}
 
 	/**
-	 * Check if we need to re-bundle the certificates because one of the sources has updated
+	 * Determine whether the generated bundle must be rebuilt because the source
+	 * CA bundle has changed or the target bundle is missing.
 	 */
 	private function needsRebundling(): bool {
 		$targetBundle = $this->getCertificateBundle();
@@ -248,12 +282,15 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * get mtime of ca-bundle shipped by Nextcloud
+	 * Return the modification time of the shipped default CA bundle.
 	 */
 	protected function getFilemtimeOfCaBundle(): int {
 		return filemtime($this->getDefaultCertificatesBundlePath());
 	}
 
+	/**
+	 * Return the configured path to the shipped default CA bundle.
+	 */
 	#[\Override]
 	public function getDefaultCertificatesBundlePath(): string {
 		return $this->config->getSystemValueString('default_certificates_bundle_path', \OC::$SERVERROOT . '/resources/config/ca-bundle.crt');

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -219,7 +219,7 @@ class CertificateManager implements ICertificateManager {
 	 * The uploaded certificates and generated bundle are stored under the
 	 * files_external path for historical reasons, maintaining compatibility
 	 * with pre-existing deployments.
- 	*/
+	 */
 	private function getPathToCertificates(): string {
 		return '/files_external/';
 	}

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -15,17 +15,6 @@ use OCP\IConfig;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
-/**
- * Manage trusted certificates and the effective CA bundle used by Nextcloud.
- *
- * Uploaded PEM certificates are merged with the shipped default CA bundle to
- * produce the effective bundle consumed by HTTP clients and external storage
- * integrations.
- *
- * The uploaded certificates and generated bundle are stored under the
- * files_external path for historical reasons, maintaining compatibility
- * with pre-existing deployments.
- */
 class CertificateManager implements ICertificateManager {
 	private ?string $bundlePath = null;
 
@@ -37,11 +26,6 @@ class CertificateManager implements ICertificateManager {
 	) {
 	}
 
-	/**
-	 * Return the certificates stored in the internal upload area.
-	 *
-	 * @return ICertificate[]
-	 */
 	#[\Override]
 	public function listCertificates(): array {
 		if (!$this->config->getSystemValueBool('installed', false)) {
@@ -158,14 +142,6 @@ class CertificateManager implements ICertificateManager {
 		$this->view->rename($tmpPath, $certPath);
 	}
 
-	/**
-	 * Store a certificate and regenerate the effective bundle.
-	 *
-	 * @param string $certificate Certificate data in PEM format
-	 * @param string $name File name to store the certificate under
-	 * @return ICertificate
-	 * @throws \Exception If the certificate cannot be stored or the bundle cannot be rebuilt
-	 */
 	#[\Override]
 	public function addCertificate(string $certificate, string $name): ICertificate {
 		$path = $this->getPathToCertificates() . 'uploads/' . $name;
@@ -188,12 +164,6 @@ class CertificateManager implements ICertificateManager {
 		}
 	}
 
-	/**
-	 * Remove a stored certificate and regenerate the effective bundle.
-	 *
-	 * @param string $name File name of the certificate to remove
-	 * @return bool False if the path is invalid, true otherwise
-	 */
 	#[\Override]
 	public function removeCertificate(string $name): bool {
 		$path = $this->getPathToCertificates() . 'uploads/' . $name;
@@ -212,25 +182,11 @@ class CertificateManager implements ICertificateManager {
 		return true;
 	}
 
-	/**
-	 * Get the relative path to the generated certificate bundle.
-	 */
 	#[\Override]
 	public function getCertificateBundle(): string {
 		return $this->getPathToCertificates() . 'rootcerts.crt';
 	}
 
-	/**
-	 * Get the local filesystem path to the effective certificate bundle.
-	 *
-	 * Returns the generated bundle when uploaded certificates exist, otherwise
-	 * falls back to the shipped default CA bundle.
-	 *
-	 * If resolving the generated bundle fails, the default bundle is returned as
-	 * a safe fallback.
-	 *
-	 * @throws \Exception If unable to retrieve/confirm the bundle path for any reason.
-	 */
 	#[\Override]
 	public function getAbsoluteBundlePath(): string {
 		try {
@@ -260,9 +216,10 @@ class CertificateManager implements ICertificateManager {
 	/**
 	 * Get the base path used to store uploaded certificates and the generated bundle.
 	 *
-	 * Kept under the files_external namespace for compatibility with existing
-	 * deployments.
-	 */
+	 * The uploaded certificates and generated bundle are stored under the
+	 * files_external path for historical reasons, maintaining compatibility
+	 * with pre-existing deployments.
+ 	*/
 	private function getPathToCertificates(): string {
 		return '/files_external/';
 	}
@@ -288,9 +245,6 @@ class CertificateManager implements ICertificateManager {
 		return filemtime($this->getDefaultCertificatesBundlePath());
 	}
 
-	/**
-	 * Return the configured path to the shipped default CA bundle.
-	 */
 	#[\Override]
 	public function getDefaultCertificatesBundlePath(): string {
 		return $this->config->getSystemValueString('default_certificates_bundle_path', \OC::$SERVERROOT . '/resources/config/ca-bundle.crt');

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -71,13 +71,14 @@ class CertificateManager implements ICertificateManager {
 		if (!$this->view->is_dir($path)) {
 			return false;
 		}
-		$result = [];
+
 		$handle = $this->view->opendir($path);
 		if (!is_resource($handle)) {
 			return false;
 		}
 		while (false !== ($file = readdir($handle))) {
 			if ($file !== '.' && $file !== '..') {
+				closedir($handle);
 				return true;
 			}
 		}
@@ -86,10 +87,9 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * Rebuild the generated effected certificate bundle from:
+	 * Rebuild the generated effective certificate bundle from:
 	 * - uploaded certificates
-	 * - the shipped default CA bundle
-	 * - the current system CA bundle, if present and different from the target
+	 * - the configured default CA bundle (defaults to Nextcloud's shipped CA bundle)
 	 *
 	 * The bundle is written atomically to /files_external/rootcerts.crt.
 	 */
@@ -102,14 +102,13 @@ class CertificateManager implements ICertificateManager {
 		}
 
 		$defaultCertificates = file_get_contents($this->getDefaultCertificatesBundlePath());
-		if (strlen($defaultCertificates) < 1024) { // sanity check to verify that we have some content for our bundle
-			// log as exception so we have a stacktrace
-			$e = new \Exception('Shipped ca-bundle is empty, refusing to create certificate bundle');
+		if (!is_string($defaultCertificates) || strlen($defaultCertificates) < 1024) {
+			$e = new \Exception('Configured CA bundle is empty or unreadable, refusing to create certificate bundle');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return;
 		}
 
-		$certPath = $path . 'rootcerts.crt';
+		$certPath = $this->getCertificateBundle();
 		$tmpPath = $certPath . '.tmp' . $this->random->generate(10, ISecureRandom::CHAR_DIGITS);
 		$fhCerts = $this->view->fopen($tmpPath, 'w');
 
@@ -117,25 +116,18 @@ class CertificateManager implements ICertificateManager {
 			throw new \RuntimeException('Unable to open file handler to create certificate bundle "' . $tmpPath . '".');
 		}
 
-		// Write user certificates
+		// Write uploaded certificates.
 		foreach ($certs as $cert) {
-			$file = $path . '/uploads/' . $cert->getName();
+			$file = $path . 'uploads/' . $cert->getName();
 			$data = $this->view->file_get_contents($file);
-			if (strpos($data, 'BEGIN CERTIFICATE')) {
+			if (is_string($data) && str_contains($data, 'BEGIN CERTIFICATE')) {
 				fwrite($fhCerts, $data);
 				fwrite($fhCerts, "\r\n");
 			}
 		}
 
-		// Append the default certificates
+		// Append the configured default CA bundle.
 		fwrite($fhCerts, $defaultCertificates);
-
-		// Append the system certificate bundle
-		$systemBundle = $this->getCertificateBundle();
-		if ($systemBundle !== $certPath && $this->view->file_exists($systemBundle)) {
-			$systemCertificates = $this->view->file_get_contents($systemBundle);
-			fwrite($fhCerts, $systemCertificates);
-		}
 
 		fclose($fhCerts);
 
@@ -154,14 +146,10 @@ class CertificateManager implements ICertificateManager {
 			$this->view->mkdir($directory);
 		}
 
-		try {
-			$certificateObject = new Certificate($certificate, $name);
-			$this->view->file_put_contents($path, $certificate);
-			$this->createCertificateBundle();
-			return $certificateObject;
-		} catch (\Exception $e) {
-			throw $e;
-		}
+		$certificateObject = new Certificate($certificate, $name);
+		$this->view->file_put_contents($path, $certificate);
+		$this->createCertificateBundle();
+		return $certificateObject;
 	}
 
 	#[\Override]
@@ -239,7 +227,7 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	/**
-	 * Return the modification time of the shipped default CA bundle.
+	 * Return the modification time of the configured default CA bundle.
 	 */
 	protected function getFilemtimeOfCaBundle(): int {
 		return filemtime($this->getDefaultCertificatesBundlePath());

--- a/lib/public/ICertificateManager.php
+++ b/lib/public/ICertificateManager.php
@@ -9,12 +9,20 @@ declare(strict_types=1);
 namespace OCP;
 
 /**
- * Manage trusted certificates
+ * Manage trusted certificates and the effective CA bundle used by Nextcloud.
+ *
+ * Implementations provide access to uploaded trusted certificates and the
+ * generated bundle that is consumed by HTTP clients and external storage
+ * integrations.
+ *
  * @since 8.0.0
  */
 interface ICertificateManager {
 	/**
-	 * Returns all certificates trusted by the system
+	 * Returns all uploaded trusted certificates.
+	 *
+	 * This does not include the shipped default CA bundle or any system CA bundle
+	 * appended when building the effective bundle.
 	 *
 	 * @return \OCP\ICertificate[]
 	 * @since 8.0.0
@@ -22,23 +30,27 @@ interface ICertificateManager {
 	public function listCertificates(): array;
 
 	/**
-	 * @param string $certificate the certificate data
-	 * @param string $name the filename for the certificate
+	 * Add a trusted certificate to the certificate store.
+	 *
+	 * @param string $certificate The certificate data in PEM format
+	 * @param string $name The filename for the certificate
 	 * @return \OCP\ICertificate
-	 * @throws \Exception If the certificate could not get added
+	 * @throws \Exception If the certificate could not be added
 	 * @since 8.0.0 - since 8.1.0 throws exception instead of returning false
 	 */
 	public function addCertificate(string $certificate, string $name): \OCP\ICertificate;
 
 	/**
-	 * @param string $name
+	 * Remove a trusted certificate from the certificate store.
+	 *
+	 * @param string $name The filename for the certificate
 	 * @return bool
 	 * @since 8.0.0
 	 */
 	public function removeCertificate(string $name): bool;
 
 	/**
-	 * Get the path to the certificate bundle
+	 * Get the relative path to the generated certificate bundle.
 	 *
 	 * @return string
 	 * @since 8.0.0
@@ -46,7 +58,10 @@ interface ICertificateManager {
 	public function getCertificateBundle(): string;
 
 	/**
-	 * Get the full local path to the certificate bundle
+	 * Get the full local path to the effective certificate bundle.
+	 *
+	 * Implementations should return the generated bundle path, but may log and fall back
+	 * to the shipped default CA bundle if resolution fails.
 	 *
 	 * @return string
 	 * @since 9.0.0
@@ -54,7 +69,7 @@ interface ICertificateManager {
 	public function getAbsoluteBundlePath(): string;
 
 	/**
-	 * Get the path of the default certificates bundle.
+	 * Get the path of the shipped default certificates bundle.
 	 *
 	 * @since 33.0.0
 	 */

--- a/lib/public/ICertificateManager.php
+++ b/lib/public/ICertificateManager.php
@@ -9,11 +9,10 @@ declare(strict_types=1);
 namespace OCP;
 
 /**
- * Manage trusted certificates and the effective CA bundle used by Nextcloud.
+ * Manage uploaded trusted certificates and the CA bundle used by Nextcloud.
  *
  * Implementations provide access to uploaded trusted certificates and the
- * generated bundle that is consumed by HTTP clients and external storage
- * integrations.
+ * certificate bundle consumed by HTTP clients and external storage integrations.
  *
  * @since 8.0.0
  */
@@ -21,8 +20,7 @@ interface ICertificateManager {
 	/**
 	 * Returns all uploaded trusted certificates.
 	 *
-	 * This does not include the shipped default CA bundle or any system CA bundle
-	 * appended when building the effective bundle.
+	 * This does not include certificates in the configured default CA bundle.
 	 *
 	 * @return \OCP\ICertificate[]
 	 * @since 8.0.0
@@ -32,7 +30,7 @@ interface ICertificateManager {
 	/**
 	 * Add a trusted certificate to the certificate store.
 	 *
-	 * @param string $certificate The certificate data in PEM format
+	 * @param string $certificate The certificate data
 	 * @param string $name The filename for the certificate
 	 * @return \OCP\ICertificate
 	 * @throws \Exception If the certificate could not be added
@@ -50,7 +48,7 @@ interface ICertificateManager {
 	public function removeCertificate(string $name): bool;
 
 	/**
-	 * Get the relative path to the generated certificate bundle.
+	 * Get the virtual filesystem path to the generated certificate bundle.
 	 *
 	 * @return string
 	 * @since 8.0.0
@@ -58,10 +56,10 @@ interface ICertificateManager {
 	public function getCertificateBundle(): string;
 
 	/**
-	 * Get the full local path to the effective certificate bundle.
+	 * Get the full local path to the certificate bundle used by Nextcloud.
 	 *
-	 * Implementations should return the generated bundle path, but may log and fall back
-	 * to the shipped default CA bundle if resolution fails.
+	 * If no uploaded certificates are configured, or if resolving the generated
+	 * bundle fails, this falls back to returning the configured default CA bundle path.
 	 *
 	 * @return string
 	 * @since 9.0.0
@@ -69,7 +67,9 @@ interface ICertificateManager {
 	public function getAbsoluteBundlePath(): string;
 
 	/**
-	 * Get the path of the shipped default certificates bundle.
+	 * Get the path to the configured default CA bundle.
+	 *
+	 * By default, this is Nextcloud's shipped CA bundle.
 	 *
 	 * @since 33.0.0
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Clarify and align the `CertificateManager` implementation and `ICertificateManager` public contract around uploaded certificates, generated bundles, and the configured default CA bundle.

This also removes obsolete code from the former per-user certificate-bundle model, which was removed in #21693.

### Changes

- Document that uploaded certificates are combined with the configured default CA bundle, which defaults to Nextcloud's shipped CA bundle.
- Clarify that `getCertificateBundle()` returns a virtual filesystem path and that `getAbsoluteBundlePath()` may fall back to the configured default CA bundle.
- Make the internal `CertificateManager::createCertificateBundle()` helper private. It was already outside the interface and is only used internally.
- Remove the unreachable append of the former separate Nextcloud-wide bundle from `createCertificateBundle()`.
- Fix the certificate-header check so PEM data beginning at offset zero is included in generated bundles.
- Simplify minor related implementation details.
- Update the `config.sample.php` entry for `default_certificates_bundle_path` for alignment and improved clarity.

## TODO

- [x] Possibly make one more pass back through the implementation to drop some bits now better covered in the interface docs

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
