### PR TITLE
fix: harden object store against copying a file to itself

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -734,11 +734,11 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 				$this->copyInner($sourceCache, $child, $to . '/' . $child->getName());
 			}
 		} else {
-			$this->copyFile($sourceEntry, $to);
+			$this->copyFile($sourceCache, $sourceEntry, $to);
 		}
 	}
 
-	private function copyFile(ICacheEntry $sourceEntry, string $to) {
+	private function copyFile(ICache $sourceCache, ICacheEntry $sourceEntry, string $to) {
 		$cache = $this->getCache();
 
 		$sourceUrn = $this->getURN($sourceEntry->getId());
@@ -747,7 +747,7 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 			throw new \Exception('Invalid source cache for object store copy');
 		}
 
-		$targetId = $cache->copyFromCache($cache, $sourceEntry, $to);
+		$targetId = $cache->copyFromCache($sourceCache, $sourceEntry, $to);
 
 		$targetUrn = $this->getURN($targetId);
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -749,6 +749,18 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 
 		$targetId = $cache->copyFromCache($sourceCache, $sourceEntry, $to);
 
+		if ($targetId === $sourceEntry->getId()) {
+			// copying a file to itself? No need to do anything
+			$e = new \Exception('Object ' . $sourceEntry->getPath() . ' (' . $sourceEntry->getId() . ') being copied to itself');
+			if ($sourceEntry instanceof CacheEntry) {
+				$sourceData = $sourceEntry->getData();
+			} else {
+				$sourceData = null;
+			}
+			$this->logger->warning($e->getMessage(), ['exception' => $e, 'source' => $sourceData]);
+			return;
+		}
+
 		$targetUrn = $this->getURN($targetId);
 
 		try {


### PR DESCRIPTION
## Summary

Trying to copy an object to itself, will result in an error, which triggers removing the object.

Since a self-copy is a noop, we just return early and log a warning (with backtrace) to try and narrow down the cause.

Includes a bonus fix for passing the correct source cache to `$cache->copyFromCache`, I don't think this actually matters here. Since the source cache is primarily used for getting the folder contents, and we're always dealing with a file here.
But ensuring correctness here could prevent future issues.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
