### PR TITLE
chore(snowflake): add more randomness in server id fallback

### DIFF
--- a/lib/private/Snowflake/SnowflakeGenerator.php
+++ b/lib/private/Snowflake/SnowflakeGenerator.php
@@ -34,7 +34,7 @@ final readonly class SnowflakeGenerator implements ISnowflakeGenerator {
 		// Relative time
 		[$seconds, $milliseconds] = $this->getCurrentTime();
 
-		$serverId = $this->getServerId() & 0x1FF; // Keep 9 bits
+		$serverId = $this->getServerId(); // Already 9 bits
 		$isCli = (int)$this->isCli(); // 1 bit
 		$sequenceId = $this->sequenceGenerator->nextId($seconds, $milliseconds, $serverId); //  12 bits
 		if ($sequenceId > 0xFFF || $sequenceId === false) {
@@ -104,12 +104,20 @@ final readonly class SnowflakeGenerator implements ISnowflakeGenerator {
 
 	/**
 	 * Return configured serverid or generate one if not set
+	 *
+	 * @return int<0,511>
 	 */
 	private function getServerId(): int {
 		$serverid = $this->config->getSystemValueInt('serverid', -1);
-		return $serverid > 0
-			? $serverid
-			: crc32(gethostname() ?: random_bytes(8));
+		if ($serverid < 1) {
+			// Fallback: generates a server ID based on hostname
+			// or random bytes if hostname isn't available
+			/** @var int<0,max> */
+			$serverid = hexdec(hash('xxh32', gethostname() ?: random_bytes(8)));
+		}
+
+		/** @var int<0,511> */
+		return $serverid & 0x1FF;
 	}
 
 	private function isCli(): bool {


### PR DESCRIPTION
## Summary

CRC32 hash function can easily lead to collisions when based on hostname (and even using random strings).

Here is an example which generates a lot of duplicated server IDs from different fake hostnames:
```php 
for ($i = 1; $i <= 20; ++$i) {
	$a=sprintf('prod-%02d.nextcloud.com', $i); 
	printf("%s xxh: %3d crc:%3d\n", $a, hexdec(hash('xxh32', $a)) % 512, crc32($a) %512); 
}
```
```
prod-01.nextcloud.com xxh: 182 crc:265
prod-02.nextcloud.com xxh: 280 crc:368
prod-03.nextcloud.com xxh: 116 crc:152
prod-04.nextcloud.com xxh: 348 crc:386
prod-05.nextcloud.com xxh: 171 crc:106
prod-06.nextcloud.com xxh: 452 crc: 19
prod-07.nextcloud.com xxh:  71 crc:507
prod-08.nextcloud.com xxh: 292 crc:102
prod-09.nextcloud.com xxh: 363 crc:398
prod-10.nextcloud.com xxh:  68 crc:368
prod-11.nextcloud.com xxh: 406 crc:152
prod-12.nextcloud.com xxh: 213 crc:225
prod-13.nextcloud.com xxh: 179 crc:265
prod-14.nextcloud.com xxh:  64 crc: 19
prod-15.nextcloud.com xxh: 210 crc:507
prod-16.nextcloud.com xxh:  47 crc:386
prod-17.nextcloud.com xxh: 175 crc:106
prod-18.nextcloud.com xxh: 383 crc:503
prod-19.nextcloud.com xxh: 222 crc: 31
prod-20.nextcloud.com xxh: 274 crc:386
```
With `$a=bin2hex(random_bytes(10));` I also spotted one collision with CRC32.

Even if it's only used as a fallback, XXH32 sounds like a better alternative.

**Performance**
XXH32 should be faster but we need to convert to int:
```
Summary
  php -r 'for ($a=0;$a<10000;++$a) { crc32($a); }' ran
    1.07 ± 0.15 times faster than php -r 'for ($a=0;$a<10000;++$a) { echo hexdec(hash("xxh32", $a)); }'
    1.11 ± 0.17 times faster than php -r 'for ($a=0;$a<10000;++$a) { echo bindec(hash("xxh32", $a, true)); }'
```
It's quite close :) 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
