### PR TITLE
fix(files_external/SMB): Use 'null' explicitly for no workgroup

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -70,7 +70,7 @@ class SMB extends Backend {
 
 			$smbAuth = new BasicAuth(
 				$storage->getBackendOption('user'),
-				$storage->getBackendOption('domain'),
+				$storage->getBackendOption('domain') ?: null,
 				$storage->getBackendOption('password')
 			);
 		} else {


### PR DESCRIPTION
* Resolves: #58445

## Summary
Robin Appleman's SMB library is designed so that 'null' is to be used when no explicit workgroup is set:

    final class BasicAuth implements IAuth {
        /** @var string */
        private $username;
        /** @var string|null */ <--------------------------
        private $workgroup;
        /** @var string */
        private $password;
    //...

However, it previously was loose with its checks and would still treat any falsy value (e.g. an empty string) as "not specified" when forming arguments for the various underlying utilities, such as `smbclient`.

icewind/SMB@4a93467905 updated it's handling to be more strict and as such will now treat empty strings as distinct from null values for workgroups. An empty value for workgroup often doesn't make sense, unless the backend tool happens to convert it to "WORKGROUP". In the case of the `smbclient` utility, passing an empty string for the $workgroup paramters results in `-W ''` being used which is invalid syntax and so the invocation fails resulting in no connection being made and the user seeing an inaccurate `[Icewind\SMB\Exception\ConnectionRefusedException]` error. Therefore, it is important to always pass 'null' to this constructor for $workgroup when there isn't one.

Most code paths in the 'files_external' app already handle this correctly, but this now altered path originally just took the raw value from the app backend and passed it as-is. Assuming the user left the "Domain" box empty in the frontend, this would be an empty string. Now the the SMB library's interface is correctly honored in that case.

It's arguable that the SMB library should simply be updated to formally accept '' as a valid input meaning "no workgroup", restoring the old behavior in a canonical fashion, as there is almost no situation where one would want to pass an empty string and have it mean anything else; but regardless, there is no harm in being more explicit on the nextcloud/server side as well.

## Details

Just to cover all bases, the following should be all of the uses of `BasicAuth()`.

### Corrected Path:
https://github.com/nextcloud/server/blob/a982b6cbc631f44f3430a30f10f76ace70d84709/apps/files_external/lib/Lib/Backend/SMB.php#L71-L74

### Kerberos fallback path:
https://github.com/nextcloud/server/blob/a982b6cbc631f44f3430a30f10f76ace70d84709/apps/files_external/lib/Lib/Backend/SMB.php#L92-L111
Seems to never result in an empty workgroup.

### Primary connection path:
https://github.com/nextcloud/server/blob/a982b6cbc631f44f3430a30f10f76ace70d84709/apps/files_external/lib/Lib/Storage/SMB.php#L82-L84

This is the only one possibly worth making further changes to. It's mostly fine as `splitUser()` will correctly return `null` for the result that goes into `$workgroup` if there is no workgroup separator; however if a separator exists but with no value after it (e.g. `\\user` or  `/user`) it will return an array with an empty string, which will get placed into `$workgroup`. Since that is an invalid string for specifying workgroup/user it's possible that such strings are rejected at some point earlier before they even reach this function, and if not, I'm not sure this is the correct place to handle invalid input like that. Though, it may not hurt to handle that case here anyway just to be safe (i.e. inspect the exploded array and swap `''` for `null`.

https://github.com/nextcloud/server/blob/a982b6cbc631f44f3430a30f10f76ace70d84709/apps/files_external/lib/Lib/Storage/SMB.php#L126-L134

Thoughts?

Otherwise, the SMB library should probably be updated to throw some other kind of error when "smbclient" exits with an error, instead of "Connection Refused". Separately it could be made more robust against questionable arguments like a blank WORKGROUP (e.g. also defaulting `''` to "WORKGROUP" or emitting a warning), as touched on on the commit message.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
