### PR TITLE
fix(files): sync sidebar route on open

### DIFF
--- a/apps/files/src/components/FilesListVirtual.vue
+++ b/apps/files/src/components/FilesListVirtual.vue
@@ -313,8 +313,10 @@ export default defineComponent({
 
 		openSidebarForFile(fileId) {
 			// Open the sidebar for the given URL fileid
-			// iif we just loaded the app.
-			const node = this.nodes.find((n) => n.fileid === fileId) as INode
+			// if we just loaded the app.
+			const node = (this.currentFolder?.fileid === fileId
+				? this.currentFolder
+				: this.nodes.find((n) => n.fileid === fileId)) as INode | undefined
 			if (node && this.sidebar.available) {
 				logger.debug('Opening sidebar on file ' + node.path, { node })
 				this.sidebar.open(node)

--- a/apps/files/src/store/sidebar.ts
+++ b/apps/files/src/store/sidebar.ts
@@ -57,6 +57,7 @@ export const useSidebarStore = defineStore('sidebar', () => {
 				logger.debug('sidebar: already open for current node - switching tab', { tabId })
 				setActiveTab(tabId)
 			}
+			updateOpenRoute(node)
 			return
 		}
 
@@ -75,6 +76,7 @@ export const useSidebarStore = defineStore('sidebar', () => {
 		logger.debug(`sidebar: opening for ${node.displayname}`, { node })
 		activeStore.activeNode = node
 		isOpen.value = true
+		updateOpenRoute(node)
 	}
 
 	/**
@@ -124,6 +126,28 @@ export const useSidebarStore = defineStore('sidebar', () => {
 		activeTab.value = tabId
 	}
 
+	function updateOpenRoute(node: INode) {
+		const params = { ...(window.OCP?.Files?.Router?.params ?? {}) }
+		const query = { ...(window.OCP?.Files?.Router?.query ?? {}) }
+		const nextParams = typeof node.fileid === 'number'
+			? { ...params, fileid: String(node.fileid) }
+			: params
+
+		if (('opendetails' in query) && nextParams.fileid === params.fileid) {
+			return
+		}
+
+		window.OCP.Files.Router.goToRoute(
+			null,
+			nextParams,
+			{
+				...query,
+				opendetails: 'true',
+			},
+			true,
+		)
+	}
+
 	// update the current node if updated
 	subscribe('files:node:updated', (node: INode) => {
 		if (node.source === currentNode.value?.source) {
@@ -164,7 +188,7 @@ export const useSidebarStore = defineStore('sidebar', () => {
 		}
 	})
 
-	// watch open state and update URL query parameters
+	// watch close state and update URL query parameters
 	watch(isOpen, (isOpen) => {
 		const params = { ...(window.OCP?.Files?.Router?.params ?? {}) }
 		const query = { ...(window.OCP?.Files?.Router?.query ?? {}) }
@@ -176,18 +200,6 @@ export const useSidebarStore = defineStore('sidebar', () => {
 				null,
 				params,
 				query,
-				true,
-			)
-		}
-
-		if (isOpen && !('opendetails' in query)) {
-			window.OCP.Files.Router.goToRoute(
-				null,
-				params,
-				{
-					...query,
-					opendetails: 'true',
-				},
 				true,
 			)
 		}


### PR DESCRIPTION
Resolves: [Bug]: Sharing parent folder after creating subfolder opens child in sidebar #59923

Summary

Sync the Files sidebar route fileid to the node being opened while adding opendetails=true.
Allow opendetails route handling to resolve the current folder, not only cached child rows.
Prevent breadcrumb Share from reopening a stale newly-created child folder when the visible/current folder is the parent.