### PR TITLE
feat(file-search): add property to SearchQuery and check select fields to decide wheter to join extended cache

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -347,6 +347,15 @@ class FileSearchBackend implements ISearchBackend {
 			}
 		}, $query->orderBy);
 
+		$selectFields = [];
+		foreach ($query->select as $searchProperty) {
+			try {
+				$selectFields[] = $this->mapPropertyNameToColumn($searchProperty);
+			} catch (\InvalidArgumentException) {
+				// property does not represent a column on DB
+			}
+		}
+
 		$limit = $query->limit;
 		$maxResults = $limit->maxResults !== 0 ? (int)$limit->maxResults : 100;
 		$offset = $limit->firstResult;
@@ -380,7 +389,8 @@ class FileSearchBackend implements ISearchBackend {
 			$offset,
 			$orders,
 			$this->user,
-			$limitHome
+			$limitHome,
+			$selectFields
 		);
 	}
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -151,13 +151,16 @@ class QuerySearchHelper {
 
 		$builder = $this->getQueryBuilder();
 
-		$requestedFields = $this->searchBuilder->extractRequestedFields($searchQuery->getSearchOperation());
+		$requestedFields = array_merge(
+			$this->searchBuilder->extractRequestedFields($searchQuery->getSearchOperation()),
+			array_map(fn ($order) => $order->getField(), $searchQuery->getOrder()),
+			$searchQuery->getSelectFields(),
+		);
 
-		$orderFields = array_map(fn ($order) => $order->getField(), $searchQuery->getOrder());
-
-		$joinExtendedCache = in_array('creation_time', $requestedFields)
+		$joinExtendedCache = in_array('metadata_etag', $requestedFields)
+			|| in_array('creation_time', $requestedFields)
 			|| in_array('upload_time', $requestedFields)
-			|| in_array('last_activity', $orderFields);
+			|| in_array('last_activity', $requestedFields);
 
 		$query = $builder->selectFileCache('file', $joinExtendedCache);
 

--- a/lib/private/Files/Search/SearchQuery.php
+++ b/lib/private/Files/Search/SearchQuery.php
@@ -16,6 +16,7 @@ use OCP\IUser;
 class SearchQuery implements ISearchQuery {
 	/**
 	 * @param ISearchOrder[] $order
+	 * @param list<string> $selectFields
 	 */
 	public function __construct(
 		private ISearchOperator $searchOperation,
@@ -24,6 +25,7 @@ class SearchQuery implements ISearchQuery {
 		private array $order,
 		private ?IUser $user = null,
 		private bool $limitToHome = false,
+		private array $selectFields = [],
 	) {
 	}
 
@@ -58,5 +60,10 @@ class SearchQuery implements ISearchQuery {
 	#[\Override]
 	public function limitToHome(): bool {
 		return $this->limitToHome;
+	}
+
+	#[\Override]
+	public function getSelectFields(): array {
+		return $this->selectFields;
 	}
 }

--- a/lib/public/Files/Search/ISearchQuery.php
+++ b/lib/public/Files/Search/ISearchQuery.php
@@ -57,4 +57,12 @@ interface ISearchQuery {
 	 * @since 18.0.0
 	 */
 	public function limitToHome(): bool;
+
+	/**
+	 * The fields to include in the search results
+	 *
+	 * @return list<string>
+	 * @since 35.0.0
+	 */
+	public function getSelectFields(): array;
 }


### PR DESCRIPTION
* Resolves: #

## Summary

- file information is stored in both `oc_filecache` and `oc_filecache_extended` tables
- when searching for files using `SEARCH <nextcloud-instance>remote.php/dav/`, backend checks the requested fields from search query and decides whether to join `oc_filecache_extended` based on that
- currently, when requesting a property that represents a column stored in `oc_filecache_extended`, like `<nc:upload_time/>` (`upload_time` column), backend only joins `oc_filecache_extended` if prop is inside `<d:where>` or `<d:orderby>`
- this happens here:
```php
// apps/dav/lib/Files/FileSearchBackend::transformQuery()

$requestedFields = $this->searchBuilder->extractRequestedFields($searchQuery->getSearchOperation());

$orderFields = array_map(fn ($order) => $order->getField(), $searchQuery->getOrder());

$joinExtendedCache = in_array('creation_time', $requestedFields)
	|| in_array('upload_time', $requestedFields)
	|| in_array('last_activity', $orderFields);
```
- this means that when requesting `<nc:upload_time/>` only inside `<d:select>` as a select field, `oc_filecache_extended` is not joined and the value returned does not represent actual value on database

```xml
// Request

curl -X SEARCH "http://nextcloud.local/remote.php/dav/" \
  -u "admin:admin" \
  -H "Content-Type: application/xml" \
  -d '<?xml version="1.0" encoding="UTF-8"?>
<d:searchrequest xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:ocs="http://open-collaboration-services.org/ns" xmlns:ns="https://github.com/icewind1991/SearchDAV/ns">
    <d:basicsearch>
        <d:select>
            <d:prop>
                <nc:upload_time/>
            </d:prop>
        </d:select>
        <d:from>
            <d:scope>
                <d:href>/files/admin/</d:href>
                <d:depth>infinity</d:depth>
            </d:scope>
        </d:from>
        <d:where>
            <d:not>
                <d:eq>
                    <d:prop>
                        <d:getcontenttype/>
                    </d:prop>
                    <d:literal>httpd/unix-directory</d:literal>
                </d:eq>
            </d:not>
        </d:where>
    </d:basicsearch>
</d:searchrequest>'

// Response (before fix)

<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
    <d:response>
        <d:href>/remote.php/dav/files/admin/mock.json</d:href>
        <d:propstat>
            <d:prop>
                <nc:upload_time>0</nc:upload_time> // returns 0 instead of actual value in DB
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```

- this PR adds `selectFields` property to `lib/private/Files/Search/SearchQuery` and uses it to check if any of the columns from `oc_filecache_extended` were requested on the select part of query
- with the fix, backend correctly identifies the field from `oc_filecache_extended` and joins the table, resulting in the correct value on the respose
```xml
// Response (after fix)

<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
    <d:response>
        <d:href>/remote.php/dav/files/admin/mock.json</d:href>
        <d:propstat>
            <d:prop>
                <nc:upload_time>1780059095</nc:upload_time>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
