### PR TITLE
fix(user_ldap): allow editing profile fields not managed by LDAP

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -690,17 +690,17 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 		return match($property) {
 			// Display name is always set by LDAP
 			IAccountManager::PROPERTY_DISPLAYNAME => false,
-			IAccountManager::PROPERTY_EMAIL => ((string)$this->access->connection->ldapEmailAttribute !== ''),
-			IAccountManager::PROPERTY_PHONE => ((string)$this->access->connection->ldapAttributePhone !== ''),
-			IAccountManager::PROPERTY_WEBSITE => ((string)$this->access->connection->ldapAttributeWebsite !== ''),
-			IAccountManager::PROPERTY_ADDRESS => ((string)$this->access->connection->ldapAttributeAddress !== ''),
-			IAccountManager::PROPERTY_FEDIVERSE => ((string)$this->access->connection->ldapAttributeFediverse !== ''),
-			IAccountManager::PROPERTY_ORGANISATION => ((string)$this->access->connection->ldapAttributeOrganisation !== ''),
-			IAccountManager::PROPERTY_ROLE => ((string)$this->access->connection->ldapAttributeRole !== ''),
-			IAccountManager::PROPERTY_HEADLINE => ((string)$this->access->connection->ldapAttributeHeadline !== ''),
-			IAccountManager::PROPERTY_BIOGRAPHY => ((string)$this->access->connection->ldapAttributeBiography !== ''),
-			IAccountManager::PROPERTY_BIRTHDATE => ((string)$this->access->connection->ldapAttributeBirthDate !== ''),
-			IAccountManager::PROPERTY_PRONOUNS => ((string)$this->access->connection->ldapAttributePronouns !== ''),
+			IAccountManager::PROPERTY_EMAIL => ((string)$this->access->connection->ldapEmailAttribute === ''),
+			IAccountManager::PROPERTY_PHONE => ((string)$this->access->connection->ldapAttributePhone === ''),
+			IAccountManager::PROPERTY_WEBSITE => ((string)$this->access->connection->ldapAttributeWebsite === ''),
+			IAccountManager::PROPERTY_ADDRESS => ((string)$this->access->connection->ldapAttributeAddress === ''),
+			IAccountManager::PROPERTY_FEDIVERSE => ((string)$this->access->connection->ldapAttributeFediverse === ''),
+			IAccountManager::PROPERTY_ORGANISATION => ((string)$this->access->connection->ldapAttributeOrganisation === ''),
+			IAccountManager::PROPERTY_ROLE => ((string)$this->access->connection->ldapAttributeRole === ''),
+			IAccountManager::PROPERTY_HEADLINE => ((string)$this->access->connection->ldapAttributeHeadline === ''),
+			IAccountManager::PROPERTY_BIOGRAPHY => ((string)$this->access->connection->ldapAttributeBiography === ''),
+			IAccountManager::PROPERTY_BIRTHDATE => ((string)$this->access->connection->ldapAttributeBirthDate === ''),
+			IAccountManager::PROPERTY_PRONOUNS => ((string)$this->access->connection->ldapAttributePronouns === ''),
 			default => true,
 		};
 	}

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1460,4 +1460,37 @@ class User_LDAPTest extends TestCase {
 
 		$this->assertSame($expected, $this->backend->implementsActions($actionCode));
 	}
+
+	public static function canEditPropertyProvider(): array {
+		return [
+			// Display name is always managed by LDAP
+			[\OCP\Accounts\IAccountManager::PROPERTY_DISPLAYNAME, '', false],
+			[\OCP\Accounts\IAccountManager::PROPERTY_DISPLAYNAME, 'cn', false],
+			// Fields with no LDAP attribute configured are user-editable
+			[\OCP\Accounts\IAccountManager::PROPERTY_EMAIL, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_PHONE, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_WEBSITE, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_ADDRESS, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_FEDIVERSE, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_ORGANISATION, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_ROLE, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_HEADLINE, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_BIOGRAPHY, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_BIRTHDATE, '', true],
+			[\OCP\Accounts\IAccountManager::PROPERTY_PRONOUNS, '', true],
+			// Fields with an LDAP attribute configured are managed by LDAP, not user-editable
+			[\OCP\Accounts\IAccountManager::PROPERTY_EMAIL, 'mail', false],
+			[\OCP\Accounts\IAccountManager::PROPERTY_PHONE, 'telephoneNumber', false],
+			[\OCP\Accounts\IAccountManager::PROPERTY_WEBSITE, 'labeledURI', false],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'canEditPropertyProvider')]
+	public function testCanEditProperty(string $property, string $ldapAttributeValue, bool $expected): void {
+		$this->connection->expects($this->any())
+			->method('__get')
+			->willReturn($ldapAttributeValue);
+
+		$this->assertSame($expected, $this->backend->canEditProperty('uid', $property));
+	}
 }


### PR DESCRIPTION
## Summary

Follow up to https://github.com/nextcloud/server/pull/58002

`canEditProperty()` was returning `true` (editable) when an LDAP attribute was configured for a field, and false when no attribute was configured. This is inverted: a field with an LDAP attribute mapping is owned by LDAP and should not be user-editable, while a field with no mapping is not sourced from LDAP and the user should be free to set it themselves.

Fixes profile fields being uneditable for all LDAP users whose admin has not configured attribute mappings for those fields.

Assisted-by: ClaudeCode:claude-sonnet-4-6

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
