### PR TITLE
Add OCM Notification Received Event

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -36,6 +36,7 @@ use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
+use OCP\OCM\Events\OCMNotificationReceivedEvent;
 use OCP\OCM\IOCMDiscoveryService;
 use OCP\Security\Signature\Exceptions\IncomingRequestException;
 use OCP\Security\Signature\IIncomingSignedRequest;
@@ -402,6 +403,15 @@ class RequestHandlerController extends Controller {
 				],
 				Http::STATUS_BAD_REQUEST
 			);
+		}
+
+		try {
+			$notificationObject = $this->factory->getCloudFederationNotification();
+			$notificationObject->setMessage($notificationType, $resourceType, $providerId, $notification);
+			$notificationEvent = new OCMNotificationReceivedEvent($notificationObject);
+			$this->dispatcher->dispatchTyped($notificationEvent);
+		} catch (\Exception $e) {
+			$this->logger->warning('error while dispatching OCM notification received event', ['exception' => $e]);
 		}
 
 		return new JSONResponse($result, Http::STATUS_CREATED);

--- a/apps/cloud_federation_api/tests/RequestHandlerControllerTest.php
+++ b/apps/cloud_federation_api/tests/RequestHandlerControllerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\CloudFederationApi\Tests;
 
+use OC\Federation\CloudFederationNotification;
 use OCA\CloudFederationAPI\Config;
 use OCA\CloudFederationAPI\Controller\RequestHandlerController;
 use OCA\CloudFederationAPI\Db\FederatedInvite;
@@ -18,6 +19,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
+use OCP\Federation\ICloudFederationProvider;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\IAppConfig;
@@ -26,6 +28,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\OCM\Events\OCMNotificationReceivedEvent;
 use OCP\OCM\IOCMDiscoveryService;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -125,5 +128,44 @@ class RequestHandlerControllerTest extends TestCase {
 		$json = new JSONResponse($response, Http::STATUS_OK);
 
 		$this->assertEquals($json, $this->requestHandlerController->inviteAccepted($recipientProvider, $token, $recipientId, $recipientEmail, $recipientName));
+	}
+
+	public function testNotificationReceived(): void {
+		$notificationType = 'SHARE_ACCEPTED';
+		$resourceType = 'file';
+		$providerId = '1337';
+		$notification = ['sharedSecret' => 'secret'];
+		$notificationObject = new CloudFederationNotification();
+
+		$this->appConfig->method('getValueBool')->willReturn(true);
+		$provider = $this->createMock(ICloudFederationProvider::class);
+		$provider->method('notificationReceived')->willReturn([]);
+		$this->cloudFederationFactory->method('getCloudFederationNotification')
+			->willReturn($notificationObject);
+		$this->cloudFederationProviderManager->method('getCloudFederationProvider')
+			->willReturn($provider);
+
+		$this->eventDispatcher->expects(self::once())
+			->method('dispatchTyped')
+			->with(self::callback(
+				fn (
+					OCMNotificationReceivedEvent $event)
+					   => $event->getNotification() === $notificationObject
+			)
+			);
+		$response = $this->requestHandlerController->receiveNotification(
+			$notificationType,
+			$resourceType,
+			$providerId,
+			$notification
+		);
+		self::assertEquals(Http::STATUS_CREATED, $response->getStatus());
+		self::assertEquals([
+			'notificationType' => $notificationType,
+			'resourceType' => $resourceType,
+			'providerId' => $providerId,
+			'notification' => $notification,
+		], $notificationObject->getMessage());
+
 	}
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -740,6 +740,7 @@ return array(
     'OCP\\OCM\\Enum\\ParamType' => $baseDir . '/lib/public/OCM/Enum/ParamType.php',
     'OCP\\OCM\\Events\\LocalOCMDiscoveryEvent' => $baseDir . '/lib/public/OCM/Events/LocalOCMDiscoveryEvent.php',
     'OCP\\OCM\\Events\\OCMEndpointRequestEvent' => $baseDir . '/lib/public/OCM/Events/OCMEndpointRequestEvent.php',
+    'OCP\\OCM\\Events\\OCMNotificationReceivedEvent' => $baseDir . '/lib/public/OCM/Events/OCMNotificationReceivedEvent.php',
     'OCP\\OCM\\Events\\ResourceTypeRegisterEvent' => $baseDir . '/lib/public/OCM/Events/ResourceTypeRegisterEvent.php',
     'OCP\\OCM\\Exceptions\\OCMArgumentException' => $baseDir . '/lib/public/OCM/Exceptions/OCMArgumentException.php',
     'OCP\\OCM\\Exceptions\\OCMCapabilityException' => $baseDir . '/lib/public/OCM/Exceptions/OCMCapabilityException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -781,6 +781,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\OCM\\Enum\\ParamType' => __DIR__ . '/../../..' . '/lib/public/OCM/Enum/ParamType.php',
         'OCP\\OCM\\Events\\LocalOCMDiscoveryEvent' => __DIR__ . '/../../..' . '/lib/public/OCM/Events/LocalOCMDiscoveryEvent.php',
         'OCP\\OCM\\Events\\OCMEndpointRequestEvent' => __DIR__ . '/../../..' . '/lib/public/OCM/Events/OCMEndpointRequestEvent.php',
+        'OCP\\OCM\\Events\\OCMNotificationReceivedEvent' => __DIR__ . '/../../..' . '/lib/public/OCM/Events/OCMNotificationReceivedEvent.php',
         'OCP\\OCM\\Events\\ResourceTypeRegisterEvent' => __DIR__ . '/../../..' . '/lib/public/OCM/Events/ResourceTypeRegisterEvent.php',
         'OCP\\OCM\\Exceptions\\OCMArgumentException' => __DIR__ . '/../../..' . '/lib/public/OCM/Exceptions/OCMArgumentException.php',
         'OCP\\OCM\\Exceptions\\OCMCapabilityException' => __DIR__ . '/../../..' . '/lib/public/OCM/Exceptions/OCMCapabilityException.php',

--- a/lib/public/OCM/Events/OCMNotificationReceivedEvent.php
+++ b/lib/public/OCM/Events/OCMNotificationReceivedEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\OCM\Events;
+
+use OCP\AppFramework\Attribute\Listenable;
+use OCP\EventDispatcher\Event;
+use OCP\Federation\ICloudFederationNotification;
+
+/**
+ * @since 35.0.0
+ */
+#[Listenable(since: '35.0.0')]
+class OCMNotificationReceivedEvent extends Event {
+	/**
+	 * @since 35.0.0
+	 */
+	public function __construct(
+		private readonly ICloudFederationNotification $notification,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @since 35.0.0
+	 */
+	public function getNotification(): ICloudFederationNotification {
+		return $this->notification;
+	}
+}


### PR DESCRIPTION


## Summary
OCM is standardizing and expanding the use of notifications and having an event for acting on in apps will be very useful. The immediate use-case will be for an app the implements the proposed federated group sprecification in OCM that relies heavily on notifications.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

I will make a separate pr to nextcloud-documentation when and if this pr is accepted.

## AI

I made an AI double check my test case, and made modifications after, but I wrote the code my self.
