### PR TITLE
docs(config): clarify token_auth_enforced scope and session behavior

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -400,13 +400,18 @@ $CONFIG = [
 	 * client authentication flows that would otherwise accept either form of
 	 * credential directly.
 	 *
-	 * When enabled, these flows must use an app password/token generated in
-	 * Personal settings rather than the user's main login password.
+	 * When enabled, new authentication attempts through these flows must use an
+	 * app password/token generated in Personal settings rather than the user's
+	 * main login password.
 	 *
 	 * This applies to client-style authentication such as DAV and HTTP Basic
 	 * auth. It does not affect the standard interactive browser login, even
 	 * when the browser is used to authorize a client. To restrict password-based
 	 * browser logins, use an SSO or external identity provider.
+	 *
+	 * This setting does not automatically revoke existing sessions. To fully 
+	 * enforce this policy for users with existing sessions, invalidate those
+	 * sessions or wait for them to expire.
 	 *
 	 * Defaults to ``false``
 	 */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -396,9 +396,17 @@ $CONFIG = [
 	'auto_logout' => false,
 
 	/**
-	 * Enforce token authentication for clients, which blocks requests using the user
-	 * password for enhanced security. Users need to generate tokens in personal settings
-	 * which can be used as passwords on their clients.
+	 * Require app passwords/tokens instead of users' regular passwords for
+	 * client authentication flows that would otherwise accept either form of
+	 * credential directly.
+	 *
+	 * When enabled, these flows must use an app password/token generated in
+	 * Personal settings rather than the user's main login password.
+	 *
+	 * This applies to client-style authentication such as DAV and HTTP Basic
+	 * auth. It does not affect the standard interactive browser login, even
+	 * when the browser is used to authorize a client. To restrict password-based
+	 * browser logins, use an SSO or external identity provider.
 	 *
 	 * Defaults to ``false``
 	 */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -409,7 +409,7 @@ $CONFIG = [
 	 * when the browser is used to authorize a client. To restrict password-based
 	 * browser logins, use an SSO or external identity provider.
 	 *
-	 * This setting does not automatically revoke existing sessions. To fully 
+	 * This setting does not automatically revoke existing sessions. To fully
 	 * enforce this policy for users with existing sessions, invalidate those
 	 * sessions or wait for them to expire.
 	 *


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue --> (related to #50279)

## Summary

Clarify the `token_auth_enforced` description in `config.sample.php`.

The updated wording makes it clearer that this option:

- applies to direct client authentication flows that would otherwise accept either a regular password or an app password/token
- applies to client-style authentication such as DAV and HTTP Basic auth
- does **not** affect the standard interactive browser login, even when the browser is used to authorize a client
- does not automatically revoke existing sessions when enabled
- is not the mechanism for restricting password-based browser logins, for which SSO / an external identity provider is the intended approach

### Why

The previous wording could be read more broadly than the implementation supports. In practice, this setting applies to direct client credential-based authentication flows, not the standard interactive browser login flow.

It also does not retroactively invalidate existing sessions, so enabling it affects new authentication attempts rather than users with existing authenticated sessions.

### Additional context

Related to #50279.

This PR is documentation-only and focuses on clarifying the scope and behavior of `token_auth_enforced`. Related work in #59569 (unfinished/WIP) addresses separate follow-up work around admin-level session invalidation / revocation tooling.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI [used to review wording ideas and go rapidly back and forth with numerous drafts I played with to get the wording just right]
