### PR TITLE
chore(workflows): keep only lowest and highest supported versions of dbs

### DIFF
--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -59,16 +59,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
-        mariadb-versions: ['10.6']
         include:
-          - php-versions: '8.3'
-            mariadb-versions: '10.11'
-            coverage: ${{ github.event_name != 'pull_request' }}
-          - php-versions: '8.4'
-            mariadb-versions: '11.4'
+          - php-versions: '8.2'
+            mariadb-versions: '10.6'
           - php-versions: '8.5'
             mariadb-versions: '11.8'
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: MariaDB ${{ matrix.mariadb-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -59,16 +59,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
-        mysql-versions: ['8.0']
         include:
           - mysql-versions: '8.0'
-            php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
-          - mysql-versions: '8.4'
-            php-versions: '8.4'
+            php-versions: '8.2'
           - mysql-versions: '8.4'
             php-versions: '8.5'
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: MySQL ${{ matrix.mysql-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -62,13 +62,9 @@ jobs:
         include:
           - oracle-versions: '18'
             php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
-          - oracle-versions: '21'
-            php-versions: '8.3'
-          - oracle-versions: '23'
-            php-versions: '8.4'
           - oracle-versions: '23'
             php-versions: '8.5'
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: Oracle ${{ matrix.oracle-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -59,17 +59,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
-        # To keep the matrix smaller we ignore PostgreSQL versions in between as we already test the minimum and the maximum
-        postgres-versions: ['14']
         include:
+          - php-versions: '8.2'
+            postgres-versions: '14'
           - php-versions: '8.3'
             postgres-versions: '18'
-            coverage: ${{ github.event_name != 'pull_request' }}
           - php-versions: '8.4'
             postgres-versions: '18'
           - php-versions: '8.5'
             postgres-versions: '18'
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: PostgreSQL ${{ matrix.postgres-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -59,9 +59,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4', '8.5']
         include:
-          - php-versions: '8.2'
+          - php-versions: '8.5'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: SQLite (PHP ${{ matrix.php-versions }})


### PR DESCRIPTION
## Summary

- keep only lowest and highest supported versions of DBs for PHPUnit tests
- move whole PHP supported versions testing from SQLite to PostgreSQL

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI