### PR TITLE
test(ci): Do not always run e2e tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,7 +8,14 @@
 
 name: Cypress
 
-on: pull_request
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
 
 concurrency:
   group: cypress-${{ github.head_ref || github.run_id }}
@@ -24,13 +31,42 @@ env:
   # n.b. server will use head_ref, as we want to test the PR branch.
   BRANCH: ${{ github.base_ref || github.ref_name }}
 
-
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest-low
+    steps:
+      - name: Evaluate e2e tests execution conditions
+        id: gate-e2e
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request
+
+            const hasForceLabel = pr.labels.some((label) => label.name === 'force-e2e-tests')
+            const hasToReviewLabel = pr.labels.some((label) => label.name === '3. to review')
+            const hasToReleaseLabel = pr.labels.some((label) => label.name === '4. to release')
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            })
+            const cypressTouched = files.some((file) => file.filename.startsWith('cypress'))
+
+            if (hasForceLabel || hasToReviewLabel || hasToReleaseLabel || cypressTouched) {
+              return
+            } else {
+              core.setFailed('Skipping Cypress: draft state, missing labels or no cypress path changes.')
+            }
+
   init:
     runs-on: ubuntu-latest
+    needs: gate
     outputs:
       nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
       npmVersion: ${{ steps.versions.outputs.npmVersion }}
@@ -98,7 +134,7 @@ jobs:
 
   cypress:
     runs-on: ubuntu-latest
-    needs: init
+    needs: [gate, init]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,16 +5,51 @@ name: Playwright Tests
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
 
 permissions:
   contents: read
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest-low
+    steps:
+      - name: Evaluate e2e tests execution conditions
+        id: gate-e2e
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request
+
+            const hasForceLabel = pr.labels.some((label) => label.name === 'force-e2e-tests')
+            const hasToReviewLabel = pr.labels.some((label) => label.name === '3. to review')
+            const hasToReleaseLabel = pr.labels.some((label) => label.name === '4. to release')
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            })
+            const playwrightTouched = files.some((file) => file.filename.startsWith('tests/playwright'))
+
+            if (hasForceLabel || hasToReviewLabel || hasToReleaseLabel || playwrightTouched) {
+              return
+            } else {
+              core.setFailed('Skipping Playwright: draft state, missing labels or no playwright path changes.')
+            }
+
   playwright-setup:
     timeout-minutes: 15
     name: Playwright setup
     runs-on: ubuntu-latest
+    needs: gate
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -40,7 +75,7 @@ jobs:
         path: ./
 
   playwright-tests:
-    needs: [playwright-setup]
+    needs: [gate, playwright-setup]
     timeout-minutes: 60
     name: Playwright tests ${{ matrix.shardIndex }} / ${{ matrix.shardTotal }}
     runs-on: ubuntu-latest
@@ -115,7 +150,7 @@ jobs:
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
     if: ${{ !cancelled() }}
-    needs: [playwright-tests]
+    needs: [gate, playwright-tests]
 
     runs-on: ubuntu-latest-low
     steps:
@@ -171,7 +206,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [playwright-tests]
+    needs: [gate, playwright-tests]
 
     if: always()
 


### PR DESCRIPTION
This will run cypress and playwright only if the following conditions are met:

1. Has one of the following labels: '3. to review', '4. to release', 'force-e2e-tests'
2. A file path starting with 'cypress' or 'playwright' was touched

The workflow will be re-evaluated when a label is added.

- [x] The content of this PR was partly or fully generated using AI
