### PR TITLE
ci(integration): drop stale remoteapi_features test matrix entry

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -66,7 +66,6 @@ jobs:
           - 'openldap_features'
           - 'openldap_numerical_features'
           - 'ldap_features'
-          - 'remoteapi_features'
           - 'routing_features'
           - 'setup_features'
           - 'sharees_features'


### PR DESCRIPTION
The remoteapi Behat suite (RemoteContext.php, remote.feature and its behat.yml suite entry) was removed in 09ed12161d6 because the underlying Remote API classes (OC\Remote\* and OCP\Remote\*) were deleted in #60953. The Integration sqlite workflow matrix still referenced the suite, so the "remoteapi_features" job failed on every push and pull request with:

    No specifications found at path(s) `remoteapi_features`.

This turned a required check red on every PR and was a major contributor to the integration suite appearing flaky. Remove the dangling matrix entry so the job set matches the suites that actually exist.

Assisted-by: ClaudeCode:claude-opus-4-8

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
