### PR TITLE
refactor(taskprocessing): mark built-in text task types as internal and deprecated if needed

### DIFF
--- a/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php
+++ b/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php
@@ -12,14 +12,14 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for generic text processing
  * @since 30.0.0
  */
-class GenerateEmoji implements ITaskType {
+class GenerateEmoji implements IInternalTaskType {
 	/**
 	 * @since 30.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextChangeTone.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextChangeTone.php
@@ -12,14 +12,14 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\IInternalTaskType;
+use OCP\TaskProcessing\ITaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for text reformulation
  * @since 31.0.0
  */
-class TextToTextChangeTone implements IInternalTaskType {
+class TextToTextChangeTone implements ITaskType {
 	/**
 	 * @since 31.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextChangeTone.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextChangeTone.php
@@ -12,14 +12,14 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for text reformulation
  * @since 31.0.0
  */
-class TextToTextChangeTone implements ITaskType {
+class TextToTextChangeTone implements IInternalTaskType {
 	/**
 	 * @since 31.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php
@@ -12,14 +12,15 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for text formalization
  * @since 30.0.0
+ * @deprecated 35.0.0
  */
-class TextToTextFormalization implements ITaskType {
+class TextToTextFormalization implements IInternalTaskType {
 	/**
 	 * @since 30.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php
@@ -12,14 +12,14 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for creating headline
  * @since 30.0.0
  */
-class TextToTextHeadline implements ITaskType {
+class TextToTextHeadline implements IInternalTaskType {
 	/**
 	 * @since 30.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php
@@ -12,14 +12,14 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for reformatting text into paragraphs
  * @since 34.0.0
  */
-class TextToTextReformatParagraphs implements ITaskType {
+class TextToTextReformatParagraphs implements IInternalTaskType {
 	/**
 	 * @since 34.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php
@@ -12,14 +12,15 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for text reformulation
  * @since 30.0.0
+ * @deprecated 35.0.0
  */
-class TextToTextReformulation implements ITaskType {
+class TextToTextReformulation implements IInternalTaskType {
 	/**
 	 * @since 30.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextSimplification.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextSimplification.php
@@ -12,14 +12,15 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for text simplification
  * @since 30.0.0
+ * @deprecated 35.0.0
  */
-class TextToTextSimplification implements ITaskType {
+class TextToTextSimplification implements IInternalTaskType {
 	/**
 	 * @since 30.0.0
 	 */

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextTopics.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextTopics.php
@@ -12,14 +12,14 @@ namespace OCP\TaskProcessing\TaskTypes;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use OCP\TaskProcessing\EShapeType;
-use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\IInternalTaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
  * This is the task processing task type for topics extraction
  * @since 30.0.0
  */
-class TextToTextTopics implements ITaskType {
+class TextToTextTopics implements IInternalTaskType {
 	/**
 	 * @since 30.0.0
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Marks all tasktypes that should be hidden as internal and also deprecates TextToTextSimplification and TextToTextReformulation.

## TODO


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
