### PR TITLE
perf: avoid DIing IRootFolder at every shared storage init

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -17,6 +17,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IAuthoritativeMountProvider;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IPartialMountProvider;
+use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IStorageFactory;
@@ -262,6 +263,7 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 		$newMaxValidatedShare = $maxValidatedShare;
 		$appConfig = Server::get(IAppConfig::class);
 		$cacheDependencies = Server::get(CacheDependencies::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		foreach ($superShares as $share) {
 			[$parentShare, $groupedShares] = $share;
@@ -293,6 +295,7 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 						'shareManager' => $this->shareManager,
 						'appConfig' => $appConfig,
 						'cacheDependencies' => $cacheDependencies,
+						'rootFolder' => $rootFolder,
 					],
 					$loader,
 					$this->eventDispatcher,

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -94,6 +94,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	 */
 	private static int $initDepth = 0;
 	private CacheDependencies $cacheDependencies;
+	private IRootFolder $rootFolder;
 
 	public function __construct(array $parameters) {
 		$this->ownerView = $parameters['ownerView'];
@@ -101,6 +102,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 		$this->appConfig = $parameters['appConfig'] ?? Server::get(IAppConfig::class);
 		$this->shareManager = $parameters['shareManager'] ?? Server::get(IShareManager::class);
 		$this->cacheDependencies = $parameters['cacheDependencies'] ?? Server::get(CacheDependencies::class);
+		$this->rootFolder = $parameters['rootFolder'] ?? Server::get(IRootFolder::class);
 
 		$this->superShare = $parameters['superShare'];
 		$this->groupedShares = $parameters['groupedShares'];
@@ -160,9 +162,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 				throw new \Exception('Maximum share depth reached');
 			}
 
-			/** @var IRootFolder $rootFolder */
-			$rootFolder = Server::get(IRootFolder::class);
-			$this->ownerUserFolder = $rootFolder->getUserFolder($this->superShare->getShareOwner());
+			$this->ownerUserFolder = $this->rootFolder->getUserFolder($this->superShare->getShareOwner());
 			$sourceId = $this->superShare->getNodeId();
 			$ownerNodes = $this->ownerUserFolder->getById($sourceId);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

The `init` function in `SharedStorage` can be called thousand times in servers with many shares, avoid calling `Server::get(IRootFolder::class)` each time and inject it once per call of `MountProvider`.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
