### PR TITLE
fix: Remove uses of deprecated service string names

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -210,7 +210,7 @@ class Redis extends Cache implements IMemcacheTTL {
 
 	#[\Override]
 	public static function isAvailable(): bool {
-		return Server::get('RedisFactory')->isAvailable();
+		return Server::get(RedisFactory::class)->isAvailable();
 	}
 
 	protected function evalLua(string $scriptName, array $keys, array $args) {

--- a/tests/lib/Lockdown/Filesystem/NoFSTest.php
+++ b/tests/lib/Lockdown/Filesystem/NoFSTest.php
@@ -11,6 +11,7 @@ use OC\Authentication\Token\PublicKeyToken;
 use OC\Files\Filesystem;
 use OC\Lockdown\Filesystem\NullStorage;
 use OCP\Authentication\Token\IToken;
+use OCP\Lockdown\ILockdownManager;
 use OCP\Server;
 use Test\Traits\UserTrait;
 
@@ -24,7 +25,7 @@ class NoFSTest extends \Test\TestCase {
 		$token->setScope([
 			IToken::SCOPE_FILESYSTEM => true
 		]);
-		Server::get('LockdownManager')->setToken($token);
+		Server::get(ILockdownManager::class)->setToken($token);
 		parent::tearDown();
 	}
 
@@ -36,7 +37,7 @@ class NoFSTest extends \Test\TestCase {
 			IToken::SCOPE_FILESYSTEM => false
 		]);
 
-		Server::get('LockdownManager')->setToken($token);
+		Server::get(ILockdownManager::class)->setToken($token);
 		$this->createUser('foo', 'var');
 	}
 


### PR DESCRIPTION
Follow-up of https://github.com/nextcloud/server/pull/60957

## Summary

Use the class/interface name instead of the deprecated string to avoid logging. This was breaking in some cases as logging would trigger a deprecation warning, resulting in an infinite loop.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
