### PR TITLE
fix: don't needlessly contrain join when the left side is allow to be null

### DIFF
--- a/lib/private/DB/QueryBuilder/Partitioned/PartitionedQueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/Partitioned/PartitionedQueryBuilder.php
@@ -38,7 +38,7 @@ use OCP\IDBConnection;
 class PartitionedQueryBuilder extends ShardedQueryBuilder {
 	/** @var array<string, PartitionQuery> $splitQueries */
 	private array $splitQueries = [];
-	/** @var list<PartitionSplit> */
+	/** @var array<string, PartitionSplit> */
 	private array $partitions = [];
 
 	/** @var array{'select': string|array, 'alias': ?string}[] */
@@ -180,7 +180,7 @@ class PartitionedQueryBuilder extends ShardedQueryBuilder {
 	}
 
 	public function addPartition(PartitionSplit $partition): void {
-		$this->partitions[] = $partition;
+		$this->partitions[$partition->name] = $partition;
 	}
 
 	private function getPartition(string $table): ?PartitionSplit {
@@ -264,7 +264,7 @@ class PartitionedQueryBuilder extends ShardedQueryBuilder {
 			if (!isset($this->splitQueries[$partitionName])) {
 				$newPartition = new PartitionSplit($partitionName, [$join]);
 				$newPartition->addAlias($join, $alias);
-				$this->partitions[] = $newPartition;
+				$this->partitions[$newPartition->name] = $newPartition;
 
 				$this->splitQueries[$partitionName] = new PartitionQuery(
 					$this->newQuery(),
@@ -349,11 +349,14 @@ class PartitionedQueryBuilder extends ShardedQueryBuilder {
 		if ($where) {
 			foreach ($this->splitPredicatesByParts($where) as $alias => $predicates) {
 				if (isset($this->splitQueries[$alias])) {
+					$mergedPredicate = new CompositeExpression(CompositeExpression::TYPE_AND, $predicates);
 					// when there is a condition on a table being left-joined it starts to behave as if it's an inner join
 					// since any joined column that doesn't have the left part will not match the condition
 					// when there the condition is `$joinToColumn IS NULL` we instead mark the query as excluding the left half
 					if ($this->splitQueries[$alias]->joinMode === PartitionQuery::JOIN_MODE_LEFT) {
-						$this->splitQueries[$alias]->joinMode = PartitionQuery::JOIN_MODE_INNER;
+						if ($this->constraintsPartitionNotNull($mergedPredicate, $this->partitions[$alias])) {
+							$this->splitQueries[$alias]->joinMode = PartitionQuery::JOIN_MODE_INNER;
+						}
 
 						$column = $this->quoteHelper->quoteColumnName($this->splitQueries[$alias]->joinToColumn);
 						foreach ($predicates as $predicate) {
@@ -372,6 +375,32 @@ class PartitionedQueryBuilder extends ShardedQueryBuilder {
 			}
 		}
 		return $this;
+	}
+
+	/**
+	 * Check if any part of a predicates constraints any part of a partition to be not null
+	 *
+	 * @return bool
+	 */
+	private function constraintsPartitionNotNull($predicate, PartitionSplit $partition): bool {
+		if ($predicate instanceof CompositeExpression) {
+			if ($predicate->getType() === CompositeExpression::TYPE_OR) {
+				$all = true;
+				foreach ($predicate->getParts() as $part) {
+					$all = $all && $this->constraintsPartitionNotNull($part, $partition);
+				}
+				return $all;
+			} else {
+				foreach ($predicate->getParts() as $part) {
+					if ($this->constraintsPartitionNotNull($part, $partition)) {
+						return true;
+					}
+				}
+				return false;
+			}
+		} else {
+			return $partition->checkPredicateForTable($predicate) && !str_ends_with($predicate, 'IS NULL');
+		}
 	}
 
 	private function getPartitionForPredicate(string $predicate): ?PartitionSplit {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Currently, the left side of a `LEFT JOIN` is constrained, we implicitly transform it into an `INNER JOIN`. With the reasoning being that a row needs to exist to satisfy the constraint.
However, the constrain might still allow unset rows by allowing `null` values in the constraint. For example in: [RuleManager::getRulesForFilesByParent](https://github.com/nextcloud/groupfolders/blob/afd30df004031dd2c2463bd17bb13b1389703eb8/lib/ACL/RuleManager.php#L152-L168)

This changes it to only do the transform to `INNER JOIN` if the constraint doesn't allow `null` rows.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
