### PR TITLE
fix(preview): First cleanup from filecache and then from preview table

### DIFF
--- a/core/BackgroundJobs/PreviewMigrationJob.php
+++ b/core/BackgroundJobs/PreviewMigrationJob.php
@@ -19,6 +19,7 @@ use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use Override;
+use Psr\Log\LoggerInterface;
 
 class PreviewMigrationJob extends TimedJob {
 	private string $previewRootPath;
@@ -30,6 +31,7 @@ class PreviewMigrationJob extends TimedJob {
 		private readonly IDBConnection $connection,
 		private readonly IRootFolder $rootFolder,
 		private readonly PreviewMigrationService $migrationService,
+		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct($time);
 
@@ -95,11 +97,23 @@ class PreviewMigrationJob extends TimedJob {
 		}
 
 		foreach ($fileIds as $fileId) {
-			$this->migrationService->migrateFileId($fileId, flatPath: false);
+			try {
+				$this->migrationService->migrateFileId($fileId, flatPath: false);
+			} catch (\Exception $e) {
+				$this->logger->error('Failed to migrate preview with fileId: ' . $fileId . ' (hierarchical file structure)', [
+					'exception' => $e,
+				]);
+			}
 		}
 
 		foreach ($flatFileIds as $fileId) {
-			$this->migrationService->migrateFileId($fileId, flatPath: true);
+			try {
+				$this->migrationService->migrateFileId($fileId, flatPath: true);
+			} catch (\Exception $e) {
+				$this->logger->error('Failed to migrate preview with fileId: ' . $fileId . ' (legacy file structure)', [
+					'exception' => $e,
+				]);
+			}
 		}
 		return $foundPreview;
 	}

--- a/core/BackgroundJobs/PreviewMigrationJob.php
+++ b/core/BackgroundJobs/PreviewMigrationJob.php
@@ -51,10 +51,14 @@ class PreviewMigrationJob extends TimedJob {
 			$qb = $this->connection->getQueryBuilder();
 			$qb->select('path')
 				->from('filecache')
-				// Hierarchical preview folder structure
-				->where($qb->expr()->like('path', $qb->createNamedParameter($this->previewRootPath . '%/%/%/%/%/%/%/%/%')))
-				// Legacy flat preview folder structure
-				->orWhere($qb->expr()->like('path', $qb->createNamedParameter($this->previewRootPath . '%/%.%')))
+				->where($qb->expr()->orX(
+					// Hierarchical preview folder structure
+					$qb->expr()->like('path', $qb->createNamedParameter($this->previewRootPath . '%/%/%/%/%/%/%/%/%')),
+					// Legacy flat preview folder structure
+					$qb->expr()->like('path', $qb->createNamedParameter($this->previewRootPath . '%/%.%'))
+				))->andWhere(
+					$qb->expr()->eq('storage', $qb->createNamedParameter($this->rootFolder->getMountPoint()->getNumericStorageId()))
+				)
 				->hintShardKey('storage', $this->rootFolder->getMountPoint()->getNumericStorageId())
 				->setMaxResults(100);
 

--- a/core/Command/Preview/Cleanup.php
+++ b/core/Command/Preview/Cleanup.php
@@ -102,16 +102,6 @@ class Cleanup extends Base {
 			return 1;
 		}
 
-		try {
-			$appDataFolder->newFolder('preview');
-			$this->logger->debug('Preview folder recreated');
-			$output->writeln('Preview folder recreated', OutputInterface::VERBOSITY_VERBOSE);
-		} catch (NotPermittedException $e) {
-			$output->writeln("Preview folder was deleted, but you don't have the permission to create preview folder");
-			$this->logger->error("Preview folder was deleted, but you don't have the permission to create preview folder", ['exception' => $e]);
-			return 1;
-		}
-
 		$output->writeln('Previews removed');
 		return 0;
 	}

--- a/core/Command/Preview/Cleanup.php
+++ b/core/Command/Preview/Cleanup.php
@@ -39,11 +39,11 @@ class Cleanup extends Base {
 
 	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		if ($this->deletePreviewFromPreviewTable($output) !== 0) {
+		if ($this->deletePreviewFromFileCacheTable($output) !== 0) {
 			return 1;
 		}
 
-		return $this->deletePreviewFromFileCacheTable($output);
+		return $this->deletePreviewFromPreviewTable($output);
 	}
 
 	/**

--- a/core/Command/Preview/Cleanup.php
+++ b/core/Command/Preview/Cleanup.php
@@ -77,9 +77,8 @@ class Cleanup extends Base {
 			$previewFolder = $appDataFolder->get('preview');
 
 		} catch (NotFoundException $e) {
-			$this->logger->error("Previews can't be removed: appdata folder can't be found", ['exception' => $e]);
-			$output->writeln("Previews can't be removed: preview folder isn't deletable");
-			return 1;
+			$this->logger->info("Legacy previews can't be removed: appdata folder can't be found", ['exception' => $e]);
+			return 0;
 		}
 
 		if (!$previewFolder->isDeletable()) {

--- a/lib/private/Preview/PreviewMigrationService.php
+++ b/lib/private/Preview/PreviewMigrationService.php
@@ -109,9 +109,10 @@ class PreviewMigrationService {
 				try {
 					$preview = $this->previewMapper->insert($preview);
 				} catch (Exception) {
+					$delete = $this->connection->getQueryBuilder();
 					// We already have this preview in the preview table, skip
-					$qb->delete('filecache')
-						->where($qb->expr()->eq('fileid', $qb->createNamedParameter($file->getId())))
+					$delete->delete('filecache')
+						->where($delete->expr()->eq('fileid', $delete->createNamedParameter($file->getId())))
 						->hintShardKey('storage', $this->rootFolder->getMountPoint()->getNumericStorageId())
 						->executeStatement();
 					continue;

--- a/lib/private/Preview/PreviewMigrationService.php
+++ b/lib/private/Preview/PreviewMigrationService.php
@@ -93,8 +93,9 @@ class PreviewMigrationService {
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)))
 			->setMaxResults(1);
 
-		$result = $qb->executeQuery();
-		$result = $result->fetchAssociative();
+		$cursor = $qb->executeQuery();
+		$result = $cursor->fetchAssociative();
+		$cursor->closeCursor();
 
 		if ($result !== false) {
 			foreach ($previewFiles as $previewFile) {
@@ -108,7 +109,11 @@ class PreviewMigrationService {
 				$preview->generateId();
 				try {
 					$preview = $this->previewMapper->insert($preview);
-				} catch (Exception) {
+				} catch (Exception $e) {
+					if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+						throw $e;
+					}
+
 					$delete = $this->connection->getQueryBuilder();
 					// We already have this preview in the preview table, skip
 					$delete->delete('filecache')
@@ -180,7 +185,11 @@ class PreviewMigrationService {
 				break;
 			}
 
-			$folder = $this->appData->getFolder($current);
+			try {
+				$folder = $this->appData->getFolder($current);
+			} catch (NotFoundException) {
+				break;
+			}
 			if (count($folder->getDirectoryListing()) !== 0) {
 				break;
 			}

--- a/lib/public/Migration/Attributes/IndexMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/IndexMigrationAttribute.php
@@ -12,7 +12,7 @@ namespace OCP\Migration\Attributes;
 use OCP\AppFramework\Attribute\Consumable;
 
 /**
- * generic class related to migration attribute about index changes
+ * Generic class related to migration attribute about index changes
  */
 #[Consumable(since: '30.0.0')]
 class IndexMigrationAttribute extends MigrationAttribute {
@@ -20,7 +20,7 @@ class IndexMigrationAttribute extends MigrationAttribute {
 	 * @param string $table name of the database table
 	 * @param IndexType|null $type type of the index
 	 * @param string $description description of the migration
-	 * @param array $notes notes abour the migration/index
+	 * @param array $notes notes about the migration/index
 	 * @since 30.0.0
 	 */
 	public function __construct(

--- a/tests/Core/Command/Preview/CleanupTest.php
+++ b/tests/Core/Command/Preview/CleanupTest.php
@@ -81,8 +81,6 @@ class CleanupTest extends TestCase {
 	}
 
 	public function testCleanupWhenNotDeletable(): void {
-		$this->previewService->expects($this->once())->method('deleteAll');
-
 		$previewFolder = $this->createMock(Folder::class);
 		$previewFolder->expects($this->once())
 			->method('isDeletable')
@@ -112,8 +110,6 @@ class CleanupTest extends TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestCleanupWithDeleteException')]
 	public function testCleanupWithDeleteException(string $exceptionClass, string $errorMessage): void {
-		$this->previewService->expects($this->once())->method('deleteAll');
-
 		$previewFolder = $this->createMock(Folder::class);
 		$previewFolder->expects($this->once())
 			->method('isDeletable')
@@ -150,8 +146,6 @@ class CleanupTest extends TestCase {
 	}
 
 	public function testCleanupWithCreateException(): void {
-		$this->previewService->expects($this->once())->method('deleteAll');
-
 		$previewFolder = $this->createMock(Folder::class);
 		$previewFolder->expects($this->once())
 			->method('isDeletable')
@@ -188,13 +182,40 @@ class CleanupTest extends TestCase {
 	}
 
 	public function testCleanupWithPreviewServiceException(): void {
+		$previewFolder = $this->createMock(Folder::class);
+		$previewFolder->expects($this->once())
+			->method('isDeletable')
+			->willReturn(true);
+
+		$previewFolder->expects($this->once())
+			->method('delete');
+
+		$appDataFolder = $this->createMock(Folder::class);
+		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
+		$appDataFolder->expects($this->once())->method('newFolder')->with('preview');
+
+		$this->rootFolder->method('getAppDataDirectoryName')
+			->willReturn('appdata_some_id');
+
+		$this->rootFolder->method('get')
+			->with('appdata_some_id')
+			->willReturn($appDataFolder);
+
+		$this->output->expects($this->exactly(3))->method('writeln')
+			->with(self::callback(function (string $message): bool {
+				static $i = 0;
+				return match (++$i) {
+					1 => $message === 'Preview folder deleted',
+					2 => $message === 'Preview folder recreated',
+					3 => $message === 'Previews removed'
+				};
+			}));
+
+		$this->assertEquals(0, $this->repair->run($this->input, $this->output));
 		$this->previewService->expects($this->once())->method('deleteAll')
 			->willThrowException(new NotPermittedException('abc'));
 
 		$this->logger->expects($this->once())->method('error')->with("Previews can't be removed: exception occurred: abc");
-
-		$this->rootFolder->expects($this->never())
-			->method('get');
 
 		$this->assertEquals(1, $this->repair->run($this->input, $this->output));
 	}

--- a/tests/Core/Command/Preview/CleanupTest.php
+++ b/tests/Core/Command/Preview/CleanupTest.php
@@ -56,7 +56,6 @@ class CleanupTest extends TestCase {
 
 		$appDataFolder = $this->createMock(Folder::class);
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->once())->method('newFolder')->with('preview');
 
 		$this->rootFolder->expects($this->once())
 			->method('getAppDataDirectoryName')
@@ -67,13 +66,12 @@ class CleanupTest extends TestCase {
 			->with('appdata_some_id')
 			->willReturn($appDataFolder);
 
-		$this->output->expects($this->exactly(3))->method('writeln')
+		$this->output->expects($this->exactly(2))->method('writeln')
 			->with(self::callback(function (string $message): bool {
 				static $i = 0;
 				return match (++$i) {
 					1 => $message === 'Preview folder deleted',
-					2 => $message === 'Preview folder recreated',
-					3 => $message === 'Previews removed'
+					2 => $message === 'Previews removed'
 				};
 			}));
 
@@ -91,7 +89,6 @@ class CleanupTest extends TestCase {
 
 		$appDataFolder = $this->createMock(Folder::class);
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->never())->method('newFolder')->with('preview');
 
 		$this->rootFolder->expects($this->once())
 			->method('getAppDataDirectoryName')
@@ -121,7 +118,6 @@ class CleanupTest extends TestCase {
 
 		$appDataFolder = $this->createMock(Folder::class);
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->never())->method('newFolder')->with('preview');
 
 		$this->rootFolder->expects($this->once())
 			->method('getAppDataDirectoryName')
@@ -145,42 +141,6 @@ class CleanupTest extends TestCase {
 		];
 	}
 
-	public function testCleanupWithCreateException(): void {
-		$previewFolder = $this->createMock(Folder::class);
-		$previewFolder->expects($this->once())
-			->method('isDeletable')
-			->willReturn(true);
-
-		$previewFolder->expects($this->once())
-			->method('delete');
-
-		$appDataFolder = $this->createMock(Folder::class);
-		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->once())->method('newFolder')->with('preview')->willThrowException(new NotPermittedException());
-
-		$this->rootFolder->expects($this->once())
-			->method('getAppDataDirectoryName')
-			->willReturn('appdata_some_id');
-
-		$this->rootFolder->expects($this->once())
-			->method('get')
-			->with('appdata_some_id')
-			->willReturn($appDataFolder);
-
-		$this->output->expects($this->exactly(2))->method('writeln')
-			->with(self::callback(function (string $message): bool {
-				static $i = 0;
-				return match (++$i) {
-					1 => $message === 'Preview folder deleted',
-					2 => $message === "Preview folder was deleted, but you don't have the permission to create preview folder",
-				};
-			}));
-
-		$this->logger->expects($this->once())->method('error')->with("Preview folder was deleted, but you don't have the permission to create preview folder");
-
-		$this->assertEquals(1, $this->repair->run($this->input, $this->output));
-	}
-
 	public function testCleanupWithPreviewServiceException(): void {
 		$previewFolder = $this->createMock(Folder::class);
 		$previewFolder->expects($this->once())
@@ -192,7 +152,6 @@ class CleanupTest extends TestCase {
 
 		$appDataFolder = $this->createMock(Folder::class);
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->once())->method('newFolder')->with('preview');
 
 		$this->rootFolder->method('getAppDataDirectoryName')
 			->willReturn('appdata_some_id');
@@ -201,17 +160,15 @@ class CleanupTest extends TestCase {
 			->with('appdata_some_id')
 			->willReturn($appDataFolder);
 
-		$this->output->expects($this->exactly(3))->method('writeln')
+		$this->output->expects($this->exactly(2))->method('writeln')
 			->with(self::callback(function (string $message): bool {
 				static $i = 0;
 				return match (++$i) {
 					1 => $message === 'Preview folder deleted',
-					2 => $message === 'Preview folder recreated',
-					3 => $message === 'Previews removed'
+					2 => $message === 'Previews removed'
 				};
 			}));
 
-		$this->assertEquals(0, $this->repair->run($this->input, $this->output));
 		$this->previewService->expects($this->once())->method('deleteAll')
 			->willThrowException(new NotPermittedException('abc'));
 

--- a/tests/Core/Command/Preview/CleanupTest.php
+++ b/tests/Core/Command/Preview/CleanupTest.php
@@ -142,36 +142,13 @@ class CleanupTest extends TestCase {
 	}
 
 	public function testCleanupWithPreviewServiceException(): void {
-		$previewFolder = $this->createMock(Folder::class);
-		$previewFolder->expects($this->once())
-			->method('isDeletable')
-			->willReturn(true);
-
-		$previewFolder->expects($this->once())
-			->method('delete');
-
-		$appDataFolder = $this->createMock(Folder::class);
-		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-
 		$this->rootFolder->method('getAppDataDirectoryName')
-			->willReturn('appdata_some_id');
-
-		$this->rootFolder->method('get')
-			->with('appdata_some_id')
-			->willReturn($appDataFolder);
-
-		$this->output->expects($this->exactly(2))->method('writeln')
-			->with(self::callback(function (string $message): bool {
-				static $i = 0;
-				return match (++$i) {
-					1 => $message === 'Preview folder deleted',
-					2 => $message === 'Previews removed'
-				};
-			}));
+			->willThrowException(new NotFoundException());
 
 		$this->previewService->expects($this->once())->method('deleteAll')
 			->willThrowException(new NotPermittedException('abc'));
 
+		$this->logger->expects($this->once())->method('info')->with("Legacy previews can't be removed: appdata folder can't be found");
 		$this->logger->expects($this->once())->method('error')->with("Previews can't be removed: exception occurred: abc");
 
 		$this->assertEquals(1, $this->repair->run($this->input, $this->output));

--- a/tests/lib/Preview/PreviewMigrationJobTest.php
+++ b/tests/lib/Preview/PreviewMigrationJobTest.php
@@ -131,7 +131,8 @@ class PreviewMigrationJobTest extends TestCase {
 				$this->previewMapper,
 				$this->storageFactory,
 				Server::get(IAppDataFactory::class),
-			)
+			),
+			$this->logger,
 		);
 		$this->invokePrivate($job, 'run', [[]]);
 		$this->assertEquals(0, count($this->previewAppData->getDirectoryListing()));
@@ -168,7 +169,8 @@ class PreviewMigrationJobTest extends TestCase {
 				$this->previewMapper,
 				$this->storageFactory,
 				Server::get(IAppDataFactory::class),
-			)
+			),
+			$this->logger,
 		);
 		$this->invokePrivate($job, 'run', [[]]);
 		$this->assertEquals(0, count($this->previewAppData->getDirectoryListing()));
@@ -213,7 +215,8 @@ class PreviewMigrationJobTest extends TestCase {
 				$this->previewMapper,
 				$this->storageFactory,
 				Server::get(IAppDataFactory::class),
-			)
+			),
+			$this->logger,
 		);
 		$this->invokePrivate($job, 'run', [[]]);
 		$previews = iterator_to_array($this->previewMapper->getAvailablePreviewsForFile(5));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
