### PR TITLE
fix(files,systemtags): correct tag-folder breadcrumb, DAV root filtering, and nav label

### DIFF
--- a/apps/files/src/components/BreadCrumbs.vue
+++ b/apps/files/src/components/BreadCrumbs.vue
@@ -222,7 +222,15 @@ export default defineComponent({
 
 			const source = this.getFileSourceFromPath(path)
 			const node = source ? this.getNodeFromSource(source) : undefined
-			return node?.displayname || basename(path)
+			if (node?.displayname) {
+				return node.displayname
+			}
+			// Fallback while the path store is not yet populated (e.g. tag folder
+			// before the REPORT completes): use the active folder's display name.
+			if (this.activeStore.activeFolder?.path === path) {
+				return this.activeStore.activeFolder.displayname || basename(path)
+			}
+			return basename(path)
 		},
 
 		getTo(dir: string, node?: Node): Record<string, unknown> {

--- a/apps/files/src/store/files.ts
+++ b/apps/files/src/store/files.ts
@@ -6,6 +6,7 @@
 import type { IFolder, INode } from '@nextcloud/files'
 import type { FileSource, FilesStore, RootOptions, RootsStore, Service } from '../types.ts'
 
+import { getRootPath } from '@nextcloud/files/dav'
 import { subscribe } from '@nextcloud/event-bus'
 import { defineStore } from 'pinia'
 import Vue, { ref } from 'vue'
@@ -215,12 +216,19 @@ export const useFilesStore = defineStore('files', () => {
 	 * @param node - The updated node
 	 */
 	async function onUpdatedNode(node: INode) {
-		// If we have multiple nodes with the same file ID, we need to update all of them
+		// If we have multiple nodes with the same file ID, we need to update all of them.
+		// Filter to only nodes under the files DAV root — e.g. systemtag folder nodes share
+		// an integer ID namespace with regular files but live under /systemtags and cannot
+		// be fetched via the /files/{uid} DAV client.
 		const nodes = node.id
 			? getNodesById(node.id)
 			: getNodes([node.source])
 		if (nodes.length > 1) {
-			await Promise.all(nodes.map((node) => fetchNode(node.path))).then(updateNodes)
+			const filesRoot = getRootPath()
+			const fileNodes = nodes.filter((n) => n.root === filesRoot)
+			if (fileNodes.length > 0) {
+				await Promise.all(fileNodes.map((n) => fetchNode(n.path))).then(updateNodes)
+			}
 			logger.debug(nodes.length + ' nodes updated in store', { fileid: node.id, source: node.source })
 			return
 		}
@@ -231,7 +239,12 @@ export const useFilesStore = defineStore('files', () => {
 			return
 		}
 
-		// Otherwise, it means we receive an event for a node that is not in the store
+		// Otherwise, it means we receive an event for a node that is not in the store.
+		// Skip nodes from non-files roots (e.g. /systemtags) — they cannot be fetched
+		// via the /files/{uid} DAV client and would result in a spurious 404.
+		if (node.root !== getRootPath()) {
+			return
+		}
 		fetchNode(node.path).then((n) => updateNodes([n]))
 	}
 

--- a/apps/files/src/utils/fileUtils.ts
+++ b/apps/files/src/utils/fileUtils.ts
@@ -30,12 +30,17 @@ export function extractFilePaths(path: string): [string, string] {
  */
 export function getSummaryFor(nodes: Node[], hidden = 0): string {
 	const fileCount = nodes.filter((node) => node.type === FileType.File).length
-	const folderCount = nodes.filter((node) => node.type === FileType.Folder).length
+	const tagCount = nodes.filter((node) => node.type === FileType.Folder && node.attributes?.['is-tag']).length
+	const folderCount = nodes.filter((node) => node.type === FileType.Folder && !node.attributes?.['is-tag']).length
 
 	const summary: string[] = []
-	if (fileCount > 0 || folderCount === 0) {
+	if (fileCount > 0 || (folderCount === 0 && tagCount === 0)) {
 		const fileSummary = n('files', '%n file', '%n files', fileCount)
 		summary.push(fileSummary)
+	}
+	if (tagCount > 0) {
+		const tagSummary = n('systemtags', '%n tag', '%n tags', tagCount)
+		summary.push(tagSummary)
 	}
 	if (folderCount > 0) {
 		const folderSummary = n('files', '%n folder', '%n folders', folderCount)


### PR DESCRIPTION
## Summary

Three focused fixes for systemtags integration in the files app:

- **BreadCrumbs.vue**: Fall back to `activeFolder.displayname` while the path store is not yet populated (tag folder before REPORT completes). Previously the breadcrumb showed the raw tag URI path until the first PROPFIND response arrived.
- **files store `onUpdatedNode`**: Skip nodes whose root is not the files DAV root. Systemtag folder nodes share the integer-ID namespace but live under `/systemtags`; trying to fetch them via `/files/{uid}` produces spurious 404s when `systemtags:node:updated` fires.
- **`getSummaryFor`**: Detect the `is-tag` attribute on `Folder` nodes and report "N tag(s)" instead of "N folder(s)" using the `systemtags` translation domain.

## Test plan

- [ ] Open Files, navigate to a system tag folder — breadcrumb shows tag name immediately, not the raw path
- [ ] Confirm no 404 errors in browser console when clicking a systemtag folder
- [ ] Footer summary shows "1 tag" / "N tags" for tag-folder selections

Note: this supersedes PR #60657, which was closed after a rebase introduced unrelated workflow and template changes.

AI assistance disclosure: branch was authored with Claude Code assistance (claude-sonnet-4-6).