### PR TITLE
feat(openmetrics): export more resilient if exception happens

### DIFF
--- a/core/Controller/OpenMetricsController.php
+++ b/core/Controller/OpenMetricsController.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -51,13 +52,9 @@ class OpenMetricsController extends Controller {
 			return new Response(Http::STATUS_FORBIDDEN);
 		}
 
-		return new StreamTraversableResponse(
-			$this->generate(),
-			Http::STATUS_OK,
-			[
-				'Content-Type' => 'application/openmetrics-text; version=1.0.0; charset=utf-8',
-			]
-		);
+		return new StreamTraversableResponse($this->generate(), Http::STATUS_OK, [
+			'Content-Type' => 'application/openmetrics-text; version=1.0.0; charset=utf-8',
+		]);
 	}
 
 	private function isRemoteAddressAllowed(): bool {
@@ -80,7 +77,16 @@ class OpenMetricsController extends Controller {
 
 	private function generate(): \Generator {
 		foreach ($this->exporterManager->export() as $family) {
-			yield $this->formatFamily($family);
+			try {
+				yield $this->formatFamily($family);
+			} catch (\Exception $e) {
+				// Skip family and return a valid result
+				$this->logger->error('Exception caught when exporting family {family}', [
+					'app' => 'metrics',
+					'family' => $family->name(),
+					'exception' => $e,
+				]);
+			}
 		}
 
 		$elapsed = (string)(microtime(true) - $_SERVER['REQUEST_TIME_FLOAT']);
@@ -131,11 +137,7 @@ class OpenMetricsController extends Controller {
 	}
 
 	private function escapeString(string $string): string {
-		return json_encode(
-			$string,
-			JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
-			1
-		);
+		return json_encode($string, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR, 1);
 	}
 
 	private function formatValue(Metric $metric): string {


### PR DESCRIPTION
## Summary

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
