### PR TITLE
perf(image): remove redundant getimagesize() call in JPEG load path

### DIFF
--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -641,9 +641,8 @@ class Image implements IImage {
 					if (!$this->checkImageSize($imagePath)) {
 						return false;
 					}
-					if (@getimagesize($imagePath) !== false) {
-						$this->resource = @imagecreatefromjpeg($imagePath);
-					} else {
+					$this->resource = @imagecreatefromjpeg($imagePath);
+					if (!$this->resource) {
 						$this->logger->debug('Image->loadFromFile, JPG image not valid: ' . $imagePath, ['app' => 'core']);
 					}
 				} else {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Remove the second `getimagesize()` call from the JPEG branch in `OC\Image::loadFromFile()`.

After PR #46342 this second call become redundant. `checkImageSize()` already calls `getimagesize()` and returns `false` when the image data cannot be read, so the JPEG-specific follow-up check is redundant. The image can be passed directly to `imagecreatefromjpeg()` after the existing guard succeeds.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
