### PR TITLE
fix(occ): resolve trashed/appdata files in info:file and flag trashed orphan shares

### DIFF
--- a/apps/files_sharing/lib/Command/DeleteOrphanShares.php
+++ b/apps/files_sharing/lib/Command/DeleteOrphanShares.php
@@ -52,7 +52,11 @@ class DeleteOrphanShares extends Base {
 				$exists = $this->orphanHelper->fileExists($share['fileid']);
 				$output->writeln("<info>{$share['target']}</info> owned by <info>{$share['owner']}</info>");
 				if ($exists) {
-					$output->writeln("  file still exists but the share owner lost access to it, run <info>occ info:file {$share['fileid']}</info> for more information about the file");
+					if ($this->orphanHelper->isInTrashbin($share['fileid'])) {
+						$output->writeln("  file is in the trashbin of the share owner, run <info>occ info:file {$share['fileid']}</info> for more information about the file");
+					} else {
+						$output->writeln("  file still exists but the share owner lost access to it, run <info>occ info:file {$share['fileid']}</info> for more information about the file");
+					}
 				} else {
 					$output->writeln('  file no longer exists');
 				}

--- a/apps/files_sharing/lib/OrphanHelper.php
+++ b/apps/files_sharing/lib/OrphanHelper.php
@@ -56,6 +56,15 @@ class OrphanHelper {
 		return $query->executeQuery()->fetchOne() !== false;
 	}
 
+	public function isInTrashbin(int $fileId): bool {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('path')
+			->from('filecache')
+			->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+		$path = $query->executeQuery()->fetchOne();
+		return $path !== false && str_starts_with($path, 'files_trashbin/');
+	}
+
 	/**
 	 * @return \Traversable<int, array{id: int, owner: string, fileid: int, target: string}>
 	 */

--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -79,7 +79,12 @@ class FileUtils {
 			}
 			$mount = reset($mounts);
 			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
-			return $userFolder->getFirstNodeById((int)$fileInput);
+			$node = $userFolder->getFirstNodeById((int)$fileInput);
+			if ($node) {
+				return $node;
+			}
+			// the file might live outside of the user files folder, e.g. in the trashbin or versions
+			return $userFolder->getParent()->getFirstNodeById((int)$fileInput);
 		} else {
 			try {
 				return $this->rootFolder->get($fileInput);

--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -73,18 +73,23 @@ class FileUtils {
 	 */
 	public function getNode(string $fileInput): ?Node {
 		if (is_numeric($fileInput)) {
-			$mounts = $this->userMountCache->getMountsForFileId((int)$fileInput);
-			if (!$mounts) {
-				return null;
+			$id = (int)$fileInput;
+			$mounts = $this->userMountCache->getMountsForFileId($id);
+			if ($mounts) {
+				$mount = reset($mounts);
+				$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
+				$node = $userFolder->getFirstNodeById($id);
+				if ($node) {
+					return $node;
+				}
+				// the file might live outside of the user files folder, e.g. in the trashbin or versions
+				$node = $userFolder->getParent()->getFirstNodeById($id);
+				if ($node) {
+					return $node;
+				}
 			}
-			$mount = reset($mounts);
-			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
-			$node = $userFolder->getFirstNodeById((int)$fileInput);
-			if ($node) {
-				return $node;
-			}
-			// the file might live outside of the user files folder, e.g. in the trashbin or versions
-			return $userFolder->getParent()->getFirstNodeById((int)$fileInput);
+			// the file might not belong to a user at all, e.g. appdata on the root storage
+			return $this->getNodeFromRootMount($id);
 		} else {
 			try {
 				return $this->rootFolder->get($fileInput);
@@ -92,6 +97,23 @@ class FileUtils {
 				return null;
 			}
 		}
+	}
+
+	/**
+	 * Resolve a file id directly on the root storage, covering files that are
+	 * not part of any user mount such as appdata.
+	 */
+	private function getNodeFromRootMount(int $id): ?Node {
+		$mount = $this->rootFolder->getMount('');
+		$storage = $mount->getStorage();
+		if ($storage === null) {
+			return null;
+		}
+		$cacheEntry = $storage->getCache()->get($id);
+		if ($cacheEntry === false) {
+			return null;
+		}
+		return $this->rootFolder->getNodeFromCacheEntryAndMount($cacheEntry, $mount);
 	}
 
 	public function formatPermissions(string $type, int $permissions): string {


### PR DESCRIPTION
## Summary
`occ info:file <id>` returned "file not found" for files that aren't in a user's `/files` folder. This fixes resolution for trashbin, versions, and appdata files, and makes `sharing:delete-orphan-shares` report when an orphan's file is in the trashbin.

This can be helpful when debugging inaccessible shares and makes it easier to spot for admins how to recover a share where the owner has deleted the file
