### PR TITLE
refactor: consolidate app loading logic in bootstrap process

### DIFF
--- a/lib/OC.php
+++ b/lib/OC.php
@@ -1157,16 +1157,11 @@ class OC {
 		$appManager->loadApps(['authentication']);
 		$appManager->loadApps(['extended_authentication']);
 
-		// Load minimum set of apps
-		if (!\OCP\Util::needUpgrade()
-			&& !((bool)$systemConfig->getValue('maintenance', false))) {
-			// For logged-in users: Load everything
-			if (Server::get(IUserSession::class)->isLoggedIn()) {
-				$appManager->loadApps();
-			} else {
-				// For guests: Load only filesystem and logging
-				$appManager->loadApps(['filesystem', 'logging']);
-
+		// Try to login the user if not in maintenance mode and not logged in
+		$needsUpdate = \OCP\Util::needUpgrade();
+		$isMaintenanceMode = (bool)$systemConfig->getValue('maintenance', false);
+		if (!$needsUpdate && !$isMaintenanceMode) {
+			if (!Server::get(IUserSession::class)->isLoggedIn()) {
 				// Don't try to login when a client is trying to get a OAuth token.
 				// OAuth needs to support basic auth too, so the login is not valid
 				// inside Nextcloud and the Login exception would ruin it.
@@ -1194,25 +1189,31 @@ class OC {
 					}
 				}
 			}
+
+			// After logging in the user load the minimum required apps
+			$appManager->loadApps(['filesystem', 'logging']);
+
+			// when not on CLI load all apps
+			if (!self::$CLI) {
+				$appManager->loadApps();
+			}
+		} elseif (!$needsUpdate && $serveAppApiDuringMaintenance) {
+			// In case we are in maintenance mode and the request is for app_api, we need to load the app_api app
+			$appManager->loadApp('app_api');
 		}
 
+		// All apps are now loaded to handle the request
+		// if we are not on CLI, try to match the request to a route and handle it
 		if (!self::$CLI) {
 			try {
-				if (!\OCP\Util::needUpgrade()) {
-					$appManager->loadApps(['filesystem', 'logging']);
-					$appManager->loadApps();
-				}
-				if ($serveAppApiDuringMaintenance) {
-					// loadApps() above is a no-op during maintenance, load app_api explicitly
-					$appManager->loadApp('app_api');
-				}
 				Server::get(\OC\Route\Router::class)->match($request->getRawPathInfo());
 				return;
-			} catch (Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {
-				//header('HTTP/1.0 404 Not Found');
 			} catch (Symfony\Component\Routing\Exception\MethodNotAllowedException $e) {
 				http_response_code(405);
 				return;
+			} catch (Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {
+				// we fall through here as the following code will check for special cases
+				// in case nothing matched we will at the end of this function try to display the 404-page.
 			}
 		}
 


### PR DESCRIPTION
## Summary
Remove duplicated calls to `loadApps` by consolidating the logic.
- First we keep loading authentication apps
- Then we try to login the user if needed
- Then load filesystem and logging
- Then - if not CLI - load everything else (if possible)

The flow is not really changed, but tried to make it more clear at what step which apps are loaded.
This also allows to have a specifc point in the execution flow where all app loading is done so we can emit an event for this in the future.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
