### PR TITLE
fix: stop sorting FS wrappers continuously during wrap

### DIFF
--- a/lib/private/Files/Storage/StorageFactory.php
+++ b/lib/private/Files/Storage/StorageFactory.php
@@ -19,7 +19,14 @@ class StorageFactory implements IStorageFactory {
 	/**
 	 * @var array[] [$name=>['priority'=>$priority, 'wrapper'=>$callable] $storageWrappers
 	 */
-	private $storageWrappers = [];
+	private array $storageWrappers = [];
+
+	private bool $wrappersSorted = false;
+
+	/**
+	 * @var IStorage[]
+	 */
+	private array $wrappersList = [];
 
 	#[\Override]
 	public function addStorageWrapper(string $wrapperName, callable $callback, int $priority = 50, array $existingMounts = []): bool {
@@ -33,6 +40,7 @@ class StorageFactory implements IStorageFactory {
 		}
 
 		$this->storageWrappers[$wrapperName] = ['wrapper' => $callback, 'priority' => $priority];
+		$this->wrappersSorted = false;
 		return true;
 	}
 
@@ -44,6 +52,7 @@ class StorageFactory implements IStorageFactory {
 	 */
 	public function removeStorageWrapper(string $wrapperName): void {
 		unset($this->storageWrappers[$wrapperName]);
+		$this->wrappersSorted = false;
 	}
 
 	/**
@@ -58,15 +67,16 @@ class StorageFactory implements IStorageFactory {
 	}
 
 	public function wrap(IMountPoint $mountPoint, IStorage $storage): IStorage {
-		$wrappers = array_values($this->storageWrappers);
-		usort($wrappers, function ($a, $b) {
-			return $b['priority'] - $a['priority'];
-		});
-		/** @var callable[] $wrappers */
-		$wrappers = array_map(function ($wrapper) {
-			return $wrapper['wrapper'];
-		}, $wrappers);
-		foreach ($wrappers as $wrapper) {
+		if (!$this->wrappersSorted) {
+			uasort($this->storageWrappers, function ($a, $b) {
+				return $b['priority'] - $a['priority'];
+			});
+
+			$this->wrappersSorted = true;
+			$this->wrappersList = array_column($this->storageWrappers, 'wrapper');
+		}
+
+		foreach ($this->wrappersList as $wrapper) {
 			$storage = $wrapper($mountPoint->getMountPoint(), $storage, $mountPoint);
 			if (!($storage instanceof IStorage)) {
 				throw new \Exception('Invalid result from storage wrapper');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Keeps FS wrappers sorted to avoid doing it on `::wrap`, since it is called often for mount shares.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
