### PR TITLE
fix(onetime-qrcode): Remove password confirmation attribute

### DIFF
--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -205,7 +205,6 @@ class AppPasswordController extends OCSController {
 	 * 200: App password returned
 	 */
 	#[NoAdminRequired]
-	#[PasswordConfirmationRequired]
 	#[ApiRoute(verb: 'GET', url: '/getapppassword-onetime', root: '/core')]
 	public function getAppPasswordWithOneTimePassword(): DataResponse {
 		// Only allow with one-time app passwords

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -1765,7 +1765,6 @@
             "get": {
                 "operationId": "app_password-get-app-password-with-one-time-password",
                 "summary": "Get app password with one-time password",
-                "description": "This endpoint requires password confirmation",
                 "tags": [
                     "app_password"
                 ],

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -1765,7 +1765,6 @@
             "get": {
                 "operationId": "app_password-get-app-password-with-one-time-password",
                 "summary": "Get app password with one-time password",
-                "description": "This endpoint requires password confirmation",
                 "tags": [
                     "app_password"
                 ],

--- a/openapi.json
+++ b/openapi.json
@@ -5427,7 +5427,6 @@
             "get": {
                 "operationId": "core-app_password-get-app-password-with-one-time-password",
                 "summary": "Get app password with one-time password",
-                "description": "This endpoint requires password confirmation",
                 "tags": [
                     "core/app_password"
                 ],


### PR DESCRIPTION
- Regression from #61322 
- After that change the accidental added attribute on the onetime-qrcode API endpoint is now executed and breaks the mobile apps as they do not provide the password. The QR code is actually intended to avoid having to type the password to begin with.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
