### PR TITLE
fix(federation): reset retainJob at start of run()

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -74,6 +74,10 @@ class GetSharedSecret extends Job {
 
 	#[\Override]
 	protected function run($argument) {
+		// The DI container caches this instance, so a prior invocation in the
+		// same cron pass can leave $retainJob = true and cause this row to be
+		// re-queued unconditionally after start() removes it.
+		$this->retainJob = false;
 		$target = $argument['url'];
 		$created = isset($argument['created']) ? (int)$argument['created'] : $this->time->getTime();
 		$currentTime = $this->time->getTime();

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -87,6 +87,10 @@ class RequestSharedSecret extends Job {
 	 */
 	#[\Override]
 	protected function run($argument) {
+		// The DI container caches this instance, so a prior invocation in the
+		// same cron pass can leave $retainJob = true and cause this row to be
+		// re-queued unconditionally after start() removes it.
+		$this->retainJob = false;
 		$target = $argument['url'];
 		$created = isset($argument['created']) ? (int)$argument['created'] : $this->time->getTime();
 		$currentTime = $this->time->getTime();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`JobList::buildJob` resolves the job class via `Server::get()`, and the `SimpleContainer` caches the resulting instance as a singleton. When the cron loop processes multiple `GetSharedSecret` or `RequestSharedSecre`t rows in the same pass, the same PHP object is reused, so a prior failure's `$this->retainJob = true` persisted into the next row's success path. The overridden `start()` then re-queued an already-successful handshake, causing continuous secret rotation against healthy peers.

Reset `$this->retainJob = false` at the top of `run()` so each invocation starts from a known state regardless of prior state on the cached instance.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
