### PR TITLE
fix(appstore): use alias for translations as `appstore` is taken by `apps.nextcloud.com`

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -8,7 +8,7 @@ source_file = translationfiles/templates/admin_audit.pot
 source_lang = en
 type        = PO
 
-[o:nextcloud:p:nextcloud:r:appstore]
+[o:nextcloud:p:nextcloud:r:appstore-shipped-with-server]
 file_filter = translationfiles/<lang>/appstore.po
 source_file = translationfiles/templates/appstore.pot
 source_lang = en

--- a/build/translation-checker.php
+++ b/build/translation-checker.php
@@ -19,6 +19,7 @@ $untranslatedApps = [
 ];
 
 $txConfigAppMap = [
+	'appstore' => 'appstore-shipped-with-server',
 	'dashboard' => 'dashboard-shipped-with-server',
 	'encryption' => 'files_encryption',
 	'settings' => 'settings-1',


### PR DESCRIPTION

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/docker-ci/issues/930


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
