### PR TITLE
refactor: Use new IQueryBuilder::MAX_IN_PARAMETERS

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2988,7 +2988,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$deleteQuery = $this->db->getQueryBuilder();
 		$deleteQuery->delete('schedulingobjects')
 			->where($deleteQuery->expr()->in('id', $deleteQuery->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY));
-		foreach (array_chunk($ids, 1000) as $chunk) {
+		foreach (array_chunk($ids, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$deleteQuery->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$numDeleted += $deleteQuery->executeStatement();
 		}
@@ -3523,7 +3523,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		}
 
 		$this->atomic(function () use ($subscriptionId, $calendarObjectIds, $calendarObjectUris): void {
-			foreach (array_chunk($calendarObjectIds, 1000) as $chunk) {
+			foreach (array_chunk($calendarObjectIds, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 				$query = $this->db->getQueryBuilder();
 				$query->delete($this->dbObjectPropertiesTable)
 					->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))
@@ -3539,7 +3539,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 					->executeStatement();
 			}
 
-			foreach (array_chunk($calendarObjectUris, 1000) as $chunk) {
+			foreach (array_chunk($calendarObjectUris, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 				$query = $this->db->getQueryBuilder();
 				$query->delete('calendarchanges')
 					->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -1268,7 +1268,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createParameter('matches')));
 
-		foreach (array_chunk($matches, 1000) as $matchesChunk) {
+		foreach (array_chunk($matches, IQueryBuilder::MAX_IN_PARAMETERS) as $matchesChunk) {
 			$query->setParameter('matches', $matchesChunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$result = $query->executeQuery();
 			$cardResults[] = $result->fetchAllAssociative();

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -497,7 +497,7 @@ class CustomPropertiesBackend implements BackendInterface {
 		if (!empty($requestedProperties)) {
 			// request only a subset
 			$qb->andWhere($qb->expr()->in('propertyname', $qb->createParameter('requestedProperties')));
-			$chunks = array_chunk($requestedProperties, 1000);
+			$chunks = array_chunk($requestedProperties, IQueryBuilder::MAX_IN_PARAMETERS);
 			foreach ($chunks as $chunk) {
 				$qb->setParameter('requestedProperties', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 				$result = $qb->executeQuery();

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -35,7 +35,6 @@ use Psr\Log\LoggerInterface;
  */
 class SharesReminderJob extends TimedJob {
 	private const SECONDS_BEFORE_REMINDER = 24 * 60 * 60;
-	private const CHUNK_SIZE = 1000;
 	private int $folderMimeTypeId;
 
 	public function __construct(
@@ -131,7 +130,7 @@ class SharesReminderJob extends TimedJob {
 					$qb->expr()->isNull('f.fileid')
 				)
 			)
-			->setMaxResults(SharesReminderJob::CHUNK_SIZE);
+			->setMaxResults(IQueryBuilder::MAX_IN_PARAMETERS);
 
 		$shares = $qb->executeQuery()->fetchAllAssociative();
 		return array_map(fn ($share): array => [
@@ -178,7 +177,7 @@ class SharesReminderJob extends TimedJob {
 			'share_type' => (int)$share['share_type'],
 			'file_source' => (int)$share['file_source'],
 		], $shares);
-		return $this->filterSharesWithEmptyFolders($shares, self::CHUNK_SIZE);
+		return $this->filterSharesWithEmptyFolders($shares, IQueryBuilder::MAX_IN_PARAMETERS);
 	}
 
 	/**
@@ -193,7 +192,7 @@ class SharesReminderJob extends TimedJob {
 			->where($query->expr()->eq('size', $query->createNamedParameter(0), IQueryBuilder::PARAM_INT_ARRAY))
 			->andWhere($query->expr()->eq('mimetype', $query->createNamedParameter($this->folderMimeTypeId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->in('fileid', $query->createParameter('fileids')));
-		$chunks = array_chunk($shares, SharesReminderJob::CHUNK_SIZE);
+		$chunks = array_chunk($shares, IQueryBuilder::MAX_IN_PARAMETERS);
 		$results = [];
 		foreach ($chunks as $chunk) {
 			$chunkFileIds = array_map(fn ($share): int => $share['file_source'], $chunk);

--- a/apps/user_ldap/lib/Db/GroupMembershipMapper.php
+++ b/apps/user_ldap/lib/Db/GroupMembershipMapper.php
@@ -64,7 +64,7 @@ class GroupMembershipMapper extends QBMapper {
 		$query->delete($this->getTableName())
 			->where($query->expr()->in('groupid', $query->createParameter('groupids')));
 
-		foreach (array_chunk($removedGroups, 1000) as $removedGroupsChunk) {
+		foreach (array_chunk($removedGroups, IQueryBuilder::MAX_IN_PARAMETERS) as $removedGroupsChunk) {
 			$query->setParameter('groupids', $removedGroupsChunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$query->executeStatement();
 		}

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -703,7 +703,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$unreadComments = array_fill_keys($objectIds, 0);
-		foreach (array_chunk($objectIds, 1000) as $chunk) {
+		foreach (array_chunk($objectIds, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();

--- a/lib/private/DB/QueryBuilder/Sharded/CrossShardMoveHelper.php
+++ b/lib/private/DB/QueryBuilder/Sharded/CrossShardMoveHelper.php
@@ -85,7 +85,7 @@ class CrossShardMoveHelper {
 			->from($table)
 			->where($query->expr()->in($primaryColumn, $query->createParameter('keys')));
 
-		$chunks = array_chunk($primaryKeys, 1000);
+		$chunks = array_chunk($primaryKeys, IQueryBuilder::MAX_IN_PARAMETERS);
 
 		$results = [];
 		foreach ($chunks as $chunk) {
@@ -152,7 +152,7 @@ class CrossShardMoveHelper {
 		$query = $connection->getQueryBuilder();
 		$query->delete($table)
 			->where($query->expr()->in($primaryColumn, $query->createParameter('keys')));
-		$chunks = array_chunk($primaryKeys, 1000);
+		$chunks = array_chunk($primaryKeys, IQueryBuilder::MAX_IN_PARAMETERS);
 
 		foreach ($chunks as $chunk) {
 			$query->setParameter('keys', $chunk, IQueryBuilder::PARAM_INT_ARRAY);

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -619,7 +619,7 @@ class Cache implements ICache {
 				->where($query->expr()->in('fileid', $query->createParameter('childIds')))
 				->hintShardKey('storage', $this->getNumericStorageId());
 
-			foreach (array_chunk($childIds, 1000) as $childIdChunk) {
+			foreach (array_chunk($childIds, IQueryBuilder::MAX_IN_PARAMETERS) as $childIdChunk) {
 				$query->setParameter('childIds', $childIdChunk, IQueryBuilder::PARAM_INT_ARRAY);
 				$query->executeStatement();
 			}
@@ -645,13 +645,13 @@ class Cache implements ICache {
 		// Sorting before chunking allows the db to find the entries close to each
 		// other in the index
 		sort($parentIds, SORT_NUMERIC);
-		foreach (array_chunk($parentIds, 1000) as $parentIdChunk) {
+		foreach (array_chunk($parentIds, IQueryBuilder::MAX_IN_PARAMETERS) as $parentIdChunk) {
 			$query->setParameter('parentIds', $parentIdChunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$query->executeStatement();
 		}
 
 		$cacheEntryRemovedEvents = [];
-		foreach (array_chunk(array_combine($deletedIds, $deletedPaths), 1000) as $chunk) {
+		foreach (array_chunk(array_combine($deletedIds, $deletedPaths), IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			/** @var array<int, string> $chunk */
 			foreach ($chunk as $fileId => $filePath) {
 				$cacheEntryRemovedEvents[] = new CacheEntryRemovedEvent(
@@ -760,7 +760,7 @@ class Cache implements ICache {
 
 				$childIds = $this->getChildIds($sourceStorageId, $sourcePath);
 
-				$childChunks = array_chunk($childIds, 1000);
+				$childChunks = array_chunk($childIds, IQueryBuilder::MAX_IN_PARAMETERS);
 
 				$query = $this->getQueryBuilder();
 

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -206,7 +206,7 @@ class Propagator implements IPropagator {
 				// queries as a faster lookup than the path_hash
 				$hashes = array_map(static fn (array $a): string => $a['hash'], $this->batch);
 
-				foreach (array_chunk($hashes, 1000) as $hashesChunk) {
+				foreach (array_chunk($hashes, IQueryBuilder::MAX_IN_PARAMETERS) as $hashesChunk) {
 					$query = $this->connection->getQueryBuilder();
 					$result = $query->select('fileid', 'path', 'path_hash', 'size')
 						->from('filecache')

--- a/lib/private/Files/Cache/StorageGlobal.php
+++ b/lib/private/Files/Cache/StorageGlobal.php
@@ -45,7 +45,7 @@ class StorageGlobal {
 			->from('storages')
 			->where($builder->expr()->in('id', $builder->createParameter('ids'), IQueryBuilder::PARAM_STR_ARRAY));
 
-		foreach (array_chunk($storageIds, 1000) as $chunk) {
+		foreach (array_chunk($storageIds, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();

--- a/lib/private/Files/Search/QueryOptimizer/SplitLargeIn.php
+++ b/lib/private/Files/Search/QueryOptimizer/SplitLargeIn.php
@@ -9,6 +9,7 @@ namespace OC\Files\Search\QueryOptimizer;
 
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOperator;
@@ -22,9 +23,9 @@ class SplitLargeIn extends ReplacingOptimizerStep {
 		if (
 			$operator instanceof ISearchComparison
 			&& $operator->getType() === ISearchComparison::COMPARE_IN
-			&& count($operator->getValue()) > 1000
+			&& count($operator->getValue()) > IQueryBuilder::MAX_IN_PARAMETERS
 		) {
-			$chunks = array_chunk($operator->getValue(), 1000);
+			$chunks = array_chunk($operator->getValue(), IQueryBuilder::MAX_IN_PARAMETERS);
 			$chunkComparisons = array_map(function (array $values) use ($operator) {
 				return new SearchComparison(ISearchComparison::COMPARE_IN, $operator->getField(), $values, $operator->getExtra());
 			}, $chunks);

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -28,6 +28,7 @@ use OCA\Files_Sharing\ISharedMountPoint;
 use OCA\Files_Sharing\SharedMount;
 use OCP\App\IAppManager;
 use OCP\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IAuthoritativeMountProvider;
@@ -605,7 +606,7 @@ class SetupManager implements ISetupManager {
 				);
 
 				$rootsMetadata = [];
-				foreach (array_chunk($rootIds, 1000) as $chunk) {
+				foreach (array_chunk($rootIds, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 					foreach ($this->fileAccess->getByFileIds($chunk) as $id => $fileMetadata) {
 						$rootsMetadata[$id] = $fileMetadata;
 					}

--- a/lib/private/FilesMetadata/Service/IndexRequestService.php
+++ b/lib/private/FilesMetadata/Service/IndexRequestService.php
@@ -186,7 +186,7 @@ class IndexRequestService {
 	 * @throws DbException
 	 */
 	public function dropIndexForFiles(array $fileIds, string $key = ''): void {
-		$chunks = array_chunk($fileIds, 1000);
+		$chunks = array_chunk($fileIds, IQueryBuilder::MAX_IN_PARAMETERS);
 
 		foreach ($chunks as $chunk) {
 			$qb = $this->dbConnection->getQueryBuilder();

--- a/lib/private/FilesMetadata/Service/MetadataRequestService.php
+++ b/lib/private/FilesMetadata/Service/MetadataRequestService.php
@@ -150,7 +150,7 @@ class MetadataRequestService {
 	 * @throws Exception
 	 */
 	public function dropMetadataForFiles(int $storage, array $fileIds): void {
-		$chunks = array_chunk($fileIds, 1000);
+		$chunks = array_chunk($fileIds, IQueryBuilder::MAX_IN_PARAMETERS);
 
 		foreach ($chunks as $chunk) {
 			$qb = $this->dbConnection->getQueryBuilder();

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -342,7 +342,7 @@ class Database extends ABackend implements
 		$qb->select('gid', 'displayname')
 			->from('groups')
 			->where($qb->expr()->in('gid', $qb->createParameter('ids')));
-		foreach (array_chunk($notFoundGids, 1000) as $chunk) {
+		foreach (array_chunk($notFoundGids, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$qb->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $qb->executeQuery();
 			while ($row = $result->fetch()) {
@@ -553,7 +553,7 @@ class Database extends ABackend implements
 			}
 		}
 
-		foreach (array_chunk($notFoundGids, 1000) as $chunk) {
+		foreach (array_chunk($notFoundGids, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$query = $this->dbConn->getQueryBuilder();
 			$query->select('gid', 'displayname')
 				->from('groups')

--- a/lib/private/Preview/Storage/LocalPreviewStorage.php
+++ b/lib/private/Preview/Storage/LocalPreviewStorage.php
@@ -315,7 +315,7 @@ class LocalPreviewStorage implements IPreviewStorage {
 			->from('filecache')
 			->where($qb->expr()->in('fileid', $qb->createParameter('fileIds')))
 			->runAcrossAllShards();
-		foreach (array_chunk($fileIds, 1000) as $chunk) {
+		foreach (array_chunk($fileIds, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$qb->setParameter('fileIds', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$rows = $qb->executeQuery();
 			while ($row = $rows->fetchAssociative()) {
@@ -342,7 +342,7 @@ class LocalPreviewStorage implements IPreviewStorage {
 			->from('filecache')
 			->where($qb->expr()->in('path_hash', $qb->createParameter('pathHashes')))
 			->runAcrossAllShards();
-		foreach (array_chunk($pathHashes, 1000) as $chunk) {
+		foreach (array_chunk($pathHashes, IQueryBuilder::MAX_IN_PARAMETERS) as $chunk) {
 			$qb->setParameter('pathHashes', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 			$rows = $qb->executeQuery();
 			while ($row = $rows->fetchAssociative()) {

--- a/lib/private/Repair/RemoveBrokenProperties.php
+++ b/lib/private/Repair/RemoveBrokenProperties.php
@@ -51,7 +51,7 @@ class RemoveBrokenProperties implements IRepairStep {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete('properties')
 			->where($qb->expr()->in('id', $qb->createParameter('ids'), IQueryBuilder::PARAM_STR_ARRAY));
-		foreach (array_chunk($brokenIds, 1000) as $chunkIds) {
+		foreach (array_chunk($brokenIds, IQueryBuilder::MAX_IN_PARAMETERS) as $chunkIds) {
 			$qb->setParameter('ids', $chunkIds, IQueryBuilder::PARAM_STR_ARRAY);
 			$qb->executeStatement();
 		}

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -685,7 +685,7 @@ class DefaultShareProvider implements
 
 		$shares = [];
 
-		$chunks = array_chunk($childMountRootIds, 1000);
+		$chunks = array_chunk($childMountRootIds, IQueryBuilder::MAX_IN_PARAMETERS);
 
 		// Force the request to be run when there is 0 mount.
 		if (count($chunks) === 0) {

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -128,7 +128,7 @@ class TagManager implements ITagManager, IEventListener {
 		$qb1 = $qb1->delete('vcategory')
 			->where($qb1->expr()->in('uid', $qb1->createParameter('chunk')));
 
-		foreach (array_chunk($tagsIds, 1000) as $tagChunk) {
+		foreach (array_chunk($tagsIds, IQueryBuilder::MAX_IN_PARAMETERS) as $tagChunk) {
 			$qb->setParameter('chunk', $tagChunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$qb1->setParameter('chunk', $tagChunk, IQueryBuilder::PARAM_INT_ARRAY);
 			try {

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -121,6 +121,14 @@ interface IQueryBuilder {
 	public const MAX_ROW_DELETION = 100000;
 
 	/**
+	 * @since 35.0.0 Indicates how many parameters can be passed to a IN query
+	 * with Oracle database server.
+	 *
+	 * Mostly useful as magic value to give to array_chunk
+	 */
+	public const MAX_IN_PARAMETERS = 1000;
+
+	/**
 	 * Enable/disable automatic prefixing of table names with the oc_ prefix
 	 *
 	 * @param bool $enabled If set to true table names will be prefixed with the


### PR DESCRIPTION
## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
