### PR TITLE
fix(files_versions): create version entity instead of failing when missing

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -272,14 +272,14 @@ class FileEventsListener implements IEventListener {
 					);
 				}
 			} catch (DoesNotExistException $e) {
-				// This happens if the versions app was not enabled while the file was created or updated the last time.
-				// meaning there is no such revision and we need to create this file.
-				if ($writeHookInfo['versionCreated']) {
-					$this->created($node);
-				} else {
-					// Normally this should not happen so we re-throw the exception to not hide any potential issues.
-					throw $e;
-				}
+				// There is no version entity to update. This happens when the file has
+				// no tracked version yet, for example because the versions app was
+				// disabled when the file was last written, or because the file was just
+				// created at this location by a copy operation (the copy gets a new file
+				// id but no version entity, only NodeCopiedEvent and write events fire).
+				// In all these cases we create the version entity for the current content
+				// instead of failing the whole write/copy operation.
+				$this->created($node);
 			} catch (Exception $e) {
 				$this->logger->error('Failed to update existing version for ' . $node->getPath(), [
 					'exception' => $e,

--- a/apps/files_versions/tests/Listener/FileEventsListenerTest.php
+++ b/apps/files_versions/tests/Listener/FileEventsListenerTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 namespace OCA\Files_Versions\Tests\Listener;
 
 use OCA\Files_Versions\Listener\FileEventsListener;
-use OCA\Files_Versions\Versions\IVersionManager;
+use OCA\Files_Versions\Versions\VersionManager;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\Exception as DbException;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
@@ -20,7 +22,7 @@ use Test\TestCase;
 
 class FileEventsListenerTest extends TestCase {
 	private IRootFolder&MockObject $rootFolder;
-	private IVersionManager&MockObject $versionManager;
+	private VersionManager&MockObject $versionManager;
 	private IMimeTypeLoader&MockObject $mimeTypeLoader;
 	private IUserSession&MockObject $userSession;
 	private LoggerInterface&MockObject $logger;
@@ -30,7 +32,10 @@ class FileEventsListenerTest extends TestCase {
 		parent::setUp();
 
 		$this->rootFolder = $this->createMock(IRootFolder::class);
-		$this->versionManager = $this->createMock(IVersionManager::class);
+		// VersionManager is the real collaborator registered in the DI container and
+		// implements both IVersionManager (the constructor type) and
+		// INeedSyncVersionBackend, which the listener checks for with instanceof.
+		$this->versionManager = $this->createMock(VersionManager::class);
 		$this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
@@ -57,10 +62,32 @@ class FileEventsListenerTest extends TestCase {
 		return $node;
 	}
 
+	private function mockFile(int $id, int $mtime, int $size = 100, string $mimetype = 'text/markdown'): File&MockObject {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($id);
+		$file->method('getMTime')->willReturn($mtime);
+		$file->method('getSize')->willReturn($size);
+		$file->method('getMimetype')->willReturn($mimetype);
+		return $file;
+	}
+
 	private function getPrivateProperty(string $property): mixed {
 		$ref = new \ReflectionProperty(FileEventsListener::class, $property);
 		$ref->setAccessible(true);
 		return $ref->getValue($this->listener);
+	}
+
+	/**
+	 * Seed the private write-hook state that is normally populated by write_hook(),
+	 * which we cannot call here as it relies on the static Storage::store().
+	 */
+	private function seedWriteHookInfo(int $fileId, File $previousNode, bool $versionCreated): void {
+		self::invokePrivate($this->listener, 'writeHookInfo', [[
+			$fileId => [
+				'previousNode' => $previousNode,
+				'versionCreated' => $versionCreated,
+			],
+		]]);
 	}
 
 	public function testGetPathForNodeReturnsNullWhenUnresolvable(): void {
@@ -90,5 +117,83 @@ class FileEventsListenerTest extends TestCase {
 		$this->listener->pre_remove_hook($node);
 
 		$this->assertSame([], $this->getPrivateProperty('versionsDeleted'));
+	}
+
+	public static function provideMissingEntityCases(): array {
+		return [
+			// A copy gives the target a new file id but no version entity, and no
+			// version is stored in the FS, so versionCreated is false. This is the
+			// regression that previously crashed the COPY request.
+			'copy to a new location' => [false],
+			// Versions disabled, then re-enabled and the same file re-uploaded
+			// unchanged: a version was created in the FS but the previous entity
+			// does not exist.
+			'version created but entity missing' => [true],
+		];
+	}
+
+	/**
+	 * When there is no version entity to update, the listener must create one for
+	 * the current content instead of letting the DoesNotExistException bubble up
+	 * and fail the whole write/copy operation.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideMissingEntityCases')]
+	public function testPostWriteHookCreatesVersionEntityWhenMissing(bool $versionCreated): void {
+		$node = $this->mockFile(42, 2000);
+		// Same mtime as the node so the "version created and mtime changed" fast
+		// path is skipped and we reach updateVersionEntity().
+		$previousNode = $this->mockFile(42, 2000);
+
+		$this->mimeTypeLoader->method('getId')->willReturn(5);
+		$this->versionManager->method('getRevision')->with($previousNode)->willReturn(2000);
+		$this->versionManager->method('updateVersionEntity')
+			->willThrowException(new DoesNotExistException('no version entity'));
+
+		// The fix: the missing entity is created rather than crashing.
+		$this->versionManager->expects($this->once())
+			->method('createVersionEntity')
+			->with($node);
+
+		$this->seedWriteHookInfo(42, $previousNode, $versionCreated);
+
+		$this->listener->post_write_hook($node);
+	}
+
+	/**
+	 * The happy path must keep updating the existing entity and must not create a
+	 * spurious new one.
+	 */
+	public function testPostWriteHookUpdatesExistingVersionEntity(): void {
+		$node = $this->mockFile(42, 2000);
+		$previousNode = $this->mockFile(42, 1000);
+
+		$this->mimeTypeLoader->method('getId')->willReturn(5);
+		$this->versionManager->method('getRevision')->with($previousNode)->willReturn(1000);
+		$this->versionManager->expects($this->once())->method('updateVersionEntity');
+		$this->versionManager->expects($this->never())->method('createVersionEntity');
+
+		$this->seedWriteHookInfo(42, $previousNode, false);
+
+		$this->listener->post_write_hook($node);
+	}
+
+	/**
+	 * Real database errors must still surface and must not be turned into a
+	 * silent entity creation.
+	 */
+	public function testPostWriteHookRethrowsDatabaseErrors(): void {
+		$node = $this->mockFile(42, 2000);
+		$previousNode = $this->mockFile(42, 2000);
+
+		$this->mimeTypeLoader->method('getId')->willReturn(5);
+		$this->versionManager->method('getRevision')->willReturn(2000);
+		$this->versionManager->method('updateVersionEntity')
+			->willThrowException(new DbException('database is gone'));
+		$this->versionManager->expects($this->never())->method('createVersionEntity');
+
+		$this->seedWriteHookInfo(42, $previousNode, false);
+
+		$this->expectException(DbException::class);
+		$this->listener->post_write_hook($node);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

A COPY assigns the target a new file id without a version entity, so post_write_hook's updateVersionEntity() raised DoesNotExistException and crashed the request. Handle it in the listener (the caller) by creating the entity for the current content, leaving the backend free to keep throwing.

<details>
<summary>Error stack</summary>

```
{
  "reqId": "iNwhE8uZnaFbKbyG6WFq",
  "level": 3,
  "time": "2025-09-11T09:48:09+02:00",
  "remoteAddr": "91.6.26.13",
  "user": "fzez",
  "app": "no app in context",
  "method": "COPY",
  "url": "/remote.php/dav/files/user/folder/file.md",
  "message": "Exception thrown: OCP\\AppFramework\\Db\\DoesNotExistException",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
  "version": "30.0.14.1",
  "exception": {
    "Exception": "OCP\\AppFramework\\Db\\DoesNotExistException",
    "Message": "Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*files_versions` WHERE (`file_id` = :dcValue1) AND (`timestamp` = :dcValue2)\"; ",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/public/AppFramework/Db/QBMapper.php",
        "line": 359,
        "function": "findOneQuery",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Db/VersionsMapper.php",
        "line": 60,
        "function": "findEntity",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Versions/LegacyVersionsBackend.php",
        "line": 254,
        "function": "findVersionForFileId",
        "class": "OCA\\Files_Versions\\Db\\VersionsMapper",
        "type": "->",
        "args": [
          204706,
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Versions/VersionManager.php",
        "line": 129,
        "function": "updateVersionEntity",
        "class": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 254,
        "function": "updateVersionEntity",
        "class": "OCA\\Files_Versions\\Versions\\VersionManager",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 85,
        "function": "post_write_hook",
        "class": "OCA\\Files_Versions\\Listener\\FileEventsListener",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      ...
}
```

</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The test of this PR was partly or fully generated using AI
