### PR TITLE
Fix the ScanFiles job to not trigger scans of root directory for every single user 

### DIFF
--- a/apps/files/lib/BackgroundJob/ScanFiles.php
+++ b/apps/files/lib/BackgroundJob/ScanFiles.php
@@ -52,7 +52,7 @@ class ScanFiles extends TimedJob {
 				$this->logger,
 				$this->setupManager,
 			);
-			$scanner->backgroundScan('');
+			$scanner->backgroundScan('/' . $user);
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e, 'app' => 'files']);
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves https://github.com/nextcloud/server/issues/61510
* Possibly resolves 
  * https://github.com/nextcloud/server/issues/40018 
  * https://github.com/nextcloud/server/issues/45042
  * https://github.com/nextcloud/server/issues/24401

## Summary

- When `''` is passed `getMounts` returns `home::username` and `local:/var/www/data` mounts and both of these get scanned
- This manages to scan the appdata folder too for each and every user adding significant delays to a job that should be quick for 500 users at one time
- This method seems the same as the one used in `occ files:scan username --unscanned` and there the path resolves to `/username` and not `''`



## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
