### PR TITLE
[stable32] fix(cypress): disable unsupported-browser redirect in test container

### DIFF
--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -137,6 +137,10 @@ export const configureNextcloud = async function() {
 	await runExec(container, ['php', 'occ', 'config:system:set', 'force_locale', '--value', 'en_US'], true)
 	await runExec(container, ['php', 'occ', 'config:system:set', 'enforce_theme', '--value', 'light'], true)
 
+	// Disable the unsupported-browser redirect so Cypress (Chrome 118 / Electron 27)
+	// does not hit the "Your browser is not supported" page on every visit.
+	await runExec(container, ['php', 'occ', 'config:system:set', 'no_unsupported_browser_warning', '--value', 'true', '--type', 'boolean'], true)
+
 	// Speed up test and make them less flaky. If a cron execution is needed, it can be triggered manually.
 	await runExec(container, ['php', 'occ', 'background:cron'], true)
 


### PR DESCRIPTION
Forward port of #60790.

The Cypress browser (Chrome 118 / Electron 27) fell below the minimum version required by `@nextcloud/browserslist-config`'s `"baseline widely available"` query in April 2026 (Chrome 118 was released Oct 2023; the 30-month threshold passed). Every page visit silently redirected to "Your browser is not supported", preventing the Vue app from mounting — `#user-menu`, `[data-cy-files-list]`, `OCA.Files.Sidebar`, etc. never appeared and the entire Cypress suite failed.

Fix: set `no_unsupported_browser_warning = true` during container setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)