### PR TITLE
test(files): reload tagger in TagServiceTest to avoid flaky cache state

### DIFF
--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -35,7 +35,6 @@ class TagServiceTest extends \Test\TestCase {
 	private IManager&MockObject $activityManager;
 	private Folder $root;
 	private TagService&MockObject $tagService;
-	private ITags $tagger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -56,7 +55,6 @@ class TagServiceTest extends \Test\TestCase {
 
 		$this->root = Server::get(IRootFolder::class)->getUserFolder($this->user);
 
-		$this->tagger = Server::get(ITagManager::class)->load('files');
 		$this->tagService = $this->getTagService();
 	}
 
@@ -95,24 +93,24 @@ class TagServiceTest extends \Test\TestCase {
 		// set tags
 		$this->tagService->updateFileTags('subdir/test.txt', [$tag1, $tag2]);
 
-		// Sync to reload tags
-		$this->tagger->addMultiple([], sync:true);
-		$this->assertEquals([$fileId], $this->tagger->getIdsForTag($tag1));
-		$this->assertEquals([$fileId], $this->tagger->getIdsForTag($tag2));
+		// use a freshly loaded ITags instance after each updateFileTags() call (more realistic)
+		$tagger = Server::get(ITagManager::class)->load('files');
+		$this->assertEquals([$fileId], $tagger->getIdsForTag($tag1));
+		$this->assertEquals([$fileId], $tagger->getIdsForTag($tag2));
 
 		// remove tag
 		$this->tagService->updateFileTags('subdir/test.txt', [$tag2]);
-		// Sync to reload tags
-		$this->tagger->addMultiple([], sync:true);
-		$this->assertEquals([], $this->tagger->getIdsForTag($tag1));
-		$this->assertEquals([$fileId], $this->tagger->getIdsForTag($tag2));
+
+		$tagger = Server::get(ITagManager::class)->load('files');
+		$this->assertEquals([], $tagger->getIdsForTag($tag1));
+		$this->assertEquals([$fileId], $tagger->getIdsForTag($tag2));
 
 		// clear tags
 		$this->tagService->updateFileTags('subdir/test.txt', []);
 		// Sync to reload tags
-		$this->tagger->addMultiple([], sync:true);
-		$this->assertEquals([], $this->tagger->getIdsForTag($tag1));
-		$this->assertEquals([], $this->tagger->getIdsForTag($tag2));
+		$tagger = Server::get(ITagManager::class)->load('files');
+		$this->assertEquals([], $tagger->getIdsForTag($tag1));
+		$this->assertEquals([], $tagger->getIdsForTag($tag2));
 
 		// non-existing file
 		$caught = false;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Make `TagServiceTest::testUpdateFileTags()` deterministic by reloading the file tagger before assertions instead of reusing a cached instance.

### Problem

The test updated tags through `TagService`, which uses its own `ITags` instance internally, but asserted through a separate `$tagger` instance created in `setUp()`. That made the test depend on cross-instance cache refresh behavior and caused intermittent failures where the expected file ID was missing from `getIdsForTag()` results.

### Changes

- remove the shared `$tagger` test property
- stop initializing the tagger in `setUp()`
- load a fresh `ITags` instance before each assertion phase in `testUpdateFileTags()`
- remove the cache-refresh workaround based on `addMultiple([], sync: true)`

### Why this fixes the flake

Reloading the tagger reflects how persisted tag state is consumed in practice and avoids relying on stale in-memory state from a previously created `ITags` instance.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
