### PR TITLE
fix(files_versions): avoid version snapshot races during cross-storage renames

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -56,6 +56,16 @@ class FileEventsListener implements IEventListener {
 	 * @var array<string, Node>
 	 */
 	private array $versionsDeleted = [];
+	/**
+	 * Source paths currently involved in a cross-backend rename.
+	 *
+	 * Cross-backend renames can emit write events as part of their copy/unlink
+	 * implementation. For nodes under these paths, version creation is handled
+	 * by VersionStorageMoveListener and must not be re-triggered by write_hook().
+	 *
+	 * @var array<string, true>
+	 */
+	private array $crossBackendRenamePaths = [];
 
 	public function __construct(
 		private IRootFolder $rootFolder,
@@ -105,12 +115,61 @@ class FileEventsListener implements IEventListener {
 		}
 
 		if ($event instanceof BeforeNodeRenamedEvent) {
+			$this->markCrossBackendRenamePath($event->getSource(), $event->getTarget());
 			$this->pre_renameOrCopy_hook($event->getSource(), $event->getTarget());
 		}
 
 		if ($event instanceof BeforeNodeCopiedEvent) {
 			$this->pre_renameOrCopy_hook($event->getSource(), $event->getTarget());
 		}
+	}
+
+	private function markCrossBackendRenamePath(Node $source, Node $target): void {
+		$sourceBackend = $this->versionManager->getBackendForStorage($source->getStorage());
+		$targetBackend = $this->versionManager->getBackendForStorage($target->getParent()->getStorage());
+
+		if ($sourceBackend === $targetBackend) {
+			return;
+		}
+
+		$sourcePath = $this->getPathForNode($source);
+		if ($sourcePath === null) {
+			return;
+		}
+
+		$this->crossBackendRenamePaths[$this->normalizeRelativePath($sourcePath)] = true;
+	}
+
+	private function unmarkCrossBackendRenamePath(Node $source, Node $target): void {
+		$sourceBackend = $this->versionManager->getBackendForStorage($source->getParent()->getStorage());
+		$targetBackend = $this->versionManager->getBackendForStorage($target->getStorage());
+
+		if ($sourceBackend === $targetBackend) {
+			return;
+		}
+
+		$sourcePath = $this->getPathForNode($source);
+		if ($sourcePath === null) {
+			return;
+		}
+
+		unset($this->crossBackendRenamePaths[$this->normalizeRelativePath($sourcePath)]);
+	}
+
+	private function normalizeRelativePath(string $path): string {
+		return trim($path, '/');
+	}
+
+	private function isCrossBackendRenamePath(string $path): bool {
+		$path = $this->normalizeRelativePath($path);
+
+		foreach ($this->crossBackendRenamePaths as $renamePath => $_true) {
+			if ($path === $renamePath || ($renamePath !== '' && str_starts_with($path, $renamePath . '/'))) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public function pre_touch_hook(Node $node): void {
@@ -211,6 +270,25 @@ class FileEventsListener implements IEventListener {
 		if ($path === null) {
 			return;
 		}
+
+		// Cross-backend renames can emit write events while the file is being
+		// copied away from the source storage. In that case, the dedicated
+		// VersionStorageMoveListener handles preserving versions.
+		if ($this->isCrossBackendRenamePath($path)) {
+			$this->logger->debug('Skipping version creation during cross-backend rename', [
+				'path' => $path,
+				'node' => [
+					'id' => $node->getId(),
+					'path' => $node->getPath(),
+					'size' => $node->getSize(),
+					'mtime' => $node->getMTime(),
+				],
+				'activeCrossBackendRenamePaths' => array_keys($this->crossBackendRenamePaths),
+			]);
+
+			return;
+		}
+
 		$result = Storage::store($path);
 
 		// Store the result of the version creation so it can be used in post_write_hook.
@@ -345,6 +423,8 @@ class FileEventsListener implements IEventListener {
 	 * of the stored versions along the actual file
 	 */
 	public function rename_hook(Node $source, Node $target): void {
+		$this->unmarkCrossBackendRenamePath($source, $target);
+
 		$sourceBackend = $this->versionManager->getBackendForStorage($source->getParent()->getStorage());
 		$targetBackend = $this->versionManager->getBackendForStorage($target->getStorage());
 		// If different backends, do nothing.


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue --> (possibly some existing bug reports; see user-visible symptoms list below)

## Summary

Cross-storage moves already have dedicated version handling via `VersionStorageMoveListener`, which handles moving existing versions across backends.

At the same time, `FileEventsListener::write_hook()` can still call `Storage::store()` while that move is in progress. For moves between backends, that is redundant and can race with the move flow by snapshotting the source path while it is already being moved.

Changes:

* track source paths for active cross-backend moves in `FileEventsListener`
* skip `Storage::store()` in `write_hook()` for writes under those paths
* clear the tracked path again when the move completes

I found this while investigating intermittent failures in `apps/files_trashbin/tests/StorageTest.php::testKeepFileAndVersionsWhenMovingFileBetweenStorages`. The existing test already covers the affected scenario; the problem is the race in the implementation, not missing scenario coverage.

Possible user-visible symptoms:

* intermittent failure when moving a file between storages
* generic move/file operation error caused by version creation racing with the move

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
