### PR TITLE
debug: add logging when hook node has null path

### DIFF
--- a/lib/private/Files/Node/HookConnector.php
+++ b/lib/private/Files/Node/HookConnector.php
@@ -214,15 +214,36 @@ class HookConnector {
 				$info = null;
 			}
 			if ($isDir || Filesystem::is_dir($path)) {
-				return new NonExistingFolder($this->root, $this->view, $fullPath, $info);
+				$node = new NonExistingFolder($this->root, $this->view, $fullPath, $info);
 			} else {
-				return new NonExistingFile($this->root, $this->view, $fullPath, $info);
+				$node = new NonExistingFile($this->root, $this->view, $fullPath, $info);
+			}
+		} else {
+			if ($info->getType() === FileInfo::TYPE_FILE) {
+				$node = new File($this->root, $this->view, $info->getPath(), $info);
+			} else {
+				$node = new Folder($this->root, $this->view, $info->getPath(), $info);
 			}
 		}
-		if ($info->getType() === FileInfo::TYPE_FILE) {
-			return new File($this->root, $this->view, $info->getPath(), $info);
-		} else {
-			return new Folder($this->root, $this->view, $info->getPath(), $info);
+		if ($node->getPath() === null) {
+			$e = new \Exception("null path when trying to get node for hook");
+			$data = [
+				'exception' => $e,
+				'original_path' => $path,
+				'view_root' => Filesystem::getView()->getRoot(),
+			];
+			if ($info) {
+				$data = $data + [
+						'mount_point' => $info->getMountPoint()->getMountPoint(),
+						'mount_provider_class' => $info->getMountPoint()->getMountProvider(),
+						'storage' => $info->getStorage()->getId(),
+						'file_id' => $info->getId(),
+					];
+			} else {
+				$data['info'] = 'not-found';
+			}
+			$this->logger->error($e->getMessage(), $data);
 		}
+		return $node;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
