### PR TITLE
fix: guard against null keys/aliases to fix PHP 8.4 deprecation warnings

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -703,7 +703,7 @@ class Access extends LDAPUtility {
 					if (is_null($nameByLDAP)) {
 						continue;
 					}
-					$sndName = $ldapObject[$sndAttribute][0] ?? '';
+					$sndName = $sndAttribute !== null ? ($ldapObject[$sndAttribute][0] ?? '') : '';
 					$this->applyUserDisplayName($ncName, $nameByLDAP, $sndName);
 				} elseif ($nameByLDAP !== null) {
 					$this->cacheGroupDisplayName($ncName, $nameByLDAP);

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -725,7 +725,7 @@ class QueryBuilder extends TypedQueryBuilder {
 		$this->queryBuilder->join(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),
-			$this->quoteAlias($alias),
+			$this->quoteAlias($alias) ?? '',
 			$condition
 		);
 
@@ -754,7 +754,7 @@ class QueryBuilder extends TypedQueryBuilder {
 		$this->queryBuilder->innerJoin(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),
-			$this->quoteAlias($alias),
+			$this->quoteAlias($alias) ?? '',
 			$condition
 		);
 
@@ -783,7 +783,7 @@ class QueryBuilder extends TypedQueryBuilder {
 		$this->queryBuilder->leftJoin(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),
-			$this->quoteAlias($alias),
+			$this->quoteAlias($alias) ?? '',
 			$condition
 		);
 
@@ -812,7 +812,7 @@ class QueryBuilder extends TypedQueryBuilder {
 		$this->queryBuilder->rightJoin(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),
-			$this->quoteAlias($alias),
+			$this->quoteAlias($alias) ?? '',
 			$condition
 		);
 

--- a/lib/public/Cache/CappedMemoryCache.php
+++ b/lib/public/Cache/CappedMemoryCache.php
@@ -37,6 +37,9 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 	 */
 	#[\Override]
 	public function hasKey($key): bool {
+		if ($key === null) {
+			return false;
+		}
 		return isset($this->cache[$key]);
 	}
 
@@ -46,6 +49,9 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 	 */
 	#[\Override]
 	public function get($key) {
+		if ($key === null) {
+			return null;
+		}
 		return $this->cache[$key] ?? null;
 	}
 
@@ -73,6 +79,9 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 	 */
 	#[\Override]
 	public function remove($key): bool {
+		if ($key === null) {
+			return false;
+		}
 		unset($this->cache[$key]);
 		return true;
 	}

--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -532,7 +532,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		return [
 			[
 				'd1', 'data2', null, null,
-				['`d1`' => [['joinType' => 'inner', 'joinTable' => '`*PREFIX*data2`', 'joinAlias' => null, 'joinCondition' => null]]],
+				['`d1`' => [['joinType' => 'inner', 'joinTable' => '`*PREFIX*data2`', 'joinAlias' => '', 'joinCondition' => null]]],
 				'`*PREFIX*data1` `d1` INNER JOIN `*PREFIX*data2` '
 			],
 			[
@@ -613,7 +613,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		return [
 			[
 				'd1', 'data2', null, null,
-				['`d1`' => [['joinType' => 'left', 'joinTable' => '`*PREFIX*data2`', 'joinAlias' => null, 'joinCondition' => null]]],
+				['`d1`' => [['joinType' => 'left', 'joinTable' => '`*PREFIX*data2`', 'joinAlias' => '', 'joinCondition' => null]]],
 				'`*PREFIX*data1` `d1` LEFT JOIN `*PREFIX*data2` '
 			],
 			[
@@ -663,7 +663,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		return [
 			[
 				'd1', 'data2', null, null,
-				['`d1`' => [['joinType' => 'right', 'joinTable' => '`*PREFIX*data2`', 'joinAlias' => null, 'joinCondition' => null]]],
+				['`d1`' => [['joinType' => 'right', 'joinTable' => '`*PREFIX*data2`', 'joinAlias' => '', 'joinCondition' => null]]],
 				'`*PREFIX*data1` `d1` RIGHT JOIN `*PREFIX*data2` '
 			],
 			[


### PR DESCRIPTION
## Summary

Fixes three PHP 8.4 deprecation warnings that surface as CI noise and will become failures on PHP 9:

- **`CappedMemoryCache`**: `get()`, `hasKey()`, and `remove()` used null as an array offset when a caller passed a null key (e.g. `AccountManager::getAccount()` with a mock user whose `getUID()` returns null). Guard each method with an early null return.
- **`QueryBuilder::quoteAlias()`**: returned `null` when given a null alias, which then passed through to DBAL's join methods and triggered `array_key_exists(null, ...)` deprecations. Return `''` instead — DBAL treats an empty alias the same as null (no alias in the generated SQL). Updated `QueryBuilderTest` join expectations accordingly (`'joinAlias' => null` → `'joinAlias' => ''`).
- **`user_ldap/Access`**: `$sndAttribute` is null when `ldapUserDisplayName2` is not configured (group path sets it to null explicitly), but was used as array offset inside the `$isUsers` branch without a null check.

## Test plan

- [ ] Run `NOCOVERAGE=1 ./autotest.sh sqlite tests/lib/Accounts/AccountManagerTest.php`
- [ ] Run `NOCOVERAGE=1 ./autotest.sh sqlite tests/lib/DB/QueryBuilder/QueryBuilderTest.php`
- [ ] Confirm the three deprecations no longer appear in CI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)