### PR TITLE
fix: use correct permissions mask for non-home storage public links

### DIFF
--- a/apps/dav/appinfo/v2/publicremote.php
+++ b/apps/dav/appinfo/v2/publicremote.php
@@ -7,6 +7,7 @@
  */
 use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\DirPermissionsMask;
+use OC\Files\Storage\Wrapper\PermissionsMask;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\PublicAuth;
 use OCA\DAV\Connector\Sabre\ServerFactory;
@@ -21,6 +22,7 @@ use OCP\App\IAppManager;
 use OCP\BeforeSabrePubliclyLoadedEvent;
 use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IHomeStorage;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\ICacheFactory;
@@ -115,11 +117,15 @@ $server = $serverFactory->createServer(true, $baseuri, $requestUri, $authPlugin,
 			$mask |= Constants::PERMISSION_READ | Constants::PERMISSION_DELETE;
 		}
 
-		return new DirPermissionsMask([
-			'storage' => $storage,
-			'mask' => $mask,
-			'path' => 'files',
-		]);
+		if ($storage instanceof IHomeStorage) {
+			return new DirPermissionsMask([
+				'storage' => $storage,
+				'mask' => $mask,
+				'path' => 'files',
+			]);
+		} else {
+			return new PermissionsMask(['storage' => $storage, 'mask' => $mask]);
+		}
 	});
 
 	/** @psalm-suppress MissingClosureParamType */

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -335,6 +335,23 @@ trait WebDav {
 	}
 
 	/**
+	 * @When Uploading public file :filename with content :content
+	 */
+	public function uploadingPublicFile(string $filename, string $content) {
+		$token = $this->lastShareData->data->token;
+		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/dav/files/$token/$filename";
+
+		$client = new GClient();
+		try {
+			$this->response = $client->request('PUT', $fullUrl, [
+				'body' => $content
+			]);
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
 	 * @Then /^as "([^"]*)" gets properties of (file|folder|entry) "([^"]*)" with$/
 	 * @param string $user
 	 * @param string $elementType

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -556,7 +556,28 @@ Feature: sharing
     And Share fields of last share match with
       | expiration | +3 days |
 
-  Scenario: getting all shares of a user using that user
+Scenario: Writing to a read-only link share of an external storage
+	Given user "user0" exists
+	Then As an "user0"
+	When creating a share with
+		| path | local_storage |
+		| shareType | 3 |
+	And the OCS status code should be "100"
+	And the HTTP status code should be "200"
+	Then Uploading public file "foo.txt" with content "bar"
+	And the HTTP status code should be "403"
+
+Scenario: Writing to a read-write link share of an external storage
+	Given user "user0" exists
+	Then As an "user0"
+	When creating a share with
+		| path | local_storage |
+		| shareType | 3 |
+		| permissions | 7 |
+	Then Uploading public file "foo.txt" with content "bar"
+	And the HTTP status code should be "201"
+
+Scenario: getting all shares of a user using that user
     Given user "user0" exists
     And user "user1" exists
     When User "user1" deletes file "/textfile0.txt"

--- a/lib/private/Files/Storage/Wrapper/DirPermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/DirPermissionsMask.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Cache\Wrapper\CacheDirPermissionsMask;
-use OC\Files\Storage\Storage;
 use OCP\Files\Cache\ICache;
+use OCP\Files\Storage\IStorage;
 
 /**
  * While PermissionMask can mask a whole storage this  can
@@ -30,7 +30,7 @@ class DirPermissionsMask extends PermissionsMask {
 	private readonly int $pathLength;
 
 	/**
-	 * @param array{storage: Storage, mask: int, path: string, ...} $parameters
+	 * @param array{storage: IStorage, mask: int, path: string, ...} $parameters
 	 * @psalm-suppress MoreSpecificImplementedParamType
 	 *
 	 * $storage: The storage the permissions mask should be applied on


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

For  non-home storages we need to mask the entire thing, not just the files directory.

Fixes https://github.com/nextcloud/server/issues/61021

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
