### PR TITLE
refactor(log): clarify LogDetails timestamp and message normalization paths

### DIFF
--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -19,12 +19,20 @@ abstract class LogDetails {
 	) {
 	}
 
+	/**
+	 * Build a structured log entry from request context and message data.
+	 *
+	 * Array messages are normalized into either an exception payload or a
+	 * top-level message plus structured context data.
+	 *
+	 * @return array<string, mixed>
+	 */
 	public function logDetails(string $app, string|array $message, int $level): array {
 		$version = $this->config->getValue('version', '');
 		// Default to ATOM/ISO8601 formatting and UTC timezone.
 		$format = $this->config->getValue('logdateformat', \DateTimeInterface::ATOM);
 		$configuredTimeZone = $this->config->getValue('logtimezone', 'UTC');
-		
+
 		try {
 			$timezone = new \DateTimeZone($configuredTimeZone);
 		} catch (\Exception $e) {
@@ -34,14 +42,14 @@ abstract class LogDetails {
 		$timestamp = number_format(microtime(true), 4, '.', '');
 		$time = \DateTime::createFromFormat('U.u', $timestamp);
 		if ($time !== false) {
-			// UNIX timestamps are timezone-independent; apply the configured display timezone.
+			// UNIX timestamps are timezone-independent; apply the configured log timezone.
 			$time->setTimezone($timezone);
 		} else {
-			// Fall back to a current wall-clock time if parsing fails.
+			// Fall back to the current time in the configured timezone if parsing fails.
 			$time = new \DateTime('now', $timezone);
 		}
 		$formattedTime = $time->format($format);
-	
+
 		$request = Server::get(IRequest::class);
 
 		$reqId = $request->getId();
@@ -65,6 +73,26 @@ abstract class LogDetails {
 			$user = \OC_User::getUser() ?: '--';
 		}
 
+		$normalizedMessage = $message;
+		$exception = null;
+		$data = null;
+
+		if (is_array($message)) {
+			// Normalize array messages into one of two forms:
+			// - exception payloads ('Exception' present): keep the full payload in 'exception'
+			//   and derive the top-level 'message' from CustomMessage/Message
+			// - structured payloads: use 'message' as the top-level message and store the
+			//   remaining fields under 'data'
+			if (array_key_exists('Exception', $message)) {
+				$exception = $message;
+				$normalizedMessage = $message['CustomMessage'] !== '--' ? $message['CustomMessage'] : $message['Message'];
+			} else {
+				$normalizedMessage = $message['message'] ?? '(no message provided)';
+				unset($message['message']);
+				$data = $message;
+			}
+		}
+
 		$entry = [
 			'reqId' => $reqId,
 			'level' => $level,
@@ -75,7 +103,7 @@ abstract class LogDetails {
 			'method' => $method,
 			'url' => $url,
 			'scriptName' => $scriptName,
-			'message' => $message,
+			'message' => $normalizedMessage,
 			'userAgent' => $userAgent,
 			'version' => $version,
 		];
@@ -89,20 +117,11 @@ abstract class LogDetails {
 			$entry['occ_command'] = array_slice($_SERVER['argv'] ?? [], 0, 2);
 		}
 
-		if (is_array($message)) {
-			// Array messages are normalized into one of two forms:
-			// - exception payloads ('Exception' present): keep the full payload in 'exception'
-			//   and derive the top-level 'message' from CustomMessage/Message
-			// - structured payloads: use 'message' as the top-level message and store the
-			//   remaining fields under 'data'
-			if (array_key_exists('Exception', $message)) {
-				$entry['exception'] = $message;
-				$entry['message'] = $message['CustomMessage'] !== '--' ? $message['CustomMessage'] : $message['Message'];
-			} else {
-				$entry['message'] = $message['message'] ?? '(no message provided)';
-				unset($message['message']);
-				$entry['data'] = $message;
-			}
+		if ($exception !== null) {
+			$entry['exception'] = $exception;
+		}
+		if ($data !== null) {
+			$entry['data'] = $data;
 		}
 
 		return $entry;

--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -20,66 +20,81 @@ abstract class LogDetails {
 	}
 
 	public function logDetails(string $app, string|array $message, int $level): array {
-		// default to ISO8601
+		$version = $this->config->getValue('version', '');
+		// Default to ATOM/ISO8601 formatting and UTC timezone.
 		$format = $this->config->getValue('logdateformat', \DateTimeInterface::ATOM);
-		$logTimeZone = $this->config->getValue('logtimezone', 'UTC');
+		$configuredTimeZone = $this->config->getValue('logtimezone', 'UTC');
+		
 		try {
-			$timezone = new \DateTimeZone($logTimeZone);
+			$timezone = new \DateTimeZone($configuredTimeZone);
 		} catch (\Exception $e) {
 			$timezone = new \DateTimeZone('UTC');
 		}
-		$time = \DateTime::createFromFormat('U.u', number_format(microtime(true), 4, '.', ''));
-		if ($time === false) {
-			$time = new \DateTime('now', $timezone);
-		} else {
-			// apply timezone if $time is created from UNIX timestamp
+
+		$timestamp = number_format(microtime(true), 4, '.', '');
+		$time = \DateTime::createFromFormat('U.u', $timestamp);
+		if ($time !== false) {
+			// UNIX timestamps are timezone-independent; apply the configured display timezone.
 			$time->setTimezone($timezone);
+		} else {
+			// Fall back to a current wall-clock time if parsing fails.
+			$time = new \DateTime('now', $timezone);
 		}
+		$formattedTime = $time->format($format);
+	
 		$request = Server::get(IRequest::class);
+
 		$reqId = $request->getId();
 		$remoteAddr = $request->getRemoteAddress();
-		// remove username/passwords from URLs before writing the to the log file
-		$time = $time->format($format);
-		$url = ($request->getRequestUri() !== '') ? $request->getRequestUri() : '--';
 		$method = $request->getMethod();
-		if ($this->config->getValue('installed', false)) {
-			$user = \OC_User::getUser() ?: '--';
-		} else {
-			$user = '--';
-		}
+		$url = $request->getRequestUri();
+		$scriptName = $request->getScriptName();
 		$userAgent = $request->getHeader('User-Agent');
+		$clientReqId = $request->getHeader('X-Request-Id');
+
+		if ($url === '') {
+			$url = '--';
+		}
+
 		if ($userAgent === '') {
 			$userAgent = '--';
 		}
-		$version = $this->config->getValue('version', '');
-		$scriptName = $request->getScriptName();
-		$entry = compact(
-			'reqId',
-			'level',
-			'time',
-			'remoteAddr',
-			'user',
-			'app',
-			'method',
-			'url',
-			'scriptName',
-			'message',
-			'userAgent',
-			'version',
-		);
-		$clientReqId = $request->getHeader('X-Request-Id');
+
+		$user = '--';
+		if ($this->config->getValue('installed', false)) {
+			$user = \OC_User::getUser() ?: '--';
+		}
+
+		$entry = [
+			'reqId' => $reqId,
+			'level' => $level,
+			'time' => $formattedTime,
+			'remoteAddr' => $remoteAddr,
+			'user' => $user,
+			'app' => $app,
+			'method' => $method,
+			'url' => $url,
+			'scriptName' => $scriptName,
+			'message' => $message,
+			'userAgent' => $userAgent,
+			'version' => $version,
+		];
+
 		if ($clientReqId !== '') {
 			$entry['clientReqId'] = $clientReqId;
 		}
+
 		if (\OC::$CLI) {
-			/* Only logging the command, not the parameters */
+			// Only logging the command, not the parameters
 			$entry['occ_command'] = array_slice($_SERVER['argv'] ?? [], 0, 2);
 		}
 
 		if (is_array($message)) {
-			// Exception messages are extracted and the exception is put into a separate field
-			// anything else modern is split to 'message' (string) and
-			// data (array) fields
+			// Array messages are normalized into one of two forms:
+			// - exception payloads ('Exception' present): keep the full payload in 'exception'
+			//   and derive the top-level 'message' from CustomMessage/Message
+			// - structured payloads: use 'message' as the top-level message and store the
+			//   remaining fields under 'data'
 			if (array_key_exists('Exception', $message)) {
 				$entry['exception'] = $message;
 				$entry['message'] = $message['CustomMessage'] !== '--' ? $message['CustomMessage'] : $message['Message'];


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Refactor `LogDetails::logDetails()` for clarity without changing behavior.

This makes the method easier to follow by splitting timestamp creation into named steps, replacing `compact()` with an explicit entry array, and normalizing array messages before building the final log entry.

## Changes

- clarify timestamp creation and fallback handling
- avoid reusing `$time` as both a `DateTime` and formatted string
- replace `compact()` with an explicit associative array
- group request-derived fields more clearly
- improve inline comments around timestamp and message normalization logic

## Behavior

No intended functional changes. Existing timestamp, timezone fallback, and message normalization behavior is preserved.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
