### PR TITLE
fix(OCM): Remove comment meant only for OCP APIs

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/TokenController.php
+++ b/apps/cloud_federation_api/lib/Controller/TokenController.php
@@ -38,8 +38,6 @@ use Psr\Log\LoggerInterface;
 /**
  * Controller for the /token endpoint
  * Exchanges long-lived refresh tokens for short-lived access tokens
- *
- * @since 32.0.0
  */
 class TokenController extends ApiController {
 	public function __construct(


### PR DESCRIPTION
Just removing a minor paper cut that was introduced in #57234 
