### PR TITLE
refactor(Template): clarify TemplateLayout naming, comments, and docblocks

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -52,8 +52,8 @@ class TemplateLayout {
 	/** @var string[] */
 	private array $cacheBusterCache = [];
 
-	public ?CSSResourceLocator $cssLocator = null;
-	public ?JSResourceLocator $jsLocator = null;
+	private ?CSSResourceLocator $cssLocator = null;
+	private ?JSResourceLocator $jsLocator = null;
 
 	public function __construct(
 		private IConfig $config,
@@ -77,7 +77,13 @@ class TemplateLayout {
 	 * @return ITemplate Prepared layout template
 	 */
 	public function getPageTemplate(string $renderAs, string $appId): ITemplate {
-		// Add fallback theming variables if not rendered as user
+		$userSession = Server::get(IUserSession::class);
+		$urlGenerator = Server::get(IURLGenerator::class);
+		$l10nFactory = Server::get(IFactory::class);
+
+		$isInstalled = $this->config->getSystemValueBool('installed', false);
+
+		// Add fallback theming variables when no authenticated user layout is rendered.
 		if ($renderAs !== TemplateResponse::RENDER_AS_USER) {
 			// TODO cache generated default theme if enabled for fallback if server is erroring ?
 			Util::addStyle('theming', 'default');
@@ -97,10 +103,27 @@ class TemplateLayout {
 				$this->initialState->provideInitialState('core', 'active-app', $this->navigationManager->getActiveEntry());
 				$this->initialState->provideInitialState('core', 'apps', array_values($this->navigationManager->getAll()));
 
-				$this->initialState->provideInitialState('unified-search', 'min-search-length', $this->appConfig->getValueInt(Application::APP_ID, ConfigLexicon::UNIFIED_SEARCH_MIN_SEARCH_LENGTH));
-				if ($this->config->getSystemValueBool('unified_search.enabled', false) || !$this->config->getSystemValueBool('enable_non-accessible_features', true)) {
-					$this->initialState->provideInitialState('unified-search', 'limit-default', (int)$this->config->getAppValue('core', 'unified-search.limit-default', (string)SearchQuery::LIMIT_DEFAULT));
-					$this->initialState->provideInitialState('unified-search', 'live-search', $this->config->getAppValue('core', 'unified-search.live-search', 'yes') === 'yes');
+				$this->initialState->provideInitialState(
+					'unified-search',
+					'min-search-length',
+					$this->appConfig->getValueInt(Application::APP_ID, ConfigLexicon::UNIFIED_SEARCH_MIN_SEARCH_LENGTH),
+				);
+
+				$unifiedSearchEnabled = $this->config->getSystemValueBool('unified_search.enabled', false);
+				$nonAccessibleFeaturesEnabled = $this->config->getSystemValueBool('enable_non-accessible_features', true);
+	
+				if ($unifiedSearchEnabled || !$nonAccessibleFeaturesEnabled) {
+					$this->initialState->provideInitialState(
+						'unified-search',
+						'limit-default',
+						(int)$this->config->getAppValue('core', 'unified-search.limit-default', (string)SearchQuery::LIMIT_DEFAULT),
+					);
+					$this->initialState->provideInitialState(
+						'unified-search',
+						'live-search',
+						$this->config->getAppValue('core', 'unified-search.live-search', 'yes') === 'yes',
+					);
+
 					Util::addScript('core', 'legacy-unified-search', 'core');
 				} else {
 					Util::addScript('core', 'unified-search', 'core');
@@ -138,7 +161,7 @@ class TemplateLayout {
 					}
 				}
 
-				$user = Server::get(IUserSession::class)->getUser();
+				$user = $userSession->getUser();
 
 				if ($user === null) {
 					$template->assign('user_uid', false);
@@ -164,7 +187,7 @@ class TemplateLayout {
 				$template->assign('bodyid', 'body-login');
 
 				$userDisplayName = false;
-				$user = Server::get(IUserSession::class)->getUser();
+				$user = $userSession->getUser();
 				if ($user) {
 					$userDisplayName = $user->getDisplayName();
 				}
@@ -197,7 +220,6 @@ class TemplateLayout {
 				}
 
 				if ($this->appManager->isEnabledForUser('registration')) {
-					$urlGenerator = Server::get(IURLGenerator::class);
 					$signUpLink = $urlGenerator->getAbsoluteURL('/index.php/apps/registration/');
 				}
 
@@ -210,7 +232,6 @@ class TemplateLayout {
 		}
 
 		// Expose localization metadata to the selected layout.
-		$l10nFactory = Server::get(IFactory::class);
 		$lang = $l10nFactory->findLanguage();
 		$locale = $l10nFactory->findLocale($lang);
 		$direction = $l10nFactory->getLanguageDirection($lang);
@@ -224,11 +245,12 @@ class TemplateLayout {
 		try {
 			$themesService = Server::get(ThemesService::class);
 		} catch (\Exception) {
+			// theming service may be unavailable during early/bootstrap/error states
 			$themesService = null;
 		}
 		$template->assign('enabledThemes', $themesService?->getEnabledThemes() ?? []);
 
-		if ($this->config->getSystemValueBool('installed', false)) {
+		if ($isInstalled) {
 			if (empty($this->versionHash)) {
 				$v = $this->appManager->getAppInstalledVersions(true);
 				$v['core'] = implode('.', $this->serverVersion->getVersion());
@@ -241,7 +263,7 @@ class TemplateLayout {
 		// Resolve and append JavaScript assets.
 		$jsFiles = $this->findJavascriptFiles(Util::getScripts());
 		$template->assign('jsfiles', []);
-		if ($this->config->getSystemValueBool('installed', false) && $renderAs !== TemplateResponse::RENDER_AS_ERROR) {
+		if ($isInstalled && $renderAs !== TemplateResponse::RENDER_AS_ERROR) {
 			// Intentionally build JS config before deciding how to deliver it so the
 			// initial state is populated as a side effect of getConfig().
 			// See PR #22636 for historical context.
@@ -251,12 +273,12 @@ class TemplateLayout {
 				Server::get(Defaults::class),
 				$this->appManager,
 				Server::get(ISession::class),
-				Server::get(IUserSession::class)->getUser(),
+				$userSession->getUser(),
 				$this->config,
 				$this->appConfig,
 				Server::get(IGroupManager::class),
 				Server::get(IniGetWrapper::class),
-				Server::get(IURLGenerator::class),
+				$urlGenerator,
 				Server::get(CapabilitiesManager::class),
 				Server::get(IInitialStateService::class),
 				Server::get(IProvider::class),
@@ -266,7 +288,7 @@ class TemplateLayout {
 			if (Server::get(ContentSecurityPolicyNonceManager::class)->browserSupportsCspV3()) {
 				$template->assign('inline_ocjs', $config);
 			} else {
-				$template->append('jsfiles', Server::get(IURLGenerator::class)->linkToRoute('core.OCJS.getConfig', ['v' => $this->versionHash]));
+				$template->append('jsfiles', $urlGenerator->linkToRoute('core.OCJS.getConfig', ['v' => $this->versionHash]));
 			}
 		}
 		/** @var array{0:string,1:string,2:string} $resourceInfo */
@@ -278,12 +300,13 @@ class TemplateLayout {
 		try {
 			$pathInfo = $this->request->getPathInfo();
 		} catch (\Exception $e) {
+			// FIXME: When might this happen? Why?
 			$pathInfo = '';
 		}
 
 		// Only use compiled SCSS assets on fully installed, non-upgrade, non-error,
 		// non-login requests. Fall back to guest styling otherwise.
-		if ($this->config->getSystemValueBool('installed', false)
+		if ($isInstalled
 			&& !Util::needUpgrade()
 			&& $pathInfo !== ''
 			&& !preg_match('/^\/login/', $pathInfo)

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -86,12 +86,12 @@ class TemplateLayout {
 		// Select the base layout template for the requested render mode.
 		switch ($renderAs) {
 			case TemplateResponse::RENDER_AS_USER:
-				$page = $this->templateManager->getTemplate('core', 'layout.user');
+				$template = $this->templateManager->getTemplate('core', 'layout.user');
 				$pathInfo = $this->request->getPathInfo();
 				if ($pathInfo !== false && str_starts_with($pathInfo, '/settings/')) {
-					$page->assign('bodyid', 'body-settings');
+					$template->assign('bodyid', 'body-settings');
 				} else {
-					$page->assign('bodyid', 'body-user');
+					$template->assign('bodyid', 'body-user');
 				}
 
 				$this->initialState->provideInitialState('core', 'active-app', $this->navigationManager->getActiveEntry());
@@ -108,32 +108,32 @@ class TemplateLayout {
 
 				// Set logo link target
 				$logoUrl = $this->config->getSystemValueString('logo_url', '');
-				$page->assign('logoUrl', $logoUrl);
+				$template->assign('logoUrl', $logoUrl);
 
 				// Set default entry name
-				$defaultEntryId = $this->navigationManager->getDefaultEntryIdForUser();
-				$defaultEntry = $this->navigationManager->get($defaultEntryId);
-				$page->assign('defaultAppName', $defaultEntry['name'] ?? '');
+				$defaultNavigationEntryId = $this->navigationManager->getDefaultEntryIdForUser();
+				$defaultNavigationEntry = $this->navigationManager->get($defaultNavigationEntryId);
+				$template->assign('defaultAppName', $defaultNavigationEntry['name'] ?? '');
 
 				// Add navigation entry
-				$page->assign('application', '');
-				$page->assign('appid', $appId);
+				$template->assign('application', '');
+				$template->assign('appid', $appId);
 
-				$navigation = $this->navigationManager->getAll();
-				$page->assign('navigation', $navigation);
+				$mainNavigation = $this->navigationManager->getAll();
+				$template->assign('navigation', $mainNavigation);
 				$settingsNavigation = $this->navigationManager->getAll('settings');
 				$this->initialState->provideInitialState('core', 'settingsNavEntries', $settingsNavigation);
 
-				foreach ($navigation as $entry) {
+				foreach ($mainNavigation as $entry) {
 					if ($entry['active']) {
-						$page->assign('application', $entry['name']);
+						$template->assign('application', $entry['name']);
 						break;
 					}
 				}
 
 				foreach ($settingsNavigation as $entry) {
 					if ($entry['active']) {
-						$page->assign('application', $entry['name']);
+						$template->assign('application', $entry['name']);
 						break;
 					}
 				}
@@ -141,27 +141,27 @@ class TemplateLayout {
 				$user = Server::get(IUserSession::class)->getUser();
 
 				if ($user === null) {
-					$page->assign('user_uid', false);
-					$page->assign('user_displayname', false);
-					$page->assign('userAvatarSet', false);
-					$page->assign('userStatus', false);
+					$template->assign('user_uid', false);
+					$template->assign('user_displayname', false);
+					$template->assign('userAvatarSet', false);
+					$template->assign('userStatus', false);
 				} else {
-					$page->assign('user_uid', $user->getUID());
-					$page->assign('user_displayname', $user->getDisplayName());
-					$page->assign('userAvatarSet', true);
-					$page->assign('userAvatarVersion', $this->config->getUserValue($user->getUID(), 'avatar', 'version', 0));
+					$template->assign('user_uid', $user->getUID());
+					$template->assign('user_displayname', $user->getDisplayName());
+					$template->assign('userAvatarSet', true);
+					$template->assign('userAvatarVersion', $this->config->getUserValue($user->getUID(), 'avatar', 'version', 0));
 				}
 				break;
 			case TemplateResponse::RENDER_AS_ERROR:
-				$page = $this->templateManager->getTemplate('core', 'layout.guest', '', false);
-				$page->assign('bodyid', 'body-login');
-				$page->assign('user_displayname', '');
-				$page->assign('user_uid', '');
+				$template = $this->templateManager->getTemplate('core', 'layout.guest', '', false);
+				$template->assign('bodyid', 'body-login');
+				$template->assign('user_displayname', '');
+				$template->assign('user_uid', '');
 				break;
 			case TemplateResponse::RENDER_AS_GUEST:
-				$page = $this->templateManager->getTemplate('core', 'layout.guest');
+				$template = $this->templateManager->getTemplate('core', 'layout.guest');
 				Util::addStyle('guest');
-				$page->assign('bodyid', 'body-login');
+				$template->assign('bodyid', 'body-login');
 
 				$userDisplayName = false;
 				$user = Server::get(IUserSession::class)->getUser();
@@ -169,24 +169,24 @@ class TemplateLayout {
 					$userDisplayName = $user->getDisplayName();
 				}
 
-				$page->assign('user_displayname', $userDisplayName);
-				$page->assign('user_uid', \OC_User::getUser());
+				$template->assign('user_displayname', $userDisplayName);
+				$template->assign('user_uid', \OC_User::getUser());
 				break;
 			case TemplateResponse::RENDER_AS_PUBLIC:
-				$page = $this->templateManager->getTemplate('core', 'layout.public');
-				$page->assign('appid', $appId);
-				$page->assign('bodyid', 'body-public');
+				$template = $this->templateManager->getTemplate('core', 'layout.public');
+				$template->assign('appid', $appId);
+				$template->assign('bodyid', 'body-public');
 
-				$currentAppData = $this->navigationManager->get($appId);
-				$this->initialState->provideInitialState('core', 'apps', $currentAppData === null ? [] : [$currentAppData]);
+				$currentAppNavigationEntry = $this->navigationManager->get($appId);
+				$this->initialState->provideInitialState('core', 'apps', $currentAppNavigationEntry === null ? [] : [$currentAppNavigationEntry]);
 
 				// Set logo link target
 				$logoUrl = $this->config->getSystemValueString('logo_url', '');
-				$page->assign('logoUrl', $logoUrl);
+				$template->assign('logoUrl', $logoUrl);
 
-				$subscription = Server::get(IRegistry::class);
+				$subscriptionRegistry = Server::get(IRegistry::class);
 				$showSimpleSignup = $this->config->getSystemValueBool('simpleSignUpLink.shown', true);
-				if ($showSimpleSignup && $subscription->delegateHasValidSubscription()) {
+				if ($showSimpleSignup && $subscriptionRegistry->delegateHasValidSubscription()) {
 					$showSimpleSignup = false;
 				}
 
@@ -201,11 +201,11 @@ class TemplateLayout {
 					$signUpLink = $urlGenerator->getAbsoluteURL('/index.php/apps/registration/');
 				}
 
-				$page->assign('showSimpleSignUpLink', $showSimpleSignup);
-				$page->assign('signUpLink', $signUpLink);
+				$template->assign('showSimpleSignUpLink', $showSimpleSignup);
+				$template->assign('signUpLink', $signUpLink);
 				break;
 			default:
-				$page = $this->templateManager->getTemplate('core', 'layout.base');
+				$template = $this->templateManager->getTemplate('core', 'layout.base');
 				break;
 		}
 
@@ -216,9 +216,9 @@ class TemplateLayout {
 		$direction = $l10nFactory->getLanguageDirection($lang);
 
 		$lang = str_replace('_', '-', $lang);
-		$page->assign('language', $lang);
-		$page->assign('locale', $locale);
-		$page->assign('direction', $direction);
+		$template->assign('language', $lang);
+		$template->assign('locale', $locale);
+		$template->assign('direction', $direction);
 
 		// Expose enabled themes for body/theme-related rendering.
 		try {
@@ -226,7 +226,7 @@ class TemplateLayout {
 		} catch (\Exception) {
 			$themesService = null;
 		}
-		$page->assign('enabledThemes', $themesService?->getEnabledThemes() ?? []);
+		$template->assign('enabledThemes', $themesService?->getEnabledThemes() ?? []);
 
 		if ($this->config->getSystemValueBool('installed', false)) {
 			if (empty($this->versionHash)) {
@@ -240,7 +240,7 @@ class TemplateLayout {
 
 		// Resolve and append JavaScript assets.
 		$jsFiles = $this->findJavascriptFiles(Util::getScripts());
-		$page->assign('jsfiles', []);
+		$template->assign('jsfiles', []);
 		if ($this->config->getSystemValueBool('installed', false) && $renderAs !== TemplateResponse::RENDER_AS_ERROR) {
 			// Intentionally build JS config before deciding how to deliver it so the
 			// initial state is populated as a side effect of getConfig().
@@ -264,16 +264,15 @@ class TemplateLayout {
 			);
 			$config = $jsConfigHelper->getConfig();
 			if (Server::get(ContentSecurityPolicyNonceManager::class)->browserSupportsCspV3()) {
-				$page->assign('inline_ocjs', $config);
+				$template->assign('inline_ocjs', $config);
 			} else {
-				$page->append('jsfiles', Server::get(IURLGenerator::class)->linkToRoute('core.OCJS.getConfig', ['v' => $this->versionHash]));
+				$template->append('jsfiles', Server::get(IURLGenerator::class)->linkToRoute('core.OCJS.getConfig', ['v' => $this->versionHash]));
 			}
 		}
 		/** @var array{0:string,1:string,2:string} $resourceInfo */
 		foreach ($jsFiles as $info) {
-			$web = $info[1];
-			$file = $info[2];
-			$page->append('jsfiles', $web . '/' . $file . $this->getVersionHashSuffix());
+			[$absolutePath, $webPath, $resourcePath] = $info;
+			$template->append('jsfiles', $webPath . '/' . $resourcePath . $this->getVersionHashSuffix());
 		}
 
 		try {
@@ -298,23 +297,22 @@ class TemplateLayout {
 			$cssFiles = $this->findStylesheetFiles(\OC_Util::$styles);
 		}
 
-		$page->assign('cssfiles', []);
-		$page->assign('printcssfiles', []);
+		$template->assign('cssfiles', []);
+		$template->assign('printcssfiles', []);
 		$this->initialState->provideInitialState('core', 'versionHash', $this->versionHash);
 		/** @var array{0:string,1:string,2:string} $resourceInfo */
 		foreach ($cssFiles as $info) {
-			$web = $info[1];
-			$file = $info[2];
+			[$absolutePath, $webPath, $resourcePath] = $info;
 
 			if (str_ends_with($file, 'print.css')) {
-				$page->append('printcssfiles', $web . '/' . $file . $this->getVersionHashSuffix());
+				$template->append('printcssfiles', $webPath . '/' . $resourcePath . $this->getVersionHashSuffix());
 			} else {
-				$suffix = $this->getVersionHashSuffix($web, $file);
+				$suffix = $this->getVersionHashSuffix($webPath, $resourcePath);
 
 				if (!str_contains($file, '?v=')) {
-					$page->append('cssfiles', $web . '/' . $file . $suffix);
+					$template->append('cssfiles', $webPath . '/' . $resourcePath . $suffix);
 				} else {
-					$page->append('cssfiles', $web . '/' . $file . '-' . substr($suffix, 3));
+					$template->append('cssfiles', $webPath . '/' . $resourcePath . '-' . substr($suffix, 3));
 				}
 			}
 		}
@@ -322,15 +320,15 @@ class TemplateLayout {
 		if ($this->request->isUserAgent([Request::USER_AGENT_CLIENT_IOS, Request::USER_AGENT_SAFARI, Request::USER_AGENT_SAFARI_MOBILE])) {
 			// Prevent auto zoom with iOS but still allow user zoom
 			// On chrome (and others) this does not work (will also disable user zoom)
-			$page->assign('viewport_maximum_scale', '1.0');
+			$template->assign('viewport_maximum_scale', '1.0');
 		}
 
-		$page->assign('initialStates', $this->initialState->getInitialStates());
+		$template->assign('initialStates', $this->initialState->getInitialStates());
 
-		$page->assign('id-app-content', $renderAs === TemplateResponse::RENDER_AS_USER ? '#app-content' : '#content');
-		$page->assign('id-app-navigation', $renderAs === TemplateResponse::RENDER_AS_USER ? '#app-navigation' : null);
+		$template->assign('id-app-content', $renderAs === TemplateResponse::RENDER_AS_USER ? '#app-content' : '#content');
+		$template->assign('id-app-navigation', $renderAs === TemplateResponse::RENDER_AS_USER ? '#app-navigation' : null);
 
-		return $page;
+		return $template;
 	}
 
 	/**
@@ -344,7 +342,7 @@ class TemplateLayout {
 	 * @param string $file Resource file hint
 	 * @return string Query suffix beginning with "?v=", or an empty string in debug mode
 	 */
-	protected function getVersionHashSuffix(string $path = '', string $file = ''): string {
+	protected function getVersionHashSuffix(string $resourcePathHint = '', string $file = ''): string {
 		if ($this->config->getSystemValueBool('debug', false)) {
 			// allows chrome workspace mapping in debug mode
 			return '';
@@ -471,11 +469,11 @@ class TemplateLayout {
 	 * @throws \Exception If the file path is not under \OC::$SERVERROOT
 	 */
 	public static function convertToRelativePath(string $filePath): string {
-		$relativePath = explode(\OC::$SERVERROOT, $filePath);
-		if (count($relativePath) !== 2) {
+		$pathParts = explode(\OC::$SERVERROOT, $filePath);
+		if (count($pathParts) !== 2) {
 			throw new \Exception('$filePath is not under the \OC::$SERVERROOT');
 		}
 
-		return $relativePath[1];
+		return $pathParts[1];
 	}
 }

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -42,6 +42,11 @@ use OCP\Template\ITemplate;
 use OCP\Template\ITemplateManager;
 use OCP\Util;
 
+/**
+ * Builds and populates page layout templates for the different render modes
+ * (user, guest, public, error, base), including navigation, initial state,
+ * asset lists, language metadata, and cache-busting version suffixes.
+ */
 class TemplateLayout {
 	private string $versionHash = '';
 	/** @var string[] */
@@ -62,6 +67,15 @@ class TemplateLayout {
 	) {
 	}
 
+	/**
+	 * Build the layout template for the requested render mode and populate it with
+	 * common view data such as navigation, localization, initial state, user data,
+	 * and versioned JS/CSS assets.
+	 *
+	 * @param string $renderAs One of the TemplateResponse::RENDER_AS_* constants
+	 * @param string $appId Active app identifier used for navigation and public layout state
+	 * @return ITemplate Prepared layout template
+	 */
 	public function getPageTemplate(string $renderAs, string $appId): ITemplate {
 		// Add fallback theming variables if not rendered as user
 		if ($renderAs !== TemplateResponse::RENDER_AS_USER) {
@@ -69,7 +83,7 @@ class TemplateLayout {
 			Util::addStyle('theming', 'default');
 		}
 
-		// Decide which page we show
+		// Select the base layout template for the requested render mode.
 		switch ($renderAs) {
 			case TemplateResponse::RENDER_AS_USER:
 				$page = $this->templateManager->getTemplate('core', 'layout.user');
@@ -194,7 +208,8 @@ class TemplateLayout {
 				$page = $this->templateManager->getTemplate('core', 'layout.base');
 				break;
 		}
-		// Send the language, locale, and direction to our layouts
+
+		// Expose localization metadata to the selected layout.
 		$l10nFactory = Server::get(IFactory::class);
 		$lang = $l10nFactory->findLanguage();
 		$locale = $l10nFactory->findLocale($lang);
@@ -205,7 +220,7 @@ class TemplateLayout {
 		$page->assign('locale', $locale);
 		$page->assign('direction', $direction);
 
-		// Set body data-theme
+		// Expose enabled themes for body/theme-related rendering.
 		try {
 			$themesService = Server::get(ThemesService::class);
 		} catch (\Exception) {
@@ -223,12 +238,13 @@ class TemplateLayout {
 			$this->versionHash = md5('not installed');
 		}
 
-		// Add the js files
+		// Resolve and append JavaScript assets.
 		$jsFiles = $this->findJavascriptFiles(Util::getScripts());
 		$page->assign('jsfiles', []);
 		if ($this->config->getSystemValueBool('installed', false) && $renderAs !== TemplateResponse::RENDER_AS_ERROR) {
-			// this is on purpose outside of the if statement below so that the initial state is prefilled (done in the getConfig() call)
-			// see https://github.com/nextcloud/server/pull/22636 for details
+			// Intentionally build JS config before deciding how to deliver it so the
+			// initial state is populated as a side effect of getConfig().
+			// See PR #22636 for historical context.
 			$jsConfigHelper = new JSConfigHelper(
 				$this->serverVersion,
 				Util::getL10N('lib'),
@@ -253,6 +269,7 @@ class TemplateLayout {
 				$page->append('jsfiles', Server::get(IURLGenerator::class)->linkToRoute('core.OCJS.getConfig', ['v' => $this->versionHash]));
 			}
 		}
+		/** @var array{0:string,1:string,2:string} $resourceInfo */
 		foreach ($jsFiles as $info) {
 			$web = $info[1];
 			$file = $info[2];
@@ -265,8 +282,8 @@ class TemplateLayout {
 			$pathInfo = '';
 		}
 
-		// Do not initialise scss appdata until we have a fully installed instance
-		// Do not load scss for update, errors, installation or login page
+		// Only use compiled SCSS assets on fully installed, non-upgrade, non-error,
+		// non-login requests. Fall back to guest styling otherwise.
 		if ($this->config->getSystemValueBool('installed', false)
 			&& !Util::needUpgrade()
 			&& $pathInfo !== ''
@@ -284,6 +301,7 @@ class TemplateLayout {
 		$page->assign('cssfiles', []);
 		$page->assign('printcssfiles', []);
 		$this->initialState->provideInitialState('core', 'versionHash', $this->versionHash);
+		/** @var array{0:string,1:string,2:string} $resourceInfo */
 		foreach ($cssFiles as $info) {
 			$web = $info[1];
 			$file = $info[2];
@@ -315,6 +333,17 @@ class TemplateLayout {
 		return $page;
 	}
 
+	/**
+	 * Build the cache-busting query suffix for a static resource.
+	 *
+	 * In non-debug mode this prefers a hash derived from the owning app/version
+	 * when the app can be inferred from the resource path. If that fails, it falls
+	 * back to the server-wide version hash. A theming cache-buster is always appended.
+	 *
+	 * @param string $path Resource web path hint
+	 * @param string $file Resource file hint
+	 * @return string Query suffix beginning with "?v=", or an empty string in debug mode
+	 */
 	protected function getVersionHashSuffix(string $path = '', string $file = ''): string {
 		if ($this->config->getSystemValueBool('debug', false)) {
 			// allows chrome workspace mapping in debug mode
@@ -331,11 +360,11 @@ class TemplateLayout {
 		if ($path !== '') {
 			$hash = $this->getVersionHashByPath($path);
 		}
-		// If not found try the file
+		// If no hash was derived from the web path, try the file hint.
 		if ($hash === false && $file !== '') {
 			$hash = $this->getVersionHashByPath($file);
 		}
-		// As a last resort we use the server version hash
+		// Fall back to the server-wide version hash.
 		if ($hash === false) {
 			$hash = $this->versionHash;
 		}
@@ -346,17 +375,25 @@ class TemplateLayout {
 		return '?v=' . $hash . $themingSuffix;
 	}
 
+	/**
+	 * Resolve a cache-busting hash for a resource path by inferring its owning app.
+	 *
+	 * Returns false when no app can be inferred from the provided path.
+	 *
+	 * @param string $path Resource path used to infer the app name
+	 * @return string|false
+	 */
 	private function getVersionHashByPath(string $path): string|false {
 		if (array_key_exists($path, $this->cacheBusterCache) === false) {
-			// Not yet cached, so lets find the cache buster string
-			$appId = $this->getAppNamefromPath($path);
+			// Not cached yet; compute the resource cache-buster hash.
+			$appId = $this->getAppNameFromPath($path);
 			if ($appId === false) {
-				// No app Id could be guessed
+				// Unable to infer an owning app from the resource path.
 				return false;
 			}
 
 			if ($appId === 'core') {
-				// core is not a real app but the server itself
+				// "core" maps to the server version hash rather than an app version.
 				$hash = $this->versionHash;
 			} else {
 				$appVersion = $this->appManager->getAppVersion($appId);
@@ -373,6 +410,12 @@ class TemplateLayout {
 		return $this->cacheBusterCache[$path];
 	}
 
+	/**
+	 * Resolve stylesheet resources via the CSS resource locator.
+	 *
+	 * @param array $styles Registered style definitions
+	 * @return array<int, array{0:string, 1:string, 2:string}> Located stylesheet resources
+	 */
 	private function findStylesheetFiles(array $styles): array {
 		if ($this->cssLocator === null) {
 			$this->cssLocator = Server::get(CSSResourceLocator::class);
@@ -381,7 +424,18 @@ class TemplateLayout {
 		return $this->cssLocator->getResources();
 	}
 
-	public function getAppNamefromPath(string $path): string|false {
+	/**
+	 * Heuristically infer the app name from a resource path.
+	 *
+	 * Expected formats include:
+	 * - "css/<app>/..."
+	 * - "core/..."
+	 * - other resource paths where the last path segment represents the app id
+	 *
+	 * @param string $path
+	 * @return string|false Inferred app id, or false if it cannot be determined
+	 */
+	public function getAppNameFromPath(string $path): string|false {
 		if ($path !== '') {
 			$pathParts = explode('/', $path);
 			if ($pathParts[0] === 'css') {
@@ -395,6 +449,12 @@ class TemplateLayout {
 		return false;
 	}
 
+	/**
+	 * Resolve Javascript resources via the JS resource locator.
+	 *
+	 * @param array $styles Registered JS definitions
+	 * @return array<int, array{0:string, 1:string, 2:string}> Located JS resources
+	 */
 	private function findJavascriptFiles(array $scripts): array {
 		if ($this->jsLocator === null) {
 			$this->jsLocator = Server::get(JSResourceLocator::class);
@@ -404,12 +464,13 @@ class TemplateLayout {
 	}
 
 	/**
-	 * Converts the absolute file path to a relative path from \OC::$SERVERROOT
+	 * Convert an absolute file path into a path relative to \OC::$SERVERROOT.
+	 *
 	 * @param string $filePath Absolute path
 	 * @return string Relative path
-	 * @throws \Exception If $filePath is not under \OC::$SERVERROOT
+	 * @throws \Exception If the file path is not under \OC::$SERVERROOT
 	 */
-	public static function convertToRelativePath(string $filePath) {
+	public static function convertToRelativePath(string $filePath): string {
 		$relativePath = explode(\OC::$SERVERROOT, $filePath);
 		if (count($relativePath) !== 2) {
 			throw new \Exception('$filePath is not under the \OC::$SERVERROOT');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

I'm working on some other changes in this class, but figured I'd submit these easier to review changes first.

This PR aims to improve readability of `OC\TemplateLayout` by clarifying naming, comments, and docblocks. It also adds basic unit test coverage.

Specific changes:

- Adds class docblock
- Adds key function docblocks
- Some minor code reformatting (lines 106-126)
- Renames variables for improved clarity
- Replaces vague comments
- Adds clarifying comments in key spots
- Makes locator properties `private`

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
