### PR TITLE
fix: webhook payload for system tag events

### DIFF
--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -302,8 +302,8 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 	#[\Override]
 	public function setObjectIdsForTag(string $tagId, string $objectType, array $objectIds): void {
 		$currentObjectIds = $this->getObjectIdsForTags($tagId, $objectType);
-		$removedObjectIds = array_diff($currentObjectIds, $objectIds);
-		$addedObjectIds = array_diff($objectIds, $currentObjectIds);
+		$removedObjectIds = array_values(array_diff($currentObjectIds, $objectIds));
+		$addedObjectIds = array_values(array_diff($objectIds, $currentObjectIds));
 
 		$this->connection->beginTransaction();
 		$query = $this->connection->getQueryBuilder();


### PR DESCRIPTION
* Resolves: #61443

## Summary
Fix webhook payload of events `OCP\SystemTag\TagAssignedEvent`, `OCP\SystemTag\TagUnassignedEvent`: 
Ensure property `objectIds` is a list

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
