### PR TITLE
refactor(util): clean up script-related methods in OCP\Util

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -5,8 +5,6 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal Nextcloud classes
 
 namespace OCP;
 
@@ -111,9 +109,9 @@ class Util {
 	 */
 	public static function addInitScript(string $application, string $file): void {
 		if (!empty($application)) {
-			$path = "$application/js/$file";
+			$scriptPath = "$application/js/$file";
 		} else {
-			$path = "js/$file";
+			$scriptPath = "js/$file";
 		}
 
 		// Init scripts may access translations immediately on execution, so for
@@ -122,7 +120,7 @@ class Util {
 			self::addTranslations($application, null, true);
 		}
 
-		self::$scriptsInit[] = $path;
+		self::$scriptsInit[] = $scriptPath;
 	}
 
 	/**
@@ -143,9 +141,9 @@ class Util {
 	 */
 	public static function addScript(string $application, ?string $file = null, string $afterAppId = 'core', bool $prepend = false): void {
 		if (!empty($application)) {
-			$path = "$application/js/$file";
+			$scriptPath = "$application/js/$file";
 		} else {
-			$path = "js/$file";
+			$scriptPath = "js/$file";
 		}
 
 		// For non-core apps, ensure translations are registered together with the
@@ -164,9 +162,9 @@ class Util {
 		}
 
 		if ($prepend) {
-			array_unshift(self::$scripts[$application], $path);
+			array_unshift(self::$scripts[$application], $scriptPath);
 		} else {
-			self::$scripts[$application][] = $path;
+			self::$scripts[$application][] = $scriptPath;
 		}
 	}
 
@@ -184,18 +182,23 @@ class Util {
 	 */
 	public static function getScripts(): array {
 		// Sort app script groups using the registered app-level dependencies.
-		$scriptSort = Server::get(AppScriptSort::class);
-		$sortedScripts = $scriptSort->sort(self::$scripts, self::$scriptDeps);
+		$scriptSorter = Server::get(AppScriptSort::class);
+		$groupedScripts = $scriptSorter->sort(self::$scripts, self::$scriptDeps);
 
 		// Prepend init assets, flatten the grouped arrays into a single list,
 		// then remove duplicate asset paths.
-		$sortedScripts = array_merge([self::$scriptsInit], $sortedScripts);
-		$sortedScripts = array_merge(...array_values($sortedScripts));
-		$sortedScripts = array_unique($sortedScripts);
+		$groupedScripts = array_merge([self::$scriptsInit], $groupedScripts);
+		$scriptList = array_merge(...array_values($groupedScripts));
+		$scriptList = array_unique($scriptList);
 
 		// Apply explicit bootstrap ordering for selected core assets.
-		usort($sortedScripts, fn (string $a, string $b) => self::scriptOrderValue($b) <=> self::scriptOrderValue($a));
-		return $sortedScripts;
+		usort(
+			$scriptList,
+			fn (string $leftScript, string $rightScript) =>
+				self::scriptOrderValue($rightScript) <=> self::scriptOrderValue($leftScript)
+		);
+
+		return $scriptList;
 	}
 
 	/**
@@ -234,15 +237,15 @@ class Util {
 			$languageCode = Server::get(IFactory::class)->findLanguage($application);
 		}
 		if (!empty($application)) {
-			$path = "$application/l10n/$languageCode";
+			$translationPath = "$application/l10n/$languageCode";
 		} else {
-			$path = "l10n/$languageCode";
+			$translationPath = "l10n/$languageCode";
 		}
 
 		if ($init) {
-			self::$scriptsInit[] = $path;
+			self::$scriptsInit[] = $translationPath;
 		} else {
-			self::$scripts[$application][] = $path;
+			self::$scripts[$application][] = $translationPath;
 		}
 	}
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -39,7 +39,7 @@ class Util {
 	/**
 	 * App-level script dependency metadata keyed by application ID.
 	 *
-	 * @psalm-suppress ImpureStaticProperty 
+	 * @psalm-suppress ImpureStaticProperty
 	 */
 	private static array $scriptDeps = [];
 
@@ -151,6 +151,7 @@ class Util {
 	 * @param string $afterAppId App ID that should be ordered before this app's scripts.
 	 * @param bool $prepend Whether to insert the script at the beginning of the app's script list.
 	 * @since 4.0.0
+	 * @since 35.0.0 $file make non-nullable (effectively already was but now enforced)
 	 */
 	public static function addScript(
 		string $application,
@@ -227,7 +228,6 @@ class Util {
 	 * bootstrap assets to the front of the final list.
 	 *
 	 * @param string $name Script asset path
-	 * @since 34.0.0
 	 */
 	private static function scriptPriority(string $name): int {
 		return match($name) {
@@ -383,7 +383,7 @@ class Util {
 	 * Converts a numeric value to an integer or float.
 	 * 
 	 * Returns an integer if the value fits within the system's integer limits, 
-	 * ootherwise returns a float up to maximum hardware precision.
+	 * otherwise returns a float up to maximum hardware precision.
 	 * 
 	 * @param numeric-string|float|int $number The numeric value to convert.
 	 * @return int|float An integer if it fits, otherwise a float.

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -147,14 +147,14 @@ class Util {
 	 * unless the requested file already represents a translation asset.
 	 *
 	 * @param string $application Application ID. Use an empty string for unscoped assets.
-	 * @param string|null $file JavaScript file name relative to the app's js/ directory.
+	 * @param string $file JavaScript file name relative to the app's js/ directory.
 	 * @param string $afterAppId App ID that should be ordered before this app's scripts.
 	 * @param bool $prepend Whether to insert the script at the beginning of the app's script list.
 	 * @since 4.0.0
 	 */
 	public static function addScript(
 		string $application,
-		?string $file = null,
+		string $file,
 		string $afterAppId = 'core',
 		bool $prepend = false,
 	): void {

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -173,10 +173,14 @@ class Util {
 		}
 
 		// Track app-level ordering dependencies used when building the final script list.
-		if (!array_key_exists($application, self::$scriptDeps)) {
+		if (!isset(self::$scriptDeps[$application])) {
 			self::$scriptDeps[$application] = new AppScriptDependency($application, [$afterAppId]);
 		} else {
 			self::$scriptDeps[$application]->addDep($afterAppId);
+		}
+
+		if (!isset(self::$scripts[$application])) {
+			self::$scripts[$application] = [];
 		}
 
 		if ($prepend) {
@@ -258,6 +262,10 @@ class Util {
 			$translationPath = "$application/l10n/$languageCode";
 		} else {
 			$translationPath = "l10n/$languageCode";
+		}
+
+		if (!isset(self::$scripts[$application])) {
+			self::$scripts[$application] = [];
 		}
 
 		if ($init) {

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -22,22 +22,36 @@ use Psr\Container\ContainerExceptionInterface;
  * @since 4.0.0
  */
 class Util {
-	/** @psalm-suppress ImpureStaticProperty legacy stuff, keep them for now */
+	/**
+	 * List of early init script asset paths.
+	 *
+	 * @psalm-suppress ImpureStaticProperty
+	 */
 	private static array $scriptsInit = [];
-	/** @psalm-suppress ImpureStaticProperty */
+
+	/**
+	 * Script asset paths grouped by application ID.
+	 *
+	 * @psalm-suppress ImpureStaticProperty
+	 */
 	private static array $scripts = [];
-	/** @psalm-suppress ImpureStaticProperty */
+	
+	/**
+	 * App-level script dependency metadata keyed by application ID.
+	 *
+	 * @psalm-suppress ImpureStaticProperty 
+	 */
 	private static array $scriptDeps = [];
+
 	/** @psalm-suppress ImpureStaticProperty */
 	private static ?bool $needUpgradeCache = null;
 
 	/**
 	 * get the current installed version of Nextcloud
-	 * @return array
 	 * @since 4.0.0
 	 * @deprecated 31.0.0 Use \OCP\ServerVersion::getVersion
 	 */
-	public static function getVersion() {
+	public static function getVersion(): array {
 		return Server::get(ServerVersion::class)->getVersion();
 	}
 
@@ -56,27 +70,26 @@ class Util {
 
 	/**
 	 * Set current update channel
-	 * @param string $channel
 	 * @since 8.1.0
 	 * @deprecated 33.0.0 Use \OCP\ServerVersion::setChannel
 	 */
-	public static function setChannel($channel) {
+	public static function setChannel(string $channel): void {
 		Server::get(IConfig::class)->setSystemValue('updater.release.channel', $channel);
 	}
 
 	/**
 	 * Get current update channel
-	 * @return string
 	 * @since 8.1.0
 	 * @deprecated 31.0.0 Use \OCP\ServerVersion::getChannel
 	 */
-	public static function getChannel() {
+	public static function getChannel(): string {
 		return Server::get(ServerVersion::class)->getChannel();
 	}
 
 	/**
 	 * get l10n object
-	 * @since 6.0.0 - parameter $language was added in 8.0.0
+	 * @since 6.0.0
+	 * @since 8.0.0 parameter $language was added
 	 */
 	public static function getL10N(string $application, ?string $language = null): IL10N {
 		return Server::get(\OCP\L10N\IFactory::class)->get($application, $language);
@@ -143,7 +156,7 @@ class Util {
 		string $application,
 		?string $file = null,
 		string $afterAppId = 'core',
-		bool $prepend = false
+		bool $prepend = false,
 	): void {
 		if (!empty($application)) {
 			$scriptPath = "$application/js/$file";
@@ -237,7 +250,7 @@ class Util {
 	 * @param bool $init Whether to register the translation asset as an early init asset
 	 * @since 8.0.0
 	 */
-	public static function addTranslations(string $application, ?string $languageCode = null, bool $init = false) {
+	public static function addTranslations(string $application, ?string $languageCode = null, bool $init = false): void {
 		if (is_null($languageCode)) {
 			$languageCode = Server::get(IFactory::class)->findLanguage($application);
 		}
@@ -260,10 +273,10 @@ class Util {
 	 * So use "" to get a closing tag.
 	 * @param string $tag tag name of the element
 	 * @param array $attributes array of attributes for the element
-	 * @param string $text the text content for the element
+	 * @param ?string $text the text content for the element
 	 * @since 4.0.0
 	 */
-	public static function addHeader($tag, $attributes, $text = null) {
+	public static function addHeader(string $tag, array $attributes, ?string $text = null): void {
 		\OC_Util::addHeader($tag, $attributes, $text);
 	}
 
@@ -277,7 +290,7 @@ class Util {
 	 * @since 4.0.0 - parameter $args was added in 4.5.0
 	 * @deprecated 34.0.0 Use IUrlGenerator::getAbsoluteUrl and IUrlGenerator::linkTo
 	 */
-	public static function linkToAbsolute($app, $file, $args = []) {
+	public static function linkToAbsolute(string $app, string $file, array $args = []): string {
 		$urlGenerator = Server::get(IURLGenerator::class);
 		return $urlGenerator->getAbsoluteURL(
 			$urlGenerator->linkTo($app, $file, $args)
@@ -298,18 +311,18 @@ class Util {
 	}
 
 	/**
-	 * Returns the server host name without an eventual port number
-	 * @return string the server hostname
+	 * Returns the server host name without the port number.
+	 *
+	 * @return string The server hostname
 	 * @since 5.0.0
+	 *
+	 * TODO: Move to IRequest
 	 */
-	public static function getServerHostName() {
-		$host_name = Server::get(IRequest::class)->getServerHost();
-		// strip away port number (if existing)
-		$colon_pos = strpos($host_name, ':');
-		if ($colon_pos !== false) {
-			$host_name = substr($host_name, 0, $colon_pos);
-		}
-		return $host_name;
+	public static function getServerHostName(): string {
+		$host = Server::get(IRequest::class)->getServerHost();
+
+		// Extract only the host part before the colon
+		return explode(':', $host, 2)[0];
 	}
 
 	/**
@@ -345,14 +358,18 @@ class Util {
 	}
 
 	/**
-	 * Converts string to int of float depending on if it fits an int
-	 * @param numeric-string|float|int $number numeric string
-	 * @return int|float int if it fits, float if it is too big
+	 * Converts a numeric value to an integer or float.
+	 * 
+	 * Returns an integer if the value fits within the system's integer limits, 
+	 * ootherwise returns a float up to maximum hardware precision.
+	 * 
+	 * @param numeric-string|float|int $number The numeric value to convert.
+	 * @return int|float An integer if it fits, otherwise a float.
 	 * @since 26.0.0
 	 */
 	public static function numericToNumber(string|float|int $number): int|float {
-		/* This is a hack to cast to (int|float) */
-		return 0 + (string)$number;
+		// Triggers native engine-level type coercion to int or float
+		return +$number;
 	}
 
 	/**
@@ -439,7 +456,6 @@ class Util {
 	 *
 	 * This function makes it very easy to connect to use hooks.
 	 *
-	 * TODO: write example
 	 * @since 4.0.0
 	 * @deprecated 21.0.0 use \OCP\EventDispatcher\IEventDispatcher::addListener
 	 */

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -166,9 +166,7 @@ class Util {
 
 		// For non-core apps, ensure translations are registered together with the
 		// app script unless this is already a translation asset.
-		if ($application !== 'core'
-			&& $file !== null
-			&& !str_contains($file, 'l10n')) {
+		if ($application !== 'core' && !str_contains($file, 'l10n')) {
 			self::addTranslations($application);
 		}
 
@@ -179,11 +177,10 @@ class Util {
 			self::$scriptDeps[$application]->addDep($afterAppId);
 		}
 
-		if (!isset(self::$scripts[$application])) {
-			self::$scripts[$application] = [];
-		}
-
 		if ($prepend) {
+			if (!isset(self::$scripts[$application])) {
+				self::$scripts[$application] = [];
+			}
 			array_unshift(self::$scripts[$application], $scriptPath);
 		} else {
 			self::$scripts[$application][] = $scriptPath;

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -97,11 +97,15 @@ class Util {
 	}
 
 	/**
-	 * Add a standalone init js file that is loaded for initialization
+	 * Add an initialization JavaScript asset that should be emitted before
+	 * regular app scripts.
 	 *
-	 * Be careful loading scripts using this method as they are loaded early
-	 * and block the initial page rendering. They should not have dependencies
-	 * on any other scripts than core-common and core-main.
+	 * These scripts are loaded very early and can block initial page rendering.
+	 * They should therefore stay small and only rely on assets that are guaranteed
+	 * to be available at that stage, namely core/js/common and core/js/main.
+	 *
+	 * For non-core apps, the matching translation asset is added first so that
+	 * translations are available when the init script executes.
 	 *
 	 * @since 28.0.0
 	 */
@@ -112,8 +116,8 @@ class Util {
 			$path = "js/$file";
 		}
 
-		// We need to handle the translation BEFORE the init script
-		// is loaded, as the init script might use translations
+		// Init scripts may access translations immediately on execution, so for
+		// non-core apps load the translation asset before the init script itself.
 		if ($application !== 'core' && !str_contains($file, 'l10n')) {
 			self::addTranslations($application, null, true);
 		}
@@ -122,12 +126,19 @@ class Util {
 	}
 
 	/**
-	 * add a javascript file
+	 * Add a JavaScript asset for an app.
 	 *
-	 * @param string $application
-	 * @param string|null $file
-	 * @param string $afterAppId
-	 * @param bool $prepend
+	 * Scripts are grouped by app and app-level dependencies are tracked in
+	 * self::$scriptDeps. The dependency sorter uses that information later when
+	 * building the final script list.
+	 *
+	 * For non-core apps, the matching translation asset is added automatically
+	 * unless the requested file already represents a translation asset.
+	 *
+	 * @param string $application Application ID. Use an empty string for unscoped assets.
+	 * @param string|null $file JavaScript file name relative to the app's js/ directory.
+	 * @param string $afterAppId App ID that should be ordered before this app's scripts.
+	 * @param bool $prepend Whether to insert the script at the beginning of the app's script list.
 	 * @since 4.0.0
 	 */
 	public static function addScript(string $application, ?string $file = null, string $afterAppId = 'core', bool $prepend = false): void {
@@ -137,16 +148,15 @@ class Util {
 			$path = "js/$file";
 		}
 
-		// Inject js translations if we load a script for
-		// a specific app that is not core, as those js files
-		// need separate handling
+		// For non-core apps, ensure translations are registered together with the
+		// app script unless this is already a translation asset.
 		if ($application !== 'core'
 			&& $file !== null
 			&& !str_contains($file, 'l10n')) {
 			self::addTranslations($application);
 		}
 
-		// store app in dependency list
+		// Track app-level ordering dependencies used when building the final script list.
 		if (!array_key_exists($application, self::$scriptDeps)) {
 			self::$scriptDeps[$application] = new AppScriptDependency($application, [$afterAppId]);
 		} else {
@@ -161,30 +171,40 @@ class Util {
 	}
 
 	/**
-	 * Return the list of scripts injected to the page
+	 * Return the final list of JavaScript assets to inject into the page.
 	 *
-	 * @return array
+	 * The result is built in four steps:
+	 * 1. sort app script groups using app-level dependency information
+	 * 2. prepend early init assets
+	 * 3. flatten grouped assets into a single list and remove duplicates
+	 * 4. apply explicit priority rules for core bootstrap assets
+	 *
+	 * @return array<int, string>
 	 * @since 24.0.0
 	 */
 	public static function getScripts(): array {
-		// Sort scriptDeps into sortedScriptDeps
+		// Sort app script groups using the registered app-level dependencies.
 		$scriptSort = Server::get(AppScriptSort::class);
 		$sortedScripts = $scriptSort->sort(self::$scripts, self::$scriptDeps);
 
-		// Flatten array and remove duplicates
+		// Prepend init assets, flatten the grouped arrays into a single list,
+		// then remove duplicate asset paths.
 		$sortedScripts = array_merge([self::$scriptsInit], $sortedScripts);
 		$sortedScripts = array_merge(...array_values($sortedScripts));
 		$sortedScripts = array_unique($sortedScripts);
 
+		// Apply explicit bootstrap ordering for selected core assets.
 		usort($sortedScripts, fn (string $a, string $b) => self::scriptOrderValue($b) <=> self::scriptOrderValue($a));
 		return $sortedScripts;
 	}
 
 	/**
-	 * Gets a numeric value based on the script name.
-	 * This is used to ensure that the global state is initialized before all other scripts.
+	 * Return a relative priority for a script asset.
 	 *
-	 * @param string $name - The script name
+	 * Higher values are sorted earlier. This is used to force critical core
+	 * bootstrap assets to the front of the final list.
+	 *
+	 * @param string $name Script asset path
 	 * @since 34.0.0
 	 */
 	private static function scriptOrderValue(string $name): int {
@@ -192,16 +212,21 @@ class Util {
 			'core/js/common' => 3,
 			'core/js/main' => 2,
 			default => str_starts_with($name, 'core/l10n/')
-				? 1 // core translations have to be loaded directly after core-main
-				: 0, // other scripts should preserve their current order
+				? 1 // Core translations must be available immediately after core/js/main.
+				: 0, // No explicit priority; ordering is determined elsewhere.
 		};
 	}
 
 	/**
-	 * Add a translation JS file
-	 * @param string $application application id
-	 * @param string $languageCode language code, defaults to the current locale
-	 * @param bool $init whether the translations should be loaded early or not
+	 * Add a JavaScript translation asset.
+	 *
+	 * If no language code is provided, the current language for the given app is
+	 * resolved through the localization factory. Translation assets can either be
+	 * registered as early init assets or as regular app scripts.
+	 *
+	 * @param string $application Application ID
+	 * @param string $languageCode Language code; defaults to the current app language
+	 * @param bool $init Whether to register the translation asset as an early init asset
 	 * @since 8.0.0
 	 */
 	public static function addTranslations($application, $languageCode = null, $init = false) {

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -139,7 +139,12 @@ class Util {
 	 * @param bool $prepend Whether to insert the script at the beginning of the app's script list.
 	 * @since 4.0.0
 	 */
-	public static function addScript(string $application, ?string $file = null, string $afterAppId = 'core', bool $prepend = false): void {
+	public static function addScript(
+		string $application,
+		?string $file = null,
+		string $afterAppId = 'core',
+		bool $prepend = false
+	): void {
 		if (!empty($application)) {
 			$scriptPath = "$application/js/$file";
 		} else {
@@ -195,7 +200,7 @@ class Util {
 		usort(
 			$scriptList,
 			fn (string $leftScript, string $rightScript) =>
-				self::scriptOrderValue($rightScript) <=> self::scriptOrderValue($leftScript)
+				self::scriptPriority($rightScript) <=> self::scriptPriority($leftScript)
 		);
 
 		return $scriptList;
@@ -210,7 +215,7 @@ class Util {
 	 * @param string $name Script asset path
 	 * @since 34.0.0
 	 */
-	private static function scriptOrderValue(string $name): int {
+	private static function scriptPriority(string $name): int {
 		return match($name) {
 			'core/js/common' => 3,
 			'core/js/main' => 2,
@@ -228,11 +233,11 @@ class Util {
 	 * registered as early init assets or as regular app scripts.
 	 *
 	 * @param string $application Application ID
-	 * @param string $languageCode Language code; defaults to the current app language
+	 * @param ?string $languageCode Language code; defaults to the current app language
 	 * @param bool $init Whether to register the translation asset as an early init asset
 	 * @since 8.0.0
 	 */
-	public static function addTranslations($application, $languageCode = null, $init = false) {
+	public static function addTranslations(string $application, ?string $languageCode = null, bool $init = false) {
 		if (is_null($languageCode)) {
 			$languageCode = Server::get(IFactory::class)->findLanguage($application);
 		}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -258,6 +258,7 @@ class Util {
 		if (is_null($languageCode)) {
 			$languageCode = Server::get(IFactory::class)->findLanguage($application);
 		}
+
 		if (!empty($application)) {
 			$translationPath = "$application/l10n/$languageCode";
 		} else {
@@ -269,9 +270,25 @@ class Util {
 		}
 
 		if ($init) {
-			self::$scriptsInit[] = $translationPath;
+			self::appendInitScriptPathOnce($translationPath);
 		} else {
-			self::$scripts[$application][] = $translationPath;
+			self::appendAppScriptPathOnce($application, $translationPath);
+		}
+	}
+
+	private static function appendInitScriptPathOnce(string $scriptPath): void {
+		if (!in_array($scriptPath, self::$scriptsInit, true)) {
+			self::$scriptsInit[] = $scriptPath;
+		}
+	}
+
+	private static function appendAppScriptPathOnce(string $application, string $scriptPath): void {
+		if (!isset(self::$scripts[$application])) {
+			self::$scripts[$application] = [];
+		}
+
+		if (!in_array($scriptPath, self::$scripts[$application], true)) {
+			self::$scripts[$application][] = $scriptPath;
 		}
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This PR refactors the script registration methods in `OCP\Util` for clarity and safety. It improves docblocks and naming, adds missing type declarations, fixes a couple of array-initialization issues, and makes translation asset registration idempotent earlier in the pipeline.

### Changes
- expand/clarify docblocks for script-related properties and methods
- rename `scriptOrderValue()` to `scriptPriority()`
- add missing parameter/return types to several `Util` methods
- tighten `addScript()`’s `$file` parameter from `?string` to `string`
- fix potential undefined-index / missing-initialization cases in `addScript()` and `addTranslations()`
- deduplicate repeated translation asset registrations at insertion time via new private helpers
- small readability cleanups (`isset()` for `$scriptDeps`, local variable renames, docblock cleanup)

### Behavior notes
- `addScript()` no longer accepts `null` for `$file` (technically a BC, but it would have never worked anyhow)
- translation asset registration is now idempotent at insertion time

### Scope note
**This branch also currently contains a few small non-script-adjacent `Util.php` cleanups (`getServerHostName()`, `numericToNumber()`, and related docblocks). I can split those out if preferred.**

### Follow-up ideas

- Introduce a dedicated script-registry service and start migrating to it

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
