### PR TITLE
fix: Do not set last-password-confirm for apptoken sessions

### DIFF
--- a/build/integration/features/auth.feature
+++ b/build/integration/features/auth.feature
@@ -104,7 +104,7 @@ Feature: auth
 		Then the HTTP status code should be "200"
 		When the CSRF token is extracted from the previous response
 		When a new unrestricted client token is added using restricted basic token auth
-		Then the HTTP status code should be "503"
+		Then the HTTP status code should be "403"
 
 	Scenario: Creating a restricted auth token with regular login should work
 		When a new restricted client token is added
@@ -113,4 +113,3 @@ Feature: auth
 	Scenario: Creating an unrestricted auth token with regular login should work
 		When a new unrestricted client token is added
 		Then the HTTP status code should be "200"
-

--- a/build/integration/features/bootstrap/Auth.php
+++ b/build/integration/features/bootstrap/Auth.php
@@ -93,7 +93,9 @@ trait Auth {
 
 		try {
 			$this->response = $client->request('POST', $fullUrl, $options);
-		} catch (\GuzzleHttp\Exception\ServerException $e) {
+		} catch (ClientException $ex) {
+			$this->response = $ex->getResponse();
+		} catch (ServerException $e) {
 			$this->response = $e->getResponse();
 		}
 		return json_decode($this->response->getBody()->getContents());

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -68,15 +68,13 @@ class PasswordConfirmationMiddleware extends Middleware {
 		try {
 			$sessionId = $this->session->getId();
 			$token = $this->tokenProvider->getToken($sessionId);
+			$scope = $token->getScopeAsArray();
+			if (isset($scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION]) && $scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION] === true) {
+				// Users logging in from SSO backends cannot confirm their password by design
+				return;
+			}
 		} catch (SessionNotAvailableException|InvalidTokenException|WipeTokenException|ExpiredTokenException) {
-			// States we do not deal with here.
-			return;
-		}
-
-		$scope = $token->getScopeAsArray();
-		if (isset($scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION]) && $scope[IToken::SCOPE_SKIP_PASSWORD_VALIDATION] === true) {
-			// Users logging in from SSO backends cannot confirm their password by design
-			return;
+			// No scope to test
 		}
 
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -460,9 +460,12 @@ class Session implements IUserSession, Emitter {
 			} else {
 				$this->session->set('app_password', $password);
 			}
-		} elseif ($this->supportsCookies($request)) {
-			// Password login, but cookies supported -> create (browser) session token
-			$this->createSessionToken($request, $this->getUser()->getUID(), $user, $password);
+		} else {
+			$this->session->set('last-password-confirm', $this->timeFactory->getTime());
+			if ($this->supportsCookies($request)) {
+				// Password login, but cookies supported -> create (browser) session token
+				$this->createSessionToken($request, $this->getUser()->getUID(), $user, $password);
+			}
 		}
 
 		return true;
@@ -567,9 +570,6 @@ class Session implements IUserSession, Emitter {
 					$this->session->set(
 						Auth::DAV_AUTHENTICATED, $this->getUser()->getUID()
 					);
-
-					// Set the last-password-confirm session to make the sudo mode work
-					$this->session->set('last-password-confirm', $this->timeFactory->getTime());
 
 					return true;
 				}

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1125,7 +1125,6 @@ class SessionTest extends \Test\TestCase {
 			->willReturn(true);
 
 		$davAuthenticatedSet = false;
-		$lastPasswordConfirmSet = false;
 
 		$this->session
 			->method('set')
@@ -1133,9 +1132,6 @@ class SessionTest extends \Test\TestCase {
 				switch ($k) {
 					case Auth::DAV_AUTHENTICATED:
 						$davAuthenticatedSet = $v;
-						return;
-					case 'last-password-confirm':
-						$lastPasswordConfirmSet = 1000;
 						return;
 					default:
 						throw new \Exception();
@@ -1180,7 +1176,6 @@ class SessionTest extends \Test\TestCase {
 		$this->assertTrue($userSession->tryBasicAuthLogin($request, $this->throttler));
 
 		$this->assertSame('username', $davAuthenticatedSet);
-		$this->assertSame(1000, $lastPasswordConfirmSet);
 	}
 
 	public function testTryBasicAuthLoginNoLogin(): void {


### PR DESCRIPTION
## Summary

Do not set last-password-confirm for apptoken sessions

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
