### PR TITLE
refactor(core): extract upgrade code paths for improved readability/testing

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -255,45 +255,20 @@ class OC {
 		}
 	}
 
+	private const WEB_UPGRADE_USER_THRESHOLD = 50;
+	private const WEB_UPGRADE_USER_LOOKUP_LIMIT = 51;
+	private const WEB_UPGRADE_RETRY_AFTER_SECONDS = 120;
+	private const BIG_INSTANCE_OVERRIDE_PARAM = 'IKnowThatThisIsABigInstanceAndTheUpdateRequestCouldRunIntoATimeoutAndHowToRestoreABackup';
+	private const BIG_INSTANCE_OVERRIDE_VALUE = 'IAmSuperSureToDoThis';
+
 	/**
 	 * Prints the upgrade page
 	 */
 	private static function printUpgradePage(\OC\SystemConfig $systemConfig): void {
 		$cliUpgradeLink = $systemConfig->getValue('upgrade.cli-upgrade-link', '');
-		$disableWebUpdater = $systemConfig->getValue('upgrade.disable-web', false);
-		$tooBig = false;
-		if (!$disableWebUpdater) {
-			$apps = Server::get(\OCP\App\IAppManager::class);
-			if ($apps->isEnabledForAnyone('user_ldap')) {
-				$qb = Server::get(\OCP\IDBConnection::class)->getQueryBuilder();
-
-				$result = $qb->select($qb->func()->count('*', 'user_count'))
-					->from('ldap_user_mapping')
-					->executeQuery();
-				$row = $result->fetch();
-				$result->closeCursor();
-
-				$tooBig = ($row['user_count'] > 50);
-			}
-			if (!$tooBig && $apps->isEnabledForAnyone('user_saml')) {
-				$qb = Server::get(\OCP\IDBConnection::class)->getQueryBuilder();
-
-				$result = $qb->select($qb->func()->count('*', 'user_count'))
-					->from('user_saml_users')
-					->executeQuery();
-				$row = $result->fetch();
-				$result->closeCursor();
-
-				$tooBig = ($row['user_count'] > 50);
-			}
-			if (!$tooBig) {
-				// count users
-				$totalUsers = Server::get(\OCP\IUserManager::class)->countUsersTotal(51);
-				$tooBig = ($totalUsers > 50);
-			}
-		}
-		$ignoreTooBigWarning = isset($_GET['IKnowThatThisIsABigInstanceAndTheUpdateRequestCouldRunIntoATimeoutAndHowToRestoreABackup'])
-			&& $_GET['IKnowThatThisIsABigInstanceAndTheUpdateRequestCouldRunIntoATimeoutAndHowToRestoreABackup'] === 'IAmSuperSureToDoThis';
+		$disableWebUpdater = (bool)$systemConfig->getValue('upgrade.disable-web', false);
+		$tooBig = !$disableWebUpdater && self::isInstanceTooBigForWebUpgrade();
+		$ignoreTooBigWarning = self::isBigInstanceOverrideRequested();
 
 		Util::addTranslations('core');
 		Util::addScript('core', 'common');
@@ -302,24 +277,14 @@ class OC {
 
 		$initialState = Server::get(IInitialStateService::class);
 		$serverVersion = Server::get(\OCP\ServerVersion::class);
+
 		if ($disableWebUpdater || ($tooBig && !$ignoreTooBigWarning)) {
-			// send http status 503
-			http_response_code(503);
-			header('Retry-After: 120');
-
-			$urlGenerator = Server::get(IURLGenerator::class);
-			$initialState->provideInitialState('core', 'updaterView', 'adminCli');
-			$initialState->provideInitialState('core', 'updateInfo', [
-				'cliUpgradeLink' => $cliUpgradeLink ?: $urlGenerator->linkToDocs('admin-cli-upgrade'),
-				'productName' => self::getProductName(),
-				'version' => $serverVersion->getVersionString(),
-				'tooBig' => $tooBig,
-			]);
-
-			// render error page
-			Server::get(ITemplateManager::class)
-				->getTemplate('', 'update', 'guest')
-				->printPage();
+			self::renderCliUpgradeRequiredPage(
+				$initialState,
+				$serverVersion,
+				$cliUpgradeLink,
+				$tooBig,
+			);
 			die();
 		}
 
@@ -337,29 +302,36 @@ class OC {
 		$appManager = Server::get(\OCP\App\IAppManager::class);
 
 		// get third party apps
-		$ocVersion = $serverVersion->getVersion();
-		$ocVersion = implode('.', $ocVersion);
+		$ocVersion = implode('.', $serverVersion->getVersion());
 		$incompatibleApps = $appManager->getIncompatibleApps($ocVersion);
 		$incompatibleOverwrites = $systemConfig->getValue('app_install_overwrite', []);
 		$incompatibleShippedApps = [];
 		$incompatibleDisabledApps = [];
+
 		foreach ($incompatibleApps as $appInfo) {
 			if ($appManager->isShipped($appInfo['id'])) {
 				$incompatibleShippedApps[] = $appInfo['name'] . ' (' . $appInfo['id'] . ')';
 			}
-			if (!in_array($appInfo['id'], $incompatibleOverwrites)) {
+
+			if (!in_array($appInfo['id'], $incompatibleOverwrites, true)) {
 				$incompatibleDisabledApps[] = $appInfo;
 			}
 		}
 
 		if (!empty($incompatibleShippedApps)) {
 			$l = Server::get(\OCP\L10N\IFactory::class)->get('core');
-			$hint = $l->t('Application %1$s is not present or has a non-compatible version with this server. Please check the apps directory.', [implode(', ', $incompatibleShippedApps)]);
-			throw new \OCP\HintException('Application ' . implode(', ', $incompatibleShippedApps) . ' is not present or has a non-compatible version with this server. Please check the apps directory.', $hint);
+			$hint = $l->t(
+				'Application %1$s is not present or has a non-compatible version with this server. Please check the apps directory.',
+				[implode(', ', $incompatibleShippedApps)]
+			);
+			throw new \OCP\HintException(
+				'Application ' . implode(', ', $incompatibleShippedApps) . ' is not present or has a non-compatible version with this server. Please check the apps directory.',
+				$hint
+			);
 		}
 
 		$appConfig = Server::get(IAppConfig::class);
-		$appsToUpgrade = array_map(function ($app) use (&$appConfig) {
+		$appsToUpgrade = array_map(function (array $app) use (&$appConfig): array {
 			return [
 				'id' => $app['id'],
 				'name' => $app['name'],
@@ -379,6 +351,74 @@ class OC {
 
 		$initialState->provideInitialState('core', 'updaterView', 'admin');
 		$initialState->provideInitialState('core', 'updateInfo', $params);
+
+		Server::get(ITemplateManager::class)
+			->getTemplate('', 'update', 'guest')
+			->printPage();
+	}
+
+	private static function isBigInstanceOverrideRequested(): bool {
+		return isset($_GET[self::BIG_INSTANCE_OVERRIDE_PARAM])
+			&& $_GET[self::BIG_INSTANCE_OVERRIDE_PARAM] === self::BIG_INSTANCE_OVERRIDE_VALUE;
+	}
+
+	private static function isInstanceTooBigForWebUpgrade(): bool {
+		/** @var \OCP\App\IAppManager $appManager */
+		$appManager = Server::get(\OCP\App\IAppManager::class);
+
+		if ($appManager->isEnabledForAnyone('user_ldap')
+			&& self::tableRowCountExceeds('ldap_user_mapping', self::WEB_UPGRADE_USER_THRESHOLD)) {
+			return true;
+		}
+
+		if ($appManager->isEnabledForAnyone('user_saml')
+			&& self::tableRowCountExceeds('user_saml_users', self::WEB_UPGRADE_USER_THRESHOLD)) {
+			return true;
+		}
+
+		$totalUsers = Server::get(\OCP\IUserManager::class)
+			->countUsersTotal(self::WEB_UPGRADE_USER_LOOKUP_LIMIT);
+
+		return $totalUsers > self::WEB_UPGRADE_USER_THRESHOLD;
+	}
+
+	private static function tableRowCountExceeds(string $table, int $threshold): bool {
+		$qb = Server::get(\OCP\IDBConnection::class)->getQueryBuilder();
+
+		$result = $qb->select($qb->func()->count('*', 'row_count'))
+			->from($table)
+			->executeQuery();
+
+		try {
+			$row = $result->fetch();
+		} finally {
+			$result->closeCursor();
+		}
+
+		$count = is_array($row) ? (int)($row['row_count'] ?? 0) : 0;
+
+		return $count > $threshold;
+	}
+
+	private static function renderCliUpgradeRequiredPage(
+		IInitialStateService $initialState,
+		\OCP\ServerVersion $serverVersion,
+		string $cliUpgradeLink,
+		bool $tooBig,
+	): void {
+		http_response_code(503);
+		header('Retry-After: ' . self::WEB_UPGRADE_RETRY_AFTER_SECONDS);
+
+		$urlGenerator = Server::get(IURLGenerator::class);
+
+		$initialState->provideInitialState('core', 'updaterView', 'adminCli');
+		$initialState->provideInitialState('core', 'updateInfo', [
+			'cliUpgradeLink' => $cliUpgradeLink ?: $urlGenerator->linkToDocs('admin-cli-upgrade'),
+			'productName' => self::getProductName(),
+			'version' => $serverVersion->getVersionString(),
+			'tooBig' => $tooBig,
+		]);
+
 		Server::get(ITemplateManager::class)
 			->getTemplate('', 'update', 'guest')
 			->printPage();

--- a/lib/base.php
+++ b/lib/base.php
@@ -301,48 +301,11 @@ class OC {
 		/** @var \OC\App\AppManager $appManager */
 		$appManager = Server::get(\OCP\App\IAppManager::class);
 
-		// get third party apps
-		$ocVersion = implode('.', $serverVersion->getVersion());
-		$incompatibleApps = $appManager->getIncompatibleApps($ocVersion);
-		$incompatibleOverwrites = $systemConfig->getValue('app_install_overwrite', []);
-		$incompatibleShippedApps = [];
-		$incompatibleDisabledApps = [];
-
-		foreach ($incompatibleApps as $appInfo) {
-			if ($appManager->isShipped($appInfo['id'])) {
-				$incompatibleShippedApps[] = $appInfo['name'] . ' (' . $appInfo['id'] . ')';
-			}
-
-			if (!in_array($appInfo['id'], $incompatibleOverwrites, true)) {
-				$incompatibleDisabledApps[] = $appInfo;
-			}
-		}
-
-		if (!empty($incompatibleShippedApps)) {
-			$l = Server::get(\OCP\L10N\IFactory::class)->get('core');
-			$hint = $l->t(
-				'Application %1$s is not present or has a non-compatible version with this server. Please check the apps directory.',
-				[implode(', ', $incompatibleShippedApps)]
-			);
-			throw new \OCP\HintException(
-				'Application ' . implode(', ', $incompatibleShippedApps) . ' is not present or has a non-compatible version with this server. Please check the apps directory.',
-				$hint
-			);
-		}
-
-		$appConfig = Server::get(IAppConfig::class);
-		$appsToUpgrade = array_map(function (array $app) use (&$appConfig): array {
-			return [
-				'id' => $app['id'],
-				'name' => $app['name'],
-				'version' => $app['version'],
-				'oldVersion' => $appConfig->getValueString($app['id'], 'installed_version'),
-			];
-		}, $appManager->getAppsNeedingUpgrade($ocVersion));
+		$appState = self::prepareUpgradeAppState($appManager, $systemConfig, $serverVersion);
 
 		$params = [
-			'appsToUpgrade' => $appsToUpgrade,
-			'incompatibleAppsList' => $incompatibleDisabledApps,
+			'appsToUpgrade' => $appState['appsToUpgrade'],
+			'incompatibleAppsList' => $appState['incompatibleAppsList'],
 			'isAppsOnlyUpgrade' => $isAppsOnlyUpgrade,
 			'oldTheme' => $oldTheme,
 			'productName' => self::getProductName(),
@@ -355,6 +318,67 @@ class OC {
 		Server::get(ITemplateManager::class)
 			->getTemplate('', 'update', 'guest')
 			->printPage();
+	}
+
+	private static function prepareUpgradeAppState(
+		\OCP\App\IAppManager $appManager,
+		\OC\SystemConfig $systemConfig,
+		\OCP\ServerVersion $serverVersion,
+	): array {
+		// get third party apps
+		$ocVersion = implode('.', $serverVersion->getVersion());
+		$incompatibleApps = $appManager->getIncompatibleApps($ocVersion);
+		$incompatibleOverwrites = $systemConfig->getValue('app_install_overwrite', []);
+
+		$incompatibleShippedApps = [];
+		$incompatibleDisabledApps = [];
+
+		foreach ($incompatibleApps as $appInfo) {
+			if ($appManager->isShipped($appInfo['id'])) {
+				$incompatibleShippedApps[] = $appInfo['name'] . ' (' . $appInfo['id'] . ')';
+				continue;
+			}
+
+			if (!in_array($appInfo['id'], $incompatibleOverwrites, true)) {
+				$incompatibleDisabledApps[] = $appInfo;
+			}
+		}
+
+		if ($incompatibleShippedApps !== []) {
+			self::throwIncompatibleShippedAppsException($incompatibleShippedApps);
+		}
+
+		$appConfig = Server::get(IAppConfig::class);
+		$appsToUpgrade = array_map(function (array $app) use ($appConfig): array {
+			return [
+				'id' => $app['id'],
+				'name' => $app['name'],
+				'version' => $app['version'],
+				'oldVersion' => $appConfig->getValueString($app['id'], 'installed_version'),
+			];
+		}, $appManager->getAppsNeedingUpgrade($ocVersion));
+
+		return [
+			'appsToUpgrade' => $appsToUpgrade,
+			'incompatibleAppsList' => $incompatibleDisabledApps,
+		];
+	}
+
+	private static function throwIncompatibleShippedAppsException(array $incompatibleShippedApps): void {
+		$appList = implode(', ', $incompatibleShippedApps);
+
+		$message = sprintf(
+			'Application %s is not present or has a non-compatible version with this server. Please check the apps directory.',
+			$appList,
+		);
+
+		$l = Server::get(\OCP\L10N\IFactory::class)->get('core');
+		$hint = $l->t(
+			'Application %1$s is not present or has a non-compatible version with this server. Please check the apps directory.',
+			[$appList],
+		);
+
+		throw new \OCP\HintException($message, $hint);
 	}
 
 	private static function isBigInstanceOverrideRequested(): bool {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The `printUpgradePage()` function combined upgrade-size detection, app compatibility checks, and view rendering into a single method. This tight coupling made the function harder to understand, maintain, and test.

The function has been refactored to improve clarity and modularity:

* Upgrade size detection:
  - Extracted logic (isInstanceTooBigForWebUpgrade() + reusable helpers for for database queries).
  - Introduced isBigInstanceOverrideRequested() to handle override logic separately.
  - Eliminates duplicate code and streamlines parent function's logic flow.
* App compatibility checks:
  - Extracted logic (prepareUpgradeAppState() + helper to encapsulate exception handling).
  - Makes parent function logic easier to read.
* Other improvements:
  - Replaced magic numbers/strings with named constants for better readability and maintainability.
  - Minimized inline branching and variable clutter.

In addition to clarity, should improve testability going forward.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
