### PR TITLE
test(s3): fix flaky EOF check and remove PHP 8.5 skip

### DIFF
--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -150,21 +150,20 @@ class S3Test extends ObjectStoreTestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileSizes')]
 	public function testFileSizes($size): void {
-		if (str_starts_with(PHP_VERSION, '8.5') && getenv('CI')) {
-			$this->markTestSkipped('Test is unreliable and skipped on 8.5');
-		}
-
 		$this->cleanupAfter('testfilesizes');
 		$s3 = $this->getInstance();
 
 		$sourceStream = fopen('php://memory', 'wb+');
 		$writeChunkSize = 1024;
-		$chunkCount = $size / $writeChunkSize;
-		for ($i = 0; $i < $chunkCount; $i++) {
-			fwrite($sourceStream, str_repeat('A',
-				($i < $chunkCount - 1) ? $writeChunkSize : $size - ($i * $writeChunkSize)
-			));
+		$chunk = str_repeat('A', $writeChunkSize);
+		$remainingSize = $size;
+
+		while ($remainingSize > 0) {
+			$bytesToWrite = min($writeChunkSize, $remainingSize);
+			fwrite($sourceStream, ($bytesToWrite === $writeChunkSize) ? $chunk : str_repeat('A', $bytesToWrite));
+			$remainingSize -= $bytesToWrite;
 		}
+
 		rewind($sourceStream);
 		$s3->writeObject('testfilesizes', $sourceStream);
 
@@ -174,16 +173,21 @@ class S3Test extends ObjectStoreTestCase {
 		$result = $s3->readObject('testfilesizes');
 
 		// compare first 100 bytes
-		self::assertEquals(str_repeat('A', 100), fread($result, 100), 'Compare first 100 bytes');
+		self::assertSame(str_repeat('A', 100), fread($result, 100), 'Compare first 100 bytes');
 
 		// compare last 100 bytes
-		fseek($result, $size - 100);
-		self::assertEquals(str_repeat('A', 100), fread($result, 100), 'Compare last 100 bytes');
+		self::assertSame(0, fseek($result, $size - 100), 'Seek to last 100 bytes succeeds');
+		self::assertSame(str_repeat('A', 100), fread($result, 100), 'Compare last 100 bytes');
 
 		// end of file reached
-		fseek($result, $size);
-		self::assertTrue(feof($result), 'End of file reached');
+		self::assertSame(0, fseek($result, $size), 'Seek to EOF succeeds');
+		self::assertSame($size, ftell($result), 'Pointer is at the end of file');
+		self::assertSame('', fread($result, 1), 'Reading at end of file returns no bytes');
+		self::assertTrue(feof($result), 'End of file reached after read attempt');
 
 		$this->assertNoUpload('testfilesizes');
+
+		fclose($sourceStream);
+		fclose($result);
 	}
 }

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -186,8 +186,5 @@ class S3Test extends ObjectStoreTestCase {
 		self::assertTrue(feof($result), 'End of file reached after read attempt');
 
 		$this->assertNoUpload('testfilesizes');
-
-		fclose($sourceStream);
-		fclose($result);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fix `S3Test::testFileSizes()` so it no longer relies on an invalid EOF behavior assumption and remove the temporary PHP 8.5 CI skip.

### Changes

- replace the immediate `feof()` check after `fseek()` with a read-at-EOF assertion
- assert seek success explicitly
- use stricter `assertSame()` checks for byte comparisons
- simplify the chunk-writing loop used to generate test input
- remove the temporary PHP 8.5 skip

### Why

`readObject()` returns a seekable HTTP-backed stream, and `feof()` is not a reliable thing to assert immediately after seeking to the end of that stream.

Depending on buffering and wrapper behavior, EOF may only be established after a read attempt. Verifying that a read at EOF returns no bytes better matches the behavior this test intends to validate and avoids CI flakiness. The original exclusion by PHP version was for PHP 8.3 (#47388), but recently was changed to 8.5 (#61158). Presumably it's no longer needed (if evidence suggests otherwise going forward we should figure out why / fix the test).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
