### PR TITLE
fix(users): Check if the backend implements `ISetDisplayNameBackend` in `setDisplayName`

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -119,7 +119,7 @@ class User implements IUser {
 	public function setDisplayName($displayName): bool {
 		$displayName = trim($displayName);
 		$oldDisplayName = $this->getDisplayName();
-		if ($this->backend->implementsActions(Backend::SET_DISPLAYNAME) && !empty($displayName) && $displayName !== $oldDisplayName) {
+		if ($this->backend instanceof ISetDisplayNameBackend || $this->backend->implementsActions(Backend::SET_DISPLAYNAME) && !empty($displayName) && $displayName !== $oldDisplayName) {
 			/** @var ISetDisplayNameBackend $backend */
 			$backend = $this->backend;
 			$result = $backend->setDisplayName($this->uid, $displayName);

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -23,6 +23,7 @@ use OCP\IUser;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\Server;
+use OCP\User\Backend\ABackend;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -344,14 +345,11 @@ class UserTest extends TestCase {
 	}
 
 	public function testSetDisplayNameNotSupported(): void {
-		$backend = $this->createMock(Database::class);
+		$backend = $this->createMock(ABackend::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->willReturn(false);
-
-		$backend->expects($this->never())
-			->method('setDisplayName');
 
 		$user = new User('foo', $backend, $this->dispatcher);
 		$this->assertFalse($user->setDisplayName('Foo'));


### PR DESCRIPTION
I assume this was an oversight to not check it.

- Needed for https://github.com/nextcloud/user_saml/pull/1137