### PR TITLE
fix(DB): Enforce foreign key constraints in SQLite

### DIFF
--- a/lib/private/DB/SQLiteSessionInit.php
+++ b/lib/private/DB/SQLiteSessionInit.php
@@ -25,6 +25,7 @@ class SQLiteSessionInit implements EventSubscriber {
 		$sensitive = $this->caseSensitiveLike ? 'true' : 'false';
 		$args->getConnection()->executeUpdate('PRAGMA case_sensitive_like = ' . $sensitive);
 		$args->getConnection()->executeUpdate('PRAGMA journal_mode = ' . $this->journalMode);
+		$args->getConnection()->executeUpdate('PRAGMA foreign_keys = true');
 		/** @var \Doctrine\DBAL\Driver\PDO\Connection $connection */
 		$connection = $args->getConnection()->getWrappedConnection();
 		$pdo = $connection->getWrappedConnection();


### PR DESCRIPTION
Foreign keys are not enforced by default in SQLite, so the referencing rows are not deleted on cascade: https://sqlite.org/pragma.html#pragma_foreign_keys

All other DBs do this (to my knowledge), so SQLite should have the same behavior.