### PR TITLE
fix(user_ldap): return valid domain DN from getDomainDNFromDN

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1846,7 +1846,7 @@ class Access extends LDAPUtility {
 		if ($domainDN === '') {
 			return false;
 		}
-		
+
 		$cacheKey = 'getSID-' . $domainDN;
 		$sid = $this->connection->getFromCache($cacheKey);
 		if (!is_null($sid)) {

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -381,9 +381,13 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * returns a DN-string that is cleaned from not domain parts, e.g.
-	 * cn=foo,cn=bar,dc=foobar,dc=server,dc=org
-	 * becomes dc=foobar,dc=server,dc=org
+	 * Returns the domain DN portion of a full DN, from the first dc= component onward.
+	 *
+	 * For example, cn=foo,cn=bar,dc=foobar,dc=server,dc=org
+	 * becomes dc=foobar,dc=server,dc=org.
+	 *
+	 * Returns an empty string if the input is not a valid DN or if no dc=
+	 * component is present.
 	 *
 	 * @param string $dn
 	 * @return string
@@ -391,19 +395,24 @@ class Access extends LDAPUtility {
 	public function getDomainDNFromDN($dn) {
 		$allParts = $this->ldap->explodeDN($dn, 0);
 		if ($allParts === false) {
-			//not a valid DN
+			// not a valid DN
 			return '';
 		}
+
 		$domainParts = [];
 		$dcFound = false;
-		foreach ($allParts as $part) {
-			if (!$dcFound && str_starts_with($part, 'dc=')) {
+		foreach ($allParts as $key => $part) {
+			if ($key === 'count' || !is_string($part)) {
+				continue;
+			}
+			if (!$dcFound && strncasecmp($part, 'dc=', 3) === 0) {
 				$dcFound = true;
 			}
 			if ($dcFound) {
 				$domainParts[] = $part;
 			}
 		}
+
 		return implode(',', $domainParts);
 	}
 
@@ -1834,6 +1843,10 @@ class Access extends LDAPUtility {
 	 */
 	public function getSID($dn) {
 		$domainDN = $this->getDomainDNFromDN($dn);
+		if ($domainDN === '') {
+			return false;
+		}
+		
 		$cacheKey = 'getSID-' . $domainDN;
 		$sid = $this->connection->getFromCache($cacheKey);
 		if (!is_null($sid)) {

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -187,7 +187,14 @@ class AccessTest extends TestCase {
 		$this->ldap->expects($this->once())
 			->method('explodeDN')
 			->with($inputDN, 0)
-			->willReturn(explode(',', $inputDN));
+			->willReturn([
+				0 => 'uid=zaphod',
+				1 => 'cn=foobar',
+				2 => 'dc=my',
+				3 => 'dc=server',
+				4 => 'dc=com',
+				'count' => 5,
+			]);
 
 		$this->assertSame($domainDN, $this->access->getDomainDNFromDN($inputDN));
 	}
@@ -202,6 +209,38 @@ class AccessTest extends TestCase {
 			->willReturn(false);
 
 		$this->assertSame($expected, $this->access->getDomainDNFromDN($inputDN));
+	}
+
+	public function testGetDomainDNFromDNMatchesUppercaseDC(): void {
+		$inputDN = 'CN=John Doe,OU=staff,DC=example,DC=com';
+
+		$this->ldap->expects($this->once())
+			->method('explodeDN')
+			->with($inputDN, 0)
+			->willReturn([
+				0 => 'CN=John Doe',
+				1 => 'OU=staff',
+				2 => 'DC=example',
+				3 => 'DC=com',
+				'count' => 4,
+			]);
+
+		$this->assertSame('DC=example,DC=com', $this->access->getDomainDNFromDN($inputDN));
+	}
+
+	public function testGetDomainDNFromDNWithoutDomainComponentReturnsEmptyString(): void {
+		$inputDN = 'cn=John Doe,ou=staff';
+
+		$this->ldap->expects($this->once())
+			->method('explodeDN')
+			->with($inputDN, 0)
+			->willReturn([
+				0 => 'cn=John Doe',
+				1 => 'ou=staff',
+				'count' => 2,
+			]);
+
+		$this->assertSame('', $this->access->getDomainDNFromDN($inputDN));
 	}
 
 	public static function dnInputDataProvider(): array {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #61446 <!-- related github issue -->

## Summary

Fixes `getDomainDNFromDN()` so it ignores the non-DN count entry returned by `ldap_explode_dn()`, preventing invalid domain DNs like `dc=example,dc=com,4`.

Includes related fixes:
- Make the prefix check case-insensitive
- Add an explicit empty-result guard in `getSID()`

Also updates the related tests to reflect real `ldap_explode_dn()` output and cover these edge cases.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
