### PR TITLE
docs(teams): cleanup ITeamManager docs and typing

### DIFF
--- a/core/Controller/TeamsApiController.php
+++ b/core/Controller/TeamsApiController.php
@@ -68,11 +68,12 @@ class TeamsApiController extends OCSController {
 		$teams = $this->teamManager->getTeamsForResource($providerId, $resourceId, $this->userId);
 		$teamIds = array_map(static fn (Team $team): string => $team->getId(), $teams);
 		$sharesPerTeams = $this->teamManager->getSharedWithList($teamIds, $this->userId, $resourceId);
-		$listTeams = array_values(array_map(static function (Team $team) use ($sharesPerTeams) {
+
+		$listTeams = array_map(static function (Team $team) use ($sharesPerTeams) {
 			$response = $team->jsonSerialize();
 			$response['resources'] = array_map(static fn (TeamResource $resource) => $resource->jsonSerialize(), $sharesPerTeams[$team->getId()] ?? []);
 			return $response;
-		}, $teams));
+		}, $teams);
 
 		return new DataResponse([
 			'teams' => $listTeams,

--- a/lib/private/Teams/TeamManager.php
+++ b/lib/private/Teams/TeamManager.php
@@ -142,11 +142,6 @@ class TeamManager implements ITeamManager {
 		}
 	}
 
-	/**
-	 * Returns a mapping of user id to display name for all members of a given team.
-	 *
-	 * @return array<string, string> userId => displayName
-	 */
 	#[\Override]
 	public function getMembersOfTeam(string $teamId, string $userId): array {
 		$team = $this->getTeam($teamId, $userId);

--- a/lib/private/Teams/TeamManager.php
+++ b/lib/private/Teams/TeamManager.php
@@ -119,13 +119,17 @@ class TeamManager implements ITeamManager {
 		}
 
 		$provider = $this->getProvider($providerId);
-		return array_map(function (Circle $team) {
-			return new Team(
+		$result = [];
+		foreach ($this->getTeams($provider->getTeamsForResource($resourceId), $userId) as $team) {
+			$result[] = new Team(
 				$team->getSingleId(),
 				$team->getDisplayName(),
 				$this->urlGenerator->linkToRouteAbsolute('contacts.contacts.directcircle', ['singleId' => $team->getSingleId()]),
 			);
-		}, $this->getTeams($provider->getTeamsForResource($resourceId), $userId));
+		}
+
+		/** @var list<Team> $result */
+		return $result;
 	}
 
 	private function getTeam(string $teamId, string $userId, ?CircleProbe $probe = null): ?Circle {

--- a/lib/public/Teams/ITeamManager.php
+++ b/lib/public/Teams/ITeamManager.php
@@ -12,38 +12,50 @@ namespace OCP\Teams;
  */
 interface ITeamManager {
 	/**
-	 * Get all providers that have registered as a team resource provider
+	 * Get all providers that have registered as team resource providers.
 	 *
-	 * @return ITeamResourceProvider[]
+	 * @return array<string, ITeamResourceProvider> Provider ID => provider
 	 * @since 29.0.0
 	 */
 	public function getProviders(): array;
 
 	/**
-	 * Get a specific team resource provider by its id
+	 * Get a specific team resource provider by its ID.
 	 *
+	 * @param string $providerId Identifier of the provider
+	 * @return ITeamResourceProvider
+	 * @throws \RuntimeException If no provider exists for the given ID
 	 * @since 29.0.0
 	 */
 	public function getProvider(string $providerId): ITeamResourceProvider;
 
 	/**
-	 * Returns all team resources for a given team and user
+	 * Returns all team resources for a given team and user.
 	 *
+	 * @param string $teamId ID of the team whose resources are being queried
+	 * @param string $userId ID of the user from whose point of view the resources are being queried
 	 * @return list<TeamResource>
 	 * @since 29.0.0
 	 */
 	public function getSharedWith(string $teamId, string $userId): array;
 
 	/**
-	 * Returns all teams for a given resource and user
+	 * Returns all teams for a given resource and user.
 	 *
+	 * @param string $providerId Identifier of the provider (e.g. deck, talk, collectives)
+	 * @param string $resourceId Unique ID of the resource to list teams for
+	 * @param string $userId ID of the user from whose point of view the teams are being queried
+	 * @return list<Team>
 	 * @since 29.0.0
 	 */
 	public function getTeamsForResource(string $providerId, string $resourceId, string $userId): array;
 
 	/**
-	 * Returns all team resources for the given teams, user and resource
+	 * Returns team resources grouped by team ID for the given team IDs.
 	 *
+	 * @param list<string> $teams Team IDs
+	 * @param string $userId User ID
+	 * @param string $resourceId Unique ID of the resource to filter shares for, if supported by the provider
 	 * @param list<string> $teams Team IDs
 	 * @return array<string, list<TeamResource>>
 	 * @since 33.0.0
@@ -52,8 +64,9 @@ interface ITeamManager {
 	public function getSharedWithList(array $teams, string $userId, string $resourceId): array;
 
 	/**
-	 * Returns all teams that a given user is a member of
+	 * Returns all teams that a given user is a member of.
 	 *
+	 * @param string $userId ID of the user whose teams are being queried
 	 * @return list<Team>
 	 * @since 33.0.0
 	 */
@@ -62,9 +75,10 @@ interface ITeamManager {
 	/**
 	 * Returns a mapping of user ID to display name for all members of a given team.
 	 *
+	 * Includes both direct and inherited members.
+	 *
 	 * @param string $teamId ID of the team whose members are being queried
 	 * @param string $userId ID of the user from whose point of view the members are being queried
-	 *
 	 * @return array<string, string> userId => displayName
 	 * @since 34.0.0
 	 */

--- a/lib/public/Teams/ITeamManager.php
+++ b/lib/public/Teams/ITeamManager.php
@@ -56,7 +56,6 @@ interface ITeamManager {
 	 * @param list<string> $teams Team IDs
 	 * @param string $userId User ID
 	 * @param string $resourceId Unique ID of the resource to filter shares for, if supported by the provider
-	 * @param list<string> $teams Team IDs
 	 * @return array<string, list<TeamResource>>
 	 * @since 33.0.0
 	 * @since 34.0.0 Added $resourceId param

--- a/lib/public/Teams/ITeamManager.php
+++ b/lib/public/Teams/ITeamManager.php
@@ -44,6 +44,7 @@ interface ITeamManager {
 	/**
 	 * Returns all team resources for the given teams, user and resource
 	 *
+	 * @param list<string> $teams Team IDs
 	 * @return array<string, list<TeamResource>>
 	 * @since 33.0.0
 	 * @since 34.0.0 Added $resourceId param


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Align the `ITeamManager` interface docs with the current implementation and usage in the teams code:

- clarify the `ITeamManager::getSharedWithList()` contract by documenting `$teams` as a list of team ID strings, not `Team` objects
  - this matches current usage in `TeamsApiController` and the existing `TeamManager` fallback implementation
- clarify return types for team resource provider lookups
- add and normalize parameter descriptions for team- and resource-related methods
- clarify shared-resource documentation in the interface
- remove a duplicate docblock from `TeamManager` where the interface documentation is sufficient
- adjust `TeamManager` and `TeamsApiController` to satisfy the clarified `ITeamManager` return types / Psalm expectations

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
