### PR TITLE
feat: implement isSelectableGroup function to filter out unselectable groups

### DIFF
--- a/apps/settings/src/components/Users/UserFormGroups.vue
+++ b/apps/settings/src/components/Users/UserFormGroups.vue
@@ -46,6 +46,7 @@
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import logger from '../../logger.ts'
 import { searchGroups } from '../../service/groups.ts'
+import { isSelectableGroup } from './userFormUtils.ts'
 
 export default {
 	name: 'UserFormGroups',
@@ -73,7 +74,7 @@ export default {
 				? this.$store.getters.getSortedGroups
 				: this.$store.getters.getSubAdminGroups
 
-			return groups.filter(({ id }) => id !== '__nc_internal_recent' && id !== 'disabled')
+			return groups.filter(isSelectableGroup)
 		},
 
 		availableSubAdminGroups() {

--- a/apps/settings/src/components/Users/userFormUtils.spec.ts
+++ b/apps/settings/src/components/Users/userFormUtils.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { diffPayload, languageFilterBy, resolveLanguage, userToFormData, validateQuota } from './userFormUtils.ts'
+import { diffPayload, isSelectableGroup, languageFilterBy, resolveLanguage, userToFormData, validateQuota } from './userFormUtils.ts'
 
 describe('resolveLanguage', () => {
 	const serverLanguages = {
@@ -263,6 +263,18 @@ describe('diffPayload', () => {
 			password: 'newpass',
 			email: 'new@example.com',
 		})
+	})
+})
+
+describe('isSelectableGroup', () => {
+	it('allows regular groups in the groups picker', () => {
+		expect(isSelectableGroup({ id: 'devs', name: 'Developers' })).toBe(true)
+	})
+
+	it('hides internal and guest-only groups from the groups picker', () => {
+		expect(isSelectableGroup({ id: '__nc_internal_recent', name: 'Recently active' })).toBe(false)
+		expect(isSelectableGroup({ id: 'disabled', name: 'Disabled accounts' })).toBe(false)
+		expect(isSelectableGroup({ id: 'guest_app', name: 'Guests' })).toBe(false)
 	})
 })
 

--- a/apps/settings/src/components/Users/userFormUtils.ts
+++ b/apps/settings/src/components/Users/userFormUtils.ts
@@ -30,6 +30,21 @@ interface FormData {
 	manager: string | { id: string, displayname?: string }
 }
 
+const UNSELECTABLE_GROUP_IDS = [
+	'__nc_internal_recent',
+	'disabled',
+	'guest_app',
+]
+
+/**
+ * Whether a group can be offered as a selectable account group option.
+ *
+ * @param group Group option
+ */
+export function isSelectableGroup(group: IGroup): boolean {
+	return !UNSELECTABLE_GROUP_IDS.includes(group.id)
+}
+
 /**
  * Resolves the user's language code to a { code, name } object.
  *


### PR DESCRIPTION
* Resolves: #57992 

## Summary

Hide the virtual guests app group from the account manager groups picker.

The guests app exposes a virtual `guest_app` group with the display name `Guests`. This group cannot be manually assigned from the accounts UI, and selecting it would not apply guest restrictions. This PR treats it like the existing internal groups that are not selectable in the picker, while keeping existing membership data untouched.

## TODO

- [ ] Regenerate/update frontend `dist` if required by CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

### Testing

- `npx vitest --config vitest.local.config.ts run`
  - 46 tests passed
- `git diff --check`
  - OK

Note: I could not regenerate the legacy frontend `dist` locally. The full legacy build ran out of memory first, then timed out after 20 minutes even with `NODE_OPTIONS=--max-old-space-size=8192`.

## AI (if applicable)

- [x] The content of this PR was partly generated using AI
