### PR TITLE
 fix(MailPlugin): Stop applying the offset twice and the limit per wide/exact

### DIFF
--- a/lib/private/Collaboration/Collaborators/MailByMailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailByMailPlugin.php
@@ -14,6 +14,7 @@ use OCP\Contacts\IManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IEmailValidator;
 use OCP\Share\IShare;
@@ -31,6 +32,7 @@ class MailByMailPlugin extends MailPlugin {
 		KnownUserService $knownUserService,
 		IUserSession $userSession,
 		IEmailValidator $emailValidator,
+		IUserManager $userManager,
 		mixed $shareWithGroupOnlyExcludeGroupsList = [],
 	) {
 		parent::__construct(
@@ -41,6 +43,7 @@ class MailByMailPlugin extends MailPlugin {
 			$knownUserService,
 			$userSession,
 			$emailValidator,
+			$userManager,
 			$shareWithGroupOnlyExcludeGroupsList,
 			IShare::TYPE_EMAIL,
 		);

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -17,6 +17,7 @@ use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IEmailValidator;
 use OCP\Share\IShare;
@@ -42,6 +43,7 @@ class MailPlugin implements ISearchPlugin {
 		private KnownUserService $knownUserService,
 		private IUserSession $userSession,
 		private IEmailValidator $emailValidator,
+		private IUserManager $userManager,
 		private mixed $shareWithGroupOnlyExcludeGroupsList,
 		private int $shareType,
 	) {
@@ -72,6 +74,7 @@ class MailPlugin implements ISearchPlugin {
 		}
 
 		$currentUserId = $this->userSession->getUser()->getUID();
+		$userGroups = null;
 
 		$result = $userResults = ['wide' => [], 'exact' => []];
 		$userType = new SearchResultType('users');
@@ -114,26 +117,19 @@ class MailPlugin implements ISearchPlugin {
 					$exactEmailMatch = strtolower($emailAddress) === $lowerSearch;
 
 					if (isset($contact['isLocalSystemBook'])) {
+						$contactUser = $this->userManager->get($contact['UID']);
+						if ($contactUser === null) {
+							continue;
+						}
+						$contactGroups = $this->groupManager->getUserGroupIds($contactUser);
+
 						if ($this->shareWithGroupOnly) {
-							/*
-							 * Check if the user may share with the user associated with the e-mail of the just found contact
-							 */
-							$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
-
-							// ShareWithGroupOnly filtering
-							$userGroups = array_diff($userGroups, $this->shareWithGroupOnlyExcludeGroupsList);
-
-							$found = false;
-							foreach ($userGroups as $userGroup) {
-								if ($this->groupManager->isInGroup($contact['UID'], $userGroup)) {
-									$found = true;
-									break;
-								}
-							}
-							if (!$found) {
+							$userGroups ??= $this->groupManager->getUserGroupIds($this->userSession->getUser());
+							if (array_intersect($contactGroups, array_diff($userGroups, $this->shareWithGroupOnlyExcludeGroupsList)) === []) {
 								continue;
 							}
 						}
+
 						if ($exactEmailMatch && $this->shareeEnumerationFullMatch) {
 							try {
 								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
@@ -174,14 +170,8 @@ class MailPlugin implements ISearchPlugin {
 							}
 
 							if (!$addToWide && $this->shareeEnumerationInGroupOnly) {
-								$addToWide = false;
-								$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
-								foreach ($userGroups as $userGroup) {
-									if ($this->groupManager->isInGroup($contact['UID'], $userGroup)) {
-										$addToWide = true;
-										break;
-									}
-								}
+								$userGroups ??= $this->groupManager->getUserGroupIds($this->userSession->getUser());
+								$addToWide = array_intersect($contactGroups, $userGroups) !== [];
 							}
 							if ($addToWide && !$this->isCurrentUser($cloud) && !$searchResult->hasResult($userType, $cloud->getUser())) {
 								if ($this->shareType === IShare::TYPE_USER) {
@@ -247,7 +237,7 @@ class MailPlugin implements ISearchPlugin {
 		}
 
 		if ($this->shareType === IShare::TYPE_EMAIL
-				&& !$searchResult->hasExactIdMatch($emailType) && $this->emailValidator->isValid($search)) {
+			&& !$searchResult->hasExactIdMatch($emailType) && $this->emailValidator->isValid($search)) {
 			$result['exact'][] = [
 				'label' => $search,
 				'uuid' => $search,

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -154,7 +154,7 @@ class MailPlugin implements ISearchPlugin {
 									'shareWithDisplayNameUnique' => !empty($emailAddress) ? $emailAddress : $cloud->getUser()
 								]];
 								$searchResult->addResultSet($userType, [], $singleResult);
-								$searchResult->markExactIdMatch($emailType);
+								$searchResult->markExactIdMatch($userType);
 							}
 							return false;
 						}

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -21,6 +21,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IEmailValidator;
 use OCP\Share\IShare;
+use RuntimeException;
 
 class MailPlugin implements ISearchPlugin {
 	protected bool $shareWithGroupOnly;
@@ -76,16 +77,22 @@ class MailPlugin implements ISearchPlugin {
 		$currentUserId = $this->userSession->getUser()->getUID();
 		$userGroups = null;
 
-		$result = $userResults = ['wide' => [], 'exact' => []];
-		$userType = new SearchResultType('users');
-		$emailType = new SearchResultType('emails');
+		$hasMore = false;
+		$count = 0;
+		$results = ['wide' => [], 'exact' => []];
+		$type = match ($this->shareType) {
+			IShare::TYPE_USER => new SearchResultType('users'),
+			IShare::TYPE_EMAIL => new SearchResultType('emails'),
+			default => throw new RuntimeException(),
+		};
 
 		// Search in contacts
 		$addressBookContacts = $this->contactsManager->search(
 			$search,
 			['EMAIL', 'FN'],
 			[
-				'limit' => $limit,
+				// We request one more, so we can check if there are more results available
+				'limit' => $limit + 1,
 				'offset' => $offset,
 				'enumeration' => $this->shareeEnumeration,
 				'fullmatch' => $this->shareeEnumerationFullMatch,
@@ -93,52 +100,95 @@ class MailPlugin implements ISearchPlugin {
 		);
 		$lowerSearch = strtolower($search);
 		foreach ($addressBookContacts as $contact) {
-			if (isset($contact['EMAIL'])) {
-				$emailAddresses = $contact['EMAIL'];
-				if (\is_string($emailAddresses)) {
-					$emailAddresses = [$emailAddresses];
-				}
-				foreach ($emailAddresses as $type => $emailAddress) {
-					$displayName = $emailAddress;
-					$emailAddressType = null;
-					if (\is_array($emailAddress)) {
-						$emailAddressData = $emailAddress;
-						$emailAddress = $emailAddressData['value'];
-						$emailAddressType = $emailAddressData['type'];
-					}
+			if (!isset($contact['EMAIL'])) {
+				continue;
+			}
 
-					if (!filter_var($emailAddress, FILTER_VALIDATE_EMAIL)) {
+			$emailAddresses = $contact['EMAIL'];
+			if (\is_string($emailAddresses)) {
+				$emailAddresses = [$emailAddresses];
+			}
+			foreach ($emailAddresses as $emailAddress) {
+				$displayName = $emailAddress;
+				$emailAddressType = null;
+				if (\is_array($emailAddress)) {
+					$emailAddressData = $emailAddress;
+					$emailAddress = $emailAddressData['value'];
+					$emailAddressType = $emailAddressData['type'];
+				}
+
+				if (!filter_var($emailAddress, FILTER_VALIDATE_EMAIL)) {
+					continue;
+				}
+
+				if (isset($contact['FN'])) {
+					$displayName = $contact['FN'] . ' (' . $emailAddress . ')';
+				}
+				$exactEmailMatch = strtolower($emailAddress) === $lowerSearch;
+
+				if (isset($contact['isLocalSystemBook'])) {
+					$contactUser = $this->userManager->get($contact['UID']);
+					if ($contactUser === null) {
 						continue;
 					}
 
-					if (isset($contact['FN'])) {
-						$displayName = $contact['FN'] . ' (' . $emailAddress . ')';
-					}
-					$exactEmailMatch = strtolower($emailAddress) === $lowerSearch;
-
-					if (isset($contact['isLocalSystemBook'])) {
-						$contactUser = $this->userManager->get($contact['UID']);
-						if ($contactUser === null) {
+					$contactGroups = $this->groupManager->getUserGroupIds($contactUser);
+					if ($this->shareWithGroupOnly) {
+						$userGroups ??= $this->groupManager->getUserGroupIds($this->userSession->getUser());
+						if (array_intersect($contactGroups, array_diff($userGroups, $this->shareWithGroupOnlyExcludeGroupsList)) === []) {
 							continue;
 						}
-						$contactGroups = $this->groupManager->getUserGroupIds($contactUser);
+					}
 
-						if ($this->shareWithGroupOnly) {
-							$userGroups ??= $this->groupManager->getUserGroupIds($this->userSession->getUser());
-							if (array_intersect($contactGroups, array_diff($userGroups, $this->shareWithGroupOnlyExcludeGroupsList)) === []) {
-								continue;
-							}
+					if ($exactEmailMatch && $this->shareeEnumerationFullMatch) {
+						try {
+							$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
+						} catch (\InvalidArgumentException $e) {
+							continue;
 						}
 
-						if ($exactEmailMatch && $this->shareeEnumerationFullMatch) {
-							try {
-								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
-							} catch (\InvalidArgumentException $e) {
+						if ($this->shareType === IShare::TYPE_USER && !$this->isCurrentUser($cloud) && !$searchResult->hasResult($type, $cloud->getUser())) {
+							$singleResult = [[
+								'label' => $displayName,
+								'uuid' => $contact['UID'] ?? $emailAddress,
+								'name' => $contact['FN'] ?? $displayName,
+								'value' => [
+									'shareType' => IShare::TYPE_USER,
+									'shareWith' => $cloud->getUser(),
+								],
+								'shareWithDisplayNameUnique' => !empty($emailAddress) ? $emailAddress : $cloud->getUser()
+							]];
+							$searchResult->addResultSet($type, [], $singleResult);
+							$searchResult->markExactIdMatch($type);
+						}
+						return false;
+					}
+
+					if ($this->shareeEnumeration && $this->shareType === IShare::TYPE_USER) {
+						try {
+							if (!isset($contact['CLOUD'])) {
 								continue;
 							}
+							$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
+						} catch (\InvalidArgumentException $e) {
+							continue;
+						}
+						$addToWide = !($this->shareeEnumerationInGroupOnly || $this->shareeEnumerationPhone);
 
-							if ($this->shareType === IShare::TYPE_USER && !$this->isCurrentUser($cloud) && !$searchResult->hasResult($userType, $cloud->getUser())) {
-								$singleResult = [[
+						if (!$addToWide && $this->shareeEnumerationPhone && $this->knownUserService->isKnownToUser($currentUserId, $contact['UID'])) {
+							$addToWide = true;
+						}
+
+						if (!$addToWide && $this->shareeEnumerationInGroupOnly) {
+							$userGroups ??= $this->groupManager->getUserGroupIds($this->userSession->getUser());
+							$addToWide = array_intersect($contactGroups, $userGroups) !== [];
+						}
+
+						if ($addToWide && !$this->isCurrentUser($cloud) && !$searchResult->hasResult($type, $cloud->getUser())) {
+							if ($count++ >= $limit) {
+								$hasMore = true;
+							} else {
+								$results['wide'][] = [
 									'label' => $displayName,
 									'uuid' => $contact['UID'] ?? $emailAddress,
 									'name' => $contact['FN'] ?? $displayName,
@@ -147,115 +197,69 @@ class MailPlugin implements ISearchPlugin {
 										'shareWith' => $cloud->getUser(),
 									],
 									'shareWithDisplayNameUnique' => !empty($emailAddress) ? $emailAddress : $cloud->getUser()
-								]];
-								$searchResult->addResultSet($userType, [], $singleResult);
-								$searchResult->markExactIdMatch($userType);
-							}
-							return false;
-						}
-
-						if ($this->shareeEnumeration) {
-							try {
-								if (!isset($contact['CLOUD'])) {
-									continue;
-								}
-								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
-							} catch (\InvalidArgumentException $e) {
-								continue;
-							}
-
-							$addToWide = !($this->shareeEnumerationInGroupOnly || $this->shareeEnumerationPhone);
-							if (!$addToWide && $this->shareeEnumerationPhone && $this->knownUserService->isKnownToUser($currentUserId, $contact['UID'])) {
-								$addToWide = true;
-							}
-
-							if (!$addToWide && $this->shareeEnumerationInGroupOnly) {
-								$userGroups ??= $this->groupManager->getUserGroupIds($this->userSession->getUser());
-								$addToWide = array_intersect($contactGroups, $userGroups) !== [];
-							}
-							if ($addToWide && !$this->isCurrentUser($cloud) && !$searchResult->hasResult($userType, $cloud->getUser())) {
-								if ($this->shareType === IShare::TYPE_USER) {
-									$userResults['wide'][] = [
-										'label' => $displayName,
-										'uuid' => $contact['UID'] ?? $emailAddress,
-										'name' => $contact['FN'] ?? $displayName,
-										'value' => [
-											'shareType' => IShare::TYPE_USER,
-											'shareWith' => $cloud->getUser(),
-										],
-										'shareWithDisplayNameUnique' => !empty($emailAddress) ? $emailAddress : $cloud->getUser()
-									];
-								}
-								continue;
+								];
 							}
 						}
-						continue;
 					}
 
-					if ($this->shareType !== IShare::TYPE_EMAIL) {
-						continue;
+					continue;
+				}
+
+				if ($this->shareType !== IShare::TYPE_EMAIL) {
+					continue;
+				}
+
+				if ($count++ >= $limit) {
+					$hasMore = true;
+				} elseif ($exactEmailMatch || (isset($contact['FN']) && strtolower($contact['FN']) === $lowerSearch)) {
+					if ($exactEmailMatch) {
+						$searchResult->markExactIdMatch($type);
 					}
 
-					if ($exactEmailMatch
-						|| (isset($contact['FN']) && strtolower($contact['FN']) === $lowerSearch)) {
-						if ($exactEmailMatch) {
-							$searchResult->markExactIdMatch($emailType);
-						}
-						$result['exact'][] = [
-							'label' => $displayName,
-							'uuid' => $contact['UID'] ?? $emailAddress,
-							'name' => $contact['FN'] ?? $displayName,
-							'type' => $emailAddressType ?? '',
-							'value' => [
-								'shareType' => IShare::TYPE_EMAIL,
-								'shareWith' => $emailAddress,
-							],
-						];
-					} else {
-						$result['wide'][] = [
-							'label' => $displayName,
-							'uuid' => $contact['UID'] ?? $emailAddress,
-							'name' => $contact['FN'] ?? $displayName,
-							'type' => $emailAddressType ?? '',
-							'value' => [
-								'shareType' => IShare::TYPE_EMAIL,
-								'shareWith' => $emailAddress,
-							],
-						];
-					}
+					$results['exact'][] = [
+						'label' => $displayName,
+						'uuid' => $contact['UID'] ?? $emailAddress,
+						'name' => $contact['FN'] ?? $displayName,
+						'type' => $emailAddressType ?? '',
+						'value' => [
+							'shareType' => IShare::TYPE_EMAIL,
+							'shareWith' => $emailAddress,
+						],
+					];
+				} else {
+					$results['wide'][] = [
+						'label' => $displayName,
+						'uuid' => $contact['UID'] ?? $emailAddress,
+						'name' => $contact['FN'] ?? $displayName,
+						'type' => $emailAddressType ?? '',
+						'value' => [
+							'shareType' => IShare::TYPE_EMAIL,
+							'shareWith' => $emailAddress,
+						],
+					];
 				}
 			}
 		}
 
-		$reachedEnd = true;
-		if ($this->shareeEnumeration) {
-			$reachedEnd = (count($result['wide']) < $offset + $limit)
-				&& (count($userResults['wide']) < $offset + $limit);
-
-			$result['wide'] = array_slice($result['wide'], $offset, $limit);
-			$userResults['wide'] = array_slice($userResults['wide'], $offset, $limit);
-		}
-
 		if ($this->shareType === IShare::TYPE_EMAIL
-			&& !$searchResult->hasExactIdMatch($emailType) && $this->emailValidator->isValid($search)) {
-			$result['exact'][] = [
-				'label' => $search,
-				'uuid' => $search,
-				'value' => [
-					'shareType' => IShare::TYPE_EMAIL,
-					'shareWith' => $search,
-				],
-			];
+			&& !$searchResult->hasExactIdMatch($type) && $this->emailValidator->isValid($search)) {
+			if ($count++ >= $limit) {
+				$hasMore = true;
+			} else {
+				$results['exact'][] = [
+					'label' => $search,
+					'uuid' => $search,
+					'value' => [
+						'shareType' => IShare::TYPE_EMAIL,
+						'shareWith' => $search,
+					],
+				];
+			}
 		}
 
-		if ($this->shareType === IShare::TYPE_USER && !empty($userResults['wide'])) {
-			$searchResult->addResultSet($userType, $userResults['wide'], []);
-		}
-		if ($this->shareType === IShare::TYPE_EMAIL) {
-			$searchResult->addResultSet($emailType, $result['wide'], $result['exact']);
-		}
+		$searchResult->addResultSet($type, $results['wide'], $results['exact']);
 
-		return !$reachedEnd;
+		return $hasMore;
 	}
 
 	public function isCurrentUser(ICloudId $cloud): bool {

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -67,9 +67,8 @@ class MailPlugin implements ISearchPlugin {
 		}
 
 		// Extract the email address from "Foo Bar <foo.bar@example.tld>" and then search with "foo.bar@example.tld" instead
-		$result = preg_match('/<([^@]+@.+)>$/', $search, $matches);
-		if ($result && filter_var($matches[1], FILTER_VALIDATE_EMAIL)) {
-			return $this->search($matches[1], $limit, $offset, $searchResult);
+		if (preg_match('/<([^@]+@.+)>$/', $search, $matches) && filter_var($matches[1], FILTER_VALIDATE_EMAIL)) {
+			$search = $matches[1];
 		}
 
 		$currentUserId = $this->userSession->getUser()->getUID();

--- a/lib/private/Collaboration/Collaborators/UserByMailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserByMailPlugin.php
@@ -14,6 +14,7 @@ use OCP\Contacts\IManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IEmailValidator;
 use OCP\Share\IShare;
@@ -31,6 +32,7 @@ class UserByMailPlugin extends MailPlugin {
 		KnownUserService $knownUserService,
 		IUserSession $userSession,
 		IEmailValidator $emailValidator,
+		IUserManager $userManager,
 		mixed $shareWithGroupOnlyExcludeGroupsList = [],
 	) {
 		parent::__construct(
@@ -41,6 +43,7 @@ class UserByMailPlugin extends MailPlugin {
 			$knownUserService,
 			$userSession,
 			$emailValidator,
+			$userManager,
 			$shareWithGroupOnlyExcludeGroupsList,
 			IShare::TYPE_USER,
 		);

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -596,15 +596,15 @@ class MailPluginTest extends TestCase {
 	public static function dataSearchUser(): array {
 		return [
 			// data set 0
-			['test', [], true, ['exact' => []], false, false],
+			['test', [], true, ['users' => [], 'exact' => ['users' => [],]], false, false],
 			// data set 1
-			['test', [], false, ['exact' => []], false, false],
+			['test', [], false, ['users' => [], 'exact' => ['users' => [],]], false, false],
 			// data set 2
 			[
 				'test@remote.com',
 				[],
 				true,
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 			],
@@ -613,7 +613,7 @@ class MailPluginTest extends TestCase {
 				'test@remote.com',
 				[],
 				false,
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 			],
@@ -640,7 +640,7 @@ class MailPluginTest extends TestCase {
 					],
 				],
 				true,
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 			],
@@ -668,7 +668,7 @@ class MailPluginTest extends TestCase {
 					],
 				],
 				false,
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 			],
@@ -695,7 +695,7 @@ class MailPluginTest extends TestCase {
 					],
 				],
 				true,
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 			],
@@ -722,7 +722,7 @@ class MailPluginTest extends TestCase {
 					],
 				],
 				true,
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 			],
@@ -835,7 +835,7 @@ class MailPluginTest extends TestCase {
 					],
 				],
 				true,
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 			],
@@ -1045,7 +1045,7 @@ class MailPluginTest extends TestCase {
 						'UID' => 'User',
 					]
 				],
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 				[
@@ -1065,7 +1065,7 @@ class MailPluginTest extends TestCase {
 						'UID' => 'User',
 					]
 				],
-				['exact' => []],
+				['users' => [], 'exact' => ['users' => [],]],
 				false,
 				false,
 				[

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -39,6 +39,7 @@ class MailPluginTest extends TestCase {
 	protected IGroupManager&MockObject $groupManager;
 	protected KnownUserService&MockObject $knownUserService;
 	protected IUserSession&MockObject $userSession;
+	protected IUserManager&MockObject $userManager;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -49,6 +50,17 @@ class MailPluginTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->knownUserService = $this->createMock(KnownUserService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userManager
+			->method('get')
+			->willReturnCallback(function (string $uid): IUser {
+				$user = $this->createMock(IUser::class);
+				$user
+					->method('getUID')
+					->willReturn($uid);
+
+				return $user;
+			});
 		$this->cloudIdManager = new CloudIdManager(
 			$this->createMock(ICacheFactory::class),
 			$this->createMock(IEventDispatcher::class),
@@ -69,6 +81,7 @@ class MailPluginTest extends TestCase {
 			$this->knownUserService,
 			$this->userSession,
 			$this->getEmailValidatorWithStrictEmailCheck(),
+			$this->userManager,
 			[],
 			$shareType,
 		);
@@ -727,7 +740,7 @@ class MailPluginTest extends TestCase {
 					]
 				],
 				false,
-				['users' => [], 'exact' => ['users' => [['uuid' => 'uid1', 'name' => 'User', 'label' => 'User (test@example.com)','value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'], 'shareWithDisplayNameUnique' => 'test@example.com']]]],
+				['users' => [], 'exact' => ['users' => [['uuid' => 'uid1', 'name' => 'User', 'label' => 'User (test@example.com)', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'], 'shareWithDisplayNameUnique' => 'test@example.com']]]],
 				true,
 				false,
 			],
@@ -872,12 +885,6 @@ class MailPluginTest extends TestCase {
 				return $userToGroupMapping[$user->getUID()];
 			});
 
-		$this->groupManager->expects($this->any())
-			->method('isInGroup')
-			->willReturnCallback(function ($userId, $group) use ($userToGroupMapping) {
-				return in_array($group, $userToGroupMapping[$userId]);
-			});
-
 		$moreResults = $this->plugin->search($searchTerm, 2, 0, $this->searchResult);
 		$result = $this->searchResult->asArray();
 
@@ -942,7 +949,7 @@ class MailPluginTest extends TestCase {
 						'UID' => 'User',
 					]
 				],
-				['emails' => [], 'exact' => ['emails' => [['label' => 'test@example.com', 'uuid' => 'test@example.com', 'value' => ['shareType' => IShare::TYPE_EMAIL,'shareWith' => 'test@example.com']]]]],
+				['emails' => [], 'exact' => ['emails' => [['label' => 'test@example.com', 'uuid' => 'test@example.com', 'value' => ['shareType' => IShare::TYPE_EMAIL, 'shareWith' => 'test@example.com']]]]],
 				false,
 				false,
 				[
@@ -996,12 +1003,6 @@ class MailPluginTest extends TestCase {
 				return $userToGroupMapping[$user->getUID()];
 			});
 
-		$this->groupManager->expects($this->any())
-			->method('isInGroup')
-			->willReturnCallback(function ($userId, $group) use ($userToGroupMapping) {
-				return in_array($group, $userToGroupMapping[$userId]);
-			});
-
 		$moreResults = $this->plugin->search($searchTerm, 2, 0, $this->searchResult);
 		$result = $this->searchResult->asArray();
 
@@ -1024,7 +1025,7 @@ class MailPluginTest extends TestCase {
 						'UID' => 'User',
 					]
 				],
-				['users' => [['label' => 'User (test@example.com)', 'uuid' => 'User', 'name' => 'User', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'],'shareWithDisplayNameUnique' => 'test@example.com',]], 'exact' => ['users' => []]],
+				['users' => [['label' => 'User (test@example.com)', 'uuid' => 'User', 'name' => 'User', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'], 'shareWithDisplayNameUnique' => 'test@example.com',]], 'exact' => ['users' => []]],
 				false,
 				false,
 				[

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -575,7 +575,7 @@ class MailPluginTest extends TestCase {
 		$moreResults = $this->plugin->search($searchTerm, 2, 0, $this->searchResult);
 		$result = $this->searchResult->asArray();
 
-		$this->assertSame($expectedExactIdMatch, $this->searchResult->hasExactIdMatch(new SearchResultType('emails')));
+		$this->assertSame($expectedExactIdMatch, $this->searchResult->hasExactIdMatch(new SearchResultType('users')));
 		$this->assertEquals($expectedResult, $result);
 		$this->assertSame($expectedMoreResults, $moreResults);
 	}


### PR DESCRIPTION
The offset was applied twice, because it is also passed to the contacts manager for search, and the limit was applied per wide/exact and not in total.