### PR TITLE
fix(Storage): use `proxyexclude` parameter in DAV client

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -159,6 +159,11 @@ class DAV extends Common {
 		$this->client = new Client($settings);
 		$this->client->setThrowExceptions(true);
 
+		$proxyExclude = Server::get(IConfig::class)->getSystemValue('proxyexclude', []);
+		if (!empty($proxyExclude)) {
+    		$this->client->addCurlSetting(CURLOPT_NOPROXY, implode(',', $proxyExclude));
+		}
+
 		if ($this->secure === true) {
 			if ($this->verify === false) {
 				$this->client->addCurlSetting(CURLOPT_SSL_VERIFYPEER, false);

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -160,7 +160,7 @@ class DAV extends Common {
 		$this->client->setThrowExceptions(true);
 
 		$proxyExclude = Server::get(IConfig::class)->getSystemValue('proxyexclude', []);
-		if (!empty($proxyExclude)) {
+		if ($proxyExclude !== []) {
 			$this->client->addCurlSetting(CURLOPT_NOPROXY, implode(',', $proxyExclude));
 		}
 

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -161,7 +161,7 @@ class DAV extends Common {
 
 		$proxyExclude = Server::get(IConfig::class)->getSystemValue('proxyexclude', []);
 		if (!empty($proxyExclude)) {
-    		$this->client->addCurlSetting(CURLOPT_NOPROXY, implode(',', $proxyExclude));
+			$this->client->addCurlSetting(CURLOPT_NOPROXY, implode(',', $proxyExclude));
 		}
 
 		if ($this->secure === true) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #60204  <!-- related github issue -->

## Summary

The DAV backend uses Sabre `\DAV\Client` rather than our Guzzle wrapper. This adds support for the `proxyexclude` directive to the Sabre client.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
