### PR TITLE
test(db): call parent::tearDown() in DB test classes that skipped it

### DIFF
--- a/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
+++ b/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
@@ -68,6 +68,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 		$query->delete('calendar_resources_md')->executeStatement();
 		$query->delete('calendar_rooms')->executeStatement();
 		$query->delete('calendar_rooms_md')->executeStatement();
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -29,6 +29,7 @@ class AdapterTest extends TestCase {
 			->from('appconfig')
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter($this->appId)))
 			->executeStatement();
+		parent::tearDown();
 	}
 
 	public function testInsertIgnoreOnConflictDuplicate(): void {

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -90,6 +90,7 @@ class UserMountCacheTest extends TestCase {
 				->where($builder->expr()->eq('fileid', new Literal($fileId)))
 				->executeStatement();
 		}
+		parent::tearDown();
 	}
 
 	private function getStorage($storageId, $rootInternalPath = '') {

--- a/tests/lib/Files/Type/LoaderTest.php
+++ b/tests/lib/Files/Type/LoaderTest.php
@@ -31,6 +31,7 @@ class LoaderTest extends TestCase {
 				'mimetype', $deleteMimetypes->createPositionalParameter('testing/%')
 			));
 		$deleteMimetypes->executeStatement();
+		parent::tearDown();
 	}
 
 

--- a/tests/lib/Preview/PreviewMigrationJobTest.php
+++ b/tests/lib/Preview/PreviewMigrationJobTest.php
@@ -103,6 +103,7 @@ class PreviewMigrationJobTest extends TestCase {
 		$qb->delete('filecache')
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter(5)))
 			->executeStatement();
+		parent::tearDown();
 	}
 
 	#[TestDox('Test the migration from the legacy flat hierarchy to the new database format')]

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -127,6 +127,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
 		$this->dbConn->getQueryBuilder()->delete('filecache')->runAcrossAllShards()->executeStatement();
 		$this->dbConn->getQueryBuilder()->delete('storages')->executeStatement();
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/lib/Share20/ShareByMailProviderTest.php
+++ b/tests/lib/Share20/ShareByMailProviderTest.php
@@ -134,6 +134,7 @@ class ShareByMailProviderTest extends TestCase {
 		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
 		$this->dbConn->getQueryBuilder()->delete('filecache')->runAcrossAllShards()->executeStatement();
 		$this->dbConn->getQueryBuilder()->delete('storages')->executeStatement();
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -100,6 +100,7 @@ class SubAdminTest extends \Test\TestCase {
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter('orphanedUser')))
 			->orWhere($qb->expr()->eq('gid', $qb->createNamedParameter('orphanedGroup')))
 			->executeStatement();
+		parent::tearDown();
 	}
 
 	public function testCreateSubAdmin(): void {


### PR DESCRIPTION
## Summary

Eight test classes in `tests/lib/` override `tearDown()` for custom DB cleanup but never call `parent::tearDown()`.

## Why

`TestCase::tearDown()` does three things these tests were silently skipping after every single test method:

- **`ILockingProvider::releaseAll()`** — unreleased locks bleed into subsequent tests, causing unexpected deadlocks or `NotFoundException`
- **`Storage::getGlobalCache()->clearCache()`** — stale filecache entries left behind by share/storage tests cause completely unrelated `ObjectStoreStorageTest` tests to receive `false` from `fopen()`, which then makes `fseek()` fail with _"Argument #1 must be of type resource, bool given"_
- **`UserMountCache::flush()`** — stale mount cache causes share lookups in later tests to fail with `ShareNotFound`

These are the root causes of two recurring flaky failures seen in CI:
- `Test\Files\ObjectStore\ObjectStoreStorageTest::testFseekSize`
- `Test\Share20\DefaultShareProviderTest::testDeleteSingleShareLazy`

## Files changed

| File | Tables cleaned in tearDown |
|------|---------------------------|
| `tests/lib/Share20/DefaultShareProviderTest.php` | share, filecache, storages |
| `tests/lib/Share20/ShareByMailProviderTest.php` | share, filecache, storages |
| `tests/lib/Files/Config/UserMountCacheTest.php` | mounts, filecache |
| `tests/lib/SubAdminTest.php` | users, groups, group_admin |
| `tests/lib/Files/Type/LoaderTest.php` | mimetypes |
| `tests/lib/Calendar/ResourcesRoomsUpdaterTest.php` | calendar_resources, calendar_rooms |
| `tests/lib/Preview/PreviewMigrationJobTest.php` | filecache, preview data |
| `tests/lib/DB/AdapterTest.php` | appconfig |

## Test plan

- [x] DB test suite passes without the two previously-flaky tests appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)