### PR TITLE
fix(files_versions): guard null path in event listeners

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -207,6 +207,9 @@ class FileEventsListener implements IEventListener {
 		}
 
 		$path = $this->getPathForNode($node);
+		if ($path === null) {
+			return;
+		}
 		$result = Storage::store($path);
 
 		// Store the result of the version creation so it can be used in post_write_hook.
@@ -311,6 +314,9 @@ class FileEventsListener implements IEventListener {
 		$node = $this->versionsDeleted[$path];
 		$relativePath = $this->getPathForNode($node);
 		unset($this->versionsDeleted[$path]);
+		if ($relativePath === null) {
+			return;
+		}
 		Storage::delete($relativePath);
 		// If no new version was stored in the FS, no new version should be added in the DB.
 		// So we simply update the associated version.
@@ -324,6 +330,9 @@ class FileEventsListener implements IEventListener {
 	 */
 	public function pre_remove_hook(Node $node): void {
 		$path = $this->getPathForNode($node);
+		if ($path === null) {
+			return;
+		}
 		Storage::markDeletedFile($path);
 		$this->versionsDeleted[$node->getPath()] = $node;
 	}
@@ -344,6 +353,9 @@ class FileEventsListener implements IEventListener {
 
 		$oldPath = $this->getPathForNode($source);
 		$newPath = $this->getPathForNode($target);
+		if ($oldPath === null || $newPath === null) {
+			return;
+		}
 		Storage::renameOrCopy($oldPath, $newPath, 'rename');
 	}
 
@@ -363,6 +375,9 @@ class FileEventsListener implements IEventListener {
 
 		$oldPath = $this->getPathForNode($source);
 		$newPath = $this->getPathForNode($target);
+		if ($oldPath === null || $newPath === null) {
+			return;
+		}
 		Storage::renameOrCopy($oldPath, $newPath, 'copy');
 	}
 

--- a/apps/files_versions/tests/Listener/FileEventsListenerTest.php
+++ b/apps/files_versions/tests/Listener/FileEventsListenerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Versions\Tests\Listener;
+
+use OCA\Files_Versions\Listener\FileEventsListener;
+use OCA\Files_Versions\Versions\IVersionManager;
+use OCP\Files\File;
+use OCP\Files\IMimeTypeLoader;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class FileEventsListenerTest extends TestCase {
+	private IRootFolder&MockObject $rootFolder;
+	private IVersionManager&MockObject $versionManager;
+	private IMimeTypeLoader&MockObject $mimeTypeLoader;
+	private IUserSession&MockObject $userSession;
+	private LoggerInterface&MockObject $logger;
+	private FileEventsListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->versionManager = $this->createMock(IVersionManager::class);
+		$this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new FileEventsListener(
+			$this->rootFolder,
+			$this->versionManager,
+			$this->mimeTypeLoader,
+			$this->userSession,
+			$this->logger,
+		);
+	}
+
+	private function createUnresolvableFile(): File&MockObject {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$node = $this->createMock(File::class);
+		$node->method('getOwner')->willReturn(null);
+		$node->method('getPath')->willReturn('/test.txt');
+		$node->method('getId')->willReturn(42);
+		$node->method('getSize')->willReturn(100);
+		$node->method('getMTime')->willReturn(1234567890);
+
+		return $node;
+	}
+
+	private function getPrivateProperty(string $property): mixed {
+		$ref = new \ReflectionProperty(FileEventsListener::class, $property);
+		$ref->setAccessible(true);
+		return $ref->getValue($this->listener);
+	}
+
+	public function testGetPathForNodeReturnsNullWhenUnresolvable(): void {
+		$node = $this->createUnresolvableFile();
+
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with('Failed to compute path for node', $this->anything());
+
+		$method = new \ReflectionMethod(FileEventsListener::class, 'getPathForNode');
+		$method->setAccessible(true);
+
+		$this->assertNull($method->invoke($this->listener, $node));
+	}
+
+	public function testWriteHookSkipsWhenPathUnresolvable(): void {
+		$node = $this->createUnresolvableFile();
+
+		$this->listener->write_hook($node);
+
+		$this->assertSame([], $this->getPrivateProperty('writeHookInfo'));
+	}
+
+	public function testPreRemoveHookSkipsWhenPathUnresolvable(): void {
+		$node = $this->createUnresolvableFile();
+
+		$this->listener->pre_remove_hook($node);
+
+		$this->assertSame([], $this->getPrivateProperty('versionsDeleted'));
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Resolves:
<details>
<summary>Stack trace</summary>

```
{
  "reqId": "fZ3cojisxokl7vt5hw3V",
  "level": 3,
  "time": "2026-05-28T13:08:51+02:00",
  "remoteAddr": "1.13.25.9",
  "user": "--",
  "app": "webdav",
  "method": "PUT",
  "url": "/public.php/dav/files/file.docx",
  "scriptName": "/public.php",
  "message": "OC\\Files\\View::basicOperation(): Argument #2 ($path) must be of type string, null given, called in /var/www/nextcloud/lib/private/Files/View.php on line 504",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
  "version": "32.0.9.2",
  "exception": {
    "Exception": "TypeError",
    "Message": "OC\\Files\\View::basicOperation(): Argument #2 ($path) must be of type string, null given, called in /var/www/nextcloud/lib/private/Files/View.php on line 504",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/Files/View.php",
        "line": 504,
        "function": "basicOperation",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "file_exists",
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Files/Filesystem.php",
        "line": 518,
        "function": "file_exists",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Storage.php",
        "line": 165,
        "function": "file_exists",
        "class": "OC\\Files\\Filesystem",
        "type": "::",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 209,
        "function": "store",
        "class": "OCA\\Files_Versions\\Storage",
        "type": "::",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 82,
        "function": "write_hook",
        "class": "OCA\\Files_Versions\\Listener\\FileEventsListener",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\Files\\Node\\File"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 57,
        "function": "handle",
        "class": "OCA\\Files_Versions\\Listener\\FileEventsListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 220,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          },
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 56,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            }
          ],
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 67,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          },
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 79,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Files/Node/HookConnector.php",
        "line": 74,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\BeforeNodeWrittenEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/legacy/OC_Hook.php",
        "line": 85,
        "function": "write",
        "class": "OC\\Files\\Node\\HookConnector",
        "type": "->",
        "args": [
          {
            "path": "/Groupes de travail regroupements/NAMUR - Cadets & Andenne/Rapport 360 du regroupement Namur-Cadets - Andenne.docx",
            "run": true
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/File.php",
        "line": 417,
        "function": "emit",
        "class": "OC_Hook",
        "type": "::",
        "args": [
          "OC_Filesystem",
          "write",
          {
            "path": "/Groupes de travail regroupements/NAMUR - Cadets & Andenne/Rapport 360 du regroupement Namur-Cadets - Andenne.docx",
            "run": true
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/File.php",
        "line": 285,
        "function": "emitPreHooks",
        "class": "OCA\\DAV\\Connector\\Sabre\\File",
        "type": "->",
        "args": [
          true
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 1137,
        "function": "put",
        "class": "OCA\\DAV\\Connector\\Sabre\\File",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 492,
        "function": "updateFile",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "httpPut",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 472,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "method:PUT",
          [
            {
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Server.php",
        "line": 212,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/appinfo/v2/publicremote.php",
        "line": 159,
        "function": "start",
        "class": "OCA\\DAV\\Connector\\Sabre\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/public.php",
        "line": 90,
        "args": [
          "/var/www/nextcloud/apps/dav/appinfo/v2/publicremote.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/nextcloud/lib/private/Files/View.php",
    "Line": 1180,
    "message": "OC\\Files\\View::basicOperation(): Argument #2 ($path) must be of type string, null given, called in /var/www/nextcloud/lib/private/Files/View.php on line 504",
    "exception": [],
    "CustomMessage": "OC\\Files\\View::basicOperation(): Argument #2 ($path) must be of type string, null given, called in /var/www/nextcloud/lib/private/Files/View.php on line 504"
  },
  "id": "6a19a06f32175"
}
```
</details>

## Summary

`getPathForNode()` is typed `?string` ([here](https://github.com/nextcloud/server/blob/2e662fc5eba697db59e7b250e6f6d6b85c11460b/apps/files_versions/lib/Listener/FileEventsListener.php#L431)) and legitimately returns null when a node cannot be mapped to a user-relative path, e.g. a public-link or group folder WebDAV operation where there is no session user and no per-user owner path.

Five of its six callers passed that null straight into Storage methods, which forward it to `View` methods typed `string`, throwing a TypeError.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
