### PR TITLE
perf(View):  don't sort twice the same array

### DIFF
--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -27,7 +27,7 @@ class Manager implements IMountManager {
 	private ?array $mountKeys = null;
 	/** @var CappedMemoryCache<IMountPoint> */
 	private CappedMemoryCache $pathCache;
-	/** @var CappedMemoryCache<IMountPoint[]> */
+	/** @var CappedMemoryCache<list<IMountPoint>> */
 	private CappedMemoryCache $inPathCache;
 	private SetupManager $setupManager;
 
@@ -111,11 +111,6 @@ class Manager implements IMountManager {
 		throw new NotFoundException('No mount for path ' . $path . ' existing mounts (' . count($this->mounts) . '): ' . implode(',', array_keys($this->mounts)));
 	}
 
-	/**
-	 * Find all mounts in $path
-	 *
-	 * @return IMountPoint[]
-	 */
 	#[\Override]
 	public function findIn(string $path): array {
 		$this->setupManager->setupForPath($path, true);

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -110,7 +110,7 @@ class LazyFolder implements Folder {
 	}
 
 	/**
-	 * @return IMountPoint[]
+	 * @return list<IMountPoint>
 	 */
 	public function getMountsIn(string $mountPoint): array {
 		return $this->__call(__FUNCTION__, func_get_args());

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -136,10 +136,6 @@ class Root extends Folder implements IRootFolder {
 		return $this->mountManager->find($mountPoint);
 	}
 
-	/**
-	 * @param string $mountPoint
-	 * @return IMountPoint[]
-	 */
 	#[\Override]
 	public function getMountsIn(string $mountPoint): array {
 		return $this->mountManager->findIn($mountPoint);

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -55,12 +55,11 @@ class Scanner extends PublicEmitter {
 	}
 
 	/**
-	 * get all storages for $dir
+	 * Get all storages for a specific directory.
 	 *
-	 * @param string $dir
 	 * @return array<string, IMountPoint>
 	 */
-	protected function getMounts($dir) {
+	protected function getMounts(string $dir): array {
 		//TODO: move to the node based fileapi once that's done
 		$this->setupManager->tearDown();
 
@@ -80,7 +79,7 @@ class Scanner extends PublicEmitter {
 	/**
 	 * attach listeners to the scanner
 	 */
-	protected function attachListener(MountPoint $mount) {
+	protected function attachListener(IMountPoint $mount): void {
 		/** @var \OC\Files\Cache\Scanner $scanner */
 		$scanner = $mount->getStorage()->getScanner();
 		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount): void {
@@ -104,7 +103,7 @@ class Scanner extends PublicEmitter {
 		});
 	}
 
-	public function backgroundScan(string $dir) {
+	public function backgroundScan(string $dir): void {
 		$mounts = $this->getMounts($dir);
 		foreach ($mounts as $mount) {
 			try {
@@ -245,7 +244,7 @@ class Scanner extends PublicEmitter {
 		}
 	}
 
-	private function triggerPropagator(IStorage $storage, $internalPath) {
+	private function triggerPropagator(IStorage $storage, $internalPath): void {
 		$storage->getPropagator()->propagateChange($internalPath, time());
 	}
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1570,10 +1570,6 @@ class View {
 		//add a folder for any mountpoint in this directory and add the sizes of other mountpoints to the folders
 		$mounts = Filesystem::getMountManager()->findIn($path);
 
-		// make sure nested mounts are sorted after their parent mounts
-		// otherwise doesn't propagate the etag across storage boundaries correctly
-		usort($mounts, static fn (IMountPoint $a, IMountPoint $b): int => $a->getMountPoint() <=> $b->getMountPoint());
-
 		$dirLength = strlen($path);
 		foreach ($mounts as $mount) {
 			$mountPoint = $mount->getMountPoint();

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -62,7 +62,7 @@ interface IRootFolder extends Folder, Emitter {
 	public function getFirstNodeByIdInPath(int $id, string $path): ?Node;
 
 	/**
-	 * @return IMountPoint[]
+	 * @return list<IMountPoint>
 	 *
 	 * @since 28.0.0
 	 */

--- a/lib/public/Files/Mount/IMountManager.php
+++ b/lib/public/Files/Mount/IMountManager.php
@@ -56,7 +56,7 @@ interface IMountManager {
 	 * Find all mounts in $path
 	 *
 	 * @param string $path
-	 * @return IMountPoint[]
+	 * @return list<IMountPoint> Returns a sorted list of mount point
 	 * @since 8.2.0
 	 */
 	public function findIn(string $path): array;

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -21,45 +23,35 @@ use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
+use Test\TestCase;
+use Test\Util\User\Dummy;
 
 class TestScanner extends Scanner {
-	/**
-	 * @var MountPoint[] $mounts
-	 */
-	private $mounts = [];
+	/** @var array<string, MountPoint> $mounts */
+	private array $mounts = [];
 
-	/**
-	 * @param MountPoint $mount
-	 */
-	public function addMount($mount) {
-		$this->mounts[] = $mount;
+	public function addMount(MountPoint $mount): void {
+		$this->mounts[$mount->getMountPoint()] = $mount;
 	}
 
 	#[\Override]
-	protected function getMounts($dir) {
+	protected function getMounts(string $dir): array {
 		return $this->mounts;
 	}
 }
 
-/**
- * Class ScannerTest
- *
- *
- * @package Test\Files\Utils
- */
-#[\PHPUnit\Framework\Attributes\Group('DB')]
-class ScannerTest extends \Test\TestCase {
-	/**
-	 * @var \Test\Util\User\Dummy
-	 */
-	private $userBackend;
+#[Group('DB')]
+class ScannerTest extends TestCase {
+	private Dummy $userBackend;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->userBackend = new \Test\Util\User\Dummy();
+		$this->userBackend = new Dummy();
 		Server::get(IUserManager::class)->registerBackend($this->userBackend);
 		$this->loginAsUser();
 	}
@@ -166,25 +158,14 @@ class ScannerTest extends \Test\TestCase {
 		$this->assertTrue($cache->inCache('folder/bar.txt'));
 	}
 
-	public static function invalidPathProvider(): array {
-		return [
-			[
-				'../',
-			],
-			[
-				'..\\',
-			],
-			[
-				'../..\\../',
-			],
-		];
+	public static function invalidPathProvider(): \Generator {
+		yield [ '../' ];
+		yield [ '..\\' ];
+		yield [ '../..\\../' ];
 	}
 
-	/**
-	 * @param string $invalidPath
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('invalidPathProvider')]
-	public function testInvalidPathScanning($invalidPath): void {
+	#[DataProvider(methodName: 'invalidPathProvider')]
+	public function testInvalidPathScanning(string $invalidPath): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid path to scan');
 
@@ -249,14 +230,14 @@ class ScannerTest extends \Test\TestCase {
 		);
 		$scanner->addMount($mount);
 
-		$scanner->scan('', $recusive = false);
+		$scanner->scan('', false);
 		$this->assertTrue($cache->inCache('folder'));
 		$this->assertFalse($cache->inCache('folder/subfolder'));
 		$this->assertTrue($cache->inCache('foo.txt'));
 		$this->assertFalse($cache->inCache('folder/bar.txt'));
 		$this->assertFalse($cache->inCache('folder/subfolder/foobar.txt'));
 
-		$scanner->scan('folder', $recusive = false);
+		$scanner->scan('folder', false);
 		$this->assertTrue($cache->inCache('folder'));
 		$this->assertTrue($cache->inCache('folder/subfolder'));
 		$this->assertTrue($cache->inCache('foo.txt'));


### PR DESCRIPTION
The output of findIn is already sorted as it use a binary search to create the array

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
