### PR TITLE
refactor(base): decompose initSession() into focused private helper methods

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -425,25 +425,15 @@ class OC {
 			return;
 		}
 
-		// Let the session name be changed in the initSession Hook
 		$sessionName = OC_Util::getInstanceId();
-
 		$session = self::createSession($sessionName);
 
-		//try to set the session lifetime
-		$sessionLifeTime = self::getSessionLifeTime();
-
-		// session timeout
-		if ($session->exists('LAST_ACTIVITY') && (time() - $session->get('LAST_ACTIVITY') > $sessionLifeTime)) {
-			if (isset($_COOKIE[session_name()])) {
-				setcookie(session_name(), '', -1, self::$WEBROOT ? : '/');
-			}
-			Server::get(IUserSession::class)->logout();
-		}
+		self::enforceSessionTimeout($session);
 
 		if (!self::hasSessionRelaxedExpiry()) {
-			$session->set('LAST_ACTIVITY', time());
+			$session->set(self::LAST_ACTIVITY_SESSION_KEY, time());
 		}
+
 		$session->close();
 	}
 
@@ -494,6 +484,30 @@ class OC {
 			Server::get(ITemplateManager::class)->printExceptionErrorPage($e, 500);
 			die();
 		}
+	}
+
+	private static function enforceSessionTimeout(ISession $session): void {
+		$lastActivity = $session->exists(self::LAST_ACTIVITY_SESSION_KEY)
+			? (int)$session->get(self::LAST_ACTIVITY_SESSION_KEY)
+			: null;
+
+		if ($lastActivity === null) {
+			return;
+		}
+
+		$now = time();
+		$sessionLifeTime = self::getSessionLifeTime();
+
+		if (($now - $lastActivity) <= $sessionLifeTime) {
+			return;
+		}
+
+		$sessionName = session_name();
+		if (isset($_COOKIE[$sessionName])) {
+			setcookie($sessionName, '', -1, self::$WEBROOT ?: '/');
+		}
+
+		Server::get(IUserSession::class)->logout();
 	}
 
 	private static function getSessionLifeTime(): int {

--- a/lib/base.php
+++ b/lib/base.php
@@ -412,7 +412,10 @@ class OC {
 		// Do not initialize the session if a DAV request is authenticated directly,
 		// unless there is already a Nextcloud session cookie present.
 		//
-		// Disabled due to compatibility issues; see nextcloud/server#37277 before re-enabling.
+		// DAV-specific session bypass is currently disabled due to compatibility issues
+		// with clients that use cookies (for example DAVx5). See nextcloud/server#37277
+		// before re-enabling this path.
+		//
 		// if (self::shouldBypassSessionInitializationForDirectDavAuth($request)) {
 		//	self::markDavCookieProbe($now);
 		//	return;
@@ -424,8 +427,7 @@ class OC {
 			return;
 		}
 
-		$sessionName = OC_Util::getInstanceId();
-		$session = self::createSession($sessionName);
+		$session = self::createWrappedSession(OC_Util::getInstanceId());
 
 		self::enforceSessionTimeout($session, $now);
 		// FIXME: avoid further session mutation if enforceSessionTimeout does a logout() by returning here?
@@ -472,14 +474,14 @@ class OC {
 	}
 
 	private static function shouldSkipSessionInitialization(IRequest $request): bool {
-		// Cookie parameters must be already configured so follow-up cookie handling
-		// in this request uses the correct path/domain/secure settings.
+		// Cookie parameters must be configured before this check so follow-up cookie
+		// handling in the request uses the correct path, domain, and secure settings.
 
-		// Monitoring endpoint doesn't require sessions and can flood session handlers.
+		// The monitoring endpoint does not require sessions and can flood session handlers.
 		return str_ends_with($request->getScriptName(), self::STATUS_ENDPOINT_SUFFIX);
 	}
 
-	private static function createSession(string $sessionName): ISession {
+	private static function createWrappedSession(string $sessionName): ISession {
 		try {
 			$installed = Server::get(\OC\SystemConfig::class)->getValue('installed', false);
 			$logger = null;

--- a/lib/base.php
+++ b/lib/base.php
@@ -409,8 +409,8 @@ class OC {
 		$request = Server::get(IRequest::class);
 		$now = time();
 
-		// Directly authenticated DAV requests do not need an initialized session, unless there
-		// is already a Nextcloud session cookie present.
+		// When enabled, directly authenticated DAV requests do not need an initialized
+		// session unless there is already a Nextcloud session cookie present.
 		//
 		// NOTE: This is currently disabled due to compatibility issues with clients that use
 		// cookies (e.g. DAVx5). See nextcloud/server#37277 before re-enabling.
@@ -428,7 +428,7 @@ class OC {
 
 		$session = self::createWrappedSession(OC_Util::getInstanceId());
 
-		if (self::invalidateExpiredSession($session, $now)) {
+		if (self::invalidateExpiredSession($request, $session, $now)) {
 			return;
 		}
 
@@ -505,17 +505,21 @@ class OC {
 			// TODO: Catch \Throwable instead and adapt rendering path.
 			Server::get(LoggerInterface::class)->error($e->getMessage(), ['app' => 'base', 'exception' => $e]);
 			Server::get(ITemplateManager::class)->printExceptionErrorPage($e, 500);
-			die();
+			exit();
 		}
 	}
 
-	private static function invalidateExpiredSession(ISession $session, int $now): bool {
-		// TODO: Further normalize and validate LAST_ACTIVITY before using
-		$lastActivity = $session->exists(self::LAST_ACTIVITY_SESSION_KEY)
-			? (int)$session->get(self::LAST_ACTIVITY_SESSION_KEY)
+	private static function invalidateExpiredSession(IRequest $request, ISession $session, int $now): bool {
+$		value = $session->exists(self::LAST_ACTIVITY_SESSION_KEY)
+			? $session->get(self::LAST_ACTIVITY_SESSION_KEY)
 			: null;
 
-		if ($lastActivity === null) {
+		if (!is_int($value) && !ctype_digit((string)$value)) {
+			return false;
+		}
+
+		$lastActivity = (int)$value;
+		if ($lastActivity <= 0) {
 			return false;
 		}
 
@@ -525,7 +529,8 @@ class OC {
 			return false;
 		}
 
-		self::clearSessionCookie();
+		self::clearSessionCookie($request, $now);
+
 		Server::get(IUserSession::class)->logout();
 		$session->close();
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -395,6 +395,16 @@ class OC {
 		return $productName;
 	}
 
+	private const LAST_ACTIVITY_SESSION_KEY = 'LAST_ACTIVITY';
+	private const STATUS_ENDPOINT_SUFFIX = '/status.php';
+	private const COOKIE_DOMAIN_CONFIG_KEY = 'cookie_domain';
+
+	/**
+	 * Initialize the session for the current request.
+	 *
+	 * Applies session cookie settings, skips session startup for status requests,
+	 * creates the wrapped internal session, and logs out expired sessions.
+	 */
 	public static function initSession(): void {
 		$request = Server::get(IRequest::class);
 
@@ -409,28 +419,9 @@ class OC {
 		// return;
 		// }
 
-		if ($request->getServerProtocol() === 'https') {
-			ini_set('session.cookie_secure', 'true');
-		}
+		self::configureSessionCookieSettings($request);
 
-		// prevents javascript from accessing php session cookies
-		ini_set('session.cookie_httponly', 'true');
-
-		// set the cookie path to the Nextcloud directory
-		$cookie_path = OC::$WEBROOT ? : '/';
-		ini_set('session.cookie_path', $cookie_path);
-
-		// set the cookie domain to the Nextcloud domain
-		$cookie_domain = self::$config->getValue('cookie_domain', '');
-		if ($cookie_domain) {
-			ini_set('session.cookie_domain', $cookie_domain);
-		}
-
-		// Do not initialize sessions for 'status.php' requests
-		// Monitoring endpoints can quickly flood session handlers
-		// and 'status.php' doesn't require sessions anyway
-		// We still need to run the ini_set above so that same-site cookies use the correct configuration.
-		if (str_ends_with($request->getScriptName(), '/status.php')) {
+		if (self::shouldSkipSessionInitialization($request)) {
 			return;
 		}
 
@@ -476,6 +467,31 @@ class OC {
 			$session->set('LAST_ACTIVITY', time());
 		}
 		$session->close();
+	}
+
+	private static function configureSessionCookieSettings(IRequest $request): void {
+		if ($request->getServerProtocol() === 'https') {
+			ini_set('session.cookie_secure', 'true');
+		}
+
+		// prevent javascript from accessing php session cookies
+		ini_set('session.cookie_httponly', 'true');
+
+		// set the cookie path to the Nextcloud directory
+		$webRoot = self::$WEBROOT ?: '/';
+		ini_set('session.cookie_path', $webRoot);
+
+		// set the cookie domain to the Nextcloud domain
+		$cookieDomain = self::$config->getValue(self::COOKIE_DOMAIN_CONFIG_KEY, '');
+		if ($cookieDomain !== '') {
+			ini_set('session.cookie_domain', $cookieDomain);
+		}
+	}
+
+	private static function shouldSkipSessionInitialization(IRequest $request): bool {
+		// Monitoring endpoints can quickly flood session handlers and 'status.php' doesn't require sessions anyway.
+		// Session cookie settings still need to be applied beforehand so that same-site cookies use the correct configuration.
+		return str_ends_with($request->getScriptName(), self::STATUS_ENDPOINT_SUFFIX);
 	}
 
 	private static function getSessionLifeTime(): int {

--- a/lib/base.php
+++ b/lib/base.php
@@ -428,10 +428,13 @@ class OC {
 		$sessionName = OC_Util::getInstanceId();
 		$session = self::createSession($sessionName);
 
-		self::enforceSessionTimeout($session);
+		$now = time();
+
+		self::enforceSessionTimeout($session, $now);
+		// FIXME: avoid further session mutation if enforceSessionTimeout does a logout() by returning here?
 
 		if (!self::hasSessionRelaxedExpiry()) {
-			$session->set(self::LAST_ACTIVITY_SESSION_KEY, time());
+			$session->set(self::LAST_ACTIVITY_SESSION_KEY, $now);
 		}
 
 		$session->close();
@@ -457,8 +460,10 @@ class OC {
 	}
 
 	private static function shouldSkipSessionInitialization(IRequest $request): bool {
-		// Monitoring endpoints can quickly flood session handlers and 'status.php' doesn't require sessions anyway.
-		// Session cookie settings still need to be applied beforehand so that same-site cookies use the correct configuration.
+		// Cookie parameters must be already configured so follow-up cookie handling
+		// in this request uses the correct path/domain/secure settings.
+
+		// Monitoring endpoint doesn't require sessions and can flood session handlers.
 		return str_ends_with($request->getScriptName(), self::STATUS_ENDPOINT_SUFFIX);
 	}
 
@@ -482,13 +487,15 @@ class OC {
 
 			return $session;
 		} catch (Exception $e) {
+			// TODO: Consider isolating so that termination behavior is more explicit.
 			Server::get(LoggerInterface::class)->error($e->getMessage(), ['app' => 'base', 'exception' => $e]);
 			Server::get(ITemplateManager::class)->printExceptionErrorPage($e, 500);
 			die();
 		}
 	}
 
-	private static function enforceSessionTimeout(ISession $session): void {
+	private static function enforceSessionTimeout(ISession $session, int $now): void {
+		// TODO: Further normalize and validate LAST_ACTIVITY before using
 		$lastActivity = $session->exists(self::LAST_ACTIVITY_SESSION_KEY)
 			? (int)$session->get(self::LAST_ACTIVITY_SESSION_KEY)
 			: null;
@@ -497,7 +504,6 @@ class OC {
 			return;
 		}
 
-		$now = time();
 		$sessionLifeTime = self::getSessionLifeTime();
 
 		if (($now - $lastActivity) <= $sessionLifeTime) {
@@ -506,11 +512,13 @@ class OC {
 
 		$sessionName = session_name();
 		if (isset($_COOKIE[$sessionName])) {
-			// TODO: if cookie_domain is set, should probably be included here too
+			// FIXME: if original cookie was set with a configured domain, deleting it should probably include the domain too
 			setcookie($sessionName, '', -1, self::$WEBROOT ?: '/');
 		}
 
 		Server::get(IUserSession::class)->logout();
+		// TODO: audit whether timeout logout should also clear session state explicitly /
+		// whether any other session baggage is left around unnecessarily.
 	}
 
 	private static function getSessionLifeTime(): int {

--- a/lib/base.php
+++ b/lib/base.php
@@ -525,16 +525,27 @@ class OC {
 			return false;
 		}
 
-		$sessionName = session_name();
-		if (isset($_COOKIE[$sessionName])) {
-			$domain = self::$config->getValue(self::COOKIE_DOMAIN_CONFIG_KEY, '');
-			setcookie($sessionName, '', $now - 3600, self::$WEBROOT ?: '/', $domain);
-		}
-
+		self::clearSessionCookie();
 		Server::get(IUserSession::class)->logout();
 		$session->close();
 
 		return true;
+	}
+
+	private static function clearSessionCookie(IRequest $request, int $now): void {
+		$sessionName = session_name();
+		if ($sessionName === '' || $request->getCookie($sessionName) === null) {
+			return;
+		}
+
+		$sessionCookieParams = session_get_cookie_params();
+		setcookie(
+			$sessionName,
+			'',
+			$now - 3600,
+			$sessionCookieParams['path'] ?: '/',
+			$sessionCookieParams['domain'] ?: ''
+		);
 	}
 
 	private static function getSessionLifeTime(): int {

--- a/lib/base.php
+++ b/lib/base.php
@@ -407,16 +407,15 @@ class OC {
 	 */
 	public static function initSession(): void {
 		$request = Server::get(IRequest::class);
+		$now = time();
 
-		// TODO: Temporary disabled again to solve issues with CalDAV/CardDAV clients like DAVx5 that use cookies
-		// TODO: See https://github.com/nextcloud/server/issues/37277#issuecomment-1476366147 and the other comments
-		// TODO: for further information.
-		// $isDavRequest = strpos($request->getRequestUri(), '/remote.php/dav') === 0 || strpos($request->getRequestUri(), '/remote.php/webdav') === 0;
-		// if ($request->getHeader('Authorization') !== '' && is_null($request->getCookie('cookie_test')) && $isDavRequest && !isset($_COOKIE['nc_session_id'])) {
-		// setcookie('cookie_test', 'test', time() + 3600);
-		// // Do not initialize the session if a request is authenticated directly
-		// // unless there is a session cookie already sent along
-		// return;
+		// Do not initialize the session if a DAV request is authenticated directly,
+		// unless there is already a Nextcloud session cookie present.
+		//
+		// Disabled due to compatibility issues; see nextcloud/server#37277 before re-enabling.
+		// if (self::shouldBypassSessionInitializationForDirectDavAuth($request)) {
+		//	self::markDavCookieProbe($now);
+		//	return;
 		// }
 
 		self::configureSessionCookieSettings($request);
@@ -428,8 +427,6 @@ class OC {
 		$sessionName = OC_Util::getInstanceId();
 		$session = self::createSession($sessionName);
 
-		$now = time();
-
 		self::enforceSessionTimeout($session, $now);
 		// FIXME: avoid further session mutation if enforceSessionTimeout does a logout() by returning here?
 
@@ -438,6 +435,21 @@ class OC {
 		}
 
 		$session->close();
+	}
+
+	private static function shouldBypassSessionInitializationForDirectDavAuth(IRequest $request): bool {
+		$requestUri = $request->getRequestUri();
+		$isDavRequest = str_starts_with($requestUri, '/remote.php/dav')
+			|| str_starts_with($requestUri, '/remote.php/webdav');
+
+		return $request->getHeader('Authorization') !== ''
+			&& $request->getCookie('cookie_test') === null
+			&& $isDavRequest
+			&& !isset($_COOKIE['nc_session_id']);
+	}
+
+	private static function markDavCookieProbe(int $now): void {
+		setcookie('cookie_test', 'test', $now + 3600);
 	}
 
 	private static function configureSessionCookieSettings(IRequest $request): void {
@@ -469,7 +481,7 @@ class OC {
 
 	private static function createSession(string $sessionName): ISession {
 		try {
-			$installed = Server::get(\OC\SystemConfig::class)->getValue('installed', false)
+			$installed = Server::get(\OC\SystemConfig::class)->getValue('installed', false);
 			$logger = null;
 
 			if ($installed) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -464,8 +464,10 @@ class OC {
 
 	private static function createSession(string $sessionName): ISession {
 		try {
+			$installed = Server::get(\OC\SystemConfig::class)->getValue('installed', false)
 			$logger = null;
-			if (Server::get(\OC\SystemConfig::class)->getValue('installed', false)) {
+
+			if ($installed) {
 				$logger = logger('core');
 			}
 
@@ -504,6 +506,7 @@ class OC {
 
 		$sessionName = session_name();
 		if (isset($_COOKIE[$sessionName])) {
+			// TODO: if cookie_domain is set, should probably be included here too
 			setcookie($sessionName, '', -1, self::$WEBROOT ?: '/');
 		}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -428,29 +428,7 @@ class OC {
 		// Let the session name be changed in the initSession Hook
 		$sessionName = OC_Util::getInstanceId();
 
-		try {
-			$logger = null;
-			if (Server::get(\OC\SystemConfig::class)->getValue('installed', false)) {
-				$logger = logger('core');
-			}
-
-			// set the session name to the instance id - which is unique
-			$session = new \OC\Session\Internal(
-				$sessionName,
-				$logger,
-			);
-
-			$cryptoWrapper = Server::get(\OC\Session\CryptoWrapper::class);
-			$session = $cryptoWrapper->wrapSession($session);
-			self::$server->setSession($session);
-
-			// if session can't be started break with http 500 error
-		} catch (Exception $e) {
-			Server::get(LoggerInterface::class)->error($e->getMessage(), ['app' => 'base','exception' => $e]);
-			//show the user a detailed error page
-			Server::get(ITemplateManager::class)->printExceptionErrorPage($e, 500);
-			die();
-		}
+		$session = self::createSession($sessionName);
 
 		//try to set the session lifetime
 		$sessionLifeTime = self::getSessionLifeTime();
@@ -492,6 +470,30 @@ class OC {
 		// Monitoring endpoints can quickly flood session handlers and 'status.php' doesn't require sessions anyway.
 		// Session cookie settings still need to be applied beforehand so that same-site cookies use the correct configuration.
 		return str_ends_with($request->getScriptName(), self::STATUS_ENDPOINT_SUFFIX);
+	}
+
+	private static function createSession(string $sessionName): ISession {
+		try {
+			$logger = null;
+			if (Server::get(\OC\SystemConfig::class)->getValue('installed', false)) {
+				$logger = logger('core');
+			}
+
+			// set the session name to the instance id - which is unique
+			$session = new \OC\Session\Internal(
+				$sessionName,
+				$logger,
+			);
+
+			$session = Server::get(\OC\Session\CryptoWrapper::class)->wrapSession($session);
+			self::$server->setSession($session);
+
+			return $session;
+		} catch (Exception $e) {
+			Server::get(LoggerInterface::class)->error($e->getMessage(), ['app' => 'base', 'exception' => $e]);
+			Server::get(ITemplateManager::class)->printExceptionErrorPage($e, 500);
+			die();
+		}
 	}
 
 	private static function getSessionLifeTime(): int {

--- a/lib/base.php
+++ b/lib/base.php
@@ -409,12 +409,11 @@ class OC {
 		$request = Server::get(IRequest::class);
 		$now = time();
 
-		// Do not initialize the session if a DAV request is authenticated directly,
-		// unless there is already a Nextcloud session cookie present.
+		// Directly authenticated DAV request do not need an initialized session, unless there
+		// is already a Nextcloud session cookie present.
 		//
-		// DAV-specific session bypass is currently disabled due to compatibility issues
-		// with clients that use cookies (for example DAVx5). See nextcloud/server#37277
-		// before re-enabling this path.
+		// NOTE: This is currently disabled due to compatibility issues with clients that use
+		// cookies (e.g. DAVx5). See nextcloud/server#37277 before re-enabling.
 		//
 		// if (self::shouldBypassSessionInitializationForDirectDavAuth($request)) {
 		//	self::markDavCookieProbe($now);
@@ -429,8 +428,9 @@ class OC {
 
 		$session = self::createWrappedSession(OC_Util::getInstanceId());
 
-		self::enforceSessionTimeout($session, $now);
-		// FIXME: avoid further session mutation if enforceSessionTimeout does a logout() by returning here?
+		if (self::enforceSessionTimeout($session, $now)) {
+			return;
+		}
 
 		if (!self::hasSessionRelaxedExpiry()) {
 			$session->set(self::LAST_ACTIVITY_SESSION_KEY, $now);
@@ -508,31 +508,32 @@ class OC {
 		}
 	}
 
-	private static function enforceSessionTimeout(ISession $session, int $now): void {
+	private static function invalidateExpiredSession(ISession $session, int $now): bool {
 		// TODO: Further normalize and validate LAST_ACTIVITY before using
 		$lastActivity = $session->exists(self::LAST_ACTIVITY_SESSION_KEY)
 			? (int)$session->get(self::LAST_ACTIVITY_SESSION_KEY)
 			: null;
 
 		if ($lastActivity === null) {
-			return;
+			return false;
 		}
 
 		$sessionLifeTime = self::getSessionLifeTime();
 
 		if (($now - $lastActivity) <= $sessionLifeTime) {
-			return;
+			return false;
 		}
 
 		$sessionName = session_name();
 		if (isset($_COOKIE[$sessionName])) {
-			// FIXME: if original cookie was set with a configured domain, deleting it should probably include the domain too
+			// FIXME: if original session cookie was set with a configured domain, deleting it should probably include the domain too
 			setcookie($sessionName, '', -1, self::$WEBROOT ?: '/');
 		}
 
 		Server::get(IUserSession::class)->logout();
-		// TODO: audit whether timeout logout should also clear session state explicitly /
-		// whether any other session baggage is left around unnecessarily.
+		$session->close();
+
+		return true;
 	}
 
 	private static function getSessionLifeTime(): int {

--- a/lib/base.php
+++ b/lib/base.php
@@ -409,7 +409,7 @@ class OC {
 		$request = Server::get(IRequest::class);
 		$now = time();
 
-		// Directly authenticated DAV request do not need an initialized session, unless there
+		// Directly authenticated DAV requests do not need an initialized session, unless there
 		// is already a Nextcloud session cookie present.
 		//
 		// NOTE: This is currently disabled due to compatibility issues with clients that use
@@ -428,7 +428,7 @@ class OC {
 
 		$session = self::createWrappedSession(OC_Util::getInstanceId());
 
-		if (self::enforceSessionTimeout($session, $now)) {
+		if (self::invalidateExpiredSession($session, $now)) {
 			return;
 		}
 
@@ -447,7 +447,7 @@ class OC {
 		return $request->getHeader('Authorization') !== ''
 			&& $request->getCookie('cookie_test') === null
 			&& $isDavRequest
-			&& !isset($_COOKIE['nc_session_id']);
+			&& $request->getCookie('nc_session_id') === null;
 	}
 
 	private static function markDavCookieProbe(int $now): void {
@@ -502,6 +502,7 @@ class OC {
 			return $session;
 		} catch (Exception $e) {
 			// TODO: Consider isolating so that termination behavior is more explicit.
+			// TODO: Catch \Throwable instead and adapt rendering path.
 			Server::get(LoggerInterface::class)->error($e->getMessage(), ['app' => 'base', 'exception' => $e]);
 			Server::get(ITemplateManager::class)->printExceptionErrorPage($e, 500);
 			die();
@@ -526,8 +527,8 @@ class OC {
 
 		$sessionName = session_name();
 		if (isset($_COOKIE[$sessionName])) {
-			// FIXME: if original session cookie was set with a configured domain, deleting it should probably include the domain too
-			setcookie($sessionName, '', -1, self::$WEBROOT ?: '/');
+			$domain = self::$config->getValue(self::COOKIE_DOMAIN_CONFIG_KEY, '');
+			setcookie($sessionName, '', $now - 3600, self::$WEBROOT ?: '/', $domain);
 		}
 
 		Server::get(IUserSession::class)->logout();

--- a/lib/base.php
+++ b/lib/base.php
@@ -510,7 +510,7 @@ class OC {
 	}
 
 	private static function invalidateExpiredSession(IRequest $request, ISession $session, int $now): bool {
-$		value = $session->exists(self::LAST_ACTIVITY_SESSION_KEY)
+		$value = $session->exists(self::LAST_ACTIVITY_SESSION_KEY)
 			? $session->get(self::LAST_ACTIVITY_SESSION_KEY)
 			: null;
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This PR refactors `OC::initSession()` out into smaller, focused private helpers to improve readability and testability. No behavior is changed beyond several fixes I judged low-risk/high confidence (noted below).

### Bug/robustness fixes included

- **Session cookie deletion now includes the configured domain.** Previously omitted the domain, meaning the cookie might not be cleared on instances with a configured `cookie_domain`. Also used a hardcoded `-1` expiry. Now uses `session_get_cookie_params()` to match the original cookie's path and domain, and a standard `$now - 3600` expiry.
- **DAV bypass no longer reads `$_COOKIE` directly.** `$_COOKIE['nc_session_id']` replaced with `$request->getCookie('nc_session_id')` for consistency and testability.
- **`LAST_ACTIVITY` validation hardened.** Non-numeric and non-positive values are now rejected before the timeout comparison, preventing unintended session invalidation on corrupt session data. (Aside: We may want to add debug level logging when this happens I guess so there's at least some chance of discovering it in the wild).

### Known follow-up (not in this PR)

- `catch (Exception $e)` in `createWrappedSession()` should probably be widened to `\Throwable` — noted with a TODO comment for now

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
