### PR TITLE
refactor(ocs): improve readability of v1 front controller

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -28,60 +28,73 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
-$request = Server::get(IRequest::class);
-
-if ((Util::needUpgrade() || Server::get(IConfig::class)->getSystemValueBool('maintenance')) && $request->getPathInfo() !== '/core/update') {
-	// since the behavior of apps or remotes are unpredictable during
-	// an upgrade, return a 503 directly
-	ApiHelper::respond(503, 'Service unavailable', ['X-Nextcloud-Maintenance-Mode' => '1'], 503);
-	exit;
-}
-
-/*
- * Try the appframework routes
- */
 try {
-	$appManager = Server::get(IAppManager::class);
-	$appManager->loadApps(['session']);
-	$appManager->loadApps(['authentication']);
-	$appManager->loadApps(['extended_authentication']);
+	$logger = Server::get(LoggerInterface::class);
+	$debug = Server::get(SystemConfig::class)->getValue('debug', false);
+	$request = Server::get(IRequest::class);
+	$requestPath = $request->getPathInfo();
+	$rawRequestPath = $request->getRawPathInfo();
+	$isCoreUpdateRequest = $requestPath === '/core/update';
+	$upgrade = Util::needUpgrade();
+	$maintenance = Server::get(IConfig::class)->getSystemValueBool('maintenance');
 
+	// During maintenance mode or while an upgrade is pending, return a 503 for OCS
+	// requests directly. The core update endpoint is the only exception.
+	if (($upgrade || $maintenance) && !$isCoreUpdateRequest) {
+		ApiHelper::respond(503, 'Service unavailable', ['X-Nextcloud-Maintenance-Mode' => '1'], 503);
+		exit();
+	}
+
+	$appManager = Server::get(IAppManager::class);
+	// Load the baseline apps needed before route dispatch and authentication.
+	$appManager->loadApps(['session']);
+	$appManager->loadApps(['authentication', 'extended_authentication']);
+
+	// Reject malformed request payloads before continuing.
 	$request->throwDecodingExceptionIfAny();
 
-	if ($request->getPathInfo() !== '/core/update') {
-		// load all apps to get all api routes properly setup
+	$loggedIn = Server::get(IUserSession::class)->isLoggedIn();
+
+	if ($isCoreUpdateRequest) {
+		// The update endpoint only needs the core app.
+		$appManager->loadApps(['core']);
+	} else {
+		// Load all apps so that all OCS API routes are registered.
 		// FIXME: this should ideally appear after handleLogin but will cause
 		// side effects in existing apps
 		$appManager->loadApps();
-		if (!Server::get(IUserSession::class)->isLoggedIn()) {
+
+		// Attempt login only if there is no active session yet.
+		if (!$loggedIn) {
 			OC::handleLogin($request);
 		}
-	} else {
-		$appManager->loadApps(['core']);
 	}
 
-	Server::get(Router::class)->match('/ocsapp' . $request->getRawPathInfo());
+	// OCS routes are registered under the /ocsapp prefix internally.
+	Server::get(Router::class)->match('/ocsapp' . $rawRequestPath);
+} catch (LoginException $ex) {
+	// Expected client-side failure; return an appropriate response without logging.
+	ApiHelper::respond(OCSController::RESPOND_UNAUTHORISED, 'Unauthorised');
 } catch (MaxDelayReached $ex) {
+	// Expected client-side failure; return an appropriate response without logging.
 	ApiHelper::respond(Http::STATUS_TOO_MANY_REQUESTS, $ex->getMessage());
-} catch (ResourceNotFoundException $e) {
-	$txt = 'Invalid query, please check the syntax. API specifications are here:'
-		. ' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.' . "\n";
-	ApiHelper::respond(OCSController::RESPOND_NOT_FOUND, $txt);
-} catch (MethodNotAllowedException $e) {
+} catch (ResourceNotFoundException $ex) {
+	// Expected client-side failure; return an appropriate response without logging.
+	$message = "Invalid query, please check the syntax. API specifications are here:\n"
+		. "http://www.freedesktop.org/wiki/Specifications/open-collaboration-services\n";
+	ApiHelper::respond(OCSController::RESPOND_NOT_FOUND, $message);
+} catch (MethodNotAllowedException $ex) {
+	// Expected client-side failure; return an appropriate response without logging.
 	ApiHelper::setContentType();
 	http_response_code(405);
-} catch (LoginException $e) {
-	ApiHelper::respond(OCSController::RESPOND_UNAUTHORISED, 'Unauthorised');
-} catch (\Exception $e) {
-	Server::get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
+} catch (\Exception $ex) {
+	// Server-side failure: log it because it may require admin attention.
+	$logger->error($ex->getMessage(), ['exception' => $ex]);
 
-	$txt = 'Internal Server Error' . "\n";
-	try {
-		if (Server::get(SystemConfig::class)->getValue('debug', false)) {
-			$txt .= $e->getMessage();
-		}
-	} catch (\Throwable $e) {
-		// Just to be save
+	$message = "Internal Server Error \n";
+	if ($debug) {
+		$message .= $ex->getMessage();
 	}
-	ApiHelper::respond(OCSController::RESPOND_SERVER_ERROR, $txt);
+
+	ApiHelper::respond(OCSController::RESPOND_SERVER_ERROR, $message);
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This refactors `ocs/v1.php` to make the request flow easier to read without changing the endpoint's behavior. Somewhat inspired as an incremental counterpart to #60362 (and to some extent #60293).

### What changed

- Introduced local variables for request path handling and bootstrapping state
- Made the maintenance/upgrade short-circuit more explicit
- Grouped request handling into clearer phases:
  - app bootstrap
  - request validation
  - login / update-path handling
  - route dispatch
- Kept the existing OCS exception-to-response mapping intact
- Simplified the generic error path by removing unnecessary nesting

### Notes

- This is a readability-only cleanup
- No intended behavior changes
- `/core/update` remains the only bypass for the early maintenance/upgrade response

## TODO

- [ ] Test test test

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
