### PR TITLE
chore(ci): add init job with buildjet cache to integration-sqlite workflow

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -43,11 +43,45 @@ jobs:
               - 'composer.lock'
               - 'core/shipped.json'
 
-  integration-sqlite:
+  init:
     runs-on: ubuntu-latest
 
     needs: changes
     if: needs.changes.outputs.src != 'false'
+
+    steps:
+      - name: Checkout server
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Set up php 8.4
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
+        timeout-minutes: 5
+        with:
+          php-version: '8.4'
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, ldap, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          coverage: none
+          ini-file: development
+          ini-values: disable_functions=""
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Save context
+        uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        with:
+          key: integration-sqlite-context-${{ github.run_id }}
+          path: ./
+
+  integration-sqlite:
+    runs-on: ubuntu-latest
+
+    needs: [changes, init]
+    if: needs.changes.outputs.src != 'false' && needs.init.result == 'success'
 
     strategy:
       fail-fast: false
@@ -98,8 +132,16 @@ jobs:
           SLAPD_ADDITIONAL_MODULES: memberof
 
     steps:
+      - name: Restore context
+        id: cache
+        uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        with:
+          key: integration-sqlite-context-${{ github.run_id }}
+          path: ./
+
       - name: Checkout server
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.cache.outputs.cache-hit != 'true'
         with:
           persist-credentials: false
           submodules: true
@@ -144,9 +186,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up dependencies
-        run: |
-          composer install
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: composer install
 
       - name: Set up Talk dependencies
         if: ${{ matrix.test-suite == 'videoverification_features' }}
@@ -185,7 +227,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, integration-sqlite]
+    needs: [changes, init, integration-sqlite]
 
     if: always()
 
@@ -193,4 +235,10 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.integration-sqlite.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && (needs.init.result != 'success' || needs.integration-sqlite.result != 'success') }}; then exit 1; fi
+
+      - name: Delete cache
+        uses: buildjet/cache-delete@7184288b8396c4492a56728c47dd286fbd1e96ae # v1
+        if: needs.init.result == 'success' && needs.integration-sqlite.result == 'success'
+        with:
+          cache_key: integration-sqlite-context-${{ github.run_id }}


### PR DESCRIPTION
## Summary

- Adds an `init` job that runs `composer install` once and saves the full workspace (including `vendor/`) to buildjet cache
- All 21 parallel matrix jobs restore from this cache instead of each doing a full checkout + `composer install`
- Falls back to a fresh checkout + install if the cache is missed
- Summary job cleans up the cache on success and now gates on both `init` and `integration-sqlite`

## Why

Each of the 21 parallel `integration-sqlite` jobs previously repeated a full submodule checkout and `composer install` independently. Sharing a single prepared workspace via buildjet/cache (the same pattern already used in the Cypress workflow) eliminates that redundancy.

## Notes

- The Talk app's own `composer i --no-dev` step is preserved per-job since it depends on the matrix value and the Talk repo is checked out after cache restore
- The `init` job hardcodes PHP 8.4 to match the matrix; if the matrix PHP version ever changes, the init job must be updated in the same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)