### PR TITLE
ci: compile on CI after merge to reduce conflicts and total CI time

### DIFF
--- a/.github/workflows/node-dist-unchanged.yml
+++ b/.github/workflows/node-dist-unchanged.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Check node dist files
+
+on:
+  pull_request:
+
+
+jobs:
+  changed_files:
+    runs-on: ubuntu-latest-low
+    name: Check node dist files
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
+        with:
+          files: dist/**
+
+      - name: Run step if any file(s) in the dist folder change
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "One or more files in the dist folder has changed. Do NOT commit files in there as they will be generated automatically once a pull request is merged"
+          echo "List all the files that have changed: ${{ steps.changed-files.outputs.all_changed_files }}"
+          exit 1

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -35,17 +35,14 @@ jobs:
           filters: |
             src:
               - '.github/workflows/**'
-              - '**/src/**'
-              - '**/appinfo/info.xml'
-              - 'core/css/*'
-              - 'core/img/**'
+              - 'src/**'
+              - 'appinfo/info.xml'
               - 'package.json'
-              - '**/package-lock.json'
+              - 'package-lock.json'
               - 'tsconfig.json'
               - '**.js'
               - '**.ts'
               - '**.vue'
-              - 'version.php'
 
   build:
     runs-on: ubuntu-latest
@@ -89,16 +86,17 @@ jobs:
           npm ci
           npm run build --if-present
 
-      - name: Check build changes
-        run: |
-          bash -c "[[ ! \"`git status --porcelain `\" ]] || (echo 'Please recompile and commit the assets, see the section \"Show changes on failure\" for details' && exit 1)"
+      # Not used as we compile on CI, see update-node-dist.yml and node-dist-unchanged.yml
+      # - name: Check build changes
+      #   run: |
+      #     bash -c "[[ ! \"`git status --porcelain `\" ]] || (echo 'Please recompile and commit the assets, see the section \"Show changes on failure\" for details' && exit 1)"
 
-      - name: Show changes on failure
-        if: failure()
-        run: |
-          git status
-          git --no-pager diff
-          exit 1 # make it red to grab attention
+      # - name: Show changes on failure
+      #   if: failure()
+      #   run: |
+      #     git status
+      #     git --no-pager diff
+      #     exit 1 # make it red to grab attention
 
   summary:
     permissions:

--- a/.github/workflows/update-node-dist.yml
+++ b/.github/workflows/update-node-dist.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2023-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Update Node dist
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      # implemented since 35, once branched off, add your stable branch here
+      - master
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-node-dist-${{ github.head_ref || github.ref || github.run_id }}
+
+jobs:
+  update-node-dist:
+    runs-on: ubuntu-latest-assets
+    environment: update-node-dist
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Needed to allow force push later
+          persist-credentials: true
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Read package.json node and npm engines version
+        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.1
+        id: versions
+        with:
+          fallbackNode: '^20'
+          fallbackNpm: '^9'
+
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+
+      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
+
+      - name: Setup git
+        run: |
+          git config --local user.email "nextcloud-command@users.noreply.github.com"
+          git config --local user.name "nextcloud-command"
+
+      - name: Get last commit message if it was not a recompile
+        id: last_commit
+        run: |
+          {
+            echo 'MESSAGE<<EOF'
+            git log -1 --pretty=%s | grep -v '^chore(assets): recompile assets$' || test $? -eq 1
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      - name: Install dependencies & build
+        if: steps.last_commit.outputs.MESSAGE != ''
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+        run: |
+          npm ci
+          npm run build --if-present
+
+      - name: Check webpack build changes
+        id: changes
+        continue-on-error: true
+        run: |
+          {
+            echo 'CHANGED<<EOF'
+            git status --porcelain
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add and commit
+        if: steps.changes.outputs.CHANGED != ''
+        run: |
+          git add --force dist/ core/css/
+          git commit --signoff -m 'chore(assets): recompile assets'
+          git push origin ${{ github.head_ref }}


### PR DESCRIPTION
**This will be merged begin of August as [per announcement](https://help.nextcloud.com/t/upcoming-changes-in-the-server-repository-for-compiled-assets/247193)**

## Summary
One of the biggest CI problems we currently face are conflicts, not within source code but in compiled assets.
So if you have 2 PRs targeting e.g. files then the assets will likely conflict even if the source can be merged without problems.

This causes unnecessary CI time and developer frustration.

Another really bad example: Dependency updates.

So this solution is the currently lived solution of the `text` app:
1. we add a CI check to forbid checking in compiled assets
2. we adjust the node workflow to no longer check for asset changes
3. we add a CI workflow to compile after merges.

For the corner case where a new PR is merged before the compilation has finished this will abort the first compile and start a new one for the current HEAD.
So this also reduces the repository size in cases of many quick merged like during dependabot updates.

## TODO

:warning: this needs some repository setups :warning: 

1. This needs to be aligned with the releases team, during releases:
  - either you compile in the PR and force merge with red CI for the "forbid assets" check
  - or you merge and wait for the compile to finish to tag the release
2. This needs setup of the secrets to be able to push the compiles assets
  - Setup a github environment `update-node-dist`
  - Setup secret `BOT_GITHUB_TOKEN` with push permission to the branches
  - :exclamation: see `text` repository setup for how to do this securely

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
