### PR TITLE
feat: Make it possible to add a storage wrapper using public APIs

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -21,6 +21,7 @@ use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\Storage\IStorage;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IPreview;
@@ -109,14 +110,14 @@ $server = $serverFactory->createServer(
 
 		// FIXME: should not add storage wrappers outside of preSetup, need to find a better way
 		$previousLog = Filesystem::logWarningWhenAddingStorageWrapper(false);
-		Filesystem::addStorageWrapper('sharePermissions', function ($mountPoint, $storage) use ($share) {
+		Filesystem::addStorageWrapper('sharePermissions', function (string $mountPoint, IStorage $storage) use ($share) {
 			return new DirPermissionsMask([
 				'storage' => $storage,
 				'mask' => $share->getPermissions() | Constants::PERMISSION_SHARE,
 				'path' => 'files'
 			]);
 		});
-		Filesystem::addStorageWrapper('shareOwner', function ($mountPoint, $storage) use ($share) {
+		Filesystem::addStorageWrapper('shareOwner', function (string $mountPoint, IStorage $storage) use ($share) {
 			return new PublicOwnerWrapper(['storage' => $storage, 'owner' => $share->getShareOwner()]);
 		});
 		Filesystem::logWarningWhenAddingStorageWrapper($previousLog);

--- a/apps/dav/appinfo/v2/publicremote.php
+++ b/apps/dav/appinfo/v2/publicremote.php
@@ -26,6 +26,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IHomeStorage;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\Storage\IStorage;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -120,7 +121,7 @@ $server = $serverFactory->createServer(true, $baseuri, $requestUri, $authPlugin,
 	$previousLog = Filesystem::logWarningWhenAddingStorageWrapper(false);
 
 	/** @psalm-suppress MissingClosureParamType */
-	Filesystem::addStorageWrapper('sharePermissions', function ($mountPoint, $storage) use ($requestUri, $baseuri, $share) {
+	Filesystem::addStorageWrapper('sharePermissions', function (string $mountPoint, IStorage $storage) use ($requestUri, $baseuri, $share) {
 		$mask = $share->getPermissions() | Constants::PERMISSION_SHARE;
 
 		// For chunked uploads it is necessary to have read and delete permission,
@@ -141,13 +142,13 @@ $server = $serverFactory->createServer(true, $baseuri, $requestUri, $authPlugin,
 	});
 
 	/** @psalm-suppress MissingClosureParamType */
-	Filesystem::addStorageWrapper('shareOwner', function ($mountPoint, $storage) use ($share) {
+	Filesystem::addStorageWrapper('shareOwner', function (string $mountPoint, IStorage $storage) use ($share) {
 		return new PublicOwnerWrapper(['storage' => $storage, 'owner' => $share->getShareOwner()]);
 	});
 
 	// Ensure that also private shares have the `getShare` method
 	/** @psalm-suppress MissingClosureParamType */
-	Filesystem::addStorageWrapper('getShare', function ($mountPoint, $storage) use ($share) {
+	Filesystem::addStorageWrapper('getShare', function (string $mountPoint, IStorage $storage) use ($share) {
 		return new PublicShareWrapper(['storage' => $storage, 'share' => $share]);
 	}, 0);
 

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -11,6 +11,7 @@ namespace OCA\Files_Sharing\Tests;
 use OC\Files\Filesystem;
 use OC\SystemConfig;
 use OCA\Files_Sharing\DeleteOrphanedSharesJob;
+use OCA\Files_Trashbin\Storage;
 use OCP\App\IAppManager;
 use OCP\Constants;
 use OCP\IDBConnection;
@@ -60,7 +61,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 		$appManager->disableApp('files_trashbin');
 
 		// just in case...
-		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper(Storage::class);
 	}
 
 	public static function tearDownAfterClass(): void {

--- a/apps/files_sharing/tests/UpdaterTest.php
+++ b/apps/files_sharing/tests/UpdaterTest.php
@@ -13,6 +13,7 @@ use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files_Sharing\Helper;
 use OCA\Files_Trashbin\AppInfo\Application;
+use OCA\Files_Trashbin\Storage;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\Constants;
@@ -121,7 +122,7 @@ class UpdaterTest extends TestCase {
 			$appManager->disableApp('files_trashbin');
 		}
 
-		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper(Storage::class);
 	}
 
 	public static function shareFolderProvider() {

--- a/apps/files_trashbin/lib/Listener/EventListener.php
+++ b/apps/files_trashbin/lib/Listener/EventListener.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 namespace OCA\Files_Trashbin\Listener;
 
 use OCA\Files_Trashbin\Storage;
+use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\BeforeFileSystemSetupEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
@@ -19,15 +21,22 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\Files\Storage\IStorage;
+use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\User\Events\BeforeUserDeletedEvent;
+use Psr\Log\LoggerInterface;
 
 /** @template-implements IEventListener<NodeWrittenEvent|BeforeUserDeletedEvent|BeforeFileSystemSetupEvent> */
 class EventListener implements IEventListener {
 	public function __construct(
-		private IUserManager $userManager,
-		private IRootFolder $rootFolder,
-		private ?string $userId = null,
+		private readonly IUserManager $userManager,
+		private readonly IRootFolder $rootFolder,
+		private readonly IRequest $request,
+		private readonly IEventDispatcher $eventDispatcher,
+		private readonly LoggerInterface $logger,
+		private readonly ITrashManager $trashManager,
+		private readonly ?string $userId = null,
 	) {
 	}
 
@@ -57,7 +66,20 @@ class EventListener implements IEventListener {
 		}
 
 		if ($event instanceof BeforeFileSystemSetupEvent) {
-			Storage::setupStorage();
+			$event->addStorageWrapper(
+				Storage::class,
+				function (string $mountPoint, IStorage $storage): Storage {
+					return new Storage(
+						['storage' => $storage, 'mountPoint' => $mountPoint],
+						$this->trashManager,
+						$this->userManager,
+						$this->logger,
+						$this->eventDispatcher,
+						$this->rootFolder,
+						$this->request,
+					);
+				},
+				1);
 		}
 	}
 }

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -159,7 +159,7 @@ class Storage extends Wrapper {
 		$rootFolder = Server::get(IRootFolder::class);
 		$request = Server::get(IRequest::class);
 		Filesystem::addStorageWrapper(
-			'oc_trashbin',
+			Storage::class,
 			function (string $mountPoint, IStorage $storage) use ($trashManager, $userManager, $logger, $eventDispatcher, $rootFolder, $request) {
 				return new Storage(
 					['storage' => $storage, 'mountPoint' => $mountPoint],

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -96,7 +96,7 @@ class StorageTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper(Storage::class);
 		$this->logout();
 		$user = Server::get(IUserManager::class)->get($this->user);
 		if ($user !== null) {
@@ -502,7 +502,7 @@ class StorageTest extends \Test\TestCase {
 		$storage2 = new Temporary([]);
 		Filesystem::mount($storage2, [], $this->user . '/files/substorage');
 
-		// trigger a version (multiple would not work because of the expire logic)
+		// trigger a version (multiple would not work because of the expiration logic)
 		$this->userView->file_put_contents('test.txt', 'v1');
 
 		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files');

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -19,6 +19,7 @@ use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Trashbin\AppInfo\Application as TrashbinApplication;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Helper;
+use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -96,7 +97,7 @@ class TrashbinTest extends \Test\TestCase {
 
 		\OC_Hook::clear();
 
-		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper(Storage::class);
 
 		if (self::$trashBinStatus) {
 			Server::get(IAppManager::class)->enableApp('files_trashbin');

--- a/lib/private/Encryption/Manager.php
+++ b/lib/private/Encryption/Manager.php
@@ -203,11 +203,11 @@ class Manager implements IManager {
 	/**
 	 * Add storage wrapper
 	 */
-	public function setupStorage() {
+	public function setupStorage(): void {
 		// If encryption is disabled and there are no loaded modules it makes no sense to load the wrapper
 		if (!empty($this->encryptionModules) || $this->isEnabled()) {
 			$encryptionWrapper = new EncryptionWrapper($this->arrayCache, $this, $this->logger);
-			Filesystem::addStorageWrapper('oc_encryption', [$encryptionWrapper, 'wrapStorage'], 2);
+			Filesystem::addStorageWrapper('oc_encryption', $encryptionWrapper->wrapStorage(...), 2);
 		}
 	}
 

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -207,9 +207,6 @@ class Manager implements IMountManager {
 		return $result;
 	}
 
-	/**
-	 * @return IMountPoint[]
-	 */
 	#[\Override]
 	public function getAll(): array {
 		return $this->mounts;

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -319,6 +319,10 @@ class SetupManager implements ISetupManager {
 		$event = new BeforeFileSystemSetupEvent($user);
 		$this->eventDispatcher->dispatchTyped($event);
 
+		foreach ($event->getStorageWrappers() as $name => $wrapper) {
+			Filesystem::addStorageWrapper($name, $wrapper['wrapper'], $wrapper['priority']);
+		}
+
 		Filesystem::logWarningWhenAddingStorageWrapper($prevLogging);
 
 		$userDir = '/' . $user->getUID() . '/files';

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -49,6 +49,7 @@ use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
+use OCP\Files\Storage\IStorageFactory;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\HintException;
@@ -115,6 +116,7 @@ class SetupManager implements ISetupManager {
 		private IAppManager $appManager,
 		private FileAccess $fileAccess,
 		private IAppConfig $appConfig,
+		private IStorageFactory $storageFactory,
 	) {
 		$this->cache = $cacheFactory->createDistributed('setupmanager::');
 		$this->listeningForProviders = false;
@@ -154,7 +156,10 @@ class SetupManager implements ISetupManager {
 		return false;
 	}
 
-	private function setupBuiltinWrappers(): void {
+	/**
+	 * @param IMountPoint[] $existingMounts
+	 */
+	private function setupBuiltinWrappers(array $existingMounts): void {
 		if ($this->setupBuiltinWrappersDone) {
 			return;
 		}
@@ -162,20 +167,19 @@ class SetupManager implements ISetupManager {
 
 		// load all filesystem apps before, so no setup-hook gets lost
 		$this->appManager->loadApps(['filesystem']);
-		$prevLogging = Filesystem::logWarningWhenAddingStorageWrapper(false);
 
-		Filesystem::addStorageWrapper('mount_options', function ($mountPoint, IStorage $storage, IMountPoint $mount) {
+		$this->storageFactory->addStorageWrapper('mount_options', function (string $mountPoint, IStorage $storage, IMountPoint $mount): IStorage {
 			if ($storage->instanceOfStorage(Common::class)) {
 				$options = array_merge($mount->getOptions(), ['mount_point' => $mountPoint]);
 				$storage->setMountOptions($options);
 			}
 			return $storage;
-		});
+		}, 50, $existingMounts);
 
 		$reSharingEnabled = $this->appConfig->getValueBool('core', 'shareapi_allow_resharing', true);
 		$user = $this->userSession->getUser();
 		$sharingEnabledForUser = $user ? !$this->shareDisableChecker->sharingDisabledForUser($user->getUID()) : true;
-		Filesystem::addStorageWrapper(
+		$this->storageFactory->addStorageWrapper(
 			'sharing_mask',
 			function ($mountPoint, IStorage $storage, IMountPoint $mount) use ($reSharingEnabled, $sharingEnabledForUser) {
 				$sharingEnabledForMount = $mount->getOption('enable_sharing', true);
@@ -187,27 +191,26 @@ class SetupManager implements ISetupManager {
 					]);
 				}
 				return $storage;
-			}
-		);
+			}, 50, $existingMounts);
 
 		// install storage availability wrapper, before most other wrappers
-		Filesystem::addStorageWrapper('oc_availability', function ($mountPoint, IStorage $storage, IMountPoint $mount) {
+		$this->storageFactory->addStorageWrapper(Availability::class, function (string $mountPoint, IStorage $storage, IMountPoint $mount) {
 			$externalMount = $mount instanceof ExternalMountPoint || $mount instanceof Mount;
 			if ($externalMount && !$storage->isLocal()) {
 				return new Availability(['storage' => $storage]);
 			}
 			return $storage;
-		});
+		}, 50, $existingMounts);
 
-		Filesystem::addStorageWrapper('oc_encoding', function ($mountPoint, IStorage $storage, IMountPoint $mount) {
+		$this->storageFactory->addStorageWrapper(Encoding::class, function (string $mountPoint, IStorage $storage, IMountPoint $mount) {
 			if ($mount->getOption('encoding_compatibility', false) && !$mount instanceof SharedMount) {
 				return new Encoding(['storage' => $storage]);
 			}
 			return $storage;
-		});
+		}, 50, $existingMounts);
 
 		$quotaIncludeExternal = $this->config->getSystemValue('quota_include_external_storage', false);
-		Filesystem::addStorageWrapper('oc_quota', function ($mountPoint, $storage, IMountPoint $mount) use ($quotaIncludeExternal) {
+		$this->storageFactory->addStorageWrapper(Quota::class, function ($mountPoint, $storage, IMountPoint $mount) use ($quotaIncludeExternal) {
 			// set up quota for home storages, even for other users
 			// which can happen when using sharing
 			if ($mount instanceof HomeMountPoint) {
@@ -218,9 +221,9 @@ class SetupManager implements ISetupManager {
 			}
 
 			return $storage;
-		});
+		}, 50, $existingMounts);
 
-		Filesystem::addStorageWrapper('readonly', function ($mountPoint, IStorage $storage, IMountPoint $mount) {
+		$this->storageFactory->addStorageWrapper('readonly', function (string $mountPoint, IStorage $storage, IMountPoint $mount) {
 			/*
 			 * Do not allow any operations that modify the storage
 			 */
@@ -235,9 +238,7 @@ class SetupManager implements ISetupManager {
 				]);
 			}
 			return $storage;
-		});
-
-		Filesystem::logWarningWhenAddingStorageWrapper($prevLogging);
+		}, 50, $existingMounts);
 	}
 
 	/**
@@ -299,7 +300,7 @@ class SetupManager implements ISetupManager {
 	/**
 	 * Part of the user setup that is run only once per user.
 	 */
-	private function oneTimeUserSetup(IUser $user) {
+	private function oneTimeUserSetup(IUser $user): void {
 		if ($this->isSetupStarted($user)) {
 			return;
 		}
@@ -309,21 +310,23 @@ class SetupManager implements ISetupManager {
 
 		$this->eventLogger->start('fs:setup:user:onetime', 'Onetime filesystem for user');
 
-		$this->setupBuiltinWrappers();
-
-		$prevLogging = Filesystem::logWarningWhenAddingStorageWrapper(false);
+		$mounts = $this->mountManager->getAll();
+		$this->setupBuiltinWrappers($mounts);
 
 		// TODO remove hook
+		$prevLogging = Filesystem::logWarningWhenAddingStorageWrapper(false);
 		OC_Hook::emit('OC_Filesystem', 'preSetup', ['user' => $user->getUID()]);
 
 		$event = new BeforeFileSystemSetupEvent($user);
 		$this->eventDispatcher->dispatchTyped($event);
-
-		foreach ($event->getStorageWrappers() as $name => $wrapper) {
-			Filesystem::addStorageWrapper($name, $wrapper['wrapper'], $wrapper['priority']);
-		}
-
 		Filesystem::logWarningWhenAddingStorageWrapper($prevLogging);
+
+		$storageWrappers = $event->getStorageWrappers();
+		if ($storageWrappers !== []) {
+			foreach ($storageWrappers as $wrapperName => $wrapper) {
+				$this->storageFactory->addStorageWrapper($wrapperName, $wrapper['callable'], $wrapper['priority'], $mounts);
+			}
+		}
 
 		$userDir = '/' . $user->getUID() . '/files';
 
@@ -430,7 +433,8 @@ class SetupManager implements ISetupManager {
 			return;
 		}
 
-		$this->setupBuiltinWrappers();
+		$mounts = $this->mountManager->getAll();
+		$this->setupBuiltinWrappers($mounts);
 
 		$this->rootSetup = true;
 
@@ -776,7 +780,7 @@ class SetupManager implements ISetupManager {
 		}
 	}
 
-	private function setupListeners() {
+	private function setupListeners(): void {
 		// note that this event handling is intentionally pessimistic
 		// clearing the cache to often is better than not enough
 

--- a/lib/private/Files/SetupManagerFactory.php
+++ b/lib/private/Files/SetupManagerFactory.php
@@ -16,6 +16,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\Storage\IStorageFactory;
 use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -42,6 +43,7 @@ class SetupManagerFactory {
 		private IAppManager $appManager,
 		private FileAccess $fileAccess,
 		private IAppConfig $appConfig,
+		private IStorageFactory $storageFactory,
 	) {
 		$this->setupManager = null;
 	}
@@ -64,6 +66,7 @@ class SetupManagerFactory {
 				$this->appManager,
 				$this->fileAccess,
 				$this->appConfig,
+				$this->storageFactory,
 			);
 		}
 		return $this->setupManager;

--- a/lib/private/Files/Storage/StorageFactory.php
+++ b/lib/private/Files/Storage/StorageFactory.php
@@ -16,10 +16,8 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class StorageFactory implements IStorageFactory {
-	/**
-	 * @var array[] [$name=>['priority'=>$priority, 'wrapper'=>$callable] $storageWrappers
-	 */
-	private $storageWrappers = [];
+	/** @var array<string, array{wrapper: callable(string $mountPoint, IStorage $storage): IStorage, priority: int}> $storageWrappers */
+	private array $storageWrappers = [];
 
 	#[\Override]
 	public function addStorageWrapper(string $wrapperName, callable $callback, int $priority = 50, array $existingMounts = []): bool {

--- a/lib/public/Files/Events/BeforeFileSystemSetupEvent.php
+++ b/lib/public/Files/Events/BeforeFileSystemSetupEvent.php
@@ -10,19 +10,23 @@ declare(strict_types=1);
 namespace OCP\Files\Events;
 
 use OCP\EventDispatcher\Event;
+use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 
 /**
- * Event triggered before the file system is setup
+ * Event triggered before the file system is set up.
  *
  * @since 31.0.0
  */
 class BeforeFileSystemSetupEvent extends Event {
+	/** @var array<string, array{wrapper: callable(string $mountPoint, IStorage $storage): IStorage, priority: int}> $storageWrappers */
+	private array $storageWrappers = [];
+
 	/**
 	 * @since 31.0.0
 	 */
 	public function __construct(
-		private IUser $user,
+		private readonly IUser $user,
 	) {
 		parent::__construct();
 	}
@@ -32,5 +36,26 @@ class BeforeFileSystemSetupEvent extends Event {
 	 */
 	public function getUser(): IUser {
 		return $this->user;
+	}
+
+	/**
+	 * Add a storage wrapper to the file system. This allows apps to inject storage wrappers
+	 * for every mount.
+	 *
+	 * @param callable(string $mountPoint, IStorage $storage): IStorage $wrapper
+	 * @since 35.0.0
+	 */
+	public function addStorageWrapper(string $name, callable $wrapper, int $priority = 50): void {
+		$this->storageWrappers[$name] = ['wrapper' => $wrapper, 'priority' => $priority];
+	}
+
+	/**
+	 * Get the storage wrappers.
+	 *
+	 * @since 35.0.0
+	 * @return array<string, array{wrapper: callable(string $mountPoint, IStorage $storage): IStorage, priority: int}>
+	 */
+	public function getStorageWrappers(): array {
+		return $this->storageWrappers;
 	}
 }

--- a/lib/public/Files/Events/BeforeFileSystemSetupEvent.php
+++ b/lib/public/Files/Events/BeforeFileSystemSetupEvent.php
@@ -19,7 +19,7 @@ use OCP\IUser;
  * @since 31.0.0
  */
 class BeforeFileSystemSetupEvent extends Event {
-	/** @var array<string, array{wrapper: callable(string $mountPoint, IStorage $storage): IStorage, priority: int}> $storageWrappers */
+	/** @var array<class-string<IStorage>, array{callable: callable(string $mountPoint, IStorage $storage): IStorage, priority: int<0, 100>}> $storageWrappers */
 	private array $storageWrappers = [];
 
 	/**
@@ -42,18 +42,20 @@ class BeforeFileSystemSetupEvent extends Event {
 	 * Add a storage wrapper to the file system. This allows apps to inject storage wrappers
 	 * for every mount.
 	 *
+	 * @param class-string<IStorage> $name The identifier of the wrapper.
 	 * @param callable(string $mountPoint, IStorage $storage): IStorage $wrapper
+	 * @param int<0, 100> $priority
 	 * @since 35.0.0
 	 */
 	public function addStorageWrapper(string $name, callable $wrapper, int $priority = 50): void {
-		$this->storageWrappers[$name] = ['wrapper' => $wrapper, 'priority' => $priority];
+		$this->storageWrappers[$name] = ['callable' => $wrapper, 'priority' => $priority];
 	}
 
 	/**
 	 * Get the storage wrappers.
 	 *
+	 * @return array<class-string<IStorage>, array{callable: callable(string $mountPoint, IStorage $storage): IStorage, priority: int<0, 100>}>
 	 * @since 35.0.0
-	 * @return array<string, array{wrapper: callable(string $mountPoint, IStorage $storage): IStorage, priority: int}>
 	 */
 	public function getStorageWrappers(): array {
 		return $this->storageWrappers;

--- a/lib/public/Files/Storage/IStorageFactory.php
+++ b/lib/public/Files/Storage/IStorageFactory.php
@@ -8,27 +8,36 @@
 
 namespace OCP\Files\Storage;
 
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\Files\Events\BeforeFileSystemSetupEvent;
 use OCP\Files\Mount\IMountPoint;
 
 /**
  * Creates storage instances and manages and applies storage wrappers
  * @since 8.0.0
  */
+#[Consumable(since: '8.0.0')]
 interface IStorageFactory {
 	/**
-	 * allow modifier storage behaviour by adding wrappers around storages
+	 * Allow modifier storage behaviour by adding wrappers around storages.
 	 *
-	 * $callback should be a function of type (string $mountPoint, Storage $storage) => Storage
+	 * The BeforeFileSystemSetupEvent should be used in most cases instead to add storage wrappers.
+	 *
+	 * @param non-empty-string $wrapperName
+	 * @param callable(string $mountPoint, IStorage $storage, IMountPoint $mountPoint): IStorage $callback
+	 * @param int<0, 100> $priority
+	 * @param IMountPoint[] $existingMounts
 	 *
 	 * @return bool true if the wrapper was added, false if there was already a wrapper with this
 	 *              name registered
 	 * @since 8.0.0
+	 * @see BeforeFileSystemSetupEvent
 	 */
-	public function addStorageWrapper(string $wrapperName, callable $callback);
+	public function addStorageWrapper(string $wrapperName, callable $callback, int $priority = 50, array $existingMounts = []): bool;
 
 	/**
 	 * @return IStorage
 	 * @since 8.0.0
 	 */
-	public function getInstance(IMountPoint $mountPoint, string $class, array $arguments);
+	public function getInstance(IMountPoint $mountPoint, string $class, array $arguments): IStorage;
 }

--- a/tests/lib/Files/SetupManagerTest.php
+++ b/tests/lib/Files/SetupManagerTest.php
@@ -114,6 +114,7 @@ class SetupManagerTest extends TestCase {
 			$appManager,
 			$this->fileAccess,
 			$this->createMock(IAppConfig::class),
+			$this->createMock(IStorageFactory::class),
 		);
 	}
 
@@ -614,7 +615,7 @@ class SetupManagerTest extends TestCase {
 			->method('addMount')
 			->willReturnCallback($this->getAddMountCheckCallback($invokedCount,
 				$addMountExpectations));
-		$this->mountManager->expects($this->once())->method('getAll')
+		$this->mountManager->method('getAll')
 			->willReturn([$this->mountPoint => $partialMount]);
 
 		// setting up for $path but then for user should remove the setup path


### PR DESCRIPTION
## Summary

Before that every app is using an internal call to Filesystem::addStorageWrapper. The new API enforce that this is called at the right moment.

Required for https://github.com/nextcloud/files_lock/pull/1125

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
