### PR TITLE
fix: Make the IProvideUserSecretBackend usable

### DIFF
--- a/lib/public/Authentication/IProvideUserSecretBackend.php
+++ b/lib/public/Authentication/IProvideUserSecretBackend.php
@@ -9,6 +9,8 @@
 
 namespace OCP\Authentication;
 
+use OCP\HintException;
+
 /**
  * Interface IProvideUserSecretBackend
  *
@@ -18,8 +20,14 @@ interface IProvideUserSecretBackend {
 	/**
 	 * Optionally returns a stable per-user secret. This secret is for
 	 * instance used to secure file encryption keys.
-	 * @return string
+	 *
+	 * @return non-empty-string|null Returns the per-user secret if the backend
+	 *                               is configured or null otherwise.
+	 * @throws HintException when the backend is configured to return a per-user
+	 *                       secret but is unable to do so.
+	 *
 	 * @since 23.0.0
+	 * @since 35.0.0 The returns value is now optional.
 	 */
-	public function getCurrentUserSecret(): string;
+	public function getCurrentUserSecret(): ?string;
 }

--- a/lib/public/User/Backend/ICheckPasswordBackend.php
+++ b/lib/public/User/Backend/ICheckPasswordBackend.php
@@ -14,11 +14,14 @@ namespace OCP\User\Backend;
  */
 interface ICheckPasswordBackend {
 	/**
-	 * @since 14.0.0
+	 * Check if the password is correct without logging in the user
+	 * returns the user id or false.
 	 *
-	 * @param string $loginName The loginname
+	 * @param string $loginName The login name
 	 * @param string $password The password
 	 * @return string|false The uid on success false on failure
+	 * @since 14.0.0
+	 *
 	 */
 	public function checkPassword(string $loginName, string $password);
 }


### PR DESCRIPTION
## Summary

When reviewing the implementation for user_saml (https://github.com/nextcloud/user_saml/pull/697), I noticed that we do need to make the return value nullable as otherwise there are no way for this feature to be optional for the admin.

This is not really a breaking change as we can make the return type less strict without breaking an implemtable interface and more importantly no one use this interface.

* Related to #24838

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
