### PR TITLE
chore(ci): Fix tests searching for non-existing searchbox role

### DIFF
--- a/apps/files/src/views/FilesNavigation.spec.ts
+++ b/apps/files/src/views/FilesNavigation.spec.ts
@@ -52,7 +52,7 @@ describe('Navigation', () => {
 		// see the navigation
 		await expect(component.findByRole('navigation', { name: 'Files' })).resolves.not.toThrow()
 		// see the search box
-		await expect(component.findByRole('searchbox', { name: /Search here/ })).resolves.not.toThrow()
+		await expect(component.findByRole('combobox', { name: /Search here/ })).resolves.not.toThrow()
 		// see the settings entry
 		await expect(component.findByRole('link', { name: /Files settings/ })).resolves.not.toThrow()
 	})

--- a/cypress/e2e/dav/availability.cy.ts
+++ b/cypress/e2e/dav/availability.cy.ts
@@ -94,7 +94,7 @@ describe('Calendar: Availability', { testIsolation: true }, () => {
 			.type('Happy holidays!')
 
 		cy.intercept('GET', '**/ocs/v2.php/apps/files_sharing/api/v1/sharees?*search=replacement*').as('userSearch')
-		cy.findByRole('searchbox')
+		cy.findByRole('combobox')
 			.should('be.visible')
 			.as('userSearchBox')
 			.click()

--- a/cypress/e2e/files/search.cy.ts
+++ b/cypress/e2e/files/search.cy.ts
@@ -138,7 +138,7 @@ describe('files: search', () => {
 			.should('be.visible')
 			.within(() => {
 				// see within there is a search box with the same value
-				cy.findByRole('searchbox', { name: /search for files/i })
+				cy.findByRole('combobox', { name: /search for files/i })
 					.should('be.visible')
 					.and('have.value', 'xyz')
 			})

--- a/cypress/e2e/settings/users_search.cy.ts
+++ b/cypress/e2e/settings/users_search.cy.ts
@@ -68,13 +68,13 @@ describe('Settings: Unified search for accounts and groups', { testIsolation: fa
 	})
 
 	it('shows the search input in the navigation sidebar', () => {
-		accountNav().findByRole('searchbox', { name: /search accounts and groups/i })
+		accountNav().findByRole('combobox', { name: /search accounts and groups/i })
 			.should('be.visible')
 			.and('have.value', '')
 	})
 
 	it('dispatches the query to both the users and groups API', () => {
-		accountNav().findByRole('searchbox', { name: /search accounts and groups/i })
+		accountNav().findByRole('combobox', { name: /search accounts and groups/i })
 			.type(alice.userId)
 
 		// A single keystroke sequence debounces once (300ms), then fans out
@@ -88,7 +88,7 @@ describe('Settings: Unified search for accounts and groups', { testIsolation: fa
 	})
 
 	it('filters the group list when the query matches a group name', () => {
-		accountNav().findByRole('searchbox', { name: /search accounts and groups/i })
+		accountNav().findByRole('combobox', { name: /search accounts and groups/i })
 			.clear()
 			.type(matchingGroup)
 
@@ -102,7 +102,7 @@ describe('Settings: Unified search for accounts and groups', { testIsolation: fa
 	it('resets both lists when the clear button is clicked', () => {
 		accountNav().findByRole('button', { name: /clear search/i }).click()
 
-		accountNav().findByRole('searchbox', { name: /search accounts and groups/i })
+		accountNav().findByRole('combobox', { name: /search accounts and groups/i })
 			.should('have.value', '')
 
 		waitForSearchRequest('@loadUsers', '')

--- a/cypress/pages/FilesNavigation.ts
+++ b/cypress/pages/FilesNavigation.ts
@@ -12,7 +12,7 @@ export class FilesNavigationPage {
 	}
 
 	searchInput() {
-		return this.navigation().findByRole('searchbox')
+		return this.navigation().findByRole('combobox')
 	}
 
 	searchScopeTrigger() {


### PR DESCRIPTION
## Summary

Fix some cypress failures.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
