### PR TITLE
ci(PHP): Only test against highest and lowest supported PHP versions

### DIFF
--- a/.github/workflows/autocheckers.yml
+++ b/.github/workflows/autocheckers.yml
@@ -44,10 +44,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.src != 'false'
 
-    strategy:
-      matrix:
-        php-versions: ['8.2']
-
     name: PHP checkers
 
     steps:
@@ -57,11 +53,11 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - name: Set up php ${{ matrix.php-versions }}
+      - name: Set up php
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.2'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development
@@ -77,10 +73,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.src != 'false'
 
-    strategy:
-      matrix:
-        php-versions: ['8.2']
-
     name: Translation and Files checkers
 
     steps:
@@ -90,11 +82,11 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - name: Set up php ${{ matrix.php-versions }}
+      - name: Set up php
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc #v2.37.1
         timeout-minutes: 5
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.2'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/.github/workflows/files-external-ftp.yml
+++ b/.github/workflows/files-external-ftp.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.4']
+        php-versions: ['8.2', '8.5']
         ftpd: ['proftpd', 'vsftpd', 'pure-ftpd']
 
     name: php${{ matrix.php-versions }}-${{ matrix.ftpd }}

--- a/.github/workflows/files-external-ftp.yml
+++ b/.github/workflows/files-external-ftp.yml
@@ -57,9 +57,6 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.4']
         ftpd: ['proftpd', 'vsftpd', 'pure-ftpd']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.ftpd }}
 
@@ -87,7 +84,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -110,21 +107,7 @@ jobs:
       - name: PHPUnit
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/FtpTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-ftp
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-files-external-ftp
+          --log-junit junit.xml
 
       - name: ftpd logs
         if: always()

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-s3-minio
 
@@ -129,7 +129,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-s3-localstack
 

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.4']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3', '8.4']
 
     name: php${{ matrix.php-versions }}-s3-minio
 
@@ -86,7 +83,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -111,21 +108,7 @@ jobs:
           composer run test:files_external -- \
             --group S3 \
             --log-junit junit.xml \
-            apps/files_external/tests/Storage \
-            ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-s3
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-files-external-s3
+            apps/files_external/tests/Storage
 
       - name: Nextcloud logs
         if: always()
@@ -146,10 +129,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.4']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3', '8.4']
 
     name: php${{ matrix.php-versions }}-s3-localstack
 
@@ -176,7 +156,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -194,21 +174,7 @@ jobs:
           composer run test:files_external -- \
             --group S3 \
             --log-junit junit.xml \
-            apps/files_external/tests/Storage \
-            ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-s3
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-files-external-s3
+            apps/files_external/tests/Storage
 
       - name: S3 logs
         if: always()

--- a/.github/workflows/files-external-sftp.yml
+++ b/.github/workflows/files-external-sftp.yml
@@ -57,9 +57,6 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.4']
         sftpd: ['openssh']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.sftpd }}
 
@@ -83,7 +80,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -98,21 +95,7 @@ jobs:
       - name: PHPUnit
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/SftpTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-sftp
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-files-external-sftp
+          --log-junit junit.xml
 
       - name: sftpd logs
         if: always()

--- a/.github/workflows/files-external-sftp.yml
+++ b/.github/workflows/files-external-sftp.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.4']
+        php-versions: ['8.2', '8.5']
         sftpd: ['openssh']
 
     name: php${{ matrix.php-versions }}-${{ matrix.sftpd }}

--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -55,9 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2']
 
     name: php${{ matrix.php-versions }}-smb
 
@@ -87,7 +85,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, smbclient, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -114,21 +112,7 @@ jobs:
       - name: PHPUnit
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/SmbTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-smb
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-files-external-smb
+          --log-junit junit.xml
 
   files-external-smb-summary:
     runs-on: ubuntu-latest-low

--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-smb
 

--- a/.github/workflows/files-external-webdav.yml
+++ b/.github/workflows/files-external-webdav.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-webdav
 

--- a/.github/workflows/files-external-webdav.yml
+++ b/.github/workflows/files-external-webdav.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3', '8.4']
 
     name: php${{ matrix.php-versions }}-webdav
 
@@ -82,7 +79,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -104,21 +101,7 @@ jobs:
       - name: PHPUnit
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/WebdavTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-webdav
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-files-external-webdav
+          --log-junit junit.xml
 
   files-external-webdav-summary:
     runs-on: ubuntu-latest-low

--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3', '8.4']
 
     name: php${{ matrix.php-versions }}-generic
 
@@ -76,7 +73,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -93,21 +90,7 @@ jobs:
 
       - name: PHPUnit
         run: composer run test:files_external -- \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-generic
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-files-external-generic
+          --log-junit junit.xml
 
   files-external-summary:
     runs-on: ubuntu-latest-low

--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-generic
 

--- a/.github/workflows/integration-dav.yml
+++ b/.github/workflows/integration-dav.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.2', '8.5']
         endpoint: ['old', 'new']
         service: ['CalDAV', 'CardDAV']
 

--- a/.github/workflows/integration-dav.yml
+++ b/.github/workflows/integration-dav.yml
@@ -65,7 +65,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: 'none'
+          coverage: none
           ini-file: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-litmus.yml
+++ b/.github/workflows/integration-litmus.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.2', '8.5']
         endpoint: ['webdav', 'dav']
 
     name: Litmus WebDAV ${{ matrix.endpoint }}

--- a/.github/workflows/integration-litmus.yml
+++ b/.github/workflows/integration-litmus.yml
@@ -64,7 +64,7 @@ jobs:
             php-version: ${{ matrix.php-versions }}
             # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
             extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-            coverage: 'none'
+            coverage: none
             ini-file: development
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-s3-primary.yml
+++ b/.github/workflows/integration-s3-primary.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.2', '8.5']
         key: ['objectstore', 'objectstore_multibucket']
 
     name: php${{ matrix.php-versions }}-${{ matrix.key }}-minio

--- a/.github/workflows/integration-s3-primary.yml
+++ b/.github/workflows/integration-s3-primary.yml
@@ -88,7 +88,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: 'none'
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -69,7 +69,7 @@ jobs:
           - 'videoverification_features'
           - 'guests_features'
 
-        php-versions: ['8.4']
+        php-versions: ['8.2', '8.5']
         guests-versions: ['main']
         spreed-versions: ['main']
         activity-versions: ['master']

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
+        php-versions: ['8.2', '8.5']
 
     name: php-lint
 

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-azure
 

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
-        include:
-          - php-versions: '8.4'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3', '8.4']
 
     name: php${{ matrix.php-versions }}-azure
 
@@ -91,7 +88,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -114,20 +111,7 @@ jobs:
           OBJECT_STORE: azure
           OBJECT_STORE_KEY: nextcloud
           OBJECT_STORE_SECRET: bmV4dGNsb3Vk
-        run: composer run test -- --group PRIMARY-azure --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-azure
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-azure
+        run: composer run test -- --group PRIMARY-azure --log-junit junit.xml
 
       - name: Azurite logs
         if: always()

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-s3
 

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3']
 
     name: php${{ matrix.php-versions }}-s3
 
@@ -92,7 +89,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -119,20 +116,7 @@ jobs:
           OBJECT_STORE: s3
           OBJECT_STORE_KEY: nextcloud
           OBJECT_STORE_SECRET: bWluaW8tc2VjcmV0LWtleS1uZXh0Y2xvdWQ=
-        run: composer run test -- --group PRIMARY-s3 --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-s3
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-s3
+        run: composer run test -- --group PRIMARY-s3 --log-junit junit.xml
 
       - name: S3 logs
         if: always()

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3']
 
     name: php${{ matrix.php-versions }}-swift
 
@@ -89,7 +86,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -110,20 +107,7 @@ jobs:
         env:
           OBJECT_STORE: swift
           OBJECT_STORE_SECRET: veryfast
-        run: composer run test -- --group PRIMARY-swift --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-swift
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-swift
+        run: composer run test -- --group PRIMARY-swift --log-junit junit.xml
 
       - name: Swift logs
         if: always()

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.2', '8.5']
 
     name: php${{ matrix.php-versions }}-swift
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -26,12 +26,7 @@ jobs:
     permissions:
       pull-requests: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        php-versions: ['8.2']
-
-    name: performance-${{ matrix.php-versions }}
+    name: performance
 
     steps:
 
@@ -42,11 +37,11 @@ jobs:
           submodules: true
           ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Set up php ${{ matrix.php-versions }}
+      - name: Set up php
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         timeout-minutes: 5
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.2'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.4"]
+        php-versions: ['8.2', '8,5']
 
     steps:
       - name: Checkout server

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -64,7 +64,6 @@ jobs:
             mariadb-versions: '10.6'
           - php-versions: '8.5'
             mariadb-versions: '11.8'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: MariaDB ${{ matrix.mariadb-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 
@@ -100,7 +99,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -126,23 +125,10 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
+        run: composer run test:db -- --log-junit junit.xml
         env:
           DB_ROOT_USER: root
           DB_ROOT_PASS: rootpassword
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-mariadb
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-mariadb
 
   summary:
     permissions:

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -60,10 +60,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-versions: '8.2'
-            mariadb-versions: '10.6'
-          - php-versions: '8.5'
-            mariadb-versions: '11.8'
+          - mariadb-versions: '10.6'
+            php-versions: '8.2'
+          - mariadb-versions: '11.8'
+            php-versions: '8.5'
 
     name: MariaDB ${{ matrix.mariadb-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.2', '8.5']
 
     name: Memcached (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -56,10 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4', '8.5']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
 
     name: Memcached (PHP ${{ matrix.php-versions }})
 
@@ -84,7 +81,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, memcached, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -102,20 +99,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit memcached tests
-        run: composer run test -- --group Memcache --group Memcached --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.xml
-          flags: phpunit-memcached
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-memcached
+        run: composer run test -- --group Memcache --group Memcached --log-junit junit.xml
 
       - name: Print logs
         if: always()

--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -56,8 +56,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.2"]
-        mysql-versions: ["8.4"]
+        include:
+          - mysql-versions: '8.0'
+            php-versions: '8.2'
+          - mysql-versions: '8.4'
+            php-versions: '8.5'
 
     name: Sharding - MySQL ${{ matrix.mysql-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -133,7 +133,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -160,20 +160,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-mysql
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-mysql
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Print logs
         if: always()

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -64,7 +64,6 @@ jobs:
             php-versions: '8.2'
           - mysql-versions: '8.4'
             php-versions: '8.5'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: MySQL ${{ matrix.mysql-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 
@@ -100,7 +99,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -126,23 +125,10 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
+        run: composer run test:db -- --log-junit junit.xml
         env:
           DB_ROOT_USER: root
           DB_ROOT_PASS: rootpassword
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-mysql
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-mysql
 
       - name: Print logs
         if: always()

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.2", "8.3", "8.4", "8.5"]
+        php-versions: ['8.2', '8.5']
 
     name: No DB unit tests (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -59,10 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.3", "8.4", "8.5"]
-        include:
-          - php-versions: "8.2"
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ["8.2", "8.3", "8.4", "8.5"]
 
     name: No DB unit tests (PHP ${{ matrix.php-versions }})
 
@@ -87,7 +84,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: apcu, bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, libxml, mbstring, openssl, pcntl, pdo_sqlite, posix, redis, session, simplexml, sqlite, xmlreader, xmlwriter, zip, zlib
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           # Required for tests that use pcntl
           ini-values: disable_functions=""
@@ -107,20 +104,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit nodb testsuite
-        run: composer run test -- --exclude-group DB --exclude-group SLOWDB --exclude-group Memcached --exclude-group PRIMARY-swift --exclude-group PRIMARY-s3 --exclude-group PRIMARY-azure --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.nodb.xml' || '' }}
-
-      - name: Upload nodb code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.nodb.xml
-          flags: phpunit-nodb
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-nodb
+        run: composer run test -- --exclude-group DB --exclude-group SLOWDB --exclude-group Memcached --exclude-group PRIMARY-swift --exclude-group PRIMARY-s3 --exclude-group PRIMARY-azure --log-junit junit.xml
 
       - name: Print logs
         if: always()

--- a/.github/workflows/phpunit-object-store-primary.yml
+++ b/.github/workflows/phpunit-object-store-primary.yml
@@ -49,8 +49,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.2"]
-        key: ["s3", "s3-multibucket"]
+        php-versions: ['8.2', '8.5']
+        key: ['s3', 's3-multibucket']
 
     name: php${{ matrix.php-versions }}-${{ matrix.key }}-minio
 

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -64,7 +64,6 @@ jobs:
             php-versions: '8.2'
           - oracle-versions: '23'
             php-versions: '8.5'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: Oracle ${{ matrix.oracle-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 
@@ -107,7 +106,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, oci8
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -126,20 +125,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-oci
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-oci
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Run repair steps
         run: |

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -68,7 +68,6 @@ jobs:
             postgres-versions: '18'
           - php-versions: '8.5'
             postgres-versions: '18'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: PostgreSQL ${{ matrix.postgres-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 
@@ -103,7 +102,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -124,20 +123,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit database tests
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-postgres
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-postgres
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Run repair steps
         run: |

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -60,14 +60,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-versions: '8.2'
-            postgres-versions: '14'
-          - php-versions: '8.3'
-            postgres-versions: '18'
-          - php-versions: '8.4'
-            postgres-versions: '18'
-          - php-versions: '8.5'
-            postgres-versions: '18'
+          - postgres-versions: '14'
+            php-versions: '8.2'
+          - postgres-versions: '18'
+            php-versions: '8.5'
 
     name: PostgreSQL ${{ matrix.postgres-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.5']
+        php-versions: ['8.2', '8.5']
 
     name: SQLite (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -59,9 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php-versions: '8.5'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.5']
 
     name: SQLite (PHP ${{ matrix.php-versions }})
 
@@ -86,7 +84,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -111,20 +109,7 @@ jobs:
         run: ./occ app:list && echo "======= System config =======" && ./occ config:list system
 
       - name: PHPUnit database tests
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-sqlite
-
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          flags: phpunit-sqlite
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Print logs
         if: always()

--- a/.github/workflows/rector-apply.yml
+++ b/.github/workflows/rector-apply.yml
@@ -21,11 +21,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        php-versions: [ '8.2' ]
-
     name: rector-apply
 
     steps:
@@ -36,10 +31,10 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
-      - name: Set up php${{ matrix.php-versions }}
+      - name: Set up php
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.2'
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -150,8 +150,8 @@ class S3Test extends ObjectStoreTestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileSizes')]
 	public function testFileSizes($size): void {
-		if (str_starts_with(PHP_VERSION, '8.3') && getenv('CI')) {
-			$this->markTestSkipped('Test is unreliable and skipped on 8.3');
+		if (str_starts_with(PHP_VERSION, '8.5') && getenv('CI')) {
+			$this->markTestSkipped('Test is unreliable and skipped on 8.5');
 		}
 
 		$this->cleanupAfter('testfilesizes');


### PR DESCRIPTION
I remove the coverage reports, because we don't use them at all and it just wastes time and makes the workflows messier.

While it removes the versions between 8.2 and 8.5, it also adds some versions, because some versions were only testing 8.2 (or 8.4) and not the latest version.