### PR TITLE
[stable34] fix(maintenance): allow AppAPI to serve requests during maintenance mode

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1091,8 +1091,17 @@ class OC {
 		if ($requestPath === '/heartbeat') {
 			return;
 		}
+		$serveAppApiDuringMaintenance = false;
 		if (substr($requestPath, -3) !== '.js') { // we need these files during the upgrade
-			self::checkMaintenanceMode($systemConfig);
+			if (((bool)$systemConfig->getValue('maintenance', false)) && !\OCP\Util::needUpgrade()
+				&& ($requestPath === '/apps/app_api' || str_starts_with($requestPath, '/apps/app_api/'))
+				&& Server::get(\OCP\App\IAppManager::class)->isEnabledForAnyone('app_api')) {
+				// Keep serving ExApp traffic (HaRP metadata) while the instance is in maintenance mode
+				$serveAppApiDuringMaintenance = true;
+			}
+			if (!$serveAppApiDuringMaintenance) {
+				self::checkMaintenanceMode($systemConfig);
+			}
 
 			if (\OCP\Util::needUpgrade()) {
 				if (function_exists('opcache_reset')) {
@@ -1155,6 +1164,10 @@ class OC {
 				if (!\OCP\Util::needUpgrade()) {
 					$appManager->loadApps(['filesystem', 'logging']);
 					$appManager->loadApps();
+				}
+				if ($serveAppApiDuringMaintenance) {
+					// loadApps() above is a no-op during maintenance, load app_api explicitly
+					$appManager->loadApp('app_api');
 				}
 				Server::get(\OC\Route\Router::class)->match($request->getRawPathInfo());
 				return;

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -86,6 +86,22 @@ class Application {
 				if (Util::needUpgrade()) {
 					throw new NeedsUpdateException();
 				} elseif ($this->config->getSystemValueBool('maintenance')) {
+					if ($this->appManager->isEnabledForAnyone('app_api')) {
+						// AppAPI must stay usable during maintenance mode;
+						// loading commands from register_command.php is intentionally skipped.
+						$this->appManager->loadApp('app_api');
+						$info = $this->appManager->getAppInfo('app_api');
+						if (isset($info['commands'])) {
+							try {
+								$this->loadCommandsFromInfoXml($info['commands']);
+							} catch (\Throwable $e) {
+								$output->writeln('<error>' . $e->getMessage() . '</error>');
+								$this->logger->error($e->getMessage(), [
+									'exception' => $e,
+								]);
+							}
+						}
+					}
 					$this->writeMaintenanceModeInfo($input, $output);
 				} else {
 					$this->appManager->loadApps();
@@ -160,8 +176,13 @@ class Application {
 			&& $input->getArgument('command') !== 'maintenance:mode'
 			&& $input->getArgument('command') !== 'status') {
 			$errOutput = $output->getErrorOutput();
-			$errOutput->writeln('<comment>Nextcloud is in maintenance mode, no apps are loaded.</comment>');
-			$errOutput->writeln('<comment>Commands provided by apps are unavailable.</comment>');
+			if ($this->appManager->isEnabledForAnyone('app_api')) {
+				$errOutput->writeln('<comment>Nextcloud is in maintenance mode, only AppAPI commands are loaded.</comment>');
+				$errOutput->writeln('<comment>Commands provided by other apps are unavailable.</comment>');
+			} else {
+				$errOutput->writeln('<comment>Nextcloud is in maintenance mode, no apps are loaded.</comment>');
+				$errOutput->writeln('<comment>Commands provided by apps are unavailable.</comment>');
+			}
 		}
 	}
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -30,7 +30,18 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 $request = Server::get(IRequest::class);
 
-if ((Util::needUpgrade() || Server::get(IConfig::class)->getSystemValueBool('maintenance')) && $request->getPathInfo() !== '/core/update') {
+$serveAppApiDuringMaintenance = false;
+if (!Util::needUpgrade() && Server::get(IConfig::class)->getSystemValueBool('maintenance')) {
+	$pathInfo = $request->getPathInfo();
+	// AppAPI must keep serving HaRP traffic (signed OCS calls and ExApp callbacks)
+	$serveAppApiDuringMaintenance
+		= ($pathInfo === '/apps/app_api' || str_starts_with($pathInfo, '/apps/app_api/'))
+		&& Server::get(IAppManager::class)->isEnabledForAnyone('app_api');
+}
+
+if ((Util::needUpgrade()
+	|| (Server::get(IConfig::class)->getSystemValueBool('maintenance') && !$serveAppApiDuringMaintenance))
+	&& $request->getPathInfo() !== '/core/update') {
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	ApiHelper::respond(503, 'Service unavailable', ['X-Nextcloud-Maintenance-Mode' => '1'], 503);
@@ -49,6 +60,10 @@ try {
 	$request->throwDecodingExceptionIfAny();
 
 	if ($request->getPathInfo() !== '/core/update') {
+		if ($serveAppApiDuringMaintenance) {
+			// loadApps() below is a no-op during maintenance, load app_api explicitly
+			$appManager->loadApp('app_api');
+		}
 		// load all apps to get all api routes properly setup
 		// FIXME: this should ideally appear after handleLogin but will cause
 		// side effects in existing apps


### PR DESCRIPTION
Backport of #61294. 

Manual backport since stable34 still has `lib/base.php` (renamed to `lib/OC.php` on master). so the change targets that file; `lib/private/Console/Application.php` and `ocs/v1.php` are identical to the original.

The AppAPI counterpart is already merged: https://github.com/nextcloud/app_api/pull/903
