### PR TITLE
fix(appstore): only show appstore entries if actual from appstore

### DIFF
--- a/apps/appstore/lib/Controller/ApiController.php
+++ b/apps/appstore/lib/Controller/ApiController.php
@@ -330,7 +330,14 @@ class ApiController extends OCSController {
 
 		$apps = $this->getAppsForCategory('');
 		$supportedApps = $this->subscriptionRegistry->delegateGetSupportedApps();
+		$shippedApps = $this->appManager->getAlwaysEnabledApps();
 		foreach ($apps as $app) {
+			if (in_array($app['id'], $shippedApps)) {
+				// shipped apps are no longer published on the appstore
+				// so skip them to avoid confusion with outdated data
+				continue;
+			}
+
 			$app['appstore'] = true;
 			if (!array_key_exists($app['id'], $this->allApps)) {
 				$this->allApps[$app['id']] = $app;


### PR DESCRIPTION
- resolves https://github.com/nextcloud/server/issues/61273

## Summary
Shipped apps are no longer published to the appstore, so the appstore data is outdated and confusing.
So ignore them from the app fetcher and only use the local data.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
