### PR TITLE
fix(dav): Handle GenericFileException when reading default contact file

### DIFF
--- a/apps/dav/lib/Service/ExampleContactService.php
+++ b/apps/dav/lib/Service/ExampleContactService.php
@@ -13,9 +13,12 @@ use OCA\DAV\AppInfo\Application;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\GenericFileException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IL10N;
+use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -47,11 +50,14 @@ class ExampleContactService {
 			return null;
 		}
 
-		if (!$folder->fileExists('defaultContact.vcf')) {
+		try {
+			return $folder->getFile('defaultContact.vcf')->getContent();
+		} catch (NotFoundException $e) {
+			return null;
+		} catch (GenericFileException|NotPermittedException|LockedException $e) {
+			$this->logger->error('Could not read default contact file', ['exception' => $e]);
 			return null;
 		}
-
-		return $folder->getFile('defaultContact.vcf')->getContent();
 	}
 
 	private function createInitialDefaultContact(): void {

--- a/apps/dav/lib/Service/ExampleEventService.php
+++ b/apps/dav/lib/Service/ExampleEventService.php
@@ -14,6 +14,7 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\Exception\ExampleEventException;
 use OCA\DAV\Model\ExampleEvent;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\GenericFileException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -105,7 +106,7 @@ EOF);
 
 		try {
 			return $icsFile->getContent();
-		} catch (NotFoundException|NotPermittedException $e) {
+		} catch (NotFoundException|NotPermittedException|GenericFileException $e) {
 			throw new ExampleEventException(
 				'Failed to read custom example event',
 				0,

--- a/apps/dav/tests/unit/Service/ExampleContactServiceTest.php
+++ b/apps/dav/tests/unit/Service/ExampleContactServiceTest.php
@@ -11,9 +11,9 @@ namespace OCA\DAV\Tests\unit\Service;
 
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\Service\ExampleContactService;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\GenericFileException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -27,7 +27,6 @@ use Test\TestCase;
 class ExampleContactServiceTest extends TestCase {
 	protected ExampleContactService $service;
 	protected CardDavBackend&MockObject $cardDav;
-	protected IAppManager&MockObject $appManager;
 	protected IAppDataFactory&MockObject $appDataFactory;
 	protected LoggerInterface&MockObject $logger;
 	protected IAppConfig&MockObject $appConfig;
@@ -159,6 +158,42 @@ class ExampleContactServiceTest extends TestCase {
 		$this->assertNotNull($vcard->REV);
 		$this->assertNotNull($vcard->UID);
 		$this->assertTrue(Uuid::isValid($vcard->UID->getValue()));
+	}
+
+	public function testGetCardReturnsNullWhenFolderNotFound(): void {
+		$this->appData->method('getFolder')->willThrowException(new NotFoundException());
+		$this->assertNull($this->service->getCard());
+	}
+
+	public function testGetCardReturnsNullWhenFileNotFound(): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$this->appData->method('getFolder')->willReturn($folder);
+		$folder->method('getFile')->willThrowException(new NotFoundException());
+		$this->assertNull($this->service->getCard());
+	}
+
+	public function testGetCardReturnsNullOnReadError(): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->appData->method('getFolder')->willReturn($folder);
+		$folder->method('getFile')->willReturn($file);
+		$file->method('getContent')->willThrowException(new GenericFileException());
+
+		$this->logger->expects($this->once())
+			->method('error')
+			->with('Could not read default contact file', $this->anything());
+
+		$this->assertNull($this->service->getCard());
+	}
+
+	public function testGetCardReturnsContent(): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->appData->method('getFolder')->willReturn($folder);
+		$folder->method('getFile')->willReturn($file);
+		$file->method('getContent')->willReturn('vcarddata');
+
+		$this->assertEquals('vcarddata', $this->service->getCard());
 	}
 
 	public function testDefaultContactIsNotCreatedIfEnabled(): void {

--- a/apps/dav/tests/unit/Service/ExampleEventServiceTest.php
+++ b/apps/dav/tests/unit/Service/ExampleEventServiceTest.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\Service;
 
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\Exception\ExampleEventException;
 use OCA\DAV\Service\ExampleEventService;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\GenericFileException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -171,6 +173,29 @@ class ExampleEventServiceTest extends TestCase {
 		$expectedIcs = file_get_contents(__DIR__ . '/../test_fixtures/example-event-expected.ics');
 		$actualIcs = $this->service->getExampleEvent()->getIcs();
 		$this->assertEquals($expectedIcs, $actualIcs);
+	}
+
+	public function testGetExampleEventThrowsOnReadError(): void {
+		$exampleEventFolder = $this->createMock(ISimpleFolder::class);
+		$this->appData->expects(self::once())
+			->method('getFolder')
+			->with('example_event')
+			->willReturn($exampleEventFolder);
+		$exampleEventFile = $this->createMock(ISimpleFile::class);
+		$exampleEventFolder->expects(self::once())
+			->method('getFile')
+			->with('example_event.ics')
+			->willReturn($exampleEventFile);
+		$exampleEventFile->expects(self::once())
+			->method('getContent')
+			->willThrowException(new GenericFileException());
+
+		$this->random->expects(self::once())
+			->method('generate')
+			->willReturn('RANDOM-UID');
+
+		$this->expectException(ExampleEventException::class);
+		$this->service->getExampleEvent();
 	}
 
 	public function testGetExampleEventWithDefault(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

How to test:

- Login as admin
- Go to groupware section
- Try to download default contact

Main: 500er page when downloading the default event
Here: Default event is downloaded



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
