### PR TITLE
test(filesdrop): fix duplicate scenario titles, indentation, and add clarifying comments

### DIFF
--- a/build/integration/filesdrop_features/filesdrop.feature
+++ b/build/integration/filesdrop_features/filesdrop.feature
@@ -2,13 +2,18 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 Feature: FilesDrop
 
+  # Scenarios using shareType 3 (public link drop) do not require a nickname.
+  # Scenarios using shareType 4 (file request / email share) require a nickname
+  # when the fileRequest attribute is enabled, and files are stored under a
+  # per-nickname subdirectory.
+
   Scenario: Put file via files drop
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 3 |
+      | path         | drop |
+      | shareType    | 3    |
       | publicUpload | true |
     And Updating last share with
       | permissions | 4 |
@@ -16,13 +21,13 @@ Feature: FilesDrop
     And Downloading file "/drop/a.txt"
     Then Downloaded content should be "abc"
 
-  Scenario: Put file same file multiple times via files drop
+  Scenario: Put same file multiple times via files drop (public link)
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 3 |
+      | path         | drop |
+      | shareType    | 3    |
       | publicUpload | true |
     And Updating last share with
       | permissions | 4 |
@@ -38,37 +43,37 @@ Feature: FilesDrop
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 3 |
-      | publicUpload | true |
-	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+      | path         | drop                                                     |
+      | shareType    | 3                                                        |
+      | publicUpload | true                                                     |
+      | attributes   | [{"scope":"fileRequest","key":"enabled","value":true}]   |
     And Updating last share with
       | permissions | 4 |
     When Dropping file "/folder/a.txt" with "abc"
     Then the HTTP status code should be "400"
 
-Scenario: Files drop allow MKCOL without a nickname
-	Given user "user0" exists
-	And As an "user0"
-	And user "user0" created a folder "/drop"
-	And as "user0" creating a share with
-		| path | drop |
-		| shareType | 3 |
-		| publicUpload | true |
-	And Updating last share with
-		| permissions | 4 |
-	When Creating folder "folder" in drop
-	Then the HTTP status code should be "201"
-
-	Scenario: Files request forbid MKCOL without a nickname
+  Scenario: Files drop allow MKCOL without a nickname
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 3 |
+      | path         | drop |
+      | shareType    | 3    |
       | publicUpload | true |
-	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+    And Updating last share with
+      | permissions | 4 |
+    When Creating folder "folder" in drop
+    Then the HTTP status code should be "201"
+
+  Scenario: Files request forbid MKCOL without a nickname
+    Given user "user0" exists
+    And As an "user0"
+    And user "user0" created a folder "/drop"
+    And as "user0" creating a share with
+      | path         | drop                                                     |
+      | shareType    | 3                                                        |
+      | publicUpload | true                                                     |
+      | attributes   | [{"scope":"fileRequest","key":"enabled","value":true}]   |
     And Updating last share with
       | permissions | 4 |
     When Creating folder "folder" in drop
@@ -79,10 +84,10 @@ Scenario: Files drop allow MKCOL without a nickname
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 3 |
-      | publicUpload | true |
-	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+      | path         | drop                                                     |
+      | shareType    | 3                                                        |
+      | publicUpload | true                                                     |
+      | attributes   | [{"scope":"fileRequest","key":"enabled","value":true}]   |
     And Updating last share with
       | permissions | 4 |
     When Creating folder "folder" in drop as "nickname"
@@ -93,10 +98,10 @@ Scenario: Files drop allow MKCOL without a nickname
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 3 |
-      | publicUpload | true |
-	  | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+      | path         | drop                                                     |
+      | shareType    | 3                                                        |
+      | publicUpload | true                                                     |
+      | attributes   | [{"scope":"fileRequest","key":"enabled","value":true}]   |
     And Updating last share with
       | permissions | 4 |
     When dropping file "/folder/a.txt" with "abc"
@@ -107,25 +112,30 @@ Scenario: Files drop allow MKCOL without a nickname
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder/a.txt" with "abc" as "Alice"
     And Downloading file "/drop/Alice/folder/a.txt"
     Then Downloaded content should be "abc"
 
   Scenario: File drop uploading folder with name of file
+    # When a file and a directory share the same name, the first upload keeps
+    # the original name. Here "/folder" is uploaded as a plain file first, so
+    # it retains the name "folder". The subsequent upload of "/folder/a.txt"
+    # requires a directory also named "folder", which is deduplicated to
+    # "folder (2)" because the plain file already occupies that name.
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder" with "its a file" as "Alice"
     Then the HTTP status code should be "201"
     When Dropping file "/folder/a.txt" with "abc" as "Alice"
@@ -137,15 +147,19 @@ Scenario: Files drop allow MKCOL without a nickname
     Then Downloaded content should be "abc"
 
   Scenario: File drop uploading file with name of folder
+    # Mirror of the previous scenario: the directory "/folder" is created first
+    # by uploading "/folder/a.txt", so it retains the name "folder". The
+    # subsequent upload of a plain file also named "/folder" is deduplicated
+    # to "folder (2)".
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder/a.txt" with "abc" as "Alice"
     Then the HTTP status code should be "201"
     When Dropping file "/folder" with "its a file" as "Alice"
@@ -157,20 +171,21 @@ Scenario: Files drop allow MKCOL without a nickname
     Then the HTTP status code should be "200"
     And Downloaded content should be "its a file"
 
-  Scenario: Put file same file multiple times via files drop
+  Scenario: Put same file multiple times via files drop (file request with nickname)
+    # Only files are deduplicated across repeated uploads from the same nickname.
+    # Folders are merged, not duplicated: "Mallory (2)" and "folder (2)" must
+    # not be created; only the conflicting file gets a "(2)" suffix.
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder/a.txt" with "abc" as "Mallory"
     And Dropping file "/folder/a.txt" with "def" as "Mallory"
-    # Ensure folder structure and that we only checked
-    # for files duplicates, but merged the existing folders
     Then as "user0" the folder "/drop/Mallory" exists
     Then as "user0" the folder "/drop/Mallory/folder" exists
     Then as "user0" the folder "/drop/Mallory (2)" does not exist
@@ -187,17 +202,19 @@ Scenario: Files drop allow MKCOL without a nickname
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | shareWith |  |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | shareWith   |                                                          |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
     When Dropping file "/folder/a.txt" with "abc" as "Mallory"
     When as "user0" the file "/drop/Mallory/folder/a.txt" exists
+    # Directory listings are blocked (405 Method Not Allowed)
     And Downloading public folder "Mallory"
     Then the HTTP status code should be "405"
     And Downloading public folder "Mallory/folder"
     Then the HTTP status code should be "405"
+    # Individual files are not exposed at all (404 Not Found)
     And Downloading public file "Mallory/folder/a.txt"
     Then the HTTP status code should be "404"
 
@@ -206,49 +223,54 @@ Scenario: Files drop allow MKCOL without a nickname
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder/a.txt" with "abc"
     Then the HTTP status code should be "400"
 
-  Scenario: Files request drop with invalid nickname with slashes
+  Scenario: Files request drop with invalid nickname containing slashes
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder/a.txt" with "abc" as "Alice/Bob/Mallory"
     Then the HTTP status code should be "400"
 
-  Scenario: Files request drop with invalid nickname with forbidden characters
+  Scenario: Files request drop with invalid nickname matching a server file (.htaccess)
+    # Nicknames that match web-server reserved filenames are blocked to prevent
+    # accidental or malicious overwrite of server configuration files.
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder/a.txt" with "abc" as ".htaccess"
     Then the HTTP status code should be "400"
 
-  Scenario: Files request drop with invalid nickname with forbidden characters
+  Scenario: Files request drop with invalid nickname starting with a dot
+    # Dot-prefixed nicknames are blocked because they would create hidden
+    # directories on POSIX filesystems, which is undesirable regardless of
+    # the name being otherwise harmless (e.g. ".Mallory").
     Given user "user0" exists
     And As an "user0"
     And user "user0" created a folder "/drop"
     And as "user0" creating a share with
-      | path | drop |
-      | shareType | 4 |
-      | permissions | 4 |
-      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
-      | shareWith |  |
+      | path        | drop                                                     |
+      | shareType   | 4                                                        |
+      | permissions | 4                                                        |
+      | attributes  | [{"scope":"fileRequest","key":"enabled","value":true}]   |
+      | shareWith   |                                                          |
     When Dropping file "/folder/a.txt" with "abc" as ".Mallory"
     Then the HTTP status code should be "400"


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Improves readability and correctness of `filesdrop.feature` without changing any test logic at this time.

- Rename two pairs of duplicate scenario titles (`Put same file multiple times` and `invalid nickname with forbidden characters`) so test reports are unambiguous
- Fix mixed tab/space indentation throughout the file
- Add a feature-level comment explaining the shareType 3 vs 4 split
- Add inline comments explaining the deduplication priority rules in the folder-vs-file conflict scenarios
- Add comments clarifying the 405 vs 404 distinction in the "prevents GET" scenario
- Document why dot-prefixed and `.htaccess` nicknames are blocked

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
