### PR TITLE
refactor(preview): align provider lookup in PreviewManager checks

### DIFF
--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -69,13 +69,13 @@ class PreviewManager implements IPreview {
 	private ?Generator $generator = null;
 	protected bool $providerListDirty = false;
 	protected bool $registeredCoreProviders = false;
-	/**
-	 * @var array<string, list<ProviderClosure>> $providers
-	 */
+
+	/** @var array<string, list<ProviderClosure>> $providers */
 	protected array $providers = [];
 
 	/** @var array mime type => support status */
 	protected array $mimeTypeSupportMap = [];
+
 	/** @var ?list<class-string<IProviderV2>> $defaultProviders */
 	protected ?array $defaultProviders = null;
 
@@ -119,9 +119,6 @@ class PreviewManager implements IPreview {
 		$this->providerListDirty = true;
 	}
 
-	/**
-	 * Get all providers
-	 */
 	#[\Override]
 	public function getProviders(): array {
 		if (!$this->enablePreviews) {
@@ -212,9 +209,7 @@ class PreviewManager implements IPreview {
 			return $this->mimeTypeSupportMap[$mimeType];
 		}
 
-		$this->registerCoreProviders();
-		$this->registerBootstrapProviders();
-		$providerMimeTypes = array_keys($this->providers);
+		$providerMimeTypes = array_keys($this->getProviders());
 		foreach ($providerMimeTypes as $supportedMimeType) {
 			if (preg_match($supportedMimeType, $mimeType)) {
 				$this->mimeTypeSupportMap[$mimeType] = true;
@@ -233,7 +228,6 @@ class PreviewManager implements IPreview {
 
 		$fileMimeType = $mimeType ?? $file->getMimeType();
 
-		$this->registerCoreProviders();
 		if (!$this->isMimeSupported($fileMimeType)) {
 			return false;
 		}
@@ -243,7 +237,7 @@ class PreviewManager implements IPreview {
 			return false;
 		}
 
-		foreach ($this->providers as $supportedMimeType => $providers) {
+		foreach ($this->getProviders() as $supportedMimeType => $providers) {
 			if (preg_match($supportedMimeType, $fileMimeType)) {
 				foreach ($providers as $providerClosure) {
 					$provider = $this->helper->getProvider($providerClosure);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This refactor makes preview provider support and availability checks follow the same provider-loading path as preview generation instead of reading partially initialized provider state directly.

### Why

`getProviders()` registers core and bootstrap providers and applies provider ordering. Preview generation already resolves providers through `getProviders()`, but `isMimeSupported()` and `isAvailable()` currently inspect `$this->providers` directly after partial setup.

This means support and availability checks do not use the same provider-loading and ordering path as preview generation, and `isAvailable()` also currently relies on `isMimeSupported()` side effects to register bootstrap providers before iterating providers.

This PR:

- uses `PreviewManager::getProviders()` as the shared provider-loading path
- switches `isMimeSupported()` to inspect the provider set returned by `getProviders()`
- switches `isAvailable()` to iterate providers via `getProviders()`
- removes the now-redundant direct provider registration calls in `isMimeSupported()` and `isAvailable()`

This does not change provider registration rules, MIME regexes, or preview generation logic.

In edge cases, this should also reduce the risk of preview capability checks disagreeing with the provider set ultimately used for generation. 

It also prepares the code for follow-up refactors (e.g. further centralization of provider matching / traversal logic shared between `PreviewManager` and `Generator`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
