### PR TITLE
Set preferStreaming default value to false for task processing tasks

### DIFF
--- a/core/Controller/TaskProcessingApiController.php
+++ b/core/Controller/TaskProcessingApiController.php
@@ -164,11 +164,13 @@ class TaskProcessingApiController extends OCSController {
 	private function handleScheduleTaskInternal(
 		array $input, string $type, string $appId, string $customId = '',
 		?string $webhookUri = null, ?string $webhookMethod = null, bool $includeWatermark = true,
+		bool $preferStreaming = false,
 	): DataResponse {
 		$task = new Task($type, $input, $appId, $this->userId, $customId);
 		$task->setWebhookUri($webhookUri);
 		$task->setWebhookMethod($webhookMethod);
 		$task->setIncludeWatermark($includeWatermark);
+		$task->setPreferStreaming($preferStreaming);
 		try {
 			$this->taskProcessingManager->scheduleTask($task);
 
@@ -202,6 +204,7 @@ class TaskProcessingApiController extends OCSController {
 	 * @param string|null $webhookUri URI to be requested when the task finishes
 	 * @param string|null $webhookMethod Method used for the webhook request (HTTP:GET, HTTP:POST, HTTP:PUT, HTTP:DELETE or AppAPI:APP_ID:GET, AppAPI:APP_ID:POST...)
 	 * @param bool $includeWatermark Whether to include a watermark in the output file or not
+	 * @param bool $preferStreaming Whether to prefer getting a progressive output from the provider or not
 	 * @return DataResponse<Http::STATUS_OK, array{task: CoreTaskProcessingTask}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_BAD_REQUEST|Http::STATUS_PRECONDITION_FAILED|Http::STATUS_UNAUTHORIZED, array{message: string}, array{}>
 	 *
 	 * 200: Task scheduled successfully
@@ -215,6 +218,7 @@ class TaskProcessingApiController extends OCSController {
 	public function schedule(
 		array $input, string $type, string $appId, string $customId = '',
 		?string $webhookUri = null, ?string $webhookMethod = null, bool $includeWatermark = true,
+		bool $preferStreaming = false,
 	): DataResponse {
 		return $this->handleScheduleTaskInternal(
 			$input,
@@ -224,6 +228,7 @@ class TaskProcessingApiController extends OCSController {
 			$webhookUri,
 			$webhookMethod,
 			$includeWatermark,
+			$preferStreaming,
 		);
 	}
 
@@ -239,6 +244,7 @@ class TaskProcessingApiController extends OCSController {
 	 * @param string|null $webhookUri URI to be requested when the task finishes
 	 * @param string|null $webhookMethod Method used for the webhook request (HTTP:GET, HTTP:POST, HTTP:PUT, HTTP:DELETE or AppAPI:APP_ID:GET, AppAPI:APP_ID:POST...)
 	 * @param bool $includeWatermark Whether to include a watermark in the output file or not
+	 * @param bool $preferStreaming Whether to prefer getting a progressive output from the provider or not
 	 * @return DataResponse<Http::STATUS_OK, array{task: CoreTaskProcessingTask}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_BAD_REQUEST|Http::STATUS_PRECONDITION_FAILED|Http::STATUS_UNAUTHORIZED, array{message: string}, array{}>
 	 *
 	 * 200: Task scheduled successfully
@@ -251,6 +257,7 @@ class TaskProcessingApiController extends OCSController {
 	public function scheduleExAppEndpoint(
 		array $input, string $type, string $appId, string $customId = '',
 		?string $webhookUri = null, ?string $webhookMethod = null, bool $includeWatermark = true,
+		bool $preferStreaming = false,
 	): DataResponse {
 		return $this->handleScheduleTaskInternal(
 			$input,
@@ -260,6 +267,7 @@ class TaskProcessingApiController extends OCSController {
 			$webhookUri,
 			$webhookMethod,
 			$includeWatermark,
+			$preferStreaming,
 		);
 	}
 

--- a/core/Migrations/Version35000Date20260527162338.php
+++ b/core/Migrations/Version35000Date20260527162338.php
@@ -39,7 +39,7 @@ class Version35000Date20260527162338 extends SimpleMigrationStep {
 			if (!$table->hasColumn('prefer_streaming')) {
 				$table->addColumn('prefer_streaming', Types::SMALLINT, [
 					'notnull' => true,
-					'default' => 1,
+					'default' => 0,
 					'unsigned' => true,
 				]);
 				return $schema;

--- a/core/openapi-ex_app.json
+++ b/core/openapi-ex_app.json
@@ -647,6 +647,11 @@
                                         "type": "boolean",
                                         "default": true,
                                         "description": "Whether to include a watermark in the output file or not"
+                                    },
+                                    "preferStreaming": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to prefer getting a progressive output from the provider or not"
                                     }
                                 }
                             }

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -5098,6 +5098,11 @@
                                         "type": "boolean",
                                         "default": true,
                                         "description": "Whether to include a watermark in the output file or not"
+                                    },
+                                    "preferStreaming": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to prefer getting a progressive output from the provider or not"
                                     }
                                 }
                             }
@@ -10457,6 +10462,11 @@
                                         "type": "boolean",
                                         "default": true,
                                         "description": "Whether to include a watermark in the output file or not"
+                                    },
+                                    "preferStreaming": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to prefer getting a progressive output from the provider or not"
                                     }
                                 }
                             }

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -5098,6 +5098,11 @@
                                         "type": "boolean",
                                         "default": true,
                                         "description": "Whether to include a watermark in the output file or not"
+                                    },
+                                    "preferStreaming": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to prefer getting a progressive output from the provider or not"
                                     }
                                 }
                             }

--- a/lib/public/TaskProcessing/SynchronousProviderOptions.php
+++ b/lib/public/TaskProcessing/SynchronousProviderOptions.php
@@ -22,7 +22,7 @@ class SynchronousProviderOptions {
 	 */
 	public function __construct(
 		private readonly bool $includeWatermarks = false,
-		private readonly bool $preferStreaming = true,
+		private readonly bool $preferStreaming = false,
 		?callable $reportIntermediateOutput = null,
 	) {
 		$this->reportIntermediateOutput = $reportIntermediateOutput !== null

--- a/lib/public/TaskProcessing/Task.php
+++ b/lib/public/TaskProcessing/Task.php
@@ -51,7 +51,7 @@ final class Task implements \JsonSerializable {
 
 	protected bool $includeWatermark = true;
 
-	protected bool $preferStreaming = true;
+	protected bool $preferStreaming = false;
 
 	/**
 	 * @since 30.0.0

--- a/openapi.json
+++ b/openapi.json
@@ -8803,6 +8803,11 @@
                                         "type": "boolean",
                                         "default": true,
                                         "description": "Whether to include a watermark in the output file or not"
+                                    },
+                                    "preferStreaming": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to prefer getting a progressive output from the provider or not"
                                     }
                                 }
                             }
@@ -14165,6 +14170,11 @@
                                         "type": "boolean",
                                         "default": true,
                                         "description": "Whether to include a watermark in the output file or not"
+                                    },
+                                    "preferStreaming": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to prefer getting a progressive output from the provider or not"
                                     }
                                 }
                             }


### PR DESCRIPTION
Followup of #60500

* Set the default value to false
* Allow setting preferStreaming when scheduling via the OCS API
* Generate OpenAPI specs

Documentation is on the way.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
