### PR TITLE
docs(appframework): clarify PasswordConfirmationRequired behavior in docblocks

### DIFF
--- a/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php
+++ b/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php
@@ -12,14 +12,24 @@ namespace OCP\AppFramework\Http\Attribute;
 use Attribute;
 
 /**
- * Attribute for controller methods that require the password to be confirmed with in the last 30 minutes
+ * Attribute for controller methods that require password confirmation, if
+ * supported by the active authentication backend.
+ *
+ * The exact enforcement behavior depends on the password confirmation
+ * middleware.
+ *
+ * In non-strict mode, this normally relies on a recent prior confirmation,
+ * currently defined by the middleware as within the last 30 minutes.
+ *
+ * In strict mode, confirmation is attempted as part of the current request.
  *
  * @since 27.0.0
  */
 #[Attribute]
 class PasswordConfirmationRequired {
 	/**
-	 * @param bool $strict - Whether password confirmation needs to happen in the request.
+	 * @param bool $strict Whether password confirmation must happen as part of
+	 * the current request instead of relying on a recent prior confirmation.
 	 *
 	 * @since 31.0.0
 	 */
@@ -29,10 +39,11 @@ class PasswordConfirmationRequired {
 	}
 
 	/**
+	 * Returns whether password confirmation must happen during the current request.
+	 *
 	 * @since 31.0.0
 	 */
 	public function getStrict(): bool {
 		return $this->strict;
 	}
-
 }

--- a/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php
+++ b/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php
@@ -29,7 +29,8 @@ use Attribute;
 class PasswordConfirmationRequired {
 	/**
 	 * @param bool $strict Whether password confirmation must happen as part of
-	 * the current request instead of relying on a recent prior confirmation.
+	 *                     the current request instead of relying on a recent
+	 *                     prior confirmation.
 	 *
 	 * @since 31.0.0
 	 */

--- a/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php
+++ b/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php
@@ -22,6 +22,7 @@ use Attribute;
  * currently defined by the middleware as within the last 30 minutes.
  *
  * In strict mode, confirmation is attempted as part of the current request.
+ * Credentials must be provided via Basic HTTP authentication.
  *
  * @since 27.0.0
  */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Clarify the `PasswordConfirmationRequired` docblocks to better reflect actual middleware behavior.

Changes:

* document that password confirmation is required only when supported by the active authentication backend
* clarify that enforcement behavior is handled by the password confirmation middleware
* explain the difference between non-strict and strict modes
* document that non-strict mode relies on a recent prior confirmation
* add clearer wording for the `strict` constructor parameter and `getStrict()`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
