### PR TITLE
refactor: Remove most usages of IAppContainer and IServerContainer

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -16,6 +16,7 @@ use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
 use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\L10N\IFactory;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Backend\BackendInterface;
@@ -50,7 +51,7 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 		private bool $returnCachedSubscriptions,
 	) {
 		parent::__construct($caldavBackend, $principalInfo);
-		$this->l10n = \OC::$server->getL10N('dav');
+		$this->l10n = Server::get(IFactory::class)->get('dav');
 		$this->config = Server::get(IConfig::class);
 		$this->pluginManager = new PluginManager(
 			\OC::$server,

--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -26,6 +26,7 @@ use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\ITip\Message;
@@ -46,7 +47,7 @@ class InvitationResponseServer {
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
 
 		// Add maintenance plugin
-		$this->server->addPlugin(new MaintenancePlugin(Server::get(IConfig::class), \OC::$server->getL10N('dav')));
+		$this->server->addPlugin(new MaintenancePlugin(Server::get(IConfig::class), Server::get(IFactory::class)->get('dav')));
 
 		// Set URL explicitly due to reverse-proxy situations
 		$this->server->httpRequest->setUrl($baseUri);

--- a/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
@@ -17,9 +17,6 @@ use Sabre\DAV\ServerPlugin;
 
 class MaintenancePlugin extends ServerPlugin {
 
-	/** @var IL10N */
-	private $l10n;
-
 	/**
 	 * Reference to main server object
 	 *
@@ -31,10 +28,9 @@ class MaintenancePlugin extends ServerPlugin {
 	 * @param IConfig $config
 	 */
 	public function __construct(
-		private IConfig $config,
-		IL10N $l10n,
+		private readonly IConfig $config,
+		private readonly IL10N $l10n,
 	) {
-		$this->l10n = \OC::$server->getL10N('dav');
 	}
 
 	/**
@@ -59,9 +55,8 @@ class MaintenancePlugin extends ServerPlugin {
 	 * in case the system is in maintenance mode.
 	 *
 	 * @throws ServiceUnavailable
-	 * @return bool
 	 */
-	public function checkMaintenanceMode() {
+	public function checkMaintenanceMode(): bool {
 		if ($this->config->getSystemValueBool('maintenance')) {
 			throw new ServerMaintenanceMode($this->l10n->t('System is in maintenance mode.'));
 		}

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -53,7 +53,7 @@ use Sabre\DAV\SimpleCollection;
 
 class RootCollection extends SimpleCollection {
 	public function __construct() {
-		$l10n = \OC::$server->getL10N('dav');
+		$l10n = Server::get(IFactory::class)->get('dav');
 		$random = Server::get(ISecureRandom::class);
 		$logger = Server::get(LoggerInterface::class);
 		$userManager = Server::get(IUserManager::class);

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -96,6 +96,7 @@ use OCP\ISession;
 use OCP\ITagManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
 use OCP\Profiler\IProfiler;
@@ -133,7 +134,7 @@ class Server {
 		$this->server->setLogger($logger);
 
 		// Add maintenance plugin
-		$this->server->addPlugin(new MaintenancePlugin(\OCP\Server::get(IConfig::class), \OC::$server->getL10N('dav')));
+		$this->server->addPlugin(new MaintenancePlugin(\OCP\Server::get(IConfig::class), \OCP\Server::get(IFactory::class)->get('dav')));
 
 		$this->server->addPlugin(new AppleQuirksPlugin());
 
@@ -401,7 +402,7 @@ class Server {
 					\OCP\Server::get(IURLGenerator::class),
 					\OCP\Server::get(ThemingDefaults::class),
 					\OCP\Server::get(IRequest::class),
-					\OC::$server->getL10N('dav'),
+					\OCP\Server::get(IFactory::class)->get('dav'),
 					function () {
 						return UUIDUtil::getUUID();
 					}

--- a/apps/files_external/tests/Service/StoragesServiceTestCase.php
+++ b/apps/files_external/tests/Service/StoragesServiceTestCase.php
@@ -22,7 +22,6 @@ use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\DBConfigService;
 use OCA\Files_External\Service\StoragesService;
-use OCP\AppFramework\IAppContainer;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Config\IUserMountCache;
@@ -128,14 +127,6 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 			Filesystem::CLASSNAME,
 			Filesystem::signal_delete_mount,
 			get_class($this), 'deleteHookCallback');
-
-		$containerMock = $this->createMock(IAppContainer::class);
-		$containerMock->method('query')
-			->willReturnCallback(function ($name) {
-				if ($name === 'OCA\Files_External\Service\BackendService') {
-					return $this->backendService;
-				}
-			});
 	}
 
 	protected function tearDown(): void {

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -165,7 +165,7 @@ class Application extends App implements IBootstrap {
 		// notifications api to accept incoming user shares
 		$dispatcher->addListener(ShareCreatedEvent::class, function (ShareCreatedEvent $event): void {
 			/** @var Listener $listener */
-			$listener = $this->getContainer()->query(Listener::class);
+			$listener = $this->getContainer()->get(Listener::class);
 			$listener->shareNotification($event);
 		});
 		$dispatcher->addListener(IGroup::class . '::postAddUser', function ($event): void {
@@ -173,7 +173,7 @@ class Application extends App implements IBootstrap {
 				return;
 			}
 			/** @var Listener $listener */
-			$listener = $this->getContainer()->query(Listener::class);
+			$listener = $this->getContainer()->get(Listener::class);
 			$listener->userAddedToGroup($event);
 		});
 	}

--- a/apps/settings/tests/AppInfo/ApplicationTest.php
+++ b/apps/settings/tests/AppInfo/ApplicationTest.php
@@ -17,8 +17,8 @@ use OCA\Settings\Controller\MailSettingsController;
 use OCA\Settings\Controller\UsersController;
 use OCA\Settings\Middleware\SubadminMiddleware;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\Middleware;
+use Psr\Container\ContainerInterface;
 use Test\TestCase;
 
 /**
@@ -29,7 +29,7 @@ use Test\TestCase;
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ApplicationTest extends TestCase {
 	protected Application $app;
-	protected IAppContainer $container;
+	protected ContainerInterface $container;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/theming/tests/ServicesTest.php
+++ b/apps/theming/tests/ServicesTest.php
@@ -15,11 +15,11 @@ use OCA\Theming\Settings\PersonalSection;
 use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
 use OCP\AppFramework\App;
-use OCP\AppFramework\IAppContainer;
 use OCP\Capabilities\ICapability;
 use OCP\IL10N;
 use OCP\Settings\IIconSection;
 use OCP\Settings\ISettings;
+use Psr\Container\ContainerInterface;
 use Test\TestCase;
 
 /**
@@ -31,7 +31,7 @@ use Test\TestCase;
 class ServicesTest extends TestCase {
 	protected App $app;
 
-	protected IAppContainer $container;
+	protected ContainerInterface $container;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -66,6 +66,6 @@ class ServicesTest extends TestCase {
 		if ($expected === null) {
 			$expected = $service;
 		}
-		$this->assertInstanceOf($expected, $this->container->query($service));
+		$this->assertInstanceOf($expected, $this->container->get($service));
 	}
 }

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -30,7 +30,6 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -86,7 +85,7 @@ class Application extends App implements IBootstrap {
 	public function boot(IBootContext $context): void {
 		$context->injectFn(function (
 			INotificationManager $notificationManager,
-			IAppContainer $appContainer,
+			ContainerInterface $appContainer,
 			IEventDispatcher $dispatcher,
 			IUserManager $userManager,
 			IGroupManager $groupManager,
@@ -120,7 +119,7 @@ class Application extends App implements IBootstrap {
 		);
 	}
 
-	private function registerBackendDependents(IAppContainer $appContainer, IEventDispatcher $dispatcher): void {
+	private function registerBackendDependents(ContainerInterface $appContainer, IEventDispatcher $dispatcher): void {
 		$dispatcher->addListener(
 			'OCA\\Files_External::loadAdditionalBackends',
 			function () use ($appContainer): void {

--- a/apps/user_status/lib/AppInfo/Application.php
+++ b/apps/user_status/lib/AppInfo/Application.php
@@ -68,7 +68,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(OutOfOfficeStartedEvent::class, OutOfOfficeStatusListener::class);
 		$context->registerEventListener(OutOfOfficeEndedEvent::class, OutOfOfficeStatusListener::class);
 
-		$config = $this->getContainer()->query(IConfig::class);
+		/** @var IConfig $config */
+		$config = $this->getContainer()->get(IConfig::class);
 		$shareeEnumeration = $config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$shareeEnumerationInGroupOnly = $shareeEnumeration && $config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		$shareeEnumerationPhone = $shareeEnumeration && $config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -218,9 +218,6 @@
     </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/CalendarHome.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getL10N]]></code>
-    </DeprecatedMethod>
     <InvalidNullableReturnType>
       <code><![CDATA[INode]]></code>
     </InvalidNullableReturnType>
@@ -282,11 +279,6 @@
     <FalsableReturnStatement>
       <code><![CDATA[fread($this->source, $end - $start)]]></code>
     </FalsableReturnStatement>
-  </file>
-  <file src="apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getL10N]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Outbox.php">
     <DeprecatedMethod>
@@ -762,11 +754,6 @@
       <code><![CDATA[getPath]]></code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="apps/dav/lib/Connector/Sabre/MaintenancePlugin.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getL10N]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/dav/lib/Connector/Sabre/Node.php">
     <InternalMethod>
       <code><![CDATA[changeLock]]></code>
@@ -1005,11 +992,6 @@
       <code><![CDATA[generate]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/dav/lib/RootCollection.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getL10N]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/dav/lib/Search/ACalendarSearchProvider.php">
     <UndefinedMagicPropertyFetch>
       <code><![CDATA[$component->{'RECURRENCE-ID'}]]></code>
@@ -1056,8 +1038,6 @@
       <code><![CDATA[dispatch]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getL10N]]></code>
-      <code><![CDATA[getL10N]]></code>
       <code><![CDATA[getUserFolder]]></code>
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>
@@ -1650,10 +1630,6 @@
     </ConstructorSignatureMismatch>
   </file>
   <file src="apps/files_sharing/lib/AppInfo/Application.php">
-    <DeprecatedMethod>
-      <code><![CDATA[query]]></code>
-      <code><![CDATA[query]]></code>
-    </DeprecatedMethod>
     <RedundantCondition>
       <code><![CDATA[$event instanceof OldGenericEvent]]></code>
     </RedundantCondition>
@@ -2725,10 +2701,6 @@
     </RedundantCast>
   </file>
   <file src="apps/user_ldap/lib/AppInfo/Application.php">
-    <DeprecatedInterface>
-      <code><![CDATA[IAppContainer]]></code>
-      <code><![CDATA[IAppContainer]]></code>
-    </DeprecatedInterface>
     <DeprecatedMethod>
       <code><![CDATA[Util::connectHook(
 			'\OCA\Files_Sharing\API\Server2Server',
@@ -2858,7 +2830,6 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[query]]></code>
     </DeprecatedMethod>
     <UndefinedInterfaceMethod>
       <code><![CDATA[registerProvider]]></code>

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -17,12 +17,12 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ICallbackResponse;
 use OCP\AppFramework\Http\IOutput;
-use OCP\AppFramework\QueryException;
 use OCP\Diagnostics\IEventLogger;
 use OCP\HintException;
 use OCP\IRequest;
 use OCP\Profiler\IProfiler;
 use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * Entry point for every request in your app. You can consider this as your
@@ -102,7 +102,7 @@ class App {
 		// first try $controllerName then go for \OCA\AppName\Controller\$controllerName
 		try {
 			$controller = $container->get($controllerName);
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface) {
 			if (str_contains($controllerName, '\\Controller\\')) {
 				// This is from a global registered app route that is not enabled.
 				[/*OC(A)*/, $app, /* Controller/Name*/] = explode('\\', $controllerName, 3);
@@ -115,7 +115,7 @@ class App {
 				$appNameSpace = self::buildAppNamespace($appName);
 			}
 			$controllerName = $appNameSpace . '\\Controller\\' . $controllerName;
-			$controller = $container->query($controllerName);
+			$controller = $container->get($controllerName);
 		}
 
 		$eventLogger->end('app:controller:load');

--- a/lib/private/AppFramework/Bootstrap/BootContext.php
+++ b/lib/private/AppFramework/Bootstrap/BootContext.php
@@ -10,22 +10,22 @@ declare(strict_types=1);
 namespace OC\AppFramework\Bootstrap;
 
 use OCP\AppFramework\Bootstrap\IBootContext;
-use OCP\AppFramework\IAppContainer;
 use OCP\IServerContainer;
+use Psr\Container\ContainerInterface;
 
 class BootContext implements IBootContext {
 	public function __construct(
-		private IAppContainer $appContainer,
+		private ContainerInterface $appContainer,
 	) {
 	}
 
 	#[\Override]
-	public function getAppContainer(): IAppContainer {
+	public function getAppContainer(): ContainerInterface {
 		return $this->appContainer;
 	}
 
 	#[\Override]
-	public function getServerContainer(): IServerContainer {
+	public function getServerContainer(): ContainerInterface {
 		return $this->appContainer->get(IServerContainer::class);
 	}
 

--- a/lib/private/AppFramework/Bootstrap/FunctionInjector.php
+++ b/lib/private/AppFramework/Bootstrap/FunctionInjector.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace OC\AppFramework\Bootstrap;
 
 use Closure;
-use OCP\AppFramework\QueryException;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use ReflectionFunction;
 use ReflectionParameter;
@@ -29,14 +29,14 @@ class FunctionInjector {
 			if (($type = $param->getType()) !== null) {
 				try {
 					return $this->container->get($type->getName());
-				} catch (QueryException $ex) {
+				} catch (ContainerExceptionInterface) {
 					// Ignore and try name as well
 				}
 			}
 			// Second we try by name (mostly for primitives)
 			try {
 				return $this->container->get($param->getName());
-			} catch (QueryException $ex) {
+			} catch (ContainerExceptionInterface $ex) {
 				// As a last resort we pass `null` if allowed
 				if ($type !== null && $type->allowsNull()) {
 					return null;

--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OC\AppFramework\Bootstrap;
 
 use Closure;
+use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\Support\CrashReport\Registry;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
@@ -723,9 +724,10 @@ class RegistrationContext {
 			}
 
 			try {
-				$apps[$appId]
-					->getContainer()
-					->registerCapability($registration->getService());
+				/** @var DIContainer $appContainer */
+				$appContainer = $apps[$appId]
+					->getContainer();
+				$appContainer->registerCapability($registration->getService());
 			} catch (Throwable $e) {
 				$this->logger->error("Error during capability registration of $appId: " . $e->getMessage(), [
 					'exception' => $e,
@@ -798,13 +800,14 @@ class RegistrationContext {
 				/**
 				 * Register the service and convert the callable into a \Closure if necessary
 				 */
-				$apps[$appId]
-					->getContainer()
-					->registerService(
-						$registration->getName(),
-						Closure::fromCallable($registration->getFactory()),
-						$registration->isShared()
-					);
+				/** @var DIContainer $appContainer */
+				$appContainer = $apps[$appId]
+					->getContainer();
+				$appContainer->registerService(
+					$registration->getName(),
+					Closure::fromCallable($registration->getFactory()),
+					$registration->isShared()
+				);
 			} catch (Throwable $e) {
 				$this->logger->error("Error during service registration of $appId: " . $e->getMessage(), [
 					'exception' => $e,
@@ -823,12 +826,13 @@ class RegistrationContext {
 			}
 
 			try {
-				$apps[$appId]
-					->getContainer()
-					->registerAlias(
-						$registration->getAlias(),
-						$registration->getTarget()
-					);
+				/** @var DIContainer $appContainer */
+				$appContainer = $apps[$appId]
+					->getContainer();
+				$appContainer->registerAlias(
+					$registration->getAlias(),
+					$registration->getTarget()
+				);
 			} catch (Throwable $e) {
 				$this->logger->error("Error during service alias registration of $appId: " . $e->getMessage(), [
 					'exception' => $e,
@@ -847,12 +851,13 @@ class RegistrationContext {
 			}
 
 			try {
-				$apps[$appId]
-					->getContainer()
-					->registerParameter(
-						$registration->getName(),
-						$registration->getValue()
-					);
+				/** @var DIContainer $appContainer */
+				$appContainer = $apps[$appId]
+					->getContainer();
+				$appContainer->registerParameter(
+					$registration->getName(),
+					$registration->getValue()
+				);
 			} catch (Throwable $e) {
 				$this->logger->error("Error during service parameter registration of $appId: " . $e->getMessage(), [
 					'exception' => $e,

--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -68,7 +68,6 @@ class PublicKeyTokenMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 */
 	public function getToken(string $token): PublicKeyToken {
-		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$result = $qb->select('*')
 			->from($this->tableName)

--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -9,28 +9,29 @@ namespace OC\Log;
 
 use OC\Log;
 use OC\SystemConfig;
-use OCP\AppFramework\QueryException;
-use OCP\IServerContainer;
 use OCP\Log\ILogFactory;
 use OCP\Log\IWriter;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 class LogFactory implements ILogFactory {
 	public function __construct(
-		private IServerContainer $c,
-		private SystemConfig $systemConfig,
+		private readonly ContainerInterface $c,
+		private readonly SystemConfig $systemConfig,
+		private readonly string $serverRoot,
 	) {
 	}
 
 	/**
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	#[\Override]
 	public function get(string $type):IWriter {
 		return match (strtolower($type)) {
 			'errorlog' => new Errorlog($this->systemConfig),
-			'syslog' => $this->c->resolve(Syslog::class),
-			'systemd' => $this->c->resolve(Systemdlog::class),
+			'syslog' => $this->c->get(Syslog::class),
+			'systemd' => $this->c->get(Systemdlog::class),
 			'file' => $this->buildLogFile(),
 			default => $this->buildLogFile(),
 		};
@@ -54,7 +55,7 @@ class LogFactory implements ILogFactory {
 	}
 
 	protected function buildLogFile(string $logFile = ''): File {
-		$defaultLogFile = $this->systemConfig->getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/nextcloud.log';
+		$defaultLogFile = $this->systemConfig->getValue('datadirectory', $this->serverRoot . '/data') . '/nextcloud.log';
 		if ($logFile === '') {
 			$logFile = $this->systemConfig->getValue('logfile', $defaultLogFile);
 		}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -616,7 +616,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** Only used by the PsrLoggerAdapter should not be used by apps */
 		$this->registerService(Log::class, function (Server $c) {
 			$logType = $c->get(AllConfig::class)->getSystemValue('log_type', 'file');
-			$factory = new LogFactory($c, $this->get(SystemConfig::class));
+			$factory = new LogFactory($c, $this->get(SystemConfig::class), $c->get('serverRoot'));
 			$logger = $factory->get($logType);
 			$registry = $c->get(\OCP\Support\CrashReport\IRegistry::class);
 
@@ -696,7 +696,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return new DateTimeFormatter(
 				$c->get(IDateTimeZone::class)->getTimeZone(),
-				$c->getL10N('lib', $language)
+				$c->get(IFactory::class)->get('lib', $language)
 			);
 		});
 
@@ -831,7 +831,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(LoggerInterface::class),
 				$c->get(Defaults::class),
 				$c->get(IURLGenerator::class),
-				$c->getL10N('lib'),
+				$c->get(IFactory::class)->get('lib'),
 				$c->get(IEventDispatcher::class),
 				$c->get(IFactory::class),
 				$c->get(IEmailValidator::class),

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -26,6 +26,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use OCP\Server;
 use OCP\Support\Subscription\IRegistry;
 use Psr\Container\ContainerExceptionInterface;
@@ -402,7 +403,7 @@ class OC_App {
 		//we don't want to show configuration for these
 		$blacklist = $appManager->getAlwaysEnabledApps();
 		$appList = [];
-		$langCode = \OC::$server->getL10N('core')->getLanguageCode();
+		$langCode = Server::get(IFactory::class)->get('core')->getLanguageCode();
 		$urlGenerator = Server::get(IURLGenerator::class);
 		$supportedApps = $this->getSupportedApps();
 

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -7,6 +7,7 @@
  */
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCP\Server;
 use OCP\ServerVersion;
 use OCP\Util;
@@ -214,7 +215,7 @@ class OC_Defaults {
 			return $this->theme->getSlogan($lang);
 		} else {
 			if ($this->defaultSlogan === null) {
-				$l10n = \OC::$server->getL10N('lib', $lang);
+				$l10n = Server::get(IFactory::class)->get('lib', $lang);
 				$this->defaultSlogan = $l10n->t('a safe home for all your data');
 			}
 			return $this->defaultSlogan;

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -25,6 +25,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use OCP\Server;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\User\Backend\ICustomLogout;
@@ -161,7 +162,7 @@ class OC_User {
 				$dispatcher = Server::get(IEventDispatcher::class);
 
 				if ($userSession->getUser() && !$userSession->getUser()->isEnabled()) {
-					$message = \OC::$server->getL10N('lib')->t('Account disabled');
+					$message = Server::get(IFactory::class)->get('lib')->t('Account disabled');
 					throw new DisabledUserException($message);
 				}
 				$userSession->setLoginName($uid);

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -261,7 +261,7 @@ class OC_Util {
 	 * @return array arrays with error messages and hints
 	 */
 	public static function checkServer(SystemConfig $config) {
-		$l = \OCP\Server::get(IFactory::class)->get('lib');
+		$l = Server::get(IFactory::class)->get('lib');
 		$errors = [];
 		$CONFIG_DATADIRECTORY = $config->getValue('datadirectory', OC::$SERVERROOT . '/data');
 
@@ -471,7 +471,7 @@ class OC_Util {
 			clearstatcache();
 			$perms = substr(decoct(@fileperms($dataDirectory)), -3);
 			if ($perms[2] !== '0') {
-				$l = \OC::$server->getL10N('lib');
+				$l = Server::get(IFactory::class)->get('lib');
 				return [[
 					'error' => $l->t('Your data directory is readable by other people.'),
 					'hint' => $l->t('Please change the permissions to 0770 so that the directory cannot be listed by other people.'),
@@ -490,7 +490,7 @@ class OC_Util {
 	 * @internal
 	 */
 	public static function checkDataDirectoryValidity($dataDirectory) {
-		$l = \OC::$server->getL10N('lib');
+		$l = Server::get(IFactory::class)->get('lib');
 		$errors = [];
 		if ($dataDirectory[0] !== '/') {
 			$errors[] = [

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -10,11 +10,13 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework;
 
+use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\Utility\SimpleContainer;
 use OC\ServerContainer;
 use OCP\IConfig;
 use OCP\Server;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,8 +27,7 @@ use Psr\Log\LoggerInterface;
  * @since 6.0.0
  */
 class App {
-	/** @var IAppContainer */
-	private $container;
+	private DIContainer $container;
 
 	/**
 	 * Turns an app id into a namespace by convention. The id is split at the
@@ -92,50 +93,28 @@ class App {
 		try {
 			$this->container = \OC::$server->getRegisteredAppContainer($appName);
 		} catch (ContainerExceptionInterface $e) {
-			$this->container = new \OC\AppFramework\DependencyInjection\DIContainer($appName, $urlParams);
+			$this->container = new DIContainer($appName, $urlParams);
 		}
 	}
 
 	/**
-	 * @return IAppContainer
+	 * @return ContainerInterface
 	 * @since 6.0.0
+	 * @since 35.0.0 Typed as returning a ContainerInterface instead of the deprecated IAppContainer
 	 */
-	public function getContainer(): IAppContainer {
+	public function getContainer(): ContainerInterface {
 		return $this->container;
 	}
 
 	/**
 	 * This function is called by the routing component to fire up the frameworks dispatch mechanism.
 	 *
-	 * Example code in routes.php of the task app:
-	 * $this->create('tasks_index', '/')->get()->action(
-	 *		function($params){
-	 *			$app = new TaskApp($params);
-	 *			$app->dispatch('PageController', 'index');
-	 *		}
-	 *	);
-	 *
-	 *
-	 * Example for for TaskApp implementation:
-	 * class TaskApp extends \OCP\AppFramework\App {
-	 *
-	 *		public function __construct($params){
-	 *			parent::__construct('tasks', $params);
-	 *
-	 *			$this->getContainer()->registerService('PageController', function(IAppContainer $c){
-	 *				$a = $c->query('API');
-	 *				$r = $c->query('Request');
-	 *				return new PageController($a, $r);
-	 *			});
-	 *		}
-	 *	}
-	 *
 	 * @param string $controllerName the name of the controller under which it is
 	 *                               stored in the DI container
 	 * @param string $methodName the method that you want to call
 	 * @since 6.0.0
 	 */
-	public function dispatch(string $controllerName, string $methodName) {
+	public function dispatch(string $controllerName, string $methodName): void {
 		\OC\AppFramework\App::main($controllerName, $methodName, $this->container);
 	}
 }

--- a/lib/public/AppFramework/Bootstrap/IBootContext.php
+++ b/lib/public/AppFramework/Bootstrap/IBootContext.php
@@ -9,34 +9,35 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework\Bootstrap;
 
-use OCP\AppFramework\IAppContainer;
-use OCP\IServerContainer;
+use OCP\AppFramework\Attribute\Consumable;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Throwable;
 
 /**
  * @since 20.0.0
  */
+#[Consumable(since: '20.0.0')]
 interface IBootContext {
 	/**
 	 * Get hold of the app's container
 	 *
 	 * Useful to register and query app-specific services
 	 *
-	 * @return IAppContainer
 	 * @since 20.0.0
+	 * @since 35.0.0 Typed as returning a ContainerInterface instead of the deprecated IAppContainer
 	 */
-	public function getAppContainer(): IAppContainer;
+	public function getAppContainer(): ContainerInterface;
 
 	/**
 	 * Get hold of the server DI container
 	 *
 	 * Useful to register and query system-wide services
 	 *
-	 * @return IServerContainer
 	 * @since 20.0.0
+	 * @since 35.0.0 Typed as returning a ContainerInterface instead of the deprecated IServerContainer
 	 */
-	public function getServerContainer(): IServerContainer;
+	public function getServerContainer(): ContainerInterface;
 
 	/**
 	 * Invoke the given callable and inject all parameters based on their types

--- a/lib/public/Comments/ICommentsManagerFactory.php
+++ b/lib/public/Comments/ICommentsManagerFactory.php
@@ -8,7 +8,7 @@
 
 namespace OCP\Comments;
 
-use OCP\IServerContainer;
+use Psr\Container\ContainerInterface;
 
 /**
  * Interface ICommentsManagerFactory
@@ -22,10 +22,10 @@ interface ICommentsManagerFactory {
 	/**
 	 * Constructor for the comments manager factory
 	 *
-	 * @param IServerContainer $serverContainer server container
+	 * @param ContainerInterface $serverContainer server container
 	 * @since 9.0.0
 	 */
-	public function __construct(IServerContainer $serverContainer);
+	public function __construct(ContainerInterface $serverContainer);
 
 	/**
 	 * creates and returns an instance of the ICommentsManager

--- a/lib/public/ISession.php
+++ b/lib/public/ISession.php
@@ -79,7 +79,7 @@ interface ISession {
 	 * Wrapper around session_regenerate_id
 	 *
 	 * @param bool $deleteOldSession Whether to delete the old associated session file or not.
-	 * @param bool $updateToken Wheater to update the associated auth token
+	 * @param bool $updateToken Whether to update the associated auth token
 	 * @return void
 	 * @since 9.0.0, $updateToken added in 14.0.0
 	 */

--- a/lib/public/LDAP/ILDAPProviderFactory.php
+++ b/lib/public/LDAP/ILDAPProviderFactory.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace OCP\LDAP;
 
 use OCP\AppFramework\Attribute\Consumable;
-use OCP\IServerContainer;
+use Psr\Container\ContainerInterface;
 
 /**
  * Interface ILDAPProviderFactory
@@ -27,7 +27,7 @@ interface ILDAPProviderFactory {
 	 *
 	 * @since 11.0.0
 	 */
-	public function __construct(IServerContainer $serverContainer);
+	public function __construct(ContainerInterface $serverContainer);
 
 	/**
 	 * creates and returns an instance of the ILDAPProvider

--- a/lib/public/SystemTag/ISystemTagManagerFactory.php
+++ b/lib/public/SystemTag/ISystemTagManagerFactory.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\SystemTag;
 
-use OCP\IServerContainer;
+use Psr\Container\ContainerInterface;
 
 /**
  * Interface ISystemTagManagerFactory
@@ -23,11 +23,11 @@ interface ISystemTagManagerFactory {
 	/**
 	 * Constructor for the system tag manager factory
 	 *
-	 * @param IServerContainer $serverContainer server container
+	 * @param ContainerInterface $serverContainer server container
 	 * @since 9.0.0
 	 * @deprecated 33.0.0
 	 */
-	public function __construct(IServerContainer $serverContainer);
+	public function __construct(ContainerInterface $serverContainer);
 
 	/**
 	 * creates and returns an instance of the system tag manager

--- a/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
+++ b/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
@@ -16,7 +16,6 @@ use OC\Core\Middleware\TwoFactorMiddleware;
 use OCP\AppFramework\App;
 use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 

--- a/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
+++ b/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
@@ -11,11 +11,12 @@ namespace lib\AppFramework\Bootstrap;
 
 use OC\AppFramework\Bootstrap\RegistrationContext;
 use OC\AppFramework\Bootstrap\ServiceRegistration;
+use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\Core\Middleware\TwoFactorMiddleware;
 use OCP\AppFramework\App;
-use OCP\AppFramework\IAppContainer;
 use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
@@ -37,7 +38,7 @@ class RegistrationContextTest extends TestCase {
 	public function testRegisterCapability(): void {
 		$app = $this->createMock(App::class);
 		$name = 'abc';
-		$container = $this->createMock(IAppContainer::class);
+		$container = $this->createMock(DIContainer::class);
 		$app->method('getContainer')
 			->willReturn($container);
 		$container->expects($this->once())
@@ -73,7 +74,7 @@ class RegistrationContextTest extends TestCase {
 		$factory = function () {
 			return 'def';
 		};
-		$container = $this->createMock(IAppContainer::class);
+		$container = $this->createMock(DIContainer::class);
 		$app->method('getContainer')
 			->willReturn($container);
 		$container->expects($this->once())
@@ -92,7 +93,7 @@ class RegistrationContextTest extends TestCase {
 		$app = $this->createMock(App::class);
 		$alias = 'abc';
 		$target = 'def';
-		$container = $this->createMock(IAppContainer::class);
+		$container = $this->createMock(DIContainer::class);
 		$app->method('getContainer')
 			->willReturn($container);
 		$container->expects($this->once())
@@ -111,7 +112,7 @@ class RegistrationContextTest extends TestCase {
 		$app = $this->createMock(App::class);
 		$name = 'abc';
 		$value = 'def';
-		$container = $this->createMock(IAppContainer::class);
+		$container = $this->createMock(DIContainer::class);
 		$app->method('getContainer')
 			->willReturn($container);
 		$container->expects($this->once())

--- a/tests/lib/Log/LogFactoryTest.php
+++ b/tests/lib/Log/LogFactoryTest.php
@@ -13,8 +13,8 @@ use OC\Log\LogFactory;
 use OC\Log\Syslog;
 use OC\Log\Systemdlog;
 use OC\SystemConfig;
-use OCP\AppFramework\QueryException;
-use OCP\IServerContainer;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
 use Test\TestCase;
 
 /**
@@ -23,23 +23,18 @@ use Test\TestCase;
  * @package Test\Log
  */
 class LogFactoryTest extends TestCase {
-	/** @var IServerContainer|\PHPUnit\Framework\MockObject\MockObject */
-	protected $c;
-
-	/** @var LogFactory */
-	protected $factory;
-
-	/** @var SystemConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $systemConfig;
+	protected ContainerInterface&MockObject $c;
+	protected LogFactory $factory;
+	protected SystemConfig&MockObject $systemConfig;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->c = $this->createMock(IServerContainer::class);
+		$this->c = $this->createMock(ContainerInterface::class);
 		$this->systemConfig = $this->createMock(SystemConfig::class);
 
-		$this->factory = new LogFactory($this->c, $this->systemConfig);
+		$this->factory = new LogFactory($this->c, $this->systemConfig, \OC::$SERVERROOT);
 	}
 
 	public static function fileTypeProvider(): array {
@@ -61,7 +56,6 @@ class LogFactoryTest extends TestCase {
 
 	/**
 	 * @param string $type
-	 * @throws QueryException
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('fileTypeProvider')]
 	public function testFile(string $type): void {
@@ -93,9 +87,6 @@ class LogFactoryTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @throws QueryException
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('logFilePathProvider')]
 	public function testFileCustomPath($path, $expected): void {
 		$datadir = \OC::$SERVERROOT . '/data';
@@ -114,20 +105,14 @@ class LogFactoryTest extends TestCase {
 		$this->assertSame($expected, $log->getLogFilePath());
 	}
 
-	/**
-	 * @throws QueryException
-	 */
 	public function testErrorLog(): void {
 		$log = $this->factory->get('errorlog');
 		$this->assertInstanceOf(Errorlog::class, $log);
 	}
 
-	/**
-	 * @throws QueryException
-	 */
 	public function testSystemLog(): void {
 		$this->c->expects($this->once())
-			->method('resolve')
+			->method('get')
 			->with(Syslog::class)
 			->willReturn($this->createMock(Syslog::class));
 
@@ -135,12 +120,9 @@ class LogFactoryTest extends TestCase {
 		$this->assertInstanceOf(Syslog::class, $log);
 	}
 
-	/**
-	 * @throws QueryException
-	 */
 	public function testSystemdLog(): void {
 		$this->c->expects($this->once())
-			->method('resolve')
+			->method('get')
 			->with(Systemdlog::class)
 			->willReturn($this->createMock(Systemdlog::class));
 


### PR DESCRIPTION

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
