### PR TITLE
fix(dav): default reminder on received invitations + preserve recipient VALARMs

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -118,7 +118,7 @@ if ($debugging) {
 
 $server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 $server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
-$server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class)));
+$server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class), $calDavBackend, Server::get(\OCP\Config\IUserConfig::class), Server::get(\OCP\IAppConfig::class)));
 
 if ($sendInvitations) {
 	$server->addPlugin(Server::get(IMipPlugin::class));

--- a/apps/dav/lib/CalDAV/EmbeddedCalDavServer.php
+++ b/apps/dav/lib/CalDAV/EmbeddedCalDavServer.php
@@ -86,7 +86,7 @@ class EmbeddedCalDavServer {
 		// calendar plugins
 		$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
-		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class)));
+		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class), Server::get(\OCA\DAV\CalDAV\CalDavBackend::class), Server::get(\OCP\Config\IUserConfig::class), Server::get(\OCP\IAppConfig::class)));
 		$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
 		//$this->server->addPlugin(new \OCA\DAV\DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest()));

--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -83,7 +83,7 @@ class InvitationResponseServer {
 		// calendar plugins
 		$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
-		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class)));
+		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class), Server::get(\OCA\DAV\CalDAV\CalDavBackend::class), Server::get(\OCP\Config\IUserConfig::class), Server::get(\OCP\IAppConfig::class)));
 		$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
 		//$this->server->addPlugin(new \OCA\DAV\DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest()));

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -15,6 +15,8 @@ use OCA\DAV\CalDAV\CalendarObject;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\CalDAV\Federation\FederatedCalendar;
 use OCA\DAV\CalDAV\TipBroker;
+use OCP\Config\IUserConfig;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\ICalendar;
@@ -53,13 +55,13 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 	public const CALENDAR_USER_TYPE = '{' . self::NS_CALDAV . '}calendar-user-type';
 	public const SCHEDULE_DEFAULT_CALENDAR_URL = '{' . Plugin::NS_CALDAV . '}schedule-default-calendar-URL';
 
-	/**
-	 * @param IConfig $config
-	 */
 	public function __construct(
 		private IConfig $config,
 		private LoggerInterface $logger,
 		private DefaultCalendarValidator $defaultCalendarValidator,
+		private CalDavBackend $caldavBackend,
+		private IUserConfig $userConfig,
+		private IAppConfig $appConfig,
 	) {
 	}
 
@@ -257,12 +259,16 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 		/** @var VEvent|null $vevent */
 		$vevent = $iTipMessage->message->VEVENT ?? null;
 
-		// Strip VALARMs from incoming VEVENT
-		if ($vevent && isset($vevent->VALARM)) {
-			$vevent->remove('VALARM');
+		// A remote organizer must not drive alerts on the recipient's devices.
+		foreach ($iTipMessage->message->VEVENT ?? [] as $component) {
+			$component->remove('VALARM');
 		}
 
-		parent::scheduleLocalDelivery($iTipMessage);
+		if ($vevent && strcasecmp($iTipMessage->method, 'REQUEST') === 0) {
+			$this->applyRecipientReminderPolicy($iTipMessage);
+		}
+
+		$this->delegateToSabre($iTipMessage);
 		// We only care when the message was successfully delivered locally
 		// Log all possible codes returned from the parent method that mean something went wrong
 		// 3.7, 3.8, 5.0, 5.2
@@ -776,5 +782,227 @@ EOF;
 				throw $e;
 			}
 		}
+	}
+
+	/**
+	 * Thin testable seam around the parent's `scheduleLocalDelivery`. Tests subclass and
+	 * override this to skip the Sabre delivery while still exercising our hook code.
+	 *
+	 * @param ITip\Message $iTipMessage
+	 */
+	protected function delegateToSabre(ITip\Message $iTipMessage): void {
+		parent::scheduleLocalDelivery($iTipMessage);
+	}
+
+	/**
+	 * For an incoming REQUEST, preserve the recipient's existing VALARMs or inject their default reminder.
+	 *
+	 * @param ITip\Message $iTipMessage
+	 */
+	private function applyRecipientReminderPolicy(ITip\Message $iTipMessage): void {
+		try {
+			/** @var \Sabre\DAVACL\Plugin|null $aclPlugin */
+			$aclPlugin = $this->server->getPlugin('acl');
+			if (!$aclPlugin) {
+				return;
+			}
+			$principalUri = $aclPlugin->getPrincipalByUri($iTipMessage->recipient);
+			if (!$principalUri) {
+				return;
+			}
+
+			$calendarUserType = $this->getCalendarUserTypeForPrincipal($principalUri);
+			if ($calendarUserType !== null
+				&& (strcasecmp($calendarUserType, 'ROOM') === 0 || strcasecmp($calendarUserType, 'RESOURCE') === 0)) {
+				return;
+			}
+
+			// Skip when the recipient is the organizer (self-invite).
+			/** @var VEvent|null $incomingVEvent */
+			$incomingVEvent = $iTipMessage->message->VEVENT ?? null;
+			if ($incomingVEvent && isset($incomingVEvent->ORGANIZER)) {
+				$organizerAddresses = $this->getAddressesForPrincipal($principalUri);
+				/** @var Property&Property\ICalendar\CalAddress $organizer */
+				$organizer = $incomingVEvent->ORGANIZER;
+				if (in_array($organizer->getNormalizedValue(), $organizerAddresses, true)) {
+					return;
+				}
+			}
+
+			$userId = $this->principalUriToUserId($principalUri);
+			if ($userId === null) {
+				return;
+			}
+
+			$existingVAlarms = $this->collectExistingValarmsForRecipient($principalUri, $iTipMessage->uid);
+			if ($existingVAlarms !== null) {
+				// An empty set means the recipient deleted them on purpose; never re-inject a default.
+				foreach ($iTipMessage->message->VEVENT as $vevent) {
+					$key = $this->veventRecurrenceKey($vevent);
+					foreach ($existingVAlarms[$key] ?? [] as $valarm) {
+						$vevent->add(clone $valarm);
+					}
+				}
+				return;
+			}
+
+			$toggle = $this->userConfig->getValueString($userId, 'calendar', 'applyDefaultReminderToInvitations', 'yes');
+			if ($toggle !== 'yes') {
+				return;
+			}
+			$offset = $this->resolveDefaultReminderOffset($userId, $incomingVEvent);
+			if ($offset !== 'none') {
+				$this->injectDefaultReminder($iTipMessage, $offset);
+			}
+		} catch (\Throwable $e) {
+			// Best-effort: never let reminder handling break delivery.
+			$this->logger->debug('Failed to apply recipient reminder policy on invitation', ['exception' => $e]);
+		}
+	}
+
+	/**
+	 * Collect every VALARM from the recipient's existing local copy of the given UID, keyed by
+	 * RECURRENCE-ID (empty string for the master VEVENT). Returns null when the recipient has no
+	 * local copy of this UID yet, which is the signal for the first-receipt path.
+	 *
+	 * @param string $principalUri
+	 * @param string $uid
+	 * @return array<string, list<Component>>|null
+	 */
+	private function collectExistingValarmsForRecipient(string $principalUri, string $uid): ?array {
+		$objectPath = $this->caldavBackend->getCalendarObjectByUID($principalUri, $uid);
+		if ($objectPath === null) {
+			return null;
+		}
+		[$calendarUri, $objectUri] = explode('/', $objectPath, 2);
+		$calendar = $this->caldavBackend->getCalendarByUri($principalUri, $calendarUri);
+		if (!$calendar) {
+			return [];
+		}
+		$objectData = $this->caldavBackend->getCalendarObject($calendar['id'], $objectUri);
+		if (empty($objectData['calendardata'])) {
+			return [];
+		}
+		$vCal = Reader::read($objectData['calendardata']);
+		$result = [];
+		foreach ($vCal->VEVENT ?? [] as $vevent) {
+			if (!isset($vevent->VALARM)) {
+				continue;
+			}
+			$key = $this->veventRecurrenceKey($vevent);
+			$result[$key] = [];
+			foreach ($vevent->VALARM as $valarm) {
+				$result[$key][] = $valarm;
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Stable key per VEVENT component: '' for the master, otherwise the RECURRENCE-ID as an
+	 * absolute timestamp so TZID-local and UTC spellings of the same instance still match.
+	 *
+	 * @param VEvent $vevent
+	 * @return string
+	 */
+	private function veventRecurrenceKey(VEvent $vevent): string {
+		/** @var \Sabre\VObject\Property\ICalendar\DateTime|null $rid */
+		$rid = $vevent->{'RECURRENCE-ID'} ?? null;
+		if ($rid === null) {
+			return '';
+		}
+		try {
+			return (string)$rid->getDateTime()->getTimestamp();
+		} catch (\Throwable $e) {
+			return (string)$rid;
+		}
+	}
+
+	/**
+	 * Resolves the per-user default reminder offset for a first-receipt invitation,
+	 * matching the calendar app's frontend fallback chain.
+	 *
+	 * @param string $userId
+	 * @param VEvent|null $vevent
+	 * @return string 'none' to skip, otherwise a signed integer-as-string (seconds before start).
+	 */
+	private function resolveDefaultReminderOffset(string $userId, ?VEvent $vevent): string {
+		$isAllDay = $vevent !== null && isset($vevent->DTSTART) && !$vevent->DTSTART->hasTime();
+		$typedKey = $isAllDay ? 'defaultReminderFullDay' : 'defaultReminderPartDay';
+		$typed = $this->userConfig->getValueString($userId, 'calendar', $typedKey, 'none');
+		if (filter_var($typed, FILTER_VALIDATE_INT) !== false) {
+			return $typed;
+		}
+		$legacy = $this->userConfig->getValueString($userId, 'calendar', 'defaultReminder', 'none');
+		if (filter_var($legacy, FILTER_VALIDATE_INT) !== false) {
+			return $legacy;
+		}
+		$admin = $this->appConfig->getValueString('calendar', 'defaultReminder', 'none');
+		if (filter_var($admin, FILTER_VALIDATE_INT) !== false) {
+			return $admin;
+		}
+		return 'none';
+	}
+
+	/**
+	 * Adds a DISPLAY VALARM to the master VEVENT of the iTip message.
+	 *
+	 * @param ITip\Message $iTipMessage
+	 * @param string $offset Signed integer (seconds, negative = before start), as stored by the calendar app.
+	 */
+	private function injectDefaultReminder(ITip\Message $iTipMessage, string $offset): void {
+		/** @var VEvent|null $vevent */
+		$vevent = $iTipMessage->message->VEVENT ?? null;
+		if ($vevent === null) {
+			return;
+		}
+		$seconds = (int)$offset;
+		$duration = ($seconds < 0 ? '-' : '') . $this->secondsToIso8601Duration(abs($seconds));
+		$alarm = $iTipMessage->message->createComponent('VALARM');
+		$alarm->add($iTipMessage->message->createProperty('ACTION', 'DISPLAY'));
+		$alarm->add($iTipMessage->message->createProperty('DESCRIPTION', 'Reminder'));
+		$alarm->add($iTipMessage->message->createProperty('TRIGGER', $duration, ['RELATED' => 'START']));
+		$vevent->add($alarm);
+	}
+
+	/**
+	 * Converts seconds to an ISO 8601 duration string. Helper derived from
+	 * lufer22's nextcloud/server#48226.
+	 *
+	 * @param int $secs Non-negative.
+	 * @return string
+	 */
+	private function secondsToIso8601Duration(int $secs): string {
+		$day = 24 * 60 * 60;
+		$hour = 60 * 60;
+		$minute = 60;
+		if ($secs === 0) {
+			return 'PT0S';
+		}
+		if ($secs % $day === 0) {
+			return 'P' . (int)($secs / $day) . 'D';
+		}
+		if ($secs % $hour === 0) {
+			return 'PT' . (int)($secs / $hour) . 'H';
+		}
+		if ($secs % $minute === 0) {
+			return 'PT' . (int)($secs / $minute) . 'M';
+		}
+		return 'PT' . $secs . 'S';
+	}
+
+	/**
+	 * Maps a Sabre principal URI to a first-class Nextcloud user id, or null.
+	 *
+	 * @param string $principalUri e.g. 'principals/users/alice'.
+	 * @return string|null
+	 */
+	private function principalUriToUserId(string $principalUri): ?string {
+		$prefix = 'principals/users/';
+		if (!str_starts_with($principalUri, $prefix)) {
+			return null;
+		}
+		$userId = substr($principalUri, strlen($prefix));
+		return $userId === '' ? null : $userId;
 	}
 }

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -205,7 +205,7 @@ class Server {
 			$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OCP\Server::get(IRequest::class), \OCP\Server::get(IConfig::class), \OCP\Server::get(RateLimiting::class)));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
 			$this->server->addPlugin(new ICSExportPlugin(\OCP\Server::get(IConfig::class), $logger));
-			$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OCP\Server::get(IConfig::class), \OCP\Server::get(LoggerInterface::class), \OCP\Server::get(DefaultCalendarValidator::class)));
+			$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OCP\Server::get(IConfig::class), \OCP\Server::get(LoggerInterface::class), \OCP\Server::get(DefaultCalendarValidator::class), \OCP\Server::get(\OCA\DAV\CalDAV\CalDavBackend::class), \OCP\Server::get(\OCP\Config\IUserConfig::class), \OCP\Server::get(\OCP\IAppConfig::class)));
 
 			$this->server->addPlugin(\OCP\Server::get(\OCA\DAV\CalDAV\Trashbin\Plugin::class));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\WebcalCaching\Plugin($this->request));

--- a/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
@@ -15,6 +15,8 @@ use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\CalDAV\Plugin as CalDAVPlugin;
 use OCA\DAV\CalDAV\Schedule\Plugin;
 use OCA\DAV\CalDAV\Trashbin\Plugin as TrashbinPlugin;
+use OCP\Config\IUserConfig;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,6 +44,9 @@ class PluginTest extends TestCase {
 	private IConfig&MockObject $config;
 	private LoggerInterface&MockObject $logger;
 	private DefaultCalendarValidator $calendarValidator;
+	private CalDavBackend&MockObject $caldavBackend;
+	private IUserConfig&MockObject $userConfig;
+	private IAppConfig&MockObject $appConfig;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -49,12 +54,15 @@ class PluginTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->calendarValidator = new DefaultCalendarValidator();
+		$this->caldavBackend = $this->createMock(CalDavBackend::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 
 		$this->server = $this->createMock(Server::class);
 		$this->server->httpResponse = $this->createMock(ResponseInterface::class);
 		$this->server->xml = new Service();
 
-		$this->plugin = new Plugin($this->config, $this->logger, $this->calendarValidator);
+		$this->plugin = new Plugin($this->config, $this->logger, $this->calendarValidator, $this->caldavBackend, $this->userConfig, $this->appConfig);
 		$this->plugin->initialize($this->server);
 	}
 
@@ -767,5 +775,287 @@ class PluginTest extends TestCase {
 			$modifiedFlag,
 			$newFlag
 		);
+	}
+
+	// ----------------------------------------------------------------------------
+	// nextcloud/calendar#6315: receive-side default reminder + preserve-on-update
+	// ----------------------------------------------------------------------------
+
+	private function makeTestablePlugin(): TestableSchedulePlugin {
+		$plugin = new TestableSchedulePlugin(
+			$this->config,
+			$this->logger,
+			$this->calendarValidator,
+			$this->caldavBackend,
+			$this->userConfig,
+			$this->appConfig,
+		);
+		$plugin->initialize($this->server);
+		return $plugin;
+	}
+
+	/**
+	 * Build an iTip\Message with one or more VEVENT components for testing
+	 * scheduleLocalDelivery.
+	 *
+	 * @param string $method REQUEST|REPLY|CANCEL|REFRESH
+	 * @param array $components Each item: ['rid' => null|string, 'isAllDay' => bool, 'valarms' => list of TRIGGER strings]
+	 */
+	private function makeITipMessage(string $method, array $components, string $organizerUri = 'mailto:organizer@example.org', string $recipientUri = 'mailto:test@example.org'): Message {
+		$vCal = new VCalendar();
+		foreach ($components as $i => $comp) {
+			$rid = $comp['rid'] ?? null;
+			$isAllDay = $comp['isAllDay'] ?? false;
+			$valarms = $comp['valarms'] ?? [];
+			$vevent = $vCal->add('VEVENT', [
+				'UID' => 'UID-6315',
+				'SUMMARY' => 'Test event',
+				'DTSTART' => $isAllDay
+					? new \DateTimeImmutable('2026-06-15')
+					: new \DateTimeImmutable('2026-06-15T09:00:00'),
+				'DTSTAMP' => new \DateTimeImmutable('2026-06-10T10:00:00'),
+				'ORGANIZER' => $organizerUri,
+				'ATTENDEE' => $recipientUri,
+			]);
+			if ($isAllDay) {
+				$vevent->DTSTART['VALUE'] = 'DATE';
+			}
+			if ($rid !== null) {
+				$vevent->add('RECURRENCE-ID', $rid);
+			}
+			foreach ($valarms as $trigger) {
+				$alarm = $vevent->add('VALARM');
+				$alarm->add('ACTION', 'DISPLAY');
+				$alarm->add('TRIGGER', $trigger);
+			}
+		}
+		$msg = new Message();
+		$msg->method = $method;
+		$msg->message = $vCal;
+		$msg->uid = 'UID-6315';
+		$msg->recipient = $recipientUri;
+		$msg->sender = $organizerUri;
+		return $msg;
+	}
+
+	/**
+	 * Stub the ACL plugin lookup and getProperties call (for the recipient-user-type check).
+	 */
+	private function stubAclAndUserType(string $principalUri = 'principals/users/test', string $userType = 'INDIVIDUAL'): void {
+		$aclPlugin = $this->createMock(\Sabre\DAVACL\Plugin::class);
+		$aclPlugin->method('getPrincipalByUri')->willReturn($principalUri);
+		$this->server->method('getPlugin')->willReturnMap([
+			['acl', $aclPlugin],
+		]);
+		$this->server->method('getProperties')->willReturn([
+			'{' . Plugin::NS_CALDAV . '}calendar-user-type' => $userType,
+		]);
+	}
+
+	private function countValarms(VCalendar $vCal): int {
+		$n = 0;
+		foreach ($vCal->VEVENT as $vevent) {
+			if (isset($vevent->VALARM)) {
+				$n += count($vevent->VALARM);
+			}
+		}
+		return $n;
+	}
+
+	public function testSkipsNonRequest(): void {
+		$plugin = $this->makeTestablePlugin();
+		// No mocks needed for REPLY because we return before touching the reminder logic.
+		$msg = $this->makeITipMessage('REPLY', [['valarms' => ['-PT15M']]]);
+		$plugin->scheduleLocalDelivery($msg);
+		// Existing strip still runs on all VEVENTs regardless of method.
+		$this->assertSame(0, $this->countValarms($msg->message));
+	}
+
+	public function testStripsOrganizerValarmsFromAllComponents(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn(null);
+		// Toggle on, but every reminder source resolves to 'none' so nothing is injected.
+		$this->userConfig->method('getValueString')->willReturnMap([
+			['test', 'calendar', 'applyDefaultReminderToInvitations', 'yes', 'yes'],
+			['test', 'calendar', 'defaultReminderPartDay', 'none', 'none'],
+			['test', 'calendar', 'defaultReminder', 'none', 'none'],
+		]);
+		$this->appConfig->method('getValueString')->willReturnMap([
+			['calendar', 'defaultReminder', 'none', 'none'],
+		]);
+
+		// Master + override, each with one organizer VALARM.
+		$msg = $this->makeITipMessage('REQUEST', [
+			['valarms' => ['PT0S']],
+			['rid' => '20260616T090000Z', 'valarms' => ['PT0S']],
+		]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		// All organizer VALARMs stripped, no default injected.
+		$this->assertSame(0, $this->countValarms($msg->message));
+	}
+
+	public function testFirstReceiptInjectsTypedPartDayDefault(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn(null);
+		$this->userConfig->method('getValueString')->willReturnMap([
+			['test', 'calendar', 'applyDefaultReminderToInvitations', 'yes', 'yes'],
+			['test', 'calendar', 'defaultReminderPartDay', 'none', '-900'],
+		]);
+
+		$msg = $this->makeITipMessage('REQUEST', [['valarms' => []]]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		$this->assertSame(1, $this->countValarms($msg->message));
+		$trigger = (string)$msg->message->VEVENT[0]->VALARM->TRIGGER;
+		$this->assertSame('-PT15M', $trigger);
+	}
+
+	public function testFirstReceiptInjectsTypedFullDayDefault(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn(null);
+		$this->userConfig->method('getValueString')->willReturnMap([
+			['test', 'calendar', 'applyDefaultReminderToInvitations', 'yes', 'yes'],
+			['test', 'calendar', 'defaultReminderFullDay', 'none', '-3600'],
+		]);
+
+		$msg = $this->makeITipMessage('REQUEST', [['isAllDay' => true]]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		$this->assertSame(1, $this->countValarms($msg->message));
+		$this->assertSame('-PT1H', (string)$msg->message->VEVENT[0]->VALARM->TRIGGER);
+	}
+
+	public function testFirstReceiptFallsBackToLegacyAndAppValue(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn(null);
+		// Toggle 'yes', typed PartDay 'none', legacy 'none' -> falls through to app value.
+		$this->userConfig->method('getValueString')->willReturnMap([
+			['test', 'calendar', 'applyDefaultReminderToInvitations', 'yes', 'yes'],
+			['test', 'calendar', 'defaultReminderPartDay', 'none', 'none'],
+			['test', 'calendar', 'defaultReminder', 'none', 'none'],
+		]);
+		$this->appConfig->method('getValueString')->willReturnMap([
+			['calendar', 'defaultReminder', 'none', '-300'],
+		]);
+
+		$msg = $this->makeITipMessage('REQUEST', [[]]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		$this->assertSame(1, $this->countValarms($msg->message));
+		$this->assertSame('-PT5M', (string)$msg->message->VEVENT[0]->VALARM->TRIGGER);
+	}
+
+	public function testFirstReceiptSkippedWhenToggleOff(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn(null);
+		$this->userConfig->method('getValueString')->willReturnMap([
+			['test', 'calendar', 'applyDefaultReminderToInvitations', 'yes', 'no'],
+			['test', 'calendar', 'defaultReminderPartDay', 'none', '-900'],
+		]);
+
+		$msg = $this->makeITipMessage('REQUEST', [[]]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		$this->assertSame(0, $this->countValarms($msg->message));
+	}
+
+	public function testPreservesExistingValarmsOnUpdate(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn('personal/UID-6315.ics');
+		$this->caldavBackend->method('getCalendarByUri')->willReturn(['id' => 42]);
+		$this->caldavBackend->method('getCalendarObject')->willReturn([
+			'calendardata' => "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:UID-6315\nDTSTART:20260615T090000Z\nDTSTAMP:20260610T100000Z\nBEGIN:VALARM\nACTION:DISPLAY\nTRIGGER:-PT45M\nDESCRIPTION:User reminder\nEND:VALARM\nEND:VEVENT\nEND:VCALENDAR\n",
+		]);
+		// No user-config calls should happen on update path; nothing to mock.
+
+		$msg = $this->makeITipMessage('REQUEST', [['valarms' => ['PT0S']]]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		// Organizer VALARM stripped, recipient's existing -PT45M preserved.
+		$this->assertSame(1, $this->countValarms($msg->message));
+		$this->assertSame('-PT45M', (string)$msg->message->VEVENT[0]->VALARM->TRIGGER);
+	}
+
+	public function testExistingCopyWithoutAlarmsSkipsInjection(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn('personal/UID-6315.ics');
+		$this->caldavBackend->method('getCalendarByUri')->willReturn(['id' => 42]);
+		$this->caldavBackend->method('getCalendarObject')->willReturn([
+			'calendardata' => "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:UID-6315\nDTSTART:20260615T090000Z\nDTSTAMP:20260610T100000Z\nEND:VEVENT\nEND:VCALENDAR\n",
+		]);
+		// Recipient deleted their reminder; an organizer update must not re-inject a default.
+		$this->userConfig->expects($this->never())->method('getValueString');
+
+		$msg = $this->makeITipMessage('REQUEST', [['valarms' => ['PT0S']]]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		$this->assertSame(0, $this->countValarms($msg->message));
+	}
+
+	public function testPreservesPerOverrideValarms(): void {
+		$plugin = $this->makeTestablePlugin();
+		$this->stubAclAndUserType();
+		$this->caldavBackend->method('getCalendarObjectByUID')->willReturn('personal/UID-6315.ics');
+		$this->caldavBackend->method('getCalendarByUri')->willReturn(['id' => 42]);
+		$this->caldavBackend->method('getCalendarObject')->willReturn([
+			'calendardata' => "BEGIN:VCALENDAR\nVERSION:2.0\n"
+				. "BEGIN:VEVENT\nUID:UID-6315\nDTSTART:20260615T090000Z\nDTSTAMP:20260610T100000Z\n"
+				. "BEGIN:VALARM\nACTION:DISPLAY\nTRIGGER:-PT15M\nDESCRIPTION:r\nEND:VALARM\nEND:VEVENT\n"
+				. "BEGIN:VEVENT\nUID:UID-6315\nDTSTART:20260616T090000Z\nDTSTAMP:20260610T100000Z\nRECURRENCE-ID:20260616T090000Z\n"
+				. "BEGIN:VALARM\nACTION:DISPLAY\nTRIGGER:-PT5M\nDESCRIPTION:r\nEND:VALARM\nEND:VEVENT\n"
+				. "END:VCALENDAR\n",
+		]);
+
+		// Incoming master + same override, each with organizer VALARM that must be stripped.
+		$msg = $this->makeITipMessage('REQUEST', [
+			['valarms' => ['PT0S']],
+			['rid' => '20260616T090000Z', 'valarms' => ['PT0S']],
+		]);
+		$plugin->scheduleLocalDelivery($msg);
+
+		$this->assertSame(2, $this->countValarms($msg->message));
+		// Master kept its existing -PT15M, override kept its existing -PT5M.
+		$this->assertSame('-PT15M', (string)$msg->message->VEVENT[0]->VALARM->TRIGGER);
+		$this->assertSame('-PT5M', (string)$msg->message->VEVENT[1]->VALARM->TRIGGER);
+	}
+
+	public function testSecondsToIso8601Duration(): void {
+		$plugin = $this->makeTestablePlugin();
+		$ref = new \ReflectionMethod($plugin, 'secondsToIso8601Duration');
+		$ref->setAccessible(true);
+		$this->assertSame('PT0S', $ref->invoke($plugin, 0));
+		$this->assertSame('PT30S', $ref->invoke($plugin, 30));
+		$this->assertSame('PT15M', $ref->invoke($plugin, 900));
+		$this->assertSame('PT1H', $ref->invoke($plugin, 3600));
+		$this->assertSame('P1D', $ref->invoke($plugin, 86400));
+		$this->assertSame('P7D', $ref->invoke($plugin, 604800));
+	}
+
+	public function testPrincipalUriToUserId(): void {
+		$plugin = $this->makeTestablePlugin();
+		$ref = new \ReflectionMethod($plugin, 'principalUriToUserId');
+		$ref->setAccessible(true);
+		$this->assertSame('alice', $ref->invoke($plugin, 'principals/users/alice'));
+		$this->assertNull($ref->invoke($plugin, 'principals/groups/staff'));
+		$this->assertNull($ref->invoke($plugin, 'principals/users/'));
+		$this->assertNull($ref->invoke($plugin, 'other/path'));
+	}
+}
+
+/**
+ * Subclass that no-ops the delegation to Sabre's parent::scheduleLocalDelivery,
+ * so test cases can exercise the NC hook logic without setting up a full DAV tree.
+ */
+class TestableSchedulePlugin extends Plugin {
+	protected function delegateToSabre(Message $iTipMessage): void {
+		// no-op
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: nextcloud/calendar#6315
* Refs (not closing): nextcloud/server#48226

## Summary

The PR resolves the issue where the users default reminder for events isn’t applied to NC users invitations if the event is created by the server and not just the user. This happens when the invitation comes from the same NC instance.

Additionally, with this PR, reminders set later by participants won’t be overwritten by the server if the organizer makes changes to the event.

With the switch occ user:setting <userid> calendar applyDefaultReminderToInvitations no, you could disable the application of the default reminder to an invitation from the same NC instance on a per-user basis. If the option passes the review, a follow-up issue would need to be opened in the Calendar repository to discuss whether to just document it or also implement it in the WebUI.

### AI generated summary

<details>

When a user receives a calendar invitation via Sabre's iTip scheduling, the organizer's VALARMs are stripped server-side at `apps/dav/lib/CalDAV/Schedule/Plugin.php` (security baseline - the organizer must not be able to drive notifications on the recipient's devices). The recipient's own configured default reminder is **not** applied either, so the event arrives without any VALARM and the recipient gets no reminder notification (nextcloud/calendar#6315). A second, related gap surfaces in the same code path: when the recipient manually adds a VALARM to an invited event and the organizer later modifies the event, Sabre's `Broker::processMessageRequest()` discards every component of the existing local copy and replaces it with the (VALARM-stripped) incoming one - the recipient's manually-added VALARMs are lost on every organizer update.

This PR addresses both gaps in `Plugin::scheduleLocalDelivery()`, between the existing strip block and the call to `parent::scheduleLocalDelivery()`:

* **First-receipt path** - when the recipient has no local copy of this UID yet, inject the recipient's configured default reminder. The selection follows the calendar app's existing fallback chain: `defaultReminderFullDay` for all-day events / `defaultReminderPartDay` for timed events → legacy `defaultReminder` → app-level `calendar.defaultReminder` → `'none'`. Gated by a new per-user toggle `calendar:applyDefaultReminderToInvitations` (default `'yes'`), so users who don't want this can opt out and admins who don't want it as a fleet default can flip the app value.
* **Update path** - when the recipient already has a local copy, copy every VALARM from the existing copy onto the incoming components, matched per-`RECURRENCE-ID` (master and each override individually). The Sabre broker then writes the merged shape into the recipient's calendar.

Both paths skip ROOM/RESOURCE recipients and the organizer themselves. REPLY/CANCEL/REFRESH methods bypass the new logic entirely (and RFC 5546 forbids VALARM on those anyway). The existing VALARM strip block was also fixed in the same change - it operated on only the first VEVENT of the incoming message, so for recurring REQUESTs with `RECURRENCE-ID` overrides the organizer VALARMs on the overrides survived. This stripping is now applied per-component.

The implementation reuses lufer22's `secondsToIso8601Duration` and `createAlarm` shape from nextcloud/server#48226 (Co-Authored-By trailer), but resolves recipient principals via `$aclPlugin->getPrincipalByUri()` instead of the non-unique `userManager->getByEmail()` flagged in @SebastianKrupinski's review of that PR, extends the resolution to the typed (PartDay/FullDay) defaults, adds the user-toggle gate, and adds the preserve-on-update path lufer22's PR did not have. We don't close nextcloud/server#48226 - that PR is the structural ancestor of this one and should stay discoverable for context. A short courtesy comment is being posted there.

## Why this is RFC-compliant

RFC 5545 defines VALARM structurally but is silent on receive-side semantics. RFC 5546 (iTIP) allows VALARM in REQUEST (0+) and forbids it in REPLY/CANCEL/REFRESH (the new logic respects both). RFC 6638 (CalDAV scheduling extensions) §3.2.2.1 is the load-bearing argument: attendees are explicitly permitted to "add, modify, or remove any 'VALARM' iCalendar components" without scheduling side-effects. Server-side default injection on behalf of the attendee, and preserving the attendee's own VALARMs across organizer updates, are both things the attendee is allowed to do on their own copy - the server does them earlier and automatically.

## Tested

**Live (manual, on a Nextcloud 33.0.3.2 instance, two real CalDAV users, Thunderbird and the calendar web UI; reminder defaults set through the calendar web UI, not occ):**

First-receipt injection:

- [x] **T1** - Timed single event, recipient's part-day default set in the web UI: VALARM with the matching TRIGGER appears on the recipient side (web UI + Thunderbird).
- [x] **T2** - All-day single event, recipient's all-day default set in the web UI (these are day-relative, e.g. "1 day before at 9:00" stores `-54000` / `-PT15H`): VALARM with the matching day-relative TRIGGER appears on the recipient side.

Preserve-on-update:

- [x] **T3** - Organizer re-times a single event the recipient had already accepted: a fresh invitation goes out, the recipient's existing reminders are still present afterwards.
- [x] **T4** - Recurring series where the recipient has detached one occurrence. Setup: the recipient adds an extra reminder to occurrence 3 only. Under current Nextcloud behaviour, editing a single occurrence's reminder turns that occurrence into its own `RECURRENCE-ID` override (questionable, but pre-existing and unrelated to this change). The organizer then renames the whole series. Result: occurrences 1/2/4 get the new title and keep their reminders, and the recipient's reminders on both the master and the occurrence-3 override are preserved. Occurrence 3 keeps the old title, because a master-level rename does not propagate to an override that already exists - that title-propagation gap is the separate out-of-scope item listed below, not a regression of this change.
- [x] **T5** - Recurring series, organizer updates occurrences 1-4 except an overridden 3: the recipient's VALARMs on master and on each existing override survive every update without accumulation (this is the cycle that previously produced 4-6 VALARMs per VEVENT after repeated updates).

Round-trip / replies:

- [x] **R1** - The injected reminder does not interfere with the normal accept flow. The recipient opens a fresh invitation that already carries the injected default reminder and accepts it (tested both in the calendar web UI and via Thunderbird's accept button). The organizer then sees the acceptance in the web UI and receives the REPLY mail as usual. The injected VALARM rides along on the recipient's copy without affecting the REPLY.
- [x] **R2** - Recipient deletes the injected reminder, organizer updates the event again: the deleted reminder is **not** re-injected (existence-based first-receipt detection, not "zero alarms").

Counter-tests:

- [x] **G1** - `applyDefaultReminderToInvitations=no` (per-user, set via `occ` - no web UI yet): a fresh invitation arrives without any injected VALARM; existing VALARMs on prior invitations remain.
- [x] **G2** - Recipient has no reminder default set at all (web UI "No reminder", and the keys fully unset): no VALARM injected on a fresh invitation.
- [x] **G3** - Organizer invites themselves (self-invite) with their own reminder default set: **no** injected/duplicated reminder; the recipient policy skips the organizer's own copy.
- [x] **G4** - REPLY (recipient declines) and CANCEL (organizer cancels the event): the new reminder logic does not run, because it is gated to REQUEST messages only. No reminder is injected and the organizer's VALARMs stay stripped. A reminder the recipient had already added to an event they previously accepted is correctly kept when they later decline (the recipient owns the VALARMs on their own copy).

**Blocker found and fixed during live testing:** this change adds a 4th constructor argument (`CalDavBackend`) to `Schedule\Plugin`, but `InvitationResponseServer` (the helper that builds the plugin to process incoming iTip responses) was still constructing it with only 3 arguments, which raised an `ArgumentCountError`. It was observed in the live log on the NC Mail app's `Manager::handleIMipMessage()` auto-processing path. The same `InvitationResponseServer` also backs the Accept/Decline links inside iMIP emails, so that path was broken as well (not separately exercised in this round of testing). Fixed by passing the 4th argument at the `InvitationResponseServer` call site; the error appears in the log before the fix and is gone after it.

**Unit (added in `apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php`):**

- `testSkipsNonRequest` - REPLY/CANCEL/REFRESH never run the reminder hook.
- `testStripsOrganizerValarmsFromAllComponents` - verifies the strip fix for recurring REQUESTs.
- `testFirstReceiptInjectsTypedPartDayDefault` - `-PT15M` from typed PartDay setting.
- `testFirstReceiptInjectsTypedFullDayDefault` - `-PT1H` from typed FullDay setting for an all-day event.
- `testFirstReceiptFallsBackToLegacyAndAppValue` - typed `none` + legacy `none` → admin app value.
- `testFirstReceiptSkippedWhenToggleOff` - `applyDefaultReminderToInvitations=no` skips inject.
- `testPreservesExistingValarmsOnUpdate` - recipient's existing VALARM survives organizer update.
- `testExistingCopyWithoutAlarmsSkipsInjection` - local copy with zero alarms → no re-inject (deleted stays deleted).
- `testPreservesPerOverrideValarms` - per-`RECURRENCE-ID` matching for master + override.
- `testSecondsToIso8601Duration` / `testPrincipalUriToUserId` - direct helper coverage via reflection.

**Not tested locally:** `composer test` (PHPUnit bootstrap requires an installed-and-configured DB which this worktree doesn't have); CI will validate.

## Out of scope (explicit)

- **Frontend UI** for the new toggle in `nextcloud/calendar`. Out of scope here; follow-up calendar-app PR once this lands.
- **Master-level edits not propagating to existing overrides.** When the organizer changes a property on the whole series (title, description, location, time) but an occurrence already exists as a `RECURRENCE-ID` override, that override keeps its old values. This is what T4 shows for the title (occurrence 3 keeps the old name). It is a pre-existing behaviour, separate from the reminder bug fixed here, and is left as a follow-up.
- **Per-calendar default reminder** (a reminder default set per calendar rather than per user) - follow-up.
- **Reading reminder defaults from non-calendar apps** (e.g. mail or contacts) - out of scope; only the calendar app's settings are read.
- **Stray/duplicate overrides created during REPLY handling.** A separate area in `apps/dav/lib/CalDAV/TipBroker.php`, tracked in nextcloud/server#60452, nextcloud/server#60536 and nextcloud/server#61114. Not related to reminders.

## Trade-offs

* **Wholesale preserve, not delta**: on update, every existing VALARM from the recipient's matching component is copied. Per-occurrence attendee VALARM customisations that the recipient explicitly diverged from the master are preserved as-is. Good enough; a delta approach would need a pre-update snapshot of the recipient's intent.
* **`applyDefaultReminderToInvitations` defaults to `'yes'`**: chosen so the behaviour requested in nextcloud/calendar#6315 is active without each user having to opt in first. Easy to flip to `'no'` if maintainers prefer the safer migration default - happy to change it during review.

</details>

## TODO

- [ ] Maintainer review (especially the user-toggle default value).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes (N/A - backend only)
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required (will follow once the maintainer signs off on the toggle's default)
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
- Read the nextcloud/calendar#6315 issue to understand the problem
- Reviewed nextcloud/server#48226 and deployed it on my end so I could test it
- Researched whether server-side insertion of reminders for recipients is RFC-compliant
- Researched how other big players handle this 
- Designed a solution for the blockers from the old PR nextcloud/server#48226
- Identified edge cases (organizer as recipient, rooms and resources, recurring events with exceptions)
- Ultimately wrote all code changes and unit tests themselves
- Conducted a code review with a focus on security and simplicity
- Helped draft the PR body