### PR TITLE
test(user_ldap): speed up AbstractMappingTestCase chunking test

### DIFF
--- a/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
@@ -283,17 +283,17 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 		[$mapper,] = $this->initTest();
 
 		$listOfDNs = [];
+		// List size exceeds the implementation's 65000-parameter chunk limit, forcing multiple chunked queries
 		for ($i = 0; $i < 66640; $i++) {
-			// Postgres has a limit of 65535 values in a single IN list
 			$name = 'as_' . $i;
 			$dn = 'uid=' . $name . ',dc=example,dc=org';
 			$listOfDNs[] = $dn;
-			if ($i % 20 === 0) {
+			if ($i % 5000 === 0) {
 				$mapper->map($dn, $name, 'fake-uuid-' . $i);
 			}
 		}
 
 		$result = $mapper->getListOfIdsByDn($listOfDNs);
-		$this->assertCount(66640 / 20, $result);
+		$this->assertCount(14, $result);
 	}
 }


### PR DESCRIPTION
## Summary

- The `testGetListOfIdsByDn` test mapped a DN every 20 entries across 66k entries, producing 3332 DB inserts just to exercise query chunking behaviour
- Only 14 mapped entries are needed to exceed Postgres's 65535-value IN limit and trigger chunking — map every 5000th entry instead (14 inserts, down from 3332)
- Clarify the loop comment: it explains why the list size forces chunking, not a per-iteration invariant

Split out from #60739 at reviewer request.

## Test plan

- [x] `NOCOVERAGE=1 ./autotest.sh sqlite apps/user_ldap/tests/Mapping/` passes
- [x] Test still exercises the chunking code path (list of 66640 DNs exceeds 65535 limit)
- [x] Assertion count matches: 14 mapped entries (`66640 / 5000` rounded = 13, plus index 0 = 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)