### PR TITLE
fix(federatedfilesharing): use DI in migration

### DIFF
--- a/apps/federatedfilesharing/lib/Migration/Version1012Date20260306120000.php
+++ b/apps/federatedfilesharing/lib/Migration/Version1012Date20260306120000.php
@@ -19,7 +19,6 @@ use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
-use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -36,6 +35,13 @@ use OCP\Share\IShare;
  * oc_authtoken are silently repaired.
  */
 class Version1012Date20260306120000 extends SimpleMigrationStep {
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly PublicKeyTokenProvider $tokenProvider,
+		private readonly IUserManager $userManager,
+	) {
+	}
+
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		return null;
@@ -43,11 +49,7 @@ class Version1012Date20260306120000 extends SimpleMigrationStep {
 
 	#[\Override]
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		$db = Server::get(IDBConnection::class);
-		$tokenProvider = Server::get(PublicKeyTokenProvider::class);
-		$userManager = Server::get(IUserManager::class);
-
-		$qb = $db->getQueryBuilder();
+		$qb = $this->db->getQueryBuilder();
 		$result = $qb->select('id', 'token', 'uid_initiator')
 			->from('share')
 			->where($qb->expr()->in(
@@ -78,18 +80,18 @@ class Version1012Date20260306120000 extends SimpleMigrationStep {
 
 			// Long token — check if it's already in oc_authtoken.
 			try {
-				$tokenProvider->getToken($token);
+				$this->tokenProvider->getToken($token);
 				$skipped++;
 				continue;
 			} catch (InvalidTokenException) {
 				// Not registered yet — fall through to create it.
 			}
 
-			$user = $userManager->get($uid);
+			$user = $this->userManager->get($uid);
 			$name = $user?->getDisplayName() ?? $uid;
 
 			try {
-				$tokenProvider->generateToken(
+				$this->tokenProvider->generateToken(
 					$token,
 					$uid,
 					$uid,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Addresses a comment by @nickvergessen in PR #57234 (merged) regarding the use of DI in a migration.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ x] Screenshots before/after for front-end changes
- [x ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
