### PR TITLE
test(config): fix flaky UserConfig::getAllValues assertion

### DIFF
--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -655,7 +655,7 @@ class UserConfigTest extends TestCase {
 		array $result,
 	): void {
 		$userConfig = $this->generateUserConfig();
-		$this->assertEqualsCanonicalizing($result, $userConfig->getAllValues($userId, $filtered));
+		$this->assertEquals($result, $userConfig->getAllValues($userId, $filtered));
 	}
 
 	public static function providerSearchValuesByApps(): array {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Replace `assertEqualsCanonicalizing()` with a strict equality assertion in `UserConfigTest::testGetAllValues()`.

### Why

`IUserConfig::getAllValues()` returns a keyed nested map of:

* `appId => [key => value]`

The current test uses `assertEqualsCanonicalizing()`, which is not a good fit for this structure, especially when inner config keys are numeric-like (for example `user2/app1` uses `'1'`, `'2'`, etc.). That can cause PHPUnit to normalize nested arrays in a way that makes the test flaky:

```
There was 1 failure:

1) Test\lib\Config\UserConfigTest::testGetAllValues with data set #0 ('user2', false, [['value1', 42, 17.42, true, 'value2', 17], ['value2b', 'value3', 'value4', 12], [false], ['value1']])
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     3 => Array (
         0 => 17.42
         1 => 42
-        2 => 'value1'
-        3 => true
-        4 => 17
+        2 => true
+        3 => 17
+        4 => 'value1'
         5 => 'value2'
     )
 )

/home/runner/work/server/server/tests/lib/Config/UserConfigTest.php:658
```

### Changes

* update `testGetAllValues()` to compare the returned structure directly instead of canonicalizing it

### Result
* the test now validates the actual `getAllValues()` contract
* removes flakiness caused by canonicalization of nested keyed arrays
* keeps implementation behavior unchanged

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
