### PR TITLE
fix(dav): suppress iTip REQUEST for PARTSTAT-only occurrence overrides

### DIFF
--- a/apps/dav/lib/CalDAV/TipBroker.php
+++ b/apps/dav/lib/CalDAV/TipBroker.php
@@ -215,12 +215,197 @@ class TipBroker extends Broker {
 				}
 			}
 
+			$significant = $this->isRequestSignificantForAttendee($attendee, $eventInfo, $oldEventInfo);
 			$messages[] = $this->generateMessage(
-				$instances, $organizerHref, $organizerName, $eventInfo['attendees'][$attendee], $objectId, $objectType, $objectSequence, 'REQUEST', $template
+				$instances, $organizerHref, $organizerName, $eventInfo['attendees'][$attendee], $objectId, $objectType, $objectSequence, 'REQUEST', $template, $significant
 			);
 		}
 
 		return $messages;
+	}
+
+	/**
+	 * Decide whether a REQUEST is materially relevant for a specific attendee.
+	 *
+	 * A REQUEST broadcast is meaningful only when something the attendee would
+	 * actually care about changed: scheduling-significant properties on the
+	 * master or on an instance they participate in, the introduction of a new
+	 * override that overrides inherited master state, the attendee being added
+	 * or partially removed, or a forced SCHEDULE-FORCE-SEND=REQUEST.
+	 *
+	 * PARTSTAT changes alone are NOT significant for organizer→attendee
+	 * REQUEST broadcasts; that flow is REPLY-only per RFC 5546. Suppressing
+	 * here fixes the per-occurrence accept/decline re-invite spam.
+	 */
+	protected function isRequestSignificantForAttendee(
+		string $attendeeHref,
+		array $eventInfo,
+		array $oldEventInfo,
+	): bool {
+		$newAttendee = $eventInfo['attendees'][$attendeeHref] ?? null;
+		$oldAttendee = $oldEventInfo['attendees'][$attendeeHref] ?? null;
+
+		if (($newAttendee['forceSend'] ?? null) === 'REQUEST') {
+			return true;
+		}
+		if ($oldAttendee === null) {
+			return true;
+		}
+
+		$newMaster = $eventInfo['instances']['master'] ?? null;
+		$oldMaster = $oldEventInfo['instances']['master'] ?? null;
+		if (($newMaster === null) !== ($oldMaster === null)) {
+			return true;
+		}
+		if ($newMaster !== null && $oldMaster !== null
+			&& $this->instancesDifferInSignificantProperties($newMaster, $oldMaster)) {
+			return true;
+		}
+
+		foreach (($newAttendee['instances'] ?? []) as $instanceId => $_) {
+			if ($instanceId === 'master') {
+				continue;
+			}
+			$newInstance = $eventInfo['instances'][$instanceId] ?? null;
+			if ($newInstance === null) {
+				continue;
+			}
+			$oldInstance = $oldEventInfo['instances'][$instanceId] ?? null;
+			if ($oldInstance !== null) {
+				if ($this->instancesDifferInSignificantProperties($newInstance, $oldInstance)) {
+					return true;
+				}
+			} elseif ($oldMaster !== null
+				&& $this->overrideDiffersFromInheritedMaster($newInstance, $oldMaster)) {
+				return true;
+			}
+		}
+
+		foreach (($oldAttendee['instances'] ?? []) as $instanceId => $_) {
+			if (!isset($newAttendee['instances'][$instanceId])) {
+				return true;
+			}
+		}
+
+		// Synthesized-EXDATE diff: parseEventForOrganizer injects a per-attendee
+		// EXDATE on the outbound master for every override the attendee is not
+		// part of. If this synthesized set changed between old and new state
+		// (a brand-new override now excludes them, or an override they weren't
+		// on was removed), the REQUEST content materially changes and they
+		// must receive it.
+		$newSynthExdates = $this->synthesizedExdatesForAttendee($eventInfo, $newAttendee);
+		$oldSynthExdates = $this->synthesizedExdatesForAttendee($oldEventInfo, $oldAttendee);
+		if ($newSynthExdates !== $oldSynthExdates) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param array $eventInfo An eventInfo dict as produced by parseEventInfo()
+	 * @param array $attendee The merged attendee dict for the recipient
+	 * @return list<string> Sorted list of RECURRENCE-ID values for overrides
+	 *                      this attendee is not on (the EXDATE values that would
+	 *                      be injected into their REQUEST master).
+	 */
+	protected function synthesizedExdatesForAttendee(array $eventInfo, array $attendee): array {
+		$exdates = [];
+		foreach (($eventInfo['instances'] ?? []) as $instanceId => $instance) {
+			if ($instanceId === 'master'
+				|| isset($attendee['instances'][$instanceId])
+				|| !isset($instance->{'RECURRENCE-ID'})) {
+				continue;
+			}
+			$exdates[] = (string)$instance->{'RECURRENCE-ID'}->getValue();
+		}
+		sort($exdates);
+		return $exdates;
+	}
+
+	/**
+	 * Decide whether a newly-introduced override actually changes anything the
+	 * attendee would have inherited from the master.
+	 *
+	 * Unlike a generic significant-property diff, this is asymmetric: the
+	 * override's DTSTART/DTEND are *expected* to differ from the master's
+	 * (they describe a different occurrence). What matters is whether the
+	 * override shifts the time relative to its own RECURRENCE-ID, changes
+	 * duration, or rewrites any date-independent property.
+	 */
+	protected function overrideDiffersFromInheritedMaster(Component $override, Component $master): bool {
+		foreach (['SUMMARY', 'LOCATION', 'DESCRIPTION', 'STATUS'] as $prop) {
+			$oVal = isset($override->$prop) ? (string)$override->$prop->getValue() : null;
+			$mVal = isset($master->$prop) ? (string)$master->$prop->getValue() : null;
+			if ($oVal !== $mVal) {
+				return true;
+			}
+		}
+
+		if (isset($override->DTSTART, $override->{'RECURRENCE-ID'})) {
+			try {
+				$dtstart = $override->DTSTART->getDateTime();
+				$recurId = $override->{'RECURRENCE-ID'}->getDateTime();
+				if ($dtstart->getTimestamp() !== $recurId->getTimestamp()) {
+					return true;
+				}
+			} catch (\Exception $e) {
+				return true;
+			}
+		}
+
+		try {
+			$overrideDuration = $this->computeDurationSeconds($override);
+			$masterDuration = $this->computeDurationSeconds($master);
+			if ($overrideDuration !== null && $masterDuration !== null
+				&& $overrideDuration !== $masterDuration) {
+				return true;
+			}
+		} catch (\Exception $e) {
+			return true;
+		}
+
+		// An override should not carry its own recurrence rules; if it does,
+		// the organizer is doing something unusual and we should not suppress.
+		foreach (['RRULE', 'RDATE', 'EXDATE'] as $prop) {
+			if (isset($override->$prop)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected function computeDurationSeconds(Component $vevent): ?int {
+		if (isset($vevent->DTSTART, $vevent->DTEND)) {
+			return $vevent->DTEND->getDateTime()->getTimestamp()
+				- $vevent->DTSTART->getDateTime()->getTimestamp();
+		}
+		if (isset($vevent->DURATION)) {
+			$interval = $vevent->DURATION->getDateInterval();
+			$ref = new \DateTimeImmutable('@0');
+			return $ref->add($interval)->getTimestamp();
+		}
+		return null;
+	}
+
+	protected function instancesDifferInSignificantProperties(Component $a, Component $b): bool {
+		foreach ($this->significantChangeProperties as $prop) {
+			$aValues = [];
+			foreach ($a->select($prop) as $val) {
+				$aValues[] = (string)$val->getValue();
+			}
+			$bValues = [];
+			foreach ($b->select($prop) as $val) {
+				$bValues[] = (string)$val->getValue();
+			}
+			sort($aValues);
+			sort($bValues);
+			if ($aValues !== $bValues) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -241,6 +426,9 @@ class TipBroker extends Broker {
 	 * @param int $objectSequence The sequence number of the event
 	 * @param string $method The iTip method ('REQUEST', 'CANCEL', 'REPLY', etc.)
 	 * @param VCalendar $template The template calendar object (without event components)
+	 * @param bool|null $significantChange Whether the change is significant for this attendee.
+	 *                                     Defaults to true to preserve historical behavior for
+	 *                                     CANCEL paths. REQUEST callers compute it explicitly.
 	 * @return Message The generated iTip message ready to be sent
 	 */
 	protected function generateMessage(
@@ -253,6 +441,7 @@ class TipBroker extends Broker {
 		int $objectSequence,
 		string $method,
 		VCalendar $template,
+		?bool $significantChange = null,
 	): Message {
 
 		$recipientAddress = $attendee['href'] ?? '';
@@ -277,7 +466,7 @@ class TipBroker extends Broker {
 		$message->senderName = $organizerName;
 		$message->recipient = $recipientAddress;
 		$message->recipientName = $recipientName;
-		$message->significantChange = true;
+		$message->significantChange = $significantChange ?? true;
 		$message->message = $vObject;
 
 		return $message;

--- a/apps/dav/tests/unit/CalDAV/TipBrokerTest.php
+++ b/apps/dav/tests/unit/CalDAV/TipBrokerTest.php
@@ -107,6 +107,7 @@ class TipBrokerTest extends TestCase {
 		$messages = $this->invokePrivate($this->broker, 'parseEventForOrganizer', [$mutatedCalendar, $mutatedEventInfo, $originalEventInfo]);
 		$this->assertCount(1, $messages);
 		$this->assertEquals('REQUEST', $messages[0]->method);
+		$this->assertTrue($messages[0]->significantChange);
 		$this->assertEquals($mutatedCalendar->VEVENT->ORGANIZER->getValue(), $messages[0]->sender);
 		$this->assertEquals($mutatedCalendar->VEVENT->ATTENDEE[0]->getValue(), $messages[0]->recipient);
 	}
@@ -266,6 +267,7 @@ class TipBrokerTest extends TestCase {
 		$this->assertEquals($mutatedCalendar->VEVENT->ATTENDEE[0]->getValue(), $messages[0]->recipient);
 		$this->assertCount(2, $messages[0]->message->VEVENT);
 		$this->assertEquals('20240715T080000', $messages[0]->message->VEVENT[1]->{'RECURRENCE-ID'}->getValue());
+		$this->assertTrue($messages[0]->significantChange);
 
 	}
 
@@ -327,6 +329,7 @@ class TipBrokerTest extends TestCase {
 		$this->assertEquals($mutatedCalendar->VEVENT[1]->ATTENDEE[0]->getValue(), $messages[0]->recipient);
 		$this->assertCount(2, $messages[0]->message->VEVENT);
 		$this->assertEquals('20240715T080000', $messages[0]->message->VEVENT[1]->{'RECURRENCE-ID'}->getValue());
+		$this->assertTrue($messages[0]->significantChange);
 
 	}
 
@@ -506,6 +509,7 @@ class TipBrokerTest extends TestCase {
 		$exdates = $messages[0]->message->VEVENT->EXDATE->getParts();
 		$this->assertContains('20240715T080000', $exdates);
 		$this->assertContains('20240722T080000', $exdates);
+		$this->assertTrue($messages[0]->significantChange);
 	}
 
 	/**
@@ -577,6 +581,212 @@ class TipBrokerTest extends TestCase {
 		$this->assertEquals($mutatedCalendar->VEVENT->ATTENDEE->getValue(), $messages[0]->recipient);
 		// verify SCHEDULE-FORCE-SEND is removed from the message (sanitized)
 		$this->assertFalse(isset($messages[0]->message->VEVENT->ATTENDEE['SCHEDULE-FORCE-SEND']));
+	}
+
+	/**
+	 * Regression test for #60452: an attendee declining a single occurrence
+	 * produces a RECURRENCE-ID override whose only difference from inherited
+	 * master state is one attendee's PARTSTAT. The other unaffected attendee
+	 * must NOT receive a significant REQUEST (i.e. no re-invite email).
+	 */
+	public function testParseEventForOrganizerPartstatOnlyOverrideNotSignificant(): void {
+		// Recurring event with two attendees, both already ACCEPTED on the master.
+		$originalCalendar = clone $this->vCalendar2a;
+		$originalCalendar->VEVENT->ATTENDEE[0]['PARTSTAT'] = 'ACCEPTED';
+		$originalCalendar->VEVENT->add('ATTENDEE', 'mailto:attendee2@testing.com', [
+			'CN' => 'Attendee Two',
+			'CUTYPE' => 'INDIVIDUAL',
+			'PARTSTAT' => 'ACCEPTED',
+			'ROLE' => 'REQ-PARTICIPANT',
+			'RSVP' => 'TRUE',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+
+		// Add an override at one occurrence; attendee1 declines, attendee2 stays ACCEPTED.
+		// Mirror what Thunderbird produces: DTSTART/DTEND on the override point at the
+		// specific occurrence (same as RECURRENCE-ID), the override carries no RRULE.
+		$override = clone $originalCalendar->VEVENT;
+		$override->remove('RRULE');
+		$override->DTSTART->setValue('20240715T080000');
+		$override->DTEND->setValue('20240715T090000');
+		$override->add('RECURRENCE-ID', '20240715T080000', ['TZID' => 'America/Toronto']);
+		$override->ATTENDEE[0]['PARTSTAT'] = 'DECLINED';
+
+		$mutatedCalendar = clone $originalCalendar;
+		$mutatedCalendar->add($override);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForOrganizer', [$mutatedCalendar, $mutatedEventInfo, $originalEventInfo]);
+
+		// One REQUEST per non-organizer attendee is still emitted (Sabre-aligned design:
+		// emit + mark significance). Both must be flagged non-significant so that the
+		// IMipPlugin gate at IMipPlugin.php:105 suppresses the email.
+		$this->assertCount(2, $messages);
+		foreach ($messages as $message) {
+			$this->assertEquals('REQUEST', $message->method);
+			$this->assertFalse($message->significantChange,
+				"PARTSTAT-only override must not trigger a significant REQUEST for {$message->recipient}");
+		}
+	}
+
+	/**
+	 * Counter-test to the regression: if the override changes a significant
+	 * property (DTSTART) in addition to PARTSTAT, both attendees must receive
+	 * a significant REQUEST so the time change reaches them.
+	 */
+	public function testParseEventForOrganizerOverrideWithDtstartChangeIsSignificant(): void {
+		$originalCalendar = clone $this->vCalendar2a;
+		$originalCalendar->VEVENT->ATTENDEE[0]['PARTSTAT'] = 'ACCEPTED';
+		$originalCalendar->VEVENT->add('ATTENDEE', 'mailto:attendee2@testing.com', [
+			'CN' => 'Attendee Two',
+			'CUTYPE' => 'INDIVIDUAL',
+			'PARTSTAT' => 'ACCEPTED',
+			'ROLE' => 'REQ-PARTICIPANT',
+			'RSVP' => 'TRUE',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+
+		$override = clone $originalCalendar->VEVENT;
+		$override->remove('RRULE');
+		// Override moves the occurrence: DTSTART differs from RECURRENCE-ID.
+		$override->add('RECURRENCE-ID', '20240715T080000', ['TZID' => 'America/Toronto']);
+		$override->DTSTART->setValue('20240717T080000');
+		$override->DTEND->setValue('20240717T090000');
+		$override->ATTENDEE[0]['PARTSTAT'] = 'DECLINED';
+
+		$mutatedCalendar = clone $originalCalendar;
+		$mutatedCalendar->add($override);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForOrganizer', [$mutatedCalendar, $mutatedEventInfo, $originalEventInfo]);
+
+		$this->assertCount(2, $messages);
+		foreach ($messages as $message) {
+			$this->assertEquals('REQUEST', $message->method);
+			$this->assertTrue($message->significantChange,
+				"DTSTART change on override must trigger a significant REQUEST for {$message->recipient}");
+		}
+	}
+
+	/**
+	 * Adding a new attendee must always produce a significant REQUEST for
+	 * that attendee (their initial invite), regardless of other changes.
+	 */
+	public function testParseEventForOrganizerNewAttendeeAlwaysSignificant(): void {
+		$originalCalendar = clone $this->vCalendar1a;
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+
+		$mutatedCalendar = clone $this->vCalendar1a;
+		$mutatedCalendar->VEVENT->add('ATTENDEE', 'mailto:attendee2@testing.com', [
+			'CN' => 'Attendee Two',
+			'CUTYPE' => 'INDIVIDUAL',
+			'PARTSTAT' => 'NEEDS-ACTION',
+			'ROLE' => 'REQ-PARTICIPANT',
+			'RSVP' => 'TRUE',
+		]);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForOrganizer', [$mutatedCalendar, $mutatedEventInfo, $originalEventInfo]);
+
+		$newAttendeeMessage = null;
+		foreach ($messages as $message) {
+			if ($message->recipient === 'mailto:attendee2@testing.com') {
+				$newAttendeeMessage = $message;
+				break;
+			}
+		}
+		$this->assertNotNull($newAttendeeMessage);
+		$this->assertEquals('REQUEST', $newAttendeeMessage->method);
+		$this->assertTrue($newAttendeeMessage->significantChange);
+	}
+
+	/**
+	 * SCHEDULE-FORCE-SEND=REQUEST on the attendee bypasses the significance
+	 * check: even a PARTSTAT-only override emits a significant REQUEST.
+	 */
+	public function testParseEventForOrganizerForceSendRequestOverridesSignificance(): void {
+		$originalCalendar = clone $this->vCalendar2a;
+		$originalCalendar->VEVENT->ATTENDEE[0]['PARTSTAT'] = 'ACCEPTED';
+		$originalCalendar->VEVENT->add('ATTENDEE', 'mailto:attendee2@testing.com', [
+			'CN' => 'Attendee Two',
+			'CUTYPE' => 'INDIVIDUAL',
+			'PARTSTAT' => 'ACCEPTED',
+			'ROLE' => 'REQ-PARTICIPANT',
+			'RSVP' => 'TRUE',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+
+		$override = clone $originalCalendar->VEVENT;
+		$override->remove('RRULE');
+		$override->DTSTART->setValue('20240715T080000');
+		$override->DTEND->setValue('20240715T090000');
+		$override->add('RECURRENCE-ID', '20240715T080000', ['TZID' => 'America/Toronto']);
+		$override->ATTENDEE[0]['PARTSTAT'] = 'DECLINED';
+
+		$mutatedCalendar = clone $originalCalendar;
+		// Force a re-send for attendee2 only.
+		$mutatedCalendar->VEVENT->ATTENDEE[1]->add('SCHEDULE-FORCE-SEND', 'REQUEST');
+		$mutatedCalendar->add($override);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForOrganizer', [$mutatedCalendar, $mutatedEventInfo, $originalEventInfo]);
+
+		$attendee2Message = null;
+		foreach ($messages as $message) {
+			if ($message->recipient === 'mailto:attendee2@testing.com') {
+				$attendee2Message = $message;
+			}
+		}
+		$this->assertNotNull($attendee2Message);
+		$this->assertTrue($attendee2Message->significantChange,
+			'SCHEDULE-FORCE-SEND=REQUEST must override the PARTSTAT-only suppression');
+	}
+
+	/**
+	 * Partial-exclusion regression: if a brand-new override excludes an
+	 * attendee while they are still on the master, parseEventForOrganizer's
+	 * EXDATE-injection path builds their REQUEST with a synthesized EXDATE
+	 * on the master. That REQUEST must be flagged significant so they
+	 * actually receive the notification.
+	 */
+	public function testParseEventForOrganizerNewOverrideExcludingAttendeeIsSignificant(): void {
+		// Recurring event with two attendees, both ACCEPTED on the master.
+		$originalCalendar = clone $this->vCalendar2a;
+		$originalCalendar->VEVENT->ATTENDEE[0]['PARTSTAT'] = 'ACCEPTED';
+		$originalCalendar->VEVENT->add('ATTENDEE', 'mailto:attendee2@testing.com', [
+			'CN' => 'Attendee Two',
+			'CUTYPE' => 'INDIVIDUAL',
+			'PARTSTAT' => 'ACCEPTED',
+			'ROLE' => 'REQ-PARTICIPANT',
+			'RSVP' => 'TRUE',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+
+		// Override for one occurrence; attendee1 is NOT on it (partial exclusion).
+		$override = clone $originalCalendar->VEVENT;
+		$override->remove('RRULE');
+		$override->DTSTART->setValue('20240715T080000');
+		$override->DTEND->setValue('20240715T090000');
+		$override->add('RECURRENCE-ID', '20240715T080000', ['TZID' => 'America/Toronto']);
+		$override->remove($override->ATTENDEE[0]);
+
+		$mutatedCalendar = clone $originalCalendar;
+		$mutatedCalendar->add($override);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForOrganizer', [$mutatedCalendar, $mutatedEventInfo, $originalEventInfo]);
+
+		$excludedAttendeeMessage = null;
+		foreach ($messages as $message) {
+			if ($message->recipient === 'mailto:attendee1@testing.com') {
+				$excludedAttendeeMessage = $message;
+				break;
+			}
+		}
+		$this->assertNotNull($excludedAttendeeMessage);
+		$this->assertEquals('REQUEST', $excludedAttendeeMessage->method);
+		$this->assertTrue($excludedAttendeeMessage->significantChange,
+			'Brand-new override excluding the attendee must trigger a significant REQUEST so they receive the synthesized EXDATE');
 	}
 
 }


### PR DESCRIPTION
* Resolves: #60452

## Summary

When an attendee accepts/declines a **single occurrence** of a recurring event, the resulting `RECURRENCE-ID` override VEVENT in the organizer's master calendar object causes Nextcloud's iTip broker to emit a `METHOD:REQUEST` re-invite to **all other attendees**, even though nothing material changed for them. Today every per-occurrence accept/decline/delete produces an unwanted "admin updated the event" mail for bystander attendees.

Per RFC 5546 §3.2.2 a `REQUEST` is for organizer→attendee *scheduling-information* changes (reschedule, update of event details, STATUS change, attendee additions, etc.). PARTSTAT flows the other way as `REPLY` (RFC 5546 §3.2.3). Today's behavior contradicts the standard.

### Root cause

The Nextcloud override of Sabre's `Broker` was originally introduced in #48583 (commit `3f4210e7371`, Oct 2024) and correctly preserved Sabre's per-attendee significance evaluation:

```php
$message->significantChange =
    $attendee['forceSend'] === 'REQUEST'
    || count($oldAttendeeInstances) !== count($newAttendeeInstances)
    || count(array_diff($oldAttendeeInstances, $newAttendeeInstances)) > 0
    || $oldEventInfo['significantChangeHash'] !== $eventInfo['significantChangeHash'];
```

The follow-up refactor in #50843 (commit `70d051f602f`, Feb 2025, "fix(CalDAV): iTipBroker message generation and testing") consolidated message construction into a new `generateMessage()` helper. In that move the per-attendee significance evaluation was inadvertently dropped and replaced with an unconditional `$message->significantChange = true;`. The refactor's test plan did not cover the "PARTSTAT-only override -> no broadcast" scenario, so the regression went unnoticed. The downstream gate at `IMipPlugin.php:105` already knows how to suppress non-significant updates: it just was never told `false` again.

Note: this PR doesn't simply port the old four-line check back. The original `count(array_diff(oldInstances, newInstances)) > 0` heuristic still over-fires here, because the new RECURRENCE-ID override carries all attendees (Thunderbird-style), so every recipient's instance-set grows by one entry. The new helper additionally compares the new override against the *inherited* master state for the recipient before declaring it significant. See the `Fix` section below.

### Fix

Compute `significantChange` per attendee at the REQUEST call-site in `parseEventForOrganizer()`. The new helper `isRequestSignificantForAttendee()` returns `true` iff any of the following holds:

1. `SCHEDULE-FORCE-SEND=REQUEST` is set on the attendee (RFC 6638).
2. The attendee is brand new in this update.
3. The master VEVENT changed on any property in `significantChangeProperties` (`DTSTART, DTEND, DURATION, DUE, RRULE, RDATE, EXDATE, STATUS, SUMMARY, DESCRIPTION, LOCATION`).
4. The master appeared/disappeared between old and new state.
5. An override that already existed in the old state was modified on any of the significant properties.
6. A **new** override is materially different from what the attendee would have inherited from the master. Because an override's own DTSTART/DTEND are *expected* to differ from the master (they describe a different occurrence), this comparison is asymmetric: a new override counts as a real change only when its DTSTART deviates from its own RECURRENCE-ID, its duration differs from the master's duration, it carries its own RRULE/RDATE/EXDATE, or it overrides a date-independent property (`SUMMARY, LOCATION, DESCRIPTION, STATUS`).
7. The attendee was removed from one specific instance they used to be in (partial-instance removal).
8. The synthesized EXDATE set for this recipient changed between old and new state. `parseEventForOrganizer()` already injects a per-attendee EXDATE on the outbound master for every override the attendee is not on; if that set changes (a brand-new override now excludes them, or an override they weren't on was removed), the REQUEST content materially changes and they must receive it.

PARTSTAT differences alone, for any attendee on any instance, never trigger significance. `IMipPlugin.php:105` then suppresses the email. The iTip message itself is still emitted so non-email consumers (e.g. local CalDAV inbox delivery, which keeps each attendee's synced calendar view of *other* attendees' PARTSTAT up to date) keep working.

### Reproduction matrix (from the issue)

| Scenario                                      | Before | After | Correct |
|-----------------------------------------------|:------:|:-----:|:-------:|
| Single event: attendee accepts                | No     | No    | ✅      |
| Series: attendee accepts entire series        | No     | No    | ✅      |
| Series: attendee accepts single instance      | **Yes**| **No**| ✅      |
| Series: attendee declines single instance     | **Yes**| **No**| ✅      |
| Series: attendee deletes a single instance    | **Yes**| **No**| ✅      |
| Regression: organizer modifies SUMMARY        | Yes    | Yes   | ✅      |
| Regression: organizer moves a single occurrence | Yes  | Yes   | ✅      |
| Regression: organizer adds EXDATE on master   | Yes    | Yes   | ✅      |
| Regression: organizer adds new override excluding one attendee | Yes | Yes | ✅ (defensive; see note below) |

"Before/After" = whether other (unaffected) attendees received a re-invite mail.

The last row is the partial-exclusion case (a new override is added that does not list a given attendee). Manual reproduction on a 33.0.3 (and 32.0.9.2) test instance did not produce this exact iCal shape:
  
- The Nextcloud Calendar web UI does expose per-occurrence attendee editing (the three-dot menu next to each attendee lets you remove the attendee or change their role), but saving the modified event leaves the stored object unchanged: the mutation is not persisted server-side. That appears to be a separate web UI bug, out of scope for this PR.
- Thunderbird offers the operation but converts it to an EXDATE on the master, which removes the occurrence for everyone rather than excluding a single attendee.

The check in this PR is therefore defensive: it covers direct CalDAV PUTs and any client that does produce the override-with-reduced-attendees shape. It is exercised by a unit test (testParseEventForOrganizerNewOverrideExcludingAttendeeIsSignificant) instead of a manual reproduction.

### Tested

- 23/23 unit tests in `apps/dav/tests/unit/CalDAV/TipBrokerTest.php` (5 new + 4 augmented existing assertions on `significantChange`).
- New tests:
  - `testParseEventForOrganizerPartstatOnlyOverrideNotSignificant` (the bug from #60452)
  - `testParseEventForOrganizerOverrideWithDtstartChangeIsSignificant` (override with real time shift still fires)
  - `testParseEventForOrganizerNewAttendeeAlwaysSignificant` (initial invite to a newly added attendee)
  - `testParseEventForOrganizerForceSendRequestOverridesSignificance` (RFC 6638 `SCHEDULE-FORCE-SEND=REQUEST` honored)
  - `testParseEventForOrganizerNewOverrideExcludingAttendeeIsSignificant` (defensive: synthesized-EXDATE diff for the partial-exclusion case)
- Augmented existing tests with `assertTrue($messages[0]->significantChange)`: `testParseEventForOrganizerModified`, `testParseEventForOrganizerCreatedInstance`, `testParseEventForOrganizerModifyInstance`, `testParseEventForOrganizerAddExdate`.
- Manual end-to-end on a 33.0.3 instance with Thunderbird as the deciding attendee. Verified: organizer receives REPLY only; bystander attendee receives no mail but their synced calendar still reflects the new PARTSTAT; positive-regression check that an organizer-driven SUMMARY edit still triggers REQUEST mails to all attendees.

### Backwards compatibility

`TipBroker::generateMessage()` gains an optional 10th parameter `?bool $significantChange = null` defaulting to `true`. All existing CANCEL call-sites continue to pass no value and behave exactly as before.

## TODO

- [ ] [optional] add a brief note to the dav app changelog

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting): `php-cs-fixer --dry-run` clean
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes: *N/A, backend-only change*
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required: *N/A, internal-logic fix; no user-facing API change*
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes): please backport to `stable33` and `stable32`
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component): suggested `bug`, `3. to review`, `feature: dav`, `feature: caldav`, `feature: imip`
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`): Nextcloud 34 + backport milestone

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI