### PR TITLE
feat(jobs): allow workers to keep track of executed jobs

### DIFF
--- a/core/Command/Background/JobWorker.php
+++ b/core/Command/Background/JobWorker.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -8,6 +9,8 @@ declare(strict_types=1);
 
 namespace OC\Core\Command\Background;
 
+use OC\BackgroundJob\JobClassesRegistry;
+use OC\BackgroundJob\JobRuns;
 use OC\Core\Command\InterruptedException;
 use OCP\BackgroundJob\IJobList;
 use OCP\Files\ISetupManager;
@@ -19,15 +22,17 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class JobWorker extends JobBase {
-
 	public function __construct(
 		protected IJobList $jobList,
 		protected LoggerInterface $logger,
 		private ITempManager $tempManager,
 		private ISetupManager $setupManager,
+		private readonly JobRuns $jobRuns,
+		private readonly JobClassesRegistry $jobClassesRegistry,
 	) {
 		parent::__construct($jobList, $logger);
 	}
+
 	#[\Override]
 	protected function configure(): void {
 		parent::configure();
@@ -124,13 +129,25 @@ class JobWorker extends JobBase {
 				continue;
 			}
 
-			$output->writeln('Running job ' . get_class($job) . ' with ID ' . $job->getId());
+			$jobClassName = get_class($job);
+			$output->writeln('Running job ' . $jobClassName . ' with ID ' . $job->getId());
 
 			if ($output->isVerbose()) {
 				$this->printJobInfo($job->getId(), $job, $output);
 			}
 
+			memory_reset_peak_usage();
+			$jobClassId = $this->jobClassesRegistry->getId($jobClassName);
+			$jobRunId = $this->jobRuns->started($jobClassId);
+			$startTime = microtime(true);
 			$job->start($this->jobList);
+			$timeSpent = microtime(true) - $startTime;
+			$jobMemoryPeak = memory_get_peak_usage();
+			// TODO Job failure will never be catched here because exceptions are catched within $job->start method
+			// The error will only be visible in server logs.
+			// It should be a temporary state until a proper job runner is implemented.
+			$this->jobRuns->finished($jobRunId, (int)($timeSpent * 1000), (int)($jobMemoryPeak / 1024));
+
 			$output->writeln('Job ' . $job->getId() . ' has finished', OutputInterface::VERBOSITY_VERBOSE);
 
 			// clean up after unclean jobs


### PR DESCRIPTION
- Ref: https://github.com/nextcloud/server/issues/52877

## Summary

Use job history when job are executed by a worker

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
