### PR TITLE
fix(security): don't propagate ValueError from Crypto::decrypt() fallback

### DIFF
--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -102,7 +102,13 @@ class Crypto implements ICrypto {
 		} catch (Exception $e) {
 			if ($password === '') {
 				// Retry with empty secret as a fallback for instances where the secret might not have been set by accident
-				return $this->decryptWithoutSecret($authenticatedCiphertext, '');
+				try {
+					return $this->decryptWithoutSecret($authenticatedCiphertext, '');
+				} catch (\Throwable) {
+					// Fallback failed (e.g. v3 ciphertext requires a non-empty key for hash_hkdf),
+					// rethrow the original exception
+					throw $e;
+				}
 			}
 			throw $e;
 		}

--- a/tests/lib/Security/CryptoTest.php
+++ b/tests/lib/Security/CryptoTest.php
@@ -102,6 +102,27 @@ class CryptoTest extends \Test\TestCase {
 		);
 	}
 
+	public function testDecryptWithWrongSecretThrowsHmacExceptionNotValueError(): void {
+		// Encrypt with 'secret-A'
+		$configA = $this->createMock(IConfig::class);
+		$configA->method('getSystemValue')->with('secret')->willReturn('secret-A');
+		$configA->method('getSystemValueString')->with('secret')->willReturn('secret-A');
+		$cryptoA = new Crypto($configA);
+		$ciphertext = $cryptoA->encrypt('plaintext');
+
+		// Decrypt with 'secret-B': first attempt fails (HMAC mismatch), fallback to empty
+		// string must not propagate a ValueError for v3 ciphertexts — it must rethrow the
+		// original HMAC exception instead.
+		$configB = $this->createMock(IConfig::class);
+		$configB->method('getSystemValue')->with('secret')->willReturn('secret-B');
+		$configB->method('getSystemValueString')->with('secret')->willReturn('secret-B');
+		$cryptoB = new Crypto($configB);
+
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('HMAC does not match.');
+		$cryptoB->decrypt($ciphertext);
+	}
+
 	public function testVersion3CiphertextDecryptsToCorrectPlaintext(): void {
 		$this->assertSame(
 			'Another plaintext value that will be encrypted with version 3. It addresses the related key issue. Old ciphertexts should be decrypted properly, but only use the better version for encryption.',


### PR DESCRIPTION
## Summary

- When decrypting a v3 ciphertext with a mismatched instance secret, `Crypto::decrypt()` first tries with the current secret (fails with HMAC mismatch), then falls back to an empty string
- For v3 ciphertexts, the empty-string fallback calls `hash_hkdf('sha512', '')`, which throws a `ValueError`
- `ValueError` extends `\Error`, not `\Exception`, so it bypassed the `catch (Exception $e)` block and propagated as an unhandled error, crashing the entire request
- Fix: wrap the fallback `decryptWithoutSecret()` call in its own `catch (\Throwable)` and rethrow the original HMAC exception

## Test plan

- [x] `NOCOVERAGE=1 ./autotest.sh sqlite tests/lib/Security/CryptoTest.php`
- [x] New test `testDecryptWithWrongSecretThrowsHmacExceptionNotValueError` covers the regression: encrypts with secret-A, decrypts with secret-B, asserts a proper `Exception('HMAC does not match.')` is thrown rather than a `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)