### PR TITLE
feat: Add global support for prefers-reduced-motion

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -142,3 +142,9 @@
   --color-background-plain-text: #ffffff;
   --image-background: url('/apps/theming/img/background/jo-myoung-hee-fluid.webp');
 }
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --animation-quick: 1ms;
+    --animation-slow: 1ms;
+  }
+}

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -415,9 +415,17 @@ class ThemingController extends Controller {
 			$variables .= "$variable:$value; ";
 		};
 
+		// Collapse the animation timing variables for users who requested reduced
+		// motion. Emitted right after the variables on the same selector so it
+		// overrides them in the cascade. We use 1ms rather than 0 so values read
+		// via `parseInt(...) || fallback` in JavaScript stay truthy and transition
+		// events still fire.
+		$reducedMotion = static fn (string $selector): string
+			=> "@media (prefers-reduced-motion: reduce) { $selector { --animation-quick: 1ms; --animation-slow: 1ms; } } ";
+
 		// If plain is set, the browser decides of the css priority
 		if ($plain) {
-			$css = ":root { $variables } " . $customCss;
+			$css = ":root { $variables } " . $reducedMotion(':root') . $customCss;
 		} else {
 			// If not set, we'll rely on the body class
 			// We need to separate @-rules from normal selectors, as they can't be nested
@@ -430,7 +438,7 @@ class ThemingController extends Controller {
 			$atRulesCss = implode('', $atRules[0]);
 			$scopedCss = preg_replace('/(@[^{]+{(?:[^{}]*|(?R))*})/', '', $customCssWithoutComments);
 
-			$css = "$atRulesCss [data-theme-$themeId] { $variables $scopedCss }";
+			$css = "$atRulesCss [data-theme-$themeId] { $variables $scopedCss } " . $reducedMotion("[data-theme-$themeId]");
 		}
 
 		try {

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -212,7 +212,9 @@ class DefaultTheme implements ITheme {
 			// 1.5 * font-size for accessibility
 			'--default-line-height' => '1.5',
 
-			// TODO: support "(prefers-reduced-motion)"
+			// A "(prefers-reduced-motion)" media query collapses these to 1ms;
+			// see ThemingController::getThemeStylesheet() and the static fallback
+			// in apps/theming/css/default.css.
 			'--animation-quick' => '100ms',
 			'--animation-slow' => '300ms',
 

--- a/apps/theming/tests/Themes/DefaultThemeTest.php
+++ b/apps/theming/tests/Themes/DefaultThemeTest.php
@@ -149,9 +149,13 @@ class DefaultThemeTest extends AccessibleThemeTestCase {
 		$fallbackCss = file_get_contents(__DIR__ . '/../../css/default.css');
 		// Remove comments
 		$fallbackCss = preg_replace('/\s*\/\*[\s\S]*?\*\//m', '', $fallbackCss);
+		// The fallback also carries a prefers-reduced-motion override that zeroes
+		// the animation variables; it is not part of the theme variables, so drop
+		// any @media at-rules before comparing.
+		$fallbackCss = preg_replace('/@media[^{]*\{(?:[^{}]|\{[^{}]*\})*\}/', '', $fallbackCss);
 		// Remove blank lines
 		$fallbackCss = preg_replace('/\s*\n\n/', "\n", $fallbackCss);
 
-		$this->assertEquals($css, $fallbackCss);
+		$this->assertEquals(rtrim($css), rtrim($fallbackCss));
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/55403

## Summary
Adding global support for prefers-reduced-motion so we actually respect people’s preference on that.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI