### PR TITLE
refactor(files): reduce duplication in node copy/move and tidy Node internals

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -338,16 +338,10 @@ class Node implements INode {
 
 	#[\Override]
 	public function copy($targetPath) {
-		$targetPath = $this->normalizePath($targetPath);
-		$parent = $this->root->get(dirname($targetPath));
+		[$targetPath, $targetPlaceholder] = $this->prepareTargetPath($targetPath);
 
-		if (!($parent instanceof Folder) || !$this->isValidPath($targetPath) || !$parent->isCreatable()) {
-			throw new NotPermittedException('No permission to copy to path ' . $targetPath);
-		}
-
-		$nonExisting = $this->createNonExistingNode($targetPath);
-		$this->sendHooks(['preCopy'], [$this, $nonExisting]);
-		$this->sendHooks(['preWrite'], [$nonExisting]);
+		$this->sendHooks(['preCopy'], [$this, $targetPlaceholder]);
+		$this->sendHooks(['preWrite'], [$targetPlaceholder]);
 
 		if (!$this->view->copy($this->path, $targetPath)) {
 			throw new NotPermittedException('Could not copy ' . $this->path . ' to ' . $targetPath);
@@ -362,38 +356,16 @@ class Node implements INode {
 
 	#[\Override]
 	public function move($targetPath) {
-		$targetPath = $this->normalizePath($targetPath);
-		$parent = $this->root->get(dirname($targetPath));
+		[$targetPath, $targetPlaceholder] = $this->prepareTargetPath($targetPath, true);
 
-		$isRootMovable = $parent->getInternalPath() === '' && $parent->getMountPoint() instanceof IMovableMount;
-		$canCreateInFolder = $parent->isCreatable() || $isRootMovable;
-
-		if (!($parent instanceof Folder) || !$this->isValidPath($targetPath) || !$canCreateInFolder) {
-    		throw new NotPermittedException('No permission to move to path ' . $targetPath);
-		}
-
-		$nonExisting = $this->createNonExistingNode($targetPath);
-		$this->sendHooks(['preRename'], [$this, $nonExisting]);
-		$this->sendHooks(['preWrite'], [$nonExisting]);
+		$this->sendHooks(['preRename'], [$this, $targetPlaceholder]);
+		$this->sendHooks(['preWrite'], [$targetPlaceholder]);
 
 		if (!$this->view->rename($this->path, $targetPath)) {
 			throw new NotPermittedException('Could not move ' . $this->path . ' to ' . $targetPath);
 		}
 
-		$mountPoint = $this->getMountPoint();
-		if ($mountPoint) {
-			// update the cached fileinfo with the new (internal) path
-			/** @var \OC\Files\FileInfo $oldFileInfo */
-			$oldFileInfo = $this->getFileInfo();
-			$this->fileInfo = new \OC\Files\FileInfo(
-				$targetPath,
-				$oldFileInfo->getStorage(),
-				$mountPoint->getInternalPath($targetPath),
-				$oldFileInfo->getData(),
-				$mountPoint, 
-				$oldFileInfo->getOwner()
-			);
-		}
+		$this->updateCachedFileInfoAfterMove($targetPath);
 
 		$targetNode = $this->root->get($targetPath);
 		$this->sendHooks(['postRename'], [$this, $targetNode]);
@@ -401,6 +373,53 @@ class Node implements INode {
 		$this->path = $targetPath;
 
 		return $targetNode;
+	}
+
+	private function prepareTargetPath(string $targetPath, bool $allowRootMovable = false): array {
+		$targetPath = $this->normalizePath($targetPath);
+		$targetParent = $this->root->get(dirname($targetPath));
+
+		if (!($targetParent instanceof Folder)) {
+			throw new NotPermittedException('Target parent is not a folder: ' . dirname($targetPath));
+		}
+
+		if (!$this->isValidPath($targetPath)) {
+			throw new NotPermittedException('Invalid target path: ' . $targetPath);
+		}
+
+		$isMovableRootMountTarget = $allowRootMovable
+			&& $targetParent->getInternalPath() === ''
+			&& $targetParent->getMountPoint() instanceof IMovableMount;
+
+		$canWriteToTargetParent = $targetParent->isCreatable() || $isMovableRootMountTarget;
+
+		if (!$canWriteToTargetParent) {
+			throw new NotPermittedException('No permission to write to path ' . $targetPath);
+		}
+
+		return [
+			$targetPath,
+			$this->createNonExistingNode($targetPath),
+		];
+	}
+	
+	private function updateCachedFileInfoAfterMove(string $targetPath): void {
+		$mountPoint = $this->getMountPoint();
+		if (!$mountPoint) {
+			return;
+		}
+
+		// update the cached fileinfo with the new (internal) path
+		/** @var \OC\Files\FileInfo $oldFileInfo */
+		$oldFileInfo = $this->getFileInfo();
+		$this->fileInfo = new \OC\Files\FileInfo(
+			$targetPath,
+			$oldFileInfo->getStorage(),
+			$mountPoint->getInternalPath($targetPath),
+			$oldFileInfo->getData(),
+			$mountPoint,
+			$oldFileInfo->getOwner()
+		);
 	}
 
 	#[\Override]

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -22,7 +22,6 @@ use OCP\Files\Mount\IMovableMount;
 use OCP\Files\Node as INode;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
-use OCP\Lock\LockedException;
 use OCP\PreConditionNotMetException;
 use OCP\Server;
 
@@ -402,7 +401,7 @@ class Node implements INode {
 			$this->createNonExistingNode($targetPath),
 		];
 	}
-	
+
 	private function updateCachedFileInfoAfterMove(string $targetPath): void {
 		$mountPoint = $this->getMountPoint();
 		if (!$mountPoint) {

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -336,13 +336,6 @@ class Node implements INode {
 		$this->view->unlockFile($this->path, $type);
 	}
 
-	/**
-	 * @param string $targetPath
-	 * @return INode
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 * @throws NotPermittedException if copy not allowed or failed
-	 */
 	#[\Override]
 	public function copy($targetPath) {
 		$targetPath = $this->normalizePath($targetPath);
@@ -367,14 +360,6 @@ class Node implements INode {
 		return $targetNode;
 	}
 
-	/**
-	 * @param string $targetPath
-	 * @return INode
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 * @throws NotPermittedException if move not allowed or failed
-	 * @throws LockedException
-	 */
 	#[\Override]
 	public function move($targetPath) {
 		$targetPath = $this->normalizePath($targetPath);
@@ -438,10 +423,6 @@ class Node implements INode {
 		return $this->fileInfo->getParentId();
 	}
 
-	/**
-	 * @inheritDoc
-	 * @return array<string, int|string|bool|float|string[]|int[]>
-	 */
 	#[\Override]
 	public function getMetadata(): array {
 		return $this->fileInfo->getMetadata();

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -28,32 +28,19 @@ use OCP\Server;
 
 // FIXME: this class really should be abstract (+1)
 class Node implements INode {
-	/**
-	 * @var View $view
-	 */
-	protected $view;
-
-	protected IRootFolder $root;
-
-	/**
-	 * @param View $view
-	 * @param \OCP\Files\IRootFolder $root
-	 * @param string $path
-	 * @param FileInfo $fileInfo
-	 */
 	public function __construct(
-		IRootFolder $root,
-		$view,
+		protected IRootFolder $root,
+		protected View $view,
 		protected $path,
 		protected ?FileInfo $fileInfo = null,
 		protected ?INode $parent = null,
 		private bool $infoHasSubMountsIncluded = true,
 	) {
 		if (Filesystem::normalizePath($view->getRoot()) !== '/') {
-			throw new PreConditionNotMetException('The view passed to the node should not have any fake root set');
+			throw new PreConditionNotMetException(
+				'The view passed to the node should not have any fake root set'
+			);
 		}
-		$this->view = $view;
-		$this->root = $root;
 	}
 
 	/**
@@ -73,6 +60,8 @@ class Node implements INode {
 	 * @return FileInfo
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
+	 *
+	 * @internal
 	 */
 	public function getFileInfo(bool $includeMountPoint = true) {
 		if (!$this->fileInfo) {
@@ -131,12 +120,6 @@ class Node implements INode {
 	public function delete() {
 	}
 
-	/**
-	 * @param int $mtime
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 * @throws NotPermittedException
-	 */
 	#[\Override]
 	public function touch($mtime = null) {
 		if ($this->checkPermissions(Constants::PERMISSION_UPDATE)) {
@@ -163,123 +146,67 @@ class Node implements INode {
 		return $storage;
 	}
 
-	/**
-	 * @return string
-	 */
 	#[\Override]
 	public function getPath() {
 		return $this->path;
 	}
 
-	/**
-	 * @return string
-	 */
 	#[\Override]
 	public function getInternalPath() {
 		return $this->getFileInfo(false)->getInternalPath();
 	}
 
-	/**
-	 * @return int
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function getId() {
 		return $this->getFileInfo(false)->getId() ?? -1;
 	}
 
-	/**
-	 * @return array
-	 */
 	#[\Override]
 	public function stat() {
 		return $this->view->stat($this->path);
 	}
 
-	/**
-	 * @return int
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function getMTime() {
 		return $this->getFileInfo()->getMTime();
 	}
 
-	/**
-	 * @param bool $includeMounts
-	 * @return int|float
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function getSize($includeMounts = true): int|float {
 		return $this->getFileInfo()->getSize($includeMounts);
 	}
 
-	/**
-	 * @return string
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function getEtag() {
 		return $this->getFileInfo()->getEtag();
 	}
 
-	/**
-	 * @return int
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function getPermissions() {
 		return $this->getFileInfo(false)->getPermissions();
 	}
 
-	/**
-	 * @return bool
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function isReadable() {
 		return $this->getFileInfo(false)->isReadable();
 	}
 
-	/**
-	 * @return bool
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function isUpdateable() {
 		return $this->getFileInfo(false)->isUpdateable();
 	}
 
-	/**
-	 * @return bool
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function isDeletable() {
 		return $this->getFileInfo(false)->isDeletable();
 	}
 
-	/**
-	 * @return bool
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 */
 	#[\Override]
 	public function isShareable() {
 		return $this->getFileInfo(false)->isShareable();
 	}
 
 	/**
-	 * @return bool
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
@@ -320,9 +247,6 @@ class Node implements INode {
 		return $this->parent;
 	}
 
-	/**
-	 * @return string
-	 */
 	#[\Override]
 	public function getName() {
 		return basename($this->path);
@@ -341,6 +265,8 @@ class Node implements INode {
 	 *
 	 * @param string $path
 	 * @return bool
+	 *
+	 * @internal
 	 */
 	public function isValidPath($path) {
 		return Filesystem::isValidPath($path);
@@ -395,28 +321,16 @@ class Node implements INode {
 		return $this->getFileInfo(false)->getExtension();
 	}
 
-	/**
-	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
-	 * @throws LockedException
-	 */
 	#[\Override]
 	public function lock($type) {
 		$this->view->lockFile($this->path, $type);
 	}
 
-	/**
-	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
-	 * @throws LockedException
-	 */
 	#[\Override]
 	public function changeLock($type) {
 		$this->view->changeLock($this->path, $type);
 	}
 
-	/**
-	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
-	 * @throws LockedException
-	 */
 	#[\Override]
 	public function unlock($type) {
 		$this->view->unlockFile($this->path, $type);
@@ -433,20 +347,24 @@ class Node implements INode {
 	public function copy($targetPath) {
 		$targetPath = $this->normalizePath($targetPath);
 		$parent = $this->root->get(dirname($targetPath));
-		if ($parent instanceof Folder && $this->isValidPath($targetPath) && $parent->isCreatable()) {
-			$nonExisting = $this->createNonExistingNode($targetPath);
-			$this->sendHooks(['preCopy'], [$this, $nonExisting]);
-			$this->sendHooks(['preWrite'], [$nonExisting]);
-			if (!$this->view->copy($this->path, $targetPath)) {
-				throw new NotPermittedException('Could not copy ' . $this->path . ' to ' . $targetPath);
-			}
-			$targetNode = $this->root->get($targetPath);
-			$this->sendHooks(['postCopy'], [$this, $targetNode]);
-			$this->sendHooks(['postWrite'], [$targetNode]);
-			return $targetNode;
-		} else {
+
+		if (!($parent instanceof Folder) || !$this->isValidPath($targetPath) || !$parent->isCreatable()) {
 			throw new NotPermittedException('No permission to copy to path ' . $targetPath);
 		}
+
+		$nonExisting = $this->createNonExistingNode($targetPath);
+		$this->sendHooks(['preCopy'], [$this, $nonExisting]);
+		$this->sendHooks(['preWrite'], [$nonExisting]);
+
+		if (!$this->view->copy($this->path, $targetPath)) {
+			throw new NotPermittedException('Could not copy ' . $this->path . ' to ' . $targetPath);
+		}
+
+		$targetNode = $this->root->get($targetPath);
+		$this->sendHooks(['postCopy'], [$this, $targetNode]);
+		$this->sendHooks(['postWrite'], [$targetNode]);
+
+		return $targetNode;
 	}
 
 	/**
@@ -461,40 +379,43 @@ class Node implements INode {
 	public function move($targetPath) {
 		$targetPath = $this->normalizePath($targetPath);
 		$parent = $this->root->get(dirname($targetPath));
-		if (
-			($parent instanceof Folder)
-			&& $this->isValidPath($targetPath)
-			&& (
-				$parent->isCreatable()
-				|| (
-					$parent->getInternalPath() === ''
-					&& ($parent->getMountPoint() instanceof IMovableMount)
-				)
-			)
-		) {
-			$nonExisting = $this->createNonExistingNode($targetPath);
-			$this->sendHooks(['preRename'], [$this, $nonExisting]);
-			$this->sendHooks(['preWrite'], [$nonExisting]);
-			if (!$this->view->rename($this->path, $targetPath)) {
-				throw new NotPermittedException('Could not move ' . $this->path . ' to ' . $targetPath);
-			}
 
-			$mountPoint = $this->getMountPoint();
-			if ($mountPoint) {
-				// update the cached fileinfo with the new (internal) path
-				/** @var \OC\Files\FileInfo $oldFileInfo */
-				$oldFileInfo = $this->getFileInfo();
-				$this->fileInfo = new \OC\Files\FileInfo($targetPath, $oldFileInfo->getStorage(), $mountPoint->getInternalPath($targetPath), $oldFileInfo->getData(), $mountPoint, $oldFileInfo->getOwner());
-			}
+		$isRootMovable = $parent->getInternalPath() === '' && $parent->getMountPoint() instanceof IMovableMount;
+		$canCreateInFolder = $parent->isCreatable() || $isRootMovable;
 
-			$targetNode = $this->root->get($targetPath);
-			$this->sendHooks(['postRename'], [$this, $targetNode]);
-			$this->sendHooks(['postWrite'], [$targetNode]);
-			$this->path = $targetPath;
-			return $targetNode;
-		} else {
-			throw new NotPermittedException('No permission to move to path ' . $targetPath);
+		if (!($parent instanceof Folder) || !$this->isValidPath($targetPath) || !$canCreateInFolder) {
+    		throw new NotPermittedException('No permission to move to path ' . $targetPath);
 		}
+
+		$nonExisting = $this->createNonExistingNode($targetPath);
+		$this->sendHooks(['preRename'], [$this, $nonExisting]);
+		$this->sendHooks(['preWrite'], [$nonExisting]);
+
+		if (!$this->view->rename($this->path, $targetPath)) {
+			throw new NotPermittedException('Could not move ' . $this->path . ' to ' . $targetPath);
+		}
+
+		$mountPoint = $this->getMountPoint();
+		if ($mountPoint) {
+			// update the cached fileinfo with the new (internal) path
+			/** @var \OC\Files\FileInfo $oldFileInfo */
+			$oldFileInfo = $this->getFileInfo();
+			$this->fileInfo = new \OC\Files\FileInfo(
+				$targetPath,
+				$oldFileInfo->getStorage(),
+				$mountPoint->getInternalPath($targetPath),
+				$oldFileInfo->getData(),
+				$mountPoint, 
+				$oldFileInfo->getOwner()
+			);
+		}
+
+		$targetNode = $this->root->get($targetPath);
+		$this->sendHooks(['postRename'], [$this, $targetNode]);
+		$this->sendHooks(['postWrite'], [$targetNode]);
+		$this->path = $targetPath;
+
+		return $targetNode;
 	}
 
 	#[\Override]

--- a/lib/public/Files/Node.php
+++ b/lib/public/Files/Node.php
@@ -48,6 +48,9 @@ interface Node extends FileInfo {
 	 *
 	 * @param string $targetPath the absolute target path
 	 * @return Node
+	 * @throws InvalidPathException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException if copy not allowed or failed
 	 * @since 6.0.0
 	 */
 	public function copy($targetPath);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Clean up `OC\Files\Node\Node` by extracting shared copy/move target-path logic, isolating move-specific cache updates, and simplifying related property/docblock structure.

## Changes

For `copy()` / `move()`:

* more precise variable naming
* extract common copy/move target preparation into `prepareTargetPath()`
* move cached file info refresh after rename into `updateCachedFileInfoAfterMove()`
* keep `copy()` / `move()` focused on operation-specific behavior and hooks
* retain special handling for movable root mount targets during `move()`
* distinct messaging for different `NotPermittedException` scenarios

Misc:

* convert `root` and `view` to promoted properties
* remove redundant/inherited docblocks in `Node`
* add `@internal` annotations to `getFileInfo()` and `isValidPath()`
* add missing `@throws` documentation for `OCP\Files\Node::copy()`

## Notes

This reduces duplication in copy/move handling, makes the control flow in `Node` easier to follow, and cleans up surrounding type/documentation noise without intending to change behavior.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
