### PR TITLE
fix: trim duplicate search results for external share

### DIFF
--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -98,13 +98,17 @@ class Search implements ISearch {
 		$emailType = new SearchResultType('emails');
 		$remoteType = new SearchResultType('remotes');
 
-		if (!isset($allResults[$remoteType->getLabel()])
-			|| !isset($allResults[$emailType->getLabel()])) {
+		$emailLabel = $emailType->getLabel();
+		$emailEntries = array_merge(
+			$allResults['exact'][$emailLabel] ?? [],
+			$allResults[$emailLabel] ?? []
+		);
+		if ($emailEntries === []) {
 			return;
 		}
 
 		$mailIdMap = [];
-		foreach ($allResults[$emailType->getLabel()] as $mailRow) {
+		foreach ($emailEntries as $mailRow) {
 			// sure, array_reduce looks nicer, but foreach needs less resources and is faster
 			if (!isset($mailRow['uuid'])) {
 				continue;
@@ -118,6 +122,18 @@ class Search implements ISearch {
 			}
 			if (isset($mailIdMap[$resultRow['uuid']])) {
 				$searchResult->removeCollaboratorResult($emailType, $mailIdMap[$resultRow['uuid']]);
+			}
+		}
+		$lookupType = new SearchResultType('lookup');
+		if (isset($allResults[$lookupType->getLabel()])) {
+			foreach ($allResults[$lookupType->getLabel()] as $resultRow) {
+				$userid = $resultRow['extra']['userid']['value'] ?? null;
+				if ($userid === null) {
+					continue;
+				}
+				if (isset($mailIdMap[$userid])) {
+					$searchResult->removeCollaboratorResult($emailType, $mailIdMap[$userid]);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Resolves 
  * When deduplicating collaborator results, email shares were not being removed when the same person appeared as a lookup server result.
  * Additionally, exact email matches (in the exact bucket) were being ignored entirely due to strict guard condition.

## Summary

* Merge exact and non-exact email results before deduplication
* Extend the removal logic to also cover lookup server results
* now email share entry is dropped whenever a federated or lookup match exists for the same person.

## TODO

- [ ] Test coverage?
- [ ] Manual test

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
