### PR TITLE
fix(caldav): grant sharee Acls to the delegate

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -177,16 +177,36 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 				'principal' => parent::getOwner(),
 				'protected' => true,
 			];
+			$acl[] = [
+				'privilege' => '{DAV:}read',
+				'principal' => parent::getOwner() . '/calendar-proxy-read',
+				'protected' => true,
+			];
+			$acl[] = [
+				'privilege' => '{DAV:}read',
+				'principal' => parent::getOwner() . '/calendar-proxy-write',
+				'protected' => true,
+			];
 			if ($this->canWrite()) {
 				$acl[] = [
 					'privilege' => '{DAV:}write',
 					'principal' => parent::getOwner(),
 					'protected' => true,
 				];
+				$acl[] = [
+					'privilege' => '{DAV:}write',
+					'principal' => parent::getOwner() . '/calendar-proxy-write',
+					'protected' => true,
+				];
 			} else {
 				$acl[] = [
 					'privilege' => '{DAV:}write-properties',
 					'principal' => parent::getOwner(),
+					'protected' => true,
+				];
+				$acl[] = [
+					'privilege' => '{DAV:}write-properties',
+					'principal' => parent::getOwner() . '/calendar-proxy-write',
 					'protected' => true,
 				];
 			}
@@ -205,6 +225,8 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 			$this->getOwner() . '/calendar-proxy-read',
 			$this->getOwner() . '/calendar-proxy-write',
 			parent::getOwner(),
+			parent::getOwner() . '/calendar-proxy-read',
+			parent::getOwner() . '/calendar-proxy-write',
 			'principals/system/public',
 		];
 		/** @var list<array{privilege: string, principal: string, protected: bool}> $acl */

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -236,16 +236,36 @@ class CalendarTest extends TestCase {
 				'principal' => 'user2',
 				'protected' => true
 			];
+			$expectedAcl[] = [
+				'privilege' => '{DAV:}read',
+				'principal' => 'user2/calendar-proxy-read',
+				'protected' => true
+			];
+			$expectedAcl[] = [
+				'privilege' => '{DAV:}read',
+				'principal' => 'user2/calendar-proxy-write',
+				'protected' => true
+			];
 			if ($expectsWrite) {
 				$expectedAcl[] = [
 					'privilege' => '{DAV:}write',
 					'principal' => 'user2',
 					'protected' => true
 				];
+				$expectedAcl[] = [
+					'privilege' => '{DAV:}write',
+					'principal' => 'user2/calendar-proxy-write',
+					'protected' => true
+				];
 			} else {
 				$expectedAcl[] = [
 					'privilege' => '{DAV:}write-properties',
 					'principal' => 'user2',
+					'protected' => true
+				];
+				$expectedAcl[] = [
+					'privilege' => '{DAV:}write-properties',
+					'principal' => 'user2/calendar-proxy-write',
 					'protected' => true
 				];
 			}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/calendar/pull/8085#issuecomment-4397454668

## Summary
Grant the delegate the same ACLs as the sharee depending on his write or read access

## Reproduction 

- user 1 shares calendar with user 2 (write or read) 
- user 2 delegates to user 3 (Proxy write or read) 
- uses 3 access calendar and can (read or write) the calendar shared by user 1   

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
