### PR TITLE
fix: use card interface instead of object

### DIFF
--- a/apps/dav/lib/CardDAV/HasPhotoPlugin.php
+++ b/apps/dav/lib/CardDAV/HasPhotoPlugin.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\CardDAV;
 
-use Sabre\CardDAV\Card;
+use Sabre\CardDAV\ICard;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
@@ -43,7 +43,7 @@ class HasPhotoPlugin extends ServerPlugin {
 	public function propFind(PropFind $propFind, INode $node) {
 		$ns = '{http://nextcloud.com/ns}';
 
-		if ($node instanceof Card) {
+		if ($node instanceof ICard) {
 			$propFind->handle($ns . 'has-photo', function () use ($node) {
 				$vcard = Reader::read($node->get());
 				return $vcard instanceof VCard

--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -10,7 +10,7 @@ namespace OCA\DAV\CardDAV;
 
 use OCP\AppFramework\Http;
 use OCP\Files\NotFoundException;
-use Sabre\CardDAV\Card;
+use Sabre\CardDAV\ICard;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
@@ -64,7 +64,7 @@ class ImageExportPlugin extends ServerPlugin {
 		$path = $request->getPath();
 		$node = $this->server->tree->getNodeForPath($path);
 
-		if (!$node instanceof Card) {
+		if (!$node instanceof ICard) {
 			return true;
 		}
 

--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -15,7 +15,7 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\Image;
 use Psr\Log\LoggerInterface;
-use Sabre\CardDAV\Card;
+use Sabre\CardDAV\ICard;
 use Sabre\VObject\Document;
 use Sabre\VObject\Parameter;
 use Sabre\VObject\Property\Binary;
@@ -43,7 +43,7 @@ class PhotoCache {
 	/**
 	 * @throws NotFoundException
 	 */
-	public function get(int $addressBookId, string $cardUri, int $size, Card $card): ISimpleFile {
+	public function get(int $addressBookId, string $cardUri, int $size, ICard $card): ISimpleFile {
 		$folder = $this->getFolder($addressBookId, $cardUri);
 
 		if ($this->isEmpty($folder)) {
@@ -68,7 +68,7 @@ class PhotoCache {
 	/**
 	 * @throws NotPermittedException
 	 */
-	private function init(ISimpleFolder $folder, Card $card): void {
+	private function init(ISimpleFolder $folder, ICard $card): void {
 		$data = $this->getPhoto($card);
 
 		if ($data === false || !isset($data['Content-Type'])) {
@@ -168,10 +168,10 @@ class PhotoCache {
 	}
 
 	/**
-	 * @param Card $node
+	 * @param ICard $node
 	 * @return false|array{body: string, Content-Type: string}
 	 */
-	private function getPhoto(Card $node) {
+	private function getPhoto(ICard $node) {
 		try {
 			$vObject = $this->readCard($node->get());
 			return $this->getPhotoFromVObject($vObject);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Required for: https://github.com/nextcloud/integration_davc 

## Summary
- Modified photo plugin code to use ICard interfaces instead of specific Card object

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
