### PR TITLE
fix(installer): re-enable version-incompatible apps after appstore update

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -102,6 +102,22 @@ class Installer {
 	 */
 	public function updateAppstoreApp(string $appId, bool $allowUnstable = false): bool {
 		if ($this->isUpdateAvailable($appId, $allowUnstable) !== false) {
+			// Before downloading, check whether the app is currently disabled due to version
+			// incompatibility with this NC version. If so, re-enable it after a successful update.
+			$isDisabled = !$this->appManager->isEnabledForAnyone($appId);
+			$wasIncompatible = false;
+			if ($isDisabled) {
+				$currentInfo = $this->appManager->getAppInfo($appId);
+				$ncVersion = implode('.', Util::getVersion());
+				$wasIncompatible = $currentInfo !== null && !$this->appManager->isAppCompatible($ncVersion, $currentInfo);
+				$this->logger->debug('App {appId} is disabled; incompatible with NC {version}: {incompat}', [
+					'appId' => $appId,
+					'version' => $ncVersion,
+					'incompat' => $wasIncompatible ? 'yes' : 'no',
+					'app' => 'updater',
+				]);
+			}
+
 			try {
 				$this->downloadApp($appId, $allowUnstable);
 			} catch (\Exception $e) {
@@ -110,9 +126,29 @@ class Installer {
 				]);
 				return false;
 			}
-			return $this->appManager->upgradeApp($appId);
+
+			$result = $this->appManager->upgradeApp($appId);
+
+			if ($result && $isDisabled && $wasIncompatible) {
+				$this->logger->info('Re-enabling {appId} after update: it was disabled due to version incompatibility', [
+					'appId' => $appId,
+					'app' => 'updater',
+				]);
+				try {
+					$this->appManager->enableApp($appId);
+				} catch (\Exception $e) {
+					$this->logger->warning('Could not re-enable {appId} after update: {error}', [
+						'appId' => $appId,
+						'error' => $e->getMessage(),
+						'app' => 'updater',
+					]);
+				}
+			}
+
+			return $result;
 		}
 
+		$this->logger->debug('No update available for {appId}, skipping', ['appId' => $appId, 'app' => 'updater']);
 		return false;
 	}
 
@@ -374,6 +410,7 @@ class Installer {
 		}
 
 		if ($this->isInstalledFromGit($appId) === true) {
+			$this->logger->debug('App {appId} is installed from git, skipping update check', ['appId' => $appId, 'app' => 'updater']);
 			return false;
 		}
 
@@ -386,17 +423,25 @@ class Installer {
 				$currentVersion = $this->appManager->getAppVersion($appId, true);
 
 				if (!isset($app['releases'][0]['version'])) {
+					$this->logger->debug('App {appId} has no release version in app store data', ['appId' => $appId, 'app' => 'updater']);
 					return false;
 				}
 				$newestVersion = $app['releases'][0]['version'];
 				if ($currentVersion !== '0' && version_compare($newestVersion, $currentVersion, '>')) {
 					return $newestVersion;
 				} else {
+					$this->logger->debug('No newer version available for {appId}: current={current}, newest={newest}', [
+						'appId' => $appId,
+						'current' => $currentVersion,
+						'newest' => $newestVersion,
+						'app' => 'updater',
+					]);
 					return false;
 				}
 			}
 		}
 
+		$this->logger->debug('App {appId} not found in app store', ['appId' => $appId, 'app' => 'updater']);
 		return false;
 	}
 

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -588,6 +588,107 @@ MPLX6f5V9tCJtlH6ztmEcDROfvuVc0U3rEhqx2hphoyo+MZrPFpdcJL8KkIdMKbY
 		$this->assertEquals('0.9', \OC_App::getAppVersionByPath(__DIR__ . '/../../apps/testapp/'));
 	}
 
+	public function testIsUpdateAvailableLogsDebugForGitInstall(): void {
+		$tmpDir = sys_get_temp_dir() . '/nc_test_git_' . uniqid();
+		mkdir($tmpDir . '/.git', 0700, true);
+
+		$this->appManager
+			->expects($this->once())
+			->method('getAppPath')
+			->with('myapp')
+			->willReturn($tmpDir);
+		$this->logger
+			->expects($this->once())
+			->method('debug')
+			->with(
+				'App {appId} is installed from git, skipping update check',
+				$this->callback(fn ($ctx) => $ctx['appId'] === 'myapp')
+			);
+
+		$installer = $this->getInstaller();
+		$result = $installer->isUpdateAvailable('myapp');
+		$this->assertFalse($result);
+
+		rmdir($tmpDir . '/.git');
+		rmdir($tmpDir);
+	}
+
+	protected function getPartialInstaller(array $onlyMethods): Installer&\PHPUnit\Framework\MockObject\MockObject {
+		return $this->getMockBuilder(Installer::class)
+			->setConstructorArgs([
+				$this->appFetcher,
+				$this->clientService,
+				$this->tempManager,
+				$this->logger,
+				$this->config,
+				$this->appManager,
+				$this->l10nFactory,
+				false,
+			])
+			->onlyMethods($onlyMethods)
+			->getMock();
+	}
+
+	public function testUpdateAppstoreAppReEnablesDisabledIncompatibleApp(): void {
+		$installer = $this->getPartialInstaller(['isUpdateAvailable', 'downloadApp']);
+		$installer->method('isUpdateAvailable')->willReturn('1.0.0');
+		$installer->method('downloadApp');
+
+		$this->appManager->method('isEnabledForAnyone')->with('myapp')->willReturn(false);
+		$this->appManager->method('getAppInfo')->with('myapp')->willReturn(['id' => 'myapp', 'version' => '0.0.1']);
+		$this->appManager->method('isAppCompatible')->willReturn(false);
+		$this->appManager->method('upgradeApp')->with('myapp')->willReturn(true);
+		$this->appManager->expects($this->once())->method('enableApp')->with('myapp');
+
+		$result = $installer->updateAppstoreApp('myapp');
+		$this->assertTrue($result);
+	}
+
+	public function testUpdateAppstoreAppDoesNotReEnableCompatibleButDisabledApp(): void {
+		$installer = $this->getPartialInstaller(['isUpdateAvailable', 'downloadApp']);
+		$installer->method('isUpdateAvailable')->willReturn('1.0.0');
+		$installer->method('downloadApp');
+
+		$this->appManager->method('isEnabledForAnyone')->with('myapp')->willReturn(false);
+		$this->appManager->method('getAppInfo')->with('myapp')->willReturn(['id' => 'myapp', 'version' => '1.0.0']);
+		$this->appManager->method('isAppCompatible')->willReturn(true);
+		$this->appManager->method('upgradeApp')->with('myapp')->willReturn(true);
+		$this->appManager->expects($this->never())->method('enableApp');
+
+		$result = $installer->updateAppstoreApp('myapp');
+		$this->assertTrue($result);
+	}
+
+	public function testUpdateAppstoreAppDoesNotReEnableAlreadyEnabledApp(): void {
+		$installer = $this->getPartialInstaller(['isUpdateAvailable', 'downloadApp']);
+		$installer->method('isUpdateAvailable')->willReturn('1.0.0');
+		$installer->method('downloadApp');
+
+		$this->appManager->method('isEnabledForAnyone')->with('myapp')->willReturn(true);
+		$this->appManager->method('upgradeApp')->with('myapp')->willReturn(true);
+		$this->appManager->expects($this->never())->method('enableApp');
+		$this->appManager->expects($this->never())->method('getAppInfo');
+		$this->appManager->expects($this->never())->method('isAppCompatible');
+
+		$result = $installer->updateAppstoreApp('myapp');
+		$this->assertTrue($result);
+	}
+
+	public function testUpdateAppstoreAppDoesNotReEnableWhenUpgradeFails(): void {
+		$installer = $this->getPartialInstaller(['isUpdateAvailable', 'downloadApp']);
+		$installer->method('isUpdateAvailable')->willReturn('1.0.0');
+		$installer->method('downloadApp');
+
+		$this->appManager->method('isEnabledForAnyone')->with('myapp')->willReturn(false);
+		$this->appManager->method('getAppInfo')->with('myapp')->willReturn(['id' => 'myapp', 'version' => '0.0.1']);
+		$this->appManager->method('isAppCompatible')->willReturn(false);
+		$this->appManager->method('upgradeApp')->with('myapp')->willReturn(false);
+		$this->appManager->expects($this->never())->method('enableApp');
+
+		$result = $installer->updateAppstoreApp('myapp');
+		$this->assertFalse($result);
+	}
+
 	public function testDownloadAppWithDowngrade(): void {
 		// Use previous test to download the application in version 0.9
 		$this->testDownloadAppSuccessful();


### PR DESCRIPTION
## Summary

- When a Nextcloud server is upgraded to a new major version, apps incompatible with the old version range are automatically disabled. Updating such an app via the web UI or `occ app:update` would upgrade the files but leave the app disabled, requiring a manual re-enable or reinstall.
- `updateAppstoreApp()` now checks whether the app was disabled due to version incompatibility **before** downloading the update. After a successful `upgradeApp()`, if those conditions were true, `enableApp()` is called automatically.
- Adds debug logging to previously-silent `return false` paths in `isUpdateAvailable()` (git-installed app, no newer version, app not in store) — this was causing update failures to appear as "keine Hinweise" (no hints) in debug logs.

## Context

Reported in https://github.com/nextcloud/files_mindmap/issues/269 — users upgrading from NC 31 to NC 32+ had `files_mindmap` auto-disabled during the server upgrade (old version declared `max-version="31"`). Clicking "Update" in the web UI downloaded the new compatible release but did not re-enable the app, so it remained invisible/broken until manually re-enabled.

cc @AndyScherzinger

## Test plan

- [ ] New unit tests in `tests/lib/InstallerTest.php` cover the four cases: re-enable on incompatible-disabled, no re-enable on compatible-disabled (manually disabled), no re-enable on already-enabled, no re-enable when upgrade itself fails
- [ ] Manual test: install an app with `max-version` below current NC, trigger server upgrade to auto-disable it, then update via web UI and confirm the app is re-enabled
- [ ] Check debug log output now shows specific reason when `isUpdateAvailable()` returns false

🤖 Generated with [Claude Code](https://claude.com/claude-code)