### PR TITLE
refactor: Soft remove Emitter from IRootFolder interface

### DIFF
--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -77,27 +77,6 @@ class LazyFolder implements Folder {
 	/**
 	 * @inheritDoc
 	 */
-	public function listen($scope, $method, callable $callback) {
-		$this->__call(__FUNCTION__, func_get_args());
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function removeListener($scope = null, $method = null, ?callable $callback = null) {
-		$this->__call(__FUNCTION__, func_get_args());
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function emit($scope, $method, $arguments = []) {
-		$this->__call(__FUNCTION__, func_get_args());
-	}
-
-	/**
-	 * @inheritDoc
-	 */
 	public function mount($storage, $mountPoint, $arguments = []) {
 		$this->__call(__FUNCTION__, func_get_args());
 	}

--- a/lib/private/Files/Node/LazyRoot.php
+++ b/lib/private/Files/Node/LazyRoot.php
@@ -8,6 +8,7 @@
 
 namespace OC\Files\Node;
 
+use OC\Hooks\Emitter;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
@@ -21,7 +22,7 @@ use OCP\Files\Node as INode;
  *
  * @package OC\Files\Node
  */
-class LazyRoot extends LazyFolder implements IRootFolder {
+class LazyRoot extends LazyFolder implements IRootFolder, Emitter {
 	public function __construct(\Closure $folderClosure, array $data = []) {
 		parent::__construct($this, $folderClosure, $data);
 	}
@@ -58,5 +59,19 @@ class LazyRoot extends LazyFolder implements IRootFolder {
 	#[\Override]
 	public function getAppDataDirectoryName(): string {
 		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function emit($scope, $method, $arguments = []) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function listen($scope, $method, callable $callback) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function removeListener($scope = null, $method = null, ?callable $callback = null) {
+		$this->__call(__FUNCTION__, func_get_args());
 	}
 }

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -14,6 +14,7 @@ use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Storage;
 use OC\Files\Utils\PathHelper;
 use OC\Files\View;
+use OC\Hooks\Emitter;
 use OC\Hooks\PublicEmitter;
 use OC\User\NoUserException;
 use OCA\Files\AppInfo\Application;
@@ -58,7 +59,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OC\Files\Node
  */
-class Root extends Folder implements IRootFolder {
+class Root extends Folder implements IRootFolder, Emitter {
 	private PublicEmitter $emitter;
 	private CappedMemoryCache $userFolderCache;
 	private ICache $pathByIdCache;

--- a/lib/private/Preview/WatcherConnector.php
+++ b/lib/private/Preview/WatcherConnector.php
@@ -37,6 +37,7 @@ class WatcherConnector {
 	public function connectWatcher(): void {
 		// Do not connect if we are not setup yet!
 		if ($this->config->getValue('instanceid', null) !== null) {
+			/** @psalm-suppress UndefinedInterfaceMethod both Root and LazyRoot have listen */
 			$this->root->listen('\OC\Files', 'postWrite', function (Node $node): void {
 				$this->getWatcher()->postWrite($node);
 			});

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -8,7 +8,6 @@
 
 namespace OCP\Files;
 
-use OC\Hooks\Emitter;
 use OC\User\NoUserException;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Mount\IMountPoint;
@@ -19,7 +18,7 @@ use OCP\Files\Node as INode;
  *
  * @since 8.0.0
  */
-interface IRootFolder extends Folder, Emitter {
+interface IRootFolder extends Folder {
 	/**
 	 * Returns a view to user's files folder
 	 *


### PR DESCRIPTION
Move this to the private implementation in OC, so that using IRootFolder in apps doesn't require dummy stubs.

This will create a new psalm warnings for users of this method but considering that this is deprecated for a long time and that it still works at runtime, this shouldn't cause any issue.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
