### PR TITLE
fix(bootstrap): normalize auth header sources and harden Basic credential extraction

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1249,27 +1249,45 @@ class OC {
 		return false;
 	}
 
+	/**
+	 * Normalizes authorization headers exposed through different $_SERVER keys
+	 * during early bootstrap and extracts PHP Basic auth credentials when present.
+	 *
+	 * This runs before IRequest is available, so it operates directly on $_SERVER.
+	 *
+	 * The PHP execution path and web server configuration must pass the
+	 * Authorization header through via one of the supported server variables.
+	 *
+	 * For Apache + PHP (any mode), this is handled by the distributed .htaccess file.
+	 */
 	protected static function handleAuthHeaders(): void {
-		//copy http auth headers for apache+php-fcgid work around
-		if (isset($_SERVER['HTTP_XAUTHORIZATION']) && !isset($_SERVER['HTTP_AUTHORIZATION'])) {
-			$_SERVER['HTTP_AUTHORIZATION'] = $_SERVER['HTTP_XAUTHORIZATION'];
+		$authHeaderValue = $_SERVER['HTTP_AUTHORIZATION']
+			?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION']
+			?? $_SERVER['HTTP_XAUTHORIZATION']
+			?? null;
+
+		if (!is_string($authHeaderValue) || $authHeaderValue === '') {
+			return;
 		}
 
-		// Extract PHP_AUTH_USER/PHP_AUTH_PW from other headers if necessary.
-		$vars = [
-			'HTTP_AUTHORIZATION', // apache+php-cgi work around
-			'REDIRECT_HTTP_AUTHORIZATION', // apache+php-cgi alternative
-		];
-		foreach ($vars as $var) {
-			if (isset($_SERVER[$var]) && is_string($_SERVER[$var]) && preg_match('/Basic\s+(.*)$/i', $_SERVER[$var], $matches)) {
-				$credentials = explode(':', base64_decode($matches[1]), 2);
-				if (count($credentials) === 2) {
-					$_SERVER['PHP_AUTH_USER'] = $credentials[0];
-					$_SERVER['PHP_AUTH_PW'] = $credentials[1];
-					break;
-				}
-			}
+		$_SERVER['HTTP_AUTHORIZATION'] ??= $authHeaderValue;
+
+		if (stripos($authHeaderValue, 'Basic ') !== 0) {
+			// Silently ignore non-Basic authentication requests.
+			return;
 		}
+
+		$decodedCredentials = base64_decode(substr($authHeaderValue, 6), true);
+
+		if ($decodedCredentials === false || !str_contains($decodedCredentials, ':')) {
+			// Silently ignore malformed Basic auth credentials.
+			return;
+		}
+
+		[$user, $pw] = explode(':', $decodedCredentials, 2);
+
+		$_SERVER['PHP_AUTH_USER'] = $user;
+		$_SERVER['PHP_AUTH_PW'] = $pw;
 	}
 
 	protected static function tryAppAPILogin(OCP\IRequest $request): bool {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This is mostly a refactor but technically fixes an inconsistency involving  `HTTP_XAUTHORIZATION` and `REDIRECT_HTTP_AUTHORIZATION` (see notes).

Rewrites `OC::handleAuthHeaders()` to consolidate the previously two-pass auth header normalization into a single, clearly-prioritized approach, and hardens Basic credential extraction.

### What changed

**Before:** Two separate concerns were handled sequentially:
1. Copy `HTTP_XAUTHORIZATION` → `HTTP_AUTHORIZATION` if the latter was missing (FastCGI workaround)
2. Loop over `HTTP_AUTHORIZATION` and `REDIRECT_HTTP_AUTHORIZATION` to extract PHP Basic auth credentials

**After:** A single pass with an explicit priority chain:
```
HTTP_AUTHORIZATION ?? REDIRECT_HTTP_AUTHORIZATION ?? HTTP_XAUTHORIZATION
```
The resolved value is normalized into `HTTP_AUTHORIZATION`, then Basic credentials are extracted once if present.

### Additional improvements

- Use `base64_decode(..., true)` (strict mode) to reject malformed Base64 instead of silently mangling it
- Replace `preg_match` + `count` with `stripos` + `str_contains` for cleaner, more readable logic
- Add early returns instead of deeply nested conditions
- Add a doc block explaining the context (early bootstrap, no `IRequest`, web server requirements)

### Behavioral notes

- `REDIRECT_HTTP_AUTHORIZATION` now takes priority over `HTTP_XAUTHORIZATION` when `HTTP_AUTHORIZATION` is absent. Previously `HTTP_XAUTHORIZATION` was copied first and thus took priority... mostly. But then `REDIRECT_HTTP_AUTHORIZATION` was consulting for setting the `PHP_AUTH_*` values. The new order is more semantically correct (`REDIRECT_*` is an Apache-native redirect; `HTTP_XAUTHORIZATION` is a FastCGI-specific workaround).
- The Basic scheme prefix is now matched with exactly one space (`Basic `), per [RFC 7617 §2](https://datatracker.ietf.org/doc/html/rfc7617#section-2). Non-conformant clients sending `Basic\t` or multiple spaces will no longer have credentials extracted (they were silently accepted before). Also better matches what we do elsewhere anyhow.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
