### PR TITLE
[Security] Restrict unserialize() allowed_classes in TaskProcessing distributed cache

### DIFF
--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -939,7 +939,17 @@ class Manager implements IManager {
 		if ($this->availableTaskTypes === null) {
 			$cachedValue = $this->distributedCache->get($cacheKey);
 			if ($cachedValue !== null) {
-				$this->availableTaskTypes = unserialize($cachedValue);
+				// Restrict deserialization to the exact value-object classes stored in
+				// this cache entry. Bare unserialize() would allow an attacker who
+				// can write to the distributed cache backend to trigger PHP Object
+				// Injection via arbitrary gadget chains loaded in the process.
+				$this->availableTaskTypes = unserialize($cachedValue, [
+					'allowed_classes' => [
+						ShapeDescriptor::class,
+						ShapeEnumValue::class,
+						EShapeType::class,
+					],
+				]);
 			}
 		}
 		// Either we have no cache or showDisabled is turned on, which we don't want to cache, ever.


### PR DESCRIPTION
## Summary

`TaskProcessing\Manager::getAvailableTaskTypes()` serializes `ShapeDescriptor`, `ShapeEnumValue`, and `EShapeType` objects into the distributed cache and reads them back with **bare `unserialize()`** — no `allowed_classes` restriction.

An attacker who can write to the distributed cache backend can inject a crafted PHP serialized payload containing a gadget chain and achieve **Remote Code Execution** when `getAvailableTaskTypes()` is next called.

## Attack scenario

1. Attacker can write to the distributed cache backend (unauthenticated Redis, SSRF to cache server, or a cache-poisoning vulnerability in the application).
2. Attacker injects a serialized payload using gadget classes loaded by Nextcloud/Symfony (e.g., Monolog, Doctrine, or any other library with exploitable `__destruct`/`__wakeup`).
3. On the next `getAvailableTaskTypes()` call, the gadget chain fires → **RCE**.

## Fix

Restrict `allowed_classes` to the three value-object types that are actually stored in this cache entry (`ShapeDescriptor`, `ShapeEnumValue`, `EShapeType`). Any other class in the serialized string becomes a harmless `__PHP_Incomplete_Class`.

## Files changed

- `lib/private/TaskProcessing/Manager.php` — add explicit `allowed_classes` to `unserialize()`