### PR TITLE
fix(files_sharing): 500 on /download link redirect

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -413,6 +413,9 @@ class ShareController extends AuthPublicShareController {
 		}
 
 		$davUrl = '/public.php/dav/files/' . $token . $davPath;
+		if (!str_ends_with($davUrl, '/')) {
+			$davUrl .= '/';
+		}
 		if (!empty($params)) {
 			$davUrl .= '?' . http_build_query($params);
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- Resolves: public share `/download` links crash
- Regression from: https://github.com/nextcloud/server/pull/56967
- Addition to: https://github.com/nextcloud/server/pull/59867
- Redirect URL has no trailing slash:
  - Generated: `/public.php/dav/files/FLg5DZ3X69CNZfR?accept=zip`
  - Should be: `/public.php/dav/files/FLg5DZ3X69CNZfR/?accept=zip`
  - See: https://github.com/nextcloud/3rdparty/blob/f7176e8becad6b9ef000422fc6039025b58dd2c9/sabre/dav/lib/DAV/Server.php#L576
  - This is also how the link is generated on the frontend

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
