### PR TITLE
fix: prevent editing delegated admins

### DIFF
--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -256,6 +256,9 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		if ($this->groupManager->isAdmin($user->getUID())) {
 			return false;
 		}
+		if ($this->groupManager->isDelegatedAdmin($user->getUID())) {
+			return false;
+		}
 
 		$accessibleGroups = $this->getSubAdminsGroupIds($subadmin);
 		$userGroups = $this->groupManager->getUserGroupIds($user);


### PR DESCRIPTION
## Summary

Prevent delegated admin edit

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
