### PR TITLE
fix(files): chunk filecache IN queries to respect Oracle's 1000-element limit

### DIFF
--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -81,11 +81,16 @@ class FileAccess implements IFileAccess {
 	 */
 	#[\Override]
 	public function getByFileIds(array $fileIds): array {
-		$query = $this->getQuery()->selectFileCache();
-		$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
-
-		$rows = $query->executeQuery()->fetchAll();
-		return $this->rowsToEntries($rows);
+		if (empty($fileIds)) {
+			return [];
+		}
+		$result = [];
+		foreach (array_chunk($fileIds, 1000) as $chunk) {
+			$query = $this->getQuery()->selectFileCache();
+			$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
+			$result += $this->rowsToEntries($query->executeQuery()->fetchAll());
+		}
+		return $result;
 	}
 
 	/**
@@ -95,13 +100,17 @@ class FileAccess implements IFileAccess {
 	 */
 	#[\Override]
 	public function getByFileIdsInStorage(array $fileIds, int $storageId): array {
-		$fileIds = array_values($fileIds);
-		$query = $this->getQuery()->selectFileCache();
-		$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
-		$query->andWhere($query->expr()->eq('filecache.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
-
-		$rows = $query->executeQuery()->fetchAll();
-		return $this->rowsToEntries($rows);
+		if (empty($fileIds)) {
+			return [];
+		}
+		$result = [];
+		foreach (array_chunk(array_values($fileIds), 1000) as $chunk) {
+			$query = $this->getQuery()->selectFileCache();
+			$query->andWhere($query->expr()->in('filecache.fileid', $query->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
+			$query->andWhere($query->expr()->eq('filecache.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
+			$result += $this->rowsToEntries($query->executeQuery()->fetchAll());
+		}
+		return $result;
 	}
 
 	#[\Override]

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -604,12 +604,7 @@ class SetupManager implements ISetupManager {
 					array_merge(...array_values($authoritativeCachedMounts)),
 				);
 
-				$rootsMetadata = [];
-				foreach (array_chunk($rootIds, 1000) as $chunk) {
-					foreach ($this->fileAccess->getByFileIds($chunk) as $id => $fileMetadata) {
-						$rootsMetadata[$id] = $fileMetadata;
-					}
-				}
+				$rootsMetadata = $this->fileAccess->getByFileIds($rootIds);
 				$this->setupMountProviderPaths[$mountPoint] = self::SETUP_WITH_CHILDREN;
 				foreach ($authoritativeCachedMounts as $providerClass => $cachedMounts) {
 					$providerArgs = array_values(array_filter(array_map(

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -303,6 +303,71 @@ class FileAccessTest extends TestCase {
 			->executeStatement();
 	}
 
+	public function testGetByFileIds(): void {
+		$result = $this->fileAccess->getByFileIds([1, 2, 3]);
+
+		$this->assertCount(3, $result);
+		$this->assertArrayHasKey(1, $result);
+		$this->assertArrayHasKey(2, $result);
+		$this->assertArrayHasKey(3, $result);
+	}
+
+	public function testGetByFileIdsWithEmptyArray(): void {
+		$result = $this->fileAccess->getByFileIds([]);
+		$this->assertCount(0, $result);
+	}
+
+	public function testGetByFileIdsWithNonExistentIds(): void {
+		$result = $this->fileAccess->getByFileIds([9998, 9999]);
+		$this->assertCount(0, $result);
+	}
+
+	public function testGetByFileIdsSpanningChunkBoundary(): void {
+		// 1001 IDs exceeds Oracle's 1000-element IN limit — verifies chunked queries return correct results
+		$ids = range(1, 1001);
+		$result = $this->fileAccess->getByFileIds($ids);
+
+		// Only fileids 1–7 exist in the test data
+		$this->assertCount(7, $result);
+		foreach (range(1, 7) as $id) {
+			$this->assertArrayHasKey($id, $result);
+		}
+	}
+
+	public function testGetByFileIdsInStorage(): void {
+		$result = $this->fileAccess->getByFileIdsInStorage([1, 2, 3], 1);
+
+		$this->assertCount(3, $result);
+		$this->assertArrayHasKey(1, $result);
+		$this->assertArrayHasKey(2, $result);
+		$this->assertArrayHasKey(3, $result);
+	}
+
+	public function testGetByFileIdsInStorageFiltersStorage(): void {
+		// fileids 6 and 7 belong to storage 2, not storage 1
+		$result = $this->fileAccess->getByFileIdsInStorage([1, 6, 7], 1);
+
+		$this->assertCount(1, $result);
+		$this->assertArrayHasKey(1, $result);
+	}
+
+	public function testGetByFileIdsInStorageWithEmptyArray(): void {
+		$result = $this->fileAccess->getByFileIdsInStorage([], 1);
+		$this->assertCount(0, $result);
+	}
+
+	public function testGetByFileIdsInStorageSpanningChunkBoundary(): void {
+		// 1001 IDs exceeds Oracle's 1000-element IN limit — verifies chunked queries return correct results
+		$ids = range(1, 1001);
+		$result = $this->fileAccess->getByFileIdsInStorage($ids, 1);
+
+		// fileids 1–5 are in storage 1; 6 and 7 are in storage 2
+		$this->assertCount(5, $result);
+		foreach (range(1, 5) as $id) {
+			$this->assertArrayHasKey($id, $result);
+		}
+	}
+
 	/**
 	 * Test fetching files by ancestor in storage.
 	 */


### PR DESCRIPTION
* Resolves: #

## Summary

Oracle raises ORA-01795 when an IN list exceeds 1000 elements. `getByFileIds` and `getByFileIdsInStorage` in `FileAccess` passed the full input array directly into a single IN clause with no upper bound.

`files_sharing/Updater::move()` collects all of a user's share node IDs across user, group, and room share types — without capping the count — before calling `getByFileIdsInStorage`. This is a realistic failure path for power users on Oracle.

Both methods are now chunked at 1000 elements per query with results merged, and an early return for empty input avoids issuing a vacuous IN query. Method signatures and return types are unchanged.

As a follow-up, the manual `array_chunk` loop in `SetupManager::setupForPath` that pre-chunked before calling `getByFileIds` is removed — it is now redundant since the method handles chunking itself.

## TODO

- [ ] Verify Oracle CI passes

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

Assisted-by: ClaudeCode:claude-sonnet-4-6