### PR TITLE
[stable34] chore(ci): Remove code coverage from stable branches

### DIFF
--- a/.github/workflows/files-external-ftp.yml
+++ b/.github/workflows/files-external-ftp.yml
@@ -57,9 +57,6 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.4']
         ftpd: ['proftpd', 'vsftpd', 'pure-ftpd']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.ftpd }}
 
@@ -87,7 +84,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -110,15 +107,7 @@ jobs:
       - name: PHPUnit
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/FtpTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-ftp
+          --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -56,9 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.2', '8.4']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-s3-minio
 
@@ -86,7 +83,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -111,15 +108,7 @@ jobs:
           composer run test:files_external -- \
             --group S3 \
             --log-junit junit.xml \
-            apps/files_external/tests/Storage \
-            ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-s3
+            apps/files_external/tests/Storage
 
       - name: Upload test results
         if: ${{ !cancelled() }}
@@ -147,9 +136,6 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2', '8.4']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-s3-localstack
 
@@ -176,7 +162,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -194,15 +180,7 @@ jobs:
           composer run test:files_external -- \
             --group S3 \
             --log-junit junit.xml \
-            apps/files_external/tests/Storage \
-            ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-s3
+            apps/files_external/tests/Storage
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/files-external-sftp.yml
+++ b/.github/workflows/files-external-sftp.yml
@@ -57,9 +57,6 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.4']
         sftpd: ['openssh']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.sftpd }}
 
@@ -83,7 +80,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -99,15 +96,7 @@ jobs:
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/SftpTest.php \
           apps/files_external/tests/Storage/SFTP_KeyTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-sftp
+          --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -57,7 +57,6 @@ jobs:
       matrix:
         include:
           - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-smb
 
@@ -87,7 +86,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, smbclient, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -112,15 +111,7 @@ jobs:
       - name: PHPUnit
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/SmbTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-smb
+          --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/files-external-webdav.yml
+++ b/.github/workflows/files-external-webdav.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.4']
 
     name: php${{ matrix.php-versions }}-webdav
 
@@ -82,7 +79,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -104,15 +101,7 @@ jobs:
       - name: PHPUnit
         run: composer run test:files_external -- \
           apps/files_external/tests/Storage/WebdavTest.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-webdav
+          --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.4']
 
     name: php${{ matrix.php-versions }}-generic
 
@@ -76,7 +73,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -93,15 +90,7 @@ jobs:
 
       - name: PHPUnit
         run: composer run test:files_external -- \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-files-external-generic
+          --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
-        include:
-          - php-versions: '8.4'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.4']
 
     name: php${{ matrix.php-versions }}-azure
 
@@ -91,7 +88,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -114,14 +111,7 @@ jobs:
           OBJECT_STORE: azure
           OBJECT_STORE_KEY: nextcloud
           OBJECT_STORE_SECRET: bmV4dGNsb3Vk
-        run: composer run test -- --group PRIMARY-azure --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-azure
+        run: composer run test -- --group PRIMARY-azure --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.4']
 
     name: php${{ matrix.php-versions }}-s3
 
@@ -92,7 +89,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -119,14 +116,7 @@ jobs:
           OBJECT_STORE: s3
           OBJECT_STORE_KEY: nextcloud
           OBJECT_STORE_SECRET: bWluaW8tc2VjcmV0LWtleS1uZXh0Y2xvdWQ=
-        run: composer run test -- --group PRIMARY-s3 --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-s3
+        run: composer run test -- --group PRIMARY-s3 --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -55,10 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
-        include:
-          - php-versions: '8.3'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.4']
 
     name: php${{ matrix.php-versions }}-swift
 
@@ -89,7 +86,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -110,14 +107,7 @@ jobs:
         env:
           OBJECT_STORE: swift
           OBJECT_STORE_SECRET: veryfast
-        run: composer run test -- --group PRIMARY-swift --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
-
-      - name: Upload code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.xml
-          flags: phpunit-swift
+        run: composer run test -- --group PRIMARY-swift --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -99,7 +99,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -81,7 +81,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, memcached, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:

--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -133,7 +133,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -159,14 +159,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-mysql
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -124,7 +124,7 @@ jobs:
           php -f tests/enable_all.php
 
       - name: PHPUnit
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}
+        run: composer run test:db -- --log-junit junit.xml
         env:
           DB_ROOT_USER: root
           DB_ROOT_PASS: rootpassword

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -59,10 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4', '8.5']
-        include:
-          - php-versions: '8.2'
-            coverage: ${{ github.event_name != 'pull_request' }}
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
 
     name: SQLite (PHP ${{ matrix.php-versions }})
 
@@ -87,7 +84,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           ini-file: development
           ini-values: disable_functions=""
         env:
@@ -111,14 +108,7 @@ jobs:
         run: ./occ app:list && echo "======= System config =======" && ./occ config:list system
 
       - name: PHPUnit database tests
-        run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }} tests/lib/Preview/PostscriptTest.php
-
-      - name: Upload db code coverage
-        if: ${{ !cancelled() && matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: ./clover.db.xml
-          flags: phpunit-sqlite
+        run: composer run test:db -- --log-junit junit.xml
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -150,21 +150,20 @@ class S3Test extends ObjectStoreTestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileSizes')]
 	public function testFileSizes($size): void {
-		if (str_starts_with(PHP_VERSION, '8.3') && getenv('CI')) {
-			$this->markTestSkipped('Test is unreliable and skipped on 8.3');
-		}
-
 		$this->cleanupAfter('testfilesizes');
 		$s3 = $this->getInstance();
 
 		$sourceStream = fopen('php://memory', 'wb+');
 		$writeChunkSize = 1024;
-		$chunkCount = $size / $writeChunkSize;
-		for ($i = 0; $i < $chunkCount; $i++) {
-			fwrite($sourceStream, str_repeat('A',
-				($i < $chunkCount - 1) ? $writeChunkSize : $size - ($i * $writeChunkSize)
-			));
+		$chunk = str_repeat('A', $writeChunkSize);
+		$remainingSize = $size;
+
+		while ($remainingSize > 0) {
+			$bytesToWrite = min($writeChunkSize, $remainingSize);
+			fwrite($sourceStream, ($bytesToWrite === $writeChunkSize) ? $chunk : str_repeat('A', $bytesToWrite));
+			$remainingSize -= $bytesToWrite;
 		}
+
 		rewind($sourceStream);
 		$s3->writeObject('testfilesizes', $sourceStream);
 
@@ -174,16 +173,21 @@ class S3Test extends ObjectStoreTestCase {
 		$result = $s3->readObject('testfilesizes');
 
 		// compare first 100 bytes
-		self::assertEquals(str_repeat('A', 100), fread($result, 100), 'Compare first 100 bytes');
+		self::assertSame(str_repeat('A', 100), fread($result, 100), 'Compare first 100 bytes');
 
 		// compare last 100 bytes
-		fseek($result, $size - 100);
-		self::assertEquals(str_repeat('A', 100), fread($result, 100), 'Compare last 100 bytes');
+		self::assertSame(0, fseek($result, $size - 100), 'Seek to last 100 bytes succeeds');
+		self::assertSame(str_repeat('A', 100), fread($result, 100), 'Compare last 100 bytes');
 
 		// end of file reached
-		fseek($result, $size);
-		self::assertTrue(feof($result), 'End of file reached');
+		self::assertSame(0, fseek($result, $size), 'Seek to EOF succeeds');
+		self::assertSame($size, ftell($result), 'Pointer is at the end of file');
+		self::assertSame('', fread($result, 1), 'Reading at end of file returns no bytes');
+		self::assertTrue(feof($result), 'End of file reached after read attempt');
 
 		$this->assertNoUpload('testfilesizes');
+
+		fclose($sourceStream);
+		fclose($result);
 	}
 }

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -186,8 +186,5 @@ class S3Test extends ObjectStoreTestCase {
 		self::assertTrue(feof($result), 'End of file reached after read attempt');
 
 		$this->assertNoUpload('testfilesizes');
-
-		fclose($sourceStream);
-		fclose($result);
 	}
 }


### PR DESCRIPTION
## Summary

- Follow-up of https://github.com/nextcloud/server/pull/61331
- Also includes backport of https://github.com/nextcloud/server/pull/61275

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
