### PR TITLE
fix(db): add support for MariaDB 12.3 LTS and increase min. to 10.11

### DIFF
--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -60,9 +60,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mariadb-versions: '10.6'
+          - mariadb-versions: '10.11'
             php-versions: '8.3'
-          - mariadb-versions: '11.8'
+          - mariadb-versions: '12.3'
             php-versions: '8.5'
 
     name: MariaDB ${{ matrix.mariadb-versions }} (PHP ${{ matrix.php-versions }}) - database tests

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -17,8 +17,8 @@ use OCP\SetupCheck\SetupResult;
 
 class SupportedDatabase implements ISetupCheck {
 
-	private const MIN_MARIADB = '10.6';
-	private const MAX_MARIADB = '11.8';
+	private const MIN_MARIADB = '10.11';
+	private const MAX_MARIADB = '12.3';
 	private const MIN_MYSQL = '8.4';
 	private const MAX_MYSQL = '9.7';
 	private const MIN_POSTGRES = '14';
@@ -56,10 +56,10 @@ class SupportedDatabase implements ISetupCheck {
 			[$major, $minor, ] = explode('.', $versionlc);
 			$versionConcern = $major . '.' . $minor;
 			if (str_contains($versionlc, 'mariadb')) {
-				if (version_compare($versionConcern, '10.3', '=')) {
+				if (version_compare($versionConcern, '10.6', '=')) {
 					return SetupResult::info(
 						$this->l10n->t(
-							'MariaDB version 10.3 detected, this version is end-of-life and only supported as part of Ubuntu 20.04. MariaDB >=%1$s and <=%2$s is suggested for best performance, stability and functionality with this version of Nextcloud.',
+							'MariaDB version 10.6 detected, this version is end-of-life and only supported as part of Ubuntu 22.04. MariaDB >=%1$s and <=%2$s is suggested for best performance, stability and functionality with this version of Nextcloud.',
 							[
 								self::MIN_MARIADB,
 								self::MAX_MARIADB,

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -123,12 +123,15 @@ class Manager implements IManager {
 		}
 
 		$query = $this->connection->getQueryBuilder();
-
-		$query->select('class', 'entity')
-			->selectAlias($query->expr()->castColumn('events', IQueryBuilder::PARAM_STR), 'events')
+		$subQuery = $this->connection->getQueryBuilder();
+		$subQuery->select('class', 'entity')
+			->selectAlias($subQuery->expr()->castColumn('events', IQueryBuilder::PARAM_STR), 'events')
 			->from('flow_operations')
-			->where($query->expr()->neq('events', $query->createNamedParameter('[]'), IQueryBuilder::PARAM_STR))
-			->groupBy('class', 'entity', $query->expr()->castColumn('events', IQueryBuilder::PARAM_STR));
+			->where($subQuery->expr()->neq('events', $query->createNamedParameter('[]'), IQueryBuilder::PARAM_STR));
+
+		$query->select('class', 'entity', 'events')
+			->from($query->createFunction('(' . $subQuery->getSQL() . ')'), 'sub')
+			->groupBy('class', 'entity', 'events');
 
 		$result = $query->executeQuery();
 		$operations = [];

--- a/autotest.sh
+++ b/autotest.sh
@@ -272,11 +272,11 @@ function execute_tests {
 			echo "Fire up the mariadb docker"
 			DOCKER_CONTAINER_ID=$(docker run \
 				-v $BASEDIR/tests/docker/mariadb:/etc/mysql/conf.d \
-				-e MYSQL_ROOT_PASSWORD=owncloud \
-				-e MYSQL_USER="$DATABASEUSER" \
-				-e MYSQL_PASSWORD=owncloud \
-				-e MYSQL_DATABASE="$DATABASENAME" \
-				-d mariadb)
+				-e MARIADB_ROOT_PASSWORD=owncloud \
+				-e MARIADB_USER="$DATABASEUSER" \
+				-e MARIADB_PASSWORD=owncloud \
+				-e MARIADB_DATABASE="$DATABASENAME" \
+				-d mariadb:lts)
 			DATABASEHOST=$(docker_get_ip "$DOCKER_CONTAINER_ID")
 
 			echo "Waiting for MariaDB initialisation ..."
@@ -288,12 +288,13 @@ function execute_tests {
 			echo "MariaDB is up."
 
 		else
-			if [ "MariaDB" != "$(mysql --version | grep -o MariaDB)" ] ; then
-				echo "Your mysql binary is not provided by MariaDB"
+			MARIADB_EXECUTABLE=$(command -v mariadb && echo "mariadb" || echo "mysql")
+			if [ "MariaDB" != "$($MARIADB_EXECUTABLE --version | grep -o MariaDB)" ] ; then
+				echo "Your $MARIADB_EXECUTABLE binary is not provided by MariaDB"
 				echo "To use the docker container set the USEDOCKER environment variable"
 				exit -1
 			fi
-			mysql -u "$DATABASEUSER" -powncloud -e "DROP DATABASE IF EXISTS $DATABASENAME" -h $DATABASEHOST || true
+			$MARIADB_EXECUTABLE -u "$DATABASEUSER" -powncloud -e "DROP DATABASE IF EXISTS $DATABASENAME" -h $DATABASEHOST || true
 		fi
 
 		echo "Waiting for MariaDB initialisation ..."


### PR DESCRIPTION
## Summary
10.6 will be EOL when Nextcloud 35 is released, similar to 10.3 its still somewhat supported for enterprise Ubuntu 22.04. So as we dropped 20.04 support we can increase that exception to 10.6.

Now MariaDB is supported with active LTS version 10.11 to 12.3 (new LTS).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
