### PR TITLE
chore: Add debug to AlgorithmTest to debug flakiness

### DIFF
--- a/lib/private/Security/Signature/Rfc9421/Algorithm.php
+++ b/lib/private/Security/Signature/Rfc9421/Algorithm.php
@@ -87,13 +87,16 @@ final class Algorithm {
 				throw new SignatureException('verifying Ed25519 signatures requires ext-sodium');
 			}
 			if (strlen($signature) !== SODIUM_CRYPTO_SIGN_BYTES) {
+				echo __LINE__ . " return false\n";
 				return false;
 			}
 			// parseKey hands OKP material as plain base64 of the 32 raw bytes.
 			$rawPublic = base64_decode((string)$material, true);
 			if ($rawPublic === false || strlen($rawPublic) !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+				echo __LINE__ . " return false\n";
 				return false;
 			}
+			echo __LINE__ . " return ?\n";
 			return sodium_crypto_sign_verify_detached($signature, $signatureBase, $rawPublic);
 		}
 
@@ -102,10 +105,12 @@ final class Algorithm {
 		if ($encoding === 'ecdsa') {
 			$signature = self::ecdsaRawToDer($signature, self::ecdsaCoordinateSize($resolved));
 			if ($signature === null) {
+				echo __LINE__ . " return false\n";
 				return false;
 			}
 		}
 
+		echo __LINE__ . " return ?\n";
 		return openssl_verify($signatureBase, $signature, $material, $opensslAlgo) === 1;
 	}
 

--- a/lib/private/Security/Signature/Rfc9421/Algorithm.php
+++ b/lib/private/Security/Signature/Rfc9421/Algorithm.php
@@ -110,7 +110,7 @@ final class Algorithm {
 			}
 		}
 
-		echo __LINE__ . " return ?\n";
+		echo __LINE__ . ' return ' . openssl_verify($signatureBase, $signature, $material, $opensslAlgo) . "\n";
 		return openssl_verify($signatureBase, $signature, $material, $opensslAlgo) === 1;
 	}
 

--- a/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
+++ b/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
@@ -89,7 +89,7 @@ class AlgorithmTest extends TestCase {
 		[$priv, $key] = $this->ecKeyPair('prime256v1', 'P-256', 'ES256');
 		$sig = Algorithm::sign('payload', $priv, 'ecdsa-p256-sha256');
 		echo "sig:$sig\n";
-		echo "key:$key\n";
+		// echo "key:$key\n";
 		$this->assertSame(64, strlen($sig));
 		$this->assertTrue(Algorithm::verify('payload', $sig, $key, 'ecdsa-p256-sha256'));
 		$this->assertTrue(Algorithm::verify('payload', $sig, $key, 'ES256'));

--- a/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
+++ b/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
@@ -88,6 +88,8 @@ class AlgorithmTest extends TestCase {
 	public function testEcdsaP256RoundTrip(): void {
 		[$priv, $key] = $this->ecKeyPair('prime256v1', 'P-256', 'ES256');
 		$sig = Algorithm::sign('payload', $priv, 'ecdsa-p256-sha256');
+		echo "sig:$sig\n";
+		echo "key:$key\n";
 		$this->assertSame(64, strlen($sig));
 		$this->assertTrue(Algorithm::verify('payload', $sig, $key, 'ecdsa-p256-sha256'));
 		$this->assertTrue(Algorithm::verify('payload', $sig, $key, 'ES256'));

--- a/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
+++ b/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
@@ -90,6 +90,7 @@ class AlgorithmTest extends TestCase {
 		$sig = Algorithm::sign('payload', $priv, 'ecdsa-p256-sha256');
 		echo "sig:$sig\n";
 		// echo "key:$key\n";
+		echo 'key:' . serialize($key) . "\n";
 		$this->assertSame(64, strlen($sig));
 		$this->assertTrue(Algorithm::verify('payload', $sig, $key, 'ecdsa-p256-sha256'));
 		$this->assertTrue(Algorithm::verify('payload', $sig, $key, 'ES256'));
@@ -98,6 +99,8 @@ class AlgorithmTest extends TestCase {
 	public function testEcdsaP384RoundTrip(): void {
 		[$priv, $key] = $this->ecKeyPair('secp384r1', 'P-384', 'ES384');
 		$sig = Algorithm::sign('payload', $priv, 'ecdsa-p384-sha384');
+		echo "sig:$sig\n";
+		echo 'key:' . serialize($key) . "\n";
 		$this->assertSame(96, strlen($sig));
 		$this->assertTrue(Algorithm::verify('payload', $sig, $key, 'ecdsa-p384-sha384'));
 	}


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
