### PR TITLE
feat: allow loading external storage config values from file

### DIFF
--- a/apps/files_external/lib/Command/Config.php
+++ b/apps/files_external/lib/Command/Config.php
@@ -15,6 +15,7 @@ use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\AppFramework\Http;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Config extends Base {
@@ -40,7 +41,12 @@ class Config extends Base {
 			)->addArgument(
 				'value',
 				InputArgument::OPTIONAL,
-				'value to set the config option to, when no value is provided the existing value will be printed'
+				'value to set the config option to; when omitted, the existing value is printed; with --value-from-file, this is treated as a file pat'
+			)->addOption(
+				'value-from-file',
+				null,
+				InputOption::VALUE_NONE,
+				'treat the value argument as a file path and read the config value from that file'
 			);
 		parent::configure();
 	}
@@ -58,6 +64,14 @@ class Config extends Base {
 
 		$value = $input->getArgument('value');
 		if ($value !== null) {
+			if ($input->getOption('value-from-file')) {
+				$file = $value;
+				$value = file_get_contents($file);
+				if ($value === false) {
+					$output->writeln('<error>Failed to load value from ' . $file . '</error>');
+					return 1;
+				}
+			}
 			$this->setOption($mount, $key, $value, $output);
 		} else {
 			$this->getOption($mount, $key, $output);

--- a/apps/files_external/lib/Command/Option.php
+++ b/apps/files_external/lib/Command/Option.php
@@ -10,6 +10,7 @@ namespace OCA\Files_External\Command;
 
 use OCA\Files_External\Lib\StorageConfig;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Option extends Config {
@@ -29,7 +30,12 @@ class Option extends Config {
 			)->addArgument(
 				'value',
 				InputArgument::OPTIONAL,
-				'value to set the mount option to, when no value is provided the existing value will be printed'
+				'value to set the config option to; when omitted, the existing value is printed; with --value-from-file, this is treated as a file pat'
+			)->addOption(
+				'value-from-file',
+				null,
+				InputOption::VALUE_NONE,
+				'treat the value argument as a file path and read the config value from that file'
 			);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Some values like ssh keys can be very hard to pass trough the command line because of the special characters in the value. Loading the value from a file instead can make it much easier to set these options.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
