### PR TITLE
fix(TaskProcessing): restrict allowed_classes in Manager cache deserialization

### DIFF
--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -939,12 +939,12 @@ class Manager implements IManager {
 			$cachedValue = $this->distributedCache->get($cacheKey);
 			if ($cachedValue !== null) {
 				$this->availableTaskTypes = unserialize($cachedValue, [
-				'allowed_classes' => [
-					ShapeDescriptor::class,
-					ShapeEnumValue::class,
-					EShapeType::class,
-				],
-			]);
+					'allowed_classes' => [
+						ShapeDescriptor::class,
+						ShapeEnumValue::class,
+						EShapeType::class,
+					],
+				]);
 			}
 		}
 		// Either we have no cache or showDisabled is turned on, which we don't want to cache, ever.

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -938,7 +938,13 @@ class Manager implements IManager {
 		if ($this->availableTaskTypes === null) {
 			$cachedValue = $this->distributedCache->get($cacheKey);
 			if ($cachedValue !== null) {
-				$this->availableTaskTypes = unserialize($cachedValue);
+				$this->availableTaskTypes = unserialize($cachedValue, [
+				'allowed_classes' => [
+					ShapeDescriptor::class,
+					ShapeEnumValue::class,
+					EShapeType::class,
+				],
+			]);
 			}
 		}
 		// Either we have no cache or showDisabled is turned on, which we don't want to cache, ever.


### PR DESCRIPTION
## Summary

`OC\TaskProcessing\Manager::getAvailableTaskTypes()` deserializes the task type cache from the distributed cache backend without restricting which PHP classes can be instantiated.

## The issue

```php
$cachedValue = $this->distributedCache->get($cacheKey);
if ($cachedValue !== null) {
    $this->availableTaskTypes = unserialize($cachedValue);  // ← no allowed_classes
}
```

The serialized data contains `ShapeDescriptor` objects, `ShapeEnumValue` objects, and `EShapeType` enum values. An attacker who can write to the cache backend (e.g., Redis without authentication or with weak ACLs — a common misconfiguration in cloud deployments) can inject a PHP gadget chain and achieve **Remote Code Execution via PHP Object Injection**.

## The fix

Restrict `unserialize()` to only the three known classes actually stored in the cache:

```php
$this->availableTaskTypes = unserialize($cachedValue, [
    'allowed_classes' => [
        ShapeDescriptor::class,
        ShapeEnumValue::class,
        EShapeType::class,
    ],
]);
```

This is verified by inspecting the write path: `serialize($this->availableTaskTypes)` where `$availableTaskTypes` is built from `getInputShape()`, `getOutputShape()` etc. which return arrays of `ShapeDescriptor` objects with `EShapeType` values.

## Security impact

Redis Object Injection via unprotected cache backends is a well-known attack class. Nextcloud already uses `allowed_classes` in `FileProfilerStorage`, `CommandJob`, and `QueueBus` — this PR extends the same pattern to `TaskProcessing\Manager`.

Signed-off-by: XananasX7