### PR TITLE
test(files): make row action-menu lookup atomic to fix detached-DOM f…

### DIFF
--- a/cypress/e2e/files/FilesUtils.ts
+++ b/cypress/e2e/files/FilesUtils.ts
@@ -26,9 +26,7 @@ export const getActionButtonForFile = (filename: string) => getActionsForFile(fi
 export function getActionEntryForFileId(fileid: number, actionId: string) {
 	return getActionButtonForFileId(fileid)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get(`#${menuId}`)
-			.should('exist')
-			.find(`[data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
+		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
 }
 
 /**
@@ -39,9 +37,7 @@ export function getActionEntryForFileId(fileid: number, actionId: string) {
 export function getActionEntryForFile(file: string, actionId: string) {
 	return getActionButtonForFile(file)
 		.should('have.attr', 'aria-controls')
-		.then((menuId) => cy.get(`#${menuId}`)
-			.should('exist')
-			.find(`[data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
+		.then((menuId) => cy.get(`#${menuId} [data-cy-files-list-row-action="${CSS.escape(actionId)}"]`))
 }
 
 /**


### PR DESCRIPTION
## Summary

Should make Files cypress tests a little less flaky :crossed_fingers: 

`getActionEntryFor*` in files test utils looked up the open row action menu in two steps. The menu is a teleported `NcActions` popover that re-renders, so the captured subject detaches and the chained `.find()` throws *"subject is no longer attached to the DOM"*. This seems to be one of the most frequent cypress flakes on master, hitting files-renaming, files-copy-move, etc. etc.

## Change

Collapse the lookup into one atomic query so cypress retries the whole selector against the live DOM when the popover re-renders, instead of holding a stale subject. 
