### PR TITLE
fix(previews): ffprobe hangs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@
  - Andreas Pflug <dev@admin4.org>
  - Andrew Brown <andrew@casabrown.com>
  - Andrey Borysenko <andrey.borysenko@nextcloud.com>
+ - Andrey Dyakov <adduxa@gmail.com>
  - André Gaul <gaul@web-yard.de>
  - Andy Xheli <axheli@axtsolutions.com>
  - Anna Larch <anna@nextcloud.com>

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -289,8 +289,10 @@ class Movie extends ProviderV2 {
 		if ($test_hdr_proc === false) {
 			return false;
 		}
-		$test_hdr_stdout = trim(stream_get_contents($test_hdr_pipes[1]));
+		// Read stderr before stdout: ffprobe's stderr can exceed 64KB (OS pipe buffer) for certain
+		// files, causing a deadlock if stdout is read first. stdout is always a short string.
 		$test_hdr_stderr = trim(stream_get_contents($test_hdr_pipes[2]));
+		$test_hdr_stdout = trim(stream_get_contents($test_hdr_pipes[1]));
 		proc_close($test_hdr_proc);
 		// search build options for libzimg (provides zscale filter)
 		$ffmpeg_libzimg_installed = strpos($test_hdr_stderr, '--enable-libzimg');
@@ -341,6 +343,8 @@ class Movie extends ProviderV2 {
 		$returnCode = -1;
 		$output = '';
 		if (is_resource($proc)) {
+			// Read stderr before stdout: ffmpeg's stderr can exceed 64KB (OS pipe buffer) for certain
+			// files, causing a deadlock if stdout is read first. stdout is always empty.
 			$stderr = trim(stream_get_contents($pipes[2]));
 			$stdout = trim(stream_get_contents($pipes[1]));
 			$returnCode = proc_close($proc);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #60915 <!-- related github issue -->

## Summary

Fix pipe buffer deadlock in `useHdr()` in `lib/private/Preview/Movie.php`.

When `ffprobe` produces more than ~64KB on stderr, the sequential `stream_get_contents` calls
deadlock: PHP blocks reading stdout while ffprobe blocks flushing stderr. This caused
`occ preview:generate-all` to hang indefinitely on certain video files.

A tempting workaround is to swap the two `stream_get_contents` calls (reading stderr first),
but I'm not sure if ffprobe is guaranteed to produce <64KB on the stdout for this call.

Fix drains both pipes concurrently using `stream_select` with non-blocking I/O.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
