### PR TITLE
feat(federatedsharing): store permissions on remote

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -88,6 +88,7 @@ class RequestHandlerController extends Controller {
 	 * @param array{name: list<string>, options: array<string, mixed>} $protocol e,.g. ['name' => 'webdav', 'options' => ['username' => 'john', 'permissions' => 31]]
 	 * @param string $shareType 'group' or 'user' share
 	 * @param string $resourceType 'file', 'calendar',...
+	 * @param int $permissions Permissions granted to the sharee
 	 *
 	 * @return JSONResponse<Http::STATUS_CREATED, CloudFederationAPIAddShare, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, CloudFederationAPIValidationError, array{}>|JSONResponse<Http::STATUS_NOT_IMPLEMENTED, CloudFederationAPIError, array{}>
 	 *
@@ -98,7 +99,20 @@ class RequestHandlerController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'receiveFederatedShare')]
-	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
+	public function addShare(
+		string $shareWith,
+		string $name,
+		?string $description,
+		string $providerId,
+		string $owner,
+		?string $ownerDisplayName,
+		?string $sharedBy,
+		?string $sharedByDisplayName,
+		array $protocol,
+		string $shareType,
+		string $resourceType,
+		?int $permissions
+	) {
 		if (!$this->appConfig->getValueBool('core', OCMSignatoryManager::APPCONFIG_SIGN_DISABLED, lazy: true)) {
 			try {
 				// if request is signed and well signed, no exceptions are thrown
@@ -186,7 +200,7 @@ class RequestHandlerController extends Controller {
 
 		try {
 			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider($resourceType);
-			$share = $this->factory->getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, '', $shareType, $resourceType);
+			$share = $this->factory->getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, '', $shareType, $resourceType, $permissions);
 			$share->setProtocol($protocol);
 			$provider->shareReceived($share);
 		} catch (ProviderDoesNotExistsException|ProviderCouldNotAddShareException $e) {

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -7,6 +7,7 @@
 
 namespace OCA\CloudFederationAPI\Controller;
 
+use OCP\Constants;
 use OC\OCM\OCMSignatoryManager;
 use OCA\CloudFederationAPI\Config;
 use OCA\CloudFederationAPI\Db\FederatedInviteMapper;
@@ -145,6 +146,10 @@ class RequestHandlerController extends Controller {
 				],
 				Http::STATUS_BAD_REQUEST
 			);
+		}
+
+		if ($permissions === null) {
+			$permissions = $this->appConfig->getValueInt('core', 'shareapi_default_permissions', (string)Constants::PERMISSION_ALL);
 		}
 
 		$supportedShareTypes = $this->config->getSupportedShareTypes($resourceType);

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -21,7 +21,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMovableMount;
 use OCP\Files\NotFoundException;
-use OCP\Files\Storage\IExternalSharedStorage;
+use OCP\Files\Storage\IExternalShareStorage;
 use OCP\Files\Storage\ISharedStorage;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IUser;
@@ -254,7 +254,7 @@ abstract class Node implements INode {
 			$storage = null;
 		}
 
-		if ($storage && ($storage->instanceOfStorage(ISharedStorage::class) || $storage->instanceOfStorage(IExternalSharedStorage::class))) {
+		if ($storage && ($storage->instanceOfStorage(ISharedStorage::class) || $storage->instanceOfStorage(IExternalShareStorage::class))) {
 			$permissions = $storage->getShare()->getPermissions();
 		} else {
 			$permissions = $this->info->getPermissions();

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -21,6 +21,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMovableMount;
 use OCP\Files\NotFoundException;
+use OCP\Files\Storage\IExternalSharedStorage;
 use OCP\Files\Storage\ISharedStorage;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IUser;
@@ -253,7 +254,7 @@ abstract class Node implements INode {
 			$storage = null;
 		}
 
-		if ($storage && $storage->instanceOfStorage(ISharedStorage::class)) {
+		if ($storage && ($storage->instanceOfStorage(ISharedStorage::class) || $storage->instanceOfStorage(IExternalSharedStorage::class))) {
 			$permissions = $storage->getShare()->getPermissions();
 		} else {
 			$permissions = $this->info->getPermissions();

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -201,7 +201,8 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 				$ownerCloudId->getId(),
 				$share->getSharedBy(),
 				$sharedByFederatedId,
-				$share->getShareType()
+				$share->getShareType(),
+				$share->getPermissions()
 			);
 
 			if ($send === false) {

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -323,7 +323,7 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 	protected function shouldNotifyRemote(IShare $share): bool {
 		$ownerOrSharerIsRemoteUser = !$this->userManager->userExists($share->getShareOwner())
 			|| !$this->userManager->userExists($share->getSharedBy());
-		return $ownerOrSharerIsRemoteUser && $share->getShareOwner() !== $share->getSharedBy();
+		return $ownerOrSharerIsRemoteUser && $share->getShareOwner() !== $share->getSharedBy() || !$this->userManager->userExists($share->getSharedWith());
 	}
 
 	/**
@@ -333,6 +333,13 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 	 * @throws HintException
 	 */
 	protected function sendPermissionUpdate(IShare $share): void {
+		if (!$this->userManager->userExists($share->getSharedWith())) {
+			$remoteId = $share->getId();
+			[, $remote] = $this->addressHandler->splitUserRemote($share->getSharedWith());
+			$this->notifications->sendPermissionChange($remote, $remoteId, $share->getToken(), $share->getPermissions());
+			return;
+		}
+
 		$remoteId = $this->getRemoteId($share);
 		// if the local user is the owner we send the permission change to the initiator
 		if ($this->userManager->userExists($share->getShareOwner())) {

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -47,11 +47,12 @@ class Notifications {
 	 * @param string $sharedBy
 	 * @param string $sharedByFederatedId
 	 * @param int $shareType (can be a remote user or group share)
+	 * @param int $permissions
 	 * @return bool
 	 * @throws HintException
 	 * @throws ServerNotAvailableException
 	 */
-	public function sendRemoteShare($token, $shareWith, $name, $remoteId, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId, $shareType) {
+	public function sendRemoteShare($token, $shareWith, $name, $remoteId, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId, $shareType, $permissions) {
 		[$user, $remote] = $this->addressHandler->splitUserRemote($shareWith);
 
 		if ($user && $remote) {
@@ -67,7 +68,8 @@ class Notifications {
 				'sharedBy' => $sharedBy,
 				'sharedByFederatedId' => $sharedByFederatedId,
 				'remote' => $local,
-				'shareType' => $shareType
+				'shareType' => $shareType,
+				'permissions' => $permissions
 			];
 
 			$result = $this->tryHttpPostToShareEndpoint($remote, '', $fields);
@@ -242,6 +244,7 @@ class Notifications {
 		}
 
 		$result = $this->tryHttpPostToShareEndpoint(rtrim($remote, '/'), '/' . $remoteId . '/' . $action, $fields, $action);
+
 		$status = json_decode($result['result'], true);
 
 		if ($result['success']
@@ -373,7 +376,8 @@ class Notifications {
 					$fields['sharedBy'],
 					$fields['token'],
 					$fields['shareType'],
-					'file'
+					'file',
+					$fields['permissions']
 				);
 				return $this->federationProviderManager->sendShare($share);
 			case 'reshare':

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -419,6 +419,18 @@ class Notifications {
 					]
 				);
 				return $this->federationProviderManager->sendNotification($remoteDomain, $notification);
+			case 'permissions':
+				$notification = $this->cloudFederationFactory->getCloudFederationNotification();
+				$notification->setMessage('SHAREE_CHANGE_PERMISSION',
+					'file',
+					$fields['remoteId'],
+					[
+						'sharedSecret' => $fields['token'],
+						'permissions' => $fields['permissions'],
+						'message' => 'permissions updated'
+					]
+				);
+				return $this->federationProviderManager->sendNotification($remoteDomain, $notification);
 		}
 
 		return false;

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -227,6 +227,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 			'REQUEST_RESHARE' => $this->reshareRequested($providerId, $notification),
 			'RESHARE_UNDO' => $this->undoReshare($providerId, $notification),
 			'RESHARE_CHANGE_PERMISSION' => $this->updateResharePermissions($providerId, $notification),
+			'SHAREE_CHANGE_PERMISSION' => $this->updateShareePermissions($providerId, $notification),
 			default => throw new BadRequestException([$notificationType]),
 		};
 	}
@@ -686,5 +687,21 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 		} else {
 			return $share->getShareOwner();
 		}
+	}
+
+	private function updateShareePermissions(string $id, array $notification): array {
+		if (!$this->isS2SEnabled()) {
+			throw new ActionNotSupportedException('Server does not support federated cloud sharing');
+		}
+
+		if (!isset($notification['sharedSecret'])) {
+			throw new BadRequestException(['sharedSecret']);
+		}
+
+		$share = $this->externalShareManager->getShareByToken($notification['sharedSecret']);
+		$share->setPermissions($notification['permissions']);
+		$share = $this->externalShareMapper->update($share);
+
+		return [];
 	}
 }

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -106,6 +106,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 		$sharedByFederatedId = $share->getSharedBy();
 		$ownerFederatedId = $share->getOwner();
 		$shareType = $this->mapShareTypeToNextcloud($share->getShareType());
+		$permissions = $share->getPermissions();
 
 		// if no explicit information about the person who created the share was sent
 		// we assume that the share comes from the owner
@@ -153,6 +154,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 			$externalShare->setOwner($owner);
 			$externalShare->setShareType($shareType);
 			$externalShare->setAccepted(IShare::STATUS_PENDING);
+			$externalShare->setPermissions($permissions);
 
 			try {
 				$this->externalShareManager->addShare($externalShare, $user ?: $group);

--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -89,6 +89,7 @@ return array(
     'OCA\\Files_Sharing\\Migration\\Version31000Date20240821142813' => $baseDir . '/../lib/Migration/Version31000Date20240821142813.php',
     'OCA\\Files_Sharing\\Migration\\Version32000Date20251017081948' => $baseDir . '/../lib/Migration/Version32000Date20251017081948.php',
     'OCA\\Files_Sharing\\Migration\\Version33000Date20251030081948' => $baseDir . '/../lib/Migration/Version33000Date20251030081948.php',
+	'OCA\\Files_Sharing\\Migration\\Version35000Date20260520071407' => $baseDir . '/../lib/Migration/Version35000Date20260520071407.php',
     'OCA\\Files_Sharing\\MountProvider' => $baseDir . '/../lib/MountProvider.php',
     'OCA\\Files_Sharing\\Notification\\Listener' => $baseDir . '/../lib/Notification/Listener.php',
     'OCA\\Files_Sharing\\Notification\\Notifier' => $baseDir . '/../lib/Notification/Notifier.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -104,6 +104,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Migration\\Version31000Date20240821142813' => __DIR__ . '/..' . '/../lib/Migration/Version31000Date20240821142813.php',
         'OCA\\Files_Sharing\\Migration\\Version32000Date20251017081948' => __DIR__ . '/..' . '/../lib/Migration/Version32000Date20251017081948.php',
         'OCA\\Files_Sharing\\Migration\\Version33000Date20251030081948' => __DIR__ . '/..' . '/../lib/Migration/Version33000Date20251030081948.php',
+		'OCA\\Files_Sharing\\Migration\\Version35000Date20260520071407' => __DIR__ . '/..' . '/../lib/Migration/Version35000Date20260520071407.php',
         'OCA\\Files_Sharing\\MountProvider' => __DIR__ . '/..' . '/../lib/MountProvider.php',
         'OCA\\Files_Sharing\\Notification\\Listener' => __DIR__ . '/..' . '/../lib/Notification/Listener.php',
         'OCA\\Files_Sharing\\Notification\\Notifier' => __DIR__ . '/..' . '/../lib/Notification/Notifier.php',

--- a/apps/files_sharing/lib/Controller/RemoteController.php
+++ b/apps/files_sharing/lib/Controller/RemoteController.php
@@ -122,7 +122,6 @@ class RemoteController extends OCSController {
 
 		$shareData['mimetype'] = $mountPointNode->getMimetype();
 		$shareData['mtime'] = $mountPointNode->getMTime();
-		$shareData['permissions'] = $mountPointNode->getPermissions();
 		$shareData['type'] = $mountPointNode->getType();
 		$shareData['file_id'] = $mountPointNode->getId();
 		$shareData['item_size'] = $mountPointNode->getSize();

--- a/apps/files_sharing/lib/External/ExternalShare.php
+++ b/apps/files_sharing/lib/External/ExternalShare.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Files_Sharing\External;
 
+use OCP\Share\External\IExternalShare;
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\ResponseDefinitions;
 use OCP\AppFramework\Db\SnowflakeAwareEntity;
@@ -45,7 +46,7 @@ use OCP\Share\IShare;
  *
  * @psalm-import-type Files_SharingRemoteShare from ResponseDefinitions
  */
-class ExternalShare extends SnowflakeAwareEntity implements \JsonSerializable {
+class ExternalShare extends SnowflakeAwareEntity implements \JsonSerializable, IExternalShare {
 	protected string $parent = '-1';
 	protected ?int $shareType = null;
 	protected ?string $remote = null;

--- a/apps/files_sharing/lib/External/ExternalShare.php
+++ b/apps/files_sharing/lib/External/ExternalShare.php
@@ -40,6 +40,8 @@ use OCP\Share\IShare;
  * @method void setMountpointHash(string $mountPointHash)
  * @method int getAccepted()
  * @method void setAccepted(int $accepted)
+ * @method int getPermissions()
+ * @method void setPermissions(int $permissions)
  *
  * @psalm-import-type Files_SharingRemoteShare from ResponseDefinitions
  */
@@ -56,6 +58,7 @@ class ExternalShare extends SnowflakeAwareEntity implements \JsonSerializable {
 	protected ?string $mountpoint = null;
 	protected ?string $mountpointHash = null;
 	protected ?int $accepted = null;
+	protected ?int $permissions = null;
 
 	public function __construct() {
 		$this->addType('id', Types::STRING); // Stored as a bigint
@@ -71,6 +74,7 @@ class ExternalShare extends SnowflakeAwareEntity implements \JsonSerializable {
 		$this->addType('mountpoint', Types::STRING);
 		$this->addType('mountpointHash', Types::STRING);
 		$this->addType('accepted', Types::INTEGER);
+		$this->addType('permissions', Types::SMALLINT);
 	}
 
 	public function setMountpoint(string $mountPoint): void {
@@ -105,11 +109,11 @@ class ExternalShare extends SnowflakeAwareEntity implements \JsonSerializable {
 			'user' => $this->getUser(),
 			'mountpoint' => $this->getMountpoint(),
 			'accepted' => $this->getAccepted(),
+			'permissions' => $this->getPermissions(),
 
 			// Added later on
 			'file_id' => null,
 			'mimetype' => null,
-			'permissions' => null,
 			'mtime' => null,
 			'type' => null,
 			'item_size' => null,
@@ -133,6 +137,7 @@ class ExternalShare extends SnowflakeAwareEntity implements \JsonSerializable {
 		$newShare->setMountpoint($this->getMountpoint());
 		$newShare->setAccepted($this->getAccepted());
 		$newShare->setPassword($this->getPassword());
+		$newShare->setPermissions($this->getPermissions());
 		return $newShare;
 	}
 }

--- a/apps/files_sharing/lib/External/ExternalShare.php
+++ b/apps/files_sharing/lib/External/ExternalShare.php
@@ -41,8 +41,8 @@ use OCP\Share\IShare;
  * @method void setMountpointHash(string $mountPointHash)
  * @method int getAccepted()
  * @method void setAccepted(int $accepted)
- * @method int getPermissions()
- * @method void setPermissions(int $permissions)
+ * @method int|null getPermissions()
+ * @method void setPermissions(?int $permissions)
  *
  * @psalm-import-type Files_SharingRemoteShare from ResponseDefinitions
  */

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -116,6 +116,7 @@ class Manager {
 			'mountpoint' => $externalShare->getMountpoint(),
 			'owner' => $externalShare->getOwner(),
 			'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates'),
+			'permissions' => $externalShare->getPermissions(),
 		];
 		return $this->mountShare($options, $user);
 	}
@@ -199,6 +200,7 @@ class Manager {
 				$subShare->setParent((string)$externalShare->getId());
 				$subShare->setShareType($externalShare->getShareType());
 				$subShare->setShareToken($externalShare->getShareToken());
+				$subShare->setPermissions($externalShare->getPermissions());
 				$this->externalShareMapper->insert($subShare);
 			}
 		}

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -566,5 +566,14 @@ class Manager {
 			$this->logger->emergency('Error when retrieving shares', ['exception' => $e]);
 			return [];
 		}
+
+	}
+
+	public function updateSharePermissions(string $token, int $permissions): void {
+		try {
+			$share = $this->externalShareMapper->getShareByToken($token);
+			$share->setPermissions($permissions);
+			$this->externalShareMapper->update($share);
+		} catch (DoesNotExistException) {}
 	}
 }

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -12,11 +12,11 @@ namespace OCA\Files_Sharing\External;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use OCP\Share\External\IExternalShare;
 use OC\Files\Storage\DAV;
 use OC\ForbiddenException;
 use OC\Share\Share;
 use OCA\Files_Sharing\External\Manager as ExternalShareManager;
-use OCA\Files_Sharing\ISharedStorage;
 use OCP\AppFramework\Http;
 use OCP\Constants;
 use OCP\Federation\ICloudId;
@@ -26,6 +26,7 @@ use OCP\Files\Cache\IWatcher;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\Files\Storage\IReliableEtagStorage;
+use OCP\Files\Storage\IExternalShareStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
@@ -42,7 +43,7 @@ use OCP\Server;
 use OCP\Share\IManager as IShareManager;
 use Psr\Log\LoggerInterface;
 
-class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, IReliableEtagStorage {
+class Storage extends DAV implements IExternalShareStorage, IDisableEncryptionStorage, IReliableEtagStorage {
 	private ICloudId $cloudId;
 	private string $mountPoint;
 	private string $token;
@@ -444,5 +445,9 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 			$options['verify'] = false;
 		}
 		return $options;
+	}
+
+	public function getShare(): IExternalShare {
+		return $this->manager->getShareByToken($this->token);
 	}
 }

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Exception\RequestException;
 use OCP\Share\External\IExternalShare;
 use OC\Files\Storage\DAV;
 use OC\ForbiddenException;
+use OCP\Files\ForbiddenException as FilesForbiddenException;
 use OC\Share\Share;
 use OCA\Files_Sharing\External\Manager as ExternalShareManager;
 use OCP\AppFramework\Http;
@@ -351,11 +352,18 @@ class Storage extends DAV implements IExternalShareStorage, IDisableEncryptionSt
 			|| !$this->appConfig->getValueBool('core', 'shareapi_allow_resharing', true)) {
 			return false;
 		}
-		return (bool)($this->getPermissions($path) & Constants::PERMISSION_SHARE);
+		return (bool)($this->getPermissions($path, true) & Constants::PERMISSION_SHARE);
 	}
 
 	#[\Override]
-	public function getPermissions(string $path): int {
+	public function getPermissions(string $path, bool $ignoreCache = false): int {
+		if (!$ignoreCache) {
+			$share = $this->getShare();
+			if ($share !== false && $share->getPermissions() !== null) {
+				return $share->getPermissions();
+			}
+		}
+
 		$response = $this->propfind($path);
 		if ($response === false) {
 			return 0;
@@ -371,13 +379,114 @@ class Storage extends DAV implements IExternalShareStorage, IDisableEncryptionSt
 			// permissions provided by the OCM API
 			$permissions = $this->ocmPermissions2ncPermissions($ocmPermissions, $path);
 		} elseif ($ocPermissions !== null) {
-			return $this->parsePermissions($ocPermissions);
+			$permissions = $this->parsePermissions($ocPermissions);
 		} else {
 			// use default permission if remote server doesn't provide the share permissions
 			$permissions = $this->getDefaultPermissions($path);
 		}
 
+		$this->manager->updateSharePermissions($this->token, $permissions);
 		return $permissions;
+	}
+
+	#[\Override]
+	public function mkdir(string $path): bool {
+		$permissions = $this->getPermissions('');
+		if (!($permissions & Constants::PERMISSION_CREATE)) {
+			throw new FilesForbiddenException('Permission denied: cannot create in this share', false);
+		}
+		try {
+			$canCreate = parent::mkdir($path);
+		} catch (FilesForbiddenException) {
+			$canCreate = false;
+		}
+
+		if (!$canCreate) {
+			$permissions &= ~Constants::PERMISSION_CREATE;
+			$this->manager->updateSharePermissions($this->token, $permissions);
+		}
+
+		return $canCreate;
+	}
+
+	#[\Override]
+	public function rmdir(string $path): bool {
+		$permissions = $this->getPermissions('');
+		if (!($permissions & Constants::PERMISSION_DELETE)) {
+			throw new FilesForbiddenException('Permission denied: cannot delete in this share', false);
+		}
+		try {
+			$canDelete = parent::rmdir($path);
+		} catch (FilesForbiddenException) {
+			$canDelete = false;
+		}
+
+		if (!$canDelete) {
+			$permissions &= ~Constants::PERMISSION_DELETE;
+			$this->manager->updateSharePermissions($this->token, $permissions);
+		}
+
+		return $canDelete;
+	}
+
+	#[\Override]
+	public function unlink(string $path): bool {
+		$permissions = $this->getPermissions('');
+		if (!($permissions & Constants::PERMISSION_DELETE)) {
+			throw new FilesForbiddenException('Permission denied: cannot delete in this share', false);
+		}
+		try {
+			$canDelete = parent::unlink($path);
+		} catch (FilesForbiddenException) {
+			$canDelete = false;
+		}
+
+		if (!$canDelete) {
+			$permissions &= ~Constants::PERMISSION_DELETE;
+			$this->manager->updateSharePermissions($this->token, $permissions);
+		}
+
+		return $canDelete;
+	}
+
+	#[\Override]
+	public function rename(string $source, string $target): bool {
+		$permissions = $this->getPermissions('');
+		if (!($permissions & Constants::PERMISSION_UPDATE)) {
+			throw new FilesForbiddenException('Permission denied: cannot rename/move in this share', false);
+		}
+		try {
+			$canUpdate = parent::rename($source, $target);
+		} catch (FilesForbiddenException) {
+			$canUpdate = false;
+		}
+
+		if (!$canUpdate) {
+			$permissions &= ~Constants::PERMISSION_UPDATE;
+			$this->manager->updateSharePermissions($this->token, $permissions);
+		}
+
+		return $canUpdate;
+	}
+
+	#[\Override]
+	public function copy(string $source, string $target): bool {
+		$permissions = $this->getPermissions('');
+		if (!($permissions & Constants::PERMISSION_CREATE)) {
+			throw new FilesForbiddenException('Permission denied: cannot copy in this share', false);
+		}
+		try {
+			$canCreate = parent::copy($source, $target);
+		} catch (FilesForbiddenException) {
+			$canCreate = false;
+		}
+
+		if (!$canCreate) {
+			$permissions &= ~Constants::PERMISSION_CREATE;
+			$this->manager->updateSharePermissions($this->token, $permissions);
+		}
+
+		return $canCreate;
 	}
 
 	#[\Override]
@@ -445,6 +554,81 @@ class Storage extends DAV implements IExternalShareStorage, IDisableEncryptionSt
 			$options['verify'] = false;
 		}
 		return $options;
+	}
+
+	#[\Override]
+	public function fopen(string $path, string $mode) {
+		$fileExists = false;
+		if ($mode !== 'r' && $mode !== 'rb') {
+			$permissions = $this->getPermissions('');
+			$fileExists = $this->file_exists($path);
+			if ($fileExists) {
+				if (!($permissions & Constants::PERMISSION_UPDATE)) {
+					return false;
+				}
+			} else {
+				if (!($permissions & Constants::PERMISSION_CREATE)) {
+					return false;
+				}
+			}
+		}
+
+		$canOpen = parent::fopen($path, $mode);
+		if (!$canOpen) {
+			if ($fileExists) {
+				$permissions &= ~Constants::PERMISSION_UPDATE;
+			} else {
+				$permissions &= ~Constants::PERMISSION_CREATE;
+			}
+
+			$this->manager->updateSharePermissions($this->token, $permissions);
+		}
+
+		return $canOpen;
+	}
+
+	#[\Override]
+	public function touch(string $path, ?int $mtime = null): bool {
+		$permissions = $this->getPermissions('');
+		$fileExists = $this->file_exists($path);
+		if ($fileExists) {
+			if (!($permissions & Constants::PERMISSION_UPDATE)) {
+				return false;
+			}
+		} else {
+			if (!($permissions & Constants::PERMISSION_CREATE)) {
+				return false;
+			}
+		}
+
+		$canTouch = parent::touch($path, $mtime);
+		if (!$canTouch) {
+			if ($fileExists) {
+				$permissions &= ~Constants::PERMISSION_UPDATE;
+			} else {
+				$permissions &= ~Constants::PERMISSION_CREATE;
+			}
+
+			$this->manager->updateSharePermissions($this->token, $permissions);
+		}
+
+		return $canTouch;
+	}
+
+	#[\Override]
+	public function getMetaData(string $path): ?array {
+		$metadata = parent::getMetaData($path);
+
+		if (isset($metadata['permissions'])) {
+			try {
+				$share = $this->getShare();
+			} catch (NotFoundException) {
+				return $metadata;
+			}
+			$metadata['permissions'] = $share->getPermissions();
+		}
+
+		return $metadata;
 	}
 
 	public function getShare(): IExternalShare {

--- a/apps/files_sharing/lib/Migration/Version35000Date20260520071407.php
+++ b/apps/files_sharing/lib/Migration/Version35000Date20260520071407.php
@@ -36,8 +36,8 @@ class Version35000Date20260520071407 extends SimpleMigrationStep {
 		$table = $schema->getTable('share_external');
 		if (!$table->hasColumn('permissions')) {
 			$table->addColumn('permissions', Types::SMALLINT, [
-				'notnull' => true,
-				'default' => 0
+				'notnull' => false,
+				'default' => null
 			]);
 
 			return $schema;

--- a/apps/files_sharing/lib/Migration/Version35000Date20260520071407.php
+++ b/apps/files_sharing/lib/Migration/Version35000Date20260520071407.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Sharing\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\Attributes\AddColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * FIXME Auto-generated migration step: Please modify to your needs!
+ */
+#[AddColumn(table: 'share_external', name: 'permissions', type: Types::SMALLINT)]
+class Version35000Date20260520071407 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('share_external');
+		if (!$table->hasColumn('permissions')) {
+			$table->addColumn('permissions', Types::SMALLINT, [
+				'notnull' => true,
+				'default' => 0
+			]);
+
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/private/Federation/CloudFederationFactory.php
+++ b/lib/private/Federation/CloudFederationFactory.php
@@ -26,13 +26,14 @@ class CloudFederationFactory implements ICloudFederationFactory {
 	 * @param string $sharedSecret used to authenticate requests across servers
 	 * @param string $shareType ('group' or 'user' share)
 	 * @param $resourceType ('file', 'calendar',...)
+	 * @param int $permissions permissions granted to the sharee
 	 * @return ICloudFederationShare
 	 *
 	 * @since 14.0.0
 	 */
 	#[\Override]
-	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType) {
-		return new CloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $shareType, $resourceType, $sharedSecret);
+	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType, $permissions) {
+		return new CloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $shareType, $resourceType, $sharedSecret, $permissions);
 	}
 
 	/**

--- a/lib/private/Federation/CloudFederationShare.php
+++ b/lib/private/Federation/CloudFederationShare.php
@@ -24,7 +24,8 @@ class CloudFederationShare implements ICloudFederationShare {
 		'sharedByDisplayName' => '',
 		'sender' => '',
 		'senderDisplayName' => '',
-		'protocol' => []
+		'protocol' => [],
+		'permissions' => 0
 	];
 
 	/**
@@ -41,6 +42,7 @@ class CloudFederationShare implements ICloudFederationShare {
 	 * @param string $shareType ('group' or 'user' share)
 	 * @param string $resourceType ('file', 'calendar',...)
 	 * @param string $sharedSecret
+	 * @param int $permissions permissions granted to the sharee
 	 */
 	public function __construct($shareWith = '',
 		$name = '',
@@ -53,6 +55,7 @@ class CloudFederationShare implements ICloudFederationShare {
 		$shareType = '',
 		$resourceType = '',
 		$sharedSecret = '',
+		$permissions = 0
 	) {
 		$this->setShareWith($shareWith);
 		$this->setResourceName($name);
@@ -71,6 +74,7 @@ class CloudFederationShare implements ICloudFederationShare {
 		]);
 		$this->setShareType($shareType);
 		$this->setResourceType($resourceType);
+		$this->setPermissions($permissions);
 	}
 
 	/**
@@ -209,6 +213,16 @@ class CloudFederationShare implements ICloudFederationShare {
 		} else {
 			$this->share['shareType'] = 'user';
 		}
+	}
+
+	/**
+	 * permissions granted to the sharee
+	 *
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function setPermissions(int $permissions): void {
+		$this->share['permissions'] = $permissions;
 	}
 
 	/**
@@ -365,5 +379,14 @@ class CloudFederationShare implements ICloudFederationShare {
 	#[\Override]
 	public function getProtocol() {
 		return $this->share['protocol'];
+	}
+
+	/**
+	 * get permissions granted to the sharee
+	 *
+	 * @since 35.0.0
+	 */
+	public function getPermissions(): int {
+		return $this->share['permissions'];
 	}
 }

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -8,7 +8,6 @@
 
 namespace OC\Files;
 
-use OCP\Files\Storage\IExternalShareStorage;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Mount\HomeMountPoint;
 use OCA\Files_Sharing\ISharedMountPoint;
@@ -64,13 +63,6 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 			$this->rawSize = $this->data['unencrypted_size'];
 		} else {
 			$this->rawSize = $this->data['size'] ?? 0;
-		}
-
-		if ($storage?->instanceOfStorage(IExternalShareStorage::class)) {
-			$externalSharePermissions = $storage->getShare()->getPermissions();
-			if ($this->data['permissions'] !== $externalSharePermissions) {
-				$this->data->offsetSet('permissions', $externalSharePermissions);
-			}
 		}
 	}
 

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -8,6 +8,7 @@
 
 namespace OC\Files;
 
+use OCP\Files\Storage\IExternalShareStorage;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Mount\HomeMountPoint;
 use OCA\Files_Sharing\ISharedMountPoint;
@@ -63,6 +64,13 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 			$this->rawSize = $this->data['unencrypted_size'];
 		} else {
 			$this->rawSize = $this->data['size'] ?? 0;
+		}
+
+		if ($storage?->instanceOfStorage(IExternalShareStorage::class)) {
+			$externalSharePermissions = $storage->getShare()->getPermissions();
+			if ($this->data['permissions'] !== $externalSharePermissions) {
+				$this->data->offsetSet('permissions', $externalSharePermissions);
+			}
 		}
 	}
 

--- a/lib/public/Federation/ICloudFederationFactory.php
+++ b/lib/public/Federation/ICloudFederationFactory.php
@@ -28,11 +28,12 @@ interface ICloudFederationFactory {
 	 * @param string $sharedSecret used to authenticate requests across servers
 	 * @param string $shareType ('group' or 'user' share)
 	 * @param $resourceType ('file', 'calendar',...)
+	 * @param int $permissions permissions granted to the sharee
 	 * @return ICloudFederationShare
 	 *
 	 * @since 14.0.0
 	 */
-	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType);
+	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType, $permissions);
 
 	/**
 	 * get a Cloud FederationNotification object to prepare a notification you

--- a/lib/public/Federation/ICloudFederationShare.php
+++ b/lib/public/Federation/ICloudFederationShare.php
@@ -114,6 +114,13 @@ interface ICloudFederationShare {
 	public function setShareType($shareType);
 
 	/**
+	 * permissions granted to the sharee
+	 *
+	 * @since 35.0.0
+	 */
+	public function setPermissions(int $permissions);
+
+	/**
 	 * get the whole share, ready to send out
 	 *
 	 * @return array
@@ -229,4 +236,11 @@ interface ICloudFederationShare {
 	 * @since 14.0.0
 	 */
 	public function getProtocol();
+
+	/**
+	* get permissions granted to the sharee
+	*
+	* @since 35.0.0
+	 */
+	public function getPermissions(): int;
 }

--- a/lib/public/Files/Storage/IExternalShareStorage.php
+++ b/lib/public/Files/Storage/IExternalShareStorage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OCP\Files\Storage;
+
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\Share\External\IExternalShare;
+
+/**
+ * Interface for a storage that is based on an external file share
+ *
+ * @since 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+interface IExternalShareStorage extends IStorage {
+	/**
+	 * The associated external share
+	 *
+	 * @since 35.0.0
+	 */
+	public function getShare(): IExternalShare;
+}

--- a/lib/public/Share/External/IExternalShare.php
+++ b/lib/public/Share/External/IExternalShare.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OCP\Share\External;
+
+use OCP\AppFramework\Attribute\Consumable;
+
+
+/**
+*
+* This interface allows to represent an external share object
+*
+* @since 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+interface IExternalShare {
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
This adds a feature to store permissions in external share.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
