### PR TITLE
🚀 Master is now 35

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -73,7 +73,8 @@ body:
       options:
         - "32"
         - "33"
-        - "34 (master)"
+        - "34"
+        - "35 (master)"
     validations:
       required: true
   - type: dropdown

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,7 +74,7 @@ updates:
 
 # Composer dependencies for linting and testing
 - package-ecosystem: composer
-  target-branch: stable33
+  target-branch: stable34
   directories:
     - "/"
     - "/vendor-bin/behat"
@@ -98,7 +98,7 @@ updates:
 
 # frontend dependencies
 - package-ecosystem: npm
-  target-branch: stable33
+  target-branch: stable34
   directories:
     - "/"
     - "/build/frontend"
@@ -132,6 +132,52 @@ updates:
       update-types: ["version-update:semver-major"]
 
 # Older stable releases
+
+# Composer dependencies for linting and testing
+- package-ecosystem: composer
+  target-branch: stable33
+  directories:
+    - "/"
+    - "/vendor-bin/behat"
+    - "/vendor-bin/cs-fixer"
+    - "/vendor-bin/openapi-extractor"
+    - "/vendor-bin/phpunit"
+    - "/vendor-bin/psalm"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "04:30"
+    timezone: Europe/Paris
+  labels:
+    - "3. to review"
+    - "feature: dependencies"
+  ignore:
+    # only patch updates on stable branches
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+# frontend dependencies
+- package-ecosystem: npm
+  target-branch: stable33
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "04:30"
+    timezone: Europe/Paris
+  cooldown:
+    default-days: 4
+    semver-major-days: 8
+  open-pull-requests-limit: 20
+  labels:
+    - "3. to review"
+    - "feature: dependencies"
+  # Disable automatic rebasing because without a build CI will likely fail anyway
+  rebase-strategy: "disabled"
+  ignore:
+    # no major updates on stable branches
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major"]
 
 # Composer dependencies for linting and testing
 - package-ecosystem: composer

--- a/.github/workflows/update-cacert-bundle.yml
+++ b/.github/workflows/update-cacert-bundle.yml
@@ -17,7 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['master', 'stable33', 'stable32', 'stable31', 'stable30', 'stable29',  'stable28',  'stable27', 'stable26', 'stable25', 'stable24', 'stable23', 'stable22']
+        branches:
+          - ${{ github.event.repository.default_branch }}
+          - 'stable34'
+          - 'stable33'
+          - 'stable32'
+          - 'stable31'
+          - 'stable30'
+          - 'stable29'
+          - 'stable28'
+          - 'stable27'
+          - 'stable26'
+          - 'stable25'
+          - 'stable24'
+          - 'stable23'
+          - 'stable22'
 
     name: update-ca-certificate-bundle-${{ matrix.branches }}
 

--- a/.github/workflows/update-code-signing-crl.yml
+++ b/.github/workflows/update-code-signing-crl.yml
@@ -17,7 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['master', 'stable33', 'stable32', 'stable31', 'stable30', 'stable29',  'stable28',  'stable27', 'stable26', 'stable25', 'stable24', 'stable23', 'stable22']
+        branches:
+          - ${{ github.event.repository.default_branch }}
+          - 'stable34'
+          - 'stable33'
+          - 'stable32'
+          - 'stable31'
+          - 'stable30'
+          - 'stable29'
+          - 'stable28'
+          - 'stable27'
+          - 'stable26'
+          - 'stable25'
+          - 'stable24'
+          - 'stable23'
+          - 'stable22'
 
     name: update-code-signing-crl-${{ matrix.branches }}
 

--- a/apps/admin_audit/appinfo/info.xml
+++ b/apps/admin_audit/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>Auditing / Logging</name>
 	<summary>Provides logging abilities for Nextcloud such as logging file accesses or otherwise sensitive actions.</summary>
 	<description>Provides logging abilities for Nextcloud such as logging file accesses or otherwise sensitive actions.</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<namespace>AdminAudit</namespace>
@@ -20,7 +20,7 @@
 	<category>monitoring</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\AdminAudit\BackgroundJobs\Rotate</job>

--- a/apps/appstore/appinfo/info.xml
+++ b/apps/appstore/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Nextcloud Appstore</name>
 	<summary>Nextcloud Appstore</summary>
 	<description>Nextcloud Appstore</description>
-	<version>1.0.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<namespace>Appstore</namespace>
@@ -17,6 +17,6 @@
 	<category>customization</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 </info>

--- a/apps/cloud_federation_api/appinfo/info.xml
+++ b/apps/cloud_federation_api/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Cloud Federation API</name>
 	<summary>Enable clouds to communicate with each other and exchange data</summary>
 	<description>The Cloud Federation API enables various Nextcloud instances to communicate with each other and to exchange data.</description>
-	<version>1.18.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>CloudFederationAPI</namespace>
@@ -19,6 +19,6 @@
 	<category>integration</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 </info>

--- a/apps/comments/appinfo/info.xml
+++ b/apps/comments/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>Comments</name>
 	<summary>Files app plugin to add comments to files</summary>
 	<description>Files app plugin to add comments to files</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Arthur Schiwon</author>
 	<author>Vincent Petry</author>
@@ -21,7 +21,7 @@
 	<category>social</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<activity>

--- a/apps/contactsinteraction/appinfo/info.xml
+++ b/apps/contactsinteraction/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Contacts Interaction</name>
 	<summary>Manages interaction between accounts and contacts</summary>
 	<description>Collect data about accounts and contacts interactions and provide an address book for the data</description>
-	<version>1.15.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
@@ -21,7 +21,7 @@
 	<category>social</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\ContactsInteraction\BackgroundJob\CleanupJob</job>

--- a/apps/dashboard/appinfo/info.xml
+++ b/apps/dashboard/appinfo/info.xml
@@ -12,7 +12,7 @@
 
 The Nextcloud Dashboard is your starting point of the day, giving you an overview of your upcoming appointments, urgent emails, chat messages, incoming tickets, latest tweets and much more! People can add the widgets they like and change the background to their liking.]]>
 	</description>
-	<version>7.14.0</version>
+	<version>8.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Julius Härtl</author>
 	<namespace>Dashboard</namespace>
@@ -22,7 +22,7 @@ The Nextcloud Dashboard is your starting point of the day, giving you an overvie
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<navigations>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>WebDAV</name>
 	<summary>WebDAV endpoint</summary>
 	<description>WebDAV endpoint</description>
-	<version>1.39.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>owncloud.org</author>
 	<namespace>DAV</namespace>
@@ -20,7 +20,7 @@
 	<category>integration</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -30,7 +30,7 @@
 				read the documentation to understand implications and the appropriate procedures to avoid data loss.
 		]]>
 	</description>
-	<version>2.22.0</version>
+	<version>3.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<author>Clark Tomlinson</author>
@@ -50,7 +50,7 @@
 
 	<dependencies>
 		<lib>openssl</lib>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<repair-steps>

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>Federated file sharing</name>
 	<summary>Provide federated file sharing across servers</summary>
 	<description>Provide federated file sharing across servers</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<author>Roeland Jago Douma</author>
@@ -20,7 +20,7 @@
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<settings>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>Federation</name>
 	<summary>Federation allows you to connect with other trusted servers to exchange the account directory.</summary>
 	<description>Federation allows you to connect with other trusted servers to exchange the account directory. For example this will be used to auto-complete external accounts for federated sharing.</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>Federation</namespace>
@@ -22,7 +22,7 @@
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>Files</name>
 	<summary>File Management</summary>
 	<description>File Management</description>
-	<version>2.6.0</version>
+	<version>3.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>John Molakvoæ</author>
 	<author>Robin Appelman</author>
@@ -24,7 +24,7 @@
 	<category>files</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -14,7 +14,7 @@ This application enables administrators to configure connections to external sto
 
 External storage can be configured using the GUI or at the command line. This second option provides the administration with more flexibility for configuring bulk external storage mounts and setting mount priorities. More information is available in the external storage GUI documentation and the external storage Configuration File documentation.
 	</description>
-	<version>1.26.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<author>Michael Gapczynski</author>
@@ -33,7 +33,7 @@ External storage can be configured using the GUI or at the command line. This se
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/files_reminders/appinfo/info.xml
+++ b/apps/files_reminders/appinfo/info.xml
@@ -15,7 +15,7 @@ Set file reminders.
 Note: to use the `File reminders` app, ensure that the `Notifications` app is installed and enabled. The `Notifications` app provides the necessary APIs for the `File reminders` app to work correctly.
 
 	]]></description>
-	<version>1.7.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Christopher Ng</author>
 	<namespace>FilesReminders</namespace>
@@ -25,7 +25,7 @@ Note: to use the `File reminders` app, ensure that the `Notifications` app is in
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -14,7 +14,7 @@
 Turning the feature off removes shared files and folders on the server for all share recipients, and also on the sync clients and mobile apps. More information is available in the Nextcloud Documentation.
 
 	</description>
-	<version>1.26.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Michael Gapczynski</author>
 	<author>Bjoern Schiessle</author>
@@ -27,7 +27,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<category>social</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -14,7 +14,7 @@ This application enables people to restore files that were deleted from the syst
 To prevent an account from running out of disk space, the Deleted files app will not utilize more than 50% of the currently available free quota for deleted files. If the deleted files exceed this limit, the app deletes the oldest files until it gets below this limit. More information is available in the Deleted Files documentation.
 
 	</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>Files_Trashbin</namespace>
@@ -28,7 +28,7 @@ To prevent an account from running out of disk space, the Deleted files app will
 	<category>files</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -13,7 +13,7 @@
 		This application automatically maintains older versions of files that are changed. When enabled, a hidden versions folder is provisioned in every user's directory and is used to store old file versions. A user can revert to an older version through the web interface at any time, with the replaced file becoming a version. The app automatically manages the versions folder to ensure the account does not run out of Quota because of versions.
 		In addition to the expiry of versions, the versions app makes certain never to use more than 50% of the account's currently available free space. If stored versions exceed this limit, the app will delete the oldest versions first until it meets this limit. More information is available in the Versions documentation.
 	</description>
-	<version>1.27.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Frank Karlitschek</author>
 	<author>Bjoern Schiessle</author>
@@ -28,7 +28,7 @@
 	<category>files</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/lookup_server_connector/appinfo/info.xml
+++ b/apps/lookup_server_connector/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Lookup Server Connector</name>
 	<summary>Sync public account information with the lookup server</summary>
 	<description>Sync public account information with the lookup server</description>
-	<version>1.22.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>LookupServerConnector</namespace>
@@ -20,6 +20,6 @@
 	<category>social</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 </info>

--- a/apps/oauth2/appinfo/info.xml
+++ b/apps/oauth2/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>OAuth 2.0</name>
 	<summary>Allows OAuth2 compatible authentication from other web applications.</summary>
 	<description>The OAuth2 app allows administrators to configure the built-in authentication workflow to also allow OAuth2 compatible authentication from other web applications.</description>
-	<version>1.22.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>OAuth2</namespace>
@@ -20,7 +20,7 @@
 	<category>integration</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/profile/appinfo/info.xml
+++ b/apps/profile/appinfo/info.xml
@@ -9,13 +9,13 @@
 	<name>Profile</name>
 	<summary>This application provides the profile</summary>
 	<description>Provides a customisable user profile interface.</description>
-	<version>1.3.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Nextcloud GmbH</author>
 	<namespace>Profile</namespace>
 	<category>social</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 </info>

--- a/apps/provisioning_api/appinfo/info.xml
+++ b/apps/provisioning_api/appinfo/info.xml
@@ -18,7 +18,7 @@
 		listed above. More information is available in the Provisioning API documentation, including example calls
 		and server responses.
 	</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Tom Needham</author>
 	<namespace>Provisioning_API</namespace>
@@ -31,6 +31,6 @@
 	<category>integration</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 </info>

--- a/apps/settings/appinfo/info.xml
+++ b/apps/settings/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Nextcloud settings</name>
 	<summary>Nextcloud settings</summary>
 	<description>Nextcloud settings</description>
-	<version>1.17.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<namespace>Settings</namespace>
@@ -17,7 +17,7 @@
 	<category>customization</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<commands>

--- a/apps/settings/lib/WellKnown/SecurityTxtHandler.php
+++ b/apps/settings/lib/WellKnown/SecurityTxtHandler.php
@@ -23,7 +23,7 @@ class SecurityTxtHandler implements IHandler {
 		}
 
 		$response = 'Contact: https://hackerone.com/nextcloud
-Expires: 2026-08-31T23:00:00.000Z
+Expires: 2026-12-31T23:00:00.000Z
 Acknowledgments: https://hackerone.com/nextcloud/thanks
 Acknowledgments: https://github.com/nextcloud/security-advisories/security/advisories
 Policy: https://hackerone.com/nextcloud

--- a/apps/sharebymail/appinfo/info.xml
+++ b/apps/sharebymail/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Share by mail</name>
 	<summary>Share provider which allows you to share files by mail</summary>
 	<description>Share provider which allows you to share files by mail</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>ShareByMail</namespace>
@@ -20,7 +20,7 @@
 	<category>social</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<settings>

--- a/apps/systemtags/appinfo/info.xml
+++ b/apps/systemtags/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<summary>Collaborative tagging functionality which shares tags among people.</summary>
 	<description>Collaborative tagging functionality which shares tags among people. Great for teams.
 	(If you are a provider with a multi-tenancy installation, it is advised to deactivate this app as tags are shared.)</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Vincent Petry</author>
 	<author>Joas Schilling</author>
@@ -23,7 +23,7 @@
 	<category>organization</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 	<commands>
 		<command>OCA\SystemTags\Command\Files\Add</command>

--- a/apps/testing/appinfo/info.xml
+++ b/apps/testing/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>QA testing</name>
 	<summary>This app is only for testing! It is dangerous to have it enabled in a live instance</summary>
 	<description>This app is only for testing! It is dangerous to have it enabled in a live instance</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Joas Schilling</author>
 	<types>
@@ -19,6 +19,6 @@
 	<category>monitoring</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 </info>

--- a/apps/theming/appinfo/info.xml
+++ b/apps/theming/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Theming</name>
 	<summary>Adjust the Nextcloud theme</summary>
 	<description>Adjust the Nextcloud theme</description>
-	<version>2.9.0</version>
+	<version>3.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<namespace>Theming</namespace>
@@ -21,7 +21,7 @@
 	<category>customization</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<repair-steps>

--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Two factor backup codes</name>
 	<summary>A two-factor auth backup codes provider</summary>
 	<description>A two-factor auth backup codes provider</description>
-	<version>1.23.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorBackupCodes</namespace>
@@ -17,7 +17,7 @@
 	<category>security</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<repair-steps>

--- a/apps/updatenotification/appinfo/info.xml
+++ b/apps/updatenotification/appinfo/info.xml
@@ -10,14 +10,14 @@
 	<name>Update notification</name>
 	<summary>Displays update notifications for Nextcloud, app updates, and provides the SSO for the updater.</summary>
 	<description>Displays update notifications for Nextcloud, app updates, and provides the SSO for the updater.</description>
-	<version>1.24.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>UpdateNotification</namespace>
 	<category>monitoring</category>
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -14,7 +14,7 @@
 A user logs into Nextcloud with their LDAP or AD credentials, and is granted access based on an authentication request handled by the LDAP or AD server. Nextcloud does not store LDAP or AD passwords, rather these credentials are used to authenticate a user and then Nextcloud uses a session for the user ID. More information is available in the LDAP User and Group Backend documentation.
 
 	</description>
-	<version>1.25.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Dominik Schmidt</author>
 	<author>Arthur Schiwon</author>
@@ -29,7 +29,7 @@ A user logs into Nextcloud with their LDAP or AD credentials, and is granted acc
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
 		<lib>ldap</lib>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/apps/user_status/appinfo/info.xml
+++ b/apps/user_status/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>User status</name>
 	<summary>User status</summary>
 	<description><![CDATA[User status]]></description>
-	<version>1.14.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author mail="oc.list@georgehrke.com" >Georg Ehrke</author>
 	<namespace>UserStatus</namespace>
@@ -24,7 +24,7 @@
 		</navigation>
 	</navigations>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\UserStatus\BackgroundJob\ClearOldStatusesBackgroundJob</job>

--- a/apps/weather_status/appinfo/info.xml
+++ b/apps/weather_status/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[Weather status integrated in the Dashboard app.
     The geographic location can be automatically determined or manually defined. A 6 hours forecast is then displayed.
     This status can also be integrated in other places like the Calendar app.]]></description>
-	<version>1.14.0</version>
+	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author mail="eneiluj@posteo.net">Julien Veyssier</author>
 	<namespace>WeatherStatus</namespace>
@@ -19,6 +19,6 @@
 	<category>dashboard</category>
 	<bugs>https://github.com/nextcloud/server</bugs>
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 </info>

--- a/apps/webhook_listeners/appinfo/info.xml
+++ b/apps/webhook_listeners/appinfo/info.xml
@@ -18,7 +18,7 @@ Administrators can configure webhook listeners via the app's OCS API. The app al
         ]]>
     </description>
 
-    <version>1.6.0</version>
+    <version>2.0.0-dev.0</version>
     <licence>agpl</licence>
     <author>Côme Chilliet</author>
     <namespace>WebhookListeners</namespace>
@@ -38,7 +38,7 @@ Administrators can configure webhook listeners via the app's OCS API. The app al
     <repository>https://github.com/nextcloud/server.git</repository>
 
     <dependencies>
-        <nextcloud min-version="34" max-version="34"/>
+        <nextcloud min-version="35" max-version="35"/>
     </dependencies>
 
     <commands>

--- a/apps/workflowengine/appinfo/info.xml
+++ b/apps/workflowengine/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Nextcloud workflow engine</name>
 	<summary>Nextcloud workflow engine</summary>
 	<description>Nextcloud workflow engine</description>
-	<version>2.16.0</version>
+	<version>3.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Arthur Schiwon</author>
 	<author>Julius Härtl</author>
@@ -26,7 +26,7 @@
 	<repository>https://github.com/nextcloud/server.git</repository>
 
 	<dependencies>
-		<nextcloud min-version="34" max-version="34"/>
+		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 
 	<background-jobs>

--- a/tests/Core/Command/Apps/AppsDisableTest.php
+++ b/tests/Core/Command/Apps/AppsDisableTest.php
@@ -52,20 +52,22 @@ class AppsDisableTest extends TestCase {
 		$this->assertSame($statusCode, $this->commandTester->getStatusCode());
 	}
 
+	public const VERSION_REGEX = '([\d\.\-dev]*)';
+
 	public static function dataCommandInput(): array {
 		return [
-			[['admin_audit'], 0, 'admin_audit ([\d\.]*) disabled'],
-			[['comments'], 0, 'comments ([\d\.]*) disabled'],
+			[['admin_audit'], 0, 'admin_audit ' . self::VERSION_REGEX . ' disabled'],
+			[['comments'], 0, 'comments ' . self::VERSION_REGEX . ' disabled'],
 			[['invalid_app'], 0, 'No such app enabled: invalid_app'],
 
-			[['admin_audit', 'comments'], 0, "admin_audit ([\d\.]*) disabled\ncomments ([\d\.]*) disabled"],
-			[['admin_audit', 'comments', 'invalid_app'], 0, "admin_audit ([\d\.]*) disabled\ncomments ([\d\.]*) disabled\nNo such app enabled: invalid_app"],
+			[['admin_audit', 'comments'], 0, 'admin_audit ' . self::VERSION_REGEX . " disabled\ncomments " . self::VERSION_REGEX . ' disabled'],
+			[['admin_audit', 'comments', 'invalid_app'], 0, 'admin_audit ' . self::VERSION_REGEX . " disabled\ncomments " . self::VERSION_REGEX . " disabled\nNo such app enabled: invalid_app"],
 
 			[['files'], 2, "files can't be disabled"],
 			[['provisioning_api'], 2, "provisioning_api can't be disabled"],
 
-			[['files', 'admin_audit'], 2, "files can't be disabled.\nadmin_audit ([\d\.]*) disabled"],
-			[['provisioning_api', 'comments'], 2, "provisioning_api can't be disabled.\ncomments ([\d\.]*) disabled"],
+			[['files', 'admin_audit'], 2, "files can't be disabled.\nadmin_audit " . self::VERSION_REGEX . ' disabled'],
+			[['provisioning_api', 'comments'], 2, "provisioning_api can't be disabled.\ncomments " . self::VERSION_REGEX . ' disabled'],
 		];
 	}
 }

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -60,25 +60,27 @@ class AppsEnableTest extends TestCase {
 		$this->assertSame($statusCode, $this->commandTester->getStatusCode());
 	}
 
+	public const VERSION_REGEX = '([\d\.\-dev]*)';
+
 	public static function dataCommandInput(): array {
 		return [
-			[['admin_audit'], null, 0, 'admin_audit ([\d\.]*) enabled'],
-			[['comments'], null, 0, 'comments ([\d\.]*) enabled'],
-			[['comments', 'comments'], null, 0, "comments ([\d\.]*) enabled\ncomments already enabled"],
+			[['admin_audit'], null, 0, 'admin_audit ' . self::VERSION_REGEX . ' enabled'],
+			[['comments'], null, 0, 'comments ' . self::VERSION_REGEX . ' enabled'],
+			[['comments', 'comments'], null, 0, 'comments ' . self::VERSION_REGEX . " enabled\ncomments already enabled"],
 			[['invalid_app'], null, 1, 'Could not download app invalid_app'],
 
-			[['admin_audit', 'comments'], null, 0, "admin_audit ([\d\.]*) enabled\ncomments ([\d\.]*) enabled"],
-			[['admin_audit', 'comments', 'invalid_app'], null, 1, "admin_audit ([\d\.]*) enabled\ncomments ([\d\.]*) enabled\nCould not download app invalid_app"],
+			[['admin_audit', 'comments'], null, 0, 'admin_audit ' . self::VERSION_REGEX . " enabled\ncomments " . self::VERSION_REGEX . ' enabled'],
+			[['admin_audit', 'comments', 'invalid_app'], null, 1, 'admin_audit ' . self::VERSION_REGEX . " enabled\ncomments " . self::VERSION_REGEX . " enabled\nCould not download app invalid_app"],
 
 			[['admin_audit'], ['admin'], 1, "admin_audit can't be enabled for groups"],
 			[['comments'], ['admin'], 1, "comments can't be enabled for groups"],
 
-			[['updatenotification'], ['admin'], 0, 'updatenotification ([\d\.]*) enabled for groups: admin'],
-			[['updatenotification', 'dashboard'], ['admin'], 0, "updatenotification ([\d\.]*) enabled for groups: admin\ndashboard ([\d\.]*) enabled for groups: admin"],
+			[['updatenotification'], ['admin'], 0, 'updatenotification ' . self::VERSION_REGEX . ' enabled for groups: admin'],
+			[['updatenotification', 'dashboard'], ['admin'], 0, 'updatenotification ' . self::VERSION_REGEX . " enabled for groups: admin\ndashboard " . self::VERSION_REGEX . ' enabled for groups: admin'],
 
-			[['updatenotification'], ['admin', 'invalid_group'], 0, 'updatenotification ([\d\.]*) enabled for groups: admin'],
-			[['updatenotification', 'dashboard'], ['admin', 'invalid_group'], 0, "updatenotification ([\d\.]*) enabled for groups: admin\ndashboard ([\d\.]*) enabled for groups: admin"],
-			[['updatenotification', 'dashboard', 'invalid_app'], ['admin', 'invalid_group'], 1, "updatenotification ([\d\.]*) enabled for groups: admin\ndashboard ([\d\.]*) enabled for groups: admin\nCould not download app invalid_app"],
+			[['updatenotification'], ['admin', 'invalid_group'], 0, 'updatenotification ' . self::VERSION_REGEX . ' enabled for groups: admin'],
+			[['updatenotification', 'dashboard'], ['admin', 'invalid_group'], 0, 'updatenotification ' . self::VERSION_REGEX . " enabled for groups: admin\ndashboard " . self::VERSION_REGEX . ' enabled for groups: admin'],
+			[['updatenotification', 'dashboard', 'invalid_app'], ['admin', 'invalid_group'], 1, 'updatenotification ' . self::VERSION_REGEX . " enabled for groups: admin\ndashboard " . self::VERSION_REGEX . " enabled for groups: admin\nCould not download app invalid_app"],
 		];
 	}
 }

--- a/version.php
+++ b/version.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [34, 0, 0, 6];
+$OC_Version = [35, 0, 0, 0];
 
 // The human-readable string
-$OC_VersionString = '34.0.0 beta 5';
+$OC_VersionString = '35.0.0 dev';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
-		'33.0' => true,
 		'34.0' => true,
+		'35.0' => true,
 	],
 	'owncloud' => [
 		'10.13' => true,


### PR DESCRIPTION
# ⚠️ To be merged only

- [x]  After stable34 creation
- [x]  By release manager: @Altahrim 

## Todos

possible "up front"

- [x] https://github.com/nextcloud/.github/pull/722
- [x] https://github.com/nextcloud/docker-ci/pull/928
- [x] https://github.com/nextcloud/nextcloud-config-converter/pull/19
- [x] https://github.com/nextcloud/updater/pull/755

---

"live"

- [x]  `.github/dependabot.yml`
  - [x]  Add a new section about the new `stableY` branch
- [x]  `.github/ISSUE_TEMPLATE/BUG_REPORT.yml`
  - [x]  Update the selectable server version
- [x]  `.github/workflows/update-cacert-bundle.yml`
  - [x]  Adjust backport list of cacert automation to include `stableY`
- [x]  `.github/workflows/update-code-signing-crl.yml`
  - [x]  Adjust backport list of cacert automation to include `stableY`
- [x]  `.github/workflows/npm-audit-fix.yml`
  - [x]  Adjust backport list of psalm automation to include `stableY`
  - [ ] https://github.com/nextcloud/server/pull/61660/changes
- [x]  `apps/settings/lib/WellKnown/SecurityTxtHandler.php`
  - [x]  Bump `Expires` date to be 6 months in the future
  - [x]  Trigger the backport bot for all still supported versions
- [x]  `version.php`
  - [x]  Increase the major version in `$OC_Version` and 0-ify the other digits
  - [x]  Set `$OC_VersionString` to `Major.0.0 dev`
  - [x]  Add the newest major to `$OC_VersionCanBeUpgradedFrom`
  - [x]  Remove the oldest major to `$OC_VersionCanBeUpgradedFrom`
- [x]  `apps/*/appinfo/info.xml`
  - [x]  Update Minor version of all apps and 0ify the patch version
  - [x]  Bump version requirement to the new Major
- [x]  Rebuilt frontend `npm ci && npm run build`
- [x]  Add stable-branch to 3rdparty dependabot master
  - [x]  https://github.com/nextcloud/3rdparty/pull/2419
  - [x]  Commit 3rdparty/ with the merge commit of above PR to the master branch of server
- [x]  Fix other apps on stable branch:
    - [x]  Add stable branch to cron: https://github.com/nextcloud-deps/ocp/pull/38
    - [x]  Adjust version alias on stable34 https://github.com/nextcloud-deps/ocp/pull/41
    - [x]  Run the cron (only after stable34 of server was branched off for real)
- [x]  Branch-off the stable34 branch in all affected apps, before sending this PR
    - [x]  https://github.com/nextcloud/server/pull/60394
