### PR TITLE
fix(cache): make clear() redis cluster compatible

### DIFF
--- a/lib/private/Memcache/LoggerWrapperCache.php
+++ b/lib/private/Memcache/LoggerWrapperCache.php
@@ -158,7 +158,7 @@ class LoggerWrapperCache extends Cache implements IMemcacheTTL {
 			FILE_APPEND
 		);
 
-		return $this->wrappedCache->cad($key, $old);
+		return $this->wrappedCache->ncad($key, $old);
 	}
 
 	/** @inheritDoc */

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -39,6 +39,9 @@ class Redis extends Cache implements IMemcacheTTL {
 
 	private const MAX_TTL = 30 * 24 * 60 * 60; // 1 month
 
+	/** Number of keys to request per SCAN iteration in {@see self::clear()} (only a hint to Redis) */
+	private const SCAN_COUNT = 1000;
+
 	private \Redis|\RedisCluster|null $cache = null;
 
 	public function __construct($prefix = '', string $logFile = '') {
@@ -92,12 +95,45 @@ class Redis extends Cache implements IMemcacheTTL {
 
 	#[\Override]
 	public function clear($prefix = '') {
-		// TODO: this is slow and would fail with Redis cluster
-		$prefix = $this->getPrefix() . $prefix . '*';
-		$keys = $this->getCache()->keys($prefix);
-		$deleted = $this->getCache()->del($keys);
+		$pattern = $this->getPrefix() . $prefix . '*';
+		$cache = $this->getCache();
 
-		return (is_array($keys) && (count($keys) === $deleted));
+		// Iterate with SCAN and remove with UNLINK rather than KEYS + DEL:
+		// KEYS walks the whole keyspace and blocks the server, while a
+		// multi-key DEL/UNLINK is not cluster-safe (keys spanning hash slots
+		// raise a CROSSSLOT error). SCAN is non-blocking and UNLINK reclaims
+		// memory in the background.
+		if ($cache instanceof \RedisCluster) {
+			// On a cluster SCAN must be run against each master node, and keys
+			// are unlinked one at a time so each command stays within a slot.
+			foreach ($cache->_masters() as $master) {
+				$iterator = null;
+				do {
+					/** @psalm-suppress NullArgument, PossiblyNullArgument the SCAN cursor must start as null (the phpredis stub types it as int) */
+					$keys = $cache->scan($iterator, $master, $pattern, self::SCAN_COUNT);
+					if ($keys === false) {
+						break;
+					}
+					foreach ($keys as $key) {
+						$cache->unlink($key);
+					}
+				} while ($iterator > 0);
+			}
+		} else {
+			$iterator = null;
+			do {
+				/** @psalm-suppress NullArgument, PossiblyNullArgument the SCAN cursor must start as null (the phpredis stub types it as int) */
+				$keys = $cache->scan($iterator, $pattern, self::SCAN_COUNT);
+				if ($keys === false) {
+					break;
+				}
+				if ($keys !== []) {
+					$cache->unlink($keys);
+				}
+			} while ($iterator > 0);
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/lib/Memcache/RedisTest.php
+++ b/tests/lib/Memcache/RedisTest.php
@@ -84,4 +84,37 @@ class RedisTest extends Cache {
 		// allow for 1s of inaccuracy due to time moving forward
 		$this->assertLessThan(1, 50 - $this->instance->getTTL('foo'));
 	}
+
+	public function testClearWithPrefixOnlyRemovesMatchingKeys(): void {
+		$this->instance->set('foo1', 'a');
+		$this->instance->set('foo2', 'b');
+		$this->instance->set('bar1', 'c');
+
+		$this->assertTrue($this->instance->clear('foo'));
+
+		$this->assertFalse($this->instance->hasKey('foo1'));
+		$this->assertFalse($this->instance->hasKey('foo2'));
+		$this->assertTrue($this->instance->hasKey('bar1'));
+	}
+
+	public function testClearWithoutMatchesReturnsTrue(): void {
+		// Nothing is stored under this prefix; clearing must not error out
+		// (regression guard for calling UNLINK/DEL with an empty key list).
+		$this->assertTrue($this->instance->clear('no-such-prefix'));
+	}
+
+	public function testClearRemovesEntriesAcrossMultipleScanBatches(): void {
+		// More keys than a single SCAN batch (self::SCAN_COUNT) to exercise the
+		// cursor loop and make sure nothing is left behind.
+		$count = 1500;
+		for ($i = 0; $i < $count; $i++) {
+			$this->instance->set('bulk-' . $i, $i);
+		}
+
+		$this->assertTrue($this->instance->clear('bulk-'));
+
+		$this->assertFalse($this->instance->hasKey('bulk-0'));
+		$this->assertFalse($this->instance->hasKey('bulk-' . ($count - 1)));
+		$this->assertFalse($this->instance->hasKey('bulk-' . intdiv($count, 2)));
+	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`clear()` now uses SCAN + UNLINK instead of KEYS + DEL. Added a cluster-aware branch: iterates each master via `_masters()` and unlinks keys one at a time so every command stays within a single hash slot, so `clear()` now actually works as expected on a Redis Cluster.

Aditionnally, `LoggerWrapperCache::ncad()` now correctly delegates to `ncad()`.

_Note: The `@psalm-suppress NullArgument, PossiblyNullArgument` on the SCAN calls is required because the phpredis stub types the cursor as int though it must start as null._

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
