### PR TITLE
test: replace checkbox assertions with DoesNotPerformAssertions (misc)

### DIFF
--- a/tests/lib/Authentication/Listeners/RemoteWipeActivityListenerTest.php
+++ b/tests/lib/Authentication/Listeners/RemoteWipeActivityListenerTest.php
@@ -44,12 +44,11 @@ class RemoteWipeActivityListenerTest extends TestCase {
 		);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testHandleUnrelated(): void {
 		$event = new Event();
 
 		$this->listener->handle($event);
-
-		$this->addToAssertionCount(1);
 	}
 
 	public function testHandleRemoteWipeStarted(): void {

--- a/tests/lib/Authentication/Listeners/RemoteWipeNotificationsListenerTest.php
+++ b/tests/lib/Authentication/Listeners/RemoteWipeNotificationsListenerTest.php
@@ -45,12 +45,11 @@ class RemoteWipeNotificationsListenerTest extends TestCase {
 		);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testHandleUnrelated(): void {
 		$event = new Event();
 
 		$this->listener->handle($event);
-
-		$this->addToAssertionCount(1);
 	}
 
 	public function testHandleRemoteWipeStarted(): void {

--- a/tests/lib/Authentication/LoginCredentials/StoreTest.php
+++ b/tests/lib/Authentication/LoginCredentials/StoreTest.php
@@ -65,11 +65,11 @@ class StoreTest extends TestCase {
 		$this->store->authenticate($params);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testSetSession(): void {
 		$session = $this->createMock(ISession::class);
 
 		$this->store->setSession($session);
-		$this->addToAssertionCount(1);
 	}
 
 	public function testGetLoginCredentialsNoTokenProvider(): void {

--- a/tests/lib/Contacts/ContactsMenu/EntryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/EntryTest.php
@@ -21,9 +21,9 @@ class EntryTest extends TestCase {
 		$this->entry = new Entry();
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testSetId(): void {
 		$this->entry->setId(123);
-		$this->addToAssertionCount(1);
 	}
 
 	public function testSetGetFullName(): void {

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -140,9 +140,9 @@ class CacheJailTest extends CacheTest {
 	}
 
 	#[\Override]
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testGetIncomplete(): void {
 		//not supported
-		$this->addToAssertionCount(1);
 	}
 
 	public function testMoveFromJail(): void {

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -105,12 +105,11 @@ class PathVerificationTest extends \Test\TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('providesValidPosixPaths')]
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testPathVerificationValidPaths($fileName): void {
 		$storage = new Local(['datadir' => '']);
 
 		self::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
-		// nothing thrown
-		$this->addToAssertionCount(1);
 	}
 
 	public static function providesValidPosixPaths(): array {

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -90,6 +90,7 @@ class LocalTest extends Storage {
 		$storage->file_put_contents('sym/foo', 'bar');
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testDisallowSymlinksInsideDatadir(): void {
 		$subDir1 = $this->tmpDir . 'sub1';
 		$subDir2 = $this->tmpDir . 'sub1/sub2';
@@ -102,7 +103,6 @@ class LocalTest extends Storage {
 		$storage = new Local(['datadir' => $subDir1]);
 
 		$storage->file_put_contents('sym/foo', 'bar');
-		$this->addToAssertionCount(1);
 	}
 
 	public function testWriteUmaskFilePutContents(): void {

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -757,8 +757,6 @@ class EncryptionTest extends Storage {
 			->with($sourceInternalPath, $expectedCachePut);
 
 		$this->invokePrivate($this->instance, 'copyBetweenStorage', [$storage2, $sourceInternalPath, $targetInternalPath, $preserveMtime, $isRename]);
-
-		$this->assertFalse(false);
 	}
 
 	/**
@@ -817,8 +815,6 @@ class EncryptionTest extends Storage {
 			->with($sourceInternalPath, $expectedCachePut);
 
 		$this->invokePrivate($this->instance, 'copyBetweenStorage', [$storage2, $sourceInternalPath, $targetInternalPath, $preserveMtime, $isRename]);
-
-		$this->assertFalse(false);
 	}
 
 	/**

--- a/tests/lib/Group/Backend.php
+++ b/tests/lib/Group/Backend.php
@@ -133,12 +133,11 @@ abstract class Backend extends \Test\TestCase {
 		$this->assertSame(2, $result);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testAddDouble(): void {
 		$group = $this->getGroupName();
 
 		$this->backend->createGroup($group);
 		$this->backend->createGroup($group);
-
-		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/IntegrityCheck/Helpers/FileAccessHelperTest.php
+++ b/tests/lib/IntegrityCheck/Helpers/FileAccessHelperTest.php
@@ -53,8 +53,8 @@ class FileAccessHelperTest extends TestCase {
 		$this->fileAccessHelper->assertDirectoryExists('/anabsolutelynotexistingfolder/on/the/system');
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testAssertDirectoryExists(): void {
 		$this->fileAccessHelper->assertDirectoryExists(Server::get(ITempManager::class)->getTemporaryFolder('/testfolder/'));
-		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -32,9 +32,9 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 		$this->contentSecurityPolicyManager = new ContentSecurityPolicyManager($this->dispatcher);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testAddDefaultPolicy(): void {
 		$this->contentSecurityPolicyManager->addDefaultPolicy(new ContentSecurityPolicy());
-		$this->addToAssertionCount(1);
 	}
 
 	public function testGetDefaultPolicyWithPolicies(): void {

--- a/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
+++ b/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
@@ -29,9 +29,9 @@ class FeaturePolicyManagerTest extends TestCase {
 		$this->manager = new FeaturePolicyManager($this->dispatcher);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testAddDefaultPolicy(): void {
 		$this->manager->addDefaultPolicy(new FeaturePolicy());
-		$this->addToAssertionCount(1);
 	}
 
 	public function testGetDefaultPolicyWithPoliciesViaEvent(): void {

--- a/tests/lib/Support/CrashReport/RegistryTest.php
+++ b/tests/lib/Support/CrashReport/RegistryTest.php
@@ -27,14 +27,11 @@ class RegistryTest extends TestCase {
 		$this->registry = new Registry();
 	}
 
-	/**
-	 * Doesn't assert anything, just checks whether anything "explodes"
-	 */
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testDelegateToNone(): void {
 		$exception = new Exception('test');
 
 		$this->registry->delegateReport($exception);
-		$this->addToAssertionCount(1);
 	}
 
 	public function testRegisterLazy(): void {
@@ -49,9 +46,7 @@ class RegistryTest extends TestCase {
 		$this->registry->delegateReport($exception);
 	}
 
-	/**
-	 * Doesn't assert anything, just checks whether anything "explodes"
-	 */
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRegisterLazyCantLoad(): void {
 		$reporterClass = '\OCA\MyApp\Reporter';
 		/* We do not register reporterClass in DI, so it will throw a QueryException queried */
@@ -59,7 +54,6 @@ class RegistryTest extends TestCase {
 
 		$this->registry->registerLazy($reporterClass);
 		$this->registry->delegateReport($exception);
-		$this->addToAssertionCount(1);
 	}
 
 	public function testDelegateBreadcrumbCollection(): void {

--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -49,12 +49,9 @@ class RegistryTest extends TestCase {
 		);
 	}
 
-	/**
-	 * Doesn't assert anything, just checks whether anything "explodes"
-	 */
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testDelegateToNone(): void {
 		$this->registry->delegateHasValidSubscription();
-		$this->addToAssertionCount(1);
 	}
 
 

--- a/tests/lib/Talk/ConversationOptionsTest.php
+++ b/tests/lib/Talk/ConversationOptionsTest.php
@@ -13,9 +13,8 @@ use OC\Talk\ConversationOptions;
 use Test\TestCase;
 
 class ConversationOptionsTest extends TestCase {
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testDefaults(): void {
 		ConversationOptions::default();
-
-		$this->addToAssertionCount(1);
 	}
 }


### PR DESCRIPTION
## Summary

Replaces `addToAssertionCount(1)` and `assertFalse(false)` placeholder assertions with `#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]` across 15 unrelated test files.

- 13 tests use `addToAssertionCount(1)` solely to suppress the PHPUnit "risky test" warning — they verify only that no exception is thrown
- 2 tests in `EncryptionTest` use `assertFalse(false)` as a placeholder, but both already have real `expects($this->once())` mock expectations that serve as the meaningful assertion
- The `"Doesn't assert anything"` docblock comments in `CrashReport/RegistryTest` and `Subscription/RegistryTest` are removed since `#[DoesNotPerformAssertions]` communicates the same intent

Part of a broader effort to eliminate checkbox tests across the test suite (see also #60742).

## Test plan

- [ ] Run the affected test classes locally to confirm no regressions
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)