### PR TITLE
perf: Only sort wrappers when adding them

### DIFF
--- a/lib/private/Files/Storage/StorageFactory.php
+++ b/lib/private/Files/Storage/StorageFactory.php
@@ -18,6 +18,8 @@ use Psr\Log\LoggerInterface;
 class StorageFactory implements IStorageFactory {
 	/** @var array<string, array{wrapper: callable(string $mountPoint, IStorage $storage): IStorage, priority: int}> $storageWrappers */
 	private array $storageWrappers = [];
+	/** @var bool $dirty Whether the list of storage wrappers is sorted */
+	private bool $dirty = true;
 
 	#[\Override]
 	public function addStorageWrapper(string $wrapperName, callable $callback, int $priority = 50, array $existingMounts = []): bool {
@@ -31,6 +33,7 @@ class StorageFactory implements IStorageFactory {
 		}
 
 		$this->storageWrappers[$wrapperName] = ['wrapper' => $callback, 'priority' => $priority];
+		$this->dirty = true;
 		return true;
 	}
 
@@ -56,16 +59,14 @@ class StorageFactory implements IStorageFactory {
 	}
 
 	public function wrap(IMountPoint $mountPoint, IStorage $storage): IStorage {
-		$wrappers = array_values($this->storageWrappers);
-		usort($wrappers, function ($a, $b) {
-			return $b['priority'] - $a['priority'];
-		});
-		/** @var callable[] $wrappers */
-		$wrappers = array_map(function ($wrapper) {
-			return $wrapper['wrapper'];
-		}, $wrappers);
-		foreach ($wrappers as $wrapper) {
-			$storage = $wrapper($mountPoint->getMountPoint(), $storage, $mountPoint);
+		if ($this->dirty) {
+			uasort($this->storageWrappers, static fn (array $a, array $b) => $b['priority'] - $a['priority']);
+			$this->dirty = false;
+		}
+		foreach ($this->storageWrappers as $wrapper) {
+			/** @var callable(string, IStorage, IMountPoint): IStorage $wrapperCallable */
+			$wrapperCallable = $wrapper['wrapper'];
+			$storage = $wrapperCallable($mountPoint->getMountPoint(), $storage, $mountPoint);
 			if (!($storage instanceof IStorage)) {
 				throw new \Exception('Invalid result from storage wrapper');
 			}


### PR DESCRIPTION
Instead of doing that each time a new mount point is created (e.g. for the 7000 shares we have in production).

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
