### PR TITLE
perf(ci): cache npm dependencies in Cypress init job using buildjet cache

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -73,10 +73,22 @@ jobs:
       - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
         run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
 
+      - name: Restore npm cache
+        uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        with:
+          path: ~/.npm
+          key: node-${{ steps.versions.outputs.nodeVersion }}-npm-${{ steps.versions.outputs.npmVersion }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install node dependencies & build app
         run: |
           npm ci
           TESTING=true npm run build --if-present
+
+      - name: Save npm cache
+        uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        with:
+          path: ~/.npm
+          key: node-${{ steps.versions.outputs.nodeVersion }}-npm-${{ steps.versions.outputs.npmVersion }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Save context
         uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2


### PR DESCRIPTION
## Summary

- The Cypress `init` job ran `npm ci` from scratch on every workflow invocation
- Add `buildjet/cache` restore/save steps around `npm ci`, keyed on `package-lock.json` hash, so subsequent runs with unchanged dependencies skip the registry download
- Uses `buildjet/cache` (v4.0.2) to match the existing context caching already in this workflow — avoids GitHub Actions cache service which has known performance issues on self-hosted runners

The Cypress selector fixes originally in this PR were already merged to master independently.

## Test plan

- [ ] CI passes
- [ ] Cypress init job shows cache restore on a second run with unchanged `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)