### PR TITLE
fix(log): simplify JSON log serialization for invalid UTF-8

### DIFF
--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -95,17 +95,10 @@ abstract class LogDetails {
 
 	public function logDetailsAsJSON(string $app, string|array $message, int $level): string {
 		$entry = $this->logDetails($app, $message, $level);
-		// PHP's json_encode only accept proper UTF-8 strings, loop over all
-		// elements to ensure that they are properly UTF-8 compliant or convert
-		// them manually.
-		foreach ($entry as $key => $value) {
-			if (is_string($value)) {
-				$testEncode = json_encode($value, JSON_UNESCAPED_SLASHES);
-				if ($testEncode === false) {
-					$entry[$key] = mb_convert_encoding($value, 'UTF-8', mb_detect_encoding($value));
-				}
-			}
-		}
-		return json_encode($entry, JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_UNESCAPED_SLASHES);
+
+		// Log output should remain valid JSON even if some values contain invalid UTF-8.
+		// Substitute malformed byte sequences instead of trying to guess the original encoding,
+		// which can't be relied upon anyway.
+		return json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Make `LogDetails::logDetailsAsJSON()` best-effort and deterministic by letting `json_encode()` handle malformed UTF-8 directly.

Instead of probing strings and attempting to guess their original encoding with `mb_detect_encoding()` / `mb_convert_encoding()`, this change:
- removes the per-value fallback loop
- uses `JSON_INVALID_UTF8_SUBSTITUTE` to sanitize invalid byte sequences
- keeps `JSON_PARTIAL_OUTPUT_ON_ERROR` as a defensive fallback for logging

## Why

This code path is used for logging, so the priority is to emit usable JSON rather than fail or spend extra work trying to recover the original encoding (which can't be done reliably anyhow - so this is a more "honest" implementation).

The implementation is simpler and should be faster in both the common case (valid UTF-8) and the less common case (invalid UTF-8) by avoiding per-field encoding checks and encoding detection/conversion.

## Notes

- Behavior for malformed UTF-8 changes from "best-effort repair" to deterministic substitution.
- Valid UTF-8 input should be unaffected.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
