### PR TITLE
resolve #61488

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -230,7 +230,7 @@ class Quota extends Wrapper {
 		}
 
 		if ($size !== null) {
-			if ($size < $free) {
+			if ($free < 0 || $size < $free) {
 				return parent::writeStream($path, $stream, $size);
 			} else {
 				throw new NotEnoughSpaceException();

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -13,6 +13,7 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\Local;
 use OC\Files\Storage\Wrapper\Quota;
 use OCP\Files;
+use OCP\Files\FileInfo;
 use OCP\Files\NotEnoughSpaceException;
 use OCP\ITempManager;
 use OCP\Server;
@@ -132,6 +133,34 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertFalse($count);
 		fclose($inputStream);
 		fclose($outputStream);
+	}
+
+	public function testWriteStreamWithUnlimitedFreeSpaceSucceeds(): void {
+		// object stores report SPACE_UNLIMITED for quota-exempt uploads/ paths
+		$storage = $this->getMockBuilder(Local::class)
+			->onlyMethods(['free_space'])
+			->setConstructorArgs([['datadir' => $this->tmpDir]])
+			->getMock();
+		$storage->method('free_space')->willReturn(FileInfo::SPACE_UNLIMITED);
+		$storage->mkdir('uploads');
+
+		$instance = new Quota(['storage' => $storage, 'quota' => 9]);
+
+		$stream = fopen('data://text/plain,foobar', 'r');
+		$this->assertEquals(6, $instance->writeStream('uploads/foo', $stream, 6));
+		fclose($stream);
+	}
+
+	public function testWriteStreamWithKnownSizeStillEnforcesQuota(): void {
+		$instance = $this->getLimitedStorage(9);
+
+		$stream = fopen('data://text/plain,foobarqwerty', 'r');
+		$this->expectException(NotEnoughSpaceException::class);
+		try {
+			$instance->writeStream('files/foo', $stream, 12);
+		} finally {
+			fclose($stream);
+		}
 	}
 
 	public function testReturnFalseWhenFopenFailed(): void {


### PR DESCRIPTION
* Resolves: #61488

## Summary

On primary object storage (S3 and other object stores) with a finite per-user
quota, chunked uploads fail with HTTP 413 `EntityTooLarge` / "Insufficient
space" regardless of how much quota is actually free. A ~250 MB upload was
rejected with ~8.4 GiB of free quota; reducing the chunk size had no effect,
and setting the quota to `Unlimited` worked around it.

Root cause is in `OC\Files\Storage\Wrapper\Quota::writeStream()`. Chunk parts
are written to the quota-exempt `uploads/` path, for which `free_space()`
returns the wrapped storage's value. Object stores return
`FileInfo::SPACE_UNLIMITED` (`-3`) there, so the `if ($size < $free)` check
evaluates `$size < -3`, which is always false, and the method throws
`NotEnoughSpaceException`.

`writeStream()` was the only write method missing the `$free < 0` short-circuit
that `file_put_contents()`, `copy()`, `copyFromStorage()`, and
`moveFromStorage()` already use, and that `QuotaPlugin::checkQuota()` applies at
the DAV layer. The fix adds that guard. On local storage the bug does not
trigger because `free_space()` returns a real positive value for the uploads
path.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
