### PR TITLE
fix: update cached mounts when moving share in repair step

### DIFF
--- a/apps/files_sharing/lib/Repair/CleanupShareTarget.php
+++ b/apps/files_sharing/lib/Repair/CleanupShareTarget.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Files_Sharing\Repair;
 
+use OC\Files\Cache\CacheEntry;
 use OC\Files\SetupManager;
 use OCA\Files_Sharing\ShareTargetValidator;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -111,12 +112,23 @@ class CleanupShareTarget implements IRepairStep {
 				);
 				$newTarget = $userFolder->getRelativePath($absoluteNewTarget);
 
-				$this->moveShare((string)$shareInfo['id'], $newTarget);
+				if ($newTarget !== $oldTarget) {
+					$this->moveShare((string)$shareInfo['id'], $newTarget);
 
-				$oldMountPoint = "/{$recipient->getUID()}/files$oldTarget/";
-				$newMountPoint = "/{$recipient->getUID()}/files$newTarget/";
-				$userMounts[$newMountPoint] = $userMounts[$oldMountPoint];
-				unset($userMounts[$oldMountPoint]);
+					$oldMountPoint = "/{$recipient->getUID()}/files$oldTarget/";
+					$newMountPoint = "/{$recipient->getUID()}/files$newTarget/";
+
+					/** @var ICachedMountInfo $mount */
+					$mount = $userMounts[$oldMountPoint];
+					$userMounts[$newMountPoint] = $mount;
+					unset($userMounts[$oldMountPoint]);
+
+					$this->userMountCache->removeMount($oldMountPoint);
+					$this->userMountCache->addMount($recipient, $newMountPoint, new CacheEntry([
+						'fileid' => $mount->getRootId(),
+						'storage' => $mount->getStorageId(),
+					]), $mount->getMountProvider(), $mount->getMountId());
+				}
 			} catch (\Exception $e) {
 				$msg = 'error cleaning up share target: ' . $e->getMessage();
 				$this->logger->error($msg, ['exception' => $e, 'app' => 'files_sharing']);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Properly update the mount table if we move a share

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
