### PR TITLE
fix(maintenance): allow AppAPI to serve requests during maintenance mode

### DIFF
--- a/lib/OC.php
+++ b/lib/OC.php
@@ -1128,8 +1128,17 @@ class OC {
 		if ($requestPath === '/heartbeat') {
 			return;
 		}
+		$serveAppApiDuringMaintenance = false;
 		if (substr($requestPath, -3) !== '.js') { // we need these files during the upgrade
-			self::checkMaintenanceMode($systemConfig);
+			if (((bool)$systemConfig->getValue('maintenance', false)) && !\OCP\Util::needUpgrade()
+				&& ($requestPath === '/apps/app_api' || str_starts_with($requestPath, '/apps/app_api/'))
+				&& Server::get(\OCP\App\IAppManager::class)->isEnabledForAnyone('app_api')) {
+				// Keep serving ExApp traffic (HaRP metadata) while the instance is in maintenance mode
+				$serveAppApiDuringMaintenance = true;
+			}
+			if (!$serveAppApiDuringMaintenance) {
+				self::checkMaintenanceMode($systemConfig);
+			}
 
 			if (\OCP\Util::needUpgrade()) {
 				if (function_exists('opcache_reset')) {
@@ -1192,6 +1201,10 @@ class OC {
 				if (!\OCP\Util::needUpgrade()) {
 					$appManager->loadApps(['filesystem', 'logging']);
 					$appManager->loadApps();
+				}
+				if ($serveAppApiDuringMaintenance) {
+					// loadApps() above is a no-op during maintenance, load app_api explicitly
+					$appManager->loadApp('app_api');
 				}
 				Server::get(\OC\Route\Router::class)->match($request->getRawPathInfo());
 				return;

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -87,6 +87,22 @@ class Application {
 				if (Util::needUpgrade()) {
 					throw new NeedsUpdateException();
 				} elseif ($this->config->getSystemValueBool('maintenance')) {
+					if ($this->appManager->isEnabledForAnyone('app_api')) {
+						// AppAPI must stay usable during maintenance mode;
+						// loading commands from register_command.php is intentionally skipped.
+						$this->appManager->loadApp('app_api');
+						$info = $this->appManager->getAppInfo('app_api');
+						if (isset($info['commands'])) {
+							try {
+								$this->loadCommandsFromInfoXml($info['commands']);
+							} catch (\Throwable $e) {
+								$output->writeln('<error>' . $e->getMessage() . '</error>');
+								$this->logger->error($e->getMessage(), [
+									'exception' => $e,
+								]);
+							}
+						}
+					}
 					$this->writeMaintenanceModeInfo($input, $output);
 				} else {
 					$this->appManager->loadApps();
@@ -161,8 +177,13 @@ class Application {
 			&& $input->getArgument('command') !== 'maintenance:mode'
 			&& $input->getArgument('command') !== 'status') {
 			$errOutput = $output->getErrorOutput();
-			$errOutput->writeln('<comment>Nextcloud is in maintenance mode, no apps are loaded.</comment>');
-			$errOutput->writeln('<comment>Commands provided by apps are unavailable.</comment>');
+			if ($this->appManager->isEnabledForAnyone('app_api')) {
+				$errOutput->writeln('<comment>Nextcloud is in maintenance mode, only AppAPI commands are loaded.</comment>');
+				$errOutput->writeln('<comment>Commands provided by other apps are unavailable.</comment>');
+			} else {
+				$errOutput->writeln('<comment>Nextcloud is in maintenance mode, no apps are loaded.</comment>');
+				$errOutput->writeln('<comment>Commands provided by apps are unavailable.</comment>');
+			}
 		}
 	}
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -30,7 +30,18 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 $request = Server::get(IRequest::class);
 
-if ((Util::needUpgrade() || Server::get(IConfig::class)->getSystemValueBool('maintenance')) && $request->getPathInfo() !== '/core/update') {
+$serveAppApiDuringMaintenance = false;
+if (!Util::needUpgrade() && Server::get(IConfig::class)->getSystemValueBool('maintenance')) {
+	$pathInfo = $request->getPathInfo();
+	// AppAPI must keep serving HaRP traffic (signed OCS calls and ExApp callbacks)
+	$serveAppApiDuringMaintenance
+		= ($pathInfo === '/apps/app_api' || str_starts_with($pathInfo, '/apps/app_api/'))
+		&& Server::get(IAppManager::class)->isEnabledForAnyone('app_api');
+}
+
+if ((Util::needUpgrade()
+	|| (Server::get(IConfig::class)->getSystemValueBool('maintenance') && !$serveAppApiDuringMaintenance))
+	&& $request->getPathInfo() !== '/core/update') {
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	ApiHelper::respond(503, 'Service unavailable', ['X-Nextcloud-Maintenance-Mode' => '1'], 503);
@@ -49,6 +60,10 @@ try {
 	$request->throwDecodingExceptionIfAny();
 
 	if ($request->getPathInfo() !== '/core/update') {
+		if ($serveAppApiDuringMaintenance) {
+			// loadApps() below is a no-op during maintenance, load app_api explicitly
+			$appManager->loadApp('app_api');
+		}
 		// load all apps to get all api routes properly setup
 		// FIXME: this should ideally appear after handleLogin but will cause
 		// side effects in existing apps


### PR DESCRIPTION
## Summary

This PR allows AppAPI to work during the maintenance mode.

Reason? When admin enables maintenance mode, Nextcloud returns a `503` for every app route. This also shuts down AppAPI's own routes and its `occ` commands. But maintenance mode is when admins run backups and upgrades, so today this can break the whole ExApp setup.

Main findings from bug-reports:

- HaRP can no longer read ExApp metadata from the NC or check user access from Nextcloud, so calls to running ExApps start failing with misleading `401`/`404` errors. If HaRP restarts during the maintenance window, every ExApp route stops working.
-  ExApps cannot report their status back to Nextcloud (those callbacks go over OCS), so any ExApp install or update that was in progress when maintenance started is left broken.
- The `occ app_api:*` commands are not loaded during maintenance, so an admin cannot manage or recover ExApps from the command line either.

Conditions:
1. AppAPI must be enabled to serve it's endpoints.
2. No upgrade may be pending (`needUpgrade()` must be false) - as there can be a pending upgrade of AppAPI.

Everything else stays exactly as before (I hope 🤗)

We would also like to request a backport this for Nextcloud 34, for which we are already asking admins to use [HaRP](https://github.com/nextcloud/harp) - and with it, this problem looks more serious.

Note: WebDAV and the other entry points are untouched. ExApp-provided dynamic `occ` commands (loaded from `register_command.php`) are **intentionally** not registered during maintenance.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
