### PR TITLE
fix(dav): handle Thunderbird accept-before-sync UID collisions

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -258,6 +258,7 @@ return array(
     'OCA\\DAV\\Connector\\Sabre\\SharesPlugin' => $baseDir . '/../lib/Connector/Sabre/SharesPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\TagList' => $baseDir . '/../lib/Connector/Sabre/TagList.php',
     'OCA\\DAV\\Connector\\Sabre\\TagsPlugin' => $baseDir . '/../lib/Connector/Sabre/TagsPlugin.php',
+    'OCA\\DAV\\Connector\\Sabre\\ThunderbirdPutInvitationQuirkPlugin' => $baseDir . '/../lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\UserIdHeaderPlugin' => $baseDir . '/../lib/Connector/Sabre/UserIdHeaderPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\ZipFolderPlugin' => $baseDir . '/../lib/Connector/Sabre/ZipFolderPlugin.php',
     'OCA\\DAV\\Controller\\BirthdayCalendarController' => $baseDir . '/../lib/Controller/BirthdayCalendarController.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -273,6 +273,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Connector\\Sabre\\SharesPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/SharesPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\TagList' => __DIR__ . '/..' . '/../lib/Connector/Sabre/TagList.php',
         'OCA\\DAV\\Connector\\Sabre\\TagsPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/TagsPlugin.php',
+        'OCA\\DAV\\Connector\\Sabre\\ThunderbirdPutInvitationQuirkPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\UserIdHeaderPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/UserIdHeaderPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\ZipFolderPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ZipFolderPlugin.php',
         'OCA\\DAV\\Controller\\BirthdayCalendarController' => __DIR__ . '/..' . '/../lib/Controller/BirthdayCalendarController.php',

--- a/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Connector\Sabre;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader as VObjectReader;
+
+/**
+ * When Thunderbird accepts or declines an invitation before the calendar has synced, it PUTs to a
+ * guessed object name that collides with the already-stored invitation (same UID) and fails. For
+ * such a request this plugin rewrites the URI to the existing object so the PUT updates it.
+ */
+class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
+	private ?Server $server = null;
+
+	public function __construct(
+		private readonly IDBConnection $db,
+	) {
+	}
+
+	public function initialize(Server $server) {
+		$this->server = $server;
+
+		// Run right after the ACL plugin to make sure that the current user principal is available
+		$server->on('beforeMethod:PUT', $this->beforePut(...), 21);
+	}
+
+	public function beforePut(RequestInterface $request, ResponseInterface $response): void {
+		$userAgent = $request->getHeader('User-Agent');
+		if (!$userAgent || !$this->isThunderbirdUserAgent($userAgent)) {
+			return;
+		}
+
+		if (!str_starts_with($request->getPath(), 'calendars/')) {
+			return;
+		}
+
+		if (!str_contains($request->getHeader('Content-Type') ?? '', 'text/calendar')) {
+			return;
+		}
+
+		$currentUserPrincipal = $this->getCurrentUserPrincipal();
+		if ($currentUserPrincipal === null) {
+			return;
+		}
+
+		// Need to set the body again here so that other handlers are able to read it afterward
+		$requestBody = $request->getBodyAsString();
+		$request->setBody($requestBody);
+
+		try {
+			$vCalendar = VObjectReader::read($requestBody);
+		} catch (\Throwable $e) {
+			return;
+		}
+		if (!($vCalendar instanceof VCalendar)) {
+			return;
+		}
+
+		/** @var string|null $uid */
+		$uid = $vCalendar->getBaseComponent('VEVENT')?->UID?->getValue();
+		if ($uid === null) {
+			return;
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('co.uri')
+			->from('calendarobjects', 'co')
+			->join('co', 'calendars', 'c', $qb->expr()->eq('co.calendarid', 'c.id'))
+			->where(
+				$qb->expr()->eq(
+					'c.principaluri',
+					$qb->createNamedParameter($currentUserPrincipal, IQueryBuilder::PARAM_STR),
+					IQueryBuilder::PARAM_STR,
+				),
+				$qb->expr()->eq(
+					'co.uid',
+					$qb->createNamedParameter($uid, IQueryBuilder::PARAM_STR),
+					IQueryBuilder::PARAM_STR,
+				),
+			);
+		$result = $qb->executeQuery();
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+
+		if (count($rows) !== 1) {
+			// Either no collision or too many collisions
+			return;
+		}
+
+		$requestUrl = $request->getUrl();
+		[$prefix] = \Sabre\Uri\split($requestUrl);
+		$objectUri = $rows[0]['uri'];
+		$request->setUrl("$prefix/$objectUri");
+	}
+
+	private function isThunderbirdUserAgent(string $userAgent): bool {
+		return str_contains($userAgent, 'Thunderbird/');
+	}
+
+	private function getCurrentUserPrincipal(): ?string {
+		/** @var \Sabre\DAV\Auth\Plugin $authPlugin */
+		$authPlugin = $this->server?->getPlugin('auth');
+		return $authPlugin?->getCurrentPrincipal();
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OCA\DAV\CalDAV\CalDavBackend;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Sabre\DAV\Server;
@@ -34,8 +35,8 @@ class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
 	public function initialize(Server $server) {
 		$this->server = $server;
 
-		// Run right after the ACL plugin to make sure that the current user principal is available
-		$server->on('beforeMethod:PUT', $this->beforePut(...), 21);
+		// Before the ACL plugin (priority 20) so its PUT check sees the rewritten object.
+		$server->on('beforeMethod:PUT', $this->beforePut(...), 19);
 	}
 
 	public function beforePut(RequestInterface $request, ResponseInterface $response): void {
@@ -44,9 +45,12 @@ class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
 			return;
 		}
 
-		if (!str_starts_with($request->getPath(), 'calendars/')) {
+		// calendars/{principal}/{calendar}/{object}
+		$pathParts = explode('/', $request->getPath());
+		if (count($pathParts) !== 4 || $pathParts[0] !== 'calendars') {
 			return;
 		}
+		[, , $calendarUri, $requestedObjectUri] = $pathParts;
 
 		if (!str_contains($request->getHeader('Content-Type') ?? '', 'text/calendar')) {
 			return;
@@ -76,8 +80,9 @@ class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
 			return;
 		}
 
+		// Same calendar as the request, real calendar objects only, nothing trashed.
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('co.uri')
+		$qb->select('co.uri', 'co.calendardata')
 			->from('calendarobjects', 'co')
 			->join('co', 'calendars', 'c', $qb->expr()->eq('co.calendarid', 'c.id'))
 			->where(
@@ -87,10 +92,22 @@ class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
 					IQueryBuilder::PARAM_STR,
 				),
 				$qb->expr()->eq(
+					'c.uri',
+					$qb->createNamedParameter($calendarUri, IQueryBuilder::PARAM_STR),
+					IQueryBuilder::PARAM_STR,
+				),
+				$qb->expr()->eq(
 					'co.uid',
 					$qb->createNamedParameter($uid, IQueryBuilder::PARAM_STR),
 					IQueryBuilder::PARAM_STR,
 				),
+				$qb->expr()->eq(
+					'co.calendartype',
+					$qb->createNamedParameter(CalDavBackend::CALENDAR_TYPE_CALENDAR, IQueryBuilder::PARAM_INT),
+					IQueryBuilder::PARAM_INT,
+				),
+				$qb->expr()->isNull('co.deleted_at'),
+				$qb->expr()->isNull('c.deleted_at'),
 			);
 		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
@@ -101,10 +118,67 @@ class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
 			return;
 		}
 
-		$requestUrl = $request->getUrl();
-		[$prefix] = \Sabre\Uri\split($requestUrl);
 		$objectUri = $rows[0]['uri'];
+		if ($objectUri === $requestedObjectUri) {
+			// Already synced: Thunderbird targets the real URI, leave the request untouched.
+			return;
+		}
+
+		// Restore SCHEDULE-AGENT from the stored organizer so server-side scheduling still runs.
+		$storedData = $rows[0]['calendardata'];
+		if (is_resource($storedData)) {
+			$storedData = stream_get_contents($storedData);
+		}
+		$storedScheduleAgent = null;
+		$storedHasOrganizer = false;
+		try {
+			$storedVCalendar = VObjectReader::read((string)$storedData);
+			if ($storedVCalendar instanceof VCalendar) {
+				$storedOrganizer = $storedVCalendar->getBaseComponent('VEVENT')?->ORGANIZER;
+				if ($storedOrganizer !== null) {
+					$storedHasOrganizer = true;
+					$storedScheduleAgent = isset($storedOrganizer['SCHEDULE-AGENT'])
+						? $storedOrganizer['SCHEDULE-AGENT']->getValue()
+						: null;
+				}
+			}
+		} catch (\Throwable $e) {
+			$storedHasOrganizer = false;
+		}
+
+		$organizerRestored = false;
+		if ($storedHasOrganizer) {
+			foreach ($vCalendar->getComponents() as $component) {
+				if ($component->name !== 'VEVENT') {
+					continue;
+				}
+				$organizer = $component->ORGANIZER ?? null;
+				if ($organizer === null) {
+					continue;
+				}
+				$incomingScheduleAgent = isset($organizer['SCHEDULE-AGENT'])
+					? $organizer['SCHEDULE-AGENT']->getValue()
+					: null;
+				if ($incomingScheduleAgent === $storedScheduleAgent) {
+					continue;
+				}
+				if ($storedScheduleAgent === null) {
+					unset($organizer['SCHEDULE-AGENT']);
+				} else {
+					$organizer['SCHEDULE-AGENT'] = $storedScheduleAgent;
+				}
+				$organizerRestored = true;
+			}
+		}
+		if ($organizerRestored) {
+			$request->setBody($vCalendar->serialize());
+		}
+
+		[$prefix] = \Sabre\Uri\split($request->getUrl());
 		$request->setUrl("$prefix/$objectUri");
+
+		// "If-None-Match: *" from the attempted create would fail with 412 after the rewrite
+		$request->removeHeader('If-None-Match');
 	}
 
 	private function isThunderbirdUserAgent(string $userAgent): bool {

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -53,6 +53,7 @@ use OCA\DAV\Connector\Sabre\QuotaPlugin;
 use OCA\DAV\Connector\Sabre\RequestIdHeaderPlugin;
 use OCA\DAV\Connector\Sabre\SharesPlugin;
 use OCA\DAV\Connector\Sabre\TagsPlugin;
+use OCA\DAV\Connector\Sabre\ThunderbirdPutInvitationQuirkPlugin;
 use OCA\DAV\Connector\Sabre\UserIdHeaderPlugin;
 use OCA\DAV\Connector\Sabre\ZipFolderPlugin;
 use OCA\DAV\DAV\CustomPropertiesBackend;
@@ -136,6 +137,9 @@ class Server {
 		$this->server->addPlugin(new MaintenancePlugin(\OCP\Server::get(IConfig::class), \OC::$server->getL10N('dav')));
 
 		$this->server->addPlugin(new AppleQuirksPlugin());
+		$this->server->addPlugin(new ThunderbirdPutInvitationQuirkPlugin(
+			\OCP\Server::get(IDBConnection::class),
+		));
 
 		// Backends
 		$authBackend = new Auth(

--- a/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\ThunderbirdPutInvitationQuirkPlugin;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Server;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Test\TestCase;
+
+class ThunderbirdPutInvitationQuirkPluginTest extends TestCase {
+	private readonly ThunderbirdPutInvitationQuirkPlugin $plugin;
+
+	private readonly Server&MockObject $server;
+	private readonly IDBConnection&MockObject $db;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->server = $this->createMock(Server::class);
+		$this->db = $this->createMock(IDBConnection::class);
+
+		$this->plugin = new ThunderbirdPutInvitationQuirkPlugin(
+			$this->db,
+		);
+	}
+
+	public function testInitialize(): void {
+		$this->server->expects(self::once())
+			->method('on')
+			->with('beforeMethod:PUT', $this->plugin->beforePut(...), 21);
+
+		$this->plugin->initialize($this->server);
+	}
+
+	public static function provideBeforePutData(): array {
+		return [
+			// No collision
+			[[], false],
+			// Many collisions
+			[
+				[
+					['uri' => 'sabredav-3dd349f8-58e0-483d-921f-70bc9f02366b.ics'],
+					['uri' => 'sabredav-19a50615-2db0-4046-a537-000979925e16.ics'],
+				],
+				false,
+			],
+			// Exactly one collision
+			[
+				[
+					['uri' => 'sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics'],
+				],
+				true,
+			],
+		];
+	}
+
+	#[DataProvider('provideBeforePutData')]
+	public function testBeforePut(array $rows, bool $expectUrlChange): void {
+		$ics = <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.6//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+CREATED:20250817T094141Z
+LAST-MODIFIED:20250817T094211Z
+SEQUENCE:2
+UID:cc5d41aa-7dbc-4278-8ffd-4fb5d626397c
+DTSTART;TZID=Europe/Berlin:20250819T030000
+DTEND;TZID=Europe/Berlin:20250819T080000
+STATUS:CONFIRMED
+SUMMARY:thunderbird-put-test
+ATTENDEE;CN=user a;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICI
+ PANT;RSVP=TRUE;LANGUAGE=en:mailto:usera@imap.localhost
+ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost
+DTSTAMP:20250817T094211Z
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+		$request->expects(self::once())
+			->method('getBodyAsString')
+			->willReturn($ics);
+		$request->expects(self::once())
+			->method('setBody')
+			->with($ics);
+		if ($expectUrlChange) {
+			$request->expects(self::once())
+				->method('getUrl')
+				->willReturn('remote.php/dav/calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+			$request->expects(self::once())
+				->method('setUrl')
+				->with('remote.php/dav/calendars/usera/personal/sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics');
+		} else {
+			$request->expects(self::never())
+				->method('getUrl');
+			$request->expects(self::never())
+				->method('setUrl');
+		}
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn('principals/users/usera');
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')
+			->willReturnSelf();
+		$qb->method('from')
+			->willReturnSelf();
+		$qb->method('join')
+			->willReturnSelf();
+		$qb->method('where')
+			->willReturnSelf();
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$qb->method('expr')
+			->willReturn($expr);
+		$this->db->expects(self::once())
+			->method('getQueryBuilder')
+			->willReturn($qb);
+
+		$result = $this->createMock(IResult::class);
+		$result->expects(self::once())
+			->method('fetchAll')
+			->willReturn($rows);
+		$result->expects(self::once())
+			->method('closeCursor');
+		$qb->expects(self::once())
+			->method('executeQuery')
+			->willReturn($result);
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithInvalidUserAgent(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::once())
+			->method('getHeader')
+			->with('User-Agent')
+			->willReturn('curl/8.14.1');
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithUnrelatedRequestPath(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::once())
+			->method('getHeader')
+			->with('User-Agent')
+			->willReturn('Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2');
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('foo/bar/baz');
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithInvalidContentType(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'foo/bar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithoutCurrentUserPrincipal(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn(null);
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithoutAuthPlugin(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn(null);
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public static function provideInvalidIcsData(): array {
+		$noUid = <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.6//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+CREATED:20250817T094141Z
+LAST-MODIFIED:20250817T094211Z
+SEQUENCE:2
+DTSTART;TZID=Europe/Berlin:20250819T030000
+DTEND;TZID=Europe/Berlin:20250819T080000
+STATUS:CONFIRMED
+SUMMARY:thunderbird-put-test
+ATTENDEE;CN=user a;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICI
+ PANT;RSVP=TRUE;LANGUAGE=en:mailto:usera@imap.localhost
+ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost
+DTSTAMP:20250817T094211Z
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+		$noVEvent = <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.6//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOF;
+
+		$noVCalendar = <<<EOF
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+EOF;
+
+		return [
+			[$noUid],
+			[$noVEvent],
+			[$noVCalendar],
+		];
+	}
+
+	#[DataProvider('provideInvalidIcsData')]
+	public function testBeforePutWithInvalidIcs(string $ics): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+		$request->expects(self::once())
+			->method('getBodyAsString')
+			->willReturn($ics);
+		$request->expects(self::once())
+			->method('setBody')
+			->with($ics);
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn('principals/users/usera');
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+}

--- a/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
@@ -41,27 +41,51 @@ class ThunderbirdPutInvitationQuirkPluginTest extends TestCase {
 	public function testInitialize(): void {
 		$this->server->expects(self::once())
 			->method('on')
-			->with('beforeMethod:PUT', $this->plugin->beforePut(...), 21);
+			->with('beforeMethod:PUT', $this->plugin->beforePut(...), 19);
 
 		$this->plugin->initialize($this->server);
 	}
 
+	private static function buildIcs(string $organizerLine): string {
+		return <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//IDN nextcloud.com//Calendar app//EN
+BEGIN:VEVENT
+CREATED:20250817T094141Z
+LAST-MODIFIED:20250817T094211Z
+SEQUENCE:2
+UID:cc5d41aa-7dbc-4278-8ffd-4fb5d626397c
+DTSTART:20250819T030000Z
+DTEND:20250819T080000Z
+STATUS:CONFIRMED
+SUMMARY:thunderbird-put-test
+ATTENDEE;CN=user a;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICI
+ PANT;RSVP=TRUE;LANGUAGE=en:mailto:usera@imap.localhost
+$organizerLine
+DTSTAMP:20250817T094211Z
+END:VEVENT
+END:VCALENDAR
+EOF;
+	}
+
 	public static function provideBeforePutData(): array {
+		$storedData = self::buildIcs('ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost');
 		return [
 			// No collision
 			[[], false],
 			// Many collisions
 			[
 				[
-					['uri' => 'sabredav-3dd349f8-58e0-483d-921f-70bc9f02366b.ics'],
-					['uri' => 'sabredav-19a50615-2db0-4046-a537-000979925e16.ics'],
+					['uri' => 'sabredav-3dd349f8-58e0-483d-921f-70bc9f02366b.ics', 'calendardata' => $storedData],
+					['uri' => 'sabredav-19a50615-2db0-4046-a537-000979925e16.ics', 'calendardata' => $storedData],
 				],
 				false,
 			],
 			// Exactly one collision
 			[
 				[
-					['uri' => 'sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics'],
+					['uri' => 'sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics', 'calendardata' => $storedData],
 				],
 				true,
 			],
@@ -133,11 +157,16 @@ EOF;
 			$request->expects(self::once())
 				->method('setUrl')
 				->with('remote.php/dav/calendars/usera/personal/sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics');
+			$request->expects(self::once())
+				->method('removeHeader')
+				->with('If-None-Match');
 		} else {
 			$request->expects(self::never())
 				->method('getUrl');
 			$request->expects(self::never())
 				->method('setUrl');
+			$request->expects(self::never())
+				->method('removeHeader');
 		}
 
 		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
@@ -394,6 +423,206 @@ EOF;
 			[$noVEvent],
 			[$noVCalendar],
 		];
+	}
+
+	public static function provideScheduleAgentRestoreData(): array {
+		return [
+			'incoming SCHEDULE-AGENT=CLIENT is dropped when the stored organizer has none' => [
+				'ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost',
+				'ORGANIZER;CN=Admin Account;SCHEDULE-AGENT=CLIENT:mailto:admin@imap.localhost',
+				true,
+				null,
+			],
+			'incoming SCHEDULE-AGENT matching the stored organizer is left alone' => [
+				'ORGANIZER;CN=Admin Account;SCHEDULE-AGENT=CLIENT:mailto:admin@imap.localhost',
+				'ORGANIZER;CN=Admin Account;SCHEDULE-AGENT=CLIENT:mailto:admin@imap.localhost',
+				false,
+				null,
+			],
+			'missing incoming SCHEDULE-AGENT is restored from the stored organizer' => [
+				'ORGANIZER;CN=Admin Account;SCHEDULE-AGENT=CLIENT:mailto:admin@imap.localhost',
+				'ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost',
+				true,
+				'CLIENT',
+			],
+			'unparsable stored calendar data disables the restore' => [
+				null,
+				'ORGANIZER;CN=Admin Account;SCHEDULE-AGENT=CLIENT:mailto:admin@imap.localhost',
+				false,
+				null,
+			],
+		];
+	}
+
+	#[DataProvider('provideScheduleAgentRestoreData')]
+	public function testBeforePutRestoresScheduleAgent(
+		?string $storedOrganizerLine,
+		string $incomingOrganizerLine,
+		bool $expectRestore,
+		?string $expectedAgent,
+	): void {
+		$storedData = $storedOrganizerLine === null
+			? 'THIS IS NOT A CALENDAR OBJECT'
+			: self::buildIcs($storedOrganizerLine);
+		$ics = self::buildIcs($incomingOrganizerLine);
+
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+		$request->expects(self::once())
+			->method('getBodyAsString')
+			->willReturn($ics);
+		$request->expects(self::once())
+			->method('getUrl')
+			->willReturn('remote.php/dav/calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+		$request->expects(self::once())
+			->method('setUrl')
+			->with('remote.php/dav/calendars/usera/personal/sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics');
+		$request->expects(self::once())
+			->method('removeHeader')
+			->with('If-None-Match');
+
+		$bodies = [];
+		$request->expects($expectRestore ? self::exactly(2) : self::once())
+			->method('setBody')
+			->willReturnCallback(function (string $body) use (&$bodies): void {
+				$bodies[] = $body;
+			});
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn('principals/users/usera');
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')
+			->willReturnSelf();
+		$qb->method('from')
+			->willReturnSelf();
+		$qb->method('join')
+			->willReturnSelf();
+		$qb->method('where')
+			->willReturnSelf();
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$qb->method('expr')
+			->willReturn($expr);
+		$this->db->expects(self::once())
+			->method('getQueryBuilder')
+			->willReturn($qb);
+
+		$result = $this->createMock(IResult::class);
+		$result->expects(self::once())
+			->method('fetchAll')
+			->willReturn([
+				['uri' => 'sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics', 'calendardata' => $storedData],
+			]);
+		$result->expects(self::once())
+			->method('closeCursor');
+		$qb->expects(self::once())
+			->method('executeQuery')
+			->willReturn($result);
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+
+		self::assertSame($ics, $bodies[0]);
+		if ($expectRestore) {
+			// Unfold the serialized body as long lines are split per RFC 5545
+			$unfolded = str_replace("\r\n ", '', $bodies[1]);
+			if ($expectedAgent === null) {
+				self::assertStringNotContainsString('SCHEDULE-AGENT', $unfolded);
+			} else {
+				self::assertStringContainsString('SCHEDULE-AGENT=' . $expectedAgent, $unfolded);
+			}
+		}
+	}
+
+	/**
+	 * When Thunderbird already PUTs to the object's real URI (calendar was synced), the plugin
+	 * must not rewrite anything and must leave the body untouched - in particular it must not
+	 * strip a SCHEDULE-AGENT the user set on their own organizer copy.
+	 */
+	public function testBeforePutLeavesAlreadyKnownObjectUntouched(): void {
+		$ics = self::buildIcs('ORGANIZER;CN=Admin Account;SCHEDULE-AGENT=CLIENT:mailto:admin@imap.localhost');
+
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/known-object.ics');
+		$request->expects(self::once())
+			->method('getBodyAsString')
+			->willReturn($ics);
+		// Only the initial echo-back of the unchanged body, never a rewritten one.
+		$request->expects(self::once())
+			->method('setBody')
+			->with($ics);
+		$request->expects(self::never())
+			->method('getUrl');
+		$request->expects(self::never())
+			->method('setUrl');
+		$request->expects(self::never())
+			->method('removeHeader');
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn('principals/users/usera');
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')
+			->willReturnSelf();
+		$qb->method('from')
+			->willReturnSelf();
+		$qb->method('join')
+			->willReturnSelf();
+		$qb->method('where')
+			->willReturnSelf();
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$qb->method('expr')
+			->willReturn($expr);
+		$this->db->expects(self::once())
+			->method('getQueryBuilder')
+			->willReturn($qb);
+
+		$result = $this->createMock(IResult::class);
+		$result->expects(self::once())
+			->method('fetchAll')
+			->willReturn([
+				['uri' => 'known-object.ics', 'calendardata' => self::buildIcs('ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost')],
+			]);
+		$result->expects(self::once())
+			->method('closeCursor');
+		$qb->expects(self::once())
+			->method('executeQuery')
+			->willReturn($result);
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
 	}
 
 	#[DataProvider('provideInvalidIcsData')]


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/17915

## Summary

This takes over and completes #54471 with agreement (https://github.com/nextcloud/server/pull/54471#issuecomment-4678190630).

### The problem

When someone is invited to an event, the server's scheduling code immediately writes a copy of that event into the invitee's personal calendar (under a server-generated object name). If the invitee opens the invitation email in Thunderbird and clicks Accept/Decline **before their calendar has synced**, Thunderbird does not yet know that object name. It therefore sends the PUT to a name it guesses itself. Because the event UID already exists in the calendar, the server rejects the PUT and Thunderbird shows error `80004005`; the acceptance is lost.

### What this PR does

**Commit 1 (original work by @st3iny, rebased onto master, fixup commits squashed):** a Sabre plugin that, for a Thunderbird PUT of a calendar object whose UID already exists in the *same* target calendar, rewrites the request URI to the existing object so the PUT updates it instead of failing on the collision.

**Commit 2 (this take-over):** completes and hardens that plugin.

1. **Deliver the organizer's reply.** Thunderbird's accept-before-sync body stamps the organizer with `SCHEDULE-AGENT=CLIENT`. That parameter tells the server not to perform scheduling, so no iTip REPLY is generated and the organizer never learns of the acceptance (they stay `NEEDS-ACTION`, no email). An attendee is not allowed to change the ORGANIZER property (RFC 5546), so the plugin restores `SCHEDULE-AGENT` to the value of the stored event. This is a no-op when the organizer was genuinely client-scheduled (the stored copy already carries `CLIENT`) and re-enables the reply in the common server-scheduled case.

2. **Let the rewritten PUT through.** Thunderbird sends `If-None-Match: *` because it believes it is creating a new object. After the URI has been rewritten to an existing object that precondition would fail with 412, so the header is dropped on the rewrite path.

3. **Only act on a genuine accept-before-sync.** The plugin now returns early when Thunderbird already targets the object's real URI (i.e. the calendar was already synced). This avoids touching the body on a normal update - in particular it never strips a `SCHEDULE-AGENT` that the organizer set on their own copy.

4. **Authorization for the rewrite target.** The plugin now runs before the ACL plugin (event priority 19 vs. the ACL plugin's 20; the current user principal is provided by the auth plugin at priority 10 and is available either way). The ACL plugin only checks PUT privileges when the target node exists; the original (guessed) URI never exists, so without this change the privilege check was skipped and not repeated after the rewrite. Running first means the ACL plugin evaluates `{DAV:}write-content` against the rewritten, existing object.

5. **Scope the collision lookup.** The lookup is restricted to the calendar the PUT targets (`calendars/{principal}/{calendar}/...`) and excludes subscription/federated cache rows (`calendartype`) and trashed objects/calendars (`deleted_at`). This prevents rewriting onto an object in a different calendar of the same user, onto a read-only subscription cache, or onto a deleted object.

## Testing

Manually verified on a live Nextcloud 33.0.3 instance (MariaDB, Apache/mod_php) with this patch applied, using Thunderbird as the invitee/organizer client:

- [x] Accept before the calendar syncs: no error (previously `80004005`), the PUT succeeds
- [x] Organizer receives the iTip REPLY: the attendee shows as accepted in the organizer's web calendar and the notification email is delivered
- [x] A subsequent manual sync in Thunderbird reconciles to a single event (matched by UID), still accepted, no duplicate
- [x] Accept *after* the calendar has synced: unchanged behavior, the plugin does not interfere, organizer is notified
- [x] Decline before the calendar syncs: works the same way, organizer sees the declined state and is notified
- [x] Organizer edits their own already-synced event in Thunderbird: the change is saved, attendees receive exactly one update (no duplicate), confirming the plugin leaves a known object untouched

Unit tests (`apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php`) cover the URI rewrite, the `If-None-Match` removal, the early return when the object URI already matches, and the `SCHEDULE-AGENT` restore (restored from the stored organizer, left untouched when already equal, dropped when the stored organizer has none, and skipped when the stored data is unparsable). 17 tests pass locally with the flags CI uses (`--fail-on-warning --fail-on-risky`).

The authorization change (item 4) is not reproduced as a live exploit here; it is established from the Sabre ACL plugin source (the privilege check is bound to `beforeMethod` and skipped for a non-existent node, with no second check on the update path) and covered by the unit test asserting the registration priority.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
