### PR TITLE
test(share20): replace addToAssertionCount checkbox tests in Share20 ManagerTest

### DIFF
--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2059,7 +2059,6 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn([]);
 
 		self::invokePrivate($this->manager, 'userCreateChecks', [$share]);
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -2203,7 +2202,6 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn([$share2]);
 
 		self::invokePrivate($this->manager, 'userCreateChecks', [$share]);
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -2301,7 +2299,6 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		self::invokePrivate($this->manager, 'groupCreateChecks', [$share]);
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -2357,7 +2354,6 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		self::invokePrivate($this->manager, 'groupCreateChecks', [$share]);
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -2377,6 +2373,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testFileLinkCreateChecksNoPublicUpload(): void {
 		$share = $this->manager->newShare();
 
@@ -2391,7 +2388,6 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
-		$this->addToAssertionCount(1);
 	}
 
 	public function testFolderLinkCreateChecksNoPublicUpload(): void {
@@ -2413,6 +2409,7 @@ class ManagerTest extends \Test\TestCase {
 		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testLinkCreateChecksPublicUpload(): void {
 		$share = $this->manager->newShare();
 
@@ -2429,9 +2426,9 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testLinkCreateChecksReadOnly(): void {
 		$share = $this->manager->newShare();
 
@@ -2448,7 +2445,6 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -2481,14 +2477,13 @@ class ManagerTest extends \Test\TestCase {
 		$this->mountManager->method('findIn')->with('path')->willReturn([$mount]);
 
 		self::invokePrivate($this->manager, 'pathCreateChecks', [$path]);
-		$this->addToAssertionCount(1);
 	}
 
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
 	public function testPathCreateChecksContainsNoFolder(): void {
 		$path = $this->createMock(File::class);
 
 		self::invokePrivate($this->manager, 'pathCreateChecks', [$path]);
-		$this->addToAssertionCount(1);
 	}
 
 	public static function dataIsSharingDisabledForUser() {
@@ -4689,7 +4684,6 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->method('move')->with($share, 'recipient')->willReturnArgument(0);
 
 		$this->manager->moveShare($share, 'recipient');
-		$this->addToAssertionCount(1);
 	}
 
 
@@ -4747,7 +4741,6 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->method('move')->with($share, 'recipient')->willReturnArgument(0);
 
 		$this->manager->moveShare($share, 'recipient');
-		$this->addToAssertionCount(1);
 	}
 
 	#[DataProvider('dataTestShareProviderExists')]


### PR DESCRIPTION
## Summary

- 7 tests already had `->with()` stub parameter constraints (which PHPUnit 11 counts as assertions) — remove the now-redundant `addToAssertionCount(1)` call
- 4 tests had no assertions at all and only verify no exception is thrown — add `#[DoesNotPerformAssertions]` and remove the placeholder

Affected tests: `testUserCreateChecksShareWithGroupMembersOnlySharedGroup`, `testUserCreateChecksIdenticalPathNotSharedWithUser`, `testGroupCreateChecksShareWithGroupMembersOnlyInGroup`, `testGroupCreateChecksPathAlreadySharedWithDifferentGroup`, `testFileLinkCreateChecksNoPublicUpload`, `testLinkCreateChecksPublicUpload`, `testLinkCreateChecksReadOnly`, `testPathCreateChecksContainsNoSharedMount`, `testPathCreateChecksContainsNoFolder`, `testMoveShareUser`, `testMoveShareGroup`

Part of a broader effort to eliminate checkbox tests and replace them with proper PHPUnit 11 semantics.

## Test plan

- [x] Run `NOCOVERAGE=1 ./autotest.sh sqlite tests/lib/Share20/ManagerTest.php`
- [x] Confirm no risky test warnings in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)