### PR TITLE
fix(dav): mask public-share permissions by storage type

### DIFF
--- a/apps/dav/appinfo/v2/publicremote.php
+++ b/apps/dav/appinfo/v2/publicremote.php
@@ -7,6 +7,7 @@
  */
 use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\DirPermissionsMask;
+use OC\Files\Storage\Wrapper\PermissionsMask;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\PublicAuth;
 use OCA\DAV\Connector\Sabre\ServerFactory;
@@ -21,6 +22,7 @@ use OCP\App\IAppManager;
 use OCP\BeforeSabrePubliclyLoadedEvent;
 use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IHomeStorage;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\ICacheFactory;
@@ -115,11 +117,22 @@ $server = $serverFactory->createServer(true, $baseuri, $requestUri, $authPlugin,
 			$mask |= Constants::PERMISSION_READ | Constants::PERMISSION_DELETE;
 		}
 
-		return new DirPermissionsMask([
-			'storage' => $storage,
-			'mask' => $mask,
-			'path' => 'files',
-		]);
+		// A user home storage keeps the shared files/ tree next to sibling
+		// directories (files_versions/, files_trashbin/, uploads/, …). Only the
+		// files/ subtree may be masked so versions/trashbin stay usable (see #59511).
+		// Jailed storages such as group folders are rooted at their own files area
+		// and carry no files/ prefix, so DirPermissionsMask would never match and
+		// the share mask would be bypassed. Mask the whole (already jailed) storage
+		// in that case.
+		if ($storage->instanceOfStorage(IHomeStorage::class)) {
+			return new DirPermissionsMask([
+				'storage' => $storage,
+				'mask' => $mask,
+				'path' => 'files',
+			]);
+		}
+
+		return new PermissionsMask(['storage' => $storage, 'mask' => $mask]);
 	});
 
 	/** @psalm-suppress MissingClosureParamType */


### PR DESCRIPTION
Resolves: #61012 

## Summary

Uploading a file through an "upload only" / file-request public share link that points **inside a group folder** records the file with a broken permission set since 32.0.10, so the team can no longer view, edit or delete it. This restores correct behaviour while keeping the home-storage behaviour from #59511.

**Root cause:** #59511 replaced the whole-storage `PermissionsMask` on the public-share wrapper with a `DirPermissionsMask` hard-coded to `'path' => 'files'`, and #59654 extended this to the v2 endpoint (shipped in 32.0.10). `DirPermissionsMask::checkPath()` only masks paths equal to or under `files/`. That holds for a user **home storage**, but a **group folder** is mounted as a `Jail` rooted at its own files area, so its internal paths have no `files/` prefix. `checkPath()` never matches, the share mask is bypassed, and the permission methods fall through to the unmasked underlying storage.

**Fix:** pick the masking strategy by storage type instead of hard-coding `'files'`:

- `IHomeStorage` → keep `DirPermissionsMask(path => 'files')` so `files_versions/` / `files_trashbin/` stay usable (the #59511 intent).
- any other storage (group folders, external, jailed) → mask the whole, already-jailed storage with `PermissionsMask`, as 32.0.9 did.

## TODO

- [ ] Manually verify: file drop into a group folder → group members can read/edit/delete the uploaded file
- [ ] Regression check: versions/trashbin still work for public shares on a home storage (#59511 behaviour)
- [ ] Regression check: chunked uploads through the v2 public endpoint still succeed

## Checklist

- [x] Code is [[properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [[Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md)](https://github.com/src-d/guide/blob/master/developer-comm[unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests)y/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [[integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests)](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([[manuals](https://github.com/nextcloud/documentation/)](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [[Backports requested](https://github.com/nextcloud/backportbot/#usage)](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [[Labels added](https://github.com/nextcloud/server/labels)](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [[Milestone added](https://github.com/nextcloud/server/milestones)](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI