### PR TITLE
fix(twofactor_backupcodes): Add a clean helper to set code as used

### DIFF
--- a/apps/twofactor_backupcodes/lib/Db/BackupCodeMapper.php
+++ b/apps/twofactor_backupcodes/lib/Db/BackupCodeMapper.php
@@ -55,4 +55,17 @@ class BackupCodeMapper extends QBMapper {
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)));
 		$qb->executeStatement();
 	}
+
+	/**
+	 * Marks the backup code as used, if not already marked as used in DB.
+	 * @return int number of affected rows
+	 */
+	public function markUsedIfUnused(BackupCode $code): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->getTableName())
+			->set('used', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($code->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('used', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+		return $qb->executeStatement();
+	}
 }

--- a/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
+++ b/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
@@ -86,19 +86,12 @@ class BackupCodeStorage {
 		];
 	}
 
-	/**
-	 * @param IUser $user
-	 * @param string $code
-	 * @return bool
-	 */
 	public function validateCode(IUser $user, string $code): bool {
 		$dbCodes = $this->mapper->getBackupCodes($user);
 
 		foreach ($dbCodes as $dbCode) {
 			if ((int)$dbCode->getUsed() === 0 && $this->hasher->verify($code, $dbCode->getCode())) {
-				$dbCode->setUsed(1);
-				$this->mapper->update($dbCode);
-				return true;
+				return ($this->mapper->markUsedIfUnused($dbCode) === 1);
 			}
 		}
 		return false;

--- a/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
@@ -158,12 +158,11 @@ class BackupCodeStorageTest extends TestCase {
 			->with('CHALLENGE', 'HASHEDVALUE', $this->anything())
 			->willReturn(true);
 		$this->mapper->expects($this->once())
-			->method('update')
-			->with($code);
+			->method('markUsedIfUnused')
+			->with($code)
+			->willReturn(1);
 
 		$this->assertTrue($this->storage->validateCode($user, 'CHALLENGE'));
-
-		$this->assertEquals(1, $code->getUsed());
 	}
 
 	public function testValidateUsedCode(): void {


### PR DESCRIPTION
## Summary

Makes the operation atomic.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
