### PR TITLE
test(behat): reset per-scenario state in BasicStructure and Sharing

### DIFF
--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -73,6 +73,18 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @BeforeScenario
+	 */
+	public function resetAuthState(): void {
+		$this->currentUser = '';
+		$this->currentServer = 'LOCAL';
+		$this->baseUrl = $this->localBaseUrl;
+		$this->apiVersion = 1;
+		$this->requestToken = null;
+		$this->cookieJar = new CookieJar();
+	}
+
+	/**
 	 * @Given /^using api version "(\d+)"$/
 	 */
 	public function usingApiVersion(int $version): void {

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -23,6 +23,15 @@ trait Sharing {
 	/** @var SimpleXMLElement[] */
 	private array $storedShareData = [];
 	private ?string $savedShareId = null;
+
+	/**
+	 * @BeforeScenario
+	 */
+	public function resetSharingState(): void {
+		$this->lastShareData = null;
+		$this->storedShareData = [];
+		$this->savedShareId = null;
+	}
 	/** @var ResponseInterface */
 	private $response;
 


### PR DESCRIPTION
## Summary

- `$currentUser`, `$currentServer`, `$apiVersion`, `$requestToken`, and `$cookieJar` in `BasicStructure.php` were never reset between scenarios — a scenario could silently inherit auth context from the previous one
- `$lastShareData`, `$storedShareData`, and `$savedShareId` in `Sharing.php` were never reset — 12 methods read `$lastShareData` which could carry stale data from a previous scenario

Adds `@BeforeScenario` hooks to both traits to reset these to clean defaults at the start of each scenario.

## Safety

Verified that every scenario in the integration test suite which reads `$lastShareData` (via steps like "Getting info of last share", "Deleting last share", "accepting last share") also creates a share earlier in that same scenario. The `save/restore` pattern (`storedShareData`) is always used within a single scenario boundary. No cross-scenario data dependencies exist.

## Test plan

- [ ] All integration-sqlite suites pass (CI)
- [ ] Pay particular attention to `sharing_features`, `filesdrop_features`, `files_features` which make heaviest use of the sharing steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)