### PR TITLE
feat(OCM): Make it possible to have a spec compliant discovery

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2277,6 +2277,24 @@ $CONFIG = [
 	'sharing.federation.allowSelfSignedCertificates' => false,
 
 	/**
+	 * Override the ``apiVersion`` advertised in the local OCM discovery document.
+	 * Setting this to a non-empty string also removes the non-standard ``version``
+	 * field. Leave empty for compatibility with older Nextcloud servers.
+	 *
+	 * Defaults to ``''`` (empty string)
+	 */
+	'sharing.federation.ocm.apiVersion' => '',
+
+	/**
+	 * Remove the non-standard ``publicKey`` field from the local OCM discovery
+	 * document. Enable this only when all federated peers support RFC 9421 HTTP
+	 * signatures, for example when all peers run Nextcloud 35 or higher.
+	 *
+	 * Defaults to ``false``
+	 */
+	'sharing.federation.ocm.removePublicKey' => false,
+
+	/**
 	 * Hashing
 	 */
 

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -21,6 +21,8 @@ use OCP\Security\Signature\Model\Signatory;
  */
 class OCMProvider implements IOCMProvider {
 	private bool $enabled = false;
+	private bool $removePublicKey = false;
+	private bool $removeVersion = false;
 	private string $apiVersion = '';
 	private string $inviteAcceptDialog = '';
 	private array $capabilities = [];
@@ -327,6 +329,22 @@ class OCMProvider implements IOCMProvider {
 	}
 
 	/**
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function removePublicKey(): void {
+		$this->removePublicKey = true;
+	}
+
+	/**
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function removeVersion(): void {
+		$this->removeVersion = true;
+	}
+
+	/**
 	 * @since 28.0.0
 	 */
 	#[\Override]
@@ -345,6 +363,15 @@ class OCMProvider implements IOCMProvider {
 			'provider' => $this->getProvider(),
 			'resourceTypes' => $resourceTypes
 		];
+
+		if ($this->removeVersion) {
+			$response['apiVersion'] = $this->getApiVersion();
+			unset($response['version']);
+		}
+
+		if ($this->removePublicKey) {
+			unset($response['publicKey']);
+		}
 
 		if ($this->capabilities !== []) {
 			$response['capabilities'] = $this->capabilities;

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -21,6 +21,8 @@ use OCP\Security\Signature\Model\Signatory;
  */
 class OCMProvider implements IOCMProvider {
 	private bool $enabled = false;
+	private bool $removePublicKey = false;
+	private bool $removeVersion = false;
 	private string $apiVersion = '';
 	private string $inviteAcceptDialog = '';
 	private array $capabilities = [];
@@ -351,6 +353,22 @@ class OCMProvider implements IOCMProvider {
 	}
 
 	/**
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function removePublicKey(): void {
+		$this->removePublicKey = true;
+	}
+
+	/**
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function removeVersion(): void {
+		$this->removeVersion = true;
+	}
+
+	/**
 	 * @since 28.0.0
 	 */
 	#[\Override]
@@ -369,6 +387,15 @@ class OCMProvider implements IOCMProvider {
 			'provider' => $this->getProvider(),
 			'resourceTypes' => $resourceTypes
 		];
+
+		if ($this->removeVersion) {
+			$response['apiVersion'] = $this->getApiVersion();
+			unset($response['version']);
+		}
+
+		if ($this->removePublicKey) {
+			unset($response['publicKey']);
+		}
 
 		if ($this->capabilities !== []) {
 			$response['capabilities'] = $this->capabilities;

--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -247,6 +247,15 @@ final class OCMDiscoveryService implements IOCMDiscoveryService {
 		$event = new ResourceTypeRegisterEvent($provider);
 		$this->eventDispatcher->dispatchTyped($event);
 
+		$apiVersion = $this->config->getSystemValueString('sharing.federation.ocm.apiVersion');
+		if ($apiVersion !== '') {
+			$provider->setApiVersion($apiVersion);
+			$provider->removeVersion();
+		}
+		if ($this->config->getSystemValueBool('sharing.federation.ocm.removePublicKey')) {
+			$provider->removePublicKey();
+		}
+
 		$this->localProvider = $provider;
 		return $provider;
 	}

--- a/lib/public/OCM/Events/LocalOCMDiscoveryEvent.php
+++ b/lib/public/OCM/Events/LocalOCMDiscoveryEvent.php
@@ -65,4 +65,33 @@ class LocalOCMDiscoveryEvent extends Event {
 	public function getProvider(): IOCMProvider {
 		return $this->provider;
 	}
+
+	/**
+	 * Remove the non-standard publicKey field from OCM discovery
+	 *
+	 * @since 35.0.0
+	 */
+	public function removePublicKey(): void {
+		$this->provider->removePublicKey();
+	}
+
+	/**
+	 * Remove the non-standard version field from OCM discovery
+	 *
+	 * @since 35.0.0
+	 */
+	public function removeVersion(): void {
+		$this->provider->removeVersion();
+	}
+
+	/**
+	 * Set the apiVersion
+	 *
+	 * @param string $version
+	 *
+	 * @since 35.0.0
+	 */
+	public function setApiVersion(string $version): void {
+		$this->provider->setApiVersion($version);
+	}
 }

--- a/lib/public/OCM/IOCMProvider.php
+++ b/lib/public/OCM/IOCMProvider.php
@@ -58,6 +58,20 @@ interface IOCMProvider extends JsonSerializable {
 	public function getApiVersion(): string;
 
 	/**
+	 * Remove the non-standard publicKey field from OCM discovery
+	 *
+	 * @since 35.0.0
+	 */
+	public function removePublicKey(): void;
+
+	/**
+	 * Remove the non-standard version field from OCM discovery
+	 *
+	 * @since 35.0.0
+	 */
+	public function removeVersion(): void;
+
+	/**
 	 * configure endpoint
 	 *
 	 * @param string $endPoint
@@ -219,7 +233,7 @@ interface IOCMProvider extends JsonSerializable {
 	/**
 	 * @return array{
 	 *     enabled: bool,
-	 *     apiVersion: '1.0-proposal1',
+	 *     apiVersion: string,
 	 *     endPoint: string,
 	 *     publicKey?: array{
 	 *         keyId: string,
@@ -230,7 +244,7 @@ interface IOCMProvider extends JsonSerializable {
 	 *         shareTypes: list<string>,
 	 *         protocols: array<string, string>
 	 *     }>,
-	 *     version: string
+	 *     version?: string
 	 * }
 	 * @since 28.0.0
 	 */

--- a/lib/public/OCM/IOCMProvider.php
+++ b/lib/public/OCM/IOCMProvider.php
@@ -58,6 +58,20 @@ interface IOCMProvider extends JsonSerializable {
 	public function getApiVersion(): string;
 
 	/**
+	 * Remove the non-standard publicKey field from OCM discovery
+	 *
+	 * @since 35.0.0
+	 */
+	public function removePublicKey(): void;
+
+	/**
+	 * Remove the non-standard version field from OCM discovery
+	 *
+	 * @since 35.0.0
+	 */
+	public function removeVersion(): void;
+
+	/**
 	 * configure endpoint
 	 *
 	 * @param string $endPoint
@@ -240,7 +254,7 @@ interface IOCMProvider extends JsonSerializable {
 	/**
 	 * @return array{
 	 *     enabled: bool,
-	 *     apiVersion: '1.0-proposal1',
+	 *     apiVersion: string,
 	 *     endPoint: string,
 	 *     publicKey?: array{
 	 *         keyId: string,
@@ -251,7 +265,7 @@ interface IOCMProvider extends JsonSerializable {
 	 *         shareTypes: list<string>,
 	 *         protocols: array<string, string>
 	 *     }>,
-	 *     version: string,
+	 *     version?: string,
 	 *     jwksUri?: string
 	 * }
 	 * @since 28.0.0


### PR DESCRIPTION
The current discovery document have non standard elements, which are required for backwards compatibility with old Nextcloud versions.

There may however be deployments, that are up to date, and do not require backwards compatibility but instead value spec compliance and adding two new knobs to LocalOCMDiscoveryEvent can make that happen.

The new knobs are removeVersion which removes the non standard version field from the discovery and sets the correct apiVersion instead. Nextcloud prior to version 28 had an equality check for apiVersion and the hard coded string `1.0-proposal1` which is not at all the version that Nextcloud actually supports.

Along side this change a new function removePublicKey is also added. The publicKey in the discovery document is no longer used with the RFC9421 style http-signatures, and only the old legacy signatures use that key, since version 35 Nextcloud supports RFC9421 signatures, and the legacy publicKey can now be removed from the discovery if you don't require backwards compatibility with older Nextcloud versions.

Resolves: #52754

Note: For context #52758 may be of interest.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
