### PR TITLE
test(cypress): fix flakes in files-renaming and FilesUtils

### DIFF
--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -18,17 +18,25 @@ export const getActionsForFile = (filename: string) => cy.get(`[data-cy-files-li
 export const getActionButtonForFileId = (fileid: number) => getActionsForFileId(fileid).findByRole('button', { name: 'Actions' })
 export const getActionButtonForFile = (filename: string) => getActionsForFile(filename).findByRole('button', { name: 'Actions' })
 
+// Atomic query for the rename input that appears inside a row when in rename mode.
+// `aria-label` matches the NcTextField that the files app renders (either "Filename" or
+// "Folder name"). Using a single cy.get from the document root avoids "subject no longer
+// attached" when the row re-renders as it swaps the name-link for an input.
+export const getRenameInputForFile = (filename: string) =>
+	cy.get(`[data-cy-files-list-row-name="${CSS.escape(filename)}"] [data-cy-files-list-row-name] input[aria-label]`)
+
 /**
  *
  * @param fileid
  * @param actionId
  */
 export function getActionEntryForFileId(fileid: number, actionId: string) {
+	// Single descendant selector in the inner cy.get() so the menu + entry are
+	// queried atomically. Chaining cy.get(`#menu`).find(entry) fails with
+	// "subject no longer attached" when Vue re-renders the open menu mid-chain.
 	return getActionButtonForFileId(fileid)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get(`#${menuId}`)
-			.should('exist')
-			.find(`[data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
+		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
 }
 
 /**
@@ -37,11 +45,12 @@ export function getActionEntryForFileId(fileid: number, actionId: string) {
  * @param actionId
  */
 export function getActionEntryForFile(file: string, actionId: string) {
+	// Single descendant selector in the inner cy.get() so the menu + entry are
+	// queried atomically. Chaining cy.get(`#menu`).find(entry) fails with
+	// "subject no longer attached" when Vue re-renders the open menu mid-chain.
 	return getActionButtonForFile(file)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get(`#${menuId}`)
-			.should('exist')
-			.find(`[data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
+		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
 }
 
 /**
@@ -72,10 +81,13 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFileId(fileid)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	getActionEntryForFileId(fileid, actionId)
-		.find('button')
-		.should('be.visible')
-		.click()
+	// Atomic selector for the action entry's <button>: menu id + entry + button
+	// is one cy.get() so Cypress can re-query the whole path when the menu re-renders.
+	getActionButtonForFileId(fileid)
+		.should('have.attr', 'aria-controls')
+		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"] button`)
+			.should('be.visible')
+			.click())
 }
 
 /**
@@ -88,10 +100,13 @@ export function triggerActionForFile(filename: string, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFile(filename)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	getActionEntryForFile(filename, actionId)
-		.find('button')
-		.should('be.visible')
-		.click()
+	// Atomic selector for the action entry's <button>: menu id + entry + button
+	// is one cy.get() so Cypress can re-query the whole path when the menu re-renders.
+	getActionButtonForFile(filename)
+		.should('have.attr', 'aria-controls')
+		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"] button`)
+			.should('be.visible')
+			.click())
 }
 
 /**
@@ -260,8 +275,9 @@ export function renameFile(fileName: string, newFileName: string) {
 	// intercept the move so we can wait for it
 	cy.intercept('MOVE', /\/(remote|public)\.php\/dav\/files\//).as('moveFile')
 
-	getRowForFile(fileName)
-		.find('[data-cy-files-list-row-name] input')
+	// Atomic selector — chaining getRowForFile(...).find(input) races with the
+	// row re-rendering when the link is swapped for the rename input.
+	cy.get(`[data-cy-files-list-row-name="${CSS.escape(fileName)}"] [data-cy-files-list-row-name] input`)
 		.type(`{selectAll}${newFileName}{enter}`)
 
 	cy.wait('@moveFile')
@@ -278,7 +294,11 @@ export function navigateToFolder(dirPath: string) {
 			continue
 		}
 
-		getRowForFile(directory).should('be.visible').find('[data-cy-files-list-row-name-link]').click()
+		// Atomic descendant selector — chaining .find() after .should('be.visible')
+		// races with row re-renders triggered by navigation.
+		cy.get(`[data-cy-files-list-row-name="${CSS.escape(directory)}"] [data-cy-files-list-row-name-link]`)
+			.should('be.visible')
+			.click()
 	}
 }
 

--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -95,24 +95,35 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFileId(fileid)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	// Look up the action's clickable button. NcActions in
-	// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
-	// N children as standalone buttons inline in the row (the action carries
-	// `data-cy-files-list-row-action` directly on the <button>), and the rest
-	// inside the teleported menu popup (the action wraps a <button>). Use the
-	// menu id from aria-controls so we look in the right popup, and union with
-	// the inline-button location to cover both cases atomically.
 	const escaped = CSS.escape(actionId)
 	getActionButtonForFileId(fileid)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get([
-			`[data-cy-files-list-row-fileid="${fileid}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escaped}"]`,
-			`#${menuId} [data-cy-files-list-row-action="${escaped}"] button`,
-			`#${menuId} button[data-cy-files-list-row-action="${escaped}"]`,
-		].join(', '))
-			.first()
-			.should('be.visible')
-			.click())
+		.then((menuId) => {
+			// Wait for actions to be hydrated on this row. Until Vue finishes resolving
+			// the row's `node` prop, `enabledRenderActions` is empty and the row's
+			// inline area + opened popup contain no `[data-cy-files-list-row-action]`
+			// element. That race is independent of app boot and is the residual flake
+			// once OCP/OCA are ready. Wait up to 10 s for at least one action to mount.
+			cy.get([
+				`[data-cy-files-list-row-fileid="${fileid}"] [data-cy-files-list-row-actions] [data-cy-files-list-row-action]`,
+				`#${menuId} [data-cy-files-list-row-action]`,
+			].join(', '), { timeout: 10000 }).should('exist')
+			// Look up the action's clickable button. NcActions in
+			// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
+			// N children as standalone buttons inline in the row (the action carries
+			// `data-cy-files-list-row-action` directly on the <button>), and the rest
+			// inside the teleported menu popup (the action wraps a <button>). Use the
+			// menu id from aria-controls so we look in the right popup, and union with
+			// the inline-button location to cover both cases atomically.
+			cy.get([
+				`[data-cy-files-list-row-fileid="${fileid}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escaped}"]`,
+				`#${menuId} [data-cy-files-list-row-action="${escaped}"] button`,
+				`#${menuId} button[data-cy-files-list-row-action="${escaped}"]`,
+			].join(', '))
+				.first()
+				.should('be.visible')
+				.click()
+		})
 }
 
 /**
@@ -134,25 +145,36 @@ export function triggerActionForFile(filename: string, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFile(filename)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	// Look up the action's clickable button. NcActions in
-	// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
-	// N children as standalone buttons inline in the row (the action carries
-	// `data-cy-files-list-row-action` directly on the <button>), and the rest
-	// inside the teleported menu popup (the action wraps a <button>). Use the
-	// menu id from aria-controls so we look in the right popup, and union with
-	// the inline-button location to cover both cases atomically.
 	const escapedAction = CSS.escape(actionId)
 	const escapedName = CSS.escape(filename)
 	getActionButtonForFile(filename)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get([
-			`[data-cy-files-list-row-name="${escapedName}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escapedAction}"]`,
-			`#${menuId} [data-cy-files-list-row-action="${escapedAction}"] button`,
-			`#${menuId} button[data-cy-files-list-row-action="${escapedAction}"]`,
-		].join(', '))
-			.first()
-			.should('be.visible')
-			.click())
+		.then((menuId) => {
+			// Wait for actions to be hydrated on this row. Until Vue finishes resolving
+			// the row's `node` prop, `enabledRenderActions` is empty and the row's
+			// inline area + opened popup contain no `[data-cy-files-list-row-action]`
+			// element. That race is independent of app boot and is the residual flake
+			// once OCP/OCA are ready. Wait up to 10 s for at least one action to mount.
+			cy.get([
+				`[data-cy-files-list-row-name="${escapedName}"] [data-cy-files-list-row-actions] [data-cy-files-list-row-action]`,
+				`#${menuId} [data-cy-files-list-row-action]`,
+			].join(', '), { timeout: 10000 }).should('exist')
+			// Look up the action's clickable button. NcActions in
+			// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
+			// N children as standalone buttons inline in the row (the action carries
+			// `data-cy-files-list-row-action` directly on the <button>), and the rest
+			// inside the teleported menu popup (the action wraps a <button>). Use the
+			// menu id from aria-controls so we look in the right popup, and union with
+			// the inline-button location to cover both cases atomically.
+			cy.get([
+				`[data-cy-files-list-row-name="${escapedName}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escapedAction}"]`,
+				`#${menuId} [data-cy-files-list-row-action="${escapedAction}"] button`,
+				`#${menuId} button[data-cy-files-list-row-action="${escapedAction}"]`,
+			].join(', '))
+				.first()
+				.should('be.visible')
+				.click()
+		})
 }
 
 /**

--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -86,20 +86,24 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFileId(fileid)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	// After the menu opens, the action button can live either inline in this row
-	// (NcActions renders the first N children as standalone buttons outside the
-	// popup, see apps/files/src/components/FileEntry/FileEntryActions.vue) or
-	// inside the teleported menu popup. The inline match is scoped to the row;
-	// the menu popup is unique on the page so unscoped is fine.
+	// Look up the action's clickable button. NcActions in
+	// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
+	// N children as standalone buttons inline in the row (the action carries
+	// `data-cy-files-list-row-action` directly on the <button>), and the rest
+	// inside the teleported menu popup (the action wraps a <button>). Use the
+	// menu id from aria-controls so we look in the right popup, and union with
+	// the inline-button location to cover both cases atomically.
 	const escaped = CSS.escape(actionId)
-	cy.get([
-		`[data-cy-files-list-row-fileid="${fileid}"] button[data-cy-files-list-row-action="${escaped}"]`,
-		`[role="menu"] [data-cy-files-list-row-action="${escaped}"] button`,
-		`[role="menu"] button[data-cy-files-list-row-action="${escaped}"]`,
-	].join(', '))
-		.filter(':visible')
-		.first()
-		.click()
+	getActionButtonForFileId(fileid)
+		.should('have.attr', 'aria-controls')
+		.then((menuId) => cy.get([
+			`[data-cy-files-list-row-fileid="${fileid}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escaped}"]`,
+			`#${menuId} [data-cy-files-list-row-action="${escaped}"] button`,
+			`#${menuId} button[data-cy-files-list-row-action="${escaped}"]`,
+		].join(', '))
+			.first()
+			.should('be.visible')
+			.click())
 }
 
 /**
@@ -112,21 +116,25 @@ export function triggerActionForFile(filename: string, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFile(filename)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	// After the menu opens, the action button can live either inline in this row
-	// (NcActions renders the first N children as standalone buttons outside the
-	// popup, see apps/files/src/components/FileEntry/FileEntryActions.vue) or
-	// inside the teleported menu popup. The inline match is scoped to the row;
-	// the menu popup is unique on the page so unscoped is fine.
+	// Look up the action's clickable button. NcActions in
+	// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
+	// N children as standalone buttons inline in the row (the action carries
+	// `data-cy-files-list-row-action` directly on the <button>), and the rest
+	// inside the teleported menu popup (the action wraps a <button>). Use the
+	// menu id from aria-controls so we look in the right popup, and union with
+	// the inline-button location to cover both cases atomically.
 	const escapedAction = CSS.escape(actionId)
 	const escapedName = CSS.escape(filename)
-	cy.get([
-		`[data-cy-files-list-row-name="${escapedName}"] button[data-cy-files-list-row-action="${escapedAction}"]`,
-		`[role="menu"] [data-cy-files-list-row-action="${escapedAction}"] button`,
-		`[role="menu"] button[data-cy-files-list-row-action="${escapedAction}"]`,
-	].join(', '))
-		.filter(':visible')
-		.first()
-		.click()
+	getActionButtonForFile(filename)
+		.should('have.attr', 'aria-controls')
+		.then((menuId) => cy.get([
+			`[data-cy-files-list-row-name="${escapedName}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escapedAction}"]`,
+			`#${menuId} [data-cy-files-list-row-action="${escapedAction}"] button`,
+			`#${menuId} button[data-cy-files-list-row-action="${escapedAction}"]`,
+		].join(', '))
+			.first()
+			.should('be.visible')
+			.click())
 }
 
 /**

--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -18,12 +18,17 @@ export const getActionsForFile = (filename: string) => cy.get(`[data-cy-files-li
 export const getActionButtonForFileId = (fileid: number) => getActionsForFileId(fileid).findByRole('button', { name: 'Actions' })
 export const getActionButtonForFile = (filename: string) => getActionsForFile(filename).findByRole('button', { name: 'Actions' })
 
-// Atomic query for the rename input that appears inside a row when in rename mode.
-// `aria-label` matches the NcTextField that the files app renders (either "Filename" or
-// "Folder name"). Using a single cy.get from the document root avoids "subject no longer
-// attached" when the row re-renders as it swaps the name-link for an input.
-export const getRenameInputForFile = (filename: string) =>
-	cy.get(`[data-cy-files-list-row-name="${CSS.escape(filename)}"] [data-cy-files-list-row-name] input[aria-label]`)
+/**
+ * Atomic query for the rename input that appears inside a row when in rename mode.
+ * `aria-label` matches the NcTextField that the files app renders (either "Filename" or
+ * "Folder name"). Using a single cy.get from the document root avoids "subject no longer
+ * attached" when the row re-renders as it swaps the name-link for an input.
+ *
+ * @param filename
+ */
+export function getRenameInputForFile(filename: string) {
+	return cy.get(`[data-cy-files-list-row-name="${CSS.escape(filename)}"] [data-cy-files-list-row-name] input[aria-label]`)
+}
 
 /**
  *

--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -86,13 +86,20 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFileId(fileid)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	// Atomic selector for the action entry's <button>: menu id + entry + button
-	// is one cy.get() so Cypress can re-query the whole path when the menu re-renders.
-	getActionButtonForFileId(fileid)
-		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"] button`)
-			.should('be.visible')
-			.click())
+	// After the menu opens, the action button can live either inline in this row
+	// (NcActions renders the first N children as standalone buttons outside the
+	// popup, see apps/files/src/components/FileEntry/FileEntryActions.vue) or
+	// inside the teleported menu popup. The inline match is scoped to the row;
+	// the menu popup is unique on the page so unscoped is fine.
+	const escaped = CSS.escape(actionId)
+	cy.get([
+		`[data-cy-files-list-row-fileid="${fileid}"] button[data-cy-files-list-row-action="${escaped}"]`,
+		`[role="menu"] [data-cy-files-list-row-action="${escaped}"] button`,
+		`[role="menu"] button[data-cy-files-list-row-action="${escaped}"]`,
+	].join(', '))
+		.filter(':visible')
+		.first()
+		.click()
 }
 
 /**
@@ -105,13 +112,21 @@ export function triggerActionForFile(filename: string, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFile(filename)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
-	// Atomic selector for the action entry's <button>: menu id + entry + button
-	// is one cy.get() so Cypress can re-query the whole path when the menu re-renders.
-	getActionButtonForFile(filename)
-		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"] button`)
-			.should('be.visible')
-			.click())
+	// After the menu opens, the action button can live either inline in this row
+	// (NcActions renders the first N children as standalone buttons outside the
+	// popup, see apps/files/src/components/FileEntry/FileEntryActions.vue) or
+	// inside the teleported menu popup. The inline match is scoped to the row;
+	// the menu popup is unique on the page so unscoped is fine.
+	const escapedAction = CSS.escape(actionId)
+	const escapedName = CSS.escape(filename)
+	cy.get([
+		`[data-cy-files-list-row-name="${escapedName}"] button[data-cy-files-list-row-action="${escapedAction}"]`,
+		`[role="menu"] [data-cy-files-list-row-action="${escapedAction}"] button`,
+		`[role="menu"] button[data-cy-files-list-row-action="${escapedAction}"]`,
+	].join(', '))
+		.filter(':visible')
+		.first()
+		.click()
 }
 
 /**

--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -82,6 +82,13 @@ export function getInlineActionEntryForFile(file: string, actionId: string) {
  * @param actionId
  */
 export function triggerActionForFileId(fileid: number, actionId: string) {
+	// The 'details' action is filtered as not-enabled until the sidebar service
+	// registers on the window (see apps/files/src/actions/sidebarAction.ts and
+	// apps/files/src/sidebar.ts). Wait for it before opening the menu, otherwise
+	// the action button is missing from both the inline area and the popup.
+	if (actionId === 'details') {
+		cy.window({ timeout: 15000 }).its('OCA.Files._sidebar').should('be.a', 'function')
+	}
 	getActionButtonForFileId(fileid)
 		.scrollIntoView()
 	getActionButtonForFileId(fileid)
@@ -112,6 +119,13 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
  * @param actionId
  */
 export function triggerActionForFile(filename: string, actionId: string) {
+	// The 'details' action is filtered as not-enabled until the sidebar service
+	// registers on the window (see apps/files/src/actions/sidebarAction.ts and
+	// apps/files/src/sidebar.ts). Wait for it before opening the menu, otherwise
+	// the action button is missing from both the inline area and the popup.
+	if (actionId === 'details') {
+		cy.window({ timeout: 15000 }).its('OCA.Files._sidebar').should('be.a', 'function')
+	}
 	getActionButtonForFile(filename)
 		.scrollIntoView()
 	getActionButtonForFile(filename)

--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -82,12 +82,14 @@ export function getInlineActionEntryForFile(file: string, actionId: string) {
  * @param actionId
  */
 export function triggerActionForFileId(fileid: number, actionId: string) {
-	// The 'details' action is filtered as not-enabled until the sidebar service
-	// registers on the window (see apps/files/src/actions/sidebarAction.ts and
-	// apps/files/src/sidebar.ts). Wait for it before opening the menu, otherwise
-	// the action button is missing from both the inline area and the popup.
+	// Wait for the files app to finish booting before opening the action menu.
+	// `OCP.Files.Router` is wired up by apps/files/src/init.ts after file actions
+	// are registered, and `OCA.Files._sidebar` is set by apps/files/src/sidebar.ts
+	// — without both, the row's action menu can render empty (the 'details' action
+	// in particular depends on `getSidebar().available`).
+	cy.window({ timeout: 20000 }).its('OCP.Files.Router').should('exist')
 	if (actionId === 'details') {
-		cy.window({ timeout: 15000 }).its('OCA.Files._sidebar').should('be.a', 'function')
+		cy.window({ timeout: 20000 }).its('OCA.Files._sidebar').should('be.a', 'function')
 	}
 	getActionButtonForFileId(fileid)
 		.scrollIntoView()
@@ -119,12 +121,14 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
  * @param actionId
  */
 export function triggerActionForFile(filename: string, actionId: string) {
-	// The 'details' action is filtered as not-enabled until the sidebar service
-	// registers on the window (see apps/files/src/actions/sidebarAction.ts and
-	// apps/files/src/sidebar.ts). Wait for it before opening the menu, otherwise
-	// the action button is missing from both the inline area and the popup.
+	// Wait for the files app to finish booting before opening the action menu.
+	// `OCP.Files.Router` is wired up by apps/files/src/init.ts after file actions
+	// are registered, and `OCA.Files._sidebar` is set by apps/files/src/sidebar.ts
+	// — without both, the row's action menu can render empty (the 'details' action
+	// in particular depends on `getSidebar().available`).
+	cy.window({ timeout: 20000 }).its('OCP.Files.Router').should('exist')
 	if (actionId === 'details') {
-		cy.window({ timeout: 15000 }).its('OCA.Files._sidebar').should('be.a', 'function')
+		cy.window({ timeout: 20000 }).its('OCA.Files._sidebar').should('be.a', 'function')
 	}
 	getActionButtonForFile(filename)
 		.scrollIntoView()

--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -95,35 +95,24 @@ export function triggerActionForFileId(fileid: number, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFileId(fileid)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
+	// Look up the action's clickable button. NcActions in
+	// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
+	// N children as standalone buttons inline in the row (the action carries
+	// `data-cy-files-list-row-action` directly on the <button>), and the rest
+	// inside the teleported menu popup (the action wraps a <button>). Use the
+	// menu id from aria-controls so we look in the right popup, and union with
+	// the inline-button location to cover both cases atomically.
 	const escaped = CSS.escape(actionId)
 	getActionButtonForFileId(fileid)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => {
-			// Wait for actions to be hydrated on this row. Until Vue finishes resolving
-			// the row's `node` prop, `enabledRenderActions` is empty and the row's
-			// inline area + opened popup contain no `[data-cy-files-list-row-action]`
-			// element. That race is independent of app boot and is the residual flake
-			// once OCP/OCA are ready. Wait up to 10 s for at least one action to mount.
-			cy.get([
-				`[data-cy-files-list-row-fileid="${fileid}"] [data-cy-files-list-row-actions] [data-cy-files-list-row-action]`,
-				`#${menuId} [data-cy-files-list-row-action]`,
-			].join(', '), { timeout: 10000 }).should('exist')
-			// Look up the action's clickable button. NcActions in
-			// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
-			// N children as standalone buttons inline in the row (the action carries
-			// `data-cy-files-list-row-action` directly on the <button>), and the rest
-			// inside the teleported menu popup (the action wraps a <button>). Use the
-			// menu id from aria-controls so we look in the right popup, and union with
-			// the inline-button location to cover both cases atomically.
-			cy.get([
-				`[data-cy-files-list-row-fileid="${fileid}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escaped}"]`,
-				`#${menuId} [data-cy-files-list-row-action="${escaped}"] button`,
-				`#${menuId} button[data-cy-files-list-row-action="${escaped}"]`,
-			].join(', '))
-				.first()
-				.should('be.visible')
-				.click()
-		})
+		.then((menuId) => cy.get([
+			`[data-cy-files-list-row-fileid="${fileid}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escaped}"]`,
+			`#${menuId} [data-cy-files-list-row-action="${escaped}"] button`,
+			`#${menuId} button[data-cy-files-list-row-action="${escaped}"]`,
+		].join(', '))
+			.first()
+			.should('be.visible')
+			.click())
 }
 
 /**
@@ -145,36 +134,25 @@ export function triggerActionForFile(filename: string, actionId: string) {
 		.scrollIntoView()
 	getActionButtonForFile(filename)
 		.click({ force: true }) // force to avoid issues with overlaying file list header
+	// Look up the action's clickable button. NcActions in
+	// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
+	// N children as standalone buttons inline in the row (the action carries
+	// `data-cy-files-list-row-action` directly on the <button>), and the rest
+	// inside the teleported menu popup (the action wraps a <button>). Use the
+	// menu id from aria-controls so we look in the right popup, and union with
+	// the inline-button location to cover both cases atomically.
 	const escapedAction = CSS.escape(actionId)
 	const escapedName = CSS.escape(filename)
 	getActionButtonForFile(filename)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => {
-			// Wait for actions to be hydrated on this row. Until Vue finishes resolving
-			// the row's `node` prop, `enabledRenderActions` is empty and the row's
-			// inline area + opened popup contain no `[data-cy-files-list-row-action]`
-			// element. That race is independent of app boot and is the residual flake
-			// once OCP/OCA are ready. Wait up to 10 s for at least one action to mount.
-			cy.get([
-				`[data-cy-files-list-row-name="${escapedName}"] [data-cy-files-list-row-actions] [data-cy-files-list-row-action]`,
-				`#${menuId} [data-cy-files-list-row-action]`,
-			].join(', '), { timeout: 10000 }).should('exist')
-			// Look up the action's clickable button. NcActions in
-			// apps/files/src/components/FileEntry/FileEntryActions.vue renders the first
-			// N children as standalone buttons inline in the row (the action carries
-			// `data-cy-files-list-row-action` directly on the <button>), and the rest
-			// inside the teleported menu popup (the action wraps a <button>). Use the
-			// menu id from aria-controls so we look in the right popup, and union with
-			// the inline-button location to cover both cases atomically.
-			cy.get([
-				`[data-cy-files-list-row-name="${escapedName}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escapedAction}"]`,
-				`#${menuId} [data-cy-files-list-row-action="${escapedAction}"] button`,
-				`#${menuId} button[data-cy-files-list-row-action="${escapedAction}"]`,
-			].join(', '))
-				.first()
-				.should('be.visible')
-				.click()
-		})
+		.then((menuId) => cy.get([
+			`[data-cy-files-list-row-name="${escapedName}"] [data-cy-files-list-row-actions] button[data-cy-files-list-row-action="${escapedAction}"]`,
+			`#${menuId} [data-cy-files-list-row-action="${escapedAction}"] button`,
+			`#${menuId} button[data-cy-files-list-row-action="${escapedAction}"]`,
+		].join(', '))
+			.first()
+			.should('be.visible')
+			.click())
 }
 
 /**

--- a/cypress/e2e/files/files-renaming.cy.ts
+++ b/cypress/e2e/files/files-renaming.cy.ts
@@ -141,7 +141,7 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 		getRowForFile('file.txt').should('be.visible')
 		// Atomic descendant selector — avoid chaining .find() on the row subject
 		// which would be detached when the rename input unmounts.
-		cy.get(`[data-cy-files-list-row-name="file.txt"] input[type="text"]`)
+		cy.get('[data-cy-files-list-row-name="file.txt"] input[type="text"]')
 			.should('not.exist')
 	})
 
@@ -157,7 +157,7 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		// See it is not renamed
 		getRowForFile('file.txt').should('be.visible')
-		cy.get(`[data-cy-files-list-row-name="file.txt"] input[type="text"]`)
+		cy.get('[data-cy-files-list-row-name="file.txt"] input[type="text"]')
 			.should('not.exist')
 	})
 
@@ -196,7 +196,7 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 		// Atomic descendant selector to assert the rename input is gone.
 		// Match the rename input specifically by aria-label, not just any input
 		// (the row also contains a checkbox <input> with aria-label="Toggle selection…").
-		cy.get(`[data-cy-files-list-row-name="zzz.txt"] [data-cy-files-list-row-name] input`)
+		cy.get('[data-cy-files-list-row-name="zzz.txt"] [data-cy-files-list-row-name] input')
 			.should('not.exist')
 	})
 

--- a/cypress/e2e/files/files-renaming.cy.ts
+++ b/cypress/e2e/files/files-renaming.cy.ts
@@ -5,7 +5,7 @@
 
 import type { User } from '@nextcloud/e2e-test-server/cypress'
 
-import { calculateViewportHeight, createFolder, getRowForFile, haveValidity, renameFile, triggerActionForFile } from './FilesUtils.ts'
+import { calculateViewportHeight, createFolder, getRenameInputForFile, getRowForFile, haveValidity, renameFile, triggerActionForFile } from './FilesUtils.ts'
 
 describe('files: Rename nodes', { testIsolation: true }, () => {
 	let user: User
@@ -31,9 +31,9 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		triggerActionForFile('file.txt', 'rename')
 
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
+			.and('have.attr', 'aria-label', 'Filename')
 			.type('{selectAll}other.txt')
 			.should(haveValidity(''))
 			.type('{enter}')
@@ -52,9 +52,9 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		triggerActionForFile('file.txt', 'rename')
 
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
+			.and('have.attr', 'aria-label', 'Filename')
 			.should((el) => {
 				const input = el.get(0) as HTMLInputElement
 				expect(input.selectionStart).to.equal(0)
@@ -68,8 +68,7 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		triggerActionForFile('file.txt', 'rename')
 
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
 			.type('{selectAll}.htaccess')
 			// See validity
@@ -96,8 +95,7 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		// Start the renaming
 		triggerActionForFile('file.txt', 'rename')
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
 			.type('{selectAll}new-name.txt{enter}')
 
@@ -132,8 +130,7 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		triggerActionForFile('file.txt', 'rename')
 
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
 			.type('{selectAll}other.txt')
 			.should(haveValidity(''))
@@ -141,9 +138,10 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		// See it is not renamed
 		getRowForFile('other.txt').should('not.exist')
-		getRowForFile('file.txt')
-			.should('be.visible')
-			.find('input[type="text"]')
+		getRowForFile('file.txt').should('be.visible')
+		// Atomic descendant selector — avoid chaining .find() on the row subject
+		// which would be detached when the rename input unmounts.
+		cy.get(`[data-cy-files-list-row-name="file.txt"] input[type="text"]`)
 			.should('not.exist')
 	})
 
@@ -153,15 +151,13 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 
 		triggerActionForFile('file.txt', 'rename')
 
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
 			.type('{enter}')
 
 		// See it is not renamed
-		getRowForFile('file.txt')
-			.should('be.visible')
-			.find('input[type="text"]')
+		getRowForFile('file.txt').should('be.visible')
+		cy.get(`[data-cy-files-list-row-name="file.txt"] input[type="text"]`)
 			.should('not.exist')
 	})
 
@@ -196,9 +192,11 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 			.scrollTo('bottom')
 		cy.screenshot()
 		// The file is no longer in rename state
-		getRowForFile('zzz.txt')
-			.should('be.visible')
-			.findByRole('textbox', { name: 'Filename' })
+		getRowForFile('zzz.txt').should('be.visible')
+		// Atomic descendant selector to assert the rename input is gone.
+		// Match the rename input specifically by aria-label, not just any input
+		// (the row also contains a checkbox <input> with aria-label="Toggle selection…").
+		cy.get(`[data-cy-files-list-row-name="zzz.txt"] [data-cy-files-list-row-name] input`)
 			.should('not.exist')
 	})
 
@@ -206,16 +204,16 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 		getRowForFile('file.txt').should('be.visible')
 
 		triggerActionForFile('file.txt', 'rename')
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
 			.type('{selectAll}file.md')
 			.type('{enter}')
 
-		// See warning dialog
+		// See warning dialog. Use a global cy.findByRole for the button so the
+		// chain is not broken when the dialog body re-renders.
 		cy.findByRole('dialog', { name: 'Change file extension' })
 			.should('be.visible')
-			.findByRole('button', { name: 'Use .md' })
+		cy.findByRole('button', { name: 'Use .md' })
 			.click()
 
 		// See it is renamed
@@ -226,16 +224,16 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 		getRowForFile('file.txt').should('be.visible')
 
 		triggerActionForFile('file.txt', 'rename')
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
 			.type('{selectAll}document.md')
 			.type('{enter}')
 
-		// See warning dialog
+		// See warning dialog. Use a global cy.findByRole for the button so the
+		// chain is not broken when the dialog body re-renders.
 		cy.findByRole('dialog', { name: 'Change file extension' })
 			.should('be.visible')
-			.findByRole('button', { name: 'Keep .txt' })
+		cy.findByRole('button', { name: 'Keep .txt' })
 			.click()
 
 		// See it is renamed
@@ -246,18 +244,18 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 		getRowForFile('file.txt').should('be.visible')
 
 		triggerActionForFile('file.txt', 'rename')
-		getRowForFile('file.txt')
-			.findByRole('textbox', { name: 'Filename' })
+		getRenameInputForFile('file.txt')
 			.should('be.visible')
 			.type('{selectAll}file')
 			.type('{enter}')
 
+		// Use global cy.findByRole for the dialog buttons so the chain is not
+		// broken when the dialog body re-renders.
 		cy.findByRole('dialog', { name: 'Change file extension' })
 			.should('be.visible')
-			.findByRole('button', { name: 'Keep .txt' })
+		cy.findByRole('button', { name: 'Keep .txt' })
 			.should('be.visible')
-		cy.findByRole('dialog', { name: 'Change file extension' })
-			.findByRole('button', { name: 'Remove extension' })
+		cy.findByRole('button', { name: 'Remove extension' })
 			.should('be.visible')
 			.click()
 
@@ -272,9 +270,9 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 		getRowForFile('folder.2024').should('be.visible')
 
 		triggerActionForFile('folder.2024', 'rename')
-		getRowForFile('folder.2024')
-			.findByRole('textbox', { name: 'Folder name' })
+		getRenameInputForFile('folder.2024')
 			.should('be.visible')
+			.and('have.attr', 'aria-label', 'Folder name')
 			.type('{selectAll}folder.2025')
 			.should(haveValidity(''))
 			.type('{enter}')

--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -26,13 +26,6 @@ export function openVersionsPanel(fileName: string) {
 	// Detect the versions list fetch
 	cy.intercept('PROPFIND', '**/dav/versions/*/versions/**').as('getVersions')
 
-	// Wait for the sidebar service to register itself before triggering 'details'.
-	// `getSidebar().available` (see apps/files/src/actions/sidebarAction.ts) returns
-	// false until window.OCA.Files._sidebar is set by apps/files/src/sidebar.ts on
-	// app boot. If we click before then, the 'details' action is filtered out as
-	// not-enabled and triggerActionForFile fails to find any clickable element.
-	cy.window({ timeout: 15000 }).its('OCA.Files._sidebar').should('be.a', 'function')
-
 	triggerActionForFile(basename(fileName), 'details')
 	cy.get('[data-cy-sidebar]')
 		.as('sidebar')

--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -26,6 +26,13 @@ export function openVersionsPanel(fileName: string) {
 	// Detect the versions list fetch
 	cy.intercept('PROPFIND', '**/dav/versions/*/versions/**').as('getVersions')
 
+	// Wait for the sidebar service to register itself before triggering 'details'.
+	// `getSidebar().available` (see apps/files/src/actions/sidebarAction.ts) returns
+	// false until window.OCA.Files._sidebar is set by apps/files/src/sidebar.ts on
+	// app boot. If we click before then, the 'details' action is filtered out as
+	// not-enabled and triggerActionForFile fails to find any clickable element.
+	cy.window({ timeout: 15000 }).its('OCA.Files._sidebar').should('be.a', 'function')
+
 	triggerActionForFile(basename(fileName), 'details')
 	cy.get('[data-cy-sidebar]')
 		.as('sidebar')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Make the queries atomic so Cypress re-queries the whole path on retry

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
