### PR TITLE
fix(settings): show app menu current-app button on settings pages

### DIFF
--- a/apps/settings/lib/Controller/CommonSettingsTrait.php
+++ b/apps/settings/lib/Controller/CommonSettingsTrait.php
@@ -152,14 +152,14 @@ trait CommonSettingsTrait {
 			if ($section === 'theming') {
 				$this->navigationManager->setActiveEntry('accessibility_settings');
 			} else {
-				$this->navigationManager->setActiveEntry('settings');
+				$this->navigationManager->setActiveEntry('settings_personal');
 			}
 		} elseif ($type === 'admin') {
 			$settings = array_values($this->settingsManager->getAllowedAdminSettings($section, $user));
 			if (empty($settings) && empty($declarativeSettings)) {
 				throw new NotAdminException('Logged in user does not have permission to access these settings.');
 			}
-			$this->navigationManager->setActiveEntry('admin_settings');
+			$this->navigationManager->setActiveEntry('settings_administration');
 		} else {
 			throw new InvalidArgumentException('$type must be either "admin" or "personal"');
 		}

--- a/apps/settings/tests/Controller/PersonalSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/PersonalSettingsControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\Settings\Tests\Controller;
 
-use OCA\Settings\Controller\AdminSettingsController;
+use OCA\Settings\Controller\PersonalSettingsController;
 use OCA\Settings\Settings\Personal\ServerDevNotice;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -25,13 +25,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
- * Class AdminSettingsControllerTest
- *
- *
  * @package Tests\Settings\Controller
  */
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
-class AdminSettingsControllerTest extends TestCase {
+class PersonalSettingsControllerTest extends TestCase {
 
 	private IRequest&MockObject $request;
 	private INavigationManager&MockObject $navigationManager;
@@ -42,8 +39,8 @@ class AdminSettingsControllerTest extends TestCase {
 	private IDeclarativeManager&MockObject $declarativeSettingsManager;
 	private IInitialState&MockObject $initialState;
 
-	private string $adminUid = 'lololo';
-	private AdminSettingsController $adminSettingsController;
+	private string $uid = 'personalsettingsuser';
+	private PersonalSettingsController $personalSettingsController;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -57,7 +54,7 @@ class AdminSettingsControllerTest extends TestCase {
 		$this->declarativeSettingsManager = $this->createMock(IDeclarativeManager::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 
-		$this->adminSettingsController = new AdminSettingsController(
+		$this->personalSettingsController = new PersonalSettingsController(
 			'settings',
 			$this->request,
 			$this->navigationManager,
@@ -69,14 +66,13 @@ class AdminSettingsControllerTest extends TestCase {
 			$this->initialState,
 		);
 
-		$user = Server::get(IUserManager::class)->createUser($this->adminUid, 'mylongrandompassword');
+		$user = Server::get(IUserManager::class)->createUser($this->uid, 'mylongrandompassword');
 		\OC_User::setUserId($user->getUID());
-		Server::get(IGroupManager::class)->createGroup('admin')->addUser($user);
 	}
 
 	protected function tearDown(): void {
 		Server::get(IUserManager::class)
-			->get($this->adminUid)
+			->get($this->uid)
 			->delete();
 		\OC_User::setUserId(null);
 		Server::get(IUserSession::class)->setUser(null);
@@ -84,69 +80,52 @@ class AdminSettingsControllerTest extends TestCase {
 		parent::tearDown();
 	}
 
-	public function testIndex(): void {
+	/**
+	 * Marks the section we are about to render so the rest of getIndexResponse()
+	 * has something to format. The actual content is irrelevant to these tests.
+	 */
+	private function stubSettingsFor(string $section): void {
 		$user = $this->createMock(IUser::class);
-		$this->userSession
-			->method('getUser')
-			->willReturn($user);
 		$user->method('getUID')->willReturn('user123');
-		$this->groupManager
-			->method('isAdmin')
-			->with('user123')
-			->willReturn(true);
-		$this->subAdmin
-			->method('isSubAdmin')
-			->with($user)
-			->willReturn(false);
+		$this->userSession->method('getUser')->willReturn($user);
 
 		$form = new TemplateResponse('settings', 'settings/empty');
 		$setting = $this->createMock(ServerDevNotice::class);
-		$setting->expects(self::any())
-			->method('getForm')
-			->willReturn($form);
-		$this->settingsManager
-			->expects($this->once())
-			->method('getAdminSections')
-			->willReturn([]);
-		$this->settingsManager
-			->expects($this->once())
-			->method('getPersonalSections')
-			->willReturn([]);
-		$this->settingsManager
-			->expects($this->once())
-			->method('getAllowedAdminSettings')
-			->with('test')
-			->willReturn([5 => [$setting]]);
-		$this->declarativeSettingsManager
-			->expects($this->any())
-			->method('getFormIDs')
-			->with($user, 'admin', 'test')
-			->willReturn([]);
+		$setting->method('getForm')->willReturn($form);
 
-		// The active entry must match the id the admin nav entry is registered
-		// under in Application.php, otherwise the header current-app button is hidden.
+		$this->settingsManager
+			->method('getPersonalSettings')
+			->with($section)
+			->willReturn([5 => [$setting]]);
+		$this->settingsManager->method('getPersonalSections')->willReturn([]);
+		$this->settingsManager->method('getAdminSections')->willReturn([]);
+		$this->declarativeSettingsManager->method('getFormIDs')->willReturn([]);
+		$this->declarativeSettingsManager->method('getFormsWithValues')->willReturn([]);
+	}
+
+	public function testIndexActivatesPersonalNavEntry(): void {
+		$this->stubSettingsFor('additional');
+
+		// Must match the id the personal nav entry is registered under in
+		// Application.php ('settings_personal'), otherwise the header
+		// current-app button is hidden on personal settings pages.
 		$this->navigationManager
 			->expects($this->once())
 			->method('setActiveEntry')
-			->with('settings_administration');
+			->with('settings_personal');
 
-		$initialState = [];
-		$this->initialState->expects(self::atLeastOnce())
-			->method('provideInitialState')
-			->willReturnCallback(function () use (&$initialState): void {
-				$initialState[] = func_get_args();
-			});
+		$this->personalSettingsController->index('additional');
+	}
 
-		$expected = new TemplateResponse(
-			'settings',
-			'settings/frame',
-			[
-				'content' => ''
-			],
-		);
-		$this->assertEquals($expected, $this->adminSettingsController->index('test'));
-		$this->assertEquals([
-			['sections', ['admin' => [], 'personal' => []]],
-		], $initialState);
+	public function testThemingSectionActivatesAccessibilityNavEntry(): void {
+		$this->stubSettingsFor('theming');
+
+		// The appearance/accessibility section keeps its own nav entry.
+		$this->navigationManager
+			->expects($this->once())
+			->method('setActiveEntry')
+			->with('accessibility_settings');
+
+		$this->personalSettingsController->index('theming');
 	}
 }


### PR DESCRIPTION
## Summary

On personal and admin settings pages the app menu's current-app button (the icon + name next to the waffle) is missing. 

`CommonSettingsTrait` marks the active navigation entry with stale ids: `settings`, `admin_settings`. These no longer match the registered entries: `settings_personal`, `settings_administration`, so nothing is flagged active and the button stays hidden. 

Accessibility is the exception because its id `accessibility_settings` still matches.

This aligns the two `setActiveEntry()` calls with the registered ids and adds controller tests pinning them.

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>
<img width="314" height="196" alt="Screenshot_2026-06-18_13-54-26" src="https://github.com/user-attachments/assets/0deb5458-2b8b-4db6-8e29-3f2916de82c2" />
</td>
 <td>
<img width="314" height="196" alt="Screenshot_2026-06-18_13-54-02" src="https://github.com/user-attachments/assets/f5ffc838-0fa6-404c-9d5b-53f08b50f160" />
</td>
<tr>
 <td>
<img width="314" height="486" alt="Screenshot_2026-06-18_13-54-40" src="https://github.com/user-attachments/assets/27d39b55-3e34-4404-9d92-d813a5619ce3" />
</td>
 <td>
<img width="314" height="486" alt="Screenshot_2026-06-18_13-54-51" src="https://github.com/user-attachments/assets/df84f428-2b47-47ff-89ef-a66fcf68603e" />
</td>
</table>

## Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation (manuals or wiki) has been updated or is not required
- [x] Backports requested where applicable (ex: critical bugfixes)
- [x] Labels added where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] Milestone added for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly generated using AI. (Claude helped with tests)