### PR TITLE
docs(federation): refine app metadata for federation-related built-in apps

### DIFF
--- a/apps/cloud_federation_api/appinfo/info.xml
+++ b/apps/cloud_federation_api/appinfo/info.xml
@@ -7,8 +7,8 @@
 	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>cloud_federation_api</id>
 	<name>Cloud Federation API</name>
-	<summary>Enable clouds to communicate with each other and exchange data</summary>
-	<description>The Cloud Federation API enables various Nextcloud instances to communicate with each other and to exchange data.</description>
+	<summary>Implements a common federation API for sharing across compatible servers</summary>
+	<description>Provides a common federation API for sharing, notifications, and invitations across compatible servers.</description>
 	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>

--- a/apps/cloud_federation_api/openapi.json
+++ b/apps/cloud_federation_api/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "cloud_federation_api",
         "version": "0.0.1",
-        "description": "Enable clouds to communicate with each other and exchange data",
+        "description": "Implements a common federation API for sharing across compatible servers",
         "license": {
             "name": "agpl"
         }

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -8,8 +8,8 @@
 	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>federatedfilesharing</id>
 	<name>Federated file sharing</name>
-	<summary>Provide federated file sharing across servers</summary>
-	<description>Provide federated file sharing across servers</description>
+	<summary>Enables federated file sharing across compatible servers</summary>
+	<description>Provides federated file and folder sharing across compatible servers, including remote share invitations and notifications.</description>
 	<version>2.0.0-dev.1</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>

--- a/apps/federatedfilesharing/openapi.json
+++ b/apps/federatedfilesharing/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "federatedfilesharing",
         "version": "0.0.1",
-        "description": "Provide federated file sharing across servers",
+        "description": "Enables federated file sharing across compatible servers",
         "license": {
             "name": "agpl"
         }

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -8,8 +8,8 @@
 	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>federation</id>
 	<name>Federation</name>
-	<summary>Federation allows you to connect with other trusted servers to exchange the account directory.</summary>
-	<description>Federation allows you to connect with other trusted servers to exchange the account directory. For example this will be used to auto-complete external accounts for federated sharing.</description>
+	<summary>Connects trusted servers to support optional account discovery</summary>
+	<description>Manages trusted server connections, shared-secret exchange, and account discovery for optional federation features such as external account lookup.</description>
 	<version>2.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>

--- a/apps/federation/openapi-administration.json
+++ b/apps/federation/openapi-administration.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "federation-administration",
         "version": "0.0.1",
-        "description": "Federation allows you to connect with other trusted servers to exchange the account directory.",
+        "description": "Connects trusted servers to support optional account discovery",
         "license": {
             "name": "agpl"
         }

--- a/apps/federation/openapi-federation.json
+++ b/apps/federation/openapi-federation.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "federation-federation",
         "version": "0.0.1",
-        "description": "Federation allows you to connect with other trusted servers to exchange the account directory.",
+        "description": "Connects trusted servers to support optional account discovery",
         "license": {
             "name": "agpl"
         }

--- a/apps/federation/openapi-full.json
+++ b/apps/federation/openapi-full.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "federation-full",
         "version": "0.0.1",
-        "description": "Federation allows you to connect with other trusted servers to exchange the account directory.",
+        "description": "Connects trusted servers to support optional account discovery",
         "license": {
             "name": "agpl"
         }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Refine the `info.xml` summary and description fields for the federation-related built-in apps.

The previous metadata felt overly generic, repetitive, or too narrowly framed. These updates make the app descriptions more accurate and clearer about each app’s role:

- `cloud_federation_api` as the common federation/OCM API layer
- `federatedfilesharing` as the file-sharing implementation built on that API layer
- `federation` as the optional trusted-server/account-discovery layer

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
