### PR TITLE
fix(l18n): Don't introduce new translatable string

### DIFF
--- a/core/src/components/UnifiedSearch/UnifiedSearchInput.vue
+++ b/core/src/components/UnifiedSearch/UnifiedSearchInput.vue
@@ -61,7 +61,7 @@ defineEmits<{
 }>()
 
 const isSmallMobile = useIsSmallMobile()
-const placeholderText = t('core', 'Search apps, files, tags, messages …')
+const placeholderText = t('core', 'Search apps, files, tags, messages')
 </script>
 
 <style lang="scss" scoped>

--- a/core/src/components/UnifiedSearch/UnifiedSearchModal.vue
+++ b/core/src/components/UnifiedSearch/UnifiedSearchModal.vue
@@ -27,7 +27,7 @@
 				v-model="searchQuery"
 				data-cy-unified-search-input
 				type="text"
-				:label="t('core', 'Search apps, files, tags, messages') + '...'"
+				:label="t('core', 'Search apps, files, tags, messages')"
 				@update:value="debouncedFind" />
 			<div class="unified-search-modal__filters" data-cy-unified-search-filters>
 				<NcActions :open.sync="providerActionMenuIsOpen" :menu-name="t('core', 'Places')" data-cy-unified-search-filter="places">


### PR DESCRIPTION
## Summary

A very similar string is already present in `UnifiedSearchModal.vue`.

This also removes the ellipses since they were not properly localizable and we're past string freeze for the release.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
