### PR TITLE
chore: fix SearchBinaryOperator constructor type hint

### DIFF
--- a/lib/private/Files/Search/SearchBinaryOperator.php
+++ b/lib/private/Files/Search/SearchBinaryOperator.php
@@ -13,13 +13,13 @@ use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchOperator;
 
 class SearchBinaryOperator implements ISearchBinaryOperator {
-	private $hints = [];
+	private array $hints = [];
 
 	/**
 	 * SearchBinaryOperator constructor.
 	 *
 	 * @param string $type
-	 * @param (SearchBinaryOperator|SearchComparison)[] $arguments
+	 * @param ISearchOperator[] $arguments
 	 */
 	public function __construct(
 		private $type,
@@ -62,6 +62,7 @@ class SearchBinaryOperator implements ISearchBinaryOperator {
 	}
 
 	public function __toString(): string {
+		/** @var (SearchBinaryOperator|SearchComparison)[] $this->arguments */
 		if ($this->type === ISearchBinaryOperator::OPERATOR_NOT) {
 			return '(not ' . $this->arguments[0] . ')';
 		}


### PR DESCRIPTION
## Summary

Use the common interface instead of concrete types.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
