### PR TITLE
fix(Share): Add missing optional parameter to IManager::shareApiAllowLinks()

### DIFF
--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -290,7 +290,7 @@ interface IManager {
 	 * @since 9.0.0
 	 * @since 33.0.0 Added optional $user parameter
 	 */
-	public function shareApiAllowLinks(): bool;
+	public function shareApiAllowLinks(?IUser $user = null): bool;
 
 	/**
 	 * Is password on public link required


### PR DESCRIPTION
This parameter was added to the interface and the implementation in https://github.com/nextcloud/server/commit/6bccaf778a2d7da020788f5ed8f0d2f42d9c8fff. For some strange reason it was removed from the interface signature in https://github.com/nextcloud/server/commit/3183ea79d22c42e1f86d09da3f05c0440936478f, but not from the docs or the implementation. I suspect it might have been a rebase mistake.