### PR TITLE
fix(files_reminders): keep batch alive on per-row failure

### DIFF
--- a/apps/files_reminders/lib/BackgroundJob/ScheduledNotifications.php
+++ b/apps/files_reminders/lib/BackgroundJob/ScheduledNotifications.php
@@ -11,10 +11,10 @@ namespace OCA\FilesReminders\BackgroundJob;
 
 use OCA\FilesReminders\Db\ReminderMapper;
 use OCA\FilesReminders\Service\ReminderService;
-use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class ScheduledNotifications extends TimedJob {
 	public function __construct(
@@ -37,8 +37,11 @@ class ScheduledNotifications extends TimedJob {
 		foreach ($reminders as $reminder) {
 			try {
 				$this->reminderService->send($reminder);
-			} catch (DoesNotExistException $e) {
-				$this->logger->debug('Could not send notification for reminder with id ' . $reminder->getId());
+			} catch (Throwable $e) {
+				// A single broken reminder (e.g. orphaned user record) must not
+				// stall the rest of the queue, which is ordered by due_date ASC
+				// and would otherwise re-hit the same row on every cron tick.
+				$this->logger->error('Could not send notification for reminder with id ' . $reminder->getId(), ['exception' => $e]);
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The job iterates overdue reminders ordered by `due_date` ASC and only caught `DoesNotExistException`. A `UserNotFoundException` (thrown by `ReminderService::send` when the recipient user record is missing, e.g.: an orphaned LDAP user that was removed without firing `UserDeletedEvent`) or any other Throwable escaped the foreach, terminating the whole batch.

Because `findOverdue` re-pulls the same oldest row on every cron tick, this stalled the entire reminder pipeline indefinitely.

Catch Throwable, log at error level, and continue to the next reminder.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
