### PR TITLE
test(cache): avoid ordering assumptions in testExtended

### DIFF
--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -799,26 +799,31 @@ class CacheTest extends \Test\TestCase {
 		$entries = $this->cache->getFolderContents('');
 		$this->assertCount(4, $entries);
 
-		$this->assertEquals('foo1', $entries[0]->getName());
-		$this->assertEquals('foo2', $entries[1]->getName());
-		$this->assertEquals('foo3', $entries[2]->getName());
-		$this->assertEquals('foo4', $entries[3]->getName());
+		$entriesByName = [];
+		foreach ($entries as $entry) {
+			$entriesByName[$entry->getName()] = $entry;
+		}
 
-		$this->assertEquals(20, $entries[0]->getCreationTime());
-		$this->assertEquals(0, $entries[0]->getUploadTime());
-		$this->assertEquals(null, $entries[0]->getMetadataEtag());
+		$this->assertArrayHasKey('foo1', $entriesByName);
+		$this->assertArrayHasKey('foo2', $entriesByName);
+		$this->assertArrayHasKey('foo3', $entriesByName);
+		$this->assertArrayHasKey('foo4', $entriesByName);
 
-		$this->assertEquals(0, $entries[1]->getCreationTime());
-		$this->assertEquals(30, $entries[1]->getUploadTime());
-		$this->assertEquals(null, $entries[1]->getMetadataEtag());
+		$this->assertEquals(20, $entriesByName['foo1']->getCreationTime());
+		$this->assertEquals(0, $entriesByName['foo1']->getUploadTime());
+		$this->assertEquals(null, $entriesByName['foo1']->getMetadataEtag());
 
-		$this->assertEquals(0, $entries[2]->getCreationTime());
-		$this->assertEquals(0, $entries[2]->getUploadTime());
-		$this->assertEquals('foo', $entries[2]->getMetadataEtag());
+		$this->assertEquals(0, $entriesByName['foo2']->getCreationTime());
+		$this->assertEquals(30, $entriesByName['foo2']->getUploadTime());
+		$this->assertEquals(null, $entriesByName['foo2']->getMetadataEtag());
 
-		$this->assertEquals(0, $entries[3]->getCreationTime());
-		$this->assertEquals(0, $entries[3]->getUploadTime());
-		$this->assertEquals(null, $entries[3]->getMetadataEtag());
+		$this->assertEquals(0, $entriesByName['foo3']->getCreationTime());
+		$this->assertEquals(0, $entriesByName['foo3']->getUploadTime());
+		$this->assertEquals('foo', $entriesByName['foo3']->getMetadataEtag());
+
+		$this->assertEquals(0, $entriesByName['foo4']->getCreationTime());
+		$this->assertEquals(0, $entriesByName['foo4']->getUploadTime());
+		$this->assertEquals(null, $entriesByName['foo4']->getMetadataEtag());
 
 		$this->cache->update($id1, ['upload_time' => 25]);
 
@@ -834,6 +839,7 @@ class CacheTest extends \Test\TestCase {
 		$entries = $this->cache->getFolderContents('sub');
 		$this->assertCount(1, $entries);
 
+		$this->assertEquals('foo1', $entries[0]->getName());
 		$this->assertEquals(20, $entries[0]->getCreationTime());
 		$this->assertEquals(25, $entries[0]->getUploadTime());
 		$this->assertEquals(null, $entries[0]->getMetadataEtag());


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This test is flaky because it assumes `getFolderContents()` returns entries in a fixed order, and sometimes it doesn’t.

AFAIK `getFolderContents()` does not promise insertion order or alphabetical order.

This updates `testExtended()` to avoid relying on ordering.

Addresses test failures such as this:

```
There was 1 failure:

1) Test\Files\Cache\Wrapper\CachePermissionsMaskTest::testExtended
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'foo1'
+'foo4'

/home/runner/actions-runner/_work/server/server/tests/lib/Files/Cache/CacheTest.php:804
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
