### PR TITLE
test: replace addToAssertionCount checkbox tests in Hooks and DI

### DIFF
--- a/tests/lib/AppFramework/Bootstrap/FunctionInjectorTest.php
+++ b/tests/lib/AppFramework/Bootstrap/FunctionInjectorTest.php
@@ -34,12 +34,10 @@ class FunctionInjectorTest extends TestCase {
 		});
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testInjectFnNotRegisteredButNullable(): void {
 		(new FunctionInjector($this->container))->injectFn(static function (?Foo $p1): void {
 		});
-
-		// Nothing to assert. No errors means everything is fine.
-		$this->addToAssertionCount(1);
 	}
 
 	public function testInjectFnByType(): void {
@@ -51,18 +49,13 @@ class FunctionInjectorTest extends TestCase {
 
 		(new FunctionInjector($this->container))->injectFn(static function (Foo $p1): void {
 		});
-
-		// Nothing to assert. No errors means everything is fine.
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testInjectFnByName(): void {
 		$this->container->registerParameter('test', 'abc');
 
 		(new FunctionInjector($this->container))->injectFn(static function ($test): void {
 		});
-
-		// Nothing to assert. No errors means everything is fine.
-		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/Hooks/BasicEmitterTest.php
+++ b/tests/lib/Hooks/BasicEmitterTest.php
@@ -148,6 +148,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->emitEvent('Test', 'test', ['foo' => 'foo', 'bar' => 'bar']);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveAllSpecified(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -155,10 +156,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener);
 		$this->emitter->removeListener('Test', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardListener(): void {
 		$listener1 = function (): void {
 			throw new EmittedException;
@@ -170,10 +170,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener2);
 		$this->emitter->removeListener('Test', 'test');
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardMethod(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -183,10 +182,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Test', null, $listener);
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Test', 'foo');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardScope(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -196,10 +194,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener(null, 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Bar', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardScopeAndMethod(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -211,8 +208,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Test', 'foo');
 		$this->emitter->emitEvent('Bar', 'foo');
-
-		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveKeepOtherCallback(): void {
@@ -228,8 +223,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener2);
 		$this->emitter->removeListener('Test', 'test', $listener1);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveKeepOtherMethod(): void {
@@ -242,8 +235,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'foo', $listener);
 		$this->emitter->removeListener('Test', 'foo', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveKeepOtherScope(): void {
@@ -256,8 +247,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Bar', 'test', $listener);
 		$this->emitter->removeListener('Bar', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveNonExistingName(): void {
@@ -269,7 +258,5 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener);
 		$this->emitter->removeListener('Bar', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/Hooks/BasicEmitterTest.php
+++ b/tests/lib/Hooks/BasicEmitterTest.php
@@ -153,6 +153,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->emitEvent('Test', 'test', ['foo' => 'foo', 'bar' => 'bar']);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveAllSpecified(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -160,10 +161,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener);
 		$this->emitter->removeListener('Test', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardListener(): void {
 		$listener1 = function (): void {
 			throw new EmittedException;
@@ -175,10 +175,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener2);
 		$this->emitter->removeListener('Test', 'test');
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardMethod(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -188,10 +187,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Test', null, $listener);
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Test', 'foo');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardScope(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -201,10 +199,9 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener(null, 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Bar', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testRemoveWildcardScopeAndMethod(): void {
 		$listener = function (): void {
 			throw new EmittedException;
@@ -216,8 +213,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Test', 'foo');
 		$this->emitter->emitEvent('Bar', 'foo');
-
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -234,8 +229,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener2);
 		$this->emitter->removeListener('Test', 'test', $listener1);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -249,8 +242,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'foo', $listener);
 		$this->emitter->removeListener('Test', 'foo', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -264,8 +255,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Bar', 'test', $listener);
 		$this->emitter->removeListener('Bar', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -278,7 +267,5 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->listen('Test', 'test', $listener);
 		$this->emitter->removeListener('Bar', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
-
-		$this->addToAssertionCount(1);
 	}
 }


### PR DESCRIPTION
## Summary

- `BasicEmitterTest`: add `#[DoesNotPerformAssertions]` to 5 tests that verify no exception is thrown after listener removal; remove unreachable `addToAssertionCount(1)` from 4 tests that already have `expectException`
- `FunctionInjectorTest`: add `#[DoesNotPerformAssertions]` to 2 tests verifying no-exception behaviour; remove unreachable placeholder from `testInjectFnByType` (factory closure assertion on line 47 is the real assertion)

Part of a broader effort to eliminate checkbox tests and replace them with proper PHPUnit 11 semantics.

## Test plan

- [x] Run `NOCOVERAGE=1 ./autotest.sh sqlite tests/lib/Hooks/BasicEmitterTest.php`
- [x] Run `NOCOVERAGE=1 ./autotest.sh sqlite tests/lib/AppFramework/Bootstrap/FunctionInjectorTest.php`
- [x] Confirm no risky test warnings in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)