### PR TITLE
chore(PHP): Drop 8.2 for Nextcloud 35

### DIFF
--- a/.github/workflows/autocheckers.yml
+++ b/.github/workflows/autocheckers.yml
@@ -57,7 +57,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development
@@ -86,7 +86,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/.github/workflows/files-external-ftp.yml
+++ b/.github/workflows/files-external-ftp.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
         ftpd: ['proftpd', 'vsftpd', 'pure-ftpd']
 
     name: php${{ matrix.php-versions }}-${{ matrix.ftpd }}

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-s3-minio
 
@@ -129,7 +129,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-s3-localstack
 

--- a/.github/workflows/files-external-sftp.yml
+++ b/.github/workflows/files-external-sftp.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
         sftpd: ['openssh']
 
     name: php${{ matrix.php-versions }}-${{ matrix.sftpd }}

--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-smb
 

--- a/.github/workflows/files-external-webdav.yml
+++ b/.github/workflows/files-external-webdav.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-webdav
 

--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-generic
 

--- a/.github/workflows/integration-dav.yml
+++ b/.github/workflows/integration-dav.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
         endpoint: ['old', 'new']
         service: ['CalDAV', 'CardDAV']
 

--- a/.github/workflows/integration-litmus.yml
+++ b/.github/workflows/integration-litmus.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
         endpoint: ['webdav', 'dav']
 
     name: Litmus WebDAV ${{ matrix.endpoint }}

--- a/.github/workflows/integration-s3-primary.yml
+++ b/.github/workflows/integration-s3-primary.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
         key: ['objectstore', 'objectstore_multibucket']
 
     name: php${{ matrix.php-versions }}-${{ matrix.key }}-minio

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -69,7 +69,7 @@ jobs:
           - 'videoverification_features'
           - 'guests_features'
 
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
         guests-versions: ['main']
         spreed-versions: ['main']
         activity-versions: ['master']

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -59,7 +59,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         timeout-minutes: 5
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php-lint
 

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-azure
 

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-s3
 

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: php${{ matrix.php-versions }}-swift
 

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -34,7 +34,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: ctype, curl, dom, fileinfo, gd, json, libxml, mbstring, openssl, pcntl, pdo, posix, session, simplexml, xml, xmlreader, xmlwriter, zip, zlib
           coverage: none
           ini-file: development

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -41,7 +41,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8,5']
+        php-versions: ['8.3', '8,5']
 
     steps:
       - name: Checkout server

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include:
           - mariadb-versions: '10.6'
-            php-versions: '8.2'
+            php-versions: '8.3'
           - mariadb-versions: '11.8'
             php-versions: '8.5'
 

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: Memcached (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         include:
           - mysql-versions: '8.0'
-            php-versions: '8.2'
+            php-versions: '8.3'
           - mysql-versions: '8.4'
             php-versions: '8.5'
 

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include:
           - mysql-versions: '8.0'
-            php-versions: '8.2'
+            php-versions: '8.3'
           - mysql-versions: '8.4'
             php-versions: '8.5'
 

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: No DB unit tests (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/phpunit-object-store-primary.yml
+++ b/.github/workflows/phpunit-object-store-primary.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
         key: ['s3', 's3-multibucket']
 
     name: php${{ matrix.php-versions }}-${{ matrix.key }}-minio

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include:
           - oracle-versions: '18'
-            php-versions: '8.2'
+            php-versions: '8.3'
           - oracle-versions: '23'
             php-versions: '8.5'
 

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include:
           - postgres-versions: '14'
-            php-versions: '8.2'
+            php-versions: '8.3'
           - postgres-versions: '18'
             php-versions: '8.5'
 

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.3', '8.5']
 
     name: SQLite (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/rector-apply.yml
+++ b/.github/workflows/rector-apply.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -64,7 +64,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
@@ -100,7 +100,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: ctype,curl,dom,fileinfo,ftp,gd,imagick,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
 
@@ -137,7 +137,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
@@ -170,7 +170,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
@@ -198,7 +198,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:

--- a/apps/settings/lib/SetupChecks/PhpOutdated.php
+++ b/apps/settings/lib/SetupChecks/PhpOutdated.php
@@ -14,10 +14,10 @@ use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
 class PhpOutdated implements ISetupCheck {
-	public const DEPRECATED_PHP_VERSION = '8.2';
-	public const DEPRECATED_SINCE = '33';
-	public const FUTURE_REQUIRED_PHP_VERSION = '8.3';
-	public const FUTURE_REQUIRED_STARTING = '34';
+	public const DEPRECATED_PHP_VERSION = '8.3';
+	public const DEPRECATED_SINCE = '35';
+	public const FUTURE_REQUIRED_PHP_VERSION = '8.4';
+	public const FUTURE_REQUIRED_STARTING = '37';
 
 	public function __construct(
 		private IL10N $l10n,
@@ -36,7 +36,7 @@ class PhpOutdated implements ISetupCheck {
 
 	#[\Override]
 	public function run(): SetupResult {
-		if (PHP_VERSION_ID < 80300) {
+		if (PHP_VERSION_ID < 80400) {
 			return SetupResult::warning($this->l10n->t('You are currently running PHP %1$s. PHP %2$s is deprecated since Nextcloud %3$s. Nextcloud %4$s may require at least PHP %5$s. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [
 				PHP_VERSION,
 				self::DEPRECATED_PHP_VERSION,

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.2"
+			"php": "8.3"
 		},
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true
@@ -26,7 +26,7 @@
 		}
 	},
 	"require": {
-		"php": "^8.2",
+		"php": "^8.3",
 		"ext-apcu": "*",
 		"ext-ctype": "*",
 		"ext-curl": "*",
@@ -63,12 +63,7 @@
 		],
 		"cs:fix": "php-cs-fixer fix",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
-		"lint": [
-			"@lint-8.2-or-earlier",
-			"@lint-8.3-or-later"
-		],
-		"lint-8.2-or-earlier": "[ $(php -r \"echo PHP_VERSION_ID;\") -ge 80300 ] || find . -type f -name '*.php' -not -path './3rdparty/*' -not -path '*/composer/*' -not -path '*/stubs/*' -not -path '*/vendor-bin/*' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P$(nproc) php -l",
-		"lint-8.3-or-later": "[ $(php -r \"echo PHP_VERSION_ID;\") -lt 80300 ] || find . -type f -name '*.php' -not -path './3rdparty/*' -not -path '*/composer/*' -not -path '*/stubs/*' -not -path '*/vendor-bin/*' -not -path '*/vendor/*' -print0 | xargs -0 -n200 -P$(nproc) php -l",
+		"lint": "find . -type f -name '*.php' -not -path './3rdparty/*' -not -path '*/composer/*' -not -path '*/stubs/*' -not -path '*/vendor-bin/*' -not -path '*/vendor/*' -print0 | xargs -0 -n200 -P$(nproc) php -l",
 		"psalm": "psalm --no-cache --threads=$(nproc)",
 		"psalm:ocp": "psalm --no-cache --threads=$(nproc) -c psalm-ocp.xml",
 		"psalm:ncu": "psalm --no-cache --threads=$(nproc) -c psalm-ncu.xml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "505d1844c1fc6ac7de3dfc1552597c22",
+    "content-hash": "6da9ca205233da5c04b027365f70174a",
     "packages": [],
     "packages-dev": [
         {
@@ -71,7 +71,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-apcu": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
@@ -93,7 +93,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/lib/composer/composer/platform_check.php
+++ b/lib/composer/composer/platform_check.php
@@ -4,8 +4,8 @@
 
 $issues = array();
 
-if (!(PHP_VERSION_ID >= 80200)) {
-    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.2.0". You are running ' . PHP_VERSION . '.';
+if (!(PHP_VERSION_ID >= 80300)) {
+    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.3.0". You are running ' . PHP_VERSION . '.';
 }
 
 if ($issues) {

--- a/lib/versioncheck.php
+++ b/lib/versioncheck.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-// Show warning if a PHP version below 8.2 is used,
-if (PHP_VERSION_ID < 80200) {
+// Show warning if a PHP version below 8.3 is used,
+if (PHP_VERSION_ID < 80300) {
 	http_response_code(500);
-	echo 'This version of Nextcloud requires at least PHP 8.2<br/>';
+	echo 'This version of Nextcloud requires at least PHP 8.3<br/>';
 	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
 	exit(1);
 }


### PR DESCRIPTION
https://www.php.net/supported-versions.php

PHP 8.2 will stop getting security updates during the lifetime of Nextcloud 35.

Redhat 8.3 and 8.4: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/installing_and_using_dynamic_programming_languages/using-the-php-scripting-language#installing-the-php-scripting-language

SLES 16 has 8.4: https://documentation.suse.com/sles/16.0/html/SLE-packages-lifecycle/index.html

Debian 13 Trixi has 8.4: https://packages.debian.org/trixie/php8.4

Ubuntu 26.04: 8.5.x
Ubuntu 24.04: 8.3.x