### PR TITLE
fix(AppSearch): Always sort apps first for search

### DIFF
--- a/apps/appstore/lib/Search/AppSearch.php
+++ b/apps/appstore/lib/Search/AppSearch.php
@@ -37,7 +37,7 @@ final readonly class AppSearch implements IProvider {
 
 	#[\Override]
 	public function getOrder(string $route, array $routeParameters): int {
-		return $route === 'appstore.Page.viewApps' ? -50 : 100;
+		return -50;
 	}
 
 	#[\Override]


### PR DESCRIPTION
## Summary

Since it's now "harder" to open apps, there is good reason to always sort them first when searching, making unified search a valid/recommended way to switch apps.

Part of #60241, more reasoning in the issue

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
