### PR TITLE
fix(config): Decrypt sensitive appconfigs when requested

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3002,11 +3002,7 @@
   <file src="core/Command/Config/ListConfigs.php">
     <DeprecatedMethod>
       <code><![CDATA[getFilteredValues]]></code>
-      <code><![CDATA[getValues]]></code>
     </DeprecatedMethod>
-    <FalsableReturnStatement>
-      <code><![CDATA[$this->appConfig->getValues($app, false)]]></code>
-    </FalsableReturnStatement>
   </file>
   <file src="core/Command/Db/ConvertType.php">
     <DeprecatedMethod>

--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -132,7 +132,7 @@ class ListConfigs extends Base {
 		if ($noSensitiveValues) {
 			return $this->appConfig->getFilteredValues($app);
 		} else {
-			return $this->appConfig->getValues($app, false);
+			return $this->appConfig->getAllValues($app);
 		}
 	}
 

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -265,6 +265,13 @@ class AppConfig implements IAppConfig {
 		);
 
 		if (!$filtered) {
+			foreach ($values as $key => $value) {
+				$sensitive = $this->isSensitive($app, $key, null);
+				if ($sensitive && is_string($value) && str_starts_with($value, self::ENCRYPTION_PREFIX)) {
+					$values[$key] = $this->crypto->decrypt(substr($value, self::ENCRYPTION_PREFIX_LENGTH));
+				}
+			}
+
 			return $values;
 		}
 

--- a/tests/Core/Command/Config/ListConfigsTest.php
+++ b/tests/Core/Command/Config/ListConfigsTest.php
@@ -107,10 +107,10 @@ class ListConfigsTest extends TestCase {
 				],
 				// app config
 				[
-					['files', false, [
+					['files', [
 						'enabled' => 'yes',
 					]],
-					['core', false, [
+					['core', [
 						'global_cache_gc_lastrun' => '1430388388',
 					]],
 				],
@@ -243,10 +243,10 @@ class ListConfigsTest extends TestCase {
 				],
 				// app config
 				[
-					['files', false, [
+					['files', [
 						'enabled' => 'yes',
 					]],
-					['core', false, [
+					['core', [
 						'global_cache_gc_lastrun' => '1430388388',
 					]],
 				],
@@ -281,7 +281,7 @@ class ListConfigsTest extends TestCase {
 				->method('getValue')
 				->willReturnMap($systemConfigMap);
 			$this->appConfig->expects($this->any())
-				->method('getValues')
+				->method('getAllValues')
 				->willReturnMap($appConfig);
 		} else {
 			$this->systemConfig->expects($this->any())
@@ -296,7 +296,7 @@ class ListConfigsTest extends TestCase {
 			->method('getApps')
 			->willReturn(['core', 'files']);
 		$this->appConfig->expects($this->any())
-			->method('getValues')
+			->method('getAllValues')
 			->willReturnMap($appConfig);
 
 		$this->consoleInput->expects($this->once())


### PR DESCRIPTION
```sh
occ config:app:set spreed recording_servers --value '{"secret":"abc"}' --sensitive
```

### Before
```sh
occ config:list spreed --private
{
    "apps": {
        "spreed": {
…
            "recording_servers": "$AppConfigEncryption$bf2f2eea60075e78a26e608f9eef90b750c8205eddd4e15cc968569af7ae78a3|55aaf290e56e56494cb8cc0b827c121a|61442de1d928f0ad2eeff1c74bd608f6ef18dac87ab7f39075fffdbdc3d10797cf02ce2f2e604bdf775d7add6584721b0d63ba4b0e2696d3fdf94e1659366bb6|3",
…
        }
    }
}

occ config:list spreed
{
    "apps": {
        "spreed": {
…
            "recording_servers": "***REMOVED SENSITIVE VALUE***",
…
        }
    }
}

```


### After
```sh
occ config:list spreed --private
{
    "apps": {
        "spreed": {
…
            "recording_servers": "{\"secret\":\"abc\"}",
…
        }
    }
}

occ config:list spreed
{
    "apps": {
        "spreed": {
…
            "recording_servers": "***REMOVED SENSITIVE VALUE***",
…
        }
    }
}

```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
