### PR TITLE
refactor(app): finalize app upgrade state before queueing follow-up jobs

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -1093,11 +1093,12 @@ class AppManager implements IAppManager {
 	 */
 	#[\Override]
 	public function upgradeApp(string $appId): bool {
-		// for apps distributed with core, we refresh app path in case the downloaded version
-		// have been installed in custom apps and not in the default path
+		// For apps distributed with core, refresh the app path in case the downloaded
+		// version was installed in custom apps and not in the default path.
 		$appPath = $this->getAppPath($appId, true);
 
 		$this->clearAppsCache();
+
 		$appInfo = $this->getAppInfo($appId);
 		if ($appInfo === null) {
 			throw new AppPathNotFoundException('Could not find ' . $appId);
@@ -1105,32 +1106,25 @@ class AppManager implements IAppManager {
 
 		$ignoreMaxApps = $this->config->getSystemValue('app_install_overwrite', []);
 		$ignoreMax = in_array($appId, $ignoreMaxApps, true);
+
 		$this->checkAppDependencies($appId, $ignoreMax);
 
 		\OC_App::registerAutoloading($appId, $appPath, true);
+
 		$this->executeRepairSteps($appId, $appInfo['repair-steps']['pre-migration']);
 
 		$ms = new MigrationService($appId, Server::get(\OC\DB\Connection::class));
 		$ms->migrate();
 
 		$this->executeRepairSteps($appId, $appInfo['repair-steps']['post-migration']);
-		$queue = Server::get(IJobList::class);
-		foreach ($appInfo['repair-steps']['live-migration'] as $step) {
-			$queue->add(BackgroundRepair::class, [
-				'app' => $appId,
-				'step' => $step]);
-		}
 
-		// update appversion in app manager
+		// Refresh cached app metadata/version after the migration finished.
 		$this->clearAppsCache();
 		$this->getAppVersion($appId, false);
 
-		// Setup background jobs
-		foreach ($appInfo['background-jobs'] as $job) {
-			$queue->add($job);
-		}
+		$this->setAppTypes($appId, $appInfo);
 
-		//set remote/public handlers
+		// Set remote/public handlers.
 		foreach ($appInfo['remote'] as $name => $path) {
 			$this->config->setAppValue('core', 'remote_' . $name, $appId . '/' . $path);
 		}
@@ -1138,15 +1132,26 @@ class AppManager implements IAppManager {
 			$this->config->setAppValue('core', 'public_' . $name, $appId . '/' . $path);
 		}
 
-		$this->setAppTypes($appId, $appInfo);
+		// Migrate eventual new config keys in the process.
+		/** @psalm-suppress InternalMethod */
+		$this->configManager->migrateConfigLexiconKeys($appId);
+		$this->configManager->updateLexiconEntries($appId);
 
 		$version = $this->getAppVersion($appId);
 		$this->config->setAppValue($appId, 'installed_version', $version);
 
-		// migrate eventual new config keys in the process
-		/** @psalm-suppress InternalMethod */
-		$this->configManager->migrateConfigLexiconKeys($appId);
-		$this->configManager->updateLexiconEntries($appId);
+		$queue = Server::get(IJobList::class);
+
+		foreach ($appInfo['repair-steps']['live-migration'] as $step) {
+			$queue->add(BackgroundRepair::class, [
+				'app' => $appId,
+				'step' => $step]);
+		}
+
+		// Set up background jobs.
+		foreach ($appInfo['background-jobs'] as $job) {
+			$queue->add($job);
+		}
 
 		$this->dispatcher->dispatchTyped(new AppUpdateEvent($appId));
 		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_UPDATE, new ManagerEvent(


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This change adjusts the app upgrade flow in `AppManager` so that app metadata, config lexicon updates, and the `installed_version` are finalized before live-migration and background jobs are queued.

This avoids scheduling background repair work while the app is still in an intermediate upgrade state and makes the upgrade sequence more consistent and safer.

With this ordering, `installed_version` more accurately reflects that synchronous upgrade work completed successfully, and deferred work is clearly treated as follow-up.

## TODO

- [ ] Confirm live migrations don't assume pre-upgrade version access in their logic
- [ ] Confirm config lexicon migrations don't assume/need pre-upgrade version

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
