### PR TITLE
Speedup share tests

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -63,7 +63,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		$this->manager = $options['manager'];
 		$this->cloudId = $options['cloudId'];
 		$this->logger = Server::get(LoggerInterface::class);
-		$discoveryService = Server::get(IOCMDiscoveryService::class);
+		$discoveryService = $options['discoveryService'] ?? Server::get(IOCMDiscoveryService::class);
 		$this->config = Server::get(IConfig::class);
 		$this->appConfig = Server::get(IAppConfig::class);
 		$this->shareManager = Server::get(IShareManager::class);

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -34,8 +34,6 @@ class CacheTest extends TestCase {
 	protected Cache $sharedCache;
 	protected Storage $ownerStorage;
 	protected Storage $sharedStorage;
-	/** @var \OCP\Share\IManager $shareManager */
-	protected $shareManager;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -50,12 +50,14 @@ use OCP\Share\IAttributes;
 use OCP\Share\IPublicShareTemplateFactory;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
+use Test\Traits\UserTrait;
 
 /**
  * @package OCA\Files_Sharing\Controllers
  */
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ShareControllerTest extends \Test\TestCase {
+	use UserTrait;
 
 	private string $user;
 	private string $oldUser;
@@ -150,7 +152,7 @@ class ShareControllerTest extends \Test\TestCase {
 		// Create a dummy user
 		$this->user = Server::get(ISecureRandom::class)->generate(12, ISecureRandom::CHAR_LOWER);
 
-		Server::get(IUserManager::class)->createUser($this->user, $this->user);
+		$this->createUser($this->user, $this->user);
 		\OC_Util::tearDownFS();
 		$this->loginAsUser($this->user);
 	}

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -17,6 +17,7 @@ use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Server;
 use OCP\Share\IShare;
+use Test\Traits\UserTrait;
 
 /**
  * Class DeleteOrphanedSharesJobTest
@@ -26,6 +27,8 @@ use OCP\Share\IShare;
  */
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DeleteOrphanedSharesJobTest extends \Test\TestCase {
+	use UserTrait;
+
 	/**
 	 * @var bool
 	 */
@@ -76,9 +79,8 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
 
-		$userManager = Server::get(IUserManager::class);
-		$userManager->createUser($this->user1, 'pass');
-		$userManager->createUser($this->user2, 'pass');
+		$this->createUser($this->user1, 'pass');
+		$this->createUser($this->user2, 'pass');
 
 		\OC::registerShareHooks(Server::get(SystemConfig::class));
 

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -32,16 +32,15 @@ class EtagPropagationTest extends PropagationTestCase {
 	 * "user4" puts the received "inside" folder into "sub1/sub2/inside" (this is to check if it propagates across multiple subfolders)
 	 */
 	protected function setUpShares() {
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1] = [];
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2] = [];
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3] = [];
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER4] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER4] = [];
 
 		$rootFolder = Server::get(IRootFolder::class);
 		$shareManager = Server::get(\OCP\Share\IManager::class);
 
 		$this->rootView = new View('');
-		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
 		$view1 = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
 		$view1->mkdir('/sub1/sub2/folder/inside');
 		$view1->mkdir('/directReshare');
@@ -99,9 +98,9 @@ class EtagPropagationTest extends PropagationTestCase {
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1][''] = $view1->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['sub1'] = $view1->getFileInfo('sub1')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['sub1/sub2'] = $view1->getFileInfo('sub1/sub2')->getId();
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1][''] = $view1->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1]['sub1'] = $view1->getFileInfo('sub1');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1]['sub1/sub2'] = $view1->getFileInfo('sub1/sub2');
 
 		/*
 		 * User 2
@@ -110,7 +109,6 @@ class EtagPropagationTest extends PropagationTestCase {
 		$view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$view2->mkdir('/sub1/sub2');
 		$view2->rename('/folder', '/sub1/sub2/folder');
-		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 
 		$insideInfo = $view2->getFileInfo('/sub1/sub2/folder/inside');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $insideInfo);
@@ -140,9 +138,9 @@ class EtagPropagationTest extends PropagationTestCase {
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER4);
 
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2][''] = $view2->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['sub1'] = $view2->getFileInfo('sub1')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['sub1/sub2'] = $view2->getFileInfo('sub1/sub2')->getId();
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2][''] = $view2->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2]['sub1'] = $view2->getFileInfo('sub1');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2]['sub1/sub2'] = $view2->getFileInfo('sub1/sub2');
 
 		/*
 		 * User 3
@@ -151,9 +149,9 @@ class EtagPropagationTest extends PropagationTestCase {
 		$view3 = new View('/' . self::TEST_FILES_SHARING_API_USER3 . '/files');
 		$view3->mkdir('/sub1/sub2');
 		$view3->rename('/folder', '/sub1/sub2/folder');
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3][''] = $view3->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3]['sub1'] = $view3->getFileInfo('sub1')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3]['sub1/sub2'] = $view3->getFileInfo('sub1/sub2')->getId();
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3][''] = $view3->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3]['sub1'] = $view3->getFileInfo('sub1');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3]['sub1/sub2'] = $view3->getFileInfo('sub1/sub2');
 
 		/*
 		 * User 4
@@ -162,18 +160,9 @@ class EtagPropagationTest extends PropagationTestCase {
 		$view4 = new View('/' . self::TEST_FILES_SHARING_API_USER4 . '/files');
 		$view4->mkdir('/sub1/sub2');
 		$view4->rename('/inside', '/sub1/sub2/inside');
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER4][''] = $view4->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER4]['sub1'] = $view4->getFileInfo('sub1')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER4]['sub1/sub2'] = $view4->getFileInfo('sub1/sub2')->getId();
-
-		foreach ($this->fileIds as $user => $ids) {
-			$this->loginAsUser($user);
-			foreach ($ids as $id) {
-				$path = $this->rootView->getPath($id);
-				$ls = $this->rootView->getDirectoryContent($path);
-				$this->fileEtags[$id] = $this->rootView->getFileInfo($path)->getEtag();
-			}
-		}
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER4][''] = $view4->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER4]['sub1'] = $view4->getFileInfo('sub1');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER4]['sub1/sub2'] = $view4->getFileInfo('sub1/sub2');
 	}
 
 	public function testOwnerWritesToShare(): void {

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -15,11 +15,11 @@ use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
 use OCP\IUser;
-use OCP\IUserManager;
 use OCP\Server;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Test\Traits\UserTrait;
 
 /**
  * Class ExpireSharesJobTest
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ExpireSharesJobTest extends \Test\TestCase {
+	use UserTrait;
 
 	private ExpireSharesJob $job;
 
@@ -51,9 +52,8 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		$user1 = $this->getUniqueID('user1_');
 		$user2 = $this->getUniqueID('user2_');
 
-		$userManager = Server::get(IUserManager::class);
-		$this->user1 = $userManager->createUser($user1, 'longrandompassword');
-		$this->user2 = $userManager->createUser($user2, 'longrandompassword');
+		$this->user1 = $this->createUser($user1, 'longrandompassword');
+		$this->user2 = $this->createUser($user2, 'longrandompassword');
 
 		\OC::registerShareHooks(Server::get(SystemConfig::class));
 

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -70,7 +70,7 @@ class ManagerTest extends TestCase {
 	protected ICloudFederationFactory&MockObject $cloudFederationFactory;
 	protected IGroupManager&MockObject $groupManager;
 	protected IUserManager&MockObject $userManager;
-	protected ISetupManager&MockObject $setupManager;
+	protected ISetupManager&MockObject $setupManagerEncTrait;
 	protected ICertificateManager&MockObject $certificateManager;
 	private ExternalShareMapper $externalShareMapper;
 	private IConfig $config;
@@ -88,7 +88,7 @@ class ManagerTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
-		$this->setupManager = $this->createMock(ISetupManager::class);
+		$this->setupManagerEncTrait = $this->createMock(ISetupManager::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->rootFolder->method('getUserFolder')
 			->willReturnCallback(function (string $userId): Folder {
@@ -170,7 +170,7 @@ class ManagerTest extends TestCase {
 					$this->eventDispatcher,
 					$this->logger,
 					$this->rootFolder,
-					$this->setupManager,
+					$this->setupManagerEncTrait,
 					$this->certificateManager,
 					$this->externalShareMapper,
 					$this->config,

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -15,6 +15,8 @@ use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\ICertificateManager;
+use OCP\OCM\IOCMDiscoveryService;
+use OCP\OCM\IOCMProvider;
 use OCP\Server;
 
 /**
@@ -62,6 +64,9 @@ class ExternalStorageTest extends \Test\TestCase {
 		$manager = $this->createMock(ExternalShareManager::class);
 		$client = $this->createMock(IClient::class);
 		$response = $this->createMock(IResponse::class);
+		$discoveryService = $this->createMock(IOCMDiscoveryService::class);
+		$ocmProvider = $this->createMock(IOCMProvider::class);
+
 		$client
 			->expects($this->any())
 			->method('get')
@@ -74,6 +79,12 @@ class ExternalStorageTest extends \Test\TestCase {
 			->expects($this->any())
 			->method('newClient')
 			->willReturn($client);
+		$discoveryService->method('discover')
+			->willReturn($ocmProvider);
+		$ocmProvider->method('extractProtocolEntry')
+			->willReturn('/public.php/webdav');
+		$ocmProvider->method('getEndPoint')
+			->willReturn($uri);
 
 		return new TestSharingExternalStorage(
 			[
@@ -86,6 +97,7 @@ class ExternalStorageTest extends \Test\TestCase {
 				'manager' => $manager,
 				'certificateManager' => $certificateManager,
 				'HttpClientService' => $httpClientService,
+				'discoveryService' => $discoveryService,
 			]
 		);
 	}

--- a/apps/files_sharing/tests/GroupEtagPropagationTest.php
+++ b/apps/files_sharing/tests/GroupEtagPropagationTest.php
@@ -25,10 +25,10 @@ class GroupEtagPropagationTest extends PropagationTestCase {
 	 * "user4" (in group 3)
 	 */
 	protected function setUpShares() {
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1] = [];
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2] = [];
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3] = [];
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER4] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3] = [];
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER4] = [];
 
 		$this->rootView = new View('');
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
@@ -43,9 +43,9 @@ class GroupEtagPropagationTest extends PropagationTestCase {
 			Constants::PERMISSION_ALL
 		);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1][''] = $view1->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['test'] = $view1->getFileInfo('test')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER1]['test/sub'] = $view1->getFileInfo('test/sub')->getId();
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1][''] = $view1->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1]['test'] = $view1->getFileInfo('test');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER1]['test/sub'] = $view1->getFileInfo('test/sub');
 
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
 		$view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
@@ -67,28 +67,20 @@ class GroupEtagPropagationTest extends PropagationTestCase {
 		);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER4);
 
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2][''] = $view2->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['test'] = $view2->getFileInfo('test')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER2]['test/sub'] = $view2->getFileInfo('test/sub')->getId();
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2][''] = $view2->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2]['test'] = $view2->getFileInfo('test');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER2]['test/sub'] = $view2->getFileInfo('test/sub');
 
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER3);
 		$view3 = new View('/' . self::TEST_FILES_SHARING_API_USER3 . '/files');
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3][''] = $view3->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3]['test'] = $view3->getFileInfo('test')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER3]['test/sub'] = $view3->getFileInfo('test/sub')->getId();
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3][''] = $view3->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3]['test'] = $view3->getFileInfo('test');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER3]['test/sub'] = $view3->getFileInfo('test/sub');
 
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER4);
 		$view4 = new View('/' . self::TEST_FILES_SHARING_API_USER4 . '/files');
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER4][''] = $view4->getFileInfo('')->getId();
-		$this->fileIds[self::TEST_FILES_SHARING_API_USER4]['sub'] = $view4->getFileInfo('sub')->getId();
-
-		foreach ($this->fileIds as $user => $ids) {
-			$this->loginAsUser($user);
-			foreach ($ids as $id) {
-				$path = $this->rootView->getPath($id);
-				$this->fileEtags[$id] = $this->rootView->getFileInfo($path)->getEtag();
-			}
-		}
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER4][''] = $view4->getFileInfo('');
+		$this->fileInfos[self::TEST_FILES_SHARING_API_USER4]['sub'] = $view4->getFileInfo('sub');
 	}
 
 	public function testGroupReShareRecipientWrites(): void {

--- a/apps/files_sharing/tests/LockingTest.php
+++ b/apps/files_sharing/tests/LockingTest.php
@@ -11,11 +11,10 @@ namespace OCA\Files_Sharing\Tests;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\Constants;
-use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
-use OCP\Server;
 use OCP\Share\IShare;
+use Test\Traits\UserTrait;
 
 /**
  * Class LockingTest
@@ -25,10 +24,7 @@ use OCP\Share\IShare;
  */
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class LockingTest extends TestCase {
-	/**
-	 * @var \Test\Util\User\Dummy
-	 */
-	private $userBackend;
+	use UserTrait;
 
 	private $ownerUid;
 	private $recipientUid;
@@ -36,13 +32,10 @@ class LockingTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->userBackend = new \Test\Util\User\Dummy();
-		Server::get(IUserManager::class)->registerBackend($this->userBackend);
-
 		$this->ownerUid = $this->getUniqueID('owner_');
 		$this->recipientUid = $this->getUniqueID('recipient_');
-		$this->userBackend->createUser($this->ownerUid, '');
-		$this->userBackend->createUser($this->recipientUid, '');
+		$this->createUser($this->ownerUid, '');
+		$this->createUser($this->recipientUid, '');
 
 		$this->loginAsUser($this->ownerUid);
 		Filesystem::mkdir('/foo');
@@ -59,11 +52,6 @@ class LockingTest extends TestCase {
 
 		$this->loginAsUser($this->recipientUid);
 		$this->assertTrue(Filesystem::file_exists('bar.txt'));
-	}
-
-	protected function tearDown(): void {
-		Server::get(IUserManager::class)->removeBackend($this->userBackend);
-		parent::tearDown();
 	}
 
 	public function testLockAsRecipient(): void {

--- a/apps/files_sharing/tests/PropagationTestCase.php
+++ b/apps/files_sharing/tests/PropagationTestCase.php
@@ -10,6 +10,7 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\View;
 use OCA\Files_Sharing\Helper;
+use OCP\Files\FileInfo;
 use OCP\IUserSession;
 use OCP\Server;
 
@@ -18,7 +19,8 @@ abstract class PropagationTestCase extends TestCase {
 	 * @var View
 	 */
 	protected $rootView;
-	protected $fileIds = []; // [$user=>[$path=>$id]]
+	/** @var array<string, array<string, FileInfo> */
+	protected array $fileInfos = []; // [$user=>[$path=>$info]]
 	protected $fileEtags = []; // [$id=>$etag]
 
 	public static function setUpBeforeClass(): void {
@@ -29,6 +31,13 @@ abstract class PropagationTestCase extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->setUpShares();
+
+		foreach ($this->fileInfos as $infos) {
+			/** @var FileInfo $info */
+			foreach ($infos as $info) {
+				$this->fileEtags[$info->getId()] = $info->getEtag();
+			}
+		}
 	}
 
 	protected function tearDown(): void {
@@ -49,7 +58,7 @@ abstract class PropagationTestCase extends TestCase {
 		$oldUser = Server::get(IUserSession::class)->getUser();
 		foreach ($users as $user) {
 			$this->loginAsUser($user);
-			$id = $this->fileIds[$user][$subPath];
+			$id = $this->fileInfos[$user][$subPath]->getId();
 			$path = $this->rootView->getPath($id);
 			$etag = $this->rootView->getFileInfo($path)->getEtag();
 			$this->assertNotEquals($this->fileEtags[$id], $etag, 'Failed asserting that the etag for "' . $subPath . '" of user ' . $user . ' has changed');
@@ -66,7 +75,7 @@ abstract class PropagationTestCase extends TestCase {
 		$oldUser = Server::get(IUserSession::class)->getUser();
 		foreach ($users as $user) {
 			$this->loginAsUser($user);
-			$id = $this->fileIds[$user][$subPath];
+			$id = $this->fileInfos[$user][$subPath]->getId();
 			$path = $this->rootView->getPath($id);
 			$etag = $this->rootView->getFileInfo($path)->getEtag();
 			$this->assertEquals($this->fileEtags[$id], $etag, 'Failed asserting that the etag for "' . $subPath . '" of user ' . $user . ' has not changed');

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -26,6 +26,7 @@ use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
+use Test\Traits\UserTrait;
 
 /**
  * Class SharesReminderJobTest
@@ -35,6 +36,8 @@ use Psr\Log\LoggerInterface;
  */
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SharesReminderJobTest extends \Test\TestCase {
+	use UserTrait;
+
 	private SharesReminderJob $job;
 	private IDBConnection $db;
 	private IManager $shareManager;
@@ -57,8 +60,8 @@ class SharesReminderJobTest extends \Test\TestCase {
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
 
-		$user1 = $this->userManager->createUser($this->user1, 'longrandompassword');
-		$user2 = $this->userManager->createUser($this->user2, 'longrandompassword');
+		$user1 = $this->createUser($this->user1, 'longrandompassword');
+		$user2 = $this->createUser($this->user2, 'longrandompassword');
 		$user1->setSystemEMailAddress('user1@test.com');
 		$user2->setSystemEMailAddress('user2@test.com');
 
@@ -80,16 +83,6 @@ class SharesReminderJobTest extends \Test\TestCase {
 
 	protected function tearDown(): void {
 		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
-
-		$userManager = Server::get(IUserManager::class);
-		$user1 = $userManager->get($this->user1);
-		if ($user1) {
-			$user1->delete();
-		}
-		$user2 = $userManager->get($this->user2);
-		if ($user2) {
-			$user2->delete();
-		}
 
 		$this->logout();
 

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -8,25 +8,26 @@
 
 namespace OCA\Files_Sharing\Tests;
 
-use OC\Files\Cache\Storage;
-use OC\Files\Filesystem;
 use OC\Files\View;
-use OC\Group\Database;
 use OC\SystemConfig;
 use OC\User\DisplayNameCache;
+use OC\User\Session;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Sharing\External\MountProvider as ExternalMountProvider;
 use OCA\Files_Sharing\Listener\SharesUpdatedListener;
 use OCA\Files_Sharing\MountProvider;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\IDBConnection;
-use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
+use OCP\Share\IManager;
 use OCP\Share\IShare;
+use Test\Traits\GroupTrait;
 use Test\Traits\MountProviderTrait;
+use Test\Traits\UserTrait;
 
 /**
  * Base class for sharing tests.
@@ -34,6 +35,8 @@ use Test\Traits\MountProviderTrait;
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 abstract class TestCase extends \Test\TestCase {
 	use MountProviderTrait;
+	use UserTrait;
+	use GroupTrait;
 
 	public const TEST_FILES_SHARING_API_USER1 = 'test-share-user1';
 	public const TEST_FILES_SHARING_API_USER2 = 'test-share-user2';
@@ -55,13 +58,21 @@ abstract class TestCase extends \Test\TestCase {
 	public $folder;
 	public $subfolder;
 
-	/** @var \OCP\Share\IManager */
+	/** @var IManager */
 	protected $shareManager;
 	/** @var IRootFolder */
 	protected $rootFolder;
+	protected Session $userSession;
+	protected ISetupManager $setupManager;
 
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->shareManager = Server::get(IManager::class);
+		$this->rootFolder = Server::get(IRootFolder::class);
+
+		$this->setupManager = Server::get(ISetupManager::class);
+		$this->userSession = Server::get(IUserSession::class);
 
 		$app = new Application();
 		$app->registerMountProviders(
@@ -70,44 +81,36 @@ abstract class TestCase extends \Test\TestCase {
 			Server::get(ExternalMountProvider::class),
 		);
 
-		// reset backend
-		Server::get(IUserManager::class)->clearBackends();
-		Server::get(IGroupManager::class)->clearBackends();
-
 		// clear share hooks
 		\OC_Hook::clear('OCP\\Share');
 		\OC::registerShareHooks(Server::get(SystemConfig::class));
 
-		// create users
-		$backend = new \Test\Util\User\Dummy();
-		Server::get(IUserManager::class)->registerBackend($backend);
-		$backend->createUser(self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER1);
-		$backend->createUser(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER2);
-		$backend->createUser(self::TEST_FILES_SHARING_API_USER3, self::TEST_FILES_SHARING_API_USER3);
-		$backend->createUser(self::TEST_FILES_SHARING_API_USER4, self::TEST_FILES_SHARING_API_USER4);
-
-		// create group
-		$groupBackend = new \Test\Util\Group\Dummy();
-		$groupBackend->createGroup(self::TEST_FILES_SHARING_API_GROUP1);
-		$groupBackend->createGroup('group');
-		$groupBackend->createGroup('group1');
-		$groupBackend->createGroup('group2');
-		$groupBackend->createGroup('group3');
-		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER1, 'group');
-		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER2, 'group');
-		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER3, 'group');
-		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER2, 'group1');
-		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER3, 'group2');
-		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER4, 'group3');
-		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_GROUP1);
-		Server::get(IGroupManager::class)->addBackend($groupBackend);
-
 		Server::get(SharesUpdatedListener::class)->setCutOffMarkTime(-1);
-	}
 
-	protected function setUp(): void {
-		parent::setUp();
 		Server::get(DisplayNameCache::class)->clear();
+
+		$this->createUser(self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER1);
+		$this->createUser(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER2);
+		$this->createUser(self::TEST_FILES_SHARING_API_USER3, self::TEST_FILES_SHARING_API_USER3);
+		$this->createUser(self::TEST_FILES_SHARING_API_USER4, self::TEST_FILES_SHARING_API_USER4);
+
+		$this->createGroup(self::TEST_FILES_SHARING_API_GROUP1, [
+			self::TEST_FILES_SHARING_API_USER2,
+		]);
+		$this->createGroup('group', [
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			self::TEST_FILES_SHARING_API_USER3,
+		]);
+		$this->createGroup('group1', [
+			self::TEST_FILES_SHARING_API_USER2,
+		]);
+		$this->createGroup('group2', [
+			self::TEST_FILES_SHARING_API_USER3,
+		]);
+		$this->createGroup('group3', [
+			self::TEST_FILES_SHARING_API_USER4,
+		]);
 
 		//login as user1
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
@@ -115,9 +118,6 @@ abstract class TestCase extends \Test\TestCase {
 		$this->data = 'foobar';
 		$this->view = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
 		$this->view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
-
-		$this->shareManager = Server::get(\OCP\Share\IManager::class);
-		$this->rootFolder = Server::get(IRootFolder::class);
 	}
 
 	protected function tearDown(): void {
@@ -133,73 +133,18 @@ abstract class TestCase extends \Test\TestCase {
 		$qb->delete('filecache')->runAcrossAllShards();
 		$qb->executeStatement();
 
+		$this->userSession->setUser(null);
+		$this->setupManager->tearDown();
+
 		parent::tearDown();
 	}
 
-	public static function tearDownAfterClass(): void {
-		// cleanup users
-		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER1);
-		if ($user !== null) {
-			$user->delete();
-		}
-		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER2);
-		if ($user !== null) {
-			$user->delete();
-		}
-		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER3);
-		if ($user !== null) {
-			$user->delete();
-		}
+	protected function loginHelper(string $uid) {
+		$this->setupManager->tearDown();
+		$user = Server::get(IUserManager::class)->get($uid);
+		$this->userSession->completeLogin($user, ['loginName' => $uid, 'password' => $uid], false);
 
-		// delete group
-		$group = Server::get(IGroupManager::class)->get(self::TEST_FILES_SHARING_API_GROUP1);
-		if ($group) {
-			$group->delete();
-		}
-
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId('');
-		Filesystem::tearDown();
-
-		// reset backend
-		Server::get(IUserManager::class)->clearBackends();
-		Server::get(IUserManager::class)->registerBackend(new \OC\User\Database());
-		Server::get(IGroupManager::class)->clearBackends();
-		Server::get(IGroupManager::class)->addBackend(new Database());
-
-		parent::tearDownAfterClass();
-	}
-
-	/**
-	 * @param string $user
-	 * @param bool $create
-	 * @param bool $password
-	 */
-	protected function loginHelper($user, $create = false, $password = false) {
-		if ($password === false) {
-			$password = $user;
-		}
-
-		if ($create) {
-			$userManager = Server::get(IUserManager::class);
-			$groupManager = Server::get(IGroupManager::class);
-
-			$userObject = $userManager->createUser($user, $password);
-			$group = $groupManager->createGroup('group');
-
-			if ($group && $userObject) {
-				$group->addUser($userObject);
-			}
-		}
-
-		\OC_Util::tearDownFS();
-		Storage::getGlobalCache()->clearCache();
-		Server::get(IUserSession::class)->setUser(null);
-		Filesystem::tearDown();
-		Server::get(IUserSession::class)->login($user, $password);
-		\OC::$server->getUserFolder($user);
-
-		\OC_Util::setupFS($user);
+		$this->rootFolder->newFolder('/' . $uid . '/files');
 	}
 
 	/**

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -1017,23 +1017,23 @@ class OC {
 					$request = Server::get(IRequest::class);
 					$throttler = Server::get(IThrottler::class);
 					$throttler->resetDelay($request->getRemoteAddress(), 'login', ['user' => $uid]);
-				}
 
-				try {
-					$cache = new \OC\Cache\File();
-					$cache->gc();
-				} catch (\OC\ServerNotAvailableException $e) {
-					// not a GC exception, pass it on
-					throw $e;
-				} catch (\OC\ForbiddenException $e) {
-					// filesystem blocked for this request, ignore
-				} catch (\Exception $e) {
-					// a GC exception should not prevent users from using OC,
-					// so log the exception
-					Server::get(LoggerInterface::class)->warning('Exception when running cache gc.', [
-						'app' => 'core',
-						'exception' => $e,
-					]);
+					try {
+						$cache = new \OC\Cache\File();
+						$cache->gc();
+					} catch (\OC\ServerNotAvailableException $e) {
+						// not a GC exception, pass it on
+						throw $e;
+					} catch (\OC\ForbiddenException $e) {
+						// filesystem blocked for this request, ignore
+					} catch (\Exception $e) {
+						// a GC exception should not prevent users from using OC,
+						// so log the exception
+						Server::get(LoggerInterface::class)->warning('Exception when running cache gc.', [
+							'app' => 'core',
+							'exception' => $e,
+						]);
+					}
 				}
 			});
 		}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -105,6 +105,14 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	#[\Override]
+	public function removeBackend(GroupInterface $backend): void {
+		$this->clearCaches();
+		if (($i = array_search($backend, $this->backends)) !== false) {
+			unset($this->backends[$i]);
+		}
+	}
+
+	#[\Override]
 	public function clearBackends() {
 		$this->backends = [];
 		$this->clearCaches();

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -40,6 +40,11 @@ interface IGroupManager {
 	public function addBackend($backend);
 
 	/**
+	 * @since 34.0.0
+	 */
+	public function removeBackend(GroupInterface $backend): void;
+
+	/**
 	 * @since 8.0.0
 	 */
 	public function clearBackends();

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -17,6 +17,7 @@ use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
 use OCP\App\IAppManager;
 use OCP\Encryption\IManager;
+use OCP\Files\ISetupManager;
 use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -38,10 +39,8 @@ trait EncryptionTrait {
 
 	private $originalEncryptionModule;
 
-	/** @var IUserManager */
-	private $userManager;
-	/** @var SetupManager */
-	private $setupManager;
+	private IUserManager $userManagerEncTrait;
+	private ISetupManager $setupManagerEncTrait;
 
 	/**
 	 * @var IConfig
@@ -59,19 +58,19 @@ trait EncryptionTrait {
 		// needed for fully logout
 		Server::get(IUserSession::class)->setUser(null);
 
-		$this->setupManager->tearDown();
+		$this->setupManagerEncTrait->tearDown();
 
 		\OC_User::setUserId($user);
 		$this->postLogin();
 		\OC_Util::setupFS($user);
-		if ($this->userManager->userExists($user)) {
+		if ($this->userManagerEncTrait->userExists($user)) {
 			\OC::$server->getUserFolder($user);
 		}
 	}
 
 	protected function setupForUser($name, $password) {
-		$this->setupManager->tearDown();
-		$this->setupManager->setupForUser($this->userManager->get($name));
+		$this->setupManagerEncTrait->tearDown();
+		$this->setupManagerEncTrait->setupForUser($this->userManagerEncTrait->get($name));
 
 		$container = $this->encryptionApp->getContainer();
 		/** @var KeyManager $keyManager */
@@ -101,8 +100,8 @@ trait EncryptionTrait {
 			$this->markTestSkipped('Encryption not ready');
 		}
 
-		$this->userManager = Server::get(IUserManager::class);
-		$this->setupManager = Server::get(SetupManager::class);
+		$this->userManagerEncTrait = Server::get(IUserManager::class);
+		$this->setupManagerEncTrait = Server::get(SetupManager::class);
 
 		Server::get(IAppManager::class)->loadApp('encryption');
 

--- a/tests/lib/Traits/GroupTrait.php
+++ b/tests/lib/Traits/GroupTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Traits;
+
+use OC\Group\Group;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Server;
+use Test\Util\Group\Dummy;
+
+class DummyGroup extends Group {
+	public function __construct(
+		private string $gid,
+	) {
+		parent::__construct(
+			$this->gid,
+			[],
+			Server::get(IEventDispatcher::class),
+			Server::get(IUserManager::class),
+		);
+	}
+
+	#[\Override]
+	public function getGID(): string {
+		return $this->gid;
+	}
+}
+
+/**
+ * Allow creating users in a temporary backend
+ */
+trait GroupTrait {
+	protected Dummy $groupBackend;
+
+	protected function createGroup(string $name, array $users = []): IGroup {
+		$this->groupBackend->createGroup($name);
+		foreach ($users as $user) {
+			$this->groupBackend->addToGroup($user, $name);
+		}
+		return new DummyGroup($name);
+	}
+
+	protected function addToGroup(string $user, string $group): void {
+		$this->groupBackend->addToGroup($user, $group);
+	}
+
+	protected function setUpGroupTrait() {
+		$this->groupBackend = new Dummy();
+		Server::get(IGroupManager::class)->addBackend($this->groupBackend);
+	}
+
+	protected function tearDownGroupTrait() {
+		Server::get(IGroupManager::class)->removeBackend($this->groupBackend);
+	}
+}

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -13,7 +13,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
-use OCP\UserInterface;
+use Test\Util\User\Dummy;
 
 class DummyUser extends User {
 	public function __construct(
@@ -32,10 +32,7 @@ class DummyUser extends User {
  * Allow creating users in a temporary backend
  */
 trait UserTrait {
-	/**
-	 * @var \Test\Util\User\Dummy|UserInterface
-	 */
-	protected $userBackend;
+	protected Dummy $userBackend;
 
 	protected function createUser($name, $password): IUser {
 		$this->userBackend->createUser($name, $password);
@@ -43,7 +40,7 @@ trait UserTrait {
 	}
 
 	protected function setUpUserTrait() {
-		$this->userBackend = new \Test\Util\User\Dummy();
+		$this->userBackend = new Dummy();
 		Server::get(IUserManager::class)->registerBackend($this->userBackend);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Mock OCM discovery
- Better dummy user/group backend usage
- don't trigger cache gc during tests
- reduce number of filesystem setups

Reduces time to run the share tests by ~2/3 in my testing

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
