### PR TITLE
feat(user_status): set busy status for single calendar events without attendees

### DIFF
--- a/apps/dav/lib/CalDAV/Status/StatusService.php
+++ b/apps/dav/lib/CalDAV/Status/StatusService.php
@@ -61,6 +61,7 @@ class StatusService {
 		if (empty($calendarEvents)) {
 			try {
 				$this->userStatusService->revertUserStatus($userId, IUserStatus::MESSAGE_CALENDAR_BUSY);
+				$this->userStatusService->revertUserStatus($userId, IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE);
 			} catch (Exception $e) {
 				if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 					// A different process might have written another status
@@ -92,32 +93,40 @@ class StatusService {
 			return;
 		}
 
-		// Filter events to see if we have any that apply to the calendar status
-		$applicableEvents = array_filter($calendarEvents, static function (array $calendarEvent) use ($userStatusTimestamp): bool {
+		// Filter events to see if we have any that apply to the calendar status,
+		// and split them into meetings (with attendees) and solo busy events (no attendees).
+		$meetingEvents = [];
+		$singleEvents = [];
+		foreach ($calendarEvents as $calendarEvent) {
 			if (empty($calendarEvent['objects'])) {
-				return false;
+				continue;
 			}
 			$component = $calendarEvent['objects'][0];
 			if (isset($component['X-NEXTCLOUD-OUT-OF-OFFICE'])) {
-				return false;
+				continue;
 			}
 			if (isset($component['DTSTART']) && $userStatusTimestamp !== null) {
 				/** @var DateTimeImmutable $dateTime */
 				$dateTime = $component['DTSTART'][0];
 				if ($dateTime instanceof DateTimeImmutable && $userStatusTimestamp > $dateTime->getTimestamp()) {
-					return false;
+					continue;
 				}
 			}
 			// Ignore events that are transparent
 			if (isset($component['TRANSP']) && strcasecmp($component['TRANSP'][0], 'TRANSPARENT') === 0) {
-				return false;
+				continue;
 			}
-			return true;
-		});
+			if (!empty($component['ATTENDEE'])) {
+				$meetingEvents[] = $calendarEvent;
+			} else {
+				$singleEvents[] = $calendarEvent;
+			}
+		}
 
-		if (empty($applicableEvents)) {
+		if (empty($meetingEvents) && empty($singleEvents)) {
 			try {
 				$this->userStatusService->revertUserStatus($userId, IUserStatus::MESSAGE_CALENDAR_BUSY);
+				$this->userStatusService->revertUserStatus($userId, IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE);
 			} catch (Exception $e) {
 				if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 					// A different process might have written another status
@@ -132,20 +141,30 @@ class StatusService {
 			return;
 		}
 
-		// Only update the status if it's neccesary otherwise we mess up the timestamp
-		if ($currentStatus === null || $currentStatus->getMessageId() !== IUserStatus::MESSAGE_CALENDAR_BUSY) {
-			// One event that fulfills all status conditions is enough
-			// 1. Not an OOO event
-			// 2. Current user status (that is not a calendar status) was not set after the start of this event
-			// 3. Event is not set to be transparent
-			$count = count($applicableEvents);
-			$this->logger->debug("Found $count applicable event(s), changing user status", ['user' => $userId]);
-			$this->userStatusService->setUserStatus(
-				$userId,
-				IUserStatus::BUSY,
-				IUserStatus::MESSAGE_CALENDAR_BUSY,
-				true
-			);
+		// Meetings (with attendees) take priority over solo busy events.
+		// Only update the status if it's necessary otherwise we mess up the timestamp.
+		if (!empty($meetingEvents)) {
+			if ($currentStatus === null || $currentStatus->getMessageId() !== IUserStatus::MESSAGE_CALENDAR_BUSY) {
+				$count = count($meetingEvents);
+				$this->logger->debug("Found $count meeting event(s), changing user status to meeting", ['user' => $userId]);
+				$this->userStatusService->setUserStatus(
+					$userId,
+					IUserStatus::BUSY,
+					IUserStatus::MESSAGE_CALENDAR_BUSY,
+					true
+				);
+			}
+		} else {
+			if ($currentStatus === null || $currentStatus->getMessageId() !== IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE) {
+				$count = count($singleEvents);
+				$this->logger->debug("Found $count single busy event(s), changing user status to busy", ['user' => $userId]);
+				$this->userStatusService->setUserStatus(
+					$userId,
+					IUserStatus::BUSY,
+					IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE,
+					true
+				);
+			}
 		}
 	}
 

--- a/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
@@ -161,7 +161,7 @@ class StatusServiceTest extends TestCase {
 			->method('getDateTime');
 		$this->calendarManager->expects(self::never())
 			->method('searchForPrincipal');
-		$this->userStatusService->expects(self::once())
+		$this->userStatusService->expects(self::exactly(2))
 			->method('revertUserStatus');
 		$this->logger->expects(self::once())
 			->method('debug');
@@ -203,7 +203,7 @@ class StatusServiceTest extends TestCase {
 		$this->calendarManager->expects(self::once())
 			->method('searchForPrincipal')
 			->willReturn([]);
-		$this->userStatusService->expects(self::once())
+		$this->userStatusService->expects(self::exactly(2))
 			->method('revertUserStatus');
 		$this->logger->expects(self::once())
 			->method('debug');
@@ -248,7 +248,7 @@ class StatusServiceTest extends TestCase {
 		$this->calendarManager->expects(self::once())
 			->method('searchForPrincipal')
 			->willReturn([['objects' => []]]);
-		$this->userStatusService->expects(self::once())
+		$this->userStatusService->expects(self::exactly(2))
 			->method('revertUserStatus');
 		$this->logger->expects(self::once())
 			->method('debug');
@@ -296,7 +296,99 @@ class StatusServiceTest extends TestCase {
 		$this->logger->expects(self::once())
 			->method('debug');
 		$this->userStatusService->expects(self::once())
-			->method('setUserStatus');
+			->method('setUserStatus')
+			->with('admin', IUserStatus::BUSY, IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE, true);
+
+		$this->service->processCalendarStatus('admin');
+	}
+
+	public function testCalendarEventWithAttendees(): void {
+		$user = $this->createConfiguredMock(IUser::class, [
+			'getUID' => 'admin',
+		]);
+
+		$this->userManager->expects(self::once())
+			->method('get')
+			->willReturn($user);
+		$this->availabilityCoordinator->expects(self::once())
+			->method('getCurrentOutOfOfficeData')
+			->willReturn(null);
+		$this->availabilityCoordinator->expects(self::never())
+			->method('isInEffect');
+		$this->cache->expects(self::once())
+			->method('get')
+			->willReturn(null);
+		$this->cache->expects(self::once())
+			->method('set');
+		$this->calendarManager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->willReturn([$this->createMock(CalendarImpl::class)]);
+		$this->calendarManager->expects(self::once())
+			->method('newQuery')
+			->willReturn(new CalendarQuery('admin'));
+		$this->timeFactory->expects(self::exactly(2))
+			->method('getDateTime')
+			->willReturn(new \DateTime());
+		$this->userStatusService->expects(self::once())
+			->method('findByUserId')
+			->willThrowException(new DoesNotExistException(''));
+		$this->calendarManager->expects(self::once())
+			->method('searchForPrincipal')
+			->willReturn([['objects' => [['ATTENDEE' => [['mailto:other@example.com', []]]]]]]);
+		$this->userStatusService->expects(self::never())
+			->method('revertUserStatus');
+		$this->logger->expects(self::once())
+			->method('debug');
+		$this->userStatusService->expects(self::once())
+			->method('setUserStatus')
+			->with('admin', IUserStatus::BUSY, IUserStatus::MESSAGE_CALENDAR_BUSY, true);
+
+		$this->service->processCalendarStatus('admin');
+	}
+
+	public function testCalendarEventMeetingTakesPriorityOverSingle(): void {
+		$user = $this->createConfiguredMock(IUser::class, [
+			'getUID' => 'admin',
+		]);
+
+		$this->userManager->expects(self::once())
+			->method('get')
+			->willReturn($user);
+		$this->availabilityCoordinator->expects(self::once())
+			->method('getCurrentOutOfOfficeData')
+			->willReturn(null);
+		$this->availabilityCoordinator->expects(self::never())
+			->method('isInEffect');
+		$this->cache->expects(self::once())
+			->method('get')
+			->willReturn(null);
+		$this->cache->expects(self::once())
+			->method('set');
+		$this->calendarManager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->willReturn([$this->createMock(CalendarImpl::class)]);
+		$this->calendarManager->expects(self::once())
+			->method('newQuery')
+			->willReturn(new CalendarQuery('admin'));
+		$this->timeFactory->expects(self::exactly(2))
+			->method('getDateTime')
+			->willReturn(new \DateTime());
+		$this->userStatusService->expects(self::once())
+			->method('findByUserId')
+			->willThrowException(new DoesNotExistException(''));
+		$this->calendarManager->expects(self::once())
+			->method('searchForPrincipal')
+			->willReturn([
+				['objects' => [[]]],
+				['objects' => [['ATTENDEE' => [['mailto:other@example.com', []]]]]],
+			]);
+		$this->userStatusService->expects(self::never())
+			->method('revertUserStatus');
+		$this->logger->expects(self::once())
+			->method('debug');
+		$this->userStatusService->expects(self::once())
+			->method('setUserStatus')
+			->with('admin', IUserStatus::BUSY, IUserStatus::MESSAGE_CALENDAR_BUSY, true);
 
 		$this->service->processCalendarStatus('admin');
 	}

--- a/apps/user_status/lib/Service/PredefinedStatusService.php
+++ b/apps/user_status/lib/Service/PredefinedStatusService.php
@@ -152,6 +152,8 @@ class PredefinedStatusService {
 				return '⏳';
 			case self::CALL:
 				return '💬';
+			case IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE:
+				return '🔴';
 			default:
 				return null;
 		}
@@ -180,6 +182,8 @@ class PredefinedStatusService {
 				return $this->l10n->t('In a call');
 			case self::BE_RIGHT_BACK:
 				return $this->l10n->t('Be right back');
+			case IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE:
+				return $this->l10n->t('Busy');
 			default:
 				return null;
 		}
@@ -203,6 +207,7 @@ class PredefinedStatusService {
 			IUserStatus::MESSAGE_VACATION,
 			IUserStatus::MESSAGE_CALENDAR_BUSY,
 			IUserStatus::MESSAGE_CALENDAR_BUSY_TENTATIVE,
+			IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE,
 		], true);
 	}
 }

--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -252,16 +252,19 @@ class StatusService {
 		$updateStatus = false;
 		if ($messageId === IUserStatus::MESSAGE_OUT_OF_OFFICE) {
 			// OUT_OF_OFFICE trumps AVAILABILITY, CALL and CALENDAR status
-			$updateStatus = $userStatus->getMessageId() === IUserStatus::MESSAGE_AVAILABILITY || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALL || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY;
+			$updateStatus = $userStatus->getMessageId() === IUserStatus::MESSAGE_AVAILABILITY || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALL || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE;
 		} elseif ($messageId === IUserStatus::MESSAGE_AVAILABILITY) {
 			// AVAILABILITY trumps CALL and CALENDAR status
-			$updateStatus = $userStatus->getMessageId() === IUserStatus::MESSAGE_CALL || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY;
+			$updateStatus = $userStatus->getMessageId() === IUserStatus::MESSAGE_CALL || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE;
 		} elseif ($messageId === IUserStatus::MESSAGE_CALL) {
 			// CALL trumps CALENDAR status
-			$updateStatus = $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY;
+			$updateStatus = $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY || $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE;
+		} elseif ($messageId === IUserStatus::MESSAGE_CALENDAR_BUSY) {
+			// A meeting trumps a solo busy event
+			$updateStatus = $userStatus->getMessageId() === IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE;
 		}
 
-		if ($messageId === IUserStatus::MESSAGE_OUT_OF_OFFICE || $messageId === IUserStatus::MESSAGE_AVAILABILITY || $messageId === IUserStatus::MESSAGE_CALL || $messageId === IUserStatus::MESSAGE_CALENDAR_BUSY) {
+		if ($messageId === IUserStatus::MESSAGE_OUT_OF_OFFICE || $messageId === IUserStatus::MESSAGE_AVAILABILITY || $messageId === IUserStatus::MESSAGE_CALL || $messageId === IUserStatus::MESSAGE_CALENDAR_BUSY || $messageId === IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE) {
 			if ($updateStatus) {
 				$this->logger->debug('User ' . $userId . ' is currently NOT available, overwriting status [status: ' . $userStatus->getStatus() . ', messageId: ' . json_encode($userStatus->getMessageId()) . ']', ['app' => 'dav']);
 			} else {

--- a/lib/public/UserStatus/IUserStatus.php
+++ b/lib/public/UserStatus/IUserStatus.php
@@ -90,6 +90,12 @@ interface IUserStatus {
 	public const MESSAGE_CALENDAR_BUSY_TENTATIVE = 'busy-tentative';
 
 	/**
+	 * @var string
+	 * @since 35.0.0
+	 */
+	public const MESSAGE_CALENDAR_BUSY_SINGLE = 'calendar-busy';
+
+	/**
 	 * Get the user this status is connected to
 	 *
 	 * @return string


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Calendar events without attendees (personal/solo blocks) now set a distinct `MESSAGE_CALENDAR_BUSY_SINGLE` ("Busy" with 🔴) status, rather than the "In a meeting" status used for events with attendees. When both types of events overlap, the meeting status takes priority.

Changes:
- Add `IUserStatus::MESSAGE_CALENDAR_BUSY_SINGLE = 'calendar-busy'` public API constant (`@since 35.0.0`)
- Register the new message ID in `PredefinedStatusService` with translated label "Busy" and 🔴 icon
- Add `MESSAGE_CALENDAR_BUSY_SINGLE` to the automated-status priority chain in `user_status/StatusService` (CALL/AVAILABILITY/OOO all still trump it; `MESSAGE_CALENDAR_BUSY` also trumps it)
- Split calendar event filtering in `dav/CalDAV/Status/StatusService` by ATTENDEE presence; revert both message IDs when no events apply

## TODO

- [ ] Manual testing on a live Nextcloud instance

## Checklist

- [ ] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable
- [x] [Labels added](https://github.com/nextcloud/server/labels)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

> Assisted by ClaudeCode:claude-sonnet-4-6