### PR TITLE
fix(ocm): merge resource types by name in discovery

### DIFF
--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -179,6 +179,21 @@ class OCMProvider implements IOCMProvider {
 	 */
 	#[\Override]
 	public function addResourceType(IOCMResource $resource): static {
+		foreach ($this->resourceTypes as $existing) {
+			if ($existing->getName() === $resource->getName()) {
+				$existing->setShareTypes(array_values(array_unique(
+					array_merge(
+						$existing->getShareTypes(),
+						$resource->getShareTypes()
+					)
+				)));
+				$existing->setProtocols(array_merge(
+					$existing->getProtocols(),
+					$resource->getProtocols()
+				));
+				return $this;
+			}
+		}
 		$this->resourceTypes[] = $resource;
 
 		return $this;

--- a/tests/lib/OCM/OCMProviderTest.php
+++ b/tests/lib/OCM/OCMProviderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\OCM;
+
+use OC\OCM\Model\OCMProvider;
+use OCP\OCM\IOCMResource;
+use Test\TestCase;
+
+class OCMProviderTest extends TestCase {
+	private OCMProvider $provider;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+		$this->provider = new OCMProvider();
+	}
+
+	private function resource(string $name, array $shareTypes, array $protocols): IOCMResource {
+		$resource = $this->provider->createNewResourceType();
+		$resource->setName($name)
+			->setShareTypes($shareTypes)
+			->setProtocols($protocols);
+		return $resource;
+	}
+
+	public function testAddResourceTypeKeepsDistinctNames(): void {
+		$this->provider->addResourceType($this->resource('file', ['user'], ['webdav' => '/dav/']));
+		$this->provider->addResourceType($this->resource('folder', ['user'], ['webapp' => []]));
+
+		$this->assertCount(2, $this->provider->getResourceTypes());
+	}
+
+	public function testAddResourceTypeMergesSameName(): void {
+		$this->provider->addResourceType($this->resource('folder', ['user'], ['webapp' => []]));
+		$this->provider->addResourceType($this->resource('folder', ['user'], ['webapp-receive' => ['targets' => ['blank', 'iframe']]]));
+
+		$resourceTypes = $this->provider->getResourceTypes();
+		$this->assertCount(1, $resourceTypes);
+		$this->assertSame(
+			['webapp' => [], 'webapp-receive' => ['targets' => ['blank', 'iframe']]],
+			$resourceTypes[0]->getProtocols(),
+		);
+	}
+
+	public function testAddResourceTypeDedupesShareTypes(): void {
+		$this->provider->addResourceType($this->resource('folder', ['user'], ['webapp' => []]));
+		$this->provider->addResourceType($this->resource('folder', ['user', 'group'], ['webapp-receive' => []]));
+
+		$shareTypes = $this->provider->getResourceTypes()[0]->getShareTypes();
+		$this->assertSame(['user', 'group'], $shareTypes);
+		// Deduplication must not leave key gaps, or shareTypes would
+		// serialize as a JSON object instead of an array.
+		$this->assertSame('["user","group"]', json_encode($shareTypes));
+	}
+
+	public function testAddResourceTypeMergeOverwritesSameProtocol(): void {
+		$this->provider->addResourceType($this->resource('folder', ['user'], ['webapp' => ['a' => 1]]));
+		$this->provider->addResourceType($this->resource('folder', ['user'], ['webapp' => ['b' => 2]]));
+
+		$this->assertSame(
+			['webapp' => ['b' => 2]],
+			$this->provider->getResourceTypes()[0]->getProtocols(),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Current code blindy adds any resources to the ocm disocvery, this makes it so that different cloud federation providers can not add different protocols for the same resourceType without the resourceType being duplicated, something that OCM does not allow:

```
REQUIRED: resourceTypes (array) - A list of all resource types this
server supports in both the Sending Server role and the Receiving
Server role, with their access protocols. Each item in this list MUST
itself be an object containing the following fields:

name (string) - A supported resource type (file, calendar, contact, ...).
Implementations MUST offer support for at least one resource type, where
file is the commonly supported one. Each resource type is identified by
its name: the list MUST NOT contain more than one resource type object
per given name.

...
```

https://datatracker.ietf.org/doc/html/draft-ietf-ocm-open-cloud-mesh-04#name-fields

This patch changes this behaviour from this example result:
```
   {
      "name": "folder",
      "shareTypes": [
        "user"
      ],
      "protocols": {
        "webapp": {}
      }
    },
    {
      "name": "folder",
      "shareTypes": [
        "user"
      ],
      "protocols": {
        "webapp-receive": {
          "targets": [
            "blank",
            "iframe"
          ]
        }
      }
```

to:

```
{
      "name": "folder",
      "shareTypes": [
        "user"
      ],
      "protocols": {
        "webapp": {},
        "webapp-receive": {
          "targets": [
            "blank",
            "iframe"
          ]
        }
      }
```

which is the correct behaviour according to OCM.

## Checklist

- [x] Sign-off message is added to all commits
- [x] Tests are included
- [x] Documentation has been updated or is not required

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
