### PR TITLE
fix(psalm-strict): Fix lib exclusions

### DIFF
--- a/lib/public/SystemTag/Events/TagCreatedEvent.php
+++ b/lib/public/SystemTag/Events/TagCreatedEvent.php
@@ -17,5 +17,5 @@ use OCP\AppFramework\Attribute\Consumable;
  * @since 35.0.0
  */
 #[Consumable(since: '35.0.0')]
-class TagCreatedEvent extends AbstractTagEvent {
+final class TagCreatedEvent extends AbstractTagEvent {
 }

--- a/lib/public/SystemTag/Events/TagDeletedEvent.php
+++ b/lib/public/SystemTag/Events/TagDeletedEvent.php
@@ -17,5 +17,5 @@ use OCP\AppFramework\Attribute\Consumable;
  * @since 35.0.0
  */
 #[Consumable(since: '35.0.0')]
-class TagDeletedEvent extends AbstractTagEvent {
+final class TagDeletedEvent extends AbstractTagEvent {
 }

--- a/lib/public/SystemTag/Events/TagUpdatedEvent.php
+++ b/lib/public/SystemTag/Events/TagUpdatedEvent.php
@@ -19,7 +19,7 @@ use OCP\SystemTag\ISystemTag;
  * @since 35.0.0
  */
 #[Consumable(since: '35.0.0')]
-class TagUpdatedEvent extends AbstractTagEvent {
+final class TagUpdatedEvent extends AbstractTagEvent {
 	/**
 	 * TagUpdatedEvent constructor
 	 * @since 35.0.0

--- a/psalm-strict.xml
+++ b/psalm-strict.xml
@@ -45,8 +45,8 @@
 			<directory name="lib/composer"/>
 			<directory name="lib/l10n"/>
 			<directory name="3rdparty"/>
-			<directory name="lib/public"/>
-			<directory name="lib/private"/>
+			<file name="lib/public/AppFramework/Controller.php"/>
+			<file name="lib/public/AppFramework/OCSController.php"/>
 			<directory name="build"/>
 		</ignoreFiles>
 	</projectFiles>


### PR DESCRIPTION
Files in lib/ weren't actually checked, because they were excluded.