### PR TITLE
fix(files_sharing): reject custom share tokens longer than the db column

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -77,6 +77,9 @@ use Psr\Log\LoggerInterface;
  */
 class ShareAPIController extends OCSController {
 
+	/** Maximum length of a custom share token, matching the oc_share.token database column. */
+	private const TOKEN_MAX_LENGTH = 32;
+
 	private ?Node $lockedNode = null;
 	/** @var array<bool> $trustedServerCache */
 	private array $trustedServerCache = [];
@@ -1363,7 +1366,7 @@ class ShareAPIController extends OCSController {
 					throw new OCSForbiddenException($this->l->t('Custom share link tokens have been disabled by the administrator'));
 				}
 				if (!$this->validateToken($token)) {
-					throw new OCSBadRequestException($this->l->t('Tokens must contain at least 1 character and may only contain letters, numbers, or a hyphen'));
+					throw new OCSBadRequestException($this->l->t('Tokens must be between 1 and %s characters long and may only contain letters, numbers, or a hyphen', [self::TOKEN_MAX_LENGTH]));
 				}
 				$share->setToken($token);
 			}
@@ -1402,7 +1405,7 @@ class ShareAPIController extends OCSController {
 	}
 
 	private function validateToken(string $token): bool {
-		if (mb_strlen($token) === 0) {
+		if (mb_strlen($token) === 0 || mb_strlen($token) > self::TOKEN_MAX_LENGTH) {
 			return false;
 		}
 		if (!preg_match('/^[a-z0-9-]+$/i', $token)) {

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1405,7 +1405,8 @@ class ShareAPIController extends OCSController {
 	}
 
 	private function validateToken(string $token): bool {
-		if (mb_strlen($token) === 0 || mb_strlen($token) > self::TOKEN_MAX_LENGTH) {
+		$length = mb_strlen($token);
+		if ($length === 0 || $length > self::TOKEN_MAX_LENGTH) {
 			return false;
 		}
 		if (!preg_match('/^[a-z0-9-]+$/i', $token)) {

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -5604,6 +5604,22 @@ class ShareAPIControllerTest extends TestCase {
 		$this->invokePrivate($ocs, 'checkInheritedAttributes', [$share]);
 	}
 
+	public static function dataValidateToken(): array {
+		return [
+			'empty token' => ['', false],
+			'single character' => ['a', true],
+			'letters numbers and hyphen' => ['abc-123', true],
+			'invalid character' => ['abc_123', false],
+			'32 characters (oc_share.token column limit)' => [str_repeat('a', 32), true],
+			'33 characters (exceeds oc_share.token column limit)' => [str_repeat('a', 33), false],
+		];
+	}
+
+	#[DataProvider('dataValidateToken')]
+	public function testValidateToken(string $token, bool $expected): void {
+		$this->assertSame($expected, $this->invokePrivate($this->ocs, 'validateToken', [$token]));
+	}
+
 	/**
 	 * Helper to allow testing Talk integration even if Talk
 	 * is not available during tests.

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -5611,6 +5611,7 @@ class ShareAPIControllerTest extends TestCase {
 			'letters numbers and hyphen' => ['abc-123', true],
 			'invalid character' => ['abc_123', false],
 			'32 characters (oc_share.token column limit)' => [str_repeat('a', 32), true],
+			'32 non-ascii characters' => [str_repeat('é', 32), false],
 			'33 characters (exceeds oc_share.token column limit)' => [str_repeat('a', 33), false],
 		];
 	}


### PR DESCRIPTION
- Fixes [#61416](https://github.com/nextcloud/server/issues/61416)

validateToken() in ShareAPIController only checked that a custom share token was non-empty and matched the allowed character set, but never checked its length. The oc_share.token database column is varchar(32), so a longer token currently passes validation and then fails at the database layer with a raw, unhelpful SQL error instead of a clean validation message.

This adds a max-length check matching the column size and updates the error message to mention the limit.

- Testing

Added a test for validateToken() covering the empty, valid, and invalid-character cases plus the new 32/33-character boundary (32 should pass, 33 should fail).

This PR was prepared with AI assistance (Claude Code); I reviewed the change before submitting it.