### PR TITLE
fix: Correctly detect appid for dist css files

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -386,7 +386,7 @@ class TemplateLayout {
 			$pathParts = explode('/', $path);
 			if ($pathParts[0] === 'dist') {
 				// Return the part before the dash in the file name
-				return explode('-', \array_last($pathParts), 2)[0];
+				return explode('-', \end($pathParts), 2)[0];
 			} elseif ($pathParts[0] === 'css') {
 				// This is a scss request
 				return $pathParts[1];

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -384,7 +384,10 @@ class TemplateLayout {
 	public function getAppNamefromPath(string $path): string|false {
 		if ($path !== '') {
 			$pathParts = explode('/', $path);
-			if ($pathParts[0] === 'css') {
+			if ($pathParts[0] === 'dist') {
+				// Return the part before the dash in the file name
+				return explode('-', \array_last($pathParts), 2)[0];
+			} elseif ($pathParts[0] === 'css') {
 				// This is a scss request
 				return $pathParts[1];
 			} elseif ($pathParts[0] === 'core') {


### PR DESCRIPTION
## Summary

Follow-up of ab551c4c8ac532a048b6a62be2713827ee963f0f

This avoids the error "Only lowercase alphanumeric characters are allowed in appIds; check paths of installed app [1 characters replaced]" in the logs, because it was trying to use "user_status-menu.css" as an appid.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
