### PR TITLE
Add embedded preview support for CorelDRAW (.cdr) files

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -2084,6 +2084,7 @@ return array(
     'OC\\Preview\\BackgroundCleanupJob' => $baseDir . '/lib/private/Preview/BackgroundCleanupJob.php',
     'OC\\Preview\\Bitmap' => $baseDir . '/lib/private/Preview/Bitmap.php',
     'OC\\Preview\\Bundled' => $baseDir . '/lib/private/Preview/Bundled.php',
+    'OC\\Preview\\CDR' => $baseDir . '/lib/private/Preview/CDR.php',
     'OC\\Preview\\Db\\Preview' => $baseDir . '/lib/private/Preview/Db/Preview.php',
     'OC\\Preview\\Db\\PreviewMapper' => $baseDir . '/lib/private/Preview/Db/PreviewMapper.php',
     'OC\\Preview\\EMF' => $baseDir . '/lib/private/Preview/EMF.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -2125,6 +2125,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Preview\\BackgroundCleanupJob' => __DIR__ . '/../../..' . '/lib/private/Preview/BackgroundCleanupJob.php',
         'OC\\Preview\\Bitmap' => __DIR__ . '/../../..' . '/lib/private/Preview/Bitmap.php',
         'OC\\Preview\\Bundled' => __DIR__ . '/../../..' . '/lib/private/Preview/Bundled.php',
+        'OC\\Preview\\CDR' => __DIR__ . '/../../..' . '/lib/private/Preview/CDR.php',
         'OC\\Preview\\Db\\Preview' => __DIR__ . '/../../..' . '/lib/private/Preview/Db/Preview.php',
         'OC\\Preview\\Db\\PreviewMapper' => __DIR__ . '/../../..' . '/lib/private/Preview/Db/PreviewMapper.php',
         'OC\\Preview\\EMF' => __DIR__ . '/../../..' . '/lib/private/Preview/EMF.php',

--- a/lib/private/Preview/CDR.php
+++ b/lib/private/Preview/CDR.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OC\Preview;
+
+use OCP\Files\File;
+use OCP\Files\FileInfo;
+use OCP\IImage;
+use OCP\Image;
+
+class CDR extends ProviderV2 {
+	#[\Override]
+	public function getMimeType(): string {
+		return '/application\/coreldraw/';
+	}
+	#[\Override]
+	public function isAvailable(FileInfo $file): bool {
+		return $file->getSize() > 0;
+	}
+	#[\Override]
+	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
+		if (!$this->isAvailable($file)) {
+			return null;
+		}
+
+		$localFile = $this->getLocalFile($file);
+
+		if ($localFile === false) {
+			return null;
+		}
+
+		$data = $this->extractThumbnail($localFile);
+		if ($data === null) {
+			return null;
+		}
+
+		$image = new Image();
+		$image->loadFromData($data);
+
+		if (!$image->valid()) {
+			return null;
+		}
+
+		$image->scaleDownToFit($maxX, $maxY);
+
+		return $image;
+	}
+	/** * Extract ONLY thumbnail (no pages) */
+	private function extractThumbnail(string $file): ?string {
+		$zip = new \ZipArchive();
+
+		if ($zip->open($file) !== true) {
+			return null;
+		}
+
+		/**
+		 * Newer CorelDRAW files store the embedded preview in previews/thumbnail.png.
+		 *
+		 * Older CorelDRAW files store the embedded BMP thumbnail in
+		 * metadata/thumbnails/thumbnail.bmp.
+		 */
+		foreach ([
+			'previews/thumbnail.png',
+			'metadata/thumbnails/thumbnail.bmp',
+		] as $thumbnail) {
+			$idx = $zip->locateName($thumbnail);
+
+			if ($idx === false) {
+				continue;
+			}
+
+			$data = $zip->getFromIndex($idx);
+			$zip->close();
+
+			return $data === false ? null : $data;
+		}
+
+		$zip->close();
+
+		return null;
+	}
+}

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -11,6 +11,7 @@ namespace OC;
 use Closure;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Preview\BMP;
+use OC\Preview\CDR;
 use OC\Preview\Db\PreviewMapper;
 use OC\Preview\EMF;
 use OC\Preview\Font;
@@ -271,6 +272,7 @@ class PreviewManager implements IPreview {
 			XBitmap::class,
 			Krita::class,
 			WebP::class,
+			CDR::class,
 		];
 
 		$this->defaultProviders = $this->config->getSystemValue('enabledPreviewProviders', array_merge([
@@ -317,6 +319,7 @@ class PreviewManager implements IPreview {
 		$this->registerCoreProvider(BMP::class, '/image\/bmp/');
 		$this->registerCoreProvider(XBitmap::class, '/image\/x-xbitmap/');
 		$this->registerCoreProvider(WebP::class, '/image\/webp/');
+		$this->registerCoreProvider(CDR::class, '/application\/coreldraw/');
 		$this->registerCoreProvider(Krita::class, '/application\/x-krita/');
 		$this->registerCoreProvider(MP3::class, '/audio\/mpeg$/');
 		$this->registerCoreProvider(OpenDocument::class, '/application\/vnd.oasis.opendocument.*/');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
<img width="1400" height="813" alt="Screen 2026-06-28 в 02 18 34" src="https://github.com/user-attachments/assets/0538df5f-8d6b-4232-ab6f-8395408d8b62" />

This pull request adds support for generating previews for CorelDRAW (.cdr) files.

Currently, CDR files are displayed with a generic icon even when they contain an embedded preview image. This change introduces a new preview provider that extracts the embedded thumbnail directly from the CDR archive.

Both modern CorelDRAW files containing `previews/thumbnail.png` and legacy files containing `metadata/thumbnails/thumbnail.bmp` are supported.

The implementation has no external dependencies and does not require ImageMagick or temporary file creation.

Tested on a production-like Nextcloud instance used within our company  with real production CDR files.

## TODO

- [ ] Add PHPUnit tests for the CDR preview provider.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
