### PR TITLE
test(playwright): fix local test server config for SQLite runs

### DIFF
--- a/tests/playwright/start-nextcloud-server.js
+++ b/tests/playwright/start-nextcloud-server.js
@@ -54,7 +54,6 @@ async function start() {
 	// createRandomUser() generates short passwords that the policy would reject
 	await runOcc(['app:disable', 'password_policy'])
 	process.stdout.write('├─ Disabled password policy for random test users\n')
-	process.stdout.write('├─ Set SQLite busy timeout for parallel workers\n')
 	await runExec(['php', '-r', '$db = new SQLite3("data/owncloud.db");$db->busyTimeout(5000);$db->exec("PRAGMA journal_mode = wal;");'])
 	process.stdout.write('├─ Enabled SQLite WAL mode for better performance\n')
 	process.stdout.write('├─ Initialize cron job...\n')

--- a/tests/playwright/start-nextcloud-server.js
+++ b/tests/playwright/start-nextcloud-server.js
@@ -54,9 +54,6 @@ async function start() {
 	// createRandomUser() generates short passwords that the policy would reject
 	await runOcc(['app:disable', 'password_policy'])
 	process.stdout.write('├─ Disabled password policy for random test users\n')
-	// PDO::ATTR_TIMEOUT (2) = SQLite busy timeout in seconds; without it parallel
-	// workers hit "database is locked" 500s on write collisions
-	await runOcc(['config:system:set', 'dbdriveroptions', '2', '--value', '5', '--type', 'integer'])
 	process.stdout.write('├─ Set SQLite busy timeout for parallel workers\n')
 	await runExec(['php', '-r', '$db = new SQLite3("data/owncloud.db");$db->busyTimeout(5000);$db->exec("PRAGMA journal_mode = wal;");'])
 	process.stdout.write('├─ Enabled SQLite WAL mode for better performance\n')

--- a/tests/playwright/start-nextcloud-server.js
+++ b/tests/playwright/start-nextcloud-server.js
@@ -51,6 +51,13 @@ async function start() {
 	process.stdout.write('\nApply custom configuration for Playwright tests\n')
 	await runOcc(['config:system:set', 'appstoreenabled', '--value', 'false', '--type', 'boolean'])
 	process.stdout.write('├─ Disabled app store\n')
+	// createRandomUser() generates short passwords that the policy would reject
+	await runOcc(['app:disable', 'password_policy'])
+	process.stdout.write('├─ Disabled password policy for random test users\n')
+	// PDO::ATTR_TIMEOUT (2) = SQLite busy timeout in seconds; without it parallel
+	// workers hit "database is locked" 500s on write collisions
+	await runOcc(['config:system:set', 'dbdriveroptions', '2', '--value', '5', '--type', 'integer'])
+	process.stdout.write('├─ Set SQLite busy timeout for parallel workers\n')
 	await runExec(['php', '-r', '$db = new SQLite3("data/owncloud.db");$db->busyTimeout(5000);$db->exec("PRAGMA journal_mode = wal;");'])
 	process.stdout.write('├─ Enabled SQLite WAL mode for better performance\n')
 	process.stdout.write('├─ Initialize cron job...\n')


### PR DESCRIPTION
## Summary

Two server-config fixes in so the Playwright suite runs reliably against the bundled SQLite container.

## Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation (manuals or wiki) has been updated or is not required
- [ ] Backports requested where applicable (ex: critical bugfixes)
- [x] Labels added where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] Milestone added for target branch/version (ex: 32.x for `stable32`)