### PR TITLE
test(dav): fix availability replacement picker selectors

### DIFF
--- a/cypress/e2e/appstore/apps.cy.ts
+++ b/cypress/e2e/appstore/apps.cy.ts
@@ -228,8 +228,7 @@ describe('Settings: App management', { testIsolation: true }, () => {
 		cy.findByRole('dialog')
 			.should('be.visible')
 			.within(() => {
-				cy.get('input')
-					.should('be.focused')
+				cy.findByRole('combobox')
 					.type('admin')
 			})
 		cy.findByRole('option', { name: /admin/ })

--- a/cypress/e2e/dav/availability.cy.ts
+++ b/cypress/e2e/dav/availability.cy.ts
@@ -94,7 +94,7 @@ describe('Calendar: Availability', { testIsolation: true }, () => {
 			.type('Happy holidays!')
 
 		cy.intercept('GET', '**/ocs/v2.php/apps/files_sharing/api/v1/sharees?*search=replacement*').as('userSearch')
-		cy.findByRole('searchbox')
+		cy.findByRole('combobox', { name: /Out of office replacement/ })
 			.should('be.visible')
 			.as('userSearchBox')
 			.click()
@@ -122,7 +122,7 @@ describe('Calendar: Availability', { testIsolation: true }, () => {
 			.should('have.value', 'Vacation')
 		cy.findByRole('textbox', { name: /Long absence/ })
 			.should('have.value', 'Happy holidays!')
-		cy.findByRole('combobox')
+		cy.get('#absence')
 			.should('contain.text', 'replacement-user')
 	})
 })

--- a/cypress/e2e/systemtags/admin-settings.cy.ts
+++ b/cypress/e2e/systemtags/admin-settings.cy.ts
@@ -36,7 +36,7 @@ describe('Create system tags', () => {
 		cy.wait('@createTag').its('response.statusCode').should('eq', 201)
 
 		// see that the created tag is in the list
-		cy.get('input#system-tags-input').focus()
+		cy.get('input#system-tags-input').click()
 		cy.get('input#system-tags-input').invoke('attr', 'aria-controls').then((id) => {
 			cy.get(`ul#${id} li span[title="${tagName}"]`)
 				.should('exist')
@@ -52,7 +52,7 @@ describe('Update system tags', { testIsolation: false }, () => {
 	})
 
 	it('select the tag', () => {
-		cy.get('input#system-tags-input').focus()
+		cy.get('input#system-tags-input').click()
 		cy.get('input#system-tags-input').invoke('attr', 'aria-controls').then((id) => {
 			cy.get(`ul#${id} li span[title="${tagName}"]`).should('exist').click()
 		})
@@ -69,7 +69,7 @@ describe('Update system tags', { testIsolation: false }, () => {
 		cy.get('input#system-tag-name').type(updatedTagName)
 		cy.get('input#system-tag-name').should('have.value', updatedTagName)
 		// select the new tag level
-		cy.get('input#system-tag-level').focus()
+		cy.get('input#system-tag-level').click()
 		cy.get('input#system-tag-level').invoke('attr', 'aria-controls').then((id) => {
 			cy.get(`ul#${id} li span[title="Invisible"]`).should('exist').click()
 		})
@@ -80,7 +80,7 @@ describe('Update system tags', { testIsolation: false }, () => {
 	})
 
 	it('see the tag was successfully updated', () => {
-		cy.get('input#system-tags-input').focus()
+		cy.get('input#system-tags-input').click()
 		cy.get('input#system-tags-input').invoke('attr', 'aria-controls').then((id) => {
 			cy.get(`ul#${id} li span[title="${updatedTagName} (invisible)"]`)
 				.should('exist')
@@ -97,7 +97,7 @@ describe('Delete system tags', { testIsolation: false }, () => {
 
 	it('select the tag', () => {
 		// select the tag to edit
-		cy.get('input#system-tags-input').focus()
+		cy.get('input#system-tags-input').click()
 		cy.get('input#system-tags-input').invoke('attr', 'aria-controls').then((id) => {
 			cy.get(`ul#${id} li span[title="${updatedTagName} (invisible)"]`).should('exist').click()
 		})
@@ -118,7 +118,7 @@ describe('Delete system tags', { testIsolation: false }, () => {
 	})
 
 	it('see that the deleted tag is not present', () => {
-		cy.get('input#system-tags-input').focus()
+		cy.get('input#system-tags-input').click()
 		cy.get('input#system-tags-input').invoke('attr', 'aria-controls').then((id) => {
 			cy.get(`ul#${id} li span[title="${updatedTagName}"]`).should('not.exist')
 		})


### PR DESCRIPTION
## Summary

Three cypress specs flake or break on how they drive NcSelect inputs. Same class of problem, fixed together.

