### PR TITLE
feat: Add frankenphp worker support for more endpoints

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -18,21 +18,20 @@ localhost {
 			file index.php
 			num 32
 			watch
+			match /index.php/*
 		}
 		worker {
 			file remote.php
 			num 32
 			watch
+			match /remote.php/*
 		}
 		worker {
 			file ocs/v1.php
 			num 32
 			watch
-		}
-		worker {
-			file ocs/v2.php
-			num 32
-			watch
+			match /ocs/v1.php/*
+			match /ocs/v2.php/*
 		}
 	}
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -14,22 +14,22 @@
 
 localhost {
 	php_server {
-        worker {
+		worker {
 			file index.php
 			num 32
 			watch
 		}
-        worker {
+		worker {
 			file remote.php
 			num 32
 			watch
 		}
-        worker {
+		worker {
 			file ocs/v1.php
 			num 32
 			watch
 		}
-        worker {
+		worker {
 			file ocs/v2.php
 			num 32
 			watch
@@ -41,42 +41,42 @@ localhost {
 		output stderr
 	}
 
-    encode gzip
+	encode gzip
 
-    redir /.well-known/carddav /remote.php/dav 301
-    redir /.well-known/caldav /remote.php/dav 301
+	redir /.well-known/carddav /remote.php/dav 301
+	redir /.well-known/caldav /remote.php/dav 301
 
-    # Rule: Maps most RFC 8615 compliant well-known URIs to our main frontend controller (/index.php) by default
-    @wellKnown {
-        path "/.well-known/"
-        not {
-            path /.well-known/acme-challenge
-            path /.well-known/pki-validation
-        }
-    }
-    rewrite @wellKnown /index.php
+	# Rule: Maps most RFC 8615 compliant well-known URIs to our main frontend controller (/index.php) by default
+	@wellKnown {
+		path "/.well-known/"
+		not {
+			path /.well-known/acme-challenge
+			path /.well-known/pki-validation
+		}
+	}
+	rewrite @wellKnown /index.php
 
-    rewrite /ocm-provider/ /index.php
+	rewrite /ocm-provider/ /index.php
 
-    @forbidden {
-        path /.htaccess
-        path /data/*
-        path /config/*
-        path /db_structure
-        path /.xml
-        path /README
-        path /3rdparty/*
-        path /lib/*
-        path /templates/*
-        path /occ
-        path /build
-        path /tests
-        path /console.php
-        path /autotest
-        path /issue
-        path /indi
-        path /db_
-        path /console
-    }
-    respond @forbidden 404
+	@forbidden {
+		path /.htaccess
+		path /data/*
+		path /config/*
+		path /db_structure
+		path /.xml
+		path /README
+		path /3rdparty/*
+		path /lib/*
+		path /templates/*
+		path /occ
+		path /build
+		path /tests
+		path /console.php
+		path /autotest
+		path /issue
+		path /indi
+		path /db_
+		path /console
+	}
+	respond @forbidden 404
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -3,11 +3,35 @@
 #
 # THIS IS AN EXPERIMENTAL FEATURE
 # DO NOT USE THIS IN PRODUCTION, YOU HAVE BEEN WARNED.
+{
+	metrics
+	frankenphp {
+		num_threads 192
+		max_threads 256
+		# max_requests 500
+	}
+}
 
 localhost {
 	php_server {
         worker {
 			file index.php
+			num 32
+			watch
+		}
+        worker {
+			file remote.php
+			num 32
+			watch
+		}
+        worker {
+			file ocs/v1.php
+			num 32
+			watch
+		}
+        worker {
+			file ocs/v2.php
+			num 32
 			watch
 		}
 	}

--- a/index.php
+++ b/index.php
@@ -25,8 +25,7 @@ require_once __DIR__ . '/lib/OC.php';
 
 \OC::handleRequests(static function () {
 	try {
-		\OC::resetStaticProperties();
-		\OC::init();
+		\OC::initForRequest();
 		\OC::handleRequest();
 	} catch (ServiceUnavailableException $ex) {
 		Server::get(LoggerInterface::class)->error($ex->getMessage(), [

--- a/index.php
+++ b/index.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-require_once __DIR__ . '/lib/versioncheck.php';
-
 use OC\ServiceUnavailableException;
 use OC\User\LoginException;
 use OCP\HintException;
@@ -19,6 +17,7 @@ use OCP\Server;
 use OCP\Template\ITemplateManager;
 use Psr\Log\LoggerInterface;
 
+require_once __DIR__ . '/lib/versioncheck.php';
 require_once __DIR__ . '/lib/OC.php';
 
 \OC::boot();

--- a/index.php
+++ b/index.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/lib/versioncheck.php';
 
-use OC\Files\Filesystem;
 use OC\ServiceUnavailableException;
 use OC\User\LoginException;
 use OCP\HintException;
@@ -24,23 +23,11 @@ require_once __DIR__ . '/lib/OC.php';
 
 \OC::boot();
 
-function resetStaticProperties(): void {
-	// FIXME needed because these use a static var
-	\OC_Hook::clear();
-	\OC_Util::$styles = [];
-	\OC_Util::$headers = [];
-	\OC_User::setIncognitoMode(false);
-	\OC_User::$_setupedBackends = [];
-	\OC_App::reset();
-	\OC_Helper::reset();
-	Filesystem::reset();
-}
-
-$handler = static function () {
+\OC::handleRequests(static function () {
 	try {
-		resetStaticProperties();
-		OC::init();
-		OC::handleRequest();
+		\OC::resetStaticProperties();
+		\OC::init();
+		\OC::handleRequest();
 	} catch (ServiceUnavailableException $ex) {
 		Server::get(LoggerInterface::class)->error($ex->getMessage(), [
 			'app' => 'index',
@@ -124,20 +111,4 @@ $handler = static function () {
 		}
 		Server::get(ITemplateManager::class)->printExceptionErrorPage($ex, 500);
 	}
-};
-
-if (function_exists('frankenphp_handle_request') && isset($_SERVER['FRANKENPHP_WORKER']) && $_SERVER['FRANKENPHP_WORKER'] === '1') {
-	$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-	for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
-		$keepRunning = \frankenphp_handle_request($handler);
-
-		// Call the garbage collector to reduce the chances of it being triggered in the middle of a page generation
-		gc_collect_cycles();
-
-		if (!$keepRunning) {
-			break;
-		}
-	}
-} else {
-	$handler();
-}
+});

--- a/index.php
+++ b/index.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/lib/versioncheck.php';
 
-use OC\Files\Filesystem;
 use OC\ServiceUnavailableException;
 use OC\User\LoginException;
 use OCP\HintException;
@@ -24,23 +23,11 @@ require_once __DIR__ . '/lib/OC.php';
 
 \OC::boot();
 
-function resetStaticProperties(): void {
-	// FIXME needed because these use a static var
-	\OC_Hook::clear();
-	\OC_Util::$styles = [];
-	\OC_Util::$headers = [];
-	\OC_User::setIncognitoMode(false);
-	\OC_User::$_setupedBackends = [];
-	\OC_App::reset();
-	\OC_Helper::reset();
-	Filesystem::reset();
-}
-
-$handler = static function (): void {
+\OC::handleRequests(static function (): void {
 	try {
-		resetStaticProperties();
-		OC::init();
-		OC::handleRequest();
+		\OC::resetStaticProperties();
+		\OC::init();
+		\OC::handleRequest();
 	} catch (ServiceUnavailableException $ex) {
 		Server::get(LoggerInterface::class)->error($ex->getMessage(), [
 			'app' => 'index',
@@ -124,20 +111,4 @@ $handler = static function (): void {
 		}
 		Server::get(ITemplateManager::class)->printExceptionErrorPage($ex, 500);
 	}
-};
-
-if (function_exists('frankenphp_handle_request') && isset($_SERVER['FRANKENPHP_WORKER']) && $_SERVER['FRANKENPHP_WORKER'] === '1') {
-	$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-	for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
-		$keepRunning = \frankenphp_handle_request($handler);
-
-		// Call the garbage collector to reduce the chances of it being triggered in the middle of a page generation
-		gc_collect_cycles();
-
-		if (!$keepRunning) {
-			break;
-		}
-	}
-} else {
-	$handler();
-}
+});

--- a/index.php
+++ b/index.php
@@ -25,8 +25,7 @@ require_once __DIR__ . '/lib/OC.php';
 
 \OC::handleRequests(static function (): void {
 	try {
-		\OC::resetStaticProperties();
-		\OC::init();
+		\OC::initForRequest();
 		\OC::handleRequest();
 	} catch (ServiceUnavailableException $ex) {
 		Server::get(LoggerInterface::class)->error($ex->getMessage(), [

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -102,6 +102,11 @@ class OC {
 	private static float $loaderEnd;
 
 	/**
+	 * @psalm-suppress ImpureStaticProperty
+	 */
+	private static bool $oneTimeChecksDone = false;
+
+	/**
 	 * @throws \RuntimeException when the 3rdparty directory is missing or
 	 *                           the app path list is empty or contains an invalid path
 	 */
@@ -727,6 +732,40 @@ class OC {
 			print($e->getMessage());
 			exit();
 		}
+		self::setRequiredIniValues();
+
+		// initialize intl fallback if necessary
+		OC_Util::isSetLocaleWorking();
+	}
+
+	/**
+	 * Run one time checks if not already run. This allows checking after server boot, to have access to translations and pretty error rendering while still checking only once in worker mode.
+	 */
+	private static function oneTimeChecks(): void {
+		if (self::$oneTimeChecksDone) {
+			return;
+		}
+
+		// Check for PHP SimpleXML extension earlier since we need it before our other checks and want to provide a useful hint for web users
+		// see https://github.com/nextcloud/server/pull/2619
+		if (!function_exists('simplexml_load_file')) {
+			throw new \OCP\HintException('The PHP SimpleXML/PHP-XML extension is not installed. Install the extension or make sure it is enabled.');
+		}
+
+		// Check whether the sample configuration has been copied
+		if (self::$config->getValue('copied_sample_config', false)) {
+			$l = Server::get(\OCP\L10N\IFactory::class)->get('lib');
+			Server::get(ITemplateManager::class)->printErrorPage(
+				$l->t('Sample configuration detected'),
+				$l->t('It has been detected that the sample configuration has been copied. This can break your installation and is unsupported. Please read the documentation before performing changes on config.php'),
+				503
+			);
+			return;
+		}
+
+		self::checkConfig();
+
+		self::$oneTimeChecksDone = true;
 	}
 
 	/*
@@ -737,19 +776,23 @@ class OC {
 
 		// First handle PHP configuration and copy auth headers to the expected
 		// $_SERVER variable before doing anything Server object related
-		self::setRequiredIniValues();
 		self::handleAuthHeaders();
 
 		// setup the basic server
 		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);
 		self::$server->boot();
 
+		self::oneTimeChecks();
+
 		$loaderStart = microtime(true);
+
+		$config = Server::get(IConfig::class);
+		$request = Server::get(IRequest::class);
 
 		try {
 			$profiler = new BuiltInProfiler(
-				Server::get(IConfig::class),
-				Server::get(IRequest::class),
+				$config,
+				$request,
 			);
 			$profiler->start();
 		} catch (\Throwable $e) {
@@ -769,10 +812,6 @@ class OC {
 			error_reporting(E_ALL);
 		}
 
-		// initialize intl fallback if necessary
-		OC_Util::isSetLocaleWorking();
-
-		$config = Server::get(IConfig::class);
 		if (!defined('PHPUNIT_RUN')) {
 			$errorHandler = new OC\Log\ErrorHandler(
 				Server::get(\Psr\Log\LoggerInterface::class),
@@ -796,12 +835,6 @@ class OC {
 
 		$eventLogger->start('init_session', 'Initialize session');
 
-		// Check for PHP SimpleXML extension earlier since we need it before our other checks and want to provide a useful hint for web users
-		// see https://github.com/nextcloud/server/pull/2619
-		if (!function_exists('simplexml_load_file')) {
-			throw new \OCP\HintException('The PHP SimpleXML/PHP-XML extension is not installed.', 'Install the extension or make sure it is enabled.');
-		}
-
 		$systemConfig = Server::get(\OC\SystemConfig::class);
 		$appManager = Server::get(\OCP\App\IAppManager::class);
 		if ($systemConfig->getValue('installed', false)) {
@@ -811,7 +844,6 @@ class OC {
 			self::initSession();
 		}
 		$eventLogger->end('init_session');
-		self::checkConfig();
 		self::checkInstalled($systemConfig);
 
 		if (!self::$CLI) {
@@ -905,18 +937,6 @@ class OC {
 		$lockProvider = Server::get(\OCP\Lock\ILockingProvider::class);
 		register_shutdown_function([$lockProvider, 'releaseAll']);
 
-		// Check whether the sample configuration has been copied
-		if ($systemConfig->getValue('copied_sample_config', false)) {
-			$l = Server::get(\OCP\L10N\IFactory::class)->get('lib');
-			Server::get(ITemplateManager::class)->printErrorPage(
-				$l->t('Sample configuration detected'),
-				$l->t('It has been detected that the sample configuration has been copied. This can break your installation and is unsupported. Please read the documentation before performing changes on config.php'),
-				503
-			);
-			return;
-		}
-
-		$request = Server::get(IRequest::class);
 		$host = $request->getInsecureServerHost();
 		/**
 		 * if the host passed in headers isn't trusted
@@ -924,7 +944,7 @@ class OC {
 		 */
 		if (!OC::$CLI
 			&& !Server::get(\OC\Security\TrustedDomainHelper::class)->isTrustedDomain($host)
-			&& $config->getSystemValueBool('installed', false)
+			&& $config->getSystemValueBool('installed')
 		) {
 			// Allow access to CSS resources
 			$isScssRequest = false;

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -104,6 +104,11 @@ class OC {
 	private static float $loaderEnd;
 
 	/**
+	 * @psalm-suppress ImpureStaticProperty
+	 */
+	private static bool $oneTimeChecksDone = false;
+
+	/**
 	 * @throws \RuntimeException when the 3rdparty directory is missing or
 	 *                           the app path list is empty or contains an invalid path
 	 */
@@ -718,6 +723,40 @@ class OC {
 			print($e->getMessage());
 			exit();
 		}
+		self::setRequiredIniValues();
+
+		// initialize intl fallback if necessary
+		OC_Util::isSetLocaleWorking();
+	}
+
+	/**
+	 * Run one time checks if not already run. This allows checking after server boot, to have access to translations and pretty error rendering while still checking only once in worker mode.
+	 */
+	private static function oneTimeChecks(): void {
+		if (self::$oneTimeChecksDone) {
+			return;
+		}
+
+		// Check for PHP SimpleXML extension earlier since we need it before our other checks and want to provide a useful hint for web users
+		// see https://github.com/nextcloud/server/pull/2619
+		if (!function_exists('simplexml_load_file')) {
+			throw new \OCP\HintException('The PHP SimpleXML/PHP-XML extension is not installed. Install the extension or make sure it is enabled.');
+		}
+
+		// Check whether the sample configuration has been copied
+		if (self::$config->getValue('copied_sample_config', false)) {
+			$l = Server::get(\OCP\L10N\IFactory::class)->get('lib');
+			Server::get(ITemplateManager::class)->printErrorPage(
+				$l->t('Sample configuration detected'),
+				$l->t('It has been detected that the sample configuration has been copied. This can break your installation and is unsupported. Please read the documentation before performing changes on config.php'),
+				503
+			);
+			return;
+		}
+
+		self::checkConfig();
+
+		self::$oneTimeChecksDone = true;
 	}
 
 	/*
@@ -728,19 +767,23 @@ class OC {
 
 		// First handle PHP configuration and copy auth headers to the expected
 		// $_SERVER variable before doing anything Server object related
-		self::setRequiredIniValues();
 		self::handleAuthHeaders();
 
 		// setup the basic server
 		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);
 		self::$server->boot();
 
+		self::oneTimeChecks();
+
 		$loaderStart = microtime(true);
+
+		$config = Server::get(IConfig::class);
+		$request = Server::get(IRequest::class);
 
 		try {
 			$profiler = new BuiltInProfiler(
-				Server::get(IConfig::class),
-				Server::get(IRequest::class),
+				$config,
+				$request,
 			);
 			$profiler->start();
 		} catch (\Throwable $e) {
@@ -760,10 +803,6 @@ class OC {
 			error_reporting(E_ALL);
 		}
 
-		// initialize intl fallback if necessary
-		OC_Util::isSetLocaleWorking();
-
-		$config = Server::get(IConfig::class);
 		if (!defined('PHPUNIT_RUN')) {
 			$errorHandler = new OC\Log\ErrorHandler(
 				Server::get(\Psr\Log\LoggerInterface::class),
@@ -787,12 +826,6 @@ class OC {
 
 		$eventLogger->start('init_session', 'Initialize session');
 
-		// Check for PHP SimpleXML extension earlier since we need it before our other checks and want to provide a useful hint for web users
-		// see https://github.com/nextcloud/server/pull/2619
-		if (!function_exists('simplexml_load_file')) {
-			throw new \OCP\HintException('The PHP SimpleXML/PHP-XML extension is not installed.', 'Install the extension or make sure it is enabled.');
-		}
-
 		$systemConfig = Server::get(\OC\SystemConfig::class);
 		$appManager = Server::get(\OCP\App\IAppManager::class);
 		if ($systemConfig->getValue('installed', false)) {
@@ -802,7 +835,6 @@ class OC {
 			self::initSession();
 		}
 		$eventLogger->end('init_session');
-		self::checkConfig();
 		self::checkInstalled($systemConfig);
 
 		if (!self::$CLI) {
@@ -896,18 +928,6 @@ class OC {
 		$lockProvider = Server::get(\OCP\Lock\ILockingProvider::class);
 		register_shutdown_function([$lockProvider, 'releaseAll']);
 
-		// Check whether the sample configuration has been copied
-		if ($systemConfig->getValue('copied_sample_config', false)) {
-			$l = Server::get(\OCP\L10N\IFactory::class)->get('lib');
-			Server::get(ITemplateManager::class)->printErrorPage(
-				$l->t('Sample configuration detected'),
-				$l->t('It has been detected that the sample configuration has been copied. This can break your installation and is unsupported. Please read the documentation before performing changes on config.php'),
-				503
-			);
-			return;
-		}
-
-		$request = Server::get(IRequest::class);
 		$host = $request->getInsecureServerHost();
 		/**
 		 * if the host passed in headers isn't trusted
@@ -915,7 +935,7 @@ class OC {
 		 */
 		if (!OC::$CLI
 			&& !Server::get(\OC\Security\TrustedDomainHelper::class)->isTrustedDomain($host)
-			&& $config->getSystemValueBool('installed', false)
+			&& $config->getSystemValueBool('installed')
 		) {
 			// Allow access to CSS resources
 			$isScssRequest = false;

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -657,6 +657,9 @@ class OC {
 		}
 	}
 
+	/*
+	 * Called only once at the beginning to setup things
+	 */
 	public static function boot(): void {
 		// prevent any XML processing from loading external entities
 		libxml_set_external_entity_loader(static function () {
@@ -717,7 +720,12 @@ class OC {
 		}
 	}
 
-	public static function init(): void {
+	/*
+	 * Called before each request served if the same worker serves several request
+	 */
+	public static function initForRequest(): void {
+		self::resetStaticProperties();
+
 		// First handle PHP configuration and copy auth headers to the expected
 		// $_SERVER variable before doing anything Server object related
 		self::setRequiredIniValues();
@@ -1337,7 +1345,7 @@ class OC {
 	/**
 	 * @internal
 	 */
-	public static function resetStaticProperties(): void {
+	private static function resetStaticProperties(): void {
 		// FIXME needed because these use a static var
 		\OC_Hook::clear();
 		\OC_Util::$styles = [];

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use OC\Files\Filesystem;
 use OC\NavigationManager;
 use OC\Profiler\BuiltInProfiler;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
@@ -1330,6 +1331,42 @@ class OC {
 			return $appAPIService->validateExAppRequestToNC($request);
 		} catch (\Psr\Container\NotFoundExceptionInterface|\Psr\Container\ContainerExceptionInterface $e) {
 			return false;
+		}
+	}
+
+	/**
+	 * @internal
+	 */
+	public static function resetStaticProperties(): void {
+		// FIXME needed because these use a static var
+		\OC_Hook::clear();
+		\OC_Util::$styles = [];
+		\OC_Util::$headers = [];
+		\OC_User::setIncognitoMode(false);
+		\OC_User::$_setupedBackends = [];
+		\OC_App::reset();
+		\OC_Helper::reset();
+		Filesystem::reset();
+	}
+
+	/**
+	 * @internal
+	 */
+	public static function handleRequests(callable $handler): void {
+		if (function_exists('frankenphp_handle_request') && isset($_SERVER['FRANKENPHP_WORKER']) && $_SERVER['FRANKENPHP_WORKER'] === '1') {
+			$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
+			for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+				$keepRunning = \frankenphp_handle_request($handler);
+
+				// Call the garbage collector to reduce the chances of it being triggered in the middle of a page generation
+				gc_collect_cycles();
+
+				if (!$keepRunning) {
+					break;
+				}
+			}
+		} else {
+			$handler();
 		}
 	}
 }

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -666,6 +666,9 @@ class OC {
 		}
 	}
 
+	/*
+	 * Called only once at the beginning to setup things
+	 */
 	public static function boot(): void {
 		// prevent any XML processing from loading external entities
 		libxml_set_external_entity_loader(static function () {
@@ -726,7 +729,12 @@ class OC {
 		}
 	}
 
-	public static function init(): void {
+	/*
+	 * Called before each request served if the same worker serves several request
+	 */
+	public static function initForRequest(): void {
+		self::resetStaticProperties();
+
 		// First handle PHP configuration and copy auth headers to the expected
 		// $_SERVER variable before doing anything Server object related
 		self::setRequiredIniValues();
@@ -1343,7 +1351,7 @@ class OC {
 	/**
 	 * @internal
 	 */
-	public static function resetStaticProperties(): void {
+	private static function resetStaticProperties(): void {
 		// FIXME needed because these use a static var
 		\OC_Hook::clear();
 		\OC_Util::$styles = [];

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use OC\Files\Filesystem;
 use OC\Profiler\BuiltInProfiler;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OC\Share20\GroupDeletedListener;
@@ -1336,6 +1337,42 @@ class OC {
 			return $appAPIService->validateExAppRequestToNC($request);
 		} catch (\Psr\Container\NotFoundExceptionInterface|\Psr\Container\ContainerExceptionInterface $e) {
 			return false;
+		}
+	}
+
+	/**
+	 * @internal
+	 */
+	public static function resetStaticProperties(): void {
+		// FIXME needed because these use a static var
+		\OC_Hook::clear();
+		\OC_Util::$styles = [];
+		\OC_Util::$headers = [];
+		\OC_User::setIncognitoMode(false);
+		\OC_User::$_setupedBackends = [];
+		\OC_App::reset();
+		\OC_Helper::reset();
+		Filesystem::reset();
+	}
+
+	/**
+	 * @internal
+	 */
+	public static function handleRequests(callable $handler): void {
+		if (function_exists('frankenphp_handle_request') && isset($_SERVER['FRANKENPHP_WORKER']) && $_SERVER['FRANKENPHP_WORKER'] === '1') {
+			$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
+			for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+				$keepRunning = \frankenphp_handle_request($handler);
+
+				// Call the garbage collector to reduce the chances of it being triggered in the middle of a page generation
+				gc_collect_cycles();
+
+				if (!$keepRunning) {
+					break;
+				}
+			}
+		} else {
+			$handler();
 		}
 	}
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -9,4 +9,4 @@ declare(strict_types=1);
 require_once __DIR__ . '/OC.php';
 
 \OC::boot();
-\OC::init();
+\OC::initForRequest();

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -8,9 +8,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-require_once __DIR__ . '/../lib/versioncheck.php';
-require_once __DIR__ . '/../lib/base.php';
-
 use OC\OCS\ApiHelper;
 use OC\Route\Router;
 use OC\SystemConfig;
@@ -28,75 +25,84 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
-$request = Server::get(IRequest::class);
+require_once __DIR__ . '/../lib/versioncheck.php';
+require_once __DIR__ . '/../lib/OC.php';
 
-$serveAppApiDuringMaintenance = false;
-if (!Util::needUpgrade() && Server::get(IConfig::class)->getSystemValueBool('maintenance')) {
-	$pathInfo = $request->getPathInfo();
-	// AppAPI must keep serving HaRP traffic (signed OCS calls and ExApp callbacks)
-	$serveAppApiDuringMaintenance
-		= ($pathInfo === '/apps/app_api' || str_starts_with($pathInfo, '/apps/app_api/'))
-		&& Server::get(IAppManager::class)->isEnabledForAnyone('app_api');
-}
+\OC::boot();
 
-if ((Util::needUpgrade()
-	|| (Server::get(IConfig::class)->getSystemValueBool('maintenance') && !$serveAppApiDuringMaintenance))
-	&& $request->getPathInfo() !== '/core/update') {
-	// since the behavior of apps or remotes are unpredictable during
-	// an upgrade, return a 503 directly
-	ApiHelper::respond(503, 'Service unavailable', ['X-Nextcloud-Maintenance-Mode' => '1'], 503);
-	exit;
-}
+\OC::handleRequests(static function () {
+	\OC::resetStaticProperties();
+	\OC::init();
+	$request = Server::get(IRequest::class);
 
-/*
- * Try the appframework routes
- */
-try {
-	$appManager = Server::get(IAppManager::class);
-	$appManager->loadApps(['session']);
-	$appManager->loadApps(['authentication']);
-	$appManager->loadApps(['extended_authentication']);
-
-	$request->throwDecodingExceptionIfAny();
-
-	if ($request->getPathInfo() !== '/core/update') {
-		if ($serveAppApiDuringMaintenance) {
-			// loadApps() below is a no-op during maintenance, load app_api explicitly
-			$appManager->loadApp('app_api');
-		}
-		// load all apps to get all api routes properly setup
-		// FIXME: this should ideally appear after handleLogin but will cause
-		// side effects in existing apps
-		$appManager->loadApps();
-		if (!Server::get(IUserSession::class)->isLoggedIn()) {
-			OC::handleLogin($request);
-		}
-	} else {
-		$appManager->loadApps(['core']);
+	$serveAppApiDuringMaintenance = false;
+	if (!Util::needUpgrade() && Server::get(IConfig::class)->getSystemValueBool('maintenance')) {
+		$pathInfo = $request->getPathInfo();
+		// AppAPI must keep serving HaRP traffic (signed OCS calls and ExApp callbacks)
+		$serveAppApiDuringMaintenance
+			= ($pathInfo === '/apps/app_api' || str_starts_with($pathInfo, '/apps/app_api/'))
+			&& Server::get(IAppManager::class)->isEnabledForAnyone('app_api');
 	}
 
-	Server::get(Router::class)->match('/ocsapp' . $request->getRawPathInfo());
-} catch (MaxDelayReached $ex) {
-	ApiHelper::respond(Http::STATUS_TOO_MANY_REQUESTS, $ex->getMessage());
-} catch (ResourceNotFoundException $e) {
-	$txt = 'Invalid query, please check the syntax. API specifications are here:'
-		. ' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.' . "\n";
-	ApiHelper::respond(OCSController::RESPOND_NOT_FOUND, $txt);
-} catch (MethodNotAllowedException $e) {
-	ApiHelper::setContentType();
-	http_response_code(405);
-} catch (LoginException $e) {
-	ApiHelper::respond(OCSController::RESPOND_UNAUTHORISED, 'Unauthorised');
-} catch (\Exception $e) {
-	Server::get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
+	if ((Util::needUpgrade()
+		|| (Server::get(IConfig::class)->getSystemValueBool('maintenance') && !$serveAppApiDuringMaintenance))
+		&& $request->getPathInfo() !== '/core/update') {
+		// since the behavior of apps or remotes are unpredictable during
+		// an upgrade, return a 503 directly
+		ApiHelper::respond(503, 'Service unavailable', ['X-Nextcloud-Maintenance-Mode' => '1'], 503);
+		exit;
+	}
 
-	$txt = 'Internal Server Error' . "\n";
+	/*
+	* Try the appframework routes
+	*/
 	try {
-		if (Server::get(SystemConfig::class)->getValue('debug', false)) {
-			$txt .= $e->getMessage();
+		$appManager = Server::get(IAppManager::class);
+		$appManager->loadApps(['session']);
+		$appManager->loadApps(['authentication']);
+		$appManager->loadApps(['extended_authentication']);
+
+		$request->throwDecodingExceptionIfAny();
+
+		if ($request->getPathInfo() !== '/core/update') {
+			if ($serveAppApiDuringMaintenance) {
+				// loadApps() below is a no-op during maintenance, load app_api explicitly
+				$appManager->loadApp('app_api');
+			}
+			// load all apps to get all api routes properly setup
+			// FIXME: this should ideally appear after handleLogin but will cause
+			// side effects in existing apps
+			$appManager->loadApps();
+			if (!Server::get(IUserSession::class)->isLoggedIn()) {
+				OC::handleLogin($request);
+			}
+		} else {
+			$appManager->loadApps(['core']);
 		}
-	} catch (\Throwable $e) {
-		// Just to be save
+
+		Server::get(Router::class)->match('/ocsapp' . $request->getRawPathInfo());
+	} catch (MaxDelayReached $ex) {
+		ApiHelper::respond(Http::STATUS_TOO_MANY_REQUESTS, $ex->getMessage());
+	} catch (ResourceNotFoundException $e) {
+		$txt = 'Invalid query, please check the syntax. API specifications are here:'
+			. ' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.' . "\n";
+		ApiHelper::respond(OCSController::RESPOND_NOT_FOUND, $txt);
+	} catch (MethodNotAllowedException $e) {
+		ApiHelper::setContentType();
+		http_response_code(405);
+	} catch (LoginException $e) {
+		ApiHelper::respond(OCSController::RESPOND_UNAUTHORISED, 'Unauthorised');
+	} catch (\Exception $e) {
+		Server::get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
+
+		$txt = 'Internal Server Error' . "\n";
+		try {
+			if (Server::get(SystemConfig::class)->getValue('debug', false)) {
+				$txt .= $e->getMessage();
+			}
+		} catch (\Throwable $e) {
+			// Just to be save
+		}
+		ApiHelper::respond(OCSController::RESPOND_SERVER_ERROR, $txt);
 	}
-	ApiHelper::respond(OCSController::RESPOND_SERVER_ERROR, $txt);
-}
+});

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -31,8 +31,7 @@ require_once __DIR__ . '/../lib/OC.php';
 \OC::boot();
 
 \OC::handleRequests(static function () {
-	\OC::resetStaticProperties();
-	\OC::init();
+	\OC::initForRequest();
 	$request = Server::get(IRequest::class);
 
 	$serveAppApiDuringMaintenance = false;

--- a/remote.php
+++ b/remote.php
@@ -103,8 +103,7 @@ require_once __DIR__ . '/lib/OC.php';
 
 \OC::handleRequests(static function () {
 	try {
-		\OC::resetStaticProperties();
-		\OC::init();
+		\OC::initForRequest();
 
 		// All resources served via the DAV endpoint should have the strictest possible
 		// policy. Exempted from this is the SabreDAV browser plugin which overwrites

--- a/remote.php
+++ b/remote.php
@@ -1,23 +1,26 @@
 <?php
 
-use OC\ServiceUnavailableException;
-use OCP\IConfig;
-use OCP\Util;
+declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\ServiceUnavailableException;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCP\App\IAppManager;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\Template\ITemplateManager;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\Server;
+
+require_once __DIR__ . '/lib/versioncheck.php';
+require_once __DIR__ . '/lib/OC.php';
 
 /**
  * Class RemoteException
@@ -94,64 +97,71 @@ function resolveService($service) {
 	return \OCP\Server::get(IConfig::class)->getAppValue('core', 'remote_' . $service);
 }
 
-try {
-	require_once __DIR__ . '/lib/base.php';
+require_once __DIR__ . '/lib/OC.php';
 
-	// All resources served via the DAV endpoint should have the strictest possible
-	// policy. Exempted from this is the SabreDAV browser plugin which overwrites
-	// this policy with a softer one if debug mode is enabled.
-	header("Content-Security-Policy: default-src 'none';");
+\OC::boot();
 
-	if (Util::needUpgrade()) {
-		// since the behavior of apps or remotes are unpredictable during
-		// an upgrade, return a 503 directly
-		throw new RemoteException('Service unavailable', 503);
+\OC::handleRequests(static function () {
+	try {
+		\OC::resetStaticProperties();
+		\OC::init();
+
+		// All resources served via the DAV endpoint should have the strictest possible
+		// policy. Exempted from this is the SabreDAV browser plugin which overwrites
+		// this policy with a softer one if debug mode is enabled.
+		header("Content-Security-Policy: default-src 'none';");
+
+		if (Util::needUpgrade()) {
+			// since the behavior of apps or remotes are unpredictable during
+			// an upgrade, return a 503 directly
+			throw new RemoteException('Service unavailable', 503);
+		}
+
+		$request = \OCP\Server::get(IRequest::class);
+		$pathInfo = $request->getPathInfo();
+		if ($pathInfo === false || $pathInfo === '') {
+			throw new RemoteException('Path not found', 404);
+		}
+		if (!$pos = strpos($pathInfo, '/', 1)) {
+			$pos = strlen($pathInfo);
+		}
+		$service = substr($pathInfo, 1, $pos - 1);
+
+		$file = resolveService($service);
+
+		if (is_null($file)) {
+			throw new RemoteException('Path not found', 404);
+		}
+
+		$file = ltrim($file, '/');
+
+		$parts = explode('/', $file, 2);
+		$app = $parts[0];
+
+		// Load all required applications
+		\OC::$REQUESTEDAPP = $app;
+		$appManager = \OCP\Server::get(IAppManager::class);
+		$appManager->loadApps(['authentication']);
+		$appManager->loadApps(['extended_authentication']);
+		$appManager->loadApps(['filesystem', 'logging']);
+
+		switch ($app) {
+			case 'core':
+				$file = OC::$SERVERROOT . '/' . $file;
+				break;
+			default:
+				if (!$appManager->isEnabledForUser($app)) {
+					throw new RemoteException('App not installed: ' . $app);
+				}
+				$appManager->loadApp($app);
+				$file = $appManager->getAppPath($app) . '/' . ($parts[1] ?? '');
+				break;
+		}
+		$baseuri = OC::$WEBROOT . '/remote.php/' . $service . '/';
+		require_once $file;
+	} catch (Exception $ex) {
+		handleException($ex);
+	} catch (Error $e) {
+		handleException($e);
 	}
-
-	$request = \OCP\Server::get(IRequest::class);
-	$pathInfo = $request->getPathInfo();
-	if ($pathInfo === false || $pathInfo === '') {
-		throw new RemoteException('Path not found', 404);
-	}
-	if (!$pos = strpos($pathInfo, '/', 1)) {
-		$pos = strlen($pathInfo);
-	}
-	$service = substr($pathInfo, 1, $pos - 1);
-
-	$file = resolveService($service);
-
-	if (is_null($file)) {
-		throw new RemoteException('Path not found', 404);
-	}
-
-	$file = ltrim($file, '/');
-
-	$parts = explode('/', $file, 2);
-	$app = $parts[0];
-
-	// Load all required applications
-	\OC::$REQUESTEDAPP = $app;
-	$appManager = \OCP\Server::get(IAppManager::class);
-	$appManager->loadApps(['authentication']);
-	$appManager->loadApps(['extended_authentication']);
-	$appManager->loadApps(['filesystem', 'logging']);
-
-	switch ($app) {
-		case 'core':
-			$file = OC::$SERVERROOT . '/' . $file;
-			break;
-		default:
-			if (!$appManager->isEnabledForUser($app)) {
-				throw new RemoteException('App not installed: ' . $app);
-			}
-			$appManager->loadApp($app);
-			$file = $appManager->getAppPath($app) . '/' . ($parts[1] ?? '');
-			break;
-	}
-	$baseuri = OC::$WEBROOT . '/remote.php/' . $service . '/';
-	require_once $file;
-} catch (Exception $ex) {
-	handleException($ex);
-} catch (Error $e) {
-	handleException($e);
-}
+});

--- a/remote.php
+++ b/remote.php
@@ -97,8 +97,6 @@ function resolveService($service) {
 	return \OCP\Server::get(IConfig::class)->getAppValue('core', 'remote_' . $service);
 }
 
-require_once __DIR__ . '/lib/OC.php';
-
 \OC::boot();
 
 \OC::handleRequests(static function () {
@@ -157,7 +155,7 @@ require_once __DIR__ . '/lib/OC.php';
 				break;
 		}
 		$baseuri = OC::$WEBROOT . '/remote.php/' . $service . '/';
-		require_once $file;
+		require $file;
 	} catch (Exception $ex) {
 		handleException($ex);
 	} catch (Error $e) {


### PR DESCRIPTION
## Summary

Extends experimental frankenphp support to ocs and webdav.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
