### PR TITLE
feat: show log messages in files_external:verify in verbose mode

### DIFF
--- a/apps/files_external/lib/Command/Verify.php
+++ b/apps/files_external/lib/Command/Verify.php
@@ -14,15 +14,21 @@ use OCA\Files_External\MountConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\AppFramework\Http;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Log\BeforeMessageLoggedEvent;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Verify extends Base {
+	/// formatting tags for the various log levels
+	public const FORMATTING = ['comment', 'comment', 'comment', 'error', 'error'];
+
 	public function __construct(
 		protected GlobalStoragesService $globalService,
+		protected IEventDispatcher $eventDispatcher,
 	) {
 		parent::__construct();
 	}
@@ -57,13 +63,36 @@ class Verify extends Base {
 			return Http::STATUS_NOT_FOUND;
 		}
 
+		$logMessages = [];
+		$logListener = null;
+		if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+			$logListener = function (BeforeMessageLoggedEvent $event) use (&$logMessages) {
+				$format = self::FORMATTING[$event->getLevel()];
+				$logMessages[] = " - <$format>" . $event->getMessage()['message'] . "</$format>";
+			};
+			$this->eventDispatcher->addListener(BeforeMessageLoggedEvent::class, $logListener);
+		}
+
 		$this->updateStorageStatus($mount, $configInput, $output);
+
+		if ($logListener) {
+			$this->eventDispatcher->removeListener(BeforeMessageLoggedEvent::class, $logListener);
+		}
 
 		$this->writeArrayInOutputFormat($input, $output, [
 			'status' => StorageNotAvailableException::getStateCodeName($mount->getStatus()),
 			'code' => $mount->getStatus(),
 			'message' => $mount->getStatusMessage()
 		]);
+
+		if (count($logMessages)) {
+			$output->writeln('');
+			$output->writeln('Messages logged during validation:');
+			foreach ($logMessages as $logMessage) {
+				$output->writeln($logMessage);
+			}
+		}
+
 		return self::SUCCESS;
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

When the verbose flag is passed, show all messages that were logged during the external storage validation

<img width="1237" height="286" alt="image" src="https://github.com/user-attachments/assets/ce49be32-cb25-4260-b58d-28565630c740" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
