### PR TITLE
feat: show the groups that an app is enabled for when using occ app:list

### DIFF
--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -9,6 +9,7 @@ namespace OC\Core\Command\App;
 
 use OC\Core\Command\Base;
 use OCP\App\IAppManager;
+use OCP\IGroupManager;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListApps extends Base {
 	public function __construct(
 		protected IAppManager $appManager,
+		protected IGroupManager $groupManager,
 	) {
 		parent::__construct();
 	}
@@ -83,7 +85,14 @@ class ListApps extends Base {
 
 			sort($enabledApps);
 			foreach ($enabledApps as $app) {
-				$apps['enabled'][$app] = $versions[$app] ?? true;
+				$appDetails = $versions[$app] ?? true;
+				$appRestrictions = $this->appManager->getAppRestriction($app);
+
+				if ($appRestrictions !== []) {
+					$appDetails .= $this->formatAppRestrictions($appRestrictions);
+				}
+
+				$apps['enabled'][$app] = $appDetails;
 			}
 		}
 
@@ -98,6 +107,15 @@ class ListApps extends Base {
 
 		$this->writeAppList($input, $output, $apps);
 		return 0;
+	}
+
+	/**
+	 * @param string[] $groupIds - List of groups the app is restricted to
+	 */
+	private function formatAppRestrictions(array $groupIds): string {
+		$groups = array_map(fn (string $groupId): string => $this->groupManager->get($groupId)?->getDisplayName() ?? $groupId, $groupIds);
+
+		return ' (enabled for groups: ' . implode(', ', $groups) . ')';
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/61376+

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
