### PR TITLE
docs(config): clarify metadata and conversion file size limits

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1602,20 +1602,27 @@ $CONFIG = [
 	],
 
 	/**
-	 * Maximum file size for metadata generation.
-	 * If a file exceeds this size, metadata generation will be skipped.
+	 * Maximum file size for file metadata generation.
 	 *
-	 * NOTE: memory equivalent to this size will be used for metadata generation.
+	 * Files larger than this limit will be skipped.
 	 *
-	 * Default: 256 megabytes.
+	 * This limit helps bound resource usage during metadata generation. Actual
+	 * resource usage depends on the active metadata providers and how they
+	 * process files. As a rough guide, memory usage may scale with file size.
+	 *
+	 * Default: 256 MiB.
 	 */
 	'metadata_max_filesize' => 256,
 
 	/**
 	 * Maximum file size for file conversion.
-	 * If a file exceeds this size, the file will not be converted.
 	 *
-	 * Default: 100 MiB
+	 * Files larger than this limit will be skipped.
+	 *
+	 * Raising this limit may increase conversion time, resource usage, and the
+	 * risk of timeouts or conversion failures depending on the provider.
+	 *
+	 * Default: 100 MiB.
 	 */
 	'max_file_conversion_filesize' => 100,
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Changes:

- correct unit for `metadata_max_filesize` to match implementation (MiB)
- improve wording/clarity around resource usage and timeouts

PR #54951 corrected the implementation of `metadata_max_filesize` to use MiB-based sizing instead of MB. This update aligns the corresponding documentation with the implementation and expands the resource-usage wording to better reflect how file metadata generation behaves in practice.

It also updates the similar `max_file_conversion_filesize` entry for the File Conversion provider feature. The unit was already correct there, but the docs now also notes the potential impact on resource usage and timeouts, based on discussion in #49922 (e.g. [timeouts](https://github.com/nextcloud/server/pull/49922#discussion_r1914363364 )) and the implementations.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
