### PR TITLE
fix(Collaborators): Fix matching emails to remote users if no remote results are present

### DIFF
--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -96,8 +96,6 @@ class Search implements ISearch {
 		$allResults = $searchResult->asArray();
 
 		$emailType = new SearchResultType('emails');
-		$remoteType = new SearchResultType('remotes');
-
 		$emailLabel = $emailType->getLabel();
 		$emailEntries = array_merge(
 			$allResults['exact'][$emailLabel] ?? [],
@@ -116,14 +114,18 @@ class Search implements ISearch {
 			$mailIdMap[$mailRow['uuid']] = $mailRow['value']['shareWith'];
 		}
 
-		foreach ($allResults[$remoteType->getLabel()] as $resultRow) {
-			if (!isset($resultRow['uuid'])) {
-				continue;
-			}
-			if (isset($mailIdMap[$resultRow['uuid']])) {
-				$searchResult->removeCollaboratorResult($emailType, $mailIdMap[$resultRow['uuid']]);
+		$remoteType = new SearchResultType('remotes');
+		if (isset($allResults[$remoteType->getLabel()])) {
+			foreach ($allResults[$remoteType->getLabel()] as $resultRow) {
+				if (!isset($resultRow['uuid'])) {
+					continue;
+				}
+				if (isset($mailIdMap[$resultRow['uuid']])) {
+					$searchResult->removeCollaboratorResult($emailType, $mailIdMap[$resultRow['uuid']]);
+				}
 			}
 		}
+
 		$lookupType = new SearchResultType('lookup');
 		if (isset($allResults[$lookupType->getLabel()])) {
 			foreach ($allResults[$lookupType->getLabel()] as $resultRow) {


### PR DESCRIPTION
There might not be any remote results in the API was called without the remote type, leading to an invalid array access.

Caused by https://github.com/nextcloud/server/pull/60587.