### PR TITLE
Fix Memcached CI job

### DIFF
--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -56,16 +56,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.5']
+        php-versions: ["8.3", "8.5"]
 
     name: Memcached (PHP ${{ matrix.php-versions }})
 
     services:
       memcached:
-        image: ghcr.io/nextcloud/continuous-integration-redis:latest # zizmor: ignore[unpinned-images]
+        image: ghcr.io/nextcloud/continuous-integration-memcached:latest # zizmor: ignore[unpinned-images]
         ports:
-          - 11212:11212/tcp
-          - 11212:11212/udp
+          - 11211:11211/tcp
 
     steps:
       - name: Checkout server
@@ -80,7 +79,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, memcached, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, memcached, openssl, pcntl, pdo_sqlite, posix, session, simplexml, sqlite, xmlreader, xmlwriter, zip, zlib
           coverage: none
           ini-file: development
           ini-values: disable_functions=""
@@ -94,12 +93,13 @@ jobs:
       - name: Set up Nextcloud
         run: |
           mkdir data
+          cp tests/memcached.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           php -f tests/enable_all.php
 
       - name: PHPUnit memcached tests
-        run: composer run test -- --group Memcache --group Memcached --log-junit junit.xml
+        run: composer run test -- --group Memcached --log-junit junit.xml
 
       - name: Print logs
         if: always()

--- a/tests/memcached.config.php
+++ b/tests/memcached.config.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+$CONFIG = [
+	'memcache.local' => '\\OC\\Memcache\\Memcached',
+	'memcache.distributed' => '\\OC\\Memcache\\Memcached',
+	'memcache.locking' => '\\OC\\Memcache\\Memcached',
+	'memcached_servers' => [
+		['localhost', 11211],
+	],
+];


### PR DESCRIPTION
## Summary

Memcached wasn't enabled and it didn't tested Memcached at all

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
