### PR TITLE
perf: reuse known instantiated storages in SharedMounts

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -264,6 +264,7 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 		$appConfig = Server::get(IAppConfig::class);
 		$cacheDependencies = Server::get(CacheDependencies::class);
 		$rootFolder = Server::get(IRootFolder::class);
+		$storagesCache = (Server::get(ICacheFactory::class))->createInMemory();
 
 		foreach ($superShares as $share) {
 			[$parentShare, $groupedShares] = $share;
@@ -296,6 +297,7 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 						'appConfig' => $appConfig,
 						'cacheDependencies' => $cacheDependencies,
 						'rootFolder' => $rootFolder,
+						'storagesCache' => $storagesCache,
 					],
 					$loader,
 					$this->eventDispatcher,

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -96,6 +96,8 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	private CacheDependencies $cacheDependencies;
 	private IRootFolder $rootFolder;
 
+	private ?\OCP\ICache $storagesCache;
+
 	public function __construct(array $parameters) {
 		$this->ownerView = $parameters['ownerView'];
 		$this->logger = $parameters['logger'] ?? Server::get(LoggerInterface::class);
@@ -103,6 +105,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 		$this->shareManager = $parameters['shareManager'] ?? Server::get(IShareManager::class);
 		$this->cacheDependencies = $parameters['cacheDependencies'] ?? Server::get(CacheDependencies::class);
 		$this->rootFolder = $parameters['rootFolder'] ?? Server::get(IRootFolder::class);
+		$this->storagesCache = $parameters['storagesCache'] ?? null;
 
 		$this->superShare = $parameters['superShare'];
 		$this->groupedShares = $parameters['groupedShares'];
@@ -162,6 +165,27 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 				throw new \Exception('Maximum share depth reached');
 			}
 
+			$nodeCacheEntry = $this->superShare->getNodeCacheEntry();
+			if ($nodeCacheEntry !== null) {
+				$storageId = $nodeCacheEntry->getStorageId();
+				$cached = $this->storagesCache?->get((string)$storageId);
+				if (is_array($cached)) {
+					/** @var IStorage $cachedStorage */
+					$cachedStorage = $cached['storage'];
+					$prefix = $cached['prefix'];
+					$this->nonMaskedStorage = $cachedStorage;
+					$this->sourcePath = $prefix . $nodeCacheEntry->getPath();
+					$this->rootPath = $nodeCacheEntry->getPath();
+					$this->cache = null;
+					$this->storage = new PermissionsMask([
+						'storage' => $cachedStorage,
+						'mask' => $this->superShare->getPermissions(),
+					]);
+					self::$initDepth--;
+					return;
+				}
+			}
+
 			$this->ownerUserFolder = $this->rootFolder->getUserFolder($this->superShare->getShareOwner());
 			$sourceId = $this->superShare->getNodeId();
 			$ownerNodes = $this->ownerUserFolder->getById($sourceId);
@@ -192,6 +216,12 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 					'storage' => $this->nonMaskedStorage,
 					'mask' => $this->superShare->getPermissions(),
 				]);
+
+				$prefix = substr($this->sourcePath, 0, strlen($this->sourcePath) - strlen($this->rootPath));
+				$this->storagesCache?->set(
+					(string)$this->nonMaskedStorage->getCache()->getNumericStorageId(),
+					['storage' => $this->nonMaskedStorage, 'prefix' => $prefix],
+				);
 			}
 		} catch (NotFoundException|UserNotFoundException $e) {
 			// original file not accessible or deleted or sharer user deleted, set FailedStorage


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
## Summary

Avoids querying over and over the DB to initiate a `SharedMount` for a storage that is already known. This stops N+1 issues when using `instanceOfStorage` on `SharedStorage` for the same root storage through different `SharedStorage` instances.

## TODO

- [x] Double-check that getting the storage ID in the way I did is okay and behaves as expected with multiple wrappers
- [ ] Add steps to reproduce and description of what the root/source path handling does

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
