### PR TITLE
feat(TaskProcessing): Add AudioToAudioTranslate TaskType

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -942,6 +942,7 @@ return array(
     'OCP\\TaskProcessing\\Task' => $baseDir . '/lib/public/TaskProcessing/Task.php',
     'OCP\\TaskProcessing\\TaskTypes\\AnalyzeImages' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AnalyzeImages.php',
     'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioChat' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php',
+    'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioTranslate' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioTranslate.php',
     'OCP\\TaskProcessing\\TaskTypes\\AudioToText' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToText.php',
     'OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToTextSubtitles.php',
     'OCP\\TaskProcessing\\TaskTypes\\ContextAgentAudioInteraction' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextAgentAudioInteraction.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -983,6 +983,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\Task' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/Task.php',
         'OCP\\TaskProcessing\\TaskTypes\\AnalyzeImages' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AnalyzeImages.php',
         'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioChat' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php',
+        'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioTranslate' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioTranslate.php',
         'OCP\\TaskProcessing\\TaskTypes\\AudioToText' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToText.php',
         'OCP\\TaskProcessing\\TaskTypes\\AudioToTextSubtitles' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToTextSubtitles.php',
         'OCP\\TaskProcessing\\TaskTypes\\ContextAgentAudioInteraction' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextAgentAudioInteraction.php',

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -71,6 +71,7 @@ use OCP\TaskProcessing\SynchronousProviderOptions;
 use OCP\TaskProcessing\Task;
 use OCP\TaskProcessing\TaskTypes\AnalyzeImages;
 use OCP\TaskProcessing\TaskTypes\AudioToAudioChat;
+use OCP\TaskProcessing\TaskTypes\AudioToAudioTranslate;
 use OCP\TaskProcessing\TaskTypes\AudioToText;
 use OCP\TaskProcessing\TaskTypes\AudioToTextSubtitles;
 use OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction;
@@ -698,6 +699,7 @@ class Manager implements IManager {
 			TextToTextReformatParagraphs::ID => Server::get(TextToTextReformatParagraphs::class),
 			TextToSpeech::ID => Server::get(TextToSpeech::class),
 			AudioToAudioChat::ID => Server::get(AudioToAudioChat::class),
+			AudioToAudioTranslate::ID => Server::get(AudioToAudioTranslate::class),
 			ContextAgentAudioInteraction::ID => Server::get(ContextAgentAudioInteraction::class),
 			AnalyzeImages::ID => Server::get(AnalyzeImages::class),
 			ImageToTextOpticalCharacterRecognition::ID => Server::get(ImageToTextOpticalCharacterRecognition::class),

--- a/lib/public/TaskProcessing/TaskTypes/AudioToAudioTranslate.php
+++ b/lib/public/TaskProcessing/TaskTypes/AudioToAudioTranslate.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\TaskProcessing\TaskTypes;
+
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\ShapeDescriptor;
+
+/**
+ * This is the task processing task type for audio to audio translation
+ * @since 35.0.0
+ */
+class AudioToAudioTranslate implements ITaskType {
+	/**
+	 * @since 35.0.0
+	 */
+	public const ID = 'core:audio2audio:translate';
+
+	private IL10N $l;
+
+	/**
+	 * @param IFactory $l10nFactory
+	 * @since 35.0.0
+	 */
+	public function __construct(
+		IFactory $l10nFactory,
+	) {
+		$this->l = $l10nFactory->get('lib');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getName(): string {
+		return $this->l->t('Translate audio');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getDescription(): string {
+		return $this->l->t('Translates the speech of an audio file or recording and outputs an audio file in the desired language.');
+	}
+
+	/**
+	 * @return string
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getId(): string {
+		return self::ID;
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getInputShape(): array {
+		return [
+			'input' => new ShapeDescriptor(
+				$this->l->t('Input audio'),
+				$this->l->t('The audio file or recording to translate'),
+				EShapeType::Audio,
+			),
+			'origin_language' => new ShapeDescriptor(
+				$this->l->t('Origin language'),
+				$this->l->t('The language of the origin audio'),
+				EShapeType::Enum,
+			),
+			'target_language' => new ShapeDescriptor(
+				$this->l->t('Target language'),
+				$this->l->t('The desired language to translate the origin audio in'),
+				EShapeType::Enum,
+			),
+		];
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getOutputShape(): array {
+		return [
+			'audio_output' => new ShapeDescriptor(
+				$this->l->t('Audio output'),
+				$this->l->t('The audio translation'),
+				EShapeType::Audio,
+			),
+		];
+	}
+}


### PR DESCRIPTION


## Summary

Adds a `core:audio2audio:translate` task type which translates an audio input and produces an audio output.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
