### PR TITLE
fix(config): add null coalescing fallback in getValueBool before strtolower

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3548,11 +3548,6 @@
       <code><![CDATA[$CONFIG]]></code>
     </UndefinedVariable>
   </file>
-  <file src="lib/private/Config/UserConfig.php">
-    <RedundantCast>
-      <code><![CDATA[(string)$this->getTypedValue($userId, $app, $key, $default ? 'true' : 'false', $lazy, ValueType::BOOL)]]></code>
-    </RedundantCast>
-  </file>
   <file src="lib/private/Console/Application.php">
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -437,7 +437,15 @@ class AppConfig implements IAppConfig {
 	 */
 	#[\Override]
 	public function getValueBool(string $app, string $key, bool $default = false, bool $lazy = false): bool {
-		$b = strtolower($this->getTypedValue($app, $key, $default ? 'true' : 'false', $lazy, self::VALUE_BOOL));
+		// The explicit (string) cast and ?? null guard defend against a PHP OPcache bug where
+		// values passed by reference across function boundaries can have their type corrupted
+		// (e.g. bool returned as int, or null). Affects PHP 8.x with OPcache enabled; fixed
+		// upstream in https://github.com/php/php-src/pull/21973. Keep until minimum PHP version
+		// is bumped. Psalm sees the declared return type (string) and flags these as redundant.
+		/** @psalm-suppress RedundantCondition, TypeDoesNotContainNull */
+		$value = $this->getTypedValue($app, $key, $default ? 'true' : 'false', $lazy, self::VALUE_BOOL) ?? ($default ? 'true' : 'false');
+		/** @psalm-suppress RedundantCast */
+		$b = strtolower((string)$value);
 		return in_array($b, ['1', 'true', 'yes', 'on']);
 	}
 

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -705,11 +705,15 @@ class UserConfig implements IUserConfig {
 		bool $default = false,
 		bool $lazy = false,
 	): bool {
-		// The explicit (string) cast guards against a PHP OPcache bug where values passed
-		// by reference across function boundaries can have their type corrupted (e.g. bool
-		// returned as int). Affects PHP 8.x with OPcache enabled; fixed upstream in
-		// https://github.com/php/php-src/pull/21973. Keep until minimum PHP version is bumped.
-		$b = strtolower((string)$this->getTypedValue($userId, $app, $key, $default ? 'true' : 'false', $lazy, ValueType::BOOL));
+		// The explicit (string) cast and ?? null guard defend against a PHP OPcache bug where
+		// values passed by reference across function boundaries can have their type corrupted
+		// (e.g. bool returned as int, or null). Affects PHP 8.x with OPcache enabled; fixed
+		// upstream in https://github.com/php/php-src/pull/21973. Keep until minimum PHP version
+		// is bumped. Psalm sees the declared return type (string) and flags these as redundant.
+		/** @psalm-suppress RedundantCondition, TypeDoesNotContainNull */
+		$value = $this->getTypedValue($userId, $app, $key, $default ? 'true' : 'false', $lazy, ValueType::BOOL) ?? ($default ? 'true' : 'false');
+		/** @psalm-suppress RedundantCast */
+		$b = strtolower((string)$value);
 		return in_array($b, ['1', 'true', 'yes', 'on']);
 	}
 


### PR DESCRIPTION
* Relates to: #59646

## Context

Despite having the patch from #59646, a customer is still experiencing the following:
```
 "url": "/index.php/login",
 "scriptName": "/index.php",
 "message": "strtolower(): Argument #1 ($string) must be of type string, string given in file '/var/www/lajen/lib/private/Config/UserConfig.php' line 688",
 "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0",
 "version": "33.0.3.3",
```

## Summary

Followup to #59646: both `AppConfig::getValueBool()` and `UserConfig::getValueBool()` pass the return value of `getTypedValue()` directly to `strtolower()`. Although the declared return type is `string`, the same OPcache/PHP bug that motivated the `(string)` cast in UserConfig can cause a null to slip through at runtime.

- Added `?? 'false'` null coalescing fallback in `UserConfig::getValueBool()`
- Added `(string)` cast, OPcache comment, **and** `?? 'false'` fallback in `AppConfig::getValueBool()`, aligning it with the pattern introduced for UserConfig in #59646

## TODO

- [x] No further changes needed — purely defensive null guard

## Checklist

- Code is properly formatted
- Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [ ] Backports requested where applicable
- [ ] Labels added where applicable (bug, `3. to review`)
- [ ] Milestone added for target branch/version

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI