### PR TITLE
fix: stop calling DI container in SharedStorage

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -10,6 +10,7 @@ namespace OCA\Files_Sharing;
 
 use Exception;
 use InvalidArgumentException;
+use OC\Files\Cache\CacheDependencies;
 use OC\Files\View;
 use OCA\Files_Sharing\Event\ShareMountedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -19,9 +20,11 @@ use OCP\Files\Config\IPartialMountProvider;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IStorageFactory;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IUser;
+use OCP\Server;
 use OCP\Share\IAttributes;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -257,6 +260,8 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 		$validShareCache = $this->cacheFactory->createLocal('share-valid-mountpoint-max');
 		$maxValidatedShare = $validShareCache->get($userId) ?? 0;
 		$newMaxValidatedShare = $maxValidatedShare;
+		$appConfig = Server::get(IAppConfig::class);
+		$cacheDependencies = Server::get(CacheDependencies::class);
 
 		foreach ($superShares as $share) {
 			[$parentShare, $groupedShares] = $share;
@@ -283,7 +288,11 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 						// children/component of the superShare
 						'groupedShares' => $groupedShares,
 						'ownerView' => $ownerViews[$owner],
-						'sharingDisabledForUser' => $sharingDisabledForUser
+						'sharingDisabledForUser' => $sharingDisabledForUser,
+						'logger' => $this->logger,
+						'shareManager' => $this->shareManager,
+						'appConfig' => $appConfig,
+						'cacheDependencies' => $cacheDependencies,
 					],
 					$loader,
 					$this->eventDispatcher,

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -93,12 +93,14 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	 * @psalm-suppress ImpureStaticProperty
 	 */
 	private static int $initDepth = 0;
+	private CacheDependencies $cacheDependencies;
 
 	public function __construct(array $parameters) {
 		$this->ownerView = $parameters['ownerView'];
-		$this->logger = Server::get(LoggerInterface::class);
-		$this->appConfig = Server::get(IAppConfig::class);
-		$this->shareManager = Server::get(IShareManager::class);
+		$this->logger = $parameters['logger'] ?? Server::get(LoggerInterface::class);
+		$this->appConfig = $parameters['appConfig'] ?? Server::get(IAppConfig::class);
+		$this->shareManager = $parameters['shareManager'] ?? Server::get(IShareManager::class);
+		$this->cacheDependencies = $parameters['cacheDependencies'] ?? Server::get(CacheDependencies::class);
 
 		$this->superShare = $parameters['superShare'];
 		$this->groupedShares = $parameters['groupedShares'];
@@ -434,7 +436,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 		$this->cache = new Cache(
 			$storage,
 			$sourceRoot,
-			Server::get(CacheDependencies::class),
+			$this->cacheDependencies,
 			$this->getShare()
 		);
 		return $this->cache;
@@ -487,7 +489,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	 */
 	public function unshareStorage(): bool {
 		foreach ($this->groupedShares as $share) {
-			Server::get(IShareManager::class)->deleteFromSelf($share, $this->user);
+			$this->shareManager->deleteFromSelf($share, $this->user);
 		}
 		return true;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Reduce amounts of calls to `Server::get` by `SharedStorage`. This becomes a CPU hog with already a few hundred shares to process.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
