### PR TITLE
Add fallback for Codespace environment variables

### DIFF
--- a/.devcontainer/codespace.config.php
+++ b/.devcontainer/codespace.config.php
@@ -7,6 +7,19 @@
 $codespaceName = getenv('CODESPACE_NAME');
 $codespaceDomain = getenv('GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN');
 
+// When running under Apache, env vars from the shell profile are not inherited.
+// Fall back to the Codespaces shared environment file and the well-known domain.
+if (empty($codespaceName)) {
+    $sharedEnvFile = '/workspaces/.codespaces/shared/environment-variables.json';
+    if (is_readable($sharedEnvFile)) {
+        $sharedEnv = json_decode(file_get_contents($sharedEnvFile), true) ?? [];
+        $codespaceName = $sharedEnv['CODESPACE_NAME'] ?? '';
+    }
+}
+if (!empty($codespaceName) && empty($codespaceDomain)) {
+    $codespaceDomain = 'app.github.dev';
+}
+
 $CONFIG = [
     'mail_from_address' => 'no-reply',
     'mail_smtpmode' => 'smtp',


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #60662

## Summary

For some reason when using Github Codepaces, the environment variables are not set and threfore the host overwrite does not work properly.

## Resolution notes

* Root cause: `getenv()` returns false under Apache because Apache is started via sudo service and never inherits the user shell's environment (which is populated by `codespaces.sh`).
* Fix: When `getenv()` returns empty (or `false`), the config now falls back to reading `CODESPACE_NAME` from `environment-variables.json` (a file Codespaces always maintains) and defaults `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` to app.github.dev (the fixed GitHub Codespaces domain). 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
