### PR TITLE
feat(ci): add /explain-ci bot command for PR failure help

### DIFF
--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -1,0 +1,516 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: CI bot
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: ci-bot-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  explain:
+    runs-on: ubuntu-latest-low
+
+    # Only on PR comments starting with /explain-ci
+    if: github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/explain-ci')
+
+    steps:
+      - name: Acknowledge command
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '+1'
+
+      - name: Post CI failure summary
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.COMMAND_BOT_PAT }}
+          script: |
+            const WORKFLOW_EXPLANATIONS = {
+              'Lint eslint': {
+                purpose: 'Checks JavaScript/TypeScript/Vue source files for ESLint rule violations.',
+                fix: [
+                  'Run `npm run lint` to see all violations.',
+                  'Run `npm run lint:fix` to auto-fix many of them, then review remaining errors manually.',
+                ],
+              },
+              'Lint stylelint': {
+                purpose: 'Checks CSS/SCSS/Vue style blocks for Stylelint rule violations.',
+                fix: [
+                  'Run `npm run stylelint` to see all violations.',
+                  'Run `npm run stylelint:fix` to auto-fix many of them.',
+                ],
+              },
+              'Lint php': {
+                purpose: 'Runs `php -l` across all PHP files to detect syntax errors.',
+                fix: [
+                  'Check the job log for the file and line number reported.',
+                  'Fix the PHP syntax error shown (missing bracket, comma, or invalid token).',
+                ],
+              },
+              'Lint php-cs': {
+                purpose: 'Enforces PHP coding-style rules defined in `.php-cs-fixer.dist.php`.',
+                fix: [
+                  'To preview what would change without modifying files: `composer run cs:check`',
+                  'To auto-fix all violations: `composer run cs:fix`',
+                  'Then review the diff with `git diff` and commit the formatted files.',
+                  'Prerequisites: run `composer install` from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit SQLite': {
+                purpose: 'Runs the PHPUnit test suite against a SQLite database.',
+                fix: [
+                  'Run from the **server repository root** (no container needed — the script sets up its own environment):',
+                  '`NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php`',
+                  'The path is relative to `tests/` — find it in the CI log, e.g. `Tests\\Files\\Cache\\CacheTest` → `lib/Files/Cache/CacheTest.php`.',
+                  'SQLite needs no external database — it is the easiest variant to run locally.',
+                  'To run a single test method: append `-- --filter testMethodName`.',
+                  'Prerequisites: PHP in your PATH, and `composer install` run at least once.',
+                ],
+              },
+              'PHPUnit MariaDB': {
+                purpose: 'Runs the PHPUnit test suite against a MariaDB database to catch DB-specific issues.',
+                flaky: true,
+                flakiness_note: 'Sporadic file-copy race condition in Files/Cache/Cache.php — same root cause as the MySQL variant.',
+                fix: [
+                  'Run from the **server repository root**. Two options:',
+                  '**With Docker** (auto-spins a MariaDB container): `USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh mariadb lib/Path/To/SpecificTest.php`',
+                  '**With a local MariaDB**: ensure a `oc_autotest` user and database exist, then: `NOCOVERAGE=1 ./autotest.sh mariadb lib/Path/To/SpecificTest.php`',
+                  'Can\'t reproduce locally? Try SQLite first (`./autotest.sh sqlite ...`) to confirm whether the failure is DB-specific.',
+                ],
+              },
+              'PHPUnit mysql': {
+                purpose: 'Runs the PHPUnit test suite against a MySQL database.',
+                flaky: true,
+                flakiness_note: 'Sporadic `RuntimeException: Failed to copy to files_versions/test.txt.v…` in Files/Cache/Cache.php — a known race condition across PHP versions.',
+                fix: [
+                  'Run from the **server repository root**. Two options:',
+                  '**With Docker** (auto-spins a MySQL container): `USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh mysql lib/Path/To/SpecificTest.php`',
+                  '**With a local MySQL**: ensure a `oc_autotest` user and database exist, then: `NOCOVERAGE=1 ./autotest.sh mysql lib/Path/To/SpecificTest.php`',
+                  'The path is relative to `tests/` — find it in the CI log.',
+                ],
+              },
+              'PHPUnit PostgreSQL': {
+                purpose: 'Runs the PHPUnit test suite against a PostgreSQL database.',
+                fix: [
+                  'Run from the **server repository root**. Two options:',
+                  '**With Docker** (auto-spins a PostgreSQL container): `USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh pgsql lib/Path/To/SpecificTest.php`',
+                  '**With a local PostgreSQL**: ensure a `oc_autotest` user and database exist, then: `NOCOVERAGE=1 ./autotest.sh pgsql lib/Path/To/SpecificTest.php`',
+                  'The path is relative to `tests/` — find it in the CI log.',
+                ],
+              },
+              'PHPUnit OCI': {
+                purpose: 'Runs the PHPUnit test suite against Oracle Database (OCI).',
+                flaky: true,
+                flakiness_note: 'The Oracle environment in CI is sometimes unavailable, causing infrastructure-level failures unrelated to code changes.',
+                fix: [
+                  'Oracle DB is not easily available locally. First check whether the failure is OCI-specific:',
+                  'Run the same test with SQLite: `NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php`',
+                  'If SQLite passes but OCI fails, the issue is in OCI-specific SQL (e.g. sequences, string functions, CLOB handling) — check the CI log for the exact query.',
+                  'If SQLite also fails, fix that first and the OCI failure will likely resolve too.',
+                ],
+              },
+              'PHPUnit nodb': {
+                purpose: 'Runs PHPUnit tests that do not require a database (unit tests and mocked integration tests).',
+                fix: [
+                  'Run from the **server repository root** — no database or Docker needed:',
+                  '`NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php`',
+                  'The path is relative to `tests/` — find it in the CI log, e.g. `Tests\\AppFramework\\Http\\RequestTest` → `lib/AppFramework/Http/RequestTest.php`.',
+                  'To run a single test method: append `-- --filter testMethodName`.',
+                  'Prerequisites: PHP in your PATH, and `composer install` run at least once.',
+                ],
+              },
+              'PHPUnit 32bits': {
+                purpose: 'Runs the PHPUnit suite in a 32-bit PHP environment to catch integer overflow and platform-specific issues.',
+                fix: [
+                  'Check the job log for the specific failing assertion.',
+                  'Common causes: integer arithmetic that overflows 32-bit, or bitwise operations with unexpected sign extension.',
+                  'Fix by using float or string where needed for large numbers.',
+                ],
+              },
+              'PHPUnit memcached': {
+                purpose: 'Runs PHPUnit tests with a Memcached cache backend to validate cache-layer behaviour.',
+                fix: [
+                  'Check the CI log for the specific failing test class and method.',
+                  'The Memcached backend lives in `lib/private/Memcache/Memcached.php` — check there for relevant code paths.',
+                  'Run with Memcached via Docker (spins up a Memcached container automatically): `ENABLE_MEMCACHE=memcached USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php -- --filter testMethodName`',
+                  'If the test passes without Memcached (plain SQLite: `NOCOVERAGE=1 ./autotest.sh sqlite ...`), the failure is cache-specific — look for assumptions about cache availability or cache key formatting in the changed code.',
+                  'Prerequisites: Docker installed and running, PHP `memcached` extension loaded (`php -m | grep memcached`; install with `sudo apt install php-memcached`), PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit sharding': {
+                purpose: 'Runs PHPUnit tests with database sharding enabled, where data is distributed across multiple MySQL instances.',
+                fix: [
+                  'Check the CI log for the specific failing test class and method.',
+                  'Sharding requires multiple MySQL databases and is not directly reproducible via `autotest.sh`. The relevant code lives in `lib/private/DB/QueryBuilder/Sharded/`.',
+                  'Start by running the failing test with SQLite: `NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php -- --filter testMethodName`',
+                  'If SQLite passes, the failure is sharding-specific — look for raw SQL that uses MySQL-only syntax, cross-shard joins, or assumptions about a single database connection in the changed code.',
+                ],
+              },
+              'PHPUnit primary object store': {
+                purpose: 'Runs PHPUnit tests with an S3-compatible object store (MinIO) as the primary storage backend instead of the local filesystem.',
+                fix: [
+                  'Check the CI log for the specific failing test class and method.',
+                  'The relevant code lives in `lib/private/Files/ObjectStore/`.',
+                  'Run locally with MinIO via Docker (spins up MinIO and installs Nextcloud automatically): `PRIMARY_STORAGE_CONFIG=s3 USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php -- --filter testMethodName`',
+                  'Or with Azurite (Azure Blob emulator): `PRIMARY_STORAGE_CONFIG=azure USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php`',
+                  'If the test passes with plain SQLite (`NOCOVERAGE=1 ./autotest.sh sqlite ...`), the failure is object-store-specific — look for code that uses direct filesystem paths (`fopen`, `file_get_contents`) instead of the storage abstraction APIs (`ISimpleStorage`, `ObjectStoreStorage`).',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit files_external generic': {
+                purpose: 'Runs files_external integration tests using a local filesystem as the external storage backend.',
+                fix: [
+                  'Run from the **server repository root**:',
+                  '`NOCOVERAGE=1 ./autotest.sh sqlite apps/files_external/tests/`',
+                  'To run a single failing test: `NOCOVERAGE=1 ./autotest.sh sqlite lib/files_external/tests/Path/To/Test.php -- --filter testMethodName`',
+                  'The path is relative to `tests/` — find the failing test class in the CI log.',
+                  'Prerequisites: run `composer install` from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit files_external FTP': {
+                purpose: 'Runs files_external integration tests against an FTP server (tested with proftpd, vsftpd, and pure-ftpd).',
+                flaky: true,
+                flakiness_note: 'Depends on an external FTP service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the specific failing test and which FTP daemon was in use.',
+                  'The relevant storage code is in `apps/files_external/lib/Storage/FTP.php`.',
+                  'Run locally with Docker (sets up FTP and Nextcloud automatically): `EXTERNAL_STORAGE=ftp NOCOVERAGE=1 ./autotest.sh`',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit files_external S3': {
+                purpose: 'Runs files_external integration tests against an S3-compatible object store (using LocalStack).',
+                flaky: true,
+                flakiness_note: 'Depends on an external S3 service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the specific failing test.',
+                  'The relevant storage code is in `apps/files_external/lib/Storage/AmazonS3.php`.',
+                  'Run locally with Docker (sets up LocalStack and Nextcloud automatically): `EXTERNAL_STORAGE=amazons3 NOCOVERAGE=1 ./autotest.sh`',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit files_external sFTP': {
+                purpose: 'Runs files_external integration tests against an sFTP server (using OpenSSH).',
+                flaky: true,
+                flakiness_note: 'Depends on an external sFTP service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the specific failing test.',
+                  'The relevant storage code is in `apps/files_external/lib/Storage/SFTP.php`.',
+                  'Run locally with Docker (sets up an sFTP server and Nextcloud automatically): `EXTERNAL_STORAGE=sftp NOCOVERAGE=1 ./autotest.sh`',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit files_external SMB': {
+                purpose: 'Runs files_external integration tests against an SMB/CIFS share.',
+                flaky: true,
+                flakiness_note: 'Depends on an external SMB service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the specific failing test.',
+                  'The relevant storage code is in `apps/files_external/lib/Storage/SMB.php` and surrounding files.',
+                  'Run locally with Docker (sets up Samba and Nextcloud automatically): `EXTERNAL_STORAGE=smb NOCOVERAGE=1 ./autotest.sh`',
+                  'Prerequisites: Docker installed and running, PHP `smbclient` extension loaded (`php -m | grep smbclient`; install with `sudo apt install php-smbclient`), `smbclient` binary installed (`sudo apt install smbclient`), PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'PHPUnit files_external WebDAV': {
+                purpose: 'Runs files_external integration tests against a WebDAV server.',
+                flaky: true,
+                flakiness_note: 'Depends on an external WebDAV service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the specific failing test.',
+                  'The relevant storage code is in `apps/files_external/lib/Storage/DAV.php`.',
+                  'Run locally with Docker (sets up an Apache WebDAV server and Nextcloud automatically): `EXTERNAL_STORAGE=webdav NOCOVERAGE=1 ./autotest.sh`',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'Samba Kerberos SSO': {
+                purpose: 'Runs Kerberos SSO integration tests against a Samba server to validate Active Directory authentication.',
+                flaky: true,
+                flakiness_note: 'Highly environment-dependent; outages of the Samba/AD service in CI cause failures unrelated to code changes.',
+                fix: [
+                  'Check the CI log for the specific failing test.',
+                  'This environment (Kerberos KDC + Samba AD) is very complex to reproduce locally.',
+                  'Focus on reviewing the changed code instead: auth middleware lives in `lib/private/Authentication/`, LDAP backend in `apps/user_ldap/lib/`, and Kerberos handling in `apps/files_external/lib/Auth/Password/Kerberos.php`.',
+                  'If the failure looks infrastructure-related (connection refused, timeout, KDC not reachable) rather than a test assertion, re-run the check first.',
+                ],
+              },
+              'Object storage S3': {
+                purpose: 'Runs integration tests with S3 as the primary object store backend (using MinIO).',
+                flaky: true,
+                flakiness_note: 'Depends on an external S3 service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the failing test.',
+                  'The relevant code lives in `lib/private/Files/ObjectStore/S3.php` and `lib/private/Files/ObjectStore/S3ConnectionTrait.php`.',
+                  'Run the affected test locally with MinIO via Docker: `PRIMARY_STORAGE_CONFIG=s3 USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php`',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'Object storage azure': {
+                purpose: 'Runs integration tests with Azure Blob Storage as the primary object store backend.',
+                flaky: true,
+                flakiness_note: 'Depends on an external Azure Blob service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the failing test.',
+                  'The relevant code lives in `lib/private/Files/ObjectStore/Azure.php`.',
+                  'Run the affected test locally with Azurite via Docker: `PRIMARY_STORAGE_CONFIG=azure USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php`',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'Object storage Swift': {
+                purpose: 'Runs integration tests with OpenStack Swift as the primary object store backend.',
+                flaky: true,
+                flakiness_note: 'Depends on an external Swift service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the failing test.',
+                  'The relevant code lives in `lib/private/Files/ObjectStore/Swift.php`.',
+                  'To reproduce locally, spin up a Keystone+Swift container:',
+                  '`docker run -d -p 5000:5000 -p 8080:8080 ghcr.io/cscfi/docker-keystone-swift`',
+                  'Alternatively, run `PRIMARY_STORAGE_CONFIG=swift NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php` if you have Swift credentials configured.',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'S3 primary storage integration tests': {
+                purpose: 'Runs higher-level Behat integration tests with MinIO as the primary storage engine (single-bucket and multi-bucket configurations).',
+                flaky: true,
+                flakiness_note: 'Depends on an external S3 service that can be temporarily unreachable.',
+                fix: [
+                  'Check the CI log for the failing scenario and feature file.',
+                  'The relevant code lives in `lib/private/Files/ObjectStore/`.',
+                  'Spin up MinIO and run the PHPUnit object store tests via autotest.sh: `PRIMARY_STORAGE_CONFIG=s3 USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Files/ObjectStore/S3Test.php`',
+                  'For the full Behat scenario, you need a running Nextcloud instance configured with MinIO as primary storage. autotest.sh sets this up automatically for PHPUnit tests but not Behat — run the failing scenario with: `./vendor/bin/behat --config tests/Integration/config/behat.yml path/to/failing.feature`',
+                  'Prerequisites: Docker installed and running, PHP in your PATH, and `composer install` run from the server repository root at least once.',
+                ],
+              },
+              'Integration sqlite': {
+                purpose: 'Runs Behat integration test scenarios (OCS API, sharing, provisioning, etc.) against a SQLite-backed Nextcloud instance.',
+                fix: [
+                  'Check the CI log for the failing scenario — it shows the `.feature` file path and scenario title.',
+                  'These tests require a fully running Nextcloud instance, not just the codebase. Set one up using your preferred method (local server, Docker, etc.).',
+                  'Run the failing scenario locally: `./vendor/bin/behat --config tests/Integration/config/behat.yml path/to/failing.feature`',
+                  'To run a single scenario by name: `./vendor/bin/behat --config tests/Integration/config/behat.yml --name "Scenario title from the log"`',
+                  'Prerequisites: a fully running Nextcloud instance, and `composer install` run from the server repository root at least once (provides `vendor/bin/behat`).',
+                ],
+              },
+              'DAV integration tests': {
+                purpose: 'Runs Behat integration tests for CalDAV and CardDAV protocol handling (calendar and contact sync).',
+                fix: [
+                  'Check the CI log for the failing scenario — it shows whether it\'s CalDAV or CardDAV, and the `.feature` file and scenario title.',
+                  'These tests require a fully running Nextcloud instance.',
+                  'Run the failing scenario locally: `./vendor/bin/behat --config apps/dav/tests/integration/config/behat.yml`',
+                  'To run a single scenario: `./vendor/bin/behat --config apps/dav/tests/integration/config/behat.yml --name "Scenario title from the log"`',
+                  'The relevant code lives in `apps/dav/lib/`.',
+                  'Prerequisites: a fully running Nextcloud instance, and `composer install` run from the server repository root at least once (provides `vendor/bin/behat`).',
+                ],
+              },
+              'Litmus integration tests': {
+                purpose: 'Runs the litmus WebDAV test suite to validate RFC compliance of the WebDAV endpoint.',
+                flaky: true,
+                flakiness_note: 'Timing-sensitive protocol tests; transient failures are common and often resolve on retry.',
+                fix: [
+                  'Check the litmus output in the CI log — it lists each failing test case by name (e.g. `PROPFIND`, `MKCOL`, `LOCK`).',
+                  'Litmus failures indicate a regression in low-level WebDAV handling. Review changes in `apps/dav/lib/` — particularly `Connector/Sabre/` for PROPFIND/PROPPATCH and `DAV/` for locking.',
+                  'To reproduce locally, install litmus (`apt install litmus` or build from source) and run it against your local Nextcloud WebDAV endpoint: `litmus http://localhost/remote.php/dav/files/admin/ admin password`',
+                  'Prerequisites: a fully running Nextcloud instance, and litmus installed.',
+                ],
+              },
+              'Psalm static code analysis': {
+                purpose: 'Runs Psalm to find type errors, undefined variables, and other static analysis issues across the PHP codebase.',
+                fix: [
+                  'Run locally: `composer run psalm`',
+                  'Psalm will list each error with the file and line number. Fix the reported type errors or add missing type annotations (`@param`, `@return`).',
+                  'Some errors can be auto-fixed: `composer run psalm:fix` (handles common return type issues).',
+                  'If the error was pre-existing and unrelated to your change, update the baseline instead: `composer run psalm:update-baseline`, then commit the updated `psalm-baseline.xml`.',
+                  'Prerequisites: run `composer install` from the server repository root at least once.',
+                ],
+              },
+              'Cypress': {
+                purpose: 'Runs end-to-end browser tests against a live Nextcloud instance using Cypress.',
+                flaky: true,
+                flakiness_note: 'Stale DOM and runner contention cause intermittent failures. The `cypress-summary` check is what gates merging — if only individual spec jobs failed, a re-run often clears it.',
+                fix: [
+                  'Check the job log and artifacts for screenshots/videos of the failing spec.',
+                  'Run locally: `npm run cypress:run -- --spec "cypress/e2e/path/to/failing.cy.ts"`',
+                  'Or open interactively: `npm run cypress:open`',
+                  'Ensure your local Nextcloud instance is running before executing Cypress.',
+                ],
+              },
+              'Node': {
+                purpose: 'Builds JavaScript/TypeScript/Vue assets and verifies no uncommitted compiled files remain.',
+                fix: [
+                  'Run: `npm ci && npm run build`',
+                  'Then commit the regenerated compiled assets: `git add js/ && git commit -m "build: recompile assets"`',
+                ],
+              },
+              'Node tests': {
+                purpose: 'Runs JavaScript unit tests (Jest/Vitest) and collects coverage.',
+                fix: [
+                  'Run locally: `npm run test`',
+                  'Check the test output for the specific failing spec file and assertion.',
+                ],
+              },
+              'REUSE Compliance Check': {
+                purpose: 'Validates that every file carries a valid SPDX-FileCopyrightText and SPDX-License-Identifier header (REUSE spec).',
+                fix: [
+                  'The CI log lists every file missing a header. Add the following two lines near the top of each file:',
+                  'PHP/JS/TS: `// SPDX-FileCopyrightText: 2026 Your Name <you@example.com>` and `// SPDX-License-Identifier: AGPL-3.0-or-later`',
+                  'YAML/shell: same but with `#` instead of `//`',
+                  'Vue `<template>`: `<!-- SPDX-FileCopyrightText: 2026 Your Name <you@example.com> -->` and `<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->`',
+                  '<details><summary>Automate with the reuse tool (requires Python)</summary>Install: `pip install reuse` (or `pipx install reuse` to avoid polluting global pip). Then run: `reuse addheader --copyright "2026 Your Name <you@example.com>" --license AGPL-3.0-or-later path/to/file.php` for each file.</details>',
+                ],
+              },
+              'OpenAPI': {
+                purpose: 'Checks that the OpenAPI specification files are up-to-date with the current route and response type annotations.',
+                fix: [
+                  'Regenerate the spec: `composer run openapi`',
+                  'Then commit the updated `openapi.json` / `openapi-*.json` files.',
+                  'This check fails when you add or change a route/response type without regenerating the spec.',
+                  'Prerequisites: run `composer install` from the server repository root at least once.',
+                ],
+              },
+              'Rector': {
+                purpose: 'Runs Rector in strict mode to detect code patterns that should be modernised according to project rules.',
+                fix: [
+                  'Run locally: `composer run rector:strict`',
+                  'This automatically applies the changes and runs `cs:fix` on the result.',
+                  'Review the diff with `git diff`, then commit the changes.',
+                  'Prerequisites: run `composer install` from the server repository root at least once.',
+                ],
+              },
+              'Block fixup and squash commits': {
+                purpose: 'Rejects PRs that contain `fixup!` or `squash!` commits, which must be squashed into their target commits before merging.',
+                fix: [
+                  'If you created fixup commits with `git commit --fixup`, the easiest approach is:',
+                  '`git rebase -i --autosquash`',
+                  'Git will automatically move and mark the fixup commits for squashing. Save the editor, then: `git push --force-with-lease`',
+                  'Alternatively, use a plain interactive rebase: `git rebase -i HEAD~N` (replace N with the number of commits in your PR), change `pick` to `fixup` for each fixup commit, save, then force-push.',
+                ],
+              },
+              'Block unconventional commits': {
+                purpose: 'Enforces the Conventional Commits format for all commit messages on the PR.',
+                fix: [
+                  'Full spec: https://www.conventionalcommits.org/',
+                  'Format: `<type>(<optional scope>): <short description>`',
+                  'Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`',
+                  'Examples of good messages: `fix(sharing): resolve permission check for public links` · `feat(files): add bulk move operation` · `chore: update dependencies`',
+                  'To fix bad messages: `git rebase -i HEAD~N`, change `pick` to `reword` for each commit to rename, save, then update the messages when prompted. Force-push when done.',
+                ],
+              },
+              'Block merging with outdated 3rdparty/': {
+                purpose: 'Ensures the `3rdparty/` submodule points to the latest commit on the target branch.',
+                fix: [
+                  'Update the submodule: `git submodule update --remote 3rdparty`',
+                  'Commit the result: `git add 3rdparty && git commit -m "chore: Update 3rdparty"`',
+                ],
+              },
+              'Code checkers': {
+                purpose: 'Runs PHP-based consistency checkers: autoloader integrity, translation file validity, .htaccess rules, expected file list, and Psalm app coverage.',
+                fix: [
+                  'Check the job log to identify which specific checker failed, then run it locally:',
+                  '- Autoloader: `bash ./build/autoloaderchecker.sh`',
+                  '- Translations: `php ./build/translation-checker.php`',
+                  '- Htaccess: `php ./build/htaccess-checker.php`',
+                  '- Files list: `php ./build/files-checker.php`',
+                  '- Psalm app coverage: `sh ./build/psalm-checker.sh`',
+                ],
+              },
+              'CodeQL Advanced': {
+                purpose: 'Runs GitHub CodeQL security analysis on JavaScript/TypeScript and GitHub Actions workflow files.',
+                fix: [
+                  'Go to the "Security" tab of this repository and review the CodeQL alert linked in the job log.',
+                  'Fix the identified security issue — click "Show more" on the alert for remediation guidance.',
+                ],
+              },
+            }
+
+            // Resolve PR head SHA
+            const pull = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })
+            const headSha = pull.data.head.sha
+
+            // Find completed workflow runs for this commit
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: headSha,
+              status: 'completed',
+              per_page: 100,
+            })
+
+            // Deduplicate by workflow name, keeping only the most recent run per workflow
+            const latestByName = new Map()
+            for (const run of runs.workflow_runs) {
+              const existing = latestByName.get(run.name)
+              if (!existing || new Date(run.updated_at) > new Date(existing.updated_at)) {
+                latestByName.set(run.name, run)
+              }
+            }
+
+            const failed = [...latestByName.values()].filter(r => r.conclusion === 'failure')
+
+            if (failed.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `No failing CI checks found for commit \`${headSha.substring(0, 7)}\`. All completed checks are passing (some may still be running).`,
+              })
+              return
+            }
+
+            // Build summary comment
+            const shortSha = headSha.substring(0, 7)
+            const flaky = failed.filter(r => WORKFLOW_EXPLANATIONS[r.name]?.flaky)
+            const genuine = failed.filter(r => !WORKFLOW_EXPLANATIONS[r.name]?.flaky)
+
+            const renderFlaky = run => {
+              const info = WORKFLOW_EXPLANATIONS[run.name]
+              return `### ${run.name}\n> **Known flaky:** ${info.flakiness_note}\n\nTry re-running this check first — if it passes on retry, no code change is needed.\n\n[Re-run failed jobs](${run.html_url})`
+            }
+
+            const renderGenuine = run => {
+              const info = WORKFLOW_EXPLANATIONS[run.name]
+              if (!info) {
+                return `### ${run.name}\n\nPlease [check the run logs](${run.html_url}) for details.`
+              }
+              const fixLines = info.fix.map(line => `- ${line}`).join('\n')
+              return `### ${run.name}\n\n**What this checks:** ${info.purpose}\n\n**How to fix locally:**\n${fixLines}\n\n[View failed run](${run.html_url})`
+            }
+
+            const parts = []
+
+            let headline = `Found **${failed.length} failing check(s)** on commit \`${shortSha}\``
+            if (flaky.length > 0 && genuine.length > 0) {
+              headline += ` — ${flaky.length} likely flaky, ${genuine.length} need investigation`
+            }
+            parts.push(`## CI failure summary\n\n${headline}:\n`)
+
+            if (flaky.length > 0) {
+              parts.push(`---\n\n### Likely flaky — try re-running first\n\n${flaky.map(renderFlaky).join('\n\n---\n\n')}`)
+            }
+
+            if (genuine.length > 0) {
+              parts.push(`---\n\n### Needs investigation\n\n${genuine.map(renderGenuine).join('\n\n---\n\n')}`)
+            }
+
+            const body = parts.join('\n\n')
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            })

--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -149,6 +149,16 @@ jobs:
                   'Prerequisites: Docker installed and running, PHP `memcached` extension loaded (`php -m | grep memcached`; install with `sudo apt install php-memcached`), PHP in your PATH, and `composer install` run from the server repository root at least once.',
                 ],
               },
+              'PHPUnit key-value store': {
+                purpose: 'Runs PHPUnit tests against Valkey in three topologies (single server, cluster, sentinel) to validate the key-value store cache backend.',
+                fix: [
+                  'Check the CI log to see which topology (single/cluster/sentinel) and PHP version failed.',
+                  'Reproducing the cluster/sentinel topologies locally requires manually starting several Valkey containers — see the `Start Valkey (...)` steps in `.github/workflows/phpunit-kvstore.yml` for the exact commands.',
+                  'For the single-server topology: `docker run -d --name kv-single -p 6379:6379 valkey/valkey:8`, then `cp tests/kvstore-single.config.php config/` before installing Nextcloud.',
+                  'Run the suite with: `composer run test -- --group KeyValueCache --log-junit junit.xml`',
+                  'If only one topology fails, look for topology-specific assumptions (e.g. single-node vs multi-node key routing) in the changed code.',
+                ],
+              },
               'PHPUnit sharding': {
                 purpose: 'Runs PHPUnit tests with database sharding enabled, where data is distributed across multiple MySQL instances.',
                 fix: [
@@ -345,6 +355,17 @@ jobs:
                   'Ensure your local Nextcloud instance is running before executing Cypress.',
                 ],
               },
+              'Playwright Tests': {
+                purpose: 'Runs end-to-end browser tests (Playwright) against a live Nextcloud instance, sharded across 6 jobs, plus a separate installer-test job covering every supported database backend.',
+                flaky: true,
+                flakiness_note: 'Only runs when Playwright test files changed, the PR carries `force-e2e-tests`/`3. to review`/`4. to release`, or is marked ready for review — a skipped "gate" is expected and not a real failure.',
+                fix: [
+                  'Check the job name to see which shard (1-6) or which installer DB backend (mysql/mariadb/postgres/oracle) failed, and download the HTML report artifact (`html-report--attempt-*`) for traces/screenshots.',
+                  'Run locally: `npx playwright install --with-deps && npm run playwright`',
+                  'To run just the installer/setup tests: `npm run playwright:setup`',
+                  'To target a single shard: `npm run playwright -- --shard=\'2/6\'`',
+                ],
+              },
               'Node': {
                 purpose: 'Builds JavaScript/TypeScript/Vue assets and verifies no uncommitted compiled files remain.',
                 fix: [
@@ -404,6 +425,17 @@ jobs:
                   'Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`',
                   'Examples of good messages: `fix(sharing): resolve permission check for public links` · `feat(files): add bulk move operation` · `chore: update dependencies`',
                   'To fix bad messages: `git rebase -i HEAD~N`, change `pick` to `reword` for each commit to rename, save, then update the messages when prompted. Force-push when done.',
+                ],
+              },
+              'AI Policy': {
+                purpose: 'Scans PR commit messages for coding-agent trailers. Labels the PR "AI assisted" if it finds an `Assisted-by`/`AI-Assisted-By` trailer, or an agent-associated `Signed-off-by`/`Co-Authored-By`. Fails only if a coding agent itself appears in `Signed-off-by`, since the DCO sign-off can only be attested by a human.',
+                flaky: true,
+                flakiness_note: 'Known bug on fork PRs (nextcloud/.github#767): the label-write step 403s because GitHub forces a read-only token on pull_request runs from forks, and that failure isn\'t guarded with `|| true` — so it can fail the whole job even when there\'s no real trailer violation. If the log only shows a 403 on label creation/assignment and no "Offending trailer(s)" section, this is that known issue, not a real problem with your commits.',
+                fix: [
+                  'First check the job log for an actual "Offending trailer(s)" section — if it\'s just a label-write 403 with no trailers listed, this is the known fork-PR bug (nextcloud/.github#767); a maintainer re-run from the base repo, or the upstream fix, resolves it — no action needed on your commits.',
+                  'If there IS a genuine offending trailer: amend the commit(s) to remove the agent `Signed-off-by` line, and add your own human sign-off plus an `Assisted-by` trailer instead, e.g.: `Assisted-by: Claude Code:claude-sonnet-4-6`',
+                  'Use `git commit --amend -s` (or an interactive rebase for older commits), then `git push --force-with-lease`.',
+                  'See `AGENTS.md` in this repo and https://github.com/nextcloud/.github/blob/master/AI_POLICY.md for the full policy.',
                 ],
               },
               'Block merging with outdated 3rdparty/': {

--- a/autotest.sh
+++ b/autotest.sh
@@ -11,8 +11,9 @@ DATABASEHOST=localhost
 ADMINLOGIN=admin
 BASEDIR=$PWD
 
-PRIMARY_STORAGE_CONFIGS="local swift"
+PRIMARY_STORAGE_CONFIGS="local swift s3 azure"
 DBCONFIGS="sqlite mysql mariadb pgsql oci mysqlmb4"
+EXTERNAL_STORAGE_CONFIGS="ftp sftp smb webdav amazons3"
 
 # $PHP_EXE is run through 'which' and as such e.g. 'php' is usually
 # sufficient. Due to the behaviour of 'which', $PHP_EXE may also be a path
@@ -55,6 +56,16 @@ function print_syntax {
 	echo -e "\nExample: ./autotest.sh sqlite lib/template.php" >&2
 	echo "will run the test suite from \"tests/lib/template.php\"" >&2
 	echo -e "\nIf no arguments are specified, all tests will be run with all database configs" >&2
+	echo -e "\nEnvironment variables:" >&2
+	echo -e "\tUSEDOCKER=1\t\t\tSpin up a Docker container for the database (mysql/mariadb/pgsql)," >&2
+	echo -e "\t\t\t\t\tMemcached (with ENABLE_MEMCACHE=memcached), or primary object store" >&2
+	echo -e "\t\t\t\t\t(with PRIMARY_STORAGE_CONFIG=s3 or azure)" >&2
+	echo -e "\tPRIMARY_STORAGE_CONFIG=s3\tUse MinIO as primary object store (USEDOCKER=1 recommended)" >&2
+	echo -e "\tPRIMARY_STORAGE_CONFIG=azure\tUse Azurite as primary object store (USEDOCKER=1 recommended)" >&2
+	echo -e "\tENABLE_MEMCACHE=memcached\tEnable Memcached as cache backend (USEDOCKER=1 recommended)" >&2
+	echo -e "\tEXTERNAL_STORAGE=<backend>\tRun files_external storage tests using Docker." >&2
+	echo -e "\t\t\t\t\tBackend can be one of: $EXTERNAL_STORAGE_CONFIGS" >&2
+	echo -e "\t\t\t\t\tExample: EXTERNAL_STORAGE=ftp ./autotest.sh" >&2
 }
 
 if [ -x "$PHP" ]; then
@@ -121,6 +132,20 @@ if [ "$PRIMARY_STORAGE_CONFIG" ]; then
 else
 	PRIMARY_STORAGE_CONFIG="local"
 fi
+if [ "$EXTERNAL_STORAGE" ]; then
+	FOUND=0
+	for ES in $EXTERNAL_STORAGE_CONFIGS; do
+		if [ "$EXTERNAL_STORAGE" = "$ES" ]; then
+			FOUND=1
+			break
+		fi
+	done
+	if [ $FOUND = 0 ]; then
+		echo -e "Unknown external storage backend \"$EXTERNAL_STORAGE\"\n" >&2
+		print_syntax
+		exit 2
+	fi
+fi
 
 # Back up existing (dev) config if one exists and backup not already there
 if [ -f config/config.php ] && [ ! -f config/config-autotest-backup.php ]; then
@@ -133,6 +158,12 @@ function cleanup_config {
 		echo "Kill the docker $DOCKER_CONTAINER_ID"
 		docker stop "$DOCKER_CONTAINER_ID"
 		docker rm -f "$DOCKER_CONTAINER_ID"
+	fi
+
+	if [ ! -z "$DOCKER_SERVICE_CONTAINER_ID" ]; then
+		echo "Kill the service docker $DOCKER_SERVICE_CONTAINER_ID"
+		docker stop "$DOCKER_SERVICE_CONTAINER_ID"
+		docker rm -f "$DOCKER_SERVICE_CONTAINER_ID"
 	fi
 
 	cd "$BASEDIR"
@@ -156,8 +187,16 @@ function cleanup_config {
 	if [ -f config/redis.config.php ]; then
 		rm config/redis.config.php
 	fi
+	# Remove autotest memcached config
+	rm -f config/memcached.config.php
 	# Remove mysqlmb4.config.php
 	rm -f config/mysqlmb4.config.php
+	# Remove external storage test config files written by execute_external_tests
+	rm -f apps/files_external/tests/config.ftp.php
+	rm -f apps/files_external/tests/config.sftp.php
+	rm -f apps/files_external/tests/config.smb.php
+	rm -f apps/files_external/tests/config.webdav.php
+	rm -f apps/files_external/tests/config.amazons3.php
 
 	# restore .htaccess
 	git restore .htaccess
@@ -174,6 +213,168 @@ else
 fi
 
 echo "Using database $DATABASENAME"
+
+function execute_external_tests {
+	STORAGE=$1
+	echo "Setting up environment for files_external storage testing: $STORAGE ..."
+	cd "$BASEDIR"
+
+	# Pre-flight checks for storage-specific system dependencies
+	if [ "$STORAGE" == "smb" ] ; then
+		if ! "$PHP" -m | grep -qi '^smbclient$' && ! which smbclient > /dev/null 2>&1; then
+			echo "[ERROR] Neither the PHP 'smbclient' extension nor the 'smbclient' binary is installed." >&2
+			echo "        Install one of:" >&2
+			echo "          sudo apt install php-smbclient" >&2
+			echo "          sudo apt install smbclient" >&2
+			exit 1
+		fi
+		if ! which smbclient > /dev/null 2>&1; then
+			echo "[WARNING] The 'smbclient' binary is not installed — notify tests will be skipped." >&2
+			echo "          Install with: sudo apt install smbclient" >&2
+		fi
+	fi
+
+	git checkout tests/data
+	rm -rf "$DATADIR"
+	mkdir "$DATADIR"
+	cp tests/preseed-config.php config/config.php
+
+	echo "Installing Nextcloud with SQLite for external storage tests ..."
+	"$PHP" ./occ maintenance:install -vvv \
+		--database=sqlite \
+		--database-name=nextcloud \
+		--admin-user="$ADMINLOGIN" \
+		--admin-pass=admin \
+		--data-dir="$DATADIR"
+
+	"$PHP" ./occ app:enable --force files_external
+	"$PHP" ./occ config:system:set --value true --type boolean allow_local_remote_servers
+
+	TEST_FILE=""
+
+	if [ "$STORAGE" == "ftp" ] ; then
+		echo "Fire up the FTP docker (vsftpd)"
+		mkdir -p /tmp/ftp
+		DOCKER_SERVICE_CONTAINER_ID=$(docker run -d --net host \
+			-e FTP_USER=test \
+			-e FTP_PASS=test \
+			-e PASV_ADDRESS=127.0.0.1 \
+			-v /tmp/ftp:/home/vsftpd/test \
+			fauria/vsftpd)
+		echo "Waiting for FTP initialisation ..."
+		if ! apps/files_external/tests/env/wait-for-connection localhost 21 30; then
+			echo "[ERROR] Waited 30 seconds, no FTP response" >&2
+			exit 1
+		fi
+		echo "FTP is up."
+		echo "<?php return ['run' => true, 'host' => 'localhost', 'user' => 'test', 'password' => 'test', 'root' => ''];" \
+			> apps/files_external/tests/config.ftp.php
+		TEST_FILE="apps/files_external/tests/Storage/FtpTest.php"
+	fi
+
+	if [ "$STORAGE" == "sftp" ] ; then
+		echo "Fire up the sFTP docker (atmoz/sftp)"
+		mkdir -p /tmp/sftp
+		chmod 777 /tmp/sftp
+		DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
+			-e SFTP_USERS="test:test:::upload" \
+			-p 2222:22 \
+			-v /tmp/sftp:/home/test/upload \
+			atmoz/sftp)
+		echo "Waiting for sFTP initialisation ..."
+		if ! apps/files_external/tests/env/wait-for-connection localhost 2222 30; then
+			echo "[ERROR] Waited 30 seconds, no sFTP response" >&2
+			exit 1
+		fi
+		# Give the SSH daemon a moment to finish initialising after the port is open
+		sleep 2
+		echo "sFTP is up."
+		echo "<?php return ['run' => true, 'host' => 'localhost:2222', 'user' => 'test', 'password' => 'test', 'root' => 'upload'];" \
+			> apps/files_external/tests/config.sftp.php
+		TEST_FILE="apps/files_external/tests/Storage/SftpTest.php"
+	fi
+
+	if [ "$STORAGE" == "smb" ] ; then
+		echo "Fire up the SMB docker (Samba)"
+		DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
+			-e ACCOUNT_test=test \
+			-e UID_test=1000 \
+			-e 'SAMBA_VOLUME_CONFIG_test=[public]; path=/tmp; valid users = test; guest ok = no; read only = no; browseable = yes' \
+			-p 445:445 \
+			ghcr.io/servercontainers/samba:smbd-only-a3.18.0-s4.18.2-r0)
+		echo "Waiting for SMB initialisation ..."
+		if ! apps/files_external/tests/env/wait-for-connection localhost 445 60; then
+			echo "[ERROR] Waited 60 seconds, no SMB response" >&2
+			exit 1
+		fi
+		echo "SMB is up."
+		sleep 5
+		echo "<?php return ['run' => true, 'host' => 'localhost', 'user' => 'test', 'password' => 'test', 'root' => '', 'share' => 'public'];" \
+			> apps/files_external/tests/config.smb.php
+		TEST_FILE="apps/files_external/tests/Storage/SmbTest.php"
+	fi
+
+	if [ "$STORAGE" == "webdav" ] ; then
+		echo "Fire up the WebDAV docker (Apache)"
+		DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
+			-p 8081:80 \
+			ghcr.io/nextcloud/continuous-integration-webdav-apache:latest)
+		echo "Waiting for WebDAV initialisation ..."
+		if ! apps/files_external/tests/env/wait-for-connection localhost 8081 30; then
+			echo "[ERROR] Waited 30 seconds, no WebDAV response" >&2
+			exit 1
+		fi
+		echo "WebDAV is up."
+		echo "<?php return ['run' => true, 'host' => 'localhost:8081/webdav/', 'user' => 'test', 'password' => 'pass', 'root' => '', 'wait' => 0];" \
+			> apps/files_external/tests/config.webdav.php
+		TEST_FILE="apps/files_external/tests/Storage/WebdavTest.php"
+	fi
+
+	if [ "$STORAGE" == "amazons3" ] ; then
+		echo "Fire up the LocalStack docker (S3 emulator)"
+		DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
+			-e SERVICES=s3 \
+			-e DEBUG=1 \
+			-p 4566:4566 \
+			"localstack/localstack@sha256:9d4253786e0effe974d77fe3c390358391a56090a4fff83b4600d8a64404d95d")
+		echo "Waiting for LocalStack initialisation ..."
+		if ! apps/files_external/tests/env/wait-for-connection localhost 4566 60; then
+			echo "[ERROR] Waited 60 seconds, no LocalStack response" >&2
+			exit 1
+		fi
+		# wait-for-connection only checks TCP; poll the health endpoint until S3 is running
+		for i in $(seq 1 30); do
+			if curl -sf http://localhost:4566/_localstack/health 2>/dev/null | grep -qE '"s3": "(running|available)"'; then
+				break
+			fi
+			sleep 1
+			if [ "$i" -eq 30 ]; then
+				echo "[ERROR] LocalStack S3 service did not become ready in time" >&2
+				exit 1
+			fi
+		done
+		echo "LocalStack is up."
+		echo "<?php return ['run' => true, 'localstack' => true, 'key' => 'ignored', 'secret' => 'ignored', 'bucket' => 'bucket', 'hostname' => 'localhost', 'port' => 4566, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" \
+			> apps/files_external/tests/config.amazons3.php
+		TEST_FILE="apps/files_external/tests/Storage/Amazons3Test.php apps/files_external/tests/Storage/VersionedAmazonS3Test.php apps/files_external/tests/Storage/Amazons3MultiPartTest.php"
+	fi
+
+	echo "Testing files_external/$STORAGE ..."
+	cd "$BASEDIR"
+	set +e
+	"${PHPUNIT[@]}" --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --bootstrap tests/bootstrap.php $TEST_FILE
+	RESULT=$?
+	set -e
+
+	if [ ! -z "$DOCKER_SERVICE_CONTAINER_ID" ] ; then
+		echo "Kill the service docker $DOCKER_SERVICE_CONTAINER_ID"
+		docker stop $DOCKER_SERVICE_CONTAINER_ID
+		docker rm -f $DOCKER_SERVICE_CONTAINER_ID
+		unset DOCKER_SERVICE_CONTAINER_ID
+	fi
+
+	exit $RESULT
+}
 
 function execute_tests {
 	DB=$1
@@ -192,12 +393,72 @@ function execute_tests {
 		tests/objectstore/start-swift-ceph.sh
 		cp tests/objectstore/swift.config.php config/autotest-storage-swift.config.php
 	fi
+	if [ "$PRIMARY_STORAGE_CONFIG" == "s3" ] ; then
+		if [ ! -z "$USEDOCKER" ] ; then
+			echo "Fire up the MinIO docker"
+			DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
+				-e MINIO_ROOT_USER=nextcloud \
+				-e MINIO_ROOT_PASSWORD=bWluaW8tc2VjcmV0LWtleS1uZXh0Y2xvdWQ= \
+				-p 9000:9000 \
+				minio/minio server /data)
+			echo "Waiting for MinIO initialisation ..."
+			if ! apps/files_external/tests/env/wait-for-connection localhost 9000 60; then
+				echo "[ERROR] Waited 60 seconds, no MinIO response" >&2
+				exit 1
+			fi
+			echo "MinIO is up."
+		fi
+		export OBJECT_STORE=s3
+		export OBJECT_STORE_HOST="${OBJECT_STORE_HOST:-localhost}"
+		export OBJECT_STORE_KEY="${OBJECT_STORE_KEY:-nextcloud}"
+		export OBJECT_STORE_SECRET="${OBJECT_STORE_SECRET:-bWluaW8tc2VjcmV0LWtleS1uZXh0Y2xvdWQ=}"
+	fi
+	if [ "$PRIMARY_STORAGE_CONFIG" == "azure" ] ; then
+		if [ ! -z "$USEDOCKER" ] ; then
+			echo "Fire up the Azurite docker"
+			DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
+				-e AZURITE_ACCOUNTS=nextcloud:bmV4dGNsb3Vk \
+				-p 10000:10000 \
+				mcr.microsoft.com/azure-storage/azurite)
+			echo "Waiting for Azurite initialisation ..."
+			if ! apps/files_external/tests/env/wait-for-connection localhost 10000 60; then
+				echo "[ERROR] Waited 60 seconds, no Azurite response" >&2
+				exit 1
+			fi
+			echo "Azurite is up."
+		fi
+		export OBJECT_STORE=azure
+		export OBJECT_STORE_HOST="${OBJECT_STORE_HOST:-localhost}"
+		export OBJECT_STORE_KEY="${OBJECT_STORE_KEY:-nextcloud}"
+		export OBJECT_STORE_SECRET="${OBJECT_STORE_SECRET:-bmV4dGNsb3Vk}"
+	fi
 	cp tests/preseed-config.php config/config.php
 
 	if [ "$ENABLE_REDIS" == "true" ] ; then
 		cp tests/redis.config.php config/redis.config.php
 	elif [ "$ENABLE_REDIS_CLUSTER" == "true" ] ; then
 		cp tests/redis-cluster.config.php config/redis.config.php
+	fi
+	if [ "$ENABLE_MEMCACHE" == "memcached" ] ; then
+		if ! "$PHP" -m | grep -qi '^memcached$'; then
+			echo "[ERROR] The PHP 'memcached' extension is not installed." >&2
+			echo "        Install it with: sudo apt install php-memcached" >&2
+			echo "        or: sudo pecl install memcached" >&2
+			exit 1
+		fi
+		if [ ! -z "$USEDOCKER" ] ; then
+			echo "Fire up the Memcached docker"
+			DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
+				-p 11212:11212 \
+				memcached memcached -p 11212)
+			echo "Waiting for Memcached initialisation ..."
+			if ! apps/files_external/tests/env/wait-for-connection localhost 11212 30; then
+				echo "[ERROR] Waited 30 seconds, no Memcached response" >&2
+				exit 1
+			fi
+			echo "Memcached is up."
+		fi
+		cp tests/memcached.config.php config/memcached.config.php
 	fi
 
 	_DB=$DB
@@ -408,12 +669,21 @@ function execute_tests {
 		docker rm -f $DOCKER_CONTAINER_ID
 		unset DOCKER_CONTAINER_ID
 	fi
+
+	if [ ! -z "$DOCKER_SERVICE_CONTAINER_ID" ] ; then
+		echo "Kill the service docker $DOCKER_SERVICE_CONTAINER_ID"
+		docker stop $DOCKER_SERVICE_CONTAINER_ID
+		docker rm -f $DOCKER_SERVICE_CONTAINER_ID
+		unset DOCKER_SERVICE_CONTAINER_ID
+	fi
 }
 
 #
 # start test execution
 #
-if [ -z "$1" ]
+if [ ! -z "$EXTERNAL_STORAGE" ] ; then
+	execute_external_tests "$EXTERNAL_STORAGE"
+elif [ -z "$1" ]
   then
 	# run all known database configs
 	for DBCONFIG in $DBCONFIGS; do

--- a/autotest.sh
+++ b/autotest.sh
@@ -449,10 +449,10 @@ function execute_tests {
 		if [ ! -z "$USEDOCKER" ] ; then
 			echo "Fire up the Memcached docker"
 			DOCKER_SERVICE_CONTAINER_ID=$(docker run -d \
-				-p 11212:11212 \
-				memcached memcached -p 11212)
+				-p 11211:11211 \
+				ghcr.io/nextcloud/continuous-integration-memcached:latest)
 			echo "Waiting for Memcached initialisation ..."
-			if ! apps/files_external/tests/env/wait-for-connection localhost 11212 30; then
+			if ! apps/files_external/tests/env/wait-for-connection localhost 11211 30; then
 				echo "[ERROR] Waited 30 seconds, no Memcached response" >&2
 				exit 1
 			fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci-bot.yml`: a new slash-command bot triggered by commenting `/explain-ci` on any pull request
- When invoked, `nextcloud-bot` reacts to the comment with 👍 and posts a single summary of all currently-failing CI checks, explaining what each one validates and how to fix it locally
- Covers all ~40 developer-facing PR workflows with specific fix instructions
- Extends `autotest.sh` with Docker-backed service helpers for local reproduction of external-service CI failures

## How the bot works

The bot uses the `issue_comment` trigger (same pattern as `/compile` and `/update-3rdparty`), so it has access to `COMMAND_BOT_PAT` and works on fork PRs too. It:

1. Fetches all completed workflow runs for the PR's current commit SHA via the Actions API
2. Deduplicates by workflow name (takes the most recent run per workflow)
3. Looks up each failing workflow in a static explanation map
4. Posts a formatted summary, or a "no failures found" message if everything is green

## Workflows covered

All PHPUnit variants (SQLite, MariaDB, MySQL, PostgreSQL, OCI, nodb, 32bits, memcached, key-value store, sharding, primary object store, all files_external backends), ESLint, Stylelint, PHP lint, PHP-CS-Fixer, Psalm, Cypress, Playwright, Node build/tests, REUSE, OpenAPI, Rector, Behat integration tests (DAV, Litmus, SQLite), object storage tests (S3, Azure, Swift), Samba Kerberos SSO, Code checkers, block checks (fixup commits, unconventional commits, outdated 3rdparty/), AI Policy, and CodeQL.

The AI Policy entry also flags a known issue on fork PRs (nextcloud/.github#767): the label-write step can 403 and fail the whole job even when there is no real trailer violation. The bot's explanation calls this out so contributors do not mistake it for a real policy failure.

## New `autotest.sh` Docker service helpers

`autotest.sh` now supports spinning up Docker-backed external services automatically, making it possible to reproduce CI failures locally without any manual container setup:

| Variable | What it does |
|---|---|
| `EXTERNAL_STORAGE=ftp` | Starts vsftpd, runs `files_external` FTP tests |
| `EXTERNAL_STORAGE=sftp` | Starts atmoz/sftp, runs `files_external` SFTP tests |
| `EXTERNAL_STORAGE=smb` | Starts Samba, runs `files_external` SMB tests |
| `EXTERNAL_STORAGE=webdav` | Starts Apache WebDAV, runs `files_external` WebDAV tests |
| `EXTERNAL_STORAGE=amazons3` | Starts LocalStack, runs `files_external` S3 tests |
| `PRIMARY_STORAGE_CONFIG=s3 USEDOCKER=1` | Starts MinIO as primary object store |
| `PRIMARY_STORAGE_CONFIG=azure USEDOCKER=1` | Starts Azurite as primary object store |
| `ENABLE_MEMCACHE=memcached USEDOCKER=1` | Starts the same Memcached image CI uses (`ghcr.io/nextcloud/continuous-integration-memcached`), copies `tests/memcached.config.php` |

Each helper installs Nextcloud, enables the relevant app/config, waits for the service to be healthy, runs the tests, and tears down the container, so there is no manual cleanup needed. Pre-flight checks catch missing system dependencies (e.g. `php-smbclient`, `smbclient` binary) before wasting time on an install.

I checked for existing overlap before adding these: `autotest-external.sh` and the `apps/files_external/tests/env/start-*.sh` scripts cover similar ground for files_external backends, but current CI (e.g. `files-external-ftp.yml`) no longer calls them, it sets up services directly in the workflow instead. Those scripts are legacy and unused by CI today; removing them is a separate cleanup and out of scope here.

## Example usage

Comment `/explain-ci` on a PR with failing checks. `nextcloud-bot` replies:

> **CI failure summary**
>
> Found **2 failing check(s)** on commit `abc1234`:
>
> ---
> ### Lint eslint
> **What this checks:** Checks JavaScript/TypeScript/Vue source files for ESLint rule violations.
>
> **How to fix locally:**
> - Run `npm run lint` to see all violations.
> - Run `npm run lint:fix` to auto-fix many of them, then review remaining errors manually.
>
> [View failed run](...)

## Test plan

- [ ] Comment `/explain-ci` on a PR with at least one failing check, bot reacts with 👍 and posts summary
- [ ] Comment `/explain-ci` on a PR where all checks pass, bot replies "no failing checks found"
- [ ] Comment `/explain-ci` on a fork PR, bot works (issue_comment runs in base repo context)
- [ ] Re-run a failed check, then comment `/explain-ci`, only still-failing checks appear in summary
- [ ] `EXTERNAL_STORAGE=ftp NOCOVERAGE=1 ./autotest.sh` runs all FTP tests and passes
- [ ] `EXTERNAL_STORAGE=amazons3 NOCOVERAGE=1 ./autotest.sh` runs all S3 tests and passes
- [ ] `PRIMARY_STORAGE_CONFIG=s3 USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Files/ObjectStore/S3Test.php` runs MinIO tests and passes
- [ ] `ENABLE_MEMCACHE=memcached USEDOCKER=1 NOCOVERAGE=1 ./autotest.sh sqlite lib/Path/To/SpecificTest.php` starts Memcached on port 11211 and passes

## Note on upcoming compiled-assets change

Per the engineering list announcement (2026-07-21), asset compilation is moving out of the PR workflow into a post-merge step starting early August 2026, with a new check to reject PRs that include compiled assets. That workflow (`update-node-dist.yml`) is not on master yet, so the bot does not cover it in this PR. Once it lands, the Node explanation entry should be revisited and a new entry added for the compiled-assets check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
