### PR TITLE
fix: resolve PHP deprecation of `imagedestroy`

### DIFF
--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -265,12 +265,7 @@ class ImageManager {
 						}
 					}
 					$tmpFile = $newTmpFile;
-					imagedestroy($outputImage);
 				} catch (\Exception $e) {
-					if (isset($outputImage) && is_resource($outputImage) || $outputImage instanceof \GdImage) {
-						imagedestroy($outputImage);
-					}
-
 					$this->logger->debug($e->getMessage());
 				}
 			}

--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -508,7 +508,6 @@ class Image implements IImage {
 			if ($res) {
 				if (imagealphablending($res, true)) {
 					if (imagesavealpha($res, true)) {
-						imagedestroy($this->resource);
 						$this->resource = $res;
 						return true;
 					} else {
@@ -926,7 +925,6 @@ class Image implements IImage {
 		$res = imagecopyresampled($process, $this->resource, 0, 0, 0, 0, $width, $height, $widthOrig, $heightOrig);
 		if ($res === false) {
 			$this->logger->debug(__METHOD__ . '(): Error re-sampling process image', ['app' => 'core']);
-			imagedestroy($process);
 			return false;
 		}
 		return $process;
@@ -988,7 +986,6 @@ class Image implements IImage {
 			$this->logger->debug('Image->centerCrop, Error re-sampling process image ' . $width . 'x' . $height, ['app' => 'core']);
 			return false;
 		}
-		imagedestroy($this->resource);
 		$this->resource = $process;
 		return true;
 	}
@@ -1009,7 +1006,6 @@ class Image implements IImage {
 			return false;
 		}
 		$result = $this->cropNew($x, $y, $w, $h);
-		imagedestroy($this->resource);
 		$this->resource = $result;
 		return $this->valid();
 	}


### PR DESCRIPTION
> Prior to PHP 8.0.0, imagedestroy() freed any memory associated with the image resource.
> As of 8.0.0, the GD extension uses objects instead of resources, and objects cannot be explicitly closed.

With PHP 8.5 this is deprecated and causes a deprecation warning!

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
