### PR TITLE
fix(comments): Use capped memory cache for comments

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -9,6 +9,7 @@
 namespace OC\Comments;
 
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Cache\CappedMemoryCache;
 use OCP\Comments\CommentsEvent;
 use OCP\Comments\Events\BeforeCommentUpdatedEvent;
 use OCP\Comments\Events\CommentAddedEvent;
@@ -34,8 +35,7 @@ use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class Manager implements ICommentsManager {
-	/** @var IComment[] */
-	protected array $commentsCache = [];
+	protected CappedMemoryCache $commentsCache;
 
 	/** @var \Closure[] */
 	protected array $eventHandlerClosures = [];
@@ -56,6 +56,7 @@ class Manager implements ICommentsManager {
 		protected IRootFolder $rootFolder,
 		protected IEventDispatcher $eventDispatcher,
 	) {
+		$this->commentsCache = new CappedMemoryCache(256);
 	}
 
 	/**
@@ -1322,7 +1323,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $actorId);
 
 		$affectedRows = $qb->executeStatement();
-		$this->commentsCache = [];
+		$this->commentsCache->clear();
 		return true;
 	}
 
@@ -1342,7 +1343,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $objectId);
 
 		$affectedRows = $qb->executeStatement();
-		$this->commentsCache = [];
+		$this->commentsCache->clear();
 		return true;
 	}
 
@@ -1602,7 +1603,7 @@ class Manager implements ICommentsManager {
 
 		$affectedRows = $qb->executeStatement();
 
-		$this->commentsCache = [];
+		$this->commentsCache->clear();
 
 		return $affectedRows > 0;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

In some situations (many sample conversations or scripting) Talk generates hundred/thousands of comments which currently leads to memory issues. Using a capped cache fixes this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
