### PR TITLE
fix: Fix PHP Warning foreach() argument must be of type array|object, null given

### DIFF
--- a/lib/private/Share20/ShareHelper.php
+++ b/lib/private/Share20/ShareHelper.php
@@ -104,7 +104,7 @@ class ShareHelper implements IShareHelper {
 			try {
 				$item = $item->getParent();
 
-				if ($byId[$item->getId()] !== []) {
+				if (isset($byId[$item->getId()]) && $byId[$item->getId()] !== []) {
 					foreach ($byId[$item->getId()] as $uid => $path) {
 						$results[$uid] = $path . $appendix;
 					}
@@ -161,7 +161,7 @@ class ShareHelper implements IShareHelper {
 		$item = $node;
 		while (!empty($byId)) {
 			try {
-				if ($byId[$item->getId()] !== []) {
+				if (isset($byId[$item->getId()]) && $byId[$item->getId()] !== []) {
 					$path = $this->getMountedPath($item);
 					foreach ($byId[$item->getId()] as $uid => $token) {
 						$results[$uid] = [


### PR DESCRIPTION
## Summary

- Follow-up of https://github.com/nextcloud/server/commit/2a81cba9789b2b1ea0b20c80db151a01731185f0

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
