### PR TITLE
test(cypress): fix additional DOM detachment matters in FilesUtils

### DIFF
--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -22,6 +22,7 @@ export const getActionButtonForFile = (filename: string) => getActionsForFile(fi
  *
  * @param fileid
  * @param actionId
+ * @warning: callers that chain .find() onto the result will fail if Vue re-renders.
  */
 export function getActionEntryForFileId(fileid: number, actionId: string) {
 	return getActionButtonForFileId(fileid)
@@ -35,6 +36,7 @@ export function getActionEntryForFileId(fileid: number, actionId: string) {
  *
  * @param file
  * @param actionId
+ * @warning: callers that chain .find() onto the result will fail if Vue re-renders.
  */
 export function getActionEntryForFile(file: string, actionId: string) {
 	return getActionButtonForFile(file)
@@ -72,11 +74,14 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFileId(fileid)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	getActionEntryForFileId(fileid, actionId)
-		.find('button')
-		.should('be.visible')
-		.click()
-}
+	getActionButtonForFileId(filename)
+		.should('have.attr', 'aria-controls')
+		.then((menuId) => {
+			cy.get(`#${menuId}`)
+				.find(`[data-cy-files-list-row-action="${CSS.escape(actionId)}"] button`)
+				.should('be.visible')
+				.click()
+		})
 
 /**
  *
@@ -88,10 +93,14 @@ export function triggerActionForFile(filename: string, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFile(filename)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	getActionEntryForFile(filename, actionId)
-		.find('button')
-		.should('be.visible')
-		.click()
+	getActionButtonForFile(filename)
+		.should('have.attr', 'aria-controls')
+		.then((menuId) => {
+			cy.get(`#${menuId}`)
+				.find(`[data-cy-files-list-row-action="${CSS.escape(actionId)}"] button`)
+				.should('be.visible')
+				.click()
+		})
 }
 
 /**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
