### PR TITLE
fix: remove too verbose error log line in AddExtraHeadersPlugin

### DIFF
--- a/apps/dav/lib/Connector/Sabre/AddExtraHeadersPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AddExtraHeadersPlugin.php
@@ -55,8 +55,6 @@ class AddExtraHeadersPlugin extends \Sabre\DAV\ServerPlugin {
 		}
 
 		if (!$node instanceof Node) {
-			$nodeType = get_debug_type($node);
-			$this->logger->error("Cannot set extra headers for node of type {$nodeType} for file '{$request->getPath()}'");
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Log line is too verbose and happens when editing contacts or calendar events.

Introduced in https://github.com/nextcloud/server/pull/54542

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
