### PR TITLE
fix(image): honor file path when saving WebP images

### DIFF
--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -279,7 +279,7 @@ class Image implements IImage {
 				$retVal = imagebmp($this->resource, $filePath);
 				break;
 			case IMAGETYPE_WEBP:
-				$retVal = imagewebp($this->resource, null, $this->getWebpQuality());
+				$retVal = imagewebp($this->resource, $filePath, $this->getWebpQuality());
 				break;
 			default:
 				$retVal = imagepng($this->resource, $filePath);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fix WebP image saving by passing the requested destination path to `imagewebp()`.

Previously, the WebP branch in `OC\Image::_output()` passed `null` as the target path, which could write the image to output instead of saving it to the requested file.


Noticed this in `Image::_output()` while perusing the code. While it's almost certainly a bug that breaks `save()`, admittedly I also can't find any callers of `save()`... but it is part of our public API so at least correcting this as long as the function still exists...

https://github.com/nextcloud/server/blob/ba137f0045b7023374c92a3d1af0fe42a72f248e/lib/public/IImage.php#L68-L75

Tests pass for `save()` because it only impacts `WebP` image format specifically, which isn't a format specifically covered.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
