### PR TITLE
[stable34] chore: Reduce PHPUnit test matrix on stable34 and remove coverage

### DIFF
--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -62,11 +62,6 @@ jobs:
         php-versions: ['8.2']
         mariadb-versions: ['10.6']
         include:
-          - php-versions: '8.3'
-            mariadb-versions: '10.11'
-            coverage: ${{ github.event_name != 'pull_request' }}
-          - php-versions: '8.4'
-            mariadb-versions: '11.4'
           - php-versions: '8.5'
             mariadb-versions: '11.8'
 
@@ -129,17 +124,10 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
+        run: composer run test:db -- --log-junit junit.xml
         env:
           DB_ROOT_USER: root
           DB_ROOT_PASS: rootpassword
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-mariadb
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -56,10 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4', '8.5']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.5']
 
     name: Memcached (PHP ${{ matrix.php-versions }})
 
@@ -101,14 +98,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit memcached tests
-        run: composer run test -- --group Memcache --group Memcached --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-memcached
+        run: composer run test -- --group Memcache --group Memcached --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -62,11 +62,6 @@ jobs:
         php-versions: ['8.2']
         mysql-versions: ['8.0']
         include:
-          - mysql-versions: '8.0'
-            php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
-          - mysql-versions: '8.4'
-            php-versions: '8.4'
           - mysql-versions: '8.4'
             php-versions: '8.5'
 
@@ -104,7 +99,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: 'none'
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -133,13 +128,6 @@ jobs:
         env:
           DB_ROOT_USER: root
           DB_ROOT_PASS: rootpassword
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-mysql
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -62,7 +62,6 @@ jobs:
         php-versions: ['8.3', '8.4', '8.5']
         include:
           - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: No DB unit tests (PHP ${{ matrix.php-versions }})
 
@@ -87,7 +86,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: 'none'
           ini-file: development
           # Required for tests that use pcntl
           ini-values: disable_functions=""
@@ -106,14 +105,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit nodb testsuite
-        run: composer run test -- --exclude-group DB --exclude-group SLOWDB --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.nodb.xml' || '' }}
-
-      - name: Upload nodb code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.nodb.xml
-          flags: phpunit-nodb
+        run: composer run test -- --exclude-group DB --exclude-group SLOWDB --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -62,11 +62,6 @@ jobs:
         include:
           - oracle-versions: '18'
             php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
-          - oracle-versions: '21'
-            php-versions: '8.3'
-          - oracle-versions: '23'
-            php-versions: '8.4'
           - oracle-versions: '23'
             php-versions: '8.5'
 
@@ -111,7 +106,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, oci8
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: 'none'
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -129,14 +124,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-oci
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -63,11 +63,6 @@ jobs:
         # To keep the matrix smaller we ignore PostgreSQL versions in between as we already test the minimum and the maximum
         postgres-versions: ['14']
         include:
-          - php-versions: '8.3'
-            postgres-versions: '18'
-            coverage: ${{ github.event_name != 'pull_request' }}
-          - php-versions: '8.4'
-            postgres-versions: '18'
           - php-versions: '8.5'
             postgres-versions: '18'
 
@@ -104,7 +99,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: 'none'
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -124,14 +119,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit database tests
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-postgres
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

Only keep min and max version for PHP and DB engines on stable branches.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
