### PR TITLE
chore(ci): use shared composer cache directory

### DIFF
--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -26,6 +26,9 @@ jobs:
   changes:
     runs-on: ubuntu-latest-low
 
+    env:
+      COMPOSER_HOME: /tmp/shared_on_guest/composer/
+
     outputs:
       src: ${{ steps.changes.outputs.src }}
 
@@ -51,7 +54,7 @@ jobs:
               - '**.php'
 
   phpunit-nodb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-cache
 
     needs: changes
     if: needs.changes.outputs.src != 'false'
@@ -59,9 +62,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4', '8.5']
+        php-versions: ["8.3", "8.4", "8.5"]
         include:
-          - php-versions: '8.2'
+          - php-versions: "8.2"
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: No DB unit tests (PHP ${{ matrix.php-versions }})


### PR DESCRIPTION
## Summary

Try to use a shared composer cache directory 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
