### PR TITLE
Block {DAV:} and ocs namespace properties from custom properties table.

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -90,6 +90,15 @@ class CustomPropertiesBackend implements BackendInterface {
 	];
 
 	/**
+	 * Allowed properties for the dav namespace, all other properties in the namespace are ignored
+	 *
+	 * @var string[]
+	 */
+	private const ALLOWED_DAV_PROPERTIES = [
+		'{DAV:}displayname',
+	];
+
+	/**
 	 * Properties set by one user, readable by all others
 	 *
 	 * @var string[]
@@ -278,6 +287,9 @@ class CustomPropertiesBackend implements BackendInterface {
 	private function isPropertyAllowed(string $property): bool {
 		if (in_array($property, self::IGNORED_PROPERTIES)) {
 			return false;
+		}
+		if (str_starts_with($property, '{DAV:}')) {
+			return in_array($property, self::ALLOWED_DAV_PROPERTIES);
 		}
 		if (str_starts_with($property, '{http://owncloud.org/ns}') || str_starts_with($property, '{http://nextcloud.org/ns}')) {
 			return in_array($property, self::ALLOWED_NC_PROPERTIES);

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -288,6 +288,9 @@ class CustomPropertiesBackend implements BackendInterface {
 		if (in_array($property, self::IGNORED_PROPERTIES)) {
 			return false;
 		}
+		if (str_starts_with($property, '{http://open-collaboration-services.org/ns}')) {
+			return false;
+		}
 		if (str_starts_with($property, '{DAV:}')) {
 			return in_array($property, self::ALLOWED_DAV_PROPERTIES);
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

If a property is requested, but not already provided, we need to check the custom properties table for them

Instead of blocking properties [a few at a time](https://github.com/nextcloud/server/pull/61509), we block entire namespaces (with some exceptions) as we do with the `oc`/`nc` namespaces already.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
