### PR TITLE
perf(user_ldap): chunk oracle queries for lower bind cost

### DIFF
--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -290,7 +290,13 @@ abstract class AbstractMapping {
 	public function getListOfIdsByDn(array $fdns): array {
 		$totalDBParamLimit = 65000;
 		$sliceSize = 1000;
-		$maxSlices = $this->dbc->getDatabaseProvider() === IDBConnection::PLATFORM_SQLITE ? 9 : $totalDBParamLimit / $sliceSize;
+		// SQLite's variable limit is very low; Oracle's OCI8 driver has high per-bind overhead,
+		// making large parameter lists (65k) extremely slow — use smaller batches for both.
+		$maxSlices = match ($this->dbc->getDatabaseProvider()) {
+			IDBConnection::PLATFORM_SQLITE => 9,
+			IDBConnection::PLATFORM_ORACLE => 5,
+			default => $totalDBParamLimit / $sliceSize,
+		};
 		$results = [];
 
 		$slice = 1;

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
@@ -284,7 +284,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 		[$mapper,] = $this->initTest();
 
 		$listOfDNs = [];
-		// List size exceeds the implementation's 65000-parameter chunk limit, forcing multiple chunked queries
+		// List size exceeds any single-query chunk limit (65k for most DBs, 9k for SQLite, 5k for Oracle), forcing multiple chunked queries
 		for ($i = 0; $i < 66640; $i++) {
 			$name = 'as_' . $i;
 			$dn = 'uid=' . $name . ',dc=example,dc=org';


### PR DESCRIPTION
## Problem

`getListOfIdsByDn` in `AbstractMapping` builds chunked IN queries by accumulating slices of 1 000 DNs before executing. For all non-SQLite databases the batch cap was 65 slices — 65 000 named bind parameters per query. Oracle's OCI8 driver binds each parameter individually via `OCIBindByName`, which makes 65 000-parameter queries dramatically slower than on MySQL or PostgreSQL. This caused `testGetListOfIdsByDn` to exceed the 600 s risky-test timeout and fail CI, and would degrade production LDAP syncs on large Oracle installations.

## Fix

Lower `maxSlices` to 5 for Oracle (5 000 parameters per query) via a `match` expression alongside the existing SQLite special-case. For a 66 640-item list this produces ~14 queries instead of 2, but each query is fast enough that the total time drops sharply. All other databases are unchanged.

## Performance

Times are total CI job duration (including Oracle container startup, ~3 min):

| Job | Before | After | Saved |
|---|---|---|---|
| Oracle 18 (PHP 8.2) | 63m 21s ✅ | 36m 28s ✅ | ~27 min |
| Oracle 21 (PHP 8.3) | 55m 6s ❌ (aborted — risky test at 600 s) | 36m 19s ✅ | — |
| Oracle 23 (PHP 8.4) | 35m 56s ✅ | 12m 58s ✅ | ~23 min |
| Oracle 23 (PHP 8.5) | 47m 29s ✅ | 12m 28s ✅ | ~35 min |

## Test plan

- [x] `NOCOVERAGE=1 ./autotest.sh sqlite apps/user_ldap/tests/Mapping/` passes
- [x] All Oracle CI jobs pass within the default Medium timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: ClaudeCode:claude-sonnet-4-6