### PR TITLE
test: Fix DB test grouping

### DIFF
--- a/apps/appstore/tests/Controller/ApiControllerTest.php
+++ b/apps/appstore/tests/Controller/ApiControllerTest.php
@@ -25,7 +25,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 final class ApiControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 

--- a/apps/appstore/tests/Controller/PageControllerTest.php
+++ b/apps/appstore/tests/Controller/PageControllerTest.php
@@ -22,7 +22,6 @@ use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 final class PageControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 

--- a/apps/dav/tests/integration/DAV/Sharing/CalDavSharingBackendTest.php
+++ b/apps/dav/tests/integration/DAV/Sharing/CalDavSharingBackendTest.php
@@ -79,6 +79,8 @@ class CalDavSharingBackendTest extends TestCase {
 
 	protected function tearDown(): void {
 		$this->removeFixtures();
+
+		parent::tearDown();
 	}
 
 	protected function removeFixtures(): void {

--- a/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
@@ -34,6 +34,8 @@ class ContactsMigratorTest extends TestCase {
 	private const ASSETS_DIR = __DIR__ . '/assets/address_books/';
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$app = new App(Application::APP_ID);
 		$container = $app->getContainer();
 

--- a/apps/dav/tests/unit/AppInfo/ApplicationTest.php
+++ b/apps/dav/tests/unit/AppInfo/ApplicationTest.php
@@ -20,7 +20,6 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\Unit\AppInfo
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ApplicationTest extends TestCase {
 	public function test(): void {
 		$app = new Application();

--- a/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
@@ -21,11 +21,11 @@ use OCP\Server;
 use OCP\User\IAvailabilityCoordinator;
 use OCP\UserStatus\IManager;
 use OCP\UserStatus\IUserStatus;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserStatusAutomationTest extends TestCase {
 	protected ITimeFactory&MockObject $time;
 	protected IJobList&MockObject $jobList;
@@ -86,6 +86,7 @@ class UserStatusAutomationTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataRun')]
 	public function testRunNoOOO(string $ruleDay, string $currentTime, bool $isAvailable): void {
 		$user = $this->createConfiguredMock(IUser::class, [
@@ -182,6 +183,7 @@ END:VCALENDAR');
 		self::invokePrivate($automation, 'run', [['userId' => 'user']]);
 	}
 
+	#[Group('DB')]
 	public function testRunNoAvailabilityWithOOO(): void {
 		$user = $this->createConfiguredMock(IUser::class, [
 			'getUID' => 'user'

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
@@ -14,7 +14,6 @@ use OCP\Activity\IFilter;
 use OCP\Server;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GenericTest extends TestCase {
 	public static function dataFilters(): array {
 		return [

--- a/apps/dav/tests/unit/CalDAV/EventComparisonServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/EventComparisonServiceTest.php
@@ -17,6 +17,8 @@ class EventComparisonServiceTest extends TestCase {
 	private EventComparisonService $eventComparisonService;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->eventComparisonService = new EventComparisonService();
 	}
 

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -23,6 +23,7 @@ use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -33,7 +34,6 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\unit\CalDAV
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PublicCalendarRootTest extends TestCase {
 	public const UNIT_TEST_USER = '';
 	private CalDavBackend $backend;
@@ -117,6 +117,7 @@ class PublicCalendarRootTest extends TestCase {
 		$this->assertEquals('public-calendars', $name);
 	}
 
+	#[Group('DB')]
 	public function testGetChild(): void {
 		$calendar = $this->createPublicCalendar();
 
@@ -130,6 +131,7 @@ class PublicCalendarRootTest extends TestCase {
 		$this->assertEquals($calendar, $calendarResult);
 	}
 
+	#[Group('DB')]
 	public function testGetChildren(): void {
 		$this->createPublicCalendar();
 		$calendarResults = $this->publicCalendarRoot->getChildren();

--- a/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
@@ -11,9 +11,13 @@ namespace OCA\DAV\Tests\unit\CalDAV\Reminder;
 
 use OCA\DAV\CalDAV\Reminder\Backend as ReminderBackend;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
+#[Group('DB')]
 class BackendTest extends TestCase {
 	private ReminderBackend $reminderBackend;
 	private ITimeFactory&MockObject $timeFactory;
@@ -21,19 +25,19 @@ class BackendTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('calendar_reminders')->executeStatement();
 		$query->delete('calendarobjects')->executeStatement();
 		$query->delete('calendars')->executeStatement();
 
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->reminderBackend = new ReminderBackend(self::$realDatabase, $this->timeFactory);
+		$this->reminderBackend = new ReminderBackend(Server::get(IDBConnection::class), $this->timeFactory);
 
 		$this->createRemindersTestSet();
 	}
 
 	protected function tearDown(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('calendar_reminders')->executeStatement();
 		$query->delete('calendarobjects')->executeStatement();
 		$query->delete('calendars')->executeStatement();
@@ -42,7 +46,7 @@ class BackendTest extends TestCase {
 	}
 
 	public function testCleanRemindersForEvent(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -52,7 +56,7 @@ class BackendTest extends TestCase {
 
 		$this->reminderBackend->cleanRemindersForEvent(1);
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -62,7 +66,7 @@ class BackendTest extends TestCase {
 	}
 
 	public function testCleanRemindersForCalendar(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -72,7 +76,7 @@ class BackendTest extends TestCase {
 
 		$this->reminderBackend->cleanRemindersForCalendar(1);
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -82,7 +86,7 @@ class BackendTest extends TestCase {
 	}
 
 	public function testRemoveReminder(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -92,7 +96,7 @@ class BackendTest extends TestCase {
 
 		$this->reminderBackend->removeReminder((int)$rows[3]['id']);
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -189,7 +193,7 @@ class BackendTest extends TestCase {
 	}
 
 	public function testInsertReminder(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -200,7 +204,7 @@ class BackendTest extends TestCase {
 		$this->reminderBackend->insertReminder(42, 1337, 'uid99', true, 12345678,
 			true, 'hash99', 'hash42', 'AUDIO', false, 12345670, false);
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -227,7 +231,7 @@ class BackendTest extends TestCase {
 	}
 
 	public function testUpdateReminder(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')
 			->executeQuery()
@@ -242,7 +246,7 @@ class BackendTest extends TestCase {
 
 		$this->reminderBackend->updateReminder($reminderId, $newNotificationDate);
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$row = $query->select('notification_date')
 			->from('calendar_reminders')
 			->where($query->expr()->eq('id', $query->createNamedParameter($reminderId)))
@@ -253,7 +257,7 @@ class BackendTest extends TestCase {
 	}
 
 	private function createRemindersTestSet(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendars')
 			->values([
 				'id' => $query->createNamedParameter(1),
@@ -262,7 +266,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendars')
 			->values([
 				'id' => $query->createNamedParameter(99),
@@ -271,7 +275,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendarobjects')
 			->values([
 				'id' => $query->createNamedParameter(1),
@@ -281,7 +285,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendarobjects')
 			->values([
 				'id' => $query->createNamedParameter(2),
@@ -291,7 +295,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendarobjects')
 			->values([
 				'id' => $query->createNamedParameter(10),
@@ -301,7 +305,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendar_reminders')
 			->values([
 				'calendar_id' => $query->createNamedParameter(1),
@@ -319,7 +323,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendar_reminders')
 			->values([
 				'calendar_id' => $query->createNamedParameter(1),
@@ -337,7 +341,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendar_reminders')
 			->values([
 				'calendar_id' => $query->createNamedParameter(1),
@@ -355,7 +359,7 @@ class BackendTest extends TestCase {
 			])
 			->executeStatement();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendar_reminders')
 			->values([
 				'calendar_id' => $query->createNamedParameter(99),

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
@@ -18,7 +18,6 @@ use OCA\DAV\Capabilities;
 use Psr\Container\ContainerExceptionInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class NotificationProviderManagerTest extends TestCase {
 	private NotificationProviderManager $providerManager;
 

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
@@ -51,6 +51,8 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 		$query->delete('calendar_resources_md')->executeStatement();
 		$query->delete('calendar_rooms')->executeStatement();
 		$query->delete('calendar_rooms_md')->executeStatement();
+
+		parent::tearDown();
 	}
 
 	public function testGetPrincipalsByPrefix(): void {

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
@@ -12,9 +12,12 @@ use OCA\DAV\CalDAV\Proxy\Proxy;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\CalDAV\ResourceBooking\ResourcePrincipalBackend;
 use OCA\DAV\CalDAV\ResourceBooking\RoomPrincipalBackend;
+use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\PropPatch;
@@ -42,7 +45,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 
 		$query->delete('calendar_resources')->executeStatement();
 		$query->delete('calendar_resources_md')->executeStatement();
@@ -454,7 +457,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 	}
 
 	protected function createTestDatasetInDb() {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert($this->mainDbTable)
 			->values([
 				'backend_id' => $query->createNamedParameter('backend1'),

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
@@ -17,7 +17,6 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Server;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\PropPatch;

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/ResourcePrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/ResourcePrincipalBackendTest.php
@@ -9,12 +9,16 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\CalDAV\ResourceBooking;
 
 use OCA\DAV\CalDAV\ResourceBooking\ResourcePrincipalBackend;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('DB')]
 class ResourcePrincipalBackendTest extends AbstractPrincipalBackendTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->principalBackend = new ResourcePrincipalBackend(self::$realDatabase,
+		$this->principalBackend = new ResourcePrincipalBackend(Server::get(IDBConnection::class),
 			$this->userSession, $this->groupManager, $this->logger, $this->proxyMapper);
 
 		$this->mainDbTable = 'calendar_resources';

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/RoomPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/RoomPrincipalBackendTest.php
@@ -9,12 +9,16 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\CalDAV\ResourceBooking;
 
 use OCA\DAV\CalDAV\ResourceBooking\RoomPrincipalBackend;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('DB')]
 class RoomPrincipalBackendTest extends AbstractPrincipalBackendTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->principalBackend = new RoomPrincipalBackend(self::$realDatabase,
+		$this->principalBackend = new RoomPrincipalBackend(Server::get(IDBConnection::class),
 			$this->userSession, $this->groupManager, $this->logger, $this->proxyMapper);
 
 		$this->mainDbTable = 'calendar_rooms';

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginCharsetTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginCharsetTest.php
@@ -67,6 +67,8 @@ class IMipPluginCharsetTest extends TestCase {
 	private Message $itipMessage;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		// Used by IMipService and IMipPlugin
 		$today = new \DateTime('2025-06-15 14:30');
 		$this->timeFactory = $this->createMock(ITimeFactory::class);

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -60,6 +60,8 @@ class IMipPluginTest extends TestCase {
 	private IMailMessageNew&MockObject $mailMessageNew;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->mailMessage = $this->createMock(IMessage::class);
 		$this->mailMessage->method('setFrom')->willReturn($this->mailMessage);
 		$this->mailMessage->method('setReplyTo')->willReturn($this->mailMessage);

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/ConnectionTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/ConnectionTest.php
@@ -26,6 +26,8 @@ class ConnectionTest extends TestCase {
 	private Connection $connection;
 
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->config = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);

--- a/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
@@ -16,11 +16,9 @@ use OCP\Security\Bruteforce\IThrottler;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[Group(name: 'DB')]
 class LegacyPublicAuthTest extends TestCase {
 	private ISession&MockObject $session;
 	private IRequest&MockObject $request;

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -31,7 +31,6 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AuthTest extends TestCase {
 	private ISession&MockObject $session;
 	private Session&MockObject $userSession;

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -15,12 +15,12 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class BearerAuthTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private ISession&MockObject $session;
@@ -49,6 +49,7 @@ class BearerAuthTest extends TestCase {
 		$this->assertFalse($this->bearerAuth->validateBearerToken('Token'));
 	}
 
+	#[Group('DB')]
 	public function testValidateBearerToken(): void {
 		$this->userSession
 			->expects($this->exactly(2))

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -25,6 +25,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\NotFound;
 use Test\Traits\UserTrait;
@@ -58,7 +59,6 @@ class TestViewDirectory extends View {
 	}
 }
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class DirectoryTest extends \Test\TestCase {
 	use UserTrait;
 
@@ -421,6 +421,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->getNodeForPath('/my/deep/folder/');
 	}
 
+	#[Group('DB')]
 	public function testGetQuotaInfoUnlimited(): void {
 		$this->createUser('user', 'password');
 		self::loginAsUser('user');
@@ -475,6 +476,7 @@ class DirectoryTest extends \Test\TestCase {
 		$this->assertEquals([200, -3], $dir->getQuotaInfo()); //200 used, unlimited
 	}
 
+	#[Group('DB')]
 	public function testGetQuotaInfoSpecific(): void {
 		$this->createUser('user', 'password');
 		self::loginAsUser('user');
@@ -526,6 +528,7 @@ class DirectoryTest extends \Test\TestCase {
 		$this->assertEquals([200, 800], $dir->getQuotaInfo()); //200 used, 800 free
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'moveFailedProvider')]
 	public function testMoveFailed(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -26,6 +26,7 @@ use OCP\IConfig;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\IUserSession;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
@@ -38,7 +39,6 @@ use Sabre\HTTP\ResponseInterface;
 use Sabre\Xml\Service;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FilesPluginTest extends TestCase {
 
 	private Tree&MockObject $tree;
@@ -284,6 +284,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals('M. Foo', $propFind->get(FilesPlugin::OWNER_DISPLAY_NAME_PROPERTYNAME));
 	}
 
+	#[Group('DB')]
 	public function testGetPropertiesStorageNotAvailable(): void {
 		/** @var File&MockObject $node */
 		$node = $this->createTestNode(File::class);

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -24,6 +24,7 @@ use OCP\Files\Storage\IStorage;
 use OCP\ICache;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -31,7 +32,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class NodeTest extends \Test\TestCase {
 	public static function davPermissionsProvider(): array {
 		return [
@@ -51,6 +51,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'davPermissionsProvider')]
 	public function testDavPermissions(int $permissions, string $type, bool $shared, int $shareRootPermissions, bool $mounted, string $internalPath, string $expected): void {
 		$info = $this->getMockBuilder(FileInfo::class)

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -27,7 +27,6 @@ use OCP\Files\Mount\IMountManager;
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ObjectTreeTest extends \Test\TestCase {
 	public static function copyDataProvider(): array {
 		return [

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -66,8 +66,8 @@ class PublicAuthTest extends \Test\TestCase {
 		\OC_User::setIncognitoMode(false);
 
 		// Set old user
-		\OC_User::setUserId($this->oldUser);
 		if ($this->oldUser !== false) {
+			\OC_User::setUserId($this->oldUser);
 			\OC_Util::setupFS($this->oldUser);
 		}
 

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -26,7 +26,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\DAV\Tests\unit\Connector
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PublicAuthTest extends \Test\TestCase {
 
 	private ISession&MockObject $session;

--- a/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
+++ b/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
@@ -23,7 +23,6 @@ use Test\TestCase;
  *
  * @package OCA\DAV\Tests\Unit\DAV\Migration
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CalDAVRemoveEmptyValueTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 	private CalDavBackend&MockObject $backend;

--- a/apps/dav/tests/unit/SetupChecks/SystemAddressBookSizeTest.php
+++ b/apps/dav/tests/unit/SetupChecks/SystemAddressBookSizeTest.php
@@ -23,6 +23,8 @@ class SystemAddressBookSizeTest extends TestCase {
 	private $l10n;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->l10n = $this->createMock(IL10N::class);

--- a/apps/encryption/tests/Listeners/UserEventsListenersTest.php
+++ b/apps/encryption/tests/Listeners/UserEventsListenersTest.php
@@ -29,7 +29,6 @@ use OCP\User\Events\UserLoggedOutEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserEventsListenersTest extends TestCase {
 	protected Util&MockObject $util;
 	protected Setup&MockObject $userSetup;

--- a/apps/encryption/tests/PassphraseServiceTest.php
+++ b/apps/encryption/tests/PassphraseServiceTest.php
@@ -22,7 +22,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PassphraseServiceTest extends TestCase {
 
 	protected Util&MockObject $util;

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -51,6 +51,8 @@ class RequestHandlerControllerTest extends \Test\TestCase {
 	private IEventDispatcher&MockObject $eventDispatcher;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->share = $this->createMock(IShare::class);
 		$this->federatedShareProvider = $this->createMock(FederatedShareProvider::class);
 		$this->federatedShareProvider->expects($this->any())

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -29,7 +29,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\FederatedFileSharing\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class RequestHandlerControllerTest extends \Test\TestCase {
 	private string $owner = 'owner';
 	private string $user1 = 'user1';

--- a/apps/federatedfilesharing/tests/FederatedShareProviderReshareRemoteTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderReshareRemoteTest.php
@@ -50,6 +50,8 @@ class FederatedShareProviderReshareRemoteTest extends \Test\TestCase {
 	private FederatedShareProvider $shareProvider;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->connection = $this->createMock(IDBConnection::class);
 		$this->addressHandler = $this->createMock(AddressHandler::class);
 		$this->notifications = $this->createMock(Notifications::class);

--- a/apps/files/tests/Activity/Filter/GenericTest.php
+++ b/apps/files/tests/Activity/Filter/GenericTest.php
@@ -19,7 +19,6 @@ use Test\TestCase;
  *
  * @package OCA\Files\Tests\Activity\Filter
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GenericTest extends TestCase {
 	public static function dataFilters(): array {
 		return [

--- a/apps/files/tests/Command/ScanAppDataTest.php
+++ b/apps/files/tests/Command/ScanAppDataTest.php
@@ -49,6 +49,8 @@ class ScanAppDataTest extends TestCase {
 	private string $user;
 
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->config = Server::get(IConfig::class);
 		$this->rootFolder = Server::get(IRootFolder::class);
 		$this->storageFactory = Server::get(StorageFactory::class);

--- a/apps/files_external/tests/Config/ConfigAdapterTest.php
+++ b/apps/files_external/tests/Config/ConfigAdapterTest.php
@@ -85,6 +85,8 @@ class ConfigAdapterTest extends TestCase {
 	}
 
 	public function setUp(): void {
+		parent::setUp();
+
 		// prepare BackendService mock
 		$this->backendService = $this->createMock(BackendService::class);
 
@@ -193,6 +195,8 @@ class ConfigAdapterTest extends TestCase {
 		foreach ($this->storageIds as $storageId) {
 			$this->userStoragesService->removeStorage($storageId);
 		}
+
+		parent::tearDown();
 	}
 
 	public static function pathsProvider(): \Generator {

--- a/apps/files_external/tests/Listener/StorePasswordListenerTest.php
+++ b/apps/files_external/tests/Listener/StorePasswordListenerTest.php
@@ -18,7 +18,6 @@ use OCP\User\Events\UserLoggedInEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class StorePasswordListenerTest extends TestCase {
 	protected IUser&MockObject $mockedUser;
 

--- a/apps/files_external/tests/OwnCloudFunctionsTest.php
+++ b/apps/files_external/tests/OwnCloudFunctionsTest.php
@@ -17,7 +17,6 @@ use OCA\Files_External\Lib\Storage\OwnCloud;
  *
  * @package OCA\Files_External\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class OwnCloudFunctionsTest extends \Test\TestCase {
 	public static function configUrlProvider(): array {
 		return [

--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -23,6 +23,8 @@ class BackendServiceTest extends \Test\TestCase {
 	protected LoggerInterface&MockObject $logger;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 	}

--- a/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
@@ -12,8 +12,8 @@ namespace OCA\Files_External\Tests\Service;
 use OC\Files\Filesystem;
 use OCA\Files_External\MountConfig;
 use OCA\Files_External\Service\GlobalStoragesService;
+use PHPUnit\Framework\Attributes\Group;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 	protected function setUp(): void {
 		parent::setUp();
@@ -113,6 +113,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'storageDataProvider')]
 	public function testAddStorage($storageParams): void {
 		$storage = $this->makeStorageConfig($storageParams);
@@ -135,6 +136,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		$this->assertEquals($baseId + 1, $nextStorage->getId());
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'storageDataProvider')]
 	public function testUpdateStorage($updatedStorageParams): void {
 		$updatedStorage = $this->makeStorageConfig($updatedStorageParams);
@@ -275,6 +277,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'hooksAddStorageDataProvider')]
 	public function testHooksAddStorage($applicableUsers, $applicableGroups, $expectedCalls): void {
 		$storage = $this->makeTestStorageData();
@@ -411,6 +414,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'hooksUpdateStorageDataProvider')]
 	public function testHooksUpdateStorage(
 		array $sourceApplicableUsers,
@@ -445,6 +449,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		}
 	}
 
+	#[Group('DB')]
 	public function testHooksRenameMountPoint(): void {
 		$storage = $this->makeTestStorageData();
 		$storage->setApplicableUsers(['user1', 'user2']);
@@ -568,6 +573,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'hooksDeleteStorageDataProvider')]
 	public function testHooksDeleteStorage(
 		array $sourceApplicableUsers,

--- a/apps/files_external/tests/Service/StoragesServiceTestCase.php
+++ b/apps/files_external/tests/Service/StoragesServiceTestCase.php
@@ -35,6 +35,7 @@ use OCP\IUser;
 use OCP\Security\ICrypto;
 use OCP\Server;
 use OCP\Util;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class CleaningDBConfig extends DBConfigService {
@@ -217,6 +218,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		$this->service->updateStorage($storage);
 	}
 
+	#[Group('DB')]
 	public function testNonExistingStorage(): void {
 		$this->expectException(NotFoundException::class);
 
@@ -247,6 +249,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'deleteStorageDataProvider')]
 	public function testDeleteStorage(array $backendOptions, string $rustyStorageId): void {
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\DAV');
@@ -320,6 +323,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		$this->service->removeStorage(255);
 	}
 
+	#[Group('DB')]
 	public function testDeleteUnexistingStorage(): void {
 		$this->expectException(NotFoundException::class);
 
@@ -380,6 +384,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		$this->assertInstanceOf(InvalidAuth::class, $storage->getAuthMechanism());
 	}
 
+	#[Group('DB')]
 	public function testGetStoragesBackendNotVisible(): void {
 		/** @var Backend&MockObject $backend */
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
@@ -406,6 +411,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		$this->assertEmpty($this->service->getStorages());
 	}
 
+	#[Group('DB')]
 	public function testGetStoragesAuthMechanismNotVisible(): void {
 		/** @var Backend&MockObject $backend */
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
@@ -472,6 +478,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		);
 	}
 
+	#[Group('DB')]
 	public function testUpdateStorageMountPoint(): void {
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -18,10 +18,10 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 	use UserTrait;
 
@@ -97,6 +97,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'applicableStorageProvider')]
 	public function testGetStorageWithApplicable($applicableUsers, $applicableGroups, $isVisible): void {
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
@@ -144,6 +145,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		$this->service->addStorage($storage);
 	}
 
+	#[Group('DB')]
 	public function testUpdateStorage($storageParams = null): void {
 		$this->expectException(\DomainException::class);
 
@@ -169,6 +171,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		$this->ActualNonExistingStorageTest();
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'deleteStorageDataProvider')]
 	public function testDeleteStorage($backendOptions, $rustyStorageId): void {
 		$this->expectException(\DomainException::class);
@@ -222,6 +225,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'getUniqueStoragesProvider')]
 	public function testGetUniqueStorages(
 		$priority1, $applicableUsers1, $applicableGroups1,

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -16,7 +16,6 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 #[\PHPUnit\Framework\Attributes\Group(name: 'S3')]
 class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -17,7 +17,6 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 #[\PHPUnit\Framework\Attributes\Group('S3')]
 class Amazons3Test extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;

--- a/apps/files_external/tests/Storage/FtpTest.php
+++ b/apps/files_external/tests/Storage/FtpTest.php
@@ -17,7 +17,6 @@ use OCA\Files_External\Lib\Storage\FTP;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class FtpTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/OwncloudTest.php
+++ b/apps/files_external/tests/Storage/OwncloudTest.php
@@ -17,7 +17,6 @@ use OCA\Files_External\Lib\Storage\OwnCloud;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class OwncloudTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -17,7 +17,6 @@ use OCA\Files_External\Lib\Storage\SFTP;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SftpTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/**

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -21,7 +21,6 @@ use PHPUnit\Framework\ExpectationFailedException;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SmbTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 	/**

--- a/apps/files_external/tests/Storage/SwiftTest.php
+++ b/apps/files_external/tests/Storage/SwiftTest.php
@@ -18,7 +18,6 @@ use OCA\Files_External\Lib\Storage\Swift;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SwiftTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
+++ b/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\Files_External\Tests\Storage;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 #[\PHPUnit\Framework\Attributes\Group('S3')]
 class VersionedAmazonS3Test extends Amazons3Test {
 	protected function setUp(): void {

--- a/apps/files_external/tests/Storage/WebdavTest.php
+++ b/apps/files_external/tests/Storage/WebdavTest.php
@@ -20,7 +20,6 @@ use OCP\Server;
  *
  * @package OCA\Files_External\Tests\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class WebdavTest extends \Test\Files\Storage\Storage {
 	use ConfigurableStorageTrait;
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -32,7 +32,6 @@ use Psr\Log\LoggerInterface;
 /**
  * Class CapabilitiesTest
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CapabilitiesTest extends \Test\TestCase {
 
 	/**

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -106,6 +106,8 @@ class ShareAPIControllerTest extends TestCase {
 	private TrustedServers&MockObject $trustedServers;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->shareManager
 			->expects($this->any())

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -55,6 +55,7 @@ use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
 use OCP\UserStatus\IManager as IUserStatusManager;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -76,7 +77,6 @@ interface InternalTalkShareAPIController {
  *
  * @package OCA\Files_Sharing\Tests\Controller
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ShareAPIControllerTest extends TestCase {
 	use EmailValidatorTrait;
 
@@ -2480,6 +2480,7 @@ class ShareAPIControllerTest extends TestCase {
 		$ocs->createShare('valid-path', Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, 'a1b2d3');
 	}
 
+	#[Group('DB')]
 	public function testCreateShareRemote(): void {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
@@ -5266,6 +5267,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[DataProvider(methodName: 'trustedServerProvider')]
 	public function testFormatShareWithFederatedShare(bool $isKnownServer, bool $isTrusted): void {
 		$nodeId = 12;
@@ -5330,6 +5332,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertSame($isTrusted, $result['is_trusted_server']);
 	}
 
+	#[Group('DB')]
 	public function testFormatShareWithFederatedShareWithAtInUsername(): void {
 		$nodeId = 12;
 		$nodePath = '/test.txt';

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -13,7 +13,6 @@ use OCA\Files_Sharing\External\Scanner;
 use OCA\Files_Sharing\External\Storage;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ScannerTest extends TestCase {
 	protected Scanner $scanner;
 	/** @var Storage|\PHPUnit\Framework\MockObject\MockObject */

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -22,7 +22,6 @@ use OCP\Server;
 /**
  * Tests for the external Storage class for remote shares.
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ExternalStorageTest extends \Test\TestCase {
 	public static function optionsProvider(): array {
 		return [

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -29,7 +29,6 @@ use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class MountProviderTest extends \Test\TestCase {
 
 	protected MountProvider $provider;

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -18,6 +18,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
 use OCP\UserInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,7 +32,6 @@ use Test\TestCase;
  *
  * @package OCA\Files_Trashbin\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CleanUpTest extends TestCase {
 	protected IUserManager&MockObject $userManager;
 	protected IRootFolder&MockObject $rootFolder;
@@ -79,6 +79,7 @@ class CleanUpTest extends TestCase {
 		$this->assertCount(10, $result);
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestRemoveDeletedFiles')]
 	public function testRemoveDeletedFiles(bool $nodeExists): void {
 		$this->initTable();

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -17,6 +17,7 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Storage\IStorage;
 use OCP\UserInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -26,7 +27,6 @@ use Test\TestCase;
  *
  * @package OCA\Files_Versions\Tests\Command
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CleanupTest extends TestCase {
 	protected Manager&MockObject $userManager;
 	protected IRootFolder&MockObject $rootFolder;
@@ -46,6 +46,7 @@ class CleanupTest extends TestCase {
 	/**
 	 * @param boolean $nodeExists
 	 */
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestDeleteVersions')]
 	public function testDeleteVersions(bool $nodeExists): void {
 		$this->rootFolder->expects($this->once())

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -24,7 +24,6 @@ use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class LoginRedirectorControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private IURLGenerator&MockObject $urlGenerator;

--- a/apps/oauth2/tests/Controller/SettingsControllerTest.php
+++ b/apps/oauth2/tests/Controller/SettingsControllerTest.php
@@ -12,10 +12,8 @@ namespace OCA\OAuth2\Tests\Controller;
 use OCA\OAuth2\Controller\SettingsController;
 use OCP\AppFramework\Http;
 use OCP\Server;
-use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
-#[Group(name: 'DB')]
 class SettingsControllerTest extends TestCase {
 	public function testInvalidRedirectUri(): void {
 		$settingsController = Server::get(SettingsController::class);

--- a/apps/provisioning_api/tests/CapabilitiesTest.php
+++ b/apps/provisioning_api/tests/CapabilitiesTest.php
@@ -21,7 +21,6 @@ use Test\TestCase;
  *
  * @package OCA\Provisioning_API\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class CapabilitiesTest extends TestCase {
 
 	protected IAppManager&MockObject $appManager;

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -56,6 +56,8 @@ class AppsControllerTest extends TestCase {
 
 	protected function tearDown(): void {
 		$this->userSession->setUser(null);
+
+		parent::tearDown();
 	}
 
 	public function testGetAppInfo(): void {

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -18,6 +18,7 @@ use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -26,7 +27,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\Provisioning_API\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AppsControllerTest extends TestCase {
 	private IAppManager $appManager;
 	private IAppConfig&MockObject $appConfig;
@@ -60,6 +60,7 @@ class AppsControllerTest extends TestCase {
 		parent::tearDown();
 	}
 
+	#[Group('DB')]
 	public function testGetAppInfo(): void {
 		$result = $this->api->getAppInfo('provisioning_api');
 		$expected = $this->appManager->getAppInfo('provisioning_api');
@@ -73,6 +74,7 @@ class AppsControllerTest extends TestCase {
 		$this->api->getAppInfo('not_provisioning_api');
 	}
 
+	#[Group('DB')]
 	public function testGetApps(): void {
 		$user = $this->generateUsers();
 		$this->groupManager->get('admin')->addUser($user);

--- a/apps/settings/tests/AppInfo/ApplicationTest.php
+++ b/apps/settings/tests/AppInfo/ApplicationTest.php
@@ -26,7 +26,6 @@ use Test\TestCase;
  *
  * @package Tests\Settings
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ApplicationTest extends TestCase {
 	protected Application $app;
 	protected IAppContainer $container;

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -43,7 +43,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * @package Tests\Settings\Controller
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UsersControllerTest extends \Test\TestCase {
 	private IGroupManager&MockObject $groupManager;
 	private UserManager&MockObject $userManager;

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -22,7 +22,6 @@ use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ServerTest extends TestCase {
 	private IDBConnection $connection;
 	private Server&MockObject $admin;

--- a/apps/settings/tests/Settings/Admin/SharingTest.php
+++ b/apps/settings/tests/Settings/Admin/SharingTest.php
@@ -17,11 +17,9 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Share\IManager;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[Group(name: 'DB')]
 class SharingTest extends TestCase {
 	private Sharing $admin;
 

--- a/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
+++ b/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
@@ -17,7 +17,6 @@ use OCP\Server;
 use OCP\SetupCheck\SetupResult;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SupportedDatabaseTest extends TestCase {
 	private IL10N $l10n;
 	private IUrlGenerator $urlGenerator;

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -43,7 +43,6 @@ use Test\TestCase;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AccessTest extends TestCase {
 	protected UserMapping&MockObject $userMapper;
 	protected IManager&MockObject $shareManager;

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -59,6 +59,8 @@ class AccessTest extends TestCase {
 	private Access $access;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->ldap = $this->createMock(LDAP::class);
 		$this->connection = $this->getMockBuilder(Connection::class)
 			->setConstructorArgs([$this->ldap])

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -20,7 +20,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ConnectionTest extends \Test\TestCase {
 	protected ILDAPWrapper&MockObject $ldap;
 	protected Connection $connection;

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -34,7 +34,6 @@ use Test\TestCase;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class Group_LDAPTest extends TestCase {
 	private Access&MockObject $access;
 	private GroupPluginManager&MockObject $pluginManager;

--- a/apps/user_ldap/tests/HelperTest.php
+++ b/apps/user_ldap/tests/HelperTest.php
@@ -14,7 +14,6 @@ use OCP\IDBConnection;
 use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class HelperTest extends \Test\TestCase {
 	private IAppConfig&MockObject $appConfig;
 

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class SyncTest extends TestCase {
 	protected Helper&MockObject $helper;
 	protected LDAP&MockObject $ldapWrapper;

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -23,6 +23,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -31,7 +32,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class LDAPProviderTest extends \Test\TestCase {
 	private function getUserManagerMock(IUserLDAP $userBackend) {
 		$userManager = $this->getMockBuilder(Manager::class)
@@ -466,6 +466,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->assertTrue($ldapProvider->dnExists('cn=existing_user,ou=Are Sufficient To,ou=Test,dc=example,dc=org'));
 	}
 
+	#[Group('DB')]
 	public function testFlagRecord(): void {
 		$userBackend = $this->createMock(User_LDAP::class);
 

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
@@ -25,6 +25,8 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	abstract public function getMapper(IDBConnection $dbMock, ICacheFactory $cacheFactory, IAppConfig $appConfig): AbstractMapping;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->cacheFactoryMock = $this->createMock(ICacheFactory::class);
 		$this->configMock = $this->createMock(IAppConfig::class);
 	}

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTestCase.php
@@ -14,6 +14,7 @@ use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class AbstractMappingTestCase extends \Test\TestCase {
@@ -100,6 +101,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	 * tests map() method with input that should result in not-mapping.
 	 * Hint: successful mapping is tested inherently with mapEntries().
 	 */
+	#[Group('DB')]
 	public function testMap(): void {
 		[$mapper, $data] = $this->initTest();
 
@@ -120,6 +122,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	 * tests unmap() for both successful and unsuccessful removing of
 	 * mapping entries
 	 */
+	#[Group('DB')]
 	public function testUnmap(): void {
 		[$mapper, $data] = $this->initTest();
 
@@ -140,6 +143,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	 * tests getDNByName(), getNameByDN() and getNameByUUID() for successful
 	 * and unsuccessful requests.
 	 */
+	#[Group('DB')]
 	public function testGetMethods(): void {
 		[$mapper, $data] = $this->initTest();
 
@@ -168,6 +172,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	/**
 	 * tests getNamesBySearch() for successful and unsuccessful requests.
 	 */
+	#[Group('DB')]
 	public function testSearch(): void {
 		[$mapper,] = $this->initTest();
 
@@ -184,6 +189,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	/**
 	 * tests setDNbyUUID() for successful and unsuccessful update.
 	 */
+	#[Group('DB')]
 	public function testSetDNMethod(): void {
 		[$mapper, $data] = $this->initTest();
 
@@ -203,6 +209,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	/**
 	 * tests setUUIDbyDN() for successful and unsuccessful update.
 	 */
+	#[Group('DB')]
 	public function testSetUUIDMethod(): void {
 		/** @var AbstractMapping $mapper */
 		[$mapper, $data] = $this->initTest();
@@ -223,6 +230,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	/**
 	 * tests clear() for successful update.
 	 */
+	#[Group('DB')]
 	public function testClear(): void {
 		[$mapper, $data] = $this->initTest();
 
@@ -237,6 +245,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	/**
 	 * tests clear() for successful update.
 	 */
+	#[Group('DB')]
 	public function testClearCb(): void {
 		[$mapper, $data] = $this->initTest();
 
@@ -260,6 +269,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 	/**
 	 * tests getList() method
 	 */
+	#[Group('DB')]
 	public function testList(): void {
 		[$mapper, $data] = $this->initTest();
 
@@ -281,6 +291,7 @@ abstract class AbstractMappingTestCase extends \Test\TestCase {
 		$this->assertCount(1, $results);
 	}
 
+	#[Group('DB')]
 	public function testGetListOfIdsByDn(): void {
 		/** @var AbstractMapping $mapper */
 		[$mapper,] = $this->initTest();

--- a/apps/user_ldap/tests/Mapping/GroupMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/GroupMappingTest.php
@@ -20,7 +20,6 @@ use OCP\IDBConnection;
  *
  * @package OCA\User_LDAP\Tests\Mapping
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class GroupMappingTest extends AbstractMappingTestCase {
 	public function getMapper(IDBConnection $dbMock, ICacheFactory $cacheFactory, IAppConfig $appConfig): GroupMapping {
 		return new GroupMapping($dbMock, $cacheFactory, $appConfig, true);

--- a/apps/user_ldap/tests/Mapping/UserMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/UserMappingTest.php
@@ -22,7 +22,6 @@ use OCP\Support\Subscription\IAssertion;
  *
  * @package OCA\User_LDAP\Tests\Mapping
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserMappingTest extends AbstractMappingTestCase {
 	public function getMapper(IDBConnection $dbMock, ICacheFactory $cacheFactory, IAppConfig $appConfig): UserMapping {
 		return new UserMapping($dbMock, $cacheFactory, $appConfig, true, $this->createMock(IAssertion::class), $this->createMock(IRequest::class));

--- a/apps/user_ldap/tests/Migration/UUIDFixGroupTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixGroupTest.php
@@ -17,7 +17,6 @@ use OCA\User_LDAP\Migration\UUIDFixGroup;
  *
  * @package OCA\Group_LDAP\Tests\Migration
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UUIDFixGroupTest extends AbstractUUIDFixTestCase {
 	protected function setUp(): void {
 		$this->isUser = false;

--- a/apps/user_ldap/tests/Migration/UUIDFixUserTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixUserTest.php
@@ -17,7 +17,6 @@ use OCA\User_LDAP\User_Proxy;
  *
  * @package OCA\User_LDAP\Tests\Migration
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UUIDFixUserTest extends AbstractUUIDFixTestCase {
 	protected function setUp(): void {
 		$this->isUser = true;

--- a/apps/user_ldap/tests/Service/UpdateGroupsServiceTest.php
+++ b/apps/user_ldap/tests/Service/UpdateGroupsServiceTest.php
@@ -34,6 +34,8 @@ class UpdateGroupsServiceTest extends TestCase {
 	protected UpdateGroupsService $updateGroupsService;
 
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->groupBackend = $this->createMock(Group_Proxy::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);

--- a/apps/user_ldap/tests/Settings/AdminTest.php
+++ b/apps/user_ldap/tests/Settings/AdminTest.php
@@ -15,13 +15,13 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\IL10N;
 use OCP\Server;
 use OCP\Template\ITemplateManager;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
  * @package OCA\User_LDAP\Tests\Settings
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class AdminTest extends TestCase {
 	private IL10N&MockObject $l10n;
 	private ITemplateManager $templateManager;
@@ -41,6 +41,7 @@ class AdminTest extends TestCase {
 		);
 	}
 
+	#[Group('DB')]
 	public function testGetForm(): void {
 		$parameters = [];
 

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -32,7 +32,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\User_LDAP\Tests\User
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class ManagerTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected IConfig&MockObject $config;

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -25,6 +25,8 @@ class OfflineUserTest extends TestCase {
 	protected OfflineUser $offlineUser;
 
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->uid = 'deborah';
 		$this->userConfig = $this->createMock(IUserConfig::class);
 		$this->mapping = $this->createMock(UserMapping::class);

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -33,7 +33,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\User_LDAP\Tests\User
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class UserTest extends \Test\TestCase {
 	protected Access&MockObject $access;
 	protected Connection&MockObject $connection;

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -28,6 +28,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -38,7 +39,6 @@ use Test\TestCase;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class User_LDAPTest extends TestCase {
 	protected Access&MockObject $access;
 	protected OfflineUser&MockObject $offlineUser;
@@ -1242,6 +1242,7 @@ class User_LDAPTest extends TestCase {
 		$this->assertTrue(\OC_User::setPassword('roland', 'dt'));
 	}
 
+	#[Group('DB')]
 	public function testSetPasswordValid(): void {
 		$this->prepareAccessForSetPassword($this->access);
 

--- a/apps/user_ldap/tests/WizardTest.php
+++ b/apps/user_ldap/tests/WizardTest.php
@@ -22,7 +22,6 @@ use Test\TestCase;
  *
  * @package OCA\User_LDAP\Tests
  */
-#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class WizardTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
+++ b/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
@@ -13,8 +13,12 @@ use OCA\UserStatus\Db\UserStatus;
 use OCA\UserStatus\Db\UserStatusMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\DB\Exception;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
+#[Group('DB')]
 class UserStatusMapperTest extends TestCase {
 	private UserStatusMapper $mapper;
 
@@ -22,10 +26,10 @@ class UserStatusMapperTest extends TestCase {
 		parent::setUp();
 
 		// make sure that DB is empty
-		$qb = self::$realDatabase->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->delete('user_status')->executeStatement();
 
-		$this->mapper = new UserStatusMapper(self::$realDatabase);
+		$this->mapper = new UserStatusMapper(Server::get(IDBConnection::class));
 	}
 
 	public function testGetTableName(): void {

--- a/tests/Core/Command/Apps/AppsDisableTest.php
+++ b/tests/Core/Command/Apps/AppsDisableTest.php
@@ -11,13 +11,13 @@ namespace Tests\Core\Command\Config;
 use OC\Core\Command\App\Disable;
 use OCP\App\IAppManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
 /**
  * Class AppsDisableTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppsDisableTest extends TestCase {
 	/** @var CommandTester */
 	private $commandTester;
@@ -42,6 +42,7 @@ class AppsDisableTest extends TestCase {
 	 * @param $statusCode
 	 * @param $pattern
 	 */
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCommandInput')]
 	public function testCommandInput($appId, $statusCode, $pattern): void {
 		$input = ['app-id' => $appId];

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -32,6 +32,7 @@ use OCP\Mail\IMailer;
 use OCP\Security\ICrypto;
 use OCP\Security\VerificationToken\IVerificationToken;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -41,7 +42,6 @@ use Test\TestCase;
  *
  * @package Test\Accounts
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AccountManagerTest extends TestCase {
 
 	/** accounts table name */
@@ -907,6 +907,7 @@ class AccountManagerTest extends TestCase {
 		}
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('searchDataProvider')]
 	public function testSearchUsers(string $property, array $values, array $expected): void {
 		$this->populateOrUpdate();
@@ -983,6 +984,7 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckEmailVerification')]
 	public function testCheckEmailVerification(array $userData, ?string $newEmail): void {
 		$user = $this->makeUser(...$userData);

--- a/tests/lib/Accounts/HooksTest.php
+++ b/tests/lib/Accounts/HooksTest.php
@@ -24,7 +24,6 @@ use Test\TestCase;
  *
  * @package Test\Accounts
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HooksTest extends TestCase {
 
 	private LoggerInterface&MockObject $logger;

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -12,13 +12,13 @@ use OC\AllConfig;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class AllConfigTest
  *
  * @package Test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AllConfigTest extends \Test\TestCase {
 	/** @var IDBConnection */
 	protected $connection;
@@ -38,6 +38,7 @@ class AllConfigTest extends \Test\TestCase {
 		return new AllConfig($systemConfig, $connection);
 	}
 
+	#[Group('DB')]
 	public function testDeleteUserValue(): void {
 		$config = $this->getConfig();
 
@@ -59,6 +60,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(0, $actualCount, 'There was one value in the database and after the tests there should be no entry left.');
 	}
 
+	#[Group('DB')]
 	public function testSetUserValue(): void {
 		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 		$config = $this->getConfig();
@@ -96,6 +98,7 @@ class AllConfigTest extends \Test\TestCase {
 	 * This test needs to stay! Emails are expected to be lowercase due to performance reasons.
 	 * This way we can skip the expensive casing change on the database.
 	 */
+	#[Group('DB')]
 	public function testSetUserValueSettingsEmail(): void {
 		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 		$config = $this->getConfig();
@@ -113,6 +116,7 @@ class AllConfigTest extends \Test\TestCase {
 		], $result[0]);
 	}
 
+	#[Group('DB')]
 	public function testSetUserValueWithPreCondition(): void {
 		$config = $this->getConfig();
 
@@ -167,6 +171,7 @@ class AllConfigTest extends \Test\TestCase {
 		$config->setUserValue('userSetBool', 'appSetBool', 'keySetBool', $value);
 	}
 
+	#[Group('DB')]
 	public function testSetUserValueWithPreConditionFailure(): void {
 		$this->expectException(PreConditionNotMetException::class);
 
@@ -203,6 +208,7 @@ class AllConfigTest extends \Test\TestCase {
 		$config->deleteUserValue('userPreCond1', 'appPreCond', 'keyPreCond');
 	}
 
+	#[Group('DB')]
 	public function testSetUserValueWithPreConditionFailureWhenResultStillMatches(): void {
 		$this->expectException(PreConditionNotMetException::class);
 
@@ -264,6 +270,7 @@ class AllConfigTest extends \Test\TestCase {
 		$config->setUserValue('userSetUnchanged', 'appSetUnchanged', 'keySetUnchanged', 'valueSetUnchanged');
 	}
 
+	#[Group('DB')]
 	public function testGetUserValue(): void {
 		$config = $this->getConfig();
 
@@ -302,6 +309,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(0, count($result));
 	}
 
+	#[Group('DB')]
 	public function testGetUserKeys(): void {
 		$config = $this->getConfig();
 
@@ -333,6 +341,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
 	}
 
+	#[Group('DB')]
 	public function testGetUserKeysAllInts(): void {
 		$config = $this->getConfig();
 
@@ -358,6 +367,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
 	}
 
+	#[Group('DB')]
 	public function testGetUserValueDefault(): void {
 		$config = $this->getConfig();
 
@@ -366,6 +376,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals('foobar', $config->getUserValue('userGetUnset', 'appGetUnset', 'keyGetUnset', 'foobar'));
 	}
 
+	#[Group('DB')]
 	public function testGetUserValueForUsers(): void {
 		$config = $this->getConfig();
 
@@ -407,6 +418,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
 	}
 
+	#[Group('DB')]
 	public function testDeleteAllUserValues(): void {
 		$config = $this->getConfig();
 
@@ -441,6 +453,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
 	}
 
+	#[Group('DB')]
 	public function testDeleteAppFromAllUsers(): void {
 		$config = $this->getConfig();
 
@@ -484,6 +497,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
 	}
 
+	#[Group('DB')]
 	public function testGetUsersForUserValue(): void {
 		// mock the check for the database to run the correct SQL statements for each database type
 		$systemConfig = $this->getMockBuilder('\OC\SystemConfig')

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -544,6 +544,7 @@ class AppManagerTest extends TestCase {
 		$this->assertTrue($this->manager->isEnabledForUser('test'));
 	}
 
+	#[Group('DB')]
 	public function testGetEnabledApps(): void {
 		$this->appConfig->setValue('test1', 'enabled', 'yes');
 		$this->appConfig->setValue('test2', 'enabled', 'no');

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -22,7 +22,6 @@ use OCP\IConfig;
 use OCP\IRequestId;
 use PHPUnit\Framework\MockObject\MockObject;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DIContainerTest extends \Test\TestCase {
 	private DIContainer&MockObject $container;
 

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -76,7 +76,6 @@ class TestController extends Controller {
  *
  * @package Test\AppFramework\Http
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DispatcherTest extends \Test\TestCase {
 	/** @var MiddlewareDispatcher */
 	private $middlewareDispatcher;

--- a/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
@@ -23,12 +23,12 @@ use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\AppFramework\Middleware\Security\Mock\RateLimitingMiddlewareController;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RateLimitingMiddlewareTest extends TestCase {
 	private IRequest|MockObject $request;
 	private IUserSession|MockObject $userSession;
@@ -275,6 +275,7 @@ class RateLimitingMiddlewareTest extends TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+	#[Group('DB')]
 	public function testAfterExceptionWithHtmlBody(): void {
 		$controller = new RateLimitingMiddlewareController('test', $this->request);
 		$this->request

--- a/tests/lib/AppScriptSortTest.php
+++ b/tests/lib/AppScriptSortTest.php
@@ -17,7 +17,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package Test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppScriptSortTest extends \Test\TestCase {
 	private $logger;
 

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -29,7 +29,6 @@ use Psr\Log\LoggerInterface;
 /**
  * Class AppTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class AppTest extends \Test\TestCase {
 	public const TEST_USER1 = 'user1';
 	public const TEST_USER2 = 'user2';

--- a/tests/lib/BinaryFinderTest.php
+++ b/tests/lib/BinaryFinderTest.php
@@ -23,6 +23,8 @@ class BinaryFinderTest extends TestCase {
 
 	#[\Override]
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->oldEnv = getenv('PATH');
 		// BinaryFinder always includes the "PATH" environment variable into the search path,
 		// which we want to avoid in this test because they are not usually found in webserver
@@ -36,6 +38,7 @@ class BinaryFinderTest extends TestCase {
 	#[\Override]
 	protected function tearDown(): void {
 		putenv('PATH=' . $this->oldEnv);
+		parent::tearDown();
 	}
 
 	public function testDefaultFindsCat() {

--- a/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
+++ b/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
@@ -17,6 +17,9 @@ use OCP\Calendar\Resource\IBackend;
 use OCP\Calendar\Resource\IManager as IResourceManager;
 use OCP\Calendar\Resource\IResource;
 use OCP\Calendar\Room\IManager as IRoomManager;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Test\TestCase;
@@ -24,6 +27,7 @@ use Test\TestCase;
 interface tmpI extends IResource, IMetadataProvider {
 }
 
+#[Group('DB')]
 class ResourcesRoomsUpdaterTest extends TestCase {
 	private ResourcesRoomsUpdater $updater;
 
@@ -56,14 +60,14 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 
 		$this->updater = new ResourcesRoomsUpdater(
 			$this->container,
-			self::$realDatabase,
+			Server::get(IDBConnection::class),
 			$this->calDavBackend
 		);
 	}
 
 	#[\Override]
 	protected function tearDown(): void {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('calendar_resources')->executeStatement();
 		$query->delete('calendar_resources_md')->executeStatement();
 		$query->delete('calendar_rooms')->executeStatement();
@@ -209,7 +213,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 		$this->updater->updateResources();
 		$this->updater->updateRooms();
 
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->select('*')->from('calendar_resources');
 
 		$rows = [];
@@ -280,7 +284,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 			],
 		], $rows);
 
-		$query2 = self::$realDatabase->getQueryBuilder();
+		$query2 = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query2->select('*')->from('calendar_resources_md');
 
 		$rows2 = [];
@@ -335,7 +339,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 	}
 
 	protected function createTestResourcesInCache() {
-		$query = self::$realDatabase->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->insert('calendar_resources')
 			->values([
 				'backend_id' => $query->createNamedParameter('backend1'),

--- a/tests/lib/Command/BackgroundModeTest.php
+++ b/tests/lib/Command/BackgroundModeTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class BackgroundModeTest extends TestCase {
 	private IAppConfig $appConfig;
 

--- a/tests/lib/Command/CronBusTest.php
+++ b/tests/lib/Command/CronBusTest.php
@@ -11,7 +11,6 @@ use OC\Command\CronBus;
 use OCP\BackgroundJob\IJobList;
 use Test\BackgroundJob\DummyJobList;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CronBusTest extends AsyncBusTestCase {
 	/**
 	 * @var IJobList

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -36,7 +36,6 @@ use Test\TestCase;
 /**
  * Class ManagerTest
  */
-#[Group(name: 'DB')]
 class ManagerTest extends TestCase {
 	private IDBConnection $connection;
 	private IRootFolder&MockObject $rootFolder;
@@ -99,6 +98,7 @@ class ManagerTest extends TestCase {
 		);
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetCommentNotFound(): void {
 		$this->expectException(NotFoundException::class);
 
@@ -113,6 +113,7 @@ class ManagerTest extends TestCase {
 		$manager->get('unexisting22');
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetComment(): void {
 		$manager = $this->getManager();
 
@@ -159,6 +160,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals(['last_edit_actor_id' => 'admin'], $comment->getMetaData());
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetTreeNotFound(): void {
 		$this->expectException(NotFoundException::class);
 
@@ -173,6 +175,7 @@ class ManagerTest extends TestCase {
 		$manager->getTree('unexisting22');
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetTree(): void {
 		$headId = $this->addDatabaseEntry('0', '0');
 
@@ -199,6 +202,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetTreeNoReplies(): void {
 		$id = $this->addDatabaseEntry('0', '0');
 
@@ -213,6 +217,7 @@ class ManagerTest extends TestCase {
 		$this->assertCount(0, $tree['replies']);
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetTreeWithLimitAndOffset(): void {
 		$headId = $this->addDatabaseEntry('0', '0');
 
@@ -243,6 +248,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetForObject(): void {
 		$this->addDatabaseEntry('0', '0');
 
@@ -255,6 +261,7 @@ class ManagerTest extends TestCase {
 		$this->assertSame('nice one', $comments[0]->getMessage());
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetForObjectWithLimitAndOffset(): void {
 		$this->addDatabaseEntry('0', '0', new \DateTime('-6 hours'));
 		$this->addDatabaseEntry('0', '0', new \DateTime('-5 hours'));
@@ -280,6 +287,7 @@ class ManagerTest extends TestCase {
 		} while (count($comments) > 0);
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetForObjectWithDateTimeConstraint(): void {
 		$this->addDatabaseEntry('0', '0', new \DateTime('-6 hours'));
 		$this->addDatabaseEntry('0', '0', new \DateTime('-5 hours'));
@@ -294,6 +302,7 @@ class ManagerTest extends TestCase {
 		$this->assertSame($id1, $comments[1]->getId());
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetForObjectWithLimitAndOffsetAndDateTimeConstraint(): void {
 		$this->addDatabaseEntry('0', '0', new \DateTime('-7 hours'));
 		$this->addDatabaseEntry('0', '0', new \DateTime('-6 hours'));
@@ -320,6 +329,7 @@ class ManagerTest extends TestCase {
 		} while (count($comments) > 0);
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetNumberOfCommentsForObject(): void {
 		for ($i = 1; $i < 5; $i++) {
 			$this->addDatabaseEntry('0', '0');
@@ -334,6 +344,7 @@ class ManagerTest extends TestCase {
 		$this->assertSame(4, $amount);
 	}
 
+	#[Group(name: 'DB')]
 	public function testGetNumberOfUnreadCommentsForFolder(): void {
 		$folder = $this->createMock(Folder::class);
 		$fileIds = range(1111, 1114);
@@ -377,6 +388,7 @@ class ManagerTest extends TestCase {
 		], $amount);
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'dataGetForObjectSince')]
 	public function testGetForObjectSince(?int $lastKnown, string $order, int $limit, int $resultFrom, int $resultTo): void {
 		$ids = [];
@@ -445,6 +457,7 @@ class ManagerTest extends TestCase {
 		$this->assertSame($objectId, $comment->getObjectId());
 	}
 
+	#[Group(name: 'DB')]
 	public function testDelete(): void {
 		$this->expectException(NotFoundException::class);
 
@@ -467,6 +480,7 @@ class ManagerTest extends TestCase {
 		$manager->get($id);
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'providerTestSave')]
 	public function testSave(string $message, string $actorId, string $verb, ?string $parentId, ?string $id = ''): IComment {
 		$manager = $this->getManager();
@@ -499,6 +513,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
+	#[Group(name: 'DB')]
 	public function testSaveUpdate(): void {
 		$manager = $this->getManager();
 		$comment = new Comment();
@@ -543,6 +558,7 @@ class ManagerTest extends TestCase {
 		);
 	}
 
+	#[Group(name: 'DB')]
 	public function testSaveUpdateException(): void {
 		$manager = $this->getManager();
 		$comment = new Comment();
@@ -571,6 +587,7 @@ class ManagerTest extends TestCase {
 		$manager->save($comment);
 	}
 
+	#[Group(name: 'DB')]
 	public function testSaveAsChild(): void {
 		$id = $this->addDatabaseEntry('0', '0');
 
@@ -613,6 +630,7 @@ class ManagerTest extends TestCase {
 		$manager->deleteReferencesOfActor($type, $id);
 	}
 
+	#[Group(name: 'DB')]
 	public function testDeleteReferencesOfActor(): void {
 		$ids = [];
 		$ids[] = $this->addDatabaseEntry('0', '0');
@@ -641,6 +659,7 @@ class ManagerTest extends TestCase {
 		$this->assertTrue($wasSuccessful);
 	}
 
+	#[Group(name: 'DB')]
 	public function testDeleteReferencesOfActorWithUserManagement(): void {
 		$user = Server::get(IUserManager::class)->createUser('xenia', 'NotAnEasyPassword123456+');
 		$this->assertInstanceOf(IUser::class, $user);
@@ -678,6 +697,7 @@ class ManagerTest extends TestCase {
 		$manager->deleteCommentsAtObject($type, $id);
 	}
 
+	#[Group(name: 'DB')]
 	public function testDeleteCommentsAtObject(): void {
 		$ids = [];
 		$ids[] = $this->addDatabaseEntry('0', '0');
@@ -710,6 +730,7 @@ class ManagerTest extends TestCase {
 		$this->assertTrue($wasSuccessful);
 	}
 
+	#[Group(name: 'DB')]
 	public function testDeleteCommentsExpiredAtObjectTypeAndId(): void {
 		$ids = [];
 		$ids[] = $this->addDatabaseEntry('0', '0', null, null, null, new \DateTime('+2 hours'));
@@ -758,6 +779,7 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($deleted);
 	}
 
+	#[Group(name: 'DB')]
 	public function testDeleteCommentsExpiredAtObjectType(): void {
 		$ids = [];
 		$ids[] = $this->addDatabaseEntry('0', '0', null, null, 'file1', new \DateTime('-2 hours'));
@@ -801,6 +823,7 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($deleted);
 	}
 
+	#[Group(name: 'DB')]
 	public function testSetMarkRead(): void {
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
@@ -818,6 +841,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($dateTimeSet->getTimestamp(), $dateTimeGet->getTimestamp());
 	}
 
+	#[Group(name: 'DB')]
 	public function testSetMarkReadUpdate(): void {
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
@@ -838,6 +862,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($dateTimeSet, $dateTimeGet);
 	}
 
+	#[Group(name: 'DB')]
 	public function testReadMarkDeleteUser(): void {
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
@@ -855,6 +880,7 @@ class ManagerTest extends TestCase {
 		$this->assertNull($dateTimeGet);
 	}
 
+	#[Group(name: 'DB')]
 	public function testReadMarkDeleteObject(): void {
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
@@ -872,6 +898,7 @@ class ManagerTest extends TestCase {
 		$this->assertNull($dateTimeGet);
 	}
 
+	#[Group(name: 'DB')]
 	public function testSendEvent(): void {
 		/** @psalm-suppress DeprecatedInterface Test for deprecated interface */
 		$handler1 = $this->createMock(ICommentsEventHandler::class);
@@ -961,6 +988,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'providerTestReactionAddAndDelete')]
 	public function testReactionAddAndDelete(array $comments, array $reactionsExpected): void {
 		$this->skipIfNotSupport4ByteUTF();
@@ -1046,6 +1074,7 @@ class ManagerTest extends TestCase {
 		return $comments;
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'providerTestRetrieveAllReactions')]
 	public function testRetrieveAllReactions(array $comments, array $expected): void {
 		$this->skipIfNotSupport4ByteUTF();
@@ -1169,6 +1198,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'providerTestRetrieveAllReactionsWithSpecificReaction')]
 	public function testRetrieveAllReactionsWithSpecificReaction(array $comments, string $reaction, array $expected): void {
 		$this->skipIfNotSupport4ByteUTF();
@@ -1222,6 +1252,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'providerTestGetReactionComment')]
 	public function testGetReactionComment(array $comments, array $expected, bool $notFound): void {
 		$this->skipIfNotSupport4ByteUTF();
@@ -1289,6 +1320,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'providerTestReactionMessageSize')]
 	public function testReactionMessageSize(string $reactionString, bool $valid): void {
 		$this->skipIfNotSupport4ByteUTF();
@@ -1318,6 +1350,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
+	#[Group(name: 'DB')]
 	#[DataProvider(methodName: 'providerTestReactionsSummarizeOrdered')]
 	public function testReactionsSummarizeOrdered(array $comments, array $expected, bool $isFullMatch): void {
 		$this->skipIfNotSupport4ByteUTF();

--- a/tests/lib/Config/LexiconTest.php
+++ b/tests/lib/Config/LexiconTest.php
@@ -19,6 +19,7 @@ use OCP\Exceptions\AppConfigTypeConflictException;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 use OCP\IAppConfig;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
 /**
@@ -27,7 +28,6 @@ use Test\TestCase;
  *
  * @package Test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LexiconTest extends TestCase {
 	/** @var AppConfig */
 	private IAppConfig $appConfig;
@@ -70,6 +70,7 @@ class LexiconTest extends TestCase {
 		$this->userConfig->deleteApp(TestLexicon_UserIndexedRemove::APPID);
 	}
 
+	#[Group('DB')]
 	public function testAppLexiconSetCorrect() {
 		$this->assertSame(true, $this->appConfig->setValueString(TestLexicon_E::APPID, 'key1', 'new_value'));
 		$this->assertSame(true, $this->appConfig->isLazy(TestLexicon_E::APPID, 'key1'));
@@ -77,6 +78,7 @@ class LexiconTest extends TestCase {
 		$this->appConfig->deleteKey(TestLexicon_E::APPID, 'key1');
 	}
 
+	#[Group('DB')]
 	public function testAppLexiconGetCorrect() {
 		$this->assertSame('abcde', $this->appConfig->getValueString(TestLexicon_E::APPID, 'key1', 'default'));
 	}
@@ -91,11 +93,13 @@ class LexiconTest extends TestCase {
 		$this->appConfig->getValueInt(TestLexicon_E::APPID, 'key1');
 	}
 
+	#[Group('DB')]
 	public function testAppLexiconIgnore() {
 		$this->appConfig->setValueString(TestConfigLexicon_I::APPID, 'key_ignore', 'new_value');
 		$this->assertSame('new_value', $this->appConfig->getValueString(TestConfigLexicon_I::APPID, 'key_ignore', ''));
 	}
 
+	#[Group('DB')]
 	public function testAppLexiconNotice() {
 		$this->appConfig->setValueString(TestLexicon_N::APPID, 'key_notice', 'new_value');
 		$this->assertSame('new_value', $this->appConfig->getValueString(TestLexicon_N::APPID, 'key_notice', ''));
@@ -117,6 +121,7 @@ class LexiconTest extends TestCase {
 		$this->appConfig->getValueString(TestLexicon_E::APPID, 'key_exception');
 	}
 
+	#[Group('DB')]
 	public function testUserLexiconSetCorrect() {
 		$this->assertSame(true, $this->userConfig->setValueString('user1', TestLexicon_E::APPID, 'key1', 'new_value'));
 		$this->assertSame(true, $this->userConfig->isLazy('user1', TestLexicon_E::APPID, 'key1'));
@@ -124,6 +129,7 @@ class LexiconTest extends TestCase {
 		$this->userConfig->deleteKey(TestLexicon_E::APPID, 'key1');
 	}
 
+	#[Group('DB')]
 	public function testUserLexiconGetCorrect() {
 		$this->assertSame('abcde', $this->userConfig->getValueString('user1', TestLexicon_E::APPID, 'key1', 'default'));
 	}
@@ -138,11 +144,13 @@ class LexiconTest extends TestCase {
 		$this->userConfig->getValueInt('user1', TestLexicon_E::APPID, 'key1');
 	}
 
+	#[Group('DB')]
 	public function testUserLexiconIgnore() {
 		$this->userConfig->setValueString('user1', TestConfigLexicon_I::APPID, 'key_ignore', 'new_value');
 		$this->assertSame('new_value', $this->userConfig->getValueString('user1', TestConfigLexicon_I::APPID, 'key_ignore', ''));
 	}
 
+	#[Group('DB')]
 	public function testUserLexiconNotice() {
 		$this->userConfig->setValueString('user1', TestLexicon_N::APPID, 'key_notice', 'new_value');
 		$this->assertSame('new_value', $this->userConfig->getValueString('user1', TestLexicon_N::APPID, 'key_notice', ''));
@@ -164,12 +172,14 @@ class LexiconTest extends TestCase {
 		$this->userConfig->getValueString('user1', TestLexicon_E::APPID, 'key_exception');
 	}
 
+	#[Group('DB')]
 	public function testAppConfigLexiconRenameSetNewValue() {
 		$this->assertSame(12345, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'key3', 123));
 		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'old_key3', 994);
 		$this->assertSame(994, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'key3', 123));
 	}
 
+	#[Group('DB')]
 	public function testAppConfigLexiconRenameSetOldValuePreMigration() {
 		$this->appConfig->ignoreLexiconAliases(true);
 		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'old_key3', 993);
@@ -177,6 +187,7 @@ class LexiconTest extends TestCase {
 		$this->assertSame(12345, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'key3', 123));
 	}
 
+	#[Group('DB')]
 	public function testAppConfigLexiconRenameSetOldValuePostMigration() {
 		$this->appConfig->ignoreLexiconAliases(true);
 		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'old_key3', 994);
@@ -185,11 +196,13 @@ class LexiconTest extends TestCase {
 		$this->assertSame(994, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'key3', 123));
 	}
 
+	#[Group('DB')]
 	public function testAppConfigLexiconRenameGetNewValue() {
 		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'key3', 981);
 		$this->assertSame(981, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'old_key3', 123));
 	}
 
+	#[Group('DB')]
 	public function testAppConfigLexiconRenameGetOldValuePreMigration() {
 		$this->appConfig->ignoreLexiconAliases(true);
 		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'key3', 984);
@@ -197,6 +210,7 @@ class LexiconTest extends TestCase {
 		$this->appConfig->ignoreLexiconAliases(false);
 	}
 
+	#[Group('DB')]
 	public function testAppConfigLexiconRenameGetOldValuePostMigration() {
 		$this->appConfig->ignoreLexiconAliases(true);
 		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'key3', 987);
@@ -205,6 +219,7 @@ class LexiconTest extends TestCase {
 		$this->assertSame(987, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'old_key3', 123));
 	}
 
+	#[Group('DB')]
 	public function testAppConfigLexiconRenameInvertBoolean() {
 		$this->appConfig->ignoreLexiconAliases(true);
 		$this->appConfig->setValueBool(TestConfigLexicon_I::APPID, 'old_key4', true);
@@ -214,6 +229,7 @@ class LexiconTest extends TestCase {
 		$this->assertSame(false, $this->appConfig->getValueBool(TestConfigLexicon_I::APPID, 'key4'));
 	}
 
+	#[Group('DB')]
 	public function testLexiconIndexedUpdate() {
 		$this->userConfig->setValueString('user1', TestLexicon_UserIndexed::APPID, 'key1', 'abcd');
 		$this->userConfig->setValueString('user2', TestLexicon_UserIndexed::APPID, 'key1', '1234', flags: 64);
@@ -237,6 +253,7 @@ class LexiconTest extends TestCase {
 		$this->assertSame(66, $this->userConfig->getValueFlags('user4', TestLexicon_UserIndexed::APPID, 'key1'));
 	}
 
+	#[Group('DB')]
 	public function testLexiconIndexedUpdateRemove() {
 		$this->userConfig->setValueString('user1', TestLexicon_UserIndexedRemove::APPID, 'key1', 'abcd');
 		$this->userConfig->setValueString('user2', TestLexicon_UserIndexedRemove::APPID, 'key1', '1234', flags: 64);

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -17,7 +17,6 @@ use OC\DB\Adapter;
 use OC\DB\Connection;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ConnectionTest extends TestCase {
 
 	public function testSingleNodeConnectsToPrimaryOnly(): void {

--- a/tests/lib/DB/Middleware/UtcTimezoneMiddlewareDriverTest.php
+++ b/tests/lib/DB/Middleware/UtcTimezoneMiddlewareDriverTest.php
@@ -14,14 +14,12 @@ use OC\DB\ConnectionFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Server;
-use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
 /**
  * We cannot test the actual driver here,
  * but we can at least test that it does what we want.
  */
-#[Group('DB')]
 final class UtcTimezoneMiddlewareDriverTest extends TestCase {
 	private ?Connection $connection = null;
 

--- a/tests/lib/DB/OCPostgreSqlPlatformTest.php
+++ b/tests/lib/DB/OCPostgreSqlPlatformTest.php
@@ -22,7 +22,6 @@ use Doctrine\DBAL\Types\Types;
  *
  * @package Test\DB
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class OCPostgreSqlPlatformTest extends \Test\TestCase {
 	public function testAlterBigint(): void {
 		$platform = new PostgreSQLPlatform();

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -29,7 +29,6 @@ use Test\TestCase;
  *
  * @package Test\DB\QueryBuilder
  */
-#[Group('DB')]
 class ExpressionBuilderTest extends TestCase {
 	protected ExpressionBuilder $expressionBuilder;
 	protected DoctrineExpressionBuilder $doctrineExpressionBuilder;
@@ -301,6 +300,7 @@ class ExpressionBuilderTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[DataProvider('dataClobComparisons')]
 	public function testClobComparisons(string $function, string|array $value, int $type, bool $compareKeyToValue, int $expected): void {
 		$appId = $this->getUniqueID('testing');

--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -22,6 +22,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Server;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -31,7 +32,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package Test\DB\QueryBuilder
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class QueryBuilderTest extends \Test\TestCase {
 	private SystemConfig&MockObject $config;
 	private LoggerInterface&MockObject $logger;
@@ -103,6 +103,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param int|null $firstResult
 	 * @param array $expectedSet
 	 */
+	#[Group('DB')]
 	#[DataProvider('dataFirstResult')]
 	public function testFirstResult($firstResult, $expectedSet): void {
 		$this->deleteTestingRows();
@@ -140,6 +141,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param int $maxResult
 	 * @param array $expectedSet
 	 */
+	#[Group('DB')]
 	#[DataProvider('dataMaxResults')]
 	public function testMaxResults($maxResult, $expectedSet): void {
 		$this->deleteTestingRows();
@@ -184,6 +186,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[DataProvider('dataSelect')]
 	public function testSelect(array $selectArguments, array $expected, string $expectedLiteral = ''): void {
 		$this->deleteTestingRows();
@@ -233,6 +236,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[DataProvider('dataSelectAlias')]
 	public function testSelectAlias(string $select, string $alias, array $expected): void {
 		if (str_starts_with($select, 'l::')) {
@@ -264,6 +268,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		$this->deleteTestingRows();
 	}
 
+	#[Group('DB')]
 	public function testSelectDistinct(): void {
 		$this->deleteTestingRows('testFirstResult1');
 		$this->deleteTestingRows('testFirstResult2');
@@ -292,6 +297,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		$this->deleteTestingRows('testFirstResult2');
 	}
 
+	#[Group('DB')]
 	public function testSelectDistinctMultiple(): void {
 		$this->deleteTestingRows('testFirstResult1');
 		$this->deleteTestingRows('testFirstResult2');
@@ -352,6 +358,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[DataProvider('dataAddSelect')]
 	public function testAddSelect(array $selectArguments, array $expected, string $expectedLiteral = ''): void {
 		$this->deleteTestingRows();
@@ -1144,6 +1151,7 @@ class QueryBuilderTest extends \Test\TestCase {
 		);
 	}
 
+	#[Group('DB')]
 	public function testGetLastInsertId(): void {
 		$qB = $this->connection->getQueryBuilder();
 

--- a/tests/lib/DateTimeFormatterTest.php
+++ b/tests/lib/DateTimeFormatterTest.php
@@ -10,6 +10,7 @@ namespace Test;
 
 use OC\DateTimeFormatter;
 use OCP\Util;
+use PHPUnit\Framework\Attributes\Group;
 
 class DateTimeFormatterTest extends TestCase {
 	protected DateTimeFormatter $formatter;
@@ -79,6 +80,7 @@ class DateTimeFormatterTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('formatTimeSpanData')]
 	public function testFormatTimeSpan($expected, $timestamp, $compare, $locale = null): void {
 		$this->assertEquals((string)$expected, (string)$this->formatter->formatTimeSpan($timestamp, $compare, $locale));

--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -25,6 +25,7 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -94,7 +95,6 @@ class Editor implements IEditor {
  *
  * @package Test\DirectEditing
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ManagerTest extends TestCase {
 	private $manager;
 	/**
@@ -172,6 +172,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($this->manager->getEditors(), ['testeditor' => $this->editor]);
 	}
 
+	#[Group('DB')]
 	public function testCreateToken(): void {
 		$expectedToken = 'TOKEN' . time();
 		$file = $this->createMock(File::class);
@@ -199,6 +200,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($token, $expectedToken);
 	}
 
+	#[Group('DB')]
 	public function testCreateTokenAccess(): void {
 		$expectedToken = 'TOKEN' . time();
 		$file = $this->createMock(File::class);
@@ -229,6 +231,7 @@ class ManagerTest extends TestCase {
 		$this->assertInstanceOf(NotFoundResponse::class, $secondResult);
 	}
 
+	#[Group('DB')]
 	public function testOpenByPath(): void {
 		$expectedToken = 'TOKEN' . time();
 		$file = $this->createMock(File::class);
@@ -261,6 +264,7 @@ class ManagerTest extends TestCase {
 		$this->assertInstanceOf(NotFoundResponse::class, $secondResult);
 	}
 
+	#[Group('DB')]
 	public function testOpenById(): void {
 		$expectedToken = 'TOKEN' . time();
 		$fileRead = $this->createMock(File::class);

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -18,6 +18,7 @@ use OC\Files\View;
 use OCP\Files\Storage\IStorage;
 use OCP\IUserManager;
 use OCP\UserInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -31,7 +32,6 @@ use Test\TestCase;
  *
  * @package Test\Encryption
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DecryptAllTest extends TestCase {
 	private IUserManager&MockObject $userManager;
 	private Manager&MockObject $encryptionManager;
@@ -220,6 +220,7 @@ class DecryptAllTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	public function testDecryptUsersFiles(): void {
 		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject  $instance */
 		$instance = $this->getMockBuilder('OC\Encryption\DecryptAll')

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -19,7 +19,6 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CloudIdManagerTest extends TestCase {
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;

--- a/tests/lib/Federation/CloudIdTest.php
+++ b/tests/lib/Federation/CloudIdTest.php
@@ -15,7 +15,6 @@ use OCP\Federation\ICloudIdManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CloudIdTest extends TestCase {
 	protected CloudIdManager&MockObject $cloudIdManager;
 

--- a/tests/lib/Files/Cache/WatcherTest.php
+++ b/tests/lib/Files/Cache/WatcherTest.php
@@ -22,7 +22,6 @@ use PHPUnit\Framework\Attributes\Medium;
 use Test\TestCase;
 
 #[Medium]
-#[Group(name: 'DB')]
 class WatcherTest extends TestCase {
 	/**
 	 * @var Storage[] $storages
@@ -48,6 +47,7 @@ class WatcherTest extends TestCase {
 		parent::tearDown();
 	}
 
+	#[Group('DB')]
 	public function testWatcher(): void {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
@@ -86,6 +86,7 @@ class WatcherTest extends TestCase {
 		$this->assertFalse($cache->inCache('folder/bar2.txt'));
 	}
 
+	#[Group('DB')]
 	public function testFileToFolder(): void {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
@@ -121,6 +122,7 @@ class WatcherTest extends TestCase {
 		$this->assertTrue($cache->inCache('foo.txt/bar.txt'));
 	}
 
+	#[Group('DB')]
 	public function testPolicyNever(): void {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
@@ -139,6 +141,7 @@ class WatcherTest extends TestCase {
 		$this->assertFalse($updater->checkUpdate('foo.txt'));
 	}
 
+	#[Group('DB')]
 	public function testPolicyOnce(): void {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
@@ -157,6 +160,7 @@ class WatcherTest extends TestCase {
 		$this->assertFalse($updater->checkUpdate('foo.txt'));
 	}
 
+	#[Group('DB')]
 	public function testPolicyAlways(): void {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -24,6 +24,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 class DummyMountProvider implements IMountProvider {
 	/**
@@ -53,7 +54,6 @@ class DummyMountProvider implements IMountProvider {
  *
  * @package Test\Files
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FilesystemTest extends \Test\TestCase {
 	public const TEST_FILESYSTEM_USER1 = 'test-filesystem-user1';
 	public const TEST_FILESYSTEM_USER2 = 'test-filesystem-user1';
@@ -93,6 +93,7 @@ class FilesystemTest extends \Test\TestCase {
 		parent::tearDown();
 	}
 
+	#[Group('DB')]
 	public function testMount(): void {
 		Filesystem::mount('\OC\Files\Storage\Local', self::getStorageData(), '/');
 		$this->assertEquals('/', Filesystem::getMountPoint('/'));
@@ -294,6 +295,7 @@ class FilesystemTest extends \Test\TestCase {
 		$this->assertEquals("/foo/bar\xC3\xBC", Filesystem::normalizePath("\\foo\\baru\xCC\x88"));
 	}
 
+	#[Group('DB')]
 	public function testHooks(): void {
 		if (Filesystem::getView()) {
 			$user = \OC_User::getUser();
@@ -329,6 +331,7 @@ class FilesystemTest extends \Test\TestCase {
 	 * Tests that an exception is thrown when passed user does not exist.
 	 *
 	 */
+	#[Group('DB')]
 	public function testLocalMountWhenUserDoesNotExist(): void {
 		$this->expectException(NoUserException::class);
 
@@ -361,6 +364,7 @@ class FilesystemTest extends \Test\TestCase {
 	/**
 	 * Tests that an exception is thrown when passed user does not exist.
 	 */
+	#[Group('DB')]
 	public function testLocalMountWhenUserDoesNotExistTwice(): void {
 		$thrown = 0;
 		$userId = $this->getUniqueID('user_');
@@ -383,6 +387,7 @@ class FilesystemTest extends \Test\TestCase {
 	/**
 	 * Tests that the home storage is used for the user's mount point
 	 */
+	#[Group('DB')]
 	public function testHomeMount(): void {
 		$userId = $this->getUniqueID('user_');
 
@@ -413,6 +418,7 @@ class FilesystemTest extends \Test\TestCase {
 	/**
 	 * Test that the default cache dir is part of the user's home
 	 */
+	#[Group('DB')]
 	public function testMountDefaultCacheDir(): void {
 		$userId = $this->getUniqueID('user_');
 		$config = Server::get(IConfig::class);
@@ -442,6 +448,7 @@ class FilesystemTest extends \Test\TestCase {
 	 * Test that an external cache is mounted into
 	 * the user's home
 	 */
+	#[Group('DB')]
 	public function testMountExternalCacheDir(): void {
 		$userId = $this->getUniqueID('user_');
 
@@ -469,6 +476,7 @@ class FilesystemTest extends \Test\TestCase {
 		$config->setSystemValue('cache_path', $oldCachePath);
 	}
 
+	#[Group('DB')]
 	public function testRegisterMountProviderAfterSetup(): void {
 		Filesystem::initMountPoints(self::TEST_FILESYSTEM_USER2);
 		$this->assertEquals('/', Filesystem::getMountPoint('/foo/bar'));

--- a/tests/lib/Files/Mount/CacheMountProviderTest.php
+++ b/tests/lib/Files/Mount/CacheMountProviderTest.php
@@ -14,7 +14,6 @@ use OC\Files\Storage\StorageFactory;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\IUser;
-use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
 class CacheMountProviderTestStream {
@@ -34,7 +33,6 @@ class CacheMountProviderTestStream {
 	}
 }
 
-#[Group('DB')]
 class CacheMountProviderTest extends TestCase {
 	private IConfig $config;
 	private IUser $user;

--- a/tests/lib/Files/Mount/CacheMountProviderTest.php
+++ b/tests/lib/Files/Mount/CacheMountProviderTest.php
@@ -14,6 +14,7 @@ use OC\Files\Storage\StorageFactory;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\IUser;
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
 class CacheMountProviderTestStream {
@@ -33,6 +34,7 @@ class CacheMountProviderTestStream {
 	}
 }
 
+#[Group('DB')]
 class CacheMountProviderTest extends TestCase {
 	private IConfig $config;
 	private IUser $user;
@@ -40,6 +42,8 @@ class CacheMountProviderTest extends TestCase {
 
 	#[\Override]
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->config = $this->createMock(IConfig::class);
 		$this->user = $this->createMock(IUser::class);
 		$this->storageFactory = new StorageFactory();
@@ -49,6 +53,8 @@ class CacheMountProviderTest extends TestCase {
 	#[\Override]
 	protected function tearDown(): void {
 		stream_wrapper_unregister('cachemountprovidertest');
+
+		parent::tearDown();
 	}
 
 	public function testGetMountsForUser(): void {

--- a/tests/lib/Files/Mount/RootMountProviderTest.php
+++ b/tests/lib/Files/Mount/RootMountProviderTest.php
@@ -18,7 +18,6 @@ use OCP\App\IAppManager;
 use OCP\IConfig;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RootMountProviderTest extends TestCase {
 	private StorageFactory $loader;
 

--- a/tests/lib/Files/Node/FileTest.php
+++ b/tests/lib/Files/Node/FileTest.php
@@ -24,7 +24,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package Test\Files\Node
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FileTest extends NodeTestCase {
 	#[\Override]
 	protected function createTestNode(IRootFolder $root, View&MockObject $view, string $path, array $data = [], string $internalPath = '', ?IStorage $storage = null): File {

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -40,6 +40,7 @@ use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOrder;
 use OCP\Files\Storage\IStorage;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -48,7 +49,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package Test\Files\Node
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class FolderTest extends NodeTestCase {
 	#[\Override]
 	protected function createTestNode(IRootFolder $root, View&MockObject $view, string $path, array $data = [], string $internalPath = '', ?IStorage $storage = null): Folder {
@@ -293,6 +293,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertEquals(100, $node->getFreeSpace());
 	}
 
+	#[Group('DB')]
 	public function testSearch(): void {
 		$manager = $this->createMock(Manager::class);
 		$view = $this->getRootViewMock();
@@ -340,6 +341,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
 	}
 
+	#[Group('DB')]
 	public function testSearchInRoot(): void {
 		$manager = $this->createMock(Manager::class);
 		$view = $this->getRootViewMock();
@@ -383,6 +385,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertEquals('/foo', $result[0]->getPath());
 	}
 
+	#[Group('DB')]
 	public function testSearchInStorageRoot(): void {
 		$manager = $this->createMock(Manager::class);
 		$view = $this->getRootViewMock();
@@ -425,6 +428,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
 	}
 
+	#[Group('DB')]
 	public function testSearchSubStorages(): void {
 		$manager = $this->createMock(Manager::class);
 		$view = $this->getRootViewMock();
@@ -498,6 +502,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertFalse($folder->isSubNode($file));
 	}
 
+	#[Group('DB')]
 	public function testGetById(): void {
 		$manager = $this->createMock(Manager::class);
 		$view = $this->getRootViewMock();
@@ -743,6 +748,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertEquals($expected, $node->getNonExistingName($name));
 	}
 
+	#[Group('DB')]
 	public function testRecent(): void {
 		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
@@ -811,6 +817,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertEquals([$id1, $id2, $id3], $ids);
 	}
 
+	#[Group('DB')]
 	public function testRecentFolder(): void {
 		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
@@ -877,6 +884,7 @@ class FolderTest extends NodeTestCase {
 		$this->assertEquals($baseTime - 100, $nodes[1]->getMTime());
 	}
 
+	#[Group('DB')]
 	public function testRecentJail(): void {
 		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
@@ -962,6 +970,7 @@ class FolderTest extends NodeTestCase {
 	 * @throws NotFoundException
 	 * @throws InvalidPathException
 	 */
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('offsetLimitProvider')]
 	public function testSearchSubStoragesLimitOffset(int $offset, int $limit, array $expectedPaths, array $ordering): void {
 		if (!$ordering) {

--- a/tests/lib/Files/ObjectStore/ObjectStoreScannerTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreScannerTest.php
@@ -12,9 +12,9 @@ use OC\Files\ObjectStore\ObjectStoreScanner;
 use OC\Files\Storage\Temporary;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Storage\IStorage;
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ObjectStoreScannerTest extends TestCase {
 	private IStorage $storage;
 	private ICache $cache;
@@ -58,6 +58,7 @@ class ObjectStoreScannerTest extends TestCase {
 		);
 	}
 
+	#[Group('DB')]
 	public function testBackgroundScan(): void {
 		$this->fillTestFolders();
 		$this->storage->mkdir('folder2');

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -20,7 +20,6 @@ use OCP\Server;
  *
  * @package Test\Files
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PathVerificationTest extends \Test\TestCase {
 	/**
 	 * @var View

--- a/tests/lib/Files/SetupManagerTest.php
+++ b/tests/lib/Files/SetupManagerTest.php
@@ -55,6 +55,8 @@ class SetupManagerTest extends TestCase {
 
 	#[\Override]
 	protected function setUp(): void {
+		parent::setUp();
+
 		$eventLogger = $this->createMock(IEventLogger::class);
 		$eventLogger->method('start');
 		$eventLogger->method('end');

--- a/tests/lib/Files/Storage/CommonTest.php
+++ b/tests/lib/Files/Storage/CommonTest.php
@@ -16,6 +16,7 @@ use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidPathException;
 use OCP\ITempManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -24,7 +25,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  *
  * @package Test\Files\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CommonTest extends Storage {
 
 	private string $tmpDir;
@@ -137,5 +137,10 @@ class CommonTest extends Storage {
 		$instance->file_put_contents('foo/bar/foo.txt', 'bar');
 		$instance->moveFromStorage($source, 'foo.txt', 'bar.txt');
 		$this->assertTrue($instance->file_exists('bar.txt'));
+	}
+
+	#[Group('DB')]
+	public function testCheckUpdate(): void {
+		parent::testCheckUpdate();
 	}
 }

--- a/tests/lib/Files/Storage/CopyDirectoryTest.php
+++ b/tests/lib/Files/Storage/CopyDirectoryTest.php
@@ -12,6 +12,7 @@ namespace Test\Files\Storage;
 
 use OC\Files\Storage\PolyFill\CopyDirectory;
 use OC\Files\Storage\Temporary;
+use PHPUnit\Framework\Attributes\Group;
 
 class StorageNoRecursiveCopy extends Temporary {
 	#[\Override]
@@ -33,11 +34,15 @@ class CopyDirectoryStorage extends StorageNoRecursiveCopy {
  *
  * @package Test\Files\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class CopyDirectoryTest extends Storage {
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->instance = new CopyDirectoryStorage([]);
+	}
+
+	#[Group('DB')]
+	public function testCheckUpdate(): void {
+		parent::testCheckUpdate();
 	}
 }

--- a/tests/lib/Files/Storage/HomeTest.php
+++ b/tests/lib/Files/Storage/HomeTest.php
@@ -13,6 +13,7 @@ use OC\User\User;
 use OCP\Files;
 use OCP\ITempManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 class DummyUser extends User {
 	public function __construct(
@@ -38,7 +39,6 @@ class DummyUser extends User {
  *
  * @package Test\Files\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class HomeTest extends Storage {
 	/**
 	 * @var string tmpDir
@@ -84,5 +84,10 @@ class HomeTest extends Storage {
 
 	public function testGetOwner(): void {
 		$this->assertEquals($this->userId, $this->instance->getOwner(''));
+	}
+
+	#[Group('DB')]
+	public function testCheckUpdate(): void {
+		parent::testCheckUpdate();
 	}
 }

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -15,6 +15,7 @@ use OCP\Files\ForbiddenException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\ITempManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class LocalTest
@@ -22,7 +23,6 @@ use OCP\Server;
  *
  * @package Test\Files\Storage
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class LocalTest extends Storage {
 	/**
 	 * @var string tmpDir
@@ -163,5 +163,10 @@ class LocalTest extends Storage {
 		]);
 		$jail3->moveFromStorage($jail2, 'file.txt', 'file.txt');
 		$this->assertTrue($this->instance->file_exists('target/file.txt'));
+	}
+
+	#[Group('DB')]
+	public function testCheckUpdate(): void {
+		parent::testCheckUpdate();
 	}
 }

--- a/tests/lib/Files/Storage/Wrapper/KnownMtimeTest.php
+++ b/tests/lib/Files/Storage/Wrapper/KnownMtimeTest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Clock\ClockInterface;
 use Test\Files\Storage\Storage;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class KnownMtimeTest extends Storage {
 	/** @var Temporary */
 	private $sourceStorage;

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -13,8 +13,8 @@ use OC\Files\Storage\Wrapper\PermissionsMask;
 use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\Constants;
 use OCP\Files\Cache\IScanner;
+use PHPUnit\Framework\Attributes\Group;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 	/**
 	 * @var Temporary
@@ -109,6 +109,7 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$this->assertFalse($storage->fopen('foo', 'w'));
 	}
 
+	#[Group('DB')]
 	public function testScanNewFiles(): void {
 		$storage = $this->getMaskedStorage(Constants::PERMISSION_READ + Constants::PERMISSION_CREATE);
 		$storage->file_put_contents('foo', 'bar');
@@ -118,6 +119,7 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals(Constants::PERMISSION_READ, $storage->getCache()->get('foo')->getPermissions());
 	}
 
+	#[Group('DB')]
 	public function testScanNewWrappedFiles(): void {
 		$storage = $this->getMaskedStorage(Constants::PERMISSION_READ + Constants::PERMISSION_CREATE);
 		$wrappedStorage = new Wrapper(['storage' => $storage]);
@@ -128,6 +130,7 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals(Constants::PERMISSION_READ, $storage->getCache()->get('foo')->getPermissions());
 	}
 
+	#[Group('DB')]
 	public function testScanNewFilesNested(): void {
 		$storage = $this->getMaskedStorage(Constants::PERMISSION_READ + Constants::PERMISSION_CREATE + Constants::PERMISSION_UPDATE);
 		$nestedStorage = new PermissionsMask([
@@ -143,6 +146,7 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals(Constants::PERMISSION_READ, $wrappedStorage->getCache()->get('foo')->getPermissions());
 	}
 
+	#[Group('DB')]
 	public function testScanUnchanged(): void {
 		$this->sourceStorage->mkdir('foo');
 		$this->sourceStorage->file_put_contents('foo/bar.txt', 'bar');
@@ -160,6 +164,7 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 		$this->assertFalse($called);
 	}
 
+	#[Group('DB')]
 	public function testScanUnchangedWrapped(): void {
 		$this->sourceStorage->mkdir('foo');
 		$this->sourceStorage->file_put_contents('foo/bar.txt', 'bar');

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -16,6 +16,7 @@ use OCP\Files;
 use OCP\Files\NotEnoughSpaceException;
 use OCP\ITempManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class QuotaTest
@@ -23,7 +24,6 @@ use OCP\Server;
  *
  * @package Test\Files\Storage\Wrapper
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class QuotaTest extends \Test\Files\Storage\Storage {
 	/**
 	 * @var string tmpDir
@@ -55,11 +55,13 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		return new Quota(['storage' => $storage, 'quota' => $limit]);
 	}
 
+	#[Group('DB')]
 	public function testFilePutContentsNotEnoughSpace(): void {
 		$instance = $this->getLimitedStorage(3);
 		$this->assertFalse($instance->file_put_contents('files/foo', 'foobar'));
 	}
 
+	#[Group('DB')]
 	public function testCopyNotEnoughSpace(): void {
 		$instance = $this->getLimitedStorage(9);
 		$this->assertEquals(6, $instance->file_put_contents('files/foo', 'foobar'));
@@ -67,11 +69,13 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertFalse($instance->copy('files/foo', 'files/bar'));
 	}
 
+	#[Group('DB')]
 	public function testFreeSpace(): void {
 		$instance = $this->getLimitedStorage(9);
 		$this->assertEquals(9, $instance->free_space(''));
 	}
 
+	#[Group('DB')]
 	public function testFreeSpaceWithUsedSpace(): void {
 		$instance = $this->getLimitedStorage(9);
 		$instance->getCache()->put(
@@ -80,6 +84,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals(6, $instance->free_space(''));
 	}
 
+	#[Group('DB')]
 	public function testFreeSpaceWithUnknownDiskSpace(): void {
 		$storage = $this->getMockBuilder(Local::class)
 			->onlyMethods(['free_space'])
@@ -97,6 +102,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals(6, $instance->free_space(''));
 	}
 
+	#[Group('DB')]
 	public function testFreeSpaceWithUsedSpaceAndEncryption(): void {
 		$instance = $this->getLimitedStorage(9);
 		$instance->getCache()->put(
@@ -105,6 +111,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals(2, $instance->free_space(''));
 	}
 
+	#[Group('DB')]
 	public function testFWriteNotEnoughSpace(): void {
 		$instance = $this->getLimitedStorage(9);
 		$stream = $instance->fopen('files/foo', 'w+');
@@ -114,6 +121,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals('foobarqwe', $instance->file_get_contents('files/foo'));
 	}
 
+	#[Group('DB')]
 	public function testStreamCopyWithEnoughSpace(): void {
 		$instance = $this->getLimitedStorage(16);
 		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
@@ -124,6 +132,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		fclose($outputStream);
 	}
 
+	#[Group('DB')]
 	public function testStreamCopyNotEnoughSpace(): void {
 		$instance = $this->getLimitedStorage(9);
 		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
@@ -134,6 +143,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		fclose($outputStream);
 	}
 
+	#[Group('DB')]
 	public function testReturnFalseWhenFopenFailed(): void {
 		$failStorage = $this->getMockBuilder(Local::class)
 			->onlyMethods(['fopen'])
@@ -148,6 +158,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertFalse($instance->fopen('failedfopen', 'r'));
 	}
 
+	#[Group('DB')]
 	public function testReturnRegularStreamOnRead(): void {
 		$instance = $this->getLimitedStorage(9);
 
@@ -167,6 +178,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		fclose($stream);
 	}
 
+	#[Group('DB')]
 	public function testReturnRegularStreamWhenOutsideFiles(): void {
 		$instance = $this->getLimitedStorage(9);
 		$instance->mkdir('files_other');
@@ -178,6 +190,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		fclose($stream);
 	}
 
+	#[Group('DB')]
 	public function testReturnQuotaStreamOnWrite(): void {
 		$instance = $this->getLimitedStorage(9);
 		$stream = $instance->fopen('files/foo', 'w+');
@@ -212,12 +225,14 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Wrapper\Quota'));
 	}
 
+	#[Group('DB')]
 	public function testNoMkdirQuotaZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
 		$this->assertFalse($instance->mkdir('files'));
 		$this->assertFalse($instance->mkdir('files/foobar'));
 	}
 
+	#[Group('DB')]
 	public function testMkdirQuotaZeroTrashbin(): void {
 		$instance = $this->getLimitedStorage(0.0);
 		$this->assertTrue($instance->mkdir('files_trashbin'));
@@ -226,17 +241,20 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($instance->mkdir('cache'));
 	}
 
+	#[Group('DB')]
 	public function testNoTouchQuotaZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
 		$this->assertFalse($instance->touch('foobar'));
 	}
 
+	#[Group('DB')]
 	public function testNoFopenQuotaZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
 		$fh = $instance->fopen('files/test.txt', 'w');
 		$this->assertFalse($fh);
 	}
 
+	#[Group('DB')]
 	public function testNoWriteStreamQuota(): void {
 		$instance = $this->getLimitedStorage(5.0);
 		$stream = fopen('php://temp', 'w+');
@@ -251,10 +269,195 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$instance->writeStream('files/test.txt', $stream);
 	}
 
+	#[Group('DB')]
 	public function testNoWriteStreamQuotaZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
 		$stream = fopen('php://temp', 'w+');
 		$this->expectException(NotEnoughSpaceException::class);
 		$instance->writeStream('files/test.txt', $stream);
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('directoryProvider')]
+	public function testDirectories($directory): void {
+		parent::testDirectories($directory);
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('loremFileProvider')]
+	public function testGetPutContents($sourceFile): void {
+		parent::testGetPutContents($sourceFile);
+	}
+
+	#[Group('DB')]
+	public function testMimeType(): void {
+		parent::testMimeType();
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
+	public function testCopy($source, $target): void {
+		parent::testCopy($source, $target);
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
+	public function testMove($source, $target): void {
+		parent::testMove($source, $target);
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
+	public function testCopyOverwrite($source, $target): void {
+		parent::testCopyOverwrite($source, $target);
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
+	public function testMoveOverwrite($source, $target): void {
+		parent::testMoveOverwrite($source, $target);
+	}
+
+	#[Group('DB')]
+	public function testLocal(): void {
+		parent::testLocal();
+	}
+
+	#[Group('DB')]
+	public function testStat(): void {
+		parent::testStat();
+	}
+
+	#[Group('DB')]
+	public function testUnlink(): void {
+		parent::testUnlink();
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('fileNameProvider')]
+	public function testFOpen($fileName): void {
+		parent::testFOpen($fileName);
+	}
+
+	#[Group('DB')]
+	public function testTouchCreateFile(): void {
+		parent::testTouchCreateFile();
+	}
+
+	#[Group('DB')]
+	public function testRecursiveRmdir(): void {
+		parent::testRecursiveRmdir();
+	}
+
+	#[Group('DB')]
+	public function testRmdirEmptyFolder(): void {
+		parent::testRmdirEmptyFolder();
+	}
+
+	#[Group('DB')]
+	public function testRecursiveUnlink(): void {
+		parent::testRecursiveUnlink();
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('hashProvider')]
+	public function testHash($data, $type): void {
+		parent::testHash($data, $type);
+	}
+
+	#[Group('DB')]
+	public function testHashInFileName(): void {
+		parent::testHashInFileName();
+	}
+
+	#[Group('DB')]
+	public function testCopyOverWriteFile(): void {
+		parent::testCopyOverWriteFile();
+	}
+
+	#[Group('DB')]
+	public function testRenameOverWriteFile(): void {
+		parent::testRenameOverWriteFile();
+	}
+
+	#[Group('DB')]
+	public function testRenameDirectory(): void {
+		parent::testRenameDirectory();
+	}
+
+	#[Group('DB')]
+	public function testRenameOverWriteDirectory(): void {
+		parent::testRenameOverWriteDirectory();
+	}
+
+	#[Group('DB')]
+	public function testRenameOverWriteDirectoryOverFile(): void {
+		parent::testRenameOverWriteDirectoryOverFile();
+	}
+
+	#[Group('DB')]
+	public function testCopyDirectory(): void {
+		parent::testCopyDirectory();
+	}
+
+	#[Group('DB')]
+	public function testCopyOverWriteDirectory(): void {
+		parent::testCopyOverWriteDirectory();
+	}
+
+	#[Group('DB')]
+	public function testCopyOverWriteDirectoryOverFile(): void {
+		parent::testCopyOverWriteDirectoryOverFile();
+	}
+
+	#[Group('DB')]
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
+	public function testCopyFromSameStorage($source, $target): void {
+		parent::testCopyFromSameStorage($source, $target);
+	}
+
+	#[Group('DB')]
+	public function testIsCreatable(): void {
+		parent::testIsCreatable();
+	}
+
+	#[Group('DB')]
+	public function testIsReadable(): void {
+		parent::testIsReadable();
+	}
+
+	#[Group('DB')]
+	public function testIsUpdatable(): void {
+		parent::testIsUpdatable();
+	}
+
+	#[Group('DB')]
+	public function testIsDeletable(): void {
+		parent::testIsDeletable();
+	}
+
+	#[Group('DB')]
+	public function testIsShareable(): void {
+		parent::testIsShareable();
+	}
+
+	#[Group('DB')]
+	public function testStatAfterWrite(): void {
+		parent::testStatAfterWrite();
+	}
+
+	#[Group('DB')]
+	public function testPartFile(): void {
+		parent::testPartFile();
+	}
+
+	#[Group('DB')]
+	public function testWriteStream(): void {
+		parent::testWriteStream();
+	}
+
+	#[Group('DB')]
+	public function testFseekSize(): void {
+		parent::testFseekSize();
 	}
 }

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -43,7 +43,6 @@ class TestScanner extends Scanner {
 	}
 }
 
-#[Group('DB')]
 class ScannerTest extends TestCase {
 	private Dummy $userBackend;
 
@@ -63,6 +62,7 @@ class ScannerTest extends TestCase {
 		parent::tearDown();
 	}
 
+	#[Group('DB')]
 	public function testReuseExistingRoot(): void {
 		$storage = new Temporary([]);
 		$mount = new MountPoint($storage, '');
@@ -91,6 +91,7 @@ class ScannerTest extends TestCase {
 		$this->assertEquals($oldRoot, $newRoot);
 	}
 
+	#[Group('DB')]
 	public function testReuseExistingFile(): void {
 		$storage = new Temporary([]);
 		$mount = new MountPoint($storage, '');
@@ -119,6 +120,7 @@ class ScannerTest extends TestCase {
 		$this->assertEquals($old, $new);
 	}
 
+	#[Group('DB')]
 	public function testScanSubMount(): void {
 		$uid = $this->getUniqueID();
 		$this->userBackend->createUser($uid, 'test');
@@ -179,6 +181,7 @@ class ScannerTest extends TestCase {
 		$scanner->scan($invalidPath);
 	}
 
+	#[Group('DB')]
 	public function testPropagateEtag(): void {
 		$storage = new Temporary([]);
 		$mount = new MountPoint($storage, '');
@@ -209,6 +212,7 @@ class ScannerTest extends TestCase {
 		$this->assertNotEquals($oldRoot->getEtag(), $newRoot->getEtag());
 	}
 
+	#[Group('DB')]
 	public function testShallow(): void {
 		$storage = new Temporary([]);
 		$mount = new MountPoint($storage, '');

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -11,13 +11,13 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\OpenMetrics\IMetricFamily;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class InfoXmlTest
  *
  * @package Test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class InfoXmlTest extends TestCase {
 	private IAppManager $appManager;
 
@@ -54,6 +54,7 @@ class InfoXmlTest extends TestCase {
 	/**
 	 * @param string $app
 	 */
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataApps')]
 	public function testClasses($app): void {
 		$appInfo = $this->appManager->getAppInfo($app);

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -19,6 +19,7 @@ use OCP\IConfig;
 use OCP\ITempManager;
 use OCP\L10N\IFactory;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -27,7 +28,6 @@ use Psr\Log\LoggerInterface;
  *
  * @package Test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class InstallerTest extends TestCase {
 	private static $appid = 'testapp';
 	private $appstore;
@@ -80,6 +80,7 @@ class InstallerTest extends TestCase {
 		parent::tearDown();
 	}
 
+	#[Group('DB')]
 	public function testInstallApp(): void {
 		// Read the current version of the app to check for bug #2572
 		Server::get(IAppManager::class)->getAppVersion('testapp', true);

--- a/tests/lib/Lockdown/Filesystem/NoFSTest.php
+++ b/tests/lib/Lockdown/Filesystem/NoFSTest.php
@@ -15,7 +15,6 @@ use OCP\Lockdown\ILockdownManager;
 use OCP\Server;
 use Test\Traits\UserTrait;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class NoFSTest extends \Test\TestCase {
 	use UserTrait;
 

--- a/tests/lib/Migration/MetadataManagerTest.php
+++ b/tests/lib/Migration/MetadataManagerTest.php
@@ -19,6 +19,7 @@ use OCP\Migration\Attributes\DropTable;
 use OCP\Migration\Attributes\IndexType;
 use OCP\Migration\Attributes\ModifyColumn;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class MetadataManagerTest
@@ -34,6 +35,7 @@ class MetadataManagerTest extends \Test\TestCase {
 		$this->appManager = Server::get(IAppManager::class);
 	}
 
+	#[Group('DB')]
 	public function testExtractMigrationAttributes(): void {
 		$metadataManager = Server::get(MetadataManager::class);
 		$this->appManager->loadApp('testing');

--- a/tests/lib/OCM/DiscoveryServiceTest.php
+++ b/tests/lib/OCM/DiscoveryServiceTest.php
@@ -17,13 +17,13 @@ use OCP\IConfig;
 use OCP\OCM\Events\LocalOCMDiscoveryEvent;
 use OCP\OCM\Events\OCMEndpointRequestEvent;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use Test\OCM\Listeners\LocalOCMDiscoveryTestEvent;
 use Test\OCM\Listeners\OCMEndpointRequestTestEvent;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DiscoveryServiceTest extends TestCase {
 	private LoggerInterface $logger;
 	private RegistrationContext $context;
@@ -111,6 +111,7 @@ class DiscoveryServiceTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestOCMRequest')]
 	public function testOCMRequest(string $path, int $expectedStatus, ?array $expectedResult): void {
 		$this->context->for('ocm-request-app')->registerEventListener(OCMEndpointRequestEvent::class, OCMEndpointRequestTestEvent::class);
@@ -123,11 +124,13 @@ class DiscoveryServiceTest extends TestCase {
 		}
 	}
 
+	#[Group('DB')]
 	public function testLocalBaseCapability(): void {
 		$local = $this->discoveryService->getLocalOCMProvider();
 		$this->assertEmpty(array_diff(['notifications', 'shares'], $local->getCapabilities()->toArray()));
 	}
 
+	#[Group('DB')]
 	public function testLocalCapabilitiesAdvertiseHttpSigByDefault(): void {
 		// `http-sig` is the OCM-spec flag signalling RFC 9421 support backed
 		// by /.well-known/jwks.json. Advertised whenever signing is not
@@ -136,6 +139,7 @@ class DiscoveryServiceTest extends TestCase {
 		$this->assertTrue($local->hasCapability('http-sig'));
 	}
 
+	#[Group('DB')]
 	public function testLocalAddedCapability(): void {
 		$this->context->for('ocm-capability-app')->registerEventListener(LocalOCMDiscoveryEvent::class, LocalOCMDiscoveryTestEvent::class);
 		$this->context->delegateEventListenerRegistrations($this->dispatcher);

--- a/tests/lib/Repair/Owncloud/UpdateLanguageCodesTest.php
+++ b/tests/lib/Repair/Owncloud/UpdateLanguageCodesTest.php
@@ -13,6 +13,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -22,7 +23,6 @@ use Test\TestCase;
  *
  * @package Test\Repair
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UpdateLanguageCodesTest extends TestCase {
 
 	protected IDBConnection $connection;
@@ -36,6 +36,7 @@ class UpdateLanguageCodesTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 	}
 
+	#[Group('DB')]
 	public function testRun(): void {
 		$users = [
 			['userid' => 'user1', 'configvalue' => 'fi_FI'],

--- a/tests/lib/Repair/RepairCollationTest.php
+++ b/tests/lib/Repair/RepairCollationTest.php
@@ -33,7 +33,6 @@ class TestCollationRepair extends Collation {
  *
  * @see \OC\Repair\RepairMimeTypes
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class RepairCollationTest extends TestCase {
 
 	private TestCollationRepair $repair;

--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -20,7 +20,6 @@ use OCP\IConfig;
  *
  * @package Test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class ServerTest extends \Test\TestCase {
 	/** @var Server */
 	protected $server;

--- a/tests/lib/Share20/LegacyHooksTest.php
+++ b/tests/lib/Share20/LegacyHooksTest.php
@@ -22,7 +22,6 @@ use OCP\Share\Events\ShareDeletedFromSelfEvent;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use OCP\Util;
-use PHPUnit\Framework\Attributes\Group;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -40,7 +39,6 @@ class Dummy {
 	}
 }
 
-#[Group(name: 'DB')]
 class LegacyHooksTest extends TestCase {
 	private LegacyHooks $hooks;
 	private IEventDispatcher $eventDispatcher;

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -62,7 +62,6 @@ use OCP\Share\IShareProvider;
 use OCP\Share\IShareProviderSupportsAllSharesInFolder;
 use OCP\Util;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
@@ -80,7 +79,6 @@ class DummyShareManagerListener {
  *
  * @package Test\Share20
  */
-#[Group(name: 'DB')]
 class ManagerTest extends \Test\TestCase {
 	protected Manager $manager;
 	protected LoggerInterface&MockObject $logger;

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -534,15 +534,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 			return $annotations['class']['group'] ?? [];
 		}
 
-		$r = new \ReflectionClass($this);
-		$doc = $r->getDocComment();
+		$reflectionClass = new \ReflectionClass($this);
+		/** @psalm-suppress InternalMethod */
+		$reflectionMethod = $reflectionClass->getMethod($this->name());
+		$doc = $reflectionClass->getDocComment() . '\n' . $reflectionMethod->getDocComment();
 
 		if (class_exists(Group::class)) {
 			$attributes = array_map(function (\ReflectionAttribute $attribute): string {
 				/** @var Group $group */
 				$group = $attribute->newInstance();
 				return $group->name();
-			}, $r->getAttributes(Group::class));
+			}, array_merge($reflectionClass->getAttributes(Group::class), $reflectionMethod->getAttributes(Group::class)));
 			if (count($attributes) > 0) {
 				return $attributes;
 			}

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -43,7 +43,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	private QueueBus $commandBus;
 
 	/** @psalm-suppress ImpureStaticProperty For tests it's not an issue */
-	protected static ?IDBConnection $realDatabase = null;
+	private static ?IDBConnection $realDatabase = null;
 	/** @psalm-suppress ImpureStaticProperty */
 	private static bool $wasDatabaseAllowed = false;
 	protected array $services = [];

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -10,6 +10,7 @@ namespace Test;
 
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\Command\QueueBus;
+use OC\DB\Connection;
 use OC\Files\AppData\Factory;
 use OC\Files\Cache\Storage;
 use OC\Files\Config\MountProviderCollection;
@@ -42,22 +43,11 @@ use Psr\Container\ContainerExceptionInterface;
 abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	private QueueBus $commandBus;
 
-	/** @psalm-suppress ImpureStaticProperty For tests it's not an issue */
-	private static ?IDBConnection $realDatabase = null;
-	/** @psalm-suppress ImpureStaticProperty */
-	private static bool $wasDatabaseAllowed = false;
 	protected array $services = [];
 
 	#[\Override]
 	protected function onNotSuccessfulTest(\Throwable $t): never {
 		$this->restoreAllServices();
-
-		// restore database connection
-		if (!$this->IsDatabaseAccessAllowed()) {
-			\OC::$server->registerService(IDBConnection::class, function () {
-				return self::$realDatabase;
-			});
-		}
 
 		parent::onNotSuccessfulTest($t);
 	}
@@ -134,19 +124,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		$this->overwriteService('AsyncCommandBus', $this->commandBus);
 		$this->overwriteService(IBus::class, $this->commandBus);
 
-		// detect database access
-		self::$wasDatabaseAllowed = true;
-		if (!$this->IsDatabaseAccessAllowed()) {
-			self::$wasDatabaseAllowed = false;
-			if (is_null(self::$realDatabase)) {
-				self::$realDatabase = Server::get(IDBConnection::class);
-			}
-			/** @psalm-suppress InternalMethod */
-			\OC::$server->registerService(IDBConnection::class, function (): void {
-				$this->fail('Your test case is not allowed to access the database.');
-			});
-		}
-
 		$traits = $this->getTestTraits();
 		foreach ($traits as $trait) {
 			$methodName = 'setUp' . basename(str_replace('\\', '/', $trait));
@@ -154,18 +131,30 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 				call_user_func([$this, $methodName]);
 			}
 		}
+
+		// Something outside of our test might have done something with the database already, but we ignore it.
+		$this->resetDatabaseStats();
 	}
 
 	#[\Override]
 	protected function tearDown(): void {
 		$this->restoreAllServices();
 
-		// restore database connection
-		if (!$this->IsDatabaseAccessAllowed()) {
-			/** @psalm-suppress InternalMethod */
-			\OC::$server->registerService(IDBConnection::class, function () {
-				return self::$realDatabase;
-			});
+		$databaseAllowed = $this->IsDatabaseAccessAllowed();
+		$databaseUsed = $this->wasDatabaseUsed();
+		$this->resetDatabaseStats();
+		if ($databaseUsed && !$databaseAllowed) {
+			$this->fail('The database was used, but it was not allowed');
+		}
+		// Some test methods using a data provider generate cases that both use and not use the DB
+		// Therefore we can't enable this check all the time.
+		// It's useful for manually checking if all tests are using the correct group though.
+		// 1. DB_UNUSED=1 ./autotest.sh sqlite | grep -B 1 "The database was not used, but it was allowed" | grep "::" | cut -d ":" -f 1 | cut -d " " -f 2 | sort -u
+		// 2. Remove the Group attribute from all classes from the output
+		// 3. ./autotest.sh sqlite | grep -B 1 "The database was used, but it was not allowed" | grep "::" | cut -d " " -f 2 | sort -u
+		// 4. Add the Group attribute to all methods from the output
+		if (!$databaseUsed && $databaseAllowed && getenv('DB_UNUSED') !== false) {
+			$this->fail('The database was not used, but it was allowed');
 		}
 
 		// further cleanup
@@ -298,26 +287,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 	#[\Override]
 	public static function tearDownAfterClass(): void {
-		if (!self::$wasDatabaseAllowed && self::$realDatabase !== null) {
-			// in case an error is thrown in a test, PHPUnit jumps straight to tearDownAfterClass,
-			// so we need the database again
-			\OC::$server->registerService(IDBConnection::class, function () {
-				return self::$realDatabase;
-			});
-		}
 		$dataDir = Server::get(IConfig::class)->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data-autotest');
-		if (self::$wasDatabaseAllowed && Server::get(IDBConnection::class)) {
-			$db = Server::get(IDBConnection::class);
-			if ($db->inTransaction()) {
-				$db->rollBack();
-				throw new \Exception('There was a transaction still in progress and needed to be rolled back. Please fix this in your test.');
-			}
-			$queryBuilder = $db->getQueryBuilder();
-
-			self::tearDownAfterClassCleanShares($queryBuilder);
-			self::tearDownAfterClassCleanStorages($queryBuilder);
-			self::tearDownAfterClassCleanFileCache($queryBuilder);
+		$db = Server::get(IDBConnection::class);
+		if ($db->inTransaction()) {
+			$db->rollBack();
+			self::fail('There was a transaction still in progress and needed to be rolled back. Please fix this in your test.');
 		}
+
+		$queryBuilder = $db->getQueryBuilder();
+		self::tearDownAfterClassCleanShares($queryBuilder);
+		self::tearDownAfterClassCleanStorages($queryBuilder);
+		self::tearDownAfterClassCleanFileCache($queryBuilder);
 		self::tearDownAfterClassCleanStrayDataFiles($dataDir);
 		self::tearDownAfterClassCleanStrayHooks();
 		self::tearDownAfterClassCleanStrayLocks();
@@ -556,5 +536,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	protected function IsDatabaseAccessAllowed(): bool {
 		$annotations = $this->getGroupAnnotations();
 		return in_array('DB', $annotations) || in_array('SLOWDB', $annotations);
+	}
+
+	private function wasDatabaseUsed(): bool {
+		$connection = Server::get(Connection::class);
+		$databaseStats = $connection->getStats();
+		return $databaseStats['built'] > 0 || $databaseStats['executed'] > 0;
+	}
+
+	private function resetDatabaseStats(): void {
+		$connection = Server::get(Connection::class);
+		self::invokePrivate($connection, 'queriesBuilt', [0]);
+		self::invokePrivate($connection, 'queriesExecuted', [0]);
 	}
 }

--- a/tests/lib/TextProcessing/TextProcessingTest.php
+++ b/tests/lib/TextProcessing/TextProcessingTest.php
@@ -97,7 +97,6 @@ class FreePromptProvider implements IProvider {
 	}
 }
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class TextProcessingTest extends \Test\TestCase {
 	private IManager $manager;
 	private Coordinator $coordinator;

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -59,6 +59,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	protected function tearDown(): void {
 		// Reset webRoot
 		\OC::$WEBROOT = $this->originalWebRoot;
+
+		parent::tearDown();
 	}
 
 	private function mockBaseUrl() {

--- a/tests/lib/User/Backend.php
+++ b/tests/lib/User/Backend.php
@@ -8,6 +8,8 @@
 
 namespace Test\User;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Abstract class to provide the basis of backend-specific unit test classes.
  *
@@ -33,6 +35,7 @@ abstract class Backend extends \Test\TestCase {
 		return $this->getUniqueID('test_');
 	}
 
+	#[Group('DB')]
 	public function testAddRemove(): void {
 		//get the number of groups we start with, in case there are exising groups
 		$startCount = count($this->backend->getUsers());
@@ -57,6 +60,7 @@ abstract class Backend extends \Test\TestCase {
 		$this->assertFalse((array_search($name2, $this->backend->getUsers()) !== false));
 	}
 
+	#[Group('DB')]
 	public function testLogin(): void {
 		$name1 = $this->getUser();
 		$name2 = $this->getUser();

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -14,12 +14,12 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class DatabaseTest
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class DatabaseTest extends Backend {
 	/** @var array */
 	private $users;
@@ -60,6 +60,7 @@ class DatabaseTest extends Backend {
 		parent::tearDown();
 	}
 
+	#[Group('DB')]
 	public function testVerifyPasswordEvent(): void {
 		$user = $this->getUser();
 		$this->backend->createUser($user, 'pass1');
@@ -77,6 +78,7 @@ class DatabaseTest extends Backend {
 		$this->assertSame($user, $this->backend->checkPassword($user, 'newpass'));
 	}
 
+	#[Group('DB')]
 	public function testVerifyPasswordEventFail(): void {
 		$this->expectException(HintException::class);
 		$this->expectExceptionMessage('password change failed');
@@ -115,6 +117,7 @@ class DatabaseTest extends Backend {
 		$this->assertTrue($this->backend->userExists($user1));
 	}
 
+	#[Group('DB')]
 	#[\Override]
 	public function testSearch(): void {
 		parent::testSearch();
@@ -151,6 +154,7 @@ class DatabaseTest extends Backend {
 		$this->assertCount(2, $result);
 	}
 
+	#[Group('DB')]
 	public function testUserCount(): void {
 		$base = $this->backend->countUsers() ?: 0;
 		$users = $this->backend->getUsers();

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -26,7 +26,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-#[Group('DB')]
 class ManagerTest extends TestCase {
 	private IConfig&MockObject $config;
 	private IEventDispatcher&MockObject $eventDispatcher;
@@ -508,6 +507,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals(7 + 16, $users);
 	}
 
+	#[Group('DB')]
 	public function testCountUsersOnlyDisabled(): void {
 		$this->manager = Server::get(IUserManager::class);
 		// count other users in the db before adding our own
@@ -533,6 +533,7 @@ class ManagerTest extends TestCase {
 		$user4->delete();
 	}
 
+	#[Group('DB')]
 	public function testCountUsersOnlySeen(): void {
 		$this->manager = Server::get(IUserManager::class);
 		// count other users in the db before adding our own
@@ -559,6 +560,7 @@ class ManagerTest extends TestCase {
 		$user4->delete();
 	}
 
+	#[Group('DB')]
 	public function testCallForSeenUsers(): void {
 		$this->manager = Server::get(IUserManager::class);
 		// count other users in the db before adding our own
@@ -593,6 +595,7 @@ class ManagerTest extends TestCase {
 		$user4->delete();
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
 	#[\PHPUnit\Framework\Attributes\PreserveGlobalState(enabled: false)]
 	public function testRecentlyActive(): void {
@@ -651,6 +654,7 @@ class ManagerTest extends TestCase {
 		$user5->delete();
 	}
 
+	#[Group('DB')]
 	public function testDeleteUser(): void {
 		/** @var AllConfig&MockObject */
 		$config = $this->getMockBuilder(AllConfig::class)

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -35,6 +35,7 @@ use OCP\Lockdown\ILockdownManager;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ISecureRandom;
 use OCP\User\Events\PostLoginEvent;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -44,7 +45,6 @@ use function get_class_methods;
 /**
  * @package Test\User
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class SessionTest extends \Test\TestCase {
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
@@ -113,6 +113,7 @@ class SessionTest extends \Test\TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[\PHPUnit\Framework\Attributes\DataProvider('isLoggedInData')]
 	public function testIsLoggedIn($isLoggedIn): void {
 		$session = $this->createMock(Memory::class);

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-#[Group('DB')]
 class UserTest extends TestCase {
 	protected IEventDispatcher $dispatcher;
 
@@ -87,6 +86,7 @@ class UserTest extends TestCase {
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
+	#[Group('DB')]
 	public function testSetPassword(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->method('getBackendName')->willReturn('foo');
@@ -171,6 +171,7 @@ class UserTest extends TestCase {
 		$this->assertTrue($user->canChangeAvatar());
 	}
 
+	#[Group('DB')]
 	public function testDelete(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->method('getBackendName')->willReturn('foo');
@@ -183,6 +184,7 @@ class UserTest extends TestCase {
 		$this->assertTrue($user->delete());
 	}
 
+	#[Group('DB')]
 	public function testDeleteWithDifferentHome(): void {
 		$homeProvider = Server::get(ObjectHomeMountProvider::class);
 		$user = $this->createMock(IUser::class);
@@ -358,6 +360,7 @@ class UserTest extends TestCase {
 		$this->assertEquals('foo', $user->getDisplayName());
 	}
 
+	#[Group('DB')]
 	public function testSetPasswordHooks(): void {
 		$hooksCalled = 0;
 		$test = $this;
@@ -395,6 +398,7 @@ class UserTest extends TestCase {
 		];
 	}
 
+	#[Group('DB')]
 	#[DataProvider('dataDeleteHooks')]
 	public function testDeleteHooks(bool $result, int $expectedHooks): void {
 		$hooksCalled = 0;
@@ -480,6 +484,7 @@ class UserTest extends TestCase {
 		$this->assertEquals($expectedHooks, $hooksCalled);
 	}
 
+	#[Group('DB')]
 	public function testDeleteRecoverState() {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->method('getBackendName')->willReturn('foo');
@@ -552,6 +557,7 @@ class UserTest extends TestCase {
 		$this->assertEquals($cloudId, $user->getCloudId());
 	}
 
+	#[Group('DB')]
 	public function testSetEMailAddressEmpty(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->method('getBackendName')->willReturn('foo');
@@ -581,6 +587,7 @@ class UserTest extends TestCase {
 		$user->setSystemEMailAddress('');
 	}
 
+	#[Group('DB')]
 	public function testSetEMailAddress(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->method('getBackendName')->willReturn('foo');
@@ -634,6 +641,7 @@ class UserTest extends TestCase {
 		$user->setSystemEMailAddress('foo@bar.com');
 	}
 
+	#[Group('DB')]
 	public function testSetQuota(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->method('getBackendName')->willReturn('foo');
@@ -760,6 +768,7 @@ class UserTest extends TestCase {
 		$this->assertSame(42, $user->getLastLogin());
 	}
 
+	#[Group('DB')]
 	public function testSetEnabled(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->method('getBackendName')->willReturn('foo');

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -17,7 +17,6 @@ use OCP\Util;
 /**
  * Tests for server check functions
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UtilCheckServerTest extends \Test\TestCase {
 	private $datadir;
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -15,13 +15,13 @@ use OCP\ISession;
 use OCP\ITempManager;
 use OCP\Server;
 use OCP\Util;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Class UtilTest
  *
  * @package Test
  */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
 class UtilTest extends \Test\TestCase {
 	public function testGetVersion(): void {
 		$version = Util::getVersion();
@@ -94,6 +94,7 @@ class UtilTest extends \Test\TestCase {
 	/**
 	 * If no strict email check is enabled "localhost" should validate as a valid email domain
 	 */
+	#[Group('DB')]
 	public function testGetDefaultEmailAddress(): void {
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('core', 'enforce_strict_email_check', 'no');


### PR DESCRIPTION
Some tests are using the database, but weren't running in the DB group, and some tests are running in the DB group, but weren't using the database. The check if the database is actually used is much more accurate now. Overall the change will reduce the number of tests, because many are deduplicated by only running them on nodb.