### PR TITLE
test: drop remaining setAccessible() reflection method in tests

### DIFF
--- a/apps/files_versions/tests/Listener/FileEventsListenerTest.php
+++ b/apps/files_versions/tests/Listener/FileEventsListenerTest.php
@@ -59,7 +59,6 @@ class FileEventsListenerTest extends TestCase {
 
 	private function getPrivateProperty(string $property): mixed {
 		$ref = new \ReflectionProperty(FileEventsListener::class, $property);
-		$ref->setAccessible(true);
 		return $ref->getValue($this->listener);
 	}
 
@@ -71,7 +70,6 @@ class FileEventsListenerTest extends TestCase {
 			->with('Failed to compute path for node', $this->anything());
 
 		$method = new \ReflectionMethod(FileEventsListener::class, 'getPathForNode');
-		$method->setAccessible(true);
 
 		$this->assertNull($method->invoke($this->listener, $node));
 	}

--- a/tests/lib/Files/Storage/BearerAuthAwareSabreClientTest.php
+++ b/tests/lib/Files/Storage/BearerAuthAwareSabreClientTest.php
@@ -19,7 +19,6 @@ class BearerAuthAwareSabreClientTest extends TestCase {
 	private function getCurlSetting(BearerAuthAwareSabreClient $client, int $key): mixed {
 		$reflection = new \ReflectionObject($client);
 		$property = $reflection->getProperty('curlSettings');
-		$property->setAccessible(true);
 		$settings = $property->getValue($client);
 		return $settings[$key] ?? null;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Remove remaining unnecessary and deprecated `setAccessible(true)` calls.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
