### PR TITLE
fix(password-confirmation): exempt unsupported backends from strict and non-strict confirmation checks

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -20,6 +20,7 @@ use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\Authentication\Token\IToken;
 use OCP\IRequest;
 use OCP\ISession;
+use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\User\Backend\IPasswordConfirmationBackend;
@@ -32,9 +33,9 @@ class PasswordConfirmationMiddleware extends Middleware {
 	private const PASSWORD_CONFIRMATION_GRACE_SECONDS = 15;
 
 	/**
-	 * Legacy compatibility allowlist for backends that do not participate in the
-	 * non-strict recent-confirmation flow. New backends should prefer implementing
-	 * IPasswordConfirmationBackend instead of being added here.
+	 * Backends that cannot participate in password confirmation are exempt from both
+	 * strict and non-strict password confirmation checks. New backends should prefer
+	 * implementing IPasswordConfirmationBackend instead of being added here.
 	 *
 	 * @var array<string, true>
 	 */
@@ -74,13 +75,14 @@ class PasswordConfirmationMiddleware extends Middleware {
 			$sessionId = $this->session->getId();
 			$token = $this->tokenProvider->getToken($sessionId);
 		} catch (SessionNotAvailableException|InvalidTokenException|WipeTokenException|ExpiredTokenException) {
-			// Only valid interactive session tokens participate in password confirmation. Requests without such a
-			// token are left to be rejected or otherwise handled by the normal authentication/session handling.
+			// Password confirmation is only enforced for requests backed by a valid interactive session token.
+			// Requests without such a token are left to be rejected or otherwise handled by the normal
+			// authentication/session middleware stack.
 			return;
 		}
 
 		if ($this->isTokenExemptFromPasswordConfirmation($token)) {
-			// Users logging in from SSO backends cannot confirm their password by design
+			// Some session tokens are marked to skip password validation entirely.
 			return;
 		}
 
@@ -96,11 +98,7 @@ class PasswordConfirmationMiddleware extends Middleware {
 		$minimumRequiredConfirmTime = $now
 			- (self::PASSWORD_CONFIRMATION_TIMEOUT + self::PASSWORD_CONFIRMATION_GRACE_SECONDS);
 
-		// TODO: confirm excludedUserBackEnds can go away and remove it
-		if (
-			!$this->isLegacyBackendExcludedFromRecentConfirmation($user)
-			&& $lastConfirm < $minimumRequiredConfirmTime
-		) {
+		if ($lastConfirm < $minimumRequiredConfirmTime) {
 			throw new NotConfirmedException();
 		}
 	}
@@ -124,12 +122,20 @@ class PasswordConfirmationMiddleware extends Middleware {
 		}
 
 		$backend = $user->getBackend();
-		return $backend instanceof IPasswordConfirmationBackend
-			&& !$backend->canConfirmPassword($user->getUID());
+
+		if (
+			$backend instanceof IPasswordConfirmationBackend
+			&& !$backend->canConfirmPassword($user->getUID())
+		) {
+			return true;
+		}
+
+		return $this->isLegacyBackendExcludedFromRecentConfirmation($user);
 	}
 
 	private function isLegacyBackendExcludedFromRecentConfirmation(?IUser $user): bool {
 		$backendClassName = $user?->getBackendClassName() ?? '';
+		// TODO: confirm excludedUserBackEnds can go away and remove it
 		return isset($this->excludedUserBackEnds[$backendClassName]);
 	}
 
@@ -143,9 +149,9 @@ class PasswordConfirmationMiddleware extends Middleware {
 	 * @throws NotConfirmedException
 	 */
 	private function confirmPasswordFromAuthorizationHeader(): void {
-		$authHeader = strtolower($this->request->getHeader('Authorization'));
+		$authHeader = $this->request->getHeader('Authorization');
 
-		if (!str_starts_with($authHeader, 'basic ')) {
+		if (!str_starts_with(strtolower($authHeader), 'basic ')) {
 			throw new NotConfirmedException('Required authorization header missing');
 		}
 

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -83,27 +83,7 @@ class PasswordConfirmationMiddleware extends Middleware {
 
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 		if ($this->isPasswordConfirmationStrict($reflectionMethod)) {
-			$authHeader = strtolower($this->request->getHeader('Authorization'));
-
-			if (!str_starts_with($authHeader, 'basic ')) {
-				throw new NotConfirmedException('Required authorization header missing');
-			}
-
-			$decoded = base64_decode(substr($authHeader, 6), true);
-
-			if ($decoded === false || !str_contains($decoded, ':')) {
-				throw new NotConfirmedException('Malformed authorization header');
-			}
-
-			[$ignoredUser, $password] = explode(':', $decoded, 2);
-
-			$loginName = $this->session->get('loginname');
-			$loginResult = $this->userManager->checkPassword($loginName, $password);
-
-			if ($loginResult === false) {
-				throw new NotConfirmedException();
-			}
-
+			$this->confirmPasswordFromAuthorizationHeader();
 			$this->session->set('last-password-confirm', $this->timeFactory->getTime());
 			return;
 		}
@@ -154,4 +134,29 @@ class PasswordConfirmationMiddleware extends Middleware {
 			&& $scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION] === true;
 	}
 
+	/**
+	 * @throws NotConfirmedException
+	 */
+	private function confirmPasswordFromAuthorizationHeader(): void {
+		$authHeader = strtolower($this->request->getHeader('Authorization'));
+
+		if (!str_starts_with($authHeader, 'basic ')) {
+			throw new NotConfirmedException('Required authorization header missing');
+		}
+
+		$decodedCredentials = base64_decode(substr($authHeader, 6), true);
+
+		if ($decodedCredentials === false || !str_contains($decodedCredentials, ':')) {
+			throw new NotConfirmedException('Malformed authorization header');
+		}
+
+		[$ignoredUser, $password] = explode(':', $decodedCredentials, 2);
+
+		$loginName = $this->session->get('loginname');
+		$loginResult = $this->userManager->checkPassword($loginName, $password);
+
+		if ($loginResult === false) {
+			throw new NotConfirmedException();
+		}
+	}
 }

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -28,7 +28,17 @@ use ReflectionAttribute;
 use ReflectionMethod;
 
 class PasswordConfirmationMiddleware extends Middleware {
-	private array $excludedUserBackEnds = ['user_saml' => true, 'user_globalsiteselector' => true];
+	/**
+	 * Legacy compatibility allowlist for backends that do not participate in the
+	 * non-strict recent-confirmation flow. New backends should prefer implementing
+	 * IPasswordConfirmationBackend instead of being added here.
+	 *
+	 * @var array<string, true>
+	 */
+	private array $excludedUserBackEnds = [
+		'user_saml' => true,
+		'user_globalsiteselector' => true,
+	];
 
 	public function __construct(
 		private ControllerMethodReflector $reflector,
@@ -52,16 +62,9 @@ class PasswordConfirmationMiddleware extends Middleware {
 		}
 
 		$user = $this->userSession->getUser();
-		$backendClassName = '';
-		if ($user !== null) {
-			$backend = $user->getBackend();
-			if ($backend instanceof IPasswordConfirmationBackend) {
-				if (!$backend->canConfirmPassword($user->getUID())) {
-					return;
-				}
-			}
 
-			$backendClassName = $user->getBackendClassName();
+		if ($this->isBackendExemptFromPasswordConfirmation($user)) {
+			return;
 		}
 
 		try {
@@ -73,8 +76,7 @@ class PasswordConfirmationMiddleware extends Middleware {
 			return;
 		}
 
-		$scope = $token->getScopeAsArray();
-		if (isset($scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION]) && $scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION] === true) {
+		if ($this->isTokenExemptFromPasswordConfirmation($token)) {
 			// Users logging in from SSO backends cannot confirm their password by design
 			return;
 		}
@@ -103,17 +105,26 @@ class PasswordConfirmationMiddleware extends Middleware {
 			}
 
 			$this->session->set('last-password-confirm', $this->timeFactory->getTime());
-		} else {
-			$lastConfirm = (int)$this->session->get('last-password-confirm');
-			// TODO: confirm excludedUserBackEnds can go away and remove it
-			if (!isset($this->excludedUserBackEnds[$backendClassName]) && $lastConfirm < ($this->timeFactory->getTime() - (30 * 60 + 15))) { // allow 15 seconds delay
-				throw new NotConfirmedException();
-			}
+			return;
+		}
+		
+		$lastConfirm = (int)$this->session->get('last-password-confirm');
+		$minimumRequiredConfirmTime = $this->timeFactory->getTime() - (30 * 60 + 15); // allow 15 seconds delay
+
+		// TODO: confirm excludedUserBackEnds can go away and remove it
+		if (
+			!$this->isLegacyBackendExcludedFromRecentConfirmation($user)
+			&& $lastConfirm < $minimumRequiredConfirmTime
+		) {
+			throw new NotConfirmedException();
 		}
 	}
 
 	private function needsPasswordConfirmation(): bool {
-		return $this->reflector->hasAnnotationOrAttribute('PasswordConfirmationRequired', PasswordConfirmationRequired::class);
+		return $this->reflector->hasAnnotationOrAttribute(
+			'PasswordConfirmationRequired',
+			PasswordConfirmationRequired::class
+		);
 	}
 
 	private function isPasswordConfirmationStrict(ReflectionMethod $reflectionMethod): bool {
@@ -121,4 +132,26 @@ class PasswordConfirmationMiddleware extends Middleware {
 		$attributes = $reflectionMethod->getAttributes(PasswordConfirmationRequired::class);
 		return !empty($attributes) && ($attributes[0]->newInstance()->getStrict());
 	}
+
+	private function isBackendExemptFromPasswordConfirmation(?IUser $user): bool {
+		if ($user === null) {
+			return false;
+		}
+
+		$backend = $user->getBackend();
+		return $backend instanceof IPasswordConfirmationBackend
+			&& !$backend->canConfirmPassword($user->getUID());
+	}
+
+	private function isLegacyBackendExcludedFromRecentConfirmation(?IUser $user): bool {
+		$backendClassName = $user?->getBackendClassName() ?? '';
+		return isset($this->excludedUserBackEnds[$backendClassName]);
+	}
+
+	private function isTokenExemptFromPasswordConfirmation(IToken $token): bool {
+		$scope = $token->getScopeAsArray();
+		return isset($scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION])
+			&& $scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION] === true;
+	}
+
 }

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -93,7 +93,7 @@ class PasswordConfirmationMiddleware extends Middleware {
 			$this->session->set('last-password-confirm', $now);
 			return;
 		}
-		
+
 		$lastConfirm = (int)$this->session->get('last-password-confirm');
 		$minimumRequiredConfirmTime = $now
 			- (self::PASSWORD_CONFIRMATION_TIMEOUT + self::PASSWORD_CONFIRMATION_GRACE_SECONDS);
@@ -162,7 +162,8 @@ class PasswordConfirmationMiddleware extends Middleware {
 		}
 
 		[$ignoredUser, $password] = explode(':', $decodedCredentials, 2);
-
+		// Use the session's loginname, not the one from the Authorization header,
+		// to prevent credential stuffing against arbitrary usernames.
 		$loginName = $this->session->get('loginname');
 		$loginResult = $this->userManager->checkPassword($loginName, $password);
 

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -28,6 +28,9 @@ use ReflectionAttribute;
 use ReflectionMethod;
 
 class PasswordConfirmationMiddleware extends Middleware {
+	private const PASSWORD_CONFIRMATION_TIMEOUT = 30 * 60;
+	private const PASSWORD_CONFIRMATION_GRACE_SECONDS = 15;
+
 	/**
 	 * Legacy compatibility allowlist for backends that do not participate in the
 	 * non-strict recent-confirmation flow. New backends should prefer implementing
@@ -81,15 +84,17 @@ class PasswordConfirmationMiddleware extends Middleware {
 			return;
 		}
 
+		$now = $this->timeFactory->getTime();
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 		if ($this->isPasswordConfirmationStrict($reflectionMethod)) {
 			$this->confirmPasswordFromAuthorizationHeader();
-			$this->session->set('last-password-confirm', $this->timeFactory->getTime());
+			$this->session->set('last-password-confirm', $now);
 			return;
 		}
 		
 		$lastConfirm = (int)$this->session->get('last-password-confirm');
-		$minimumRequiredConfirmTime = $this->timeFactory->getTime() - (30 * 60 + 15); // allow 15 seconds delay
+		$minimumRequiredConfirmTime = $now
+			- (self::PASSWORD_CONFIRMATION_TIMEOUT + self::PASSWORD_CONFIRMATION_GRACE_SECONDS);
 
 		// TODO: confirm excludedUserBackEnds can go away and remove it
 		if (

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -68,7 +68,8 @@ class PasswordConfirmationMiddleware extends Middleware {
 			$sessionId = $this->session->getId();
 			$token = $this->tokenProvider->getToken($sessionId);
 		} catch (SessionNotAvailableException|InvalidTokenException|WipeTokenException|ExpiredTokenException) {
-			// States we do not deal with here.
+			// Only valid interactive session tokens participate in password confirmation. Requests without such a
+			// token are left to be rejected or otherwise handled by the normal authentication/session handling.
 			return;
 		}
 
@@ -80,13 +81,23 @@ class PasswordConfirmationMiddleware extends Middleware {
 
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 		if ($this->isPasswordConfirmationStrict($reflectionMethod)) {
-			$authHeader = $this->request->getHeader('Authorization');
-			if (!str_starts_with(strtolower($authHeader), 'basic ')) {
+			$authHeader = strtolower($this->request->getHeader('Authorization'));
+
+			if (!str_starts_with($authHeader, 'basic ')) {
 				throw new NotConfirmedException('Required authorization header missing');
 			}
-			[, $password] = explode(':', base64_decode(substr($authHeader, 6)), 2);
+
+			$decoded = base64_decode(substr($authHeader, 6), true);
+
+			if ($decoded === false || !str_contains($decoded, ':')) {
+				throw new NotConfirmedException('Malformed authorization header');
+			}
+
+			[$ignoredUser, $password] = explode(':', $decoded, 2);
+
 			$loginName = $this->session->get('loginname');
 			$loginResult = $this->userManager->checkPassword($loginName, $password);
+
 			if ($loginResult === false) {
 				throw new NotConfirmedException();
 			}

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -40,8 +40,17 @@ use OCP\Util;
 
 class JSConfigHelper {
 
-	/** @var array user back-ends excluded from password verification */
-	private $excludedUserBackEnds = ['user_saml' => true, 'user_globalsiteselector' => true];
+	/**
+	 * Backends that cannot participate in password confirmation are exempt from both
+	 * strict and non-strict password confirmation checks. New backends should prefer
+	 * implementing IPasswordConfirmationBackend instead of being added here.
+	 *
+	 * @var array<string, true>
+	 */
+	private array $excludedUserBackEnds = [
+		'user_saml' => true,
+		'user_globalsiteselector' => true,
+	];
 
 	public function __construct(
 		protected ServerVersion $serverVersion,
@@ -63,18 +72,15 @@ class JSConfigHelper {
 	}
 
 	public function getConfig(): string {
-		$userBackendAllowsPasswordConfirmation = true;
+		$userCanUsePasswordConfirmation = false;
+		$canUserValidatePassword = $this->canUserValidatePassword();
+
 		if ($this->currentUser !== null) {
 			$uid = $this->currentUser->getUID();
 
-			$backend = $this->currentUser->getBackend();
-			if ($backend instanceof IPasswordConfirmationBackend) {
-				$userBackendAllowsPasswordConfirmation = $backend->canConfirmPassword($uid) && $this->canUserValidatePassword();
-			} elseif (isset($this->excludedUserBackEnds[$this->currentUser->getBackendClassName()])) {
-				$userBackendAllowsPasswordConfirmation = false;
-			} else {
-				$userBackendAllowsPasswordConfirmation = $this->canUserValidatePassword();
-			}
+			$userCanUsePasswordConfirmation =
+				$this->canBackendConfirmPassword($this->currentUser)
+				&& $canUserValidatePassword;
 		} else {
 			$uid = null;
 		}
@@ -126,7 +132,7 @@ class JSConfigHelper {
 		}
 
 		if ($this->currentUser instanceof IUser) {
-			if ($this->canUserValidatePassword()) {
+			if ($canUserValidatePassword) {
 				$lastConfirmTimestamp = $this->session->get('last-password-confirm');
 				if (!is_int($lastConfirmTimestamp)) {
 					$lastConfirmTimestamp = 0;
@@ -174,7 +180,7 @@ class JSConfigHelper {
 		$array = [
 			'_oc_debug' => $this->config->getSystemValue('debug', false) ? 'true' : 'false',
 			'_oc_isadmin' => $uid !== null && $this->groupManager->isAdmin($uid) ? 'true' : 'false',
-			'backendAllowsPasswordConfirmation' => $userBackendAllowsPasswordConfirmation ? 'true' : 'false',
+			'backendAllowsPasswordConfirmation' => $userCanUsePasswordConfirmation ? 'true' : 'false',
 			'oc_dataURL' => is_string($dataLocation) ? '"' . $dataLocation . '"' : 'false',
 			'_oc_webroot' => '"' . \OC::$WEBROOT . '"',
 			'_oc_appswebroots' => str_replace('\\/', '/', json_encode($apps_paths)), // Ugly unescape slashes waiting for better solution
@@ -304,10 +310,31 @@ class JSConfigHelper {
 		try {
 			$token = $this->tokenProvider->getToken($this->session->getId());
 		} catch (ExpiredTokenException|WipeTokenException|InvalidTokenException|SessionNotAvailableException) {
-			// actually we do not know, so we fall back to this statement
+			// If token lookup fails, fall back to allowing password validation in the UI.
 			return true;
 		}
 		$scope = $token->getScopeAsArray();
 		return !isset($scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION]) || $scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION] === false;
+	}
+
+	private function canBackendConfirmPassword(?IUser $user): bool {
+		if ($user === null) {
+			return false;
+		}
+
+		$backend = $user->getBackend();
+		if (
+			$backend instanceof IPasswordConfirmationBackend
+			&& !$backend->canConfirmPassword($user->getUID())
+		) {
+			return false;
+		}
+
+		return !$this->isLegacyBackendExcludedFromPasswordConfirmation($user);
+	}
+
+	private function isLegacyBackendExcludedFromPasswordConfirmation(?IUser $user): bool {
+		$backendClassName = $user?->getBackendClassName() ?? '';
+		return isset($this->excludedUserBackEnds[$backendClassName]);
 	}
 }

--- a/tests/lib/AppFramework/Middleware/Security/Mock/PasswordConfirmationMiddlewareController.php
+++ b/tests/lib/AppFramework/Middleware/Security/Mock/PasswordConfirmationMiddlewareController.php
@@ -32,6 +32,35 @@ class PasswordConfirmationMiddlewareController extends Controller {
 	public function testAttribute() {
 	}
 
+	// Non-strict — for backend capability and null-user tests
+	#[PasswordConfirmationRequired]
+	public function testLegacyBackendExempt() {}
+
+	#[PasswordConfirmationRequired]
+	public function testIPasswordConfirmationBackendExempt() {}
+
+	#[PasswordConfirmationRequired]
+	public function testIPasswordConfirmationBackendNotExempt() {}
+
+	#[PasswordConfirmationRequired]
+	public function testNullUser() {}
+
+	// Strict — one controller method per strict-mode test
+	#[PasswordConfirmationRequired(strict: true)]
+	public function testStrictModeValidCredentials() {}
+
+	#[PasswordConfirmationRequired(strict: true)]
+	public function testStrictModeMissingAuthHeader() {}
+
+	#[PasswordConfirmationRequired(strict: true)]
+	public function testStrictModeMalformedBase64() {}
+
+	#[PasswordConfirmationRequired(strict: true)]
+	public function testStrictModeWrongPassword() {}
+
+	#[PasswordConfirmationRequired(strict: true)]
+	public function testStrictModeLegacyBackendExempt() {}
+
 	#[PasswordConfirmationRequired]
 	public function testSSO() {
 	}

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -93,7 +93,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 		$this->middleware->beforeController($this->controller, __FUNCTION__);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderNonExemptBackend')]
 	public function testAnnotation($backend, $lastConfirm, $currentTime, $exception): void {
 		$this->reflector->reflect($this->controller, __FUNCTION__);
 
@@ -126,7 +126,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 		$this->assertSame($exception, $thrown);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderNonExemptBackend')]
 	public function testAttribute($backend, $lastConfirm, $currentTime, $exception): void {
 		$this->reflector->reflect($this->controller, __FUNCTION__);
 
@@ -159,16 +159,38 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 		$this->assertSame($exception, $thrown);
 	}
 
-
-
-	public static function dataProvider(): array {
+	public static function dataProviderNonExemptBackend(): array {
 		return [
 			['foo', 2000, 4000, true],
 			['foo', 2000, 3000, false],
-			['user_saml', 2000, 4000, false],
-			['user_saml', 2000, 3000, false],
 			['foo', 2000, 3815, false],
 			['foo', 2000, 3816, true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataProviderLegacyExemptBackends
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderLegacyExemptBackends')]
+	public function testLegacyBackendExempt(string $backend): void {
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')
+			->willReturn($backend);
+		$this->userSession->method('getUser')
+			->willReturn($this->user);
+
+		// Backend is exempt — getToken() must never be called
+		$this->tokenProvider->expects($this->never())
+			->method('getToken');
+
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	public static function dataProviderLegacyExemptBackends(): array {
+		return [
+			['user_saml'],
+			['user_globalsiteselector'],
 		];
 	}
 

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -19,6 +19,7 @@ use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Server;
+use OCP\User\Backend\IPasswordConfirmationBackend;
 use Psr\Log\LoggerInterface;
 use Test\AppFramework\Middleware\Security\Mock\PasswordConfirmationMiddlewareController;
 use Test\TestCase;
@@ -94,7 +95,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderNonExemptBackend')]
-	public function testAnnotation($backend, $lastConfirm, $currentTime, $exception): void {
+	public function testAnnotation(string $backend, int $lastConfirm, int $currentTime, bool $exception): void
 		$this->reflector->reflect($this->controller, __FUNCTION__);
 
 		$this->user->method('getBackendClassName')
@@ -127,7 +128,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderNonExemptBackend')]
-	public function testAttribute($backend, $lastConfirm, $currentTime, $exception): void {
+	public function testAttribute(string $backend, int $lastConfirm, int $currentTime, bool $exception): void {
 		$this->reflector->reflect($this->controller, __FUNCTION__);
 
 		$this->user->method('getBackendClassName')
@@ -192,6 +193,208 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 			['user_saml'],
 			['user_globalsiteselector'],
 		];
+	}
+
+	public function testIPasswordConfirmationBackendExempt(): void {
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$backend = $this->createMock(IPasswordConfirmationBackend::class);
+		$backend->method('canConfirmPassword')->with('uid')->willReturn(false);
+
+		$this->user->method('getBackend')->willReturn($backend);
+		$this->user->method('getUID')->willReturn('uid');
+		$this->userSession->method('getUser')->willReturn($this->user);
+
+		// Exempt before token check
+		$this->tokenProvider->expects($this->never())->method('getToken');
+
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	public function testIPasswordConfirmationBackendNotExempt(): void {
+		static $sessionId = 'mySession1d';
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$backend = $this->createMock(IPasswordConfirmationBackend::class);
+		$backend->method('canConfirmPassword')->with('uid')->willReturn(true);
+
+		$this->user->method('getBackend')->willReturn($backend);
+		$this->user->method('getUID')->willReturn('uid');
+		$this->user->method('getBackendClassName')->willReturn('capable_backend');
+		$this->userSession->method('getUser')->willReturn($this->user);
+
+		$this->session->method('getId')->willReturn($sessionId);
+		$this->session->method('get')->with('last-password-confirm')->willReturn(2000);
+		$this->timeFactory->method('getTime')->willReturn(3000); // within window — no exception
+
+		$token = $this->createMock(IToken::class);
+		$token->method('getScopeAsArray')->willReturn([]);
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with($sessionId)
+			->willReturn($token);
+
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	public function testNullUser(): void {
+		static $sessionId = 'mySession1d';
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->session->method('getId')->willReturn($sessionId);
+		$this->session->method('get')->with('last-password-confirm')->willReturn(2000);
+		$this->timeFactory->method('getTime')->willReturn(3000); // within window — no exception
+
+		$token = $this->createMock(IToken::class);
+		$token->method('getScopeAsArray')->willReturn([]);
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with($sessionId)
+			->willReturn($token);
+
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	public function testStrictModeValidCredentials(): void {
+		static $sessionId = 'mySession1d';
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')->willReturn('foo');
+		$this->userSession->method('getUser')->willReturn($this->user);
+		$this->session->method('getId')->willReturn($sessionId);
+		$this->timeFactory->method('getTime')->willReturn(9999);
+
+		$token = $this->createMock(IToken::class);
+		$token->method('getScopeAsArray')->willReturn([]);
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with($sessionId)
+			->willReturn($token);
+
+		$this->request->method('getHeader')
+			->with('Authorization')
+			->willReturn('Basic ' . base64_encode('user:correctpassword'));
+
+		$this->session->method('get')
+			->with('loginname')
+			->willReturn('user');
+
+		$loginUser = $this->createMock(IUser::class);
+		$this->userManager->expects($this->once())
+			->method('checkPassword')
+			->with('user', 'correctpassword')
+			->willReturn($loginUser);
+
+		// Timestamp must be written after successful strict confirmation
+		$this->session->expects($this->once())
+			->method('set')
+			->with('last-password-confirm', 9999);
+
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	public function testStrictModeMissingAuthHeader(): void {
+		static $sessionId = 'mySession1d';
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')->willReturn('foo');
+		$this->userSession->method('getUser')->willReturn($this->user);
+		$this->session->method('getId')->willReturn($sessionId);
+		$this->timeFactory->method('getTime')->willReturn(9999);
+
+		$token = $this->createMock(IToken::class);
+		$token->method('getScopeAsArray')->willReturn([]);
+		$this->tokenProvider->method('getToken')->willReturn($token);
+
+		$this->request->method('getHeader')
+			->with('Authorization')
+			->willReturn('');  // no header
+
+		$this->session->expects($this->never())->method('set');
+		$this->userManager->expects($this->never())->method('checkPassword');
+		$this->expectException(NotConfirmedException::class);
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	/**
+	 * @dataProvider dataProviderMalformedAuthHeaders
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderMalformedAuthHeaders')]
+	public function testStrictModeMalformedBase64(string $headerValue): void {
+		static $sessionId = 'mySession1d';
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')->willReturn('foo');
+		$this->userSession->method('getUser')->willReturn($this->user);
+		$this->session->method('getId')->willReturn($sessionId);
+		$this->timeFactory->method('getTime')->willReturn(9999);
+
+		$token = $this->createMock(IToken::class);
+		$token->method('getScopeAsArray')->willReturn([]);
+		$this->tokenProvider->method('getToken')->willReturn($token);
+
+		$this->request->method('getHeader')
+			->with('Authorization')
+			->willReturn($headerValue);
+
+		$this->session->expects($this->never())->method('set');
+		$this->userManager->expects($this->never())->method('checkPassword');
+		$this->expectException(NotConfirmedException::class);
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	public static function dataProviderMalformedAuthHeaders(): array {
+		return [
+			'invalid base64'       => ['Basic !!!notbase64!!!'],
+			'no colon in decoded'  => ['Basic ' . base64_encode('nodivider')],
+		];
+	}
+
+	public function testStrictModeWrongPassword(): void {
+		static $sessionId = 'mySession1d';
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')->willReturn('foo');
+		$this->userSession->method('getUser')->willReturn($this->user);
+		$this->session->method('getId')->willReturn($sessionId);
+		$this->timeFactory->method('getTime')->willReturn(9999);
+
+		$token = $this->createMock(IToken::class);
+		$token->method('getScopeAsArray')->willReturn([]);
+		$this->tokenProvider->method('getToken')->willReturn($token);
+
+		$this->request->method('getHeader')
+			->with('Authorization')
+			->willReturn('Basic ' . base64_encode('user:wrongpassword'));
+
+		$this->session->method('get')
+			->with('loginname')
+			->willReturn('user');
+
+		$this->userManager->method('checkPassword')
+			->with('user', 'wrongpassword')
+			->willReturn(false);
+
+		$this->session->expects($this->never())->method('set');
+
+		$this->expectException(NotConfirmedException::class);
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	public function testStrictModeLegacyBackendExempt(): void {
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')->willReturn('user_saml');
+		$this->userSession->method('getUser')->willReturn($this->user);
+
+		// Must exit before reaching the auth header or token checks
+		$this->tokenProvider->expects($this->never())->method('getToken');
+		$this->request->expects($this->never())->method('getHeader');
+		$this->userManager->expects($this->never())->method('checkPassword');
+
+		$this->middleware->beforeController($this->controller, __FUNCTION__);
 	}
 
 	public function testSSO(): void {

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -95,7 +95,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderNonExemptBackend')]
-	public function testAnnotation(string $backend, int $lastConfirm, int $currentTime, bool $exception): void
+	public function testAnnotation(string $backend, int $lastConfirm, int $currentTime, bool $exception): void {
 		$this->reflector->reflect($this->controller, __FUNCTION__);
 
 		$this->user->method('getBackendClassName')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue --> (possibly some password confirmation bugs where `strict` mode is used)

## Summary

Fixes a bug where backends that cannot participate in password confirmation (e.g. SSO/SAML-style backends) were only exempted from the *non-strict* confirmation flow. In the strict flow, the middleware would proceed to `checkPassword()` regardless — which would (presumably) fail for these backends.

This PR consolidates all backend exemption handling into a shared `isBackendExemptFromPasswordConfirmation()` helper that is evaluated before any strict/non-strict branching, ensuring consistent behavior across both flows.

### Changes

- **Backend exemption unified:** Both `IPasswordConfirmationBackend::canConfirmPassword()` and the legacy `$excludedUserBackEnds` allowlist now route through a single helper, checked early in `beforeController()`.
- **Extracted helpers:** Backend-level and token-level exemption logic separated into `isBackendExemptFromPasswordConfirmation()`, `isLegacyBackendExcludedFromRecentConfirmation()`, and `isTokenExemptFromPasswordConfirmation()` for clarity.
- **Improved header validation:** `confirmPasswordFromAuthorizationHeader()` now validates that the `Authorization` header decodes successfully and contains the expected `:` separator before attempting password verification.
- **Named constants:** Magic numbers for confirmation timeout and grace period replaced with `PASSWORD_CONFIRMATION_TIMEOUT` and `PASSWORD_CONFIRMATION_GRACE_SECONDS`.
- Updates and expands test coverage.
- Aligns `JSConfigHelper` exemption logic with middleware changes.

### Related:

- #12085 
- #11786 
- #43942
- #60783

## TODO

- [x] Confirm existing tests remain reasonable
- [x] Consider adding better coverage of exemption scenarios
- [ ] Backport to 34 (bug fix)
- [ ] Backport to 33 (bug fix)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
