### PR TITLE
fix(dav): handle out-of-range datetime values in file search

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -505,13 +505,33 @@ class FileSearchBackend implements ISearchBackend {
 			case SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER:
 				return 0 + $value;
 			case SearchPropertyDefinition::DATATYPE_DATETIME:
-				if (is_numeric($value)) {
-					return max(0, 0 + $value);
-				}
-				$date = \DateTime::createFromFormat(\DateTimeInterface::ATOM, (string)$value);
-				return ($date instanceof \DateTime && $date->getTimestamp() !== false) ? $date->getTimestamp() : 0;
+				return $this->castDateTimeValue($value);
 			default:
 				return $value;
+		}
+	}
+
+	private function castDateTimeValue($value) {
+		if (is_numeric($value)) {
+			return max(0, 0 + $value);
+		}
+
+		$date = \DateTime::createFromFormat(\DateTimeInterface::ATOM, (string)$value);
+		if (!$date instanceof \DateTime) {
+			return 0;
+		}
+
+		try {
+			return $date->getTimestamp();
+		} catch (\Error $e) {
+			if (!$e instanceof \ValueError && !is_a($e, 'DateRangeError')) {
+				throw $e;
+			}
+
+			// On 32-bit PHP, getTimestamp() fails for dates outside the
+			// representable integer range. Clamp broad search bounds instead of
+			// failing the whole WebDAV SEARCH request.
+			return (int) $date->format("Y") >= 2038 ? PHP_INT_MAX : 0;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Some DAV SEARCH requests use very broad datetime bounds for file search. For example, media searches may use a range such as `0001-01-01` to `4001-01-01` to search across all possible media dates.

On 32-bit PHP, those bounds are outside the timestamp range that can be represented as a native integer:

- dates before 1970 are below the representable range
- dates after 2038 are beyond the representable range

When `FileSearchBackend::castValue()` converts such a datetime with `DateTime::getTimestamp()`, PHP throws because the resulting timestamp does not fit into a 32-bit integer. PHP 8.2 throws `ValueError`; PHP 8.3 and newer throw `DateRangeError`.

`transformSearchOperation()` then turns the error into:

`InvalidArgumentException: Invalid property value for {DAV:}getlastmodified`

The whole SEARCH request fails.

## Fix

Move DATETIME casting into a small helper and handle datetime values that cannot be represented on the current platform by clamping them to the platform-supported range:

- values below the representable range to `0`
- values beyond the platform max to `PHP_INT_MAX`

This preserves the existing behavior for datetime values that can be represented on the current platform. The added handling only applies when `DateTime::getTimestamp()` cannot represent the value.

This does not extend the supported date range on 32-bit PHP. It keeps the SEARCH request executable by mapping out-of-range search bounds to the nearest documented 32-bit boundary.

## Notes

The fix is generic for DAV datetime search values and is not specific to the iOS client.

Related issues:

- Related server-side issue: nextcloud/server#35950
- Related client-side symptom: nextcloud/ios#3888

## Testing

- [x] Tested manually on 32-bit PHP with Nextcloud Server 33.0.3.2
- [x] Tested with Nextcloud iOS 33.0.8
- [x] Verified that the Photos/Media tab loads again
- [x] Verified that `Invalid property value for {DAV:}getlastmodified` no longer appears in `nextcloud.log`
- [x] Ran `php -l apps/dav/lib/Files/FileSearchBackend.php`

## Checklist

- [ ] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes are not required
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version

## AI

- [x] The content of this PR was partly or fully generated using AI.