### PR TITLE
fix(settings): Fix appstore icon color in settings menu

### DIFF
--- a/apps/appstore/REUSE.toml
+++ b/apps/appstore/REUSE.toml
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText = "2026 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "CC-BY-SA-4.0"
 
 [[annotations]]
-path = ["img/app.svg"]
+path = ["img/app.svg", "img/app-dark.svg"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2018-2024 Google LLC"
 SPDX-License-Identifier = "Apache-2.0"

--- a/apps/appstore/appinfo/info.xml
+++ b/apps/appstore/appinfo/info.xml
@@ -31,7 +31,7 @@
 		<navigation role="admin">
 			<name>Apps</name>
 			<route>appstore.page.viewApps</route>
-			<icon>app.svg</icon>
+			<icon>app-dark.svg</icon>
 			<order>5</order>
 			<type>settings</type>
 		</navigation>

--- a/apps/appstore/img/app-dark.svg
+++ b/apps/appstore/img/app-dark.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 16 16" height="16" width="16" fill="#000" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"><path d="M11 13H5v-2h6V5h2v6h6v2h-6v6h-2v-6Z" style="fill-rule:nonzero" transform="matrix(.85714 0 0 .85714 -2.286 -2.286)"/></svg>


### PR DESCRIPTION
- Regression from fixing the app menu in https://github.com/nextcloud/server/pull/60989

## Before
Bright | Dark
---|---
<img width="390" height="370" alt="Bildschirmfoto vom 2026-06-08 17-52-52" src="https://github.com/user-attachments/assets/481f3ceb-ef18-4a80-89da-9dd0bed7d186" /> | <img width="390" height="370" alt="Bildschirmfoto vom 2026-06-08 17-52-57" src="https://github.com/user-attachments/assets/9fe1171c-4724-4ca3-9bdc-01331b69438f" />
<img width="346" height="467" alt="Bildschirmfoto vom 2026-06-08 17-51-06" src="https://github.com/user-attachments/assets/c73f7b23-f97f-489a-af26-1f1db882829a" /> | <img width="346" height="467" alt="Bildschirmfoto vom 2026-06-08 17-50-58" src="https://github.com/user-attachments/assets/51f9a6ed-0056-43f5-8376-fcd324ea1d21" />

## After

Bright | Dark
---|---
<img width="388" height="371" alt="Bildschirmfoto vom 2026-06-08 17-50-24" src="https://github.com/user-attachments/assets/144dd73e-2b78-49a0-8122-92bb597ce172" /> | <img width="388" height="371" alt="Bildschirmfoto vom 2026-06-08 17-50-10" src="https://github.com/user-attachments/assets/fb5ca1d6-16ce-44f0-89d1-93da1bfb9037" />
<img width="346" height="467" alt="Bildschirmfoto vom 2026-06-08 17-50-35" src="https://github.com/user-attachments/assets/d19ab3b2-7b2d-4624-995d-6cce2d4a0193" /> | <img width="346" height="467" alt="Bildschirmfoto vom 2026-06-08 17-50-42" src="https://github.com/user-attachments/assets/d4d2e8ef-73fa-4f4f-b767-d7e8d5e73df0" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
