### PR TITLE
fix(dav): show canceled/moved occurrences in iMIP emails

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -150,7 +150,14 @@ class IMipPlugin extends SabreIMipPlugin {
 		$vEvent = array_pop($modified['new']);
 		/** @var VEvent $oldVevent */
 		$oldVevent = !empty($modified['old']) && is_array($modified['old']) ? array_pop($modified['old']) : null;
-		$isModified = isset($oldVevent);
+		// Treat as a modification (use "updated" wording) if either:
+		// - the EventComparisonService matched an old VEvent, or
+		// - the old VCalendar already contains a VEvent with the same UID (e.g. a
+		//   single-occurrence move adds a brand-new override with no old counterpart,
+		//   but the series itself is not new to the attendee).
+		$isExistingSeries = $oldEvents !== null && isset($vEvent->UID)
+			&& $this->imipService->findMasterEvent($oldEvents, (string)$vEvent->UID) !== null;
+		$isModified = isset($oldVevent) || $isExistingSeries;
 
 		// No changed events after all - this shouldn't happen if there is significant change yet here we are
 		// The scheduling status is debatable
@@ -211,7 +218,7 @@ class IMipPlugin extends SabreIMipPlugin {
 				break;
 			default:
 				$method = self::METHOD_REQUEST;
-				$data = $this->imipService->buildBodyData($vEvent, $oldVevent);
+				$data = $this->imipService->buildBodyData($vEvent, $oldVevent, $newEvents, $oldEvents);
 				break;
 		}
 

--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -152,9 +152,11 @@ class IMipService {
 	/**
 	 * @param VEvent $vEvent
 	 * @param VEvent|null $oldVEvent
+	 * @param VCalendar|null $newVCalendar full new VCalendar, used to find sibling overrides/EXDATEs
+	 * @param VCalendar|null $oldVCalendar full old VCalendar, used to diff EXDATEs and overrides
 	 * @return array
 	 */
-	public function buildBodyData(VEvent $vEvent, ?VEvent $oldVEvent): array {
+	public function buildBodyData(VEvent $vEvent, ?VEvent $oldVEvent, ?VCalendar $newVCalendar = null, ?VCalendar $oldVCalendar = null): array {
 		// construct event reader
 		$eventReaderCurrent = new EventReader($vEvent);
 		$eventReaderPrevious = !empty($oldVEvent) ? new EventReader($oldVEvent) : null;
@@ -191,7 +193,193 @@ class IMipService {
 		if ($eventReaderCurrent->recurs()) {
 			$data['meeting_occurring'] = $this->generateOccurringString($eventReaderCurrent);
 		}
+		// detect canceled / moved occurrences using full VCalendar context
+		if ($newVCalendar !== null && isset($vEvent->UID)) {
+			$changes = $this->detectRecurrenceChanges((string)$vEvent->UID, $newVCalendar, $oldVCalendar);
+			if (!empty($changes['canceled'])) {
+				$data['meeting_canceled_occurrences'] = $changes['canceled'];
+			}
+			if (!empty($changes['moved'])) {
+				$data['meeting_moved_occurrences'] = $changes['moved'];
+			}
+		}
 		return $data;
+	}
+
+	/**
+	 * Find the master VEvent (the one without RECURRENCE-ID) for the given UID.
+	 */
+	public function findMasterEvent(VCalendar $vCalendar, string $uid): ?VEvent {
+		foreach ($vCalendar->getComponents() as $component) {
+			if (!$component instanceof VEvent) {
+				continue;
+			}
+			if (!isset($component->UID) || (string)$component->UID !== $uid) {
+				continue;
+			}
+			if (!isset($component->{'RECURRENCE-ID'})) {
+				return $component;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Find all override VEvents (those with RECURRENCE-ID) for the given UID,
+	 * keyed by the RECURRENCE-ID timestamp.
+	 *
+	 * @return array<int, VEvent>
+	 */
+	private function findOverrideEvents(VCalendar $vCalendar, string $uid): array {
+		$result = [];
+		foreach ($vCalendar->getComponents() as $component) {
+			if (!$component instanceof VEvent) {
+				continue;
+			}
+			if (!isset($component->UID) || (string)$component->UID !== $uid) {
+				continue;
+			}
+			if (!isset($component->{'RECURRENCE-ID'})) {
+				continue;
+			}
+			/** @var Property\ICalendar\DateTime $recId */
+			$recId = $component->{'RECURRENCE-ID'};
+			$ts = $recId->getDateTime()->getTimestamp();
+			$result[$ts] = $component;
+		}
+		return $result;
+	}
+
+	/**
+	 * Collect EXDATE values from a master VEvent, keyed by timestamp.
+	 *
+	 * @return array<int, \DateTimeInterface>
+	 */
+	private function collectExdates(VEvent $master): array {
+		$result = [];
+		if (!isset($master->EXDATE)) {
+			return $result;
+		}
+		foreach ($master->EXDATE as $property) {
+			/** @var Property\ICalendar\DateTime $property */
+			foreach ($property->getDateTimes() as $dt) {
+				$result[$dt->getTimestamp()] = $dt;
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Build human-readable strings for newly-canceled and newly-moved occurrences
+	 * by diffing the new VCalendar against the old one.
+	 *
+	 * @return array{canceled: string[], moved: string[]}
+	 */
+	private function detectRecurrenceChanges(string $uid, VCalendar $newVCal, ?VCalendar $oldVCal): array {
+		$newMaster = $this->findMasterEvent($newVCal, $uid);
+		$oldMaster = $oldVCal !== null ? $this->findMasterEvent($oldVCal, $uid) : null;
+		$newOverrides = $this->findOverrideEvents($newVCal, $uid);
+		$oldOverrides = $oldVCal !== null ? $this->findOverrideEvents($oldVCal, $uid) : [];
+
+		// entire-day-ness comes from the master (or, as a fallback, the first new override)
+		$entireDay = false;
+		if ($newMaster !== null && isset($newMaster->DTSTART)) {
+			/** @var Property\ICalendar\DateTime $masterStart */
+			$masterStart = $newMaster->DTSTART;
+			$entireDay = !$masterStart->hasTime();
+		} elseif (!empty($newOverrides)) {
+			$firstOverride = reset($newOverrides);
+			if (isset($firstOverride->DTSTART)) {
+				/** @var Property\ICalendar\DateTime $firstStart */
+				$firstStart = $firstOverride->DTSTART;
+				$entireDay = !$firstStart->hasTime();
+			}
+		}
+
+		$newExdates = $newMaster !== null ? $this->collectExdates($newMaster) : [];
+		$oldExdates = $oldMaster !== null ? $this->collectExdates($oldMaster) : [];
+
+		$canceled = [];
+		foreach ($newExdates as $ts => $dt) {
+			if (isset($oldExdates[$ts])) {
+				continue; // already excluded previously
+			}
+			if (isset($newOverrides[$ts])) {
+				continue; // matched by an override -> treated as a move below
+			}
+			$canceled[] = $this->formatCanceledOccurrence($dt, $entireDay);
+		}
+
+		$moved = [];
+		foreach ($newOverrides as $ts => $override) {
+			if (!isset($override->DTSTART) || !isset($override->{'RECURRENCE-ID'})) {
+				continue;
+			}
+			/** @var Property\ICalendar\DateTime $overrideStart */
+			$overrideStart = $override->DTSTART;
+			/** @var Property\ICalendar\DateTime $overrideRecId */
+			$overrideRecId = $override->{'RECURRENCE-ID'};
+			$newStart = $overrideStart->getDateTime();
+			$originalStart = $overrideRecId->getDateTime();
+			if (isset($oldOverrides[$ts]) && isset($oldOverrides[$ts]->DTSTART)) {
+				/** @var Property\ICalendar\DateTime $oldOverrideStart */
+				$oldOverrideStart = $oldOverrides[$ts]->DTSTART;
+				$oldStart = $oldOverrideStart->getDateTime();
+			} else {
+				$oldStart = $originalStart;
+			}
+			if ($newStart->getTimestamp() === $oldStart->getTimestamp()) {
+				continue; // override exists but DTSTART unchanged
+			}
+			$moved[] = $this->formatMovedOccurrence($oldStart, $newStart, $entireDay);
+		}
+
+		return ['canceled' => $canceled, 'moved' => $moved];
+	}
+
+	private function formatCanceledOccurrence(\DateTimeInterface $dt, bool $entireDay): string {
+		$dt = $this->toMutableDateTime($dt);
+		$date = (string)$this->l10n->l('date', $dt, ['width' => 'full']);
+		if ($entireDay) {
+			return $date;
+		}
+		$time = (string)$this->l10n->l('time', $dt, ['width' => 'short']);
+		// TRANSLATORS: Date and time of a canceled occurrence of a recurring event. Example: "Friday, April 24, 2026 at 15:00"
+		return $this->l10n->t('%1$s at %2$s', [$date, $time]);
+	}
+
+	private function formatMovedOccurrence(\DateTimeInterface $oldDt, \DateTimeInterface $newDt, bool $entireDay): string {
+		$oldDt = $this->toMutableDateTime($oldDt);
+		$newDt = $this->toMutableDateTime($newDt);
+		$oldDate = (string)$this->l10n->l('date', $oldDt, ['width' => 'full']);
+		$newDate = (string)$this->l10n->l('date', $newDt, ['width' => 'full']);
+		if ($entireDay) {
+			if ($oldDate === $newDate) {
+				return $newDate;
+			}
+			// TRANSLATORS: A moved all-day occurrence of a recurring event. Example: "from Friday, April 24, 2026 to Saturday, April 25, 2026"
+			return $this->l10n->t('from %1$s to %2$s', [$oldDate, $newDate]);
+		}
+		$oldTime = (string)$this->l10n->l('time', $oldDt, ['width' => 'short']);
+		$newTime = (string)$this->l10n->l('time', $newDt, ['width' => 'short']);
+		if ($oldDate === $newDate) {
+			// TRANSLATORS: A moved occurrence of a recurring event, same date. Example: "Saturday, April 25, 2026 from 15:00 to 16:00"
+			return $this->l10n->t('%1$s from %2$s to %3$s', [$newDate, $oldTime, $newTime]);
+		}
+		// TRANSLATORS: A moved occurrence of a recurring event across dates. Example: "from Friday, April 24, 2026 15:00 to Saturday, April 25, 2026 16:00"
+		return $this->l10n->t('from %1$s %2$s to %3$s %4$s', [$oldDate, $oldTime, $newDate, $newTime]);
+	}
+
+	/**
+	 * Nextcloud's IL10N::l() only matches \DateTime via instanceof; a \DateTimeImmutable
+	 * (which is what Sabre's getDateTime()/getDateTimes() returns) falls through to the
+	 * numeric branch and gets cast via (int), producing timestamp 1 → epoch 0 dates.
+	 */
+	private function toMutableDateTime(\DateTimeInterface $dt): \DateTime {
+		if ($dt instanceof \DateTime) {
+			return $dt;
+		}
+		return \DateTime::createFromImmutable($dt);
 	}
 
 	/**
@@ -1126,6 +1314,20 @@ class IMipService {
 		if (isset($data['meeting_occurring'])) {
 			$template->addBodyListItem($data['meeting_occurring_html'] ?? htmlspecialchars($data['meeting_occurring']), $this->l10n->t('Occurring:'),
 				$this->getAbsoluteImagePath('caldav/time.png'), $data['meeting_occurring'], '', IMipPlugin::IMIP_INDENT);
+		}
+		if (!empty($data['meeting_canceled_occurrences'])) {
+			$values = $data['meeting_canceled_occurrences'];
+			$html = implode('<br />', array_map('htmlspecialchars', $values));
+			$plain = implode("\n", $values);
+			$template->addBodyListItem($html, $this->l10n->t('Cancelled:'),
+				$this->getAbsoluteImagePath('caldav/time.png'), $plain, '', IMipPlugin::IMIP_INDENT);
+		}
+		if (!empty($data['meeting_moved_occurrences'])) {
+			$values = $data['meeting_moved_occurrences'];
+			$html = implode('<br />', array_map('htmlspecialchars', $values));
+			$plain = implode("\n", $values);
+			$template->addBodyListItem($html, $this->l10n->t('Moved:'),
+				$this->getAbsoluteImagePath('caldav/time.png'), $plain, '', IMipPlugin::IMIP_INDENT);
 		}
 
 		$this->addAttendees($template, $vevent);

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
@@ -427,6 +427,167 @@ class IMipServiceTest extends TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
+	private function stubL10nGeneric(): void {
+		// l('date'|'time', \DateTime, opts) — the \DateTime hint also guards against
+		// regressions of the DateTimeImmutable -> epoch-0 bug, since passing an
+		// Immutable here would raise a TypeError.
+		$this->l10n->method('l')
+			->willReturnCallback(static function (string $type, \DateTime $date, $opts): string {
+				return $type === 'time' ? $date->format('H:i') : $date->format('Y-m-d');
+			});
+		$this->l10n->method('t')
+			->willReturnCallback(static function (string $tmpl, array $args = []): string {
+				return vsprintf(preg_replace('/%\d+\$s/', '%s', $tmpl), $args);
+			});
+		$this->l10n->method('n')
+			->willReturnCallback(static function (string $singular, string $plural, int $count, array $args = []): string {
+				$tmpl = $count === 1 ? $singular : $plural;
+				$tmpl = str_replace('%n', (string)$count, $tmpl);
+				$tmpl = preg_replace('/%\d+\$s/', '%s', $tmpl);
+				return vsprintf($tmpl, $args);
+			});
+	}
+
+	private function buildDailyRecurringVCal(string $uid): VCalendar {
+		$vCal = new VCalendar();
+		$vEvent = $vCal->add('VEVENT', []);
+		$vEvent->UID->setValue($uid);
+		$vEvent->add('DTSTART', '20240701T080000', ['TZID' => 'Europe/Berlin']);
+		$vEvent->add('DTEND', '20240701T090000', ['TZID' => 'Europe/Berlin']);
+		$vEvent->add('SUMMARY', 'Daily Recurring Event');
+		$vEvent->add('RRULE', 'FREQ=DAILY');
+		return $vCal;
+	}
+
+	public function testBuildBodyDataDetectsCanceledOccurrence(): void {
+		$this->stubL10nGeneric();
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime('20240630T000000'));
+
+		$uid = '96a0e6b1-d886-4a55-a60d-152b31401dcc';
+		$newVCal = $this->buildDailyRecurringVCal($uid);
+		$newVCal->VEVENT[0]->add('EXDATE', '20240703T080000', ['TZID' => 'Europe/Berlin']);
+		$oldVCal = $this->buildDailyRecurringVCal($uid);
+
+		$data = $this->service->buildBodyData(
+			$newVCal->VEVENT[0],
+			$oldVCal->VEVENT[0],
+			$newVCal,
+			$oldVCal,
+		);
+
+		$this->assertArrayHasKey('meeting_canceled_occurrences', $data);
+		$this->assertSame(['2024-07-03 at 08:00'], $data['meeting_canceled_occurrences']);
+		$this->assertArrayNotHasKey('meeting_moved_occurrences', $data);
+	}
+
+	public function testBuildBodyDataIgnoresPreexistingExdates(): void {
+		$this->stubL10nGeneric();
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime('20240630T000000'));
+
+		$uid = '96a0e6b1-d886-4a55-a60d-152b31401dcc';
+		$newVCal = $this->buildDailyRecurringVCal($uid);
+		$newVCal->VEVENT[0]->add('EXDATE', '20240703T080000', ['TZID' => 'Europe/Berlin']);
+		$newVCal->VEVENT[0]->add('EXDATE', '20240704T080000', ['TZID' => 'Europe/Berlin']);
+		$oldVCal = $this->buildDailyRecurringVCal($uid);
+		$oldVCal->VEVENT[0]->add('EXDATE', '20240703T080000', ['TZID' => 'Europe/Berlin']);
+
+		$data = $this->service->buildBodyData(
+			$newVCal->VEVENT[0],
+			$oldVCal->VEVENT[0],
+			$newVCal,
+			$oldVCal,
+		);
+
+		$this->assertSame(['2024-07-04 at 08:00'], $data['meeting_canceled_occurrences']);
+	}
+
+	public function testBuildBodyDataDetectsMovedOccurrence(): void {
+		$this->stubL10nGeneric();
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime('20240630T000000'));
+
+		$uid = '96a0e6b1-d886-4a55-a60d-152b31401dcc';
+		$newVCal = $this->buildDailyRecurringVCal($uid);
+		$override = $newVCal->add('VEVENT', []);
+		$override->UID->setValue($uid);
+		$override->add('DTSTART', '20240703T093000', ['TZID' => 'Europe/Berlin']);
+		$override->add('DTEND', '20240703T103000', ['TZID' => 'Europe/Berlin']);
+		$override->add('RECURRENCE-ID', '20240703T080000', ['TZID' => 'Europe/Berlin']);
+		$override->add('SUMMARY', 'Daily Recurring Event');
+
+		$oldVCal = $this->buildDailyRecurringVCal($uid);
+
+		// IMipPlugin pops the changed VEvent — for a new override that's the override itself.
+		$data = $this->service->buildBodyData(
+			$newVCal->VEVENT[1],
+			null,
+			$newVCal,
+			$oldVCal,
+		);
+
+		$this->assertArrayHasKey('meeting_moved_occurrences', $data);
+		$this->assertSame(['2024-07-03 from 08:00 to 09:30'], $data['meeting_moved_occurrences']);
+		$this->assertArrayNotHasKey('meeting_canceled_occurrences', $data);
+	}
+
+	public function testBuildBodyDataDetectsMovedOccurrenceAcrossDays(): void {
+		$this->stubL10nGeneric();
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime('20240630T000000'));
+
+		$uid = '96a0e6b1-d886-4a55-a60d-152b31401dcc';
+		$newVCal = $this->buildDailyRecurringVCal($uid);
+		// Move the July 3, 08:00 occurrence to July 4, 09:30 (different day + time).
+		$override = $newVCal->add('VEVENT', []);
+		$override->UID->setValue($uid);
+		$override->add('DTSTART', '20240704T093000', ['TZID' => 'Europe/Berlin']);
+		$override->add('DTEND', '20240704T103000', ['TZID' => 'Europe/Berlin']);
+		$override->add('RECURRENCE-ID', '20240703T080000', ['TZID' => 'Europe/Berlin']);
+		$override->add('SUMMARY', 'Daily Recurring Event');
+
+		$oldVCal = $this->buildDailyRecurringVCal($uid);
+
+		$data = $this->service->buildBodyData(
+			$newVCal->VEVENT[1],
+			null,
+			$newVCal,
+			$oldVCal,
+		);
+
+		// Cross-day pattern: "from <olddate> <oldtime> to <newdate> <newtime>".
+		$this->assertSame(['from 2024-07-03 08:00 to 2024-07-04 09:30'], $data['meeting_moved_occurrences']);
+	}
+
+	public function testBuildBodyDataReturnsNoExtraKeysWhenNothingRecurrenceChanged(): void {
+		$this->stubL10nGeneric();
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime('20240630T000000'));
+
+		$uid = '96a0e6b1-d886-4a55-a60d-152b31401dcc';
+		$vCal = $this->buildDailyRecurringVCal($uid);
+
+		$data = $this->service->buildBodyData(
+			$vCal->VEVENT[0],
+			$vCal->VEVENT[0],
+			$vCal,
+			$vCal,
+		);
+
+		$this->assertArrayNotHasKey('meeting_canceled_occurrences', $data);
+		$this->assertArrayNotHasKey('meeting_moved_occurrences', $data);
+	}
+
+	public function testFindMasterEventSkipsOverrides(): void {
+		$uid = '96a0e6b1-d886-4a55-a60d-152b31401dcc';
+		$vCal = $this->buildDailyRecurringVCal($uid);
+		$override = $vCal->add('VEVENT', []);
+		$override->UID->setValue($uid);
+		$override->add('DTSTART', '20240703T093000', ['TZID' => 'Europe/Berlin']);
+		$override->add('RECURRENCE-ID', '20240703T080000', ['TZID' => 'Europe/Berlin']);
+
+		$master = $this->service->findMasterEvent($vCal, $uid);
+		$this->assertNotNull($master);
+		$this->assertFalse(isset($master->{'RECURRENCE-ID'}));
+		$this->assertSame('20240701T080000', $master->DTSTART->getValue());
+	}
+
 	public function testBuildReplyBodyDataEscapesStrings(): void {
 		$this->l10n->method('l')
 			->willReturnCallback(static function (string $type, \DateTime $date, $_):string {


### PR DESCRIPTION
* Resolves: #60451

## Summary

When the organizer modifies a single occurrence of a recurring event, the iMIP notification email did not indicate which occurrence was affected - the body only described the series. This PR makes the body convey the same information that Thunderbird already extracts from the ICS attachment.

Three concrete fixes:

1. **`Cancelled:` row** added for each `EXDATE` newly present on the master `VEVENT` that has no matching `RECURRENCE-ID` override.
2. **`Moved:` row** added for each override whose `DTSTART` differs from its `RECURRENCE-ID` (or from its previous `DTSTART`). Same-day move renders as `<date> from <oldtime> to <newtime>`; cross-day move as `from <olddate> <oldtime> to <newdate> <newtime>`.
3. **"updated" wording** is now used when the recipient is already on the existing series. `EventComparisonService` cannot match a brand-new override `VEvent` to an old `VEvent`, so the previous code fell through to the "would like to invite you" wording for single-occurrence moves. We now consult the old `VCalendar` for the same `UID` to detect that case.

New rows reuse the existing `addBodyListItem` styling (italic gray label + value on its own line), matching `When:`, `Title:`, etc.

## Scope decisions (intentionally out of scope)

- **Accept/Decline button suppression on cancellation-only updates** (issue's secondary bullet) is *not* included. An earlier iteration suppressed them, but on inspection the underlying iTip message Sabre generates is still `METHOD:REQUEST`, so the user's mail client (Thunderbird etc.) keeps showing its own Accept/Decline buttons at the top of the email. Hiding only Nextcloud's body buttons would create inconsistent UI without solving the underlying problem. A proper fix would require Sabre's `TipBroker` to emit a `METHOD:CANCEL` with `RECURRENCE-ID` for single-occurrence deletions, which is a much larger change with cross-client compatibility risk and belongs in its own PR.
- **Dedicated `Renamed:` row for single-occurrence title changes** (issue's Case D) is *not* included. The current behavior already renders the renamed occurrence's title + when in the body and now uses "updated" wording, which the issue notes is "actually useful". The spec under "Expected behavior" only enumerates *Canceled* and *Moved*. Happy to add it as a follow-up if maintainers prefer.

## Implementation notes

- `IMipService::buildBodyData()` gained two optional `?VCalendar` parameters (new and old). The original two-argument signature is preserved (existing tests untouched).
- New private helpers: `detectRecurrenceChanges()`, `collectExdates()`, `findOverrideEvents()`, `formatCanceledOccurrence()`, `formatMovedOccurrence()`, `toMutableDateTime()`. One public helper `findMasterEvent()` (needed by `IMipPlugin` to detect existing series).
- **Notable footgun discovered:** `Sabre\VObject\Property\ICalendar\DateTime::getDateTimes()` returns `\DateTimeImmutable`, which is a sibling of `\DateTime`, not a subclass. `OC\L10N\L10N::l()` at `lib/private/L10N/L10N.php:156` checks `if ($data instanceof \DateTime)` and falls through to `(int)$data` for anything else - silently casting an Immutable to `1` and rendering as `1970-01-01 00:00:01`. A small `toMutableDateTime()` helper converts before formatting. Worth considering as a separate hardening of `IL10N::l()` so it accepts `\DateTimeInterface`, since any future caller wiring Sabre's parsed dates into `l()` will hit the same trap.

## Translations

~German translations for the new strings (`Cancelled:`, `Moved:`, `%1$s at %2$s`, `%1$s from %2$s to %3$s`, `from %1$s to %2$s`, `from %1$s %2$s to %3$s %4$s`) are included manually in `apps/dav/l10n/de.{js,json}` and `apps/dav/l10n/de_DE.{js,json}` so DE users see them on day one. I'm aware Transifex is the source of truth and the next sync will overwrite these - by then Transifex will have its own translation for the same strings, so the effect is the same. Happy to drop the manual entries if maintainers prefer the strict Transifex-only workflow.~

The new format strings (`%1$s at %2$s`, `from %1$s to %2$s`, etc.) are intentionally generic so they can be translated naturally per locale; TRANSLATORS comments are inline with each `l10n->t()` call to give context.

## Test plan

**Setup** (applies to all four tests):

- **User A** - organizer aka "admin"; creates a daily recurring event in the Nextcloud Calendar web UI, invites B and C via the user picker (principal-based scheduling).
- **User B** - invitee, NC locale `en`, has **not** accepted the series yet.
- **User C** - invitee, NC locale `de`, **has accepted** the series (with Thunderbird).
- Both attendees read the resulting iMIP emails in Thunderbird with CalDAV sync paused, to observe raw email content unfiltered by any client-side merging.
- Each test run twice on the same Nextcloud 33.0.3 instance: once with the upstream `stable33` code (Before), once with this PR applied (After).

### Test 1 - delete a single occurrence (issue Case A & C combined)

**Action:** User A deletes occurrence on `<DATE>` via "Delete this occurrence" in the Nextcloud Calendar web UI.

#### User B (EN, not accepted)

**Subject** (unchanged)
```
Invitation updated: Project NC Weekly
```

**Body**
```diff
  admin updated the event "Project NC Weekly"

  Title:
  Project NC Weekly

  When:
  Every Week on Monday between 10:00 AM - 10:30 AM (Europe/Berlin)

  Occurring:
  In 6 days on May 25, 2026 then on June 1, 2026 and June 8, 2026
+
+ Cancelled:
+ Monday, July 13, 2026 at 10:00 AM
```

#### User C (DE, accepted)

**Subject** (unchanged)
```
Einladung aktualisiert: Project NC Weekly
```

**Body**
```diff
  admin hat die Veranstaltung "Project NC Weekly" aktualisiert

  Titel:
  Project NC Weekly

  Wann:
  Jede Woche am Montag zwischen 10:00 - 10:30 (Europe/Berlin)

  Findet statt:
  In 6 Tagen am 25. Mai 2026 danach am 1. Juni 2026 und 8. Juni 2026
+
+ Abgesagt:
+ Montag, 13. Juli 2026 um 10:00
```

**Expected change After this PR:** new `Cancelled: <date> at <time>` (B) / `Abgesagt: <datum> um <zeit>` (C) row appears in the body. Subject and heading already used "updated" wording before the PR for the delete case, so unchanged.

---

### Test 2 - move a single occurrence, same day (issue Case B)

**Action:** User A moves the occurrence on `<DATE>` from `<oldtime>` to `<newtime>` (same day, time-only change) in the Nextcloud Calendar web UI.

#### User B (EN, not accepted)

**Subject**
```diff
- Invitation: Project NC Weekly
+ Invitation updated: Project NC Weekly
```

**Body**
```diff
- admin would like to invite you to "Project NC Weekly"
+ admin updated the event "Project NC Weekly"

  Title:
  Project NC Weekly

  When:
  In 2 months on Monday, July 20, 2026 between 2:00 PM - 2:30 PM (Europe/Berlin)
+
+ Moved:
+ Monday, July 20, 2026 from 10:00 AM to 2:00 PM
```

#### User C (DE, accepted)

**Subject**
```diff
- Einladung: Project NC Weekly
+ Einladung aktualisiert: Project NC Weekly
```

**Body**
```diff
- admin möchte dich zu "Project NC Weekly" einladen.
+ admin hat die Veranstaltung "Project NC Weekly" aktualisiert

  Titel:
  Project NC Weekly

  Wann:
  In 2 Monaten am Montag, 20. Juli 2026 zwischen 14:00 - 14:30 (Europe/Berlin)
+
+ Verschoben:
+ Montag, 20. Juli 2026 von 10:00 auf 14:00
```

**Expected change After this PR:**
1. New `Moved: <date> from <oldtime> to <newtime>` (B) / `Verschoben: <datum> von <alt> auf <neu>` (C) row appears in the body.
2. For User B specifically: subject and heading switch from "Invitation:" / "would like to invite you" to "Invitation updated:" / "updated the event" (Bug from issue's Case B).

---

### Test 3 - move a single occurrence, different day **and** time (additional, not in original issue)

**Action:** User A moves the occurrence on `<DATE>` to a different day **and** a different time in the Nextcloud Calendar web UI.

#### User B (EN, not accepted)

**Subject**
```diff
- Invitation: Project NC Weekly
+ Invitation updated: Project NC Weekly
```

**Body**
```diff
- admin would like to invite you to "Project NC Weekly"
+ admin updated the event "Project NC Weekly"

  Title:
  Project NC Weekly

  When:
  In 2 months on Tuesday, July 28, 2026 between 9:00 AM - 9:30 AM (Europe/Berlin)
+
+ Moved:
+ from Monday, July 27, 2026 10:00 AM to Tuesday, July 28, 2026 9:00 AM
```

#### User C (DE, accepted)

**Subject**
```diff
- Einladung: Project NC Weekly
+ Einladung aktualisiert: Project NC Weekly
```

**Body**
```diff
- admin möchte dich zu "Project NC Weekly" einladen.
+ admin hat die Veranstaltung "Project NC Weekly" aktualisiert

  Titel:
  Project NC Weekly

  Wann:
  In 2 Monaten am Dienstag, 28. Juli 2026 zwischen 09:00 - 09:30 (Europe/Berlin)
+
+ Verschoben:
+ von Montag, 27. Juli 2026 10:00 auf Dienstag, 28. Juli 2026 09:00
```

**Expected change After this PR:** new `Moved: from <olddate> <oldtime> to <newdate> <newtime>` (B) / `Verschoben: von <altdatum> <altzeit> auf <neudatum> <neuzeit>` (C) row.

---

### Test 4 - rename a single occurrence (issue Case D)

**Action:** User A changes the title of the occurrence on `<DATE>` to a new title in the Nextcloud Calendar web UI.

#### User B (EN, not accepted)

**Subject**
```diff
- Invitation: Project NC Weekly / Next Chapter
+ Invitation updated: Project NC Weekly / Next Chapter
```

**Body**
```diff
- admin would like to invite you to "Project NC Weekly / Next Chapter"
+ admin updated the event "Project NC Weekly / Next Chapter"

  Title:
  Project NC Weekly / Next Chapter

  When:
  In 2 months on Monday, August 3, 2026 between 10:00 AM - 10:30 AM (Europe/Berlin)
```

#### User C (DE, accepted)

**Subject**
```diff
- Einladung: Project NC Weekly / Next Chapter
+ Einladung aktualisiert: Project NC Weekly / Next Chapter
```

**Body**
```diff
- admin möchte dich zu "Project NC Weekly / Next Chapter" einladen.
+ admin hat die Veranstaltung "Project NC Weekly / Next Chapter" aktualisiert

  Titel:
  Project NC Weekly / Next Chapter

  Wann:
  In 2 Monaten am Montag, 3. August 2026 zwischen 10:00 - 10:30 (Europe/Berlin)
```

**Expected change After this PR:** heading switches from "would like to invite you" to "updated the event" for User B. No dedicated `Renamed:` row - see *Scope decisions*.

> Note: The original issue (#60451) only described User-B-style behavior for the rename case and implied this might be specific to non-accepted attendees. Re-testing for this PR showed both User B and User C (accepted) get the buggy "would like to invite" heading before the patch - git log confirms no relevant code change in the wording logic between v33.0.2 (issue version) and current stable33, so the original report likely had a small testing-setup variation. The fix in this PR covers both cases.


---

### Rendered styling (screenshots)

Text-only paste does not convey that the new `Cancelled:` / `Moved:` labels are styled identically to the existing `When:` / `Title:` rows (italic, gray `#777`, on a line of their own above the value). The screenshots below show the rendered HTML email.

**Cancelled row** (after Test 1):

<img width="535" height="334" alt="Screenshot_20260518_144939" src="https://github.com/user-attachments/assets/f16174da-a2d7-4ffe-81c0-6c334f8440cd" />


**Moved row** (after Test 2):

<img width="535" height="283" alt="Screenshot_20260518_144915" src="https://github.com/user-attachments/assets/0950c820-7e87-4319-9bad-ee1a5e8d36d6" />

## Unit tests

Added six cases in `apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php`:

| Test | Verifies |
|------|----------|
| `testBuildBodyDataDetectsCanceledOccurrence` | Newly-added EXDATE → `meeting_canceled_occurrences` populated with correct date |
| `testBuildBodyDataIgnoresPreexistingExdates` | Pre-existing EXDATE not reported as newly canceled |
| `testBuildBodyDataDetectsMovedOccurrence` | New override with shifted DTSTART → `meeting_moved_occurrences` populated (same-day) |
| `testBuildBodyDataDetectsMovedOccurrenceAcrossDays` | Same as above, cross-day format |
| `testBuildBodyDataReturnsNoExtraKeysWhenNothingRecurrenceChanged` | Identical old/new VCalendars → no canceled/moved keys |
| `testFindMasterEventSkipsOverrides` | Master finder ignores VEVENTs that carry a RECURRENCE-ID |

The l10n stub in these tests intentionally type-hints `\DateTime` (not `\DateTimeInterface`) so any regression of the `DateTimeImmutable` issue would surface as a `TypeError` rather than silently producing epoch-0 output.

Locally run against this branch (`apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php`):

```
PHPUnit 11.5.50 by Sebastian Bergmann and contributors.

................................                                  32 / 32 (100%)

Tests: 32, Assertions: 248
```

(The runner additionally emits `PHPUnit Deprecations: 1` — `"Your XML configuration validates against a deprecated schema"` referring to `apps/dav/tests/unit/phpunit.xml`. Pre-existing on master, unrelated to this PR.)

`php-cs-fixer --dry-run` reports `Found 0 of 3 files that can be fixed` on the three modified PHP files.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included - 6 new unit cases in `IMipServiceTest`
- [x] Screenshots before/after for front-end changes - text bodies pasted above for each case; rendered styling included as screenshots
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required - not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable - please backport to `stable33` (issue affects 33.x, verified there)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (paired with Claude Code; human-reviewed and manually tested on a Nextcloud 33.0.3 instance with three attendees in two languages)
