### PR TITLE
fix(theming): preserve uploaded favicon and touch icon

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -100,8 +100,8 @@ class IconController extends Controller {
 			$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/x-icon']);
 		} catch (NotFoundException $e) {
 		}
-		// retrieve or generate app specific favicon
-		if (($this->imageManager->canConvert('PNG') || $this->imageManager->canConvert('SVG')) && $this->imageManager->canConvert('ICO')) {
+		// retrieve or generate app specific favicon, but only if no custom favicon was uploaded
+		if ($iconFile === null && ($this->imageManager->canConvert('PNG') || $this->imageManager->canConvert('SVG')) && $this->imageManager->canConvert('ICO')) {
 			$color = $this->themingDefaults->getColorPrimary();
 			try {
 				$iconFile = $this->imageManager->getCachedImage('favIcon-' . $app . $color);
@@ -142,14 +142,15 @@ class IconController extends Controller {
 		}
 
 		$response = null;
+		$iconFile = null;
 		// retrieve instance favicon
 		try {
 			$iconFile = $this->imageManager->getImage('favicon');
 			$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => $iconFile->getMimeType()]);
 		} catch (NotFoundException $e) {
 		}
-		// retrieve or generate app specific touch icon
-		if ($this->imageManager->canConvert('PNG')) {
+		// retrieve or generate app specific touch icon, but only if no custom favicon was uploaded
+		if ($iconFile === null && $this->imageManager->canConvert('PNG')) {
 			$color = $this->themingDefaults->getColorPrimary();
 			try {
 				$iconFile = $this->imageManager->getCachedImage('touchIcon-' . $app . $color);

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -125,6 +125,24 @@ class IconControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->iconController->getFavicon());
 	}
 
+	public function testGetFaviconUploaded(): void {
+		// a custom favicon was uploaded, so it must be served as-is and the
+		// app-specific generation path must not overwrite it
+		$file = $this->iconFileMock('favicon.ico', 'filecontent');
+		$this->imageManager->expects($this->once())
+			->method('getImage')
+			->with('favicon', false)
+			->willReturn($file);
+		$this->imageManager->expects($this->never())
+			->method('getCachedImage');
+		$this->iconBuilder->expects($this->never())
+			->method('getFavicon');
+
+		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'image/x-icon']);
+		$expected->cacheFor(86400);
+		$this->assertEquals($expected, $this->iconController->getFavicon());
+	}
+
 	public function testGetFaviconDefault(): void {
 		$this->imageManager->expects($this->once())
 			->method('getImage')
@@ -176,6 +194,24 @@ class IconControllerTest extends TestCase {
 			->willReturn($file);
 
 		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'image/png']);
+		$expected->cacheFor(86400);
+		$this->assertEquals($expected, $this->iconController->getTouchIcon());
+	}
+
+	public function testGetTouchIconUploaded(): void {
+		// a custom favicon was uploaded, so it must be served as-is and the
+		// app-specific generation path must not overwrite it
+		$file = $this->iconFileMock('favicon.png', 'filecontent');
+		$this->imageManager->expects($this->once())
+			->method('getImage')
+			->with('favicon')
+			->willReturn($file);
+		$this->imageManager->expects($this->never())
+			->method('getCachedImage');
+		$this->iconBuilder->expects($this->never())
+			->method('getTouchIcon');
+
+		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'image type']);
 		$expected->cacheFor(86400);
 		$this->assertEquals($expected, $this->iconController->getTouchIcon());
 	}


### PR DESCRIPTION

## Summary

PR #58224 dropped the `$iconFile === null` guard around the app-specific icon generation in getFavicon()/getTouchIcon(), so an uploaded custom favicon was always overwritten by the generated, context-colored icon whenever Imagick could produce an ICO/PNG.

Restore the guard so the generation path only runs as a fallback when no custom favicon was uploaded, while keeping the improved Imagick capability detection from #58224.

Assisted-by: ClaudeCode:claude-opus-4-8

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
