### PR TITLE
fix(dav): Skip removal of classified activity when not generated anymore

### DIFF
--- a/apps/dav/lib/Migration/RemoveClassifiedEventActivity.php
+++ b/apps/dav/lib/Migration/RemoveClassifiedEventActivity.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Migration;
 
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -17,6 +18,7 @@ class RemoveClassifiedEventActivity implements IRepairStep {
 
 	public function __construct(
 		private IDBConnection $connection,
+		private IAppConfig $appConfig,
 	) {
 	}
 
@@ -33,12 +35,17 @@ class RemoveClassifiedEventActivity implements IRepairStep {
 	 */
 	#[\Override]
 	public function run(IOutput $output) {
+		if ($this->appConfig->getAppValueBool('checked_for_classified_activity')) {
+			return;
+		}
+
 		if (!$this->connection->tableExists('activity')) {
 			return;
 		}
 
 		$deletedEvents = $this->removePrivateEventActivity();
 		$deletedEvents += $this->removeConfidentialUncensoredEventActivity();
+		$this->appConfig->setAppValueBool('checked_for_classified_activity', true);
 
 		$output->info("Removed $deletedEvents activity entries");
 	}


### PR DESCRIPTION
Was fixed in Nextcloud 16, so future versions should not generate this anymore. So the delete attempt can be skipped

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
