### PR TITLE
feat: Mark 32 bits support as removed for Nextcloud Hub 27 Winter

### DIFF
--- a/apps/settings/lib/SetupChecks/SystemIs64bit.php
+++ b/apps/settings/lib/SetupChecks/SystemIs64bit.php
@@ -44,7 +44,7 @@ class SystemIs64bit implements ISetupCheck {
 		if ($this->is64bit()) {
 			return SetupResult::success($this->l10n->t('64-bit'));
 		} else {
-			return SetupResult::warning(
+			return SetupResult::error(
 				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit! The support for 32-bit system will be removed in Nextcloud Hub 27 Spring (Nextcloud 36).'),
 				$this->urlGenerator->linkToDocs('admin-system-requirements')
 			);

--- a/apps/settings/lib/SetupChecks/SystemIs64bit.php
+++ b/apps/settings/lib/SetupChecks/SystemIs64bit.php
@@ -45,7 +45,7 @@ class SystemIs64bit implements ISetupCheck {
 			return SetupResult::success($this->l10n->t('64-bit'));
 		} else {
 			return SetupResult::warning(
-				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit!'),
+				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit! The support for 32-bit system will be removed in Nextcloud Hub 27 Spring (Nextcloud 36).'),
 				$this->urlGenerator->linkToDocs('admin-system-requirements')
 			);
 		}

--- a/apps/settings/lib/SetupChecks/SystemIs64bit.php
+++ b/apps/settings/lib/SetupChecks/SystemIs64bit.php
@@ -45,7 +45,7 @@ class SystemIs64bit implements ISetupCheck {
 			return SetupResult::success($this->l10n->t('64-bit'));
 		} else {
 			return SetupResult::error(
-				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit! We will no longer block improvements to performance, security and scalability that are incompatible with 32bit support going forward and we expect that Nextcloud Hub 27 Spring (Nextcloud 36) will no longer work on 32bit systems.'),
+				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit! We will no longer block improvements to performance, security and scalability that are incompatible with 32bit support going forward and we expect that Nextcloud Hub 27 Winter (Nextcloud 36) will no longer work on 32bit systems.'),
 				$this->urlGenerator->linkToDocs('admin-system-requirements')
 			);
 		}

--- a/apps/settings/lib/SetupChecks/SystemIs64bit.php
+++ b/apps/settings/lib/SetupChecks/SystemIs64bit.php
@@ -45,7 +45,7 @@ class SystemIs64bit implements ISetupCheck {
 			return SetupResult::success($this->l10n->t('64-bit'));
 		} else {
 			return SetupResult::error(
-				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit! The support for 32-bit system will be removed in Nextcloud Hub 27 Spring (Nextcloud 36).'),
+				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit! We will no longer block improvements to performance, security and scalability that are incompatible with 32bit support going forward and we expect that Nextcloud Hub 27 Spring (Nextcloud 36) will no longer work on 32bit systems.'),
 				$this->urlGenerator->linkToDocs('admin-system-requirements')
 			);
 		}


### PR DESCRIPTION
## Summary 
There are challenges around 32bit support, and while we added a warning to the setup checks in 2023 that 32bit support would be dropped, it's time to make a real decision.

We still claim to support 32bit, but in practice it isn't working well. Meanwhile, maintaining it is blocking improvements to performance, security and scalability that our (overwhelmingly 64bit) users would benefit from. Unless some volunteers step up to maintain 32bit support and find workarounds for the issues below, we intend to phase it out, with the coming release the last one that maintains some level of support.

### Why this is getting harder

- 32bit support breaks hard after 2038, and PHP itself will likely drop 32bit support well before that. A proposal to add PHP language features that would help 32bit was denied years ago, with maintainers citing that PHP itself would drop 32bit "soon anyway".
- Realistically, this mostly affects Raspberry Pi 1 and 2 — anything below the Pi 3 isn't even supported by Nextcloud Pi anymore, and Pi 3 and up have 64bit support.

### A lot is already broken

- Some PHP logic is already broken on 32bit.
- Many Nextcloud apps no longer support it.
- Most of our supported Linux distributions no longer support it either.

We have limited automated 32bit testing and no manual testing. We recently spent real time fixing issues those tests turned up — work that will need to be repeated again and again if nothing changes.

That said, 32bit does still matter to some people: there are certainly still users running Nextcloud on Raspberry Pi 1/2, other dev boards, older NAS devices, and older routers. That's why we've kept it going this long, even though most contributors and customers have no need for it. But we've had a warning about the state of 32bit support in the setup screen since 2023, and we think it's time to move on.

### The cost of keeping it "supported"

Our half-baked attempt at keeping 32bit alive comes at a real cost.

- We're stuck on older versions of dependencies that still work on 32bit and can't upgrade to versions with fixes.
- It blocks adoption of new tech we need, like snowflake IDs: PHP auto-converts big ints to floats on 32bit, losing precision; using them as strings instead just means PHP auto-converts them back to ints when used as array indices, breaking things either way.
- A number of performance optimizations can't be applied because they would break on 32bit.

Without intervention, this situation is getting worse as libraries are no longer maintained. Bringing 32bit support back up to a good level would already be a lot of work, and will become harder and harder.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
