### PR TITLE
fix: ensure file names are string-typed

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -516,7 +516,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		$removedChildren = \array_diff(array_keys($existingChildren), $newChildNames);
 		foreach ($removedChildren as $childName) {
 			$child = $path ? $path . '/' . $childName : $childName;
-			$this->removeFromCache($child);
+			$this->removeFromCache((string)$child);
 		}
 		if ($this->useTransactions) {
 			$this->connection->commit();


### PR DESCRIPTION
- `$child` was used as an array key earlier. If they are numeric, they are automatically converted to ints, leading to type issues later.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fixes an **Argument #1 ($haystack) must be of type string, int given** on `occ files:scan` with remotely shared file/folder names that are numbers.

```
TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, int given in /var/www/nextcloud/lib/private/Files/Cache/Propagator.php:48
Stack trace:
#0 /var/www/nextcloud/lib/private/Files/Cache/Propagator.php(48): str_starts_with()
#1 /var/www/nextcloud/lib/private/Files/Utils/Scanner.php(290): OC\Files\Cache\Propagator->propagateChange()
#2 /var/www/nextcloud/lib/private/Files/Utils/Scanner.php(294): OC\Files\Utils\Scanner->triggerPropagator()
#3 /var/www/nextcloud/lib/private/Files/Utils/Scanner.php(238): OC\Files\Utils\Scanner->postProcessEntry()
#4 [internal function]: OC\Files\Utils\Scanner->OC\Files\Utils\{closure}()
#5 /var/www/nextcloud/lib/private/Hooks/EmitterTrait.php(89): call_user_func_array()
#6 /var/www/nextcloud/lib/private/Files/Cache/Scanner.php(253): OC\Hooks\BasicEmitter->emit()
#7 /var/www/nextcloud/lib/private/Files/Cache/Scanner.php(530): OC\Files\Cache\Scanner->removeFromCache()
#8 /var/www/nextcloud/lib/private/Files/Cache/Scanner.php(414): OC\Files\Cache\Scanner->handleChildren()
#9 /var/www/nextcloud/lib/private/Files/Cache/Scanner.php(323): OC\Files\Cache\Scanner->scanChildren()
#10 /var/www/nextcloud/apps/files_sharing/lib/External/Scanner.php(22): OC\Files\Cache\Scanner->scan()
#11 /var/www/nextcloud/lib/private/Files/Utils/Scanner.php(265): OCA\Files_Sharing\External\Scanner->scan()
#12 /var/www/nextcloud/apps/files/lib/Command/Scan.php(165): OC\Files\Utils\Scanner->scan()
#13 /var/www/nextcloud/apps/files/lib/Command/Scan.php(255): OCA\Files\Command\Scan->scanFiles()
#14 /var/www/nextcloud/3rdparty/symfony/console/Command/Command.php(326): OCA\Files\Command\Scan->execute()
#15 /var/www/nextcloud/core/Command/Base.php(218): Symfony\Component\Console\Command\Command->run()
#16 /var/www/nextcloud/3rdparty/symfony/console/Application.php(1083): OC\Core\Command\Base->run()
#17 /var/www/nextcloud/3rdparty/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand()
#18 /var/www/nextcloud/3rdparty/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun()
#19 /var/www/nextcloud/lib/private/Console/Application.php(187): Symfony\Component\Console\Application->run()
#20 /var/www/nextcloud/console.php(90): OC\Console\Application->run()
#21 /var/www/nextcloud/occ(33): require_once('...')
#22 {main}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
