### PR TITLE
fix(dav): allow ExternalCalendar as schedule-default-calendar-URL

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -344,11 +344,23 @@ class CustomPropertiesBackend implements BackendInterface {
 
 				// $path is the principal here as this prop is only set on principals
 				$node = $this->tree->getNodeForPath($href);
-				if (!($node instanceof Calendar) || $node->getOwner() !== $path) {
+				if ((!($node instanceof Calendar) && !($node instanceof ExternalCalendar)) || $node->getOwner() !== $path) {
 					throw new DavException('No such calendar');
 				}
 
-				$this->defaultCalendarValidator->validateScheduleDefaultCalendar($node);
+				if ($node instanceof Calendar) {
+					$this->defaultCalendarValidator->validateScheduleDefaultCalendar($node);
+				} else {
+					// ExternalCalendar: verify VEVENT support; these calendars are always writable and not subscriptions/shared/deleted
+					$sCCS = '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set';
+					$calendarProperties = $node->getProperties([$sCCS]);
+					if (isset($calendarProperties[$sCCS])) {
+						$supportedComponents = $calendarProperties[$sCCS]->getValue();
+						if (!in_array('VEVENT', $supportedComponents, true)) {
+							throw new DavException('Calendar does not support VEVENT components');
+						}
+					}
+				}
 				break;
 		}
 	}


### PR DESCRIPTION
## Summary

When a user sets an `ExternalCalendar` (e.g. a calendar provided by a third-party app via `OCA\DAV\CalDAV\Integration\ExternalCalendar`) as the default calendar for scheduling, `CustomPropertiesBackend::validateProperty()` rejects it with a "No such calendar" exception. This surfaces to the user as "Standardkalender konnte nicht gespeichert werden" in the Nextcloud Calendar widget.

**Root cause:** The `validateProperty()` method for `{urn:ietf:params:xml:ns:caldav}schedule-default-calendar-URL` checks `$node instanceof Calendar` (i.e. `OCA\DAV\CalDAV\Calendar`). `ExternalCalendar` is a sibling class — it does not extend `Calendar` — so the check always fails for any app-generated calendar.

Notably, `ExternalCalendar` is **already imported** in the file (line 17) but was not used in the validation check.

## Changes

- Extend the `instanceof` check to also accept `ExternalCalendar` nodes.
- For `Calendar` nodes the existing `DefaultCalendarValidator` path runs unchanged.
- For `ExternalCalendar` nodes a simplified check runs: verify that the calendar reports VEVENT support. The subscription/canWrite/isShared/isDeleted checks are skipped because `ExternalCalendar` does not expose those methods — and semantically, app-generated calendars are always the current user's own writable collections.

## How to reproduce

1. Install an app that provides calendars via `ExternalCalendar` (e.g. `integration_davc`)
2. In the Nextcloud Calendar widget settings, attempt to set one of those calendars as the default calendar
3. Observe the error "Standardkalender konnte nicht gespeichert werden" (default calendar could not be saved)

After this fix the PROPPATCH succeeds and the setting is saved.

## Test plan

- Set an `ExternalCalendar`-based calendar as the default scheduling calendar in the Calendar widget settings
- Verify the setting saves without error
- Verify that setting a regular `Calendar` as default still works correctly
- Verify that setting an unsupported node type still returns "No such calendar"