### PR TITLE
fix(files_metadata): skip UpdateSingleMetadata silently for non-local owners

### DIFF
--- a/lib/private/FilesMetadata/Job/UpdateSingleMetadata.php
+++ b/lib/private/FilesMetadata/Job/UpdateSingleMetadata.php
@@ -14,6 +14,7 @@ use OCP\BackgroundJob\QueuedJob;
 use OCP\Files\IRootFolder;
 use OCP\FilesMetadata\Event\MetadataLiveEvent;
 use OCP\FilesMetadata\IFilesMetadataManager;
+use OCP\User\NoUserException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -43,6 +44,8 @@ class UpdateSingleMetadata extends QueuedJob {
 			if ($node) {
 				$this->filesMetadataManager->refreshMetadata($node, IFilesMetadataManager::PROCESS_BACKGROUND);
 			}
+		} catch (NoUserException $e) {
+			// Owner is not a local user (e.g. a federated cloud ID) — skip silently
 		} catch (\Exception $e) {
 			$this->logger->warning('issue while running UpdateSingleMetadata', ['exception' => $e, 'userId' => $userId, 'fileId' => $fileId]);
 		}


### PR DESCRIPTION
## Summary

When a federated share is accepted, `FilesMetadataManager` queues `UpdateSingleMetadata` with the share owner's cloud ID (e.g. `alice@remote.host`) as the `userId`. `getUserFolder()` then throws `NoUserException` because the cloud ID is not a local user account, producing a spurious warning on every cron run:

```
issue while running UpdateSingleMetadata
OC\User\NoUserException: Backends provided no user object
```

This catch is added to handle `NoUserException` separately and skip without logging — this is an expected condition for federated shares where the file owner lives on a remote instance, not a genuine error.

## Test plan

- [ ] Accept a federated share from a remote instance
- [ ] Run cron (`php cron.php`)
- [ ] Confirm no `UpdateSingleMetadata` warning appears in the log for the federated share owner
- [ ] Confirm genuine errors (non-`NoUserException`) still log as warnings

AI assistance disclosure: fix authored with Claude Code assistance (claude-sonnet-4-6).