### PR TITLE
[stable34] fix(cypress): disable unsupported-browser redirect in test container

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -173,6 +173,9 @@ export default defineConfig({
 			await configureNextcloud()
 			// additionally we do not want to DoS the app store
 			runOcc(['config:system:set', 'appstoreenabled', '--value', 'false', '--type', 'boolean'])
+			// Disable the unsupported-browser redirect so Cypress (Chrome 118 / Electron 27)
+			// does not hit the "Your browser is not supported" page on every visit.
+			runOcc(['config:system:set', 'no_unsupported_browser_warning', '--value', 'true', '--type', 'boolean'])
 
 			// for later use in tests save the container name
 			// @ts-expect-error we are adding a custom property


### PR DESCRIPTION
Forward port of #60790.

The Cypress browser (Chrome 118 / Electron 27) fell below the minimum version required by `@nextcloud/browserslist-config`'s `"baseline widely available"` query in April 2026 (Chrome 118 was released Oct 2023; the 30-month threshold passed). Every page visit silently redirected to "Your browser is not supported", preventing the Vue app from mounting — `#user-menu`, `[data-cy-files-list]`, `OCA.Files.Sidebar`, etc. never appeared and the entire Cypress suite failed.

Fix: set `no_unsupported_browser_warning = true` during container setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)