### PR TITLE
fix(http): avoid iconv for header ascii fallback

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -15,6 +15,7 @@ use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\String\UnicodeString;
 
 class ImageExportPlugin extends ServerPlugin {
 
@@ -89,9 +90,7 @@ class ImageExportPlugin extends ServerPlugin {
 			$response->setHeader('Content-Type', $file->getMimeType());
 			$fileName = $node->getName() . '.' . PhotoCache::ALLOWED_CONTENT_TYPES[$file->getMimeType()];
 			$sanitized = str_replace(['/', '\\'], '-', $fileName);
-			$fallback = @iconv('UTF-8', 'ASCII//TRANSLIT', $sanitized) ?: $sanitized;
-			$fallback = preg_replace('/[^\x20-\x7e]/', '', $fallback);
-			$fallback = str_replace('%', '', $fallback);
+			$fallback = str_replace('%', '', (new UnicodeString($sanitized))->ascii()->toString());
 			$response->setHeader('Content-Disposition', HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $sanitized, $fallback));
 			$response->setStatus(Http::STATUS_OK);
 

--- a/apps/dav/lib/Provisioning/Apple/AppleProvisioningPlugin.php
+++ b/apps/dav/lib/Provisioning/Apple/AppleProvisioningPlugin.php
@@ -18,6 +18,7 @@ use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\String\UnicodeString;
 
 class AppleProvisioningPlugin extends ServerPlugin {
 	/**
@@ -126,9 +127,7 @@ class AppleProvisioningPlugin extends ServerPlugin {
 
 		$response->setStatus(Http::STATUS_OK);
 		$sanitized = str_replace(['/', '\\'], '-', $filename);
-		$fallback = @iconv('UTF-8', 'ASCII//TRANSLIT', $sanitized) ?: $sanitized;
-		$fallback = preg_replace('/[^\x20-\x7e]/', '', $fallback);
-		$fallback = str_replace('%', '', $fallback);
+		$fallback = str_replace('%', '', (new UnicodeString($sanitized))->ascii()->toString());
 		$response->setHeader('Content-Disposition', HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $sanitized, $fallback));
 		$response->setHeader('Content-Type', 'application/xml; charset=utf-8');
 		$response->setBody($body);

--- a/lib/public/AppFramework/Http/DownloadResponse.php
+++ b/lib/public/AppFramework/Http/DownloadResponse.php
@@ -9,6 +9,7 @@ namespace OCP\AppFramework\Http;
 
 use OCP\AppFramework\Http;
 use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\String\UnicodeString;
 
 /**
  * Prompts the user to download the a file
@@ -31,9 +32,7 @@ class DownloadResponse extends Response {
 		parent::__construct($status, $headers);
 
 		$sanitized = str_replace(['/', '\\'], '-', $filename);
-		$fallback = @iconv('UTF-8', 'ASCII//TRANSLIT', $sanitized) ?: $sanitized;
-		$fallback = preg_replace('/[^\x20-\x7e]/', '', $fallback);
-		$fallback = str_replace('%', '', $fallback);
+		$fallback = str_replace('%', '', (new UnicodeString($sanitized))->ascii()->toString());
 		$this->addHeader('Content-Disposition', HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $sanitized, $fallback));
 		$this->addHeader('Content-Type', $contentType);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

iconv transliteration is locale- and config-dependent and fails silently on some setups. UnicodeString::ascii() from symfony/string uses a built-in transliteration table backed by symfony/polyfill-intl-normalizer, so it works on all setups without requiring optional PHP extensions.

https://github.com/nextcloud/server/pull/29470 removed iconv, I brought it back with https://github.com/nextcloud/server/pull/59843 :see_no_evil: 

## TODO

- [x] Make the changes
- [x] Test the changes
  - Hard-coded filename "Täst" turns into `content-disposition: attachment; filename=Tast; filename*=utf-8''T%C3%A4st` -> ASCII fallback is `Tast` :heavy_check_mark:  
- [x] Make sure it doesn't happen again: https://github.com/nextcloud/server/pull/60655

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
