### PR TITLE
fix(dav): return RFC 4791 no-uid-conflict on duplicate calendar UID

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -67,6 +67,7 @@ return array(
     'OCA\\DAV\\CalDAV\\EventReader' => $baseDir . '/../lib/CalDAV/EventReader.php',
     'OCA\\DAV\\CalDAV\\EventReaderRDate' => $baseDir . '/../lib/CalDAV/EventReaderRDate.php',
     'OCA\\DAV\\CalDAV\\EventReaderRRule' => $baseDir . '/../lib/CalDAV/EventReaderRRule.php',
+    'OCA\\DAV\\CalDAV\\Exception\\UidConflict' => $baseDir . '/../lib/CalDAV/Exception/UidConflict.php',
     'OCA\\DAV\\CalDAV\\Export\\ExportService' => $baseDir . '/../lib/CalDAV/Export/ExportService.php',
     'OCA\\DAV\\CalDAV\\Federation\\CalendarFederationConfig' => $baseDir . '/../lib/CalDAV/Federation/CalendarFederationConfig.php',
     'OCA\\DAV\\CalDAV\\Federation\\CalendarFederationNotifier' => $baseDir . '/../lib/CalDAV/Federation/CalendarFederationNotifier.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -82,6 +82,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CalDAV\\EventReader' => __DIR__ . '/..' . '/../lib/CalDAV/EventReader.php',
         'OCA\\DAV\\CalDAV\\EventReaderRDate' => __DIR__ . '/..' . '/../lib/CalDAV/EventReaderRDate.php',
         'OCA\\DAV\\CalDAV\\EventReaderRRule' => __DIR__ . '/..' . '/../lib/CalDAV/EventReaderRRule.php',
+        'OCA\\DAV\\CalDAV\\Exception\\UidConflict' => __DIR__ . '/..' . '/../lib/CalDAV/Exception/UidConflict.php',
         'OCA\\DAV\\CalDAV\\Export\\ExportService' => __DIR__ . '/..' . '/../lib/CalDAV/Export/ExportService.php',
         'OCA\\DAV\\CalDAV\\Federation\\CalendarFederationConfig' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/CalendarFederationConfig.php',
         'OCA\\DAV\\CalDAV\\Federation\\CalendarFederationNotifier' => __DIR__ . '/..' . '/../lib/CalDAV/Federation/CalendarFederationNotifier.php',

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -13,6 +13,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Generator;
 use OCA\DAV\AppInfo\Application;
+use OCA\DAV\CalDAV\Exception\UidConflict;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarEntity;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarMapper;
 use OCA\DAV\CalDAV\Sharing\Backend;
@@ -1525,18 +1526,20 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		return $this->atomic(function () use ($calendarId, $objectUri, $calendarData, $extraData, $calendarType) {
 			// Try to detect duplicates
 			$qb = $this->db->getQueryBuilder();
-			$qb->select($qb->func()->count('*'))
+			$qb->select('uri')
 				->from('calendarobjects')
 				->where($qb->expr()->eq('calendarid', $qb->createNamedParameter($calendarId)))
 				->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($extraData['uid'])))
 				->andWhere($qb->expr()->eq('calendartype', $qb->createNamedParameter($calendarType)))
-				->andWhere($qb->expr()->isNull('deleted_at'));
+				->andWhere($qb->expr()->isNull('deleted_at'))
+				->setMaxResults(1);
 			$result = $qb->executeQuery();
-			$count = (int)$result->fetchOne();
+			$existingUri = $result->fetchOne();
 			$result->closeCursor();
 
-			if ($count !== 0) {
-				throw new BadRequest('Calendar object with uid already exists in this calendar collection.');
+			if ($existingUri !== false) {
+				// RFC 4791 no-uid-conflict (409) reporting the existing object's href.
+				throw new UidConflict((string)$existingUri);
 			}
 			// For a more specific error message we also try to explicitly look up the UID but as a deleted entry
 			$qbDel = $this->db->getQueryBuilder();

--- a/apps/dav/lib/CalDAV/Exception/UidConflict.php
+++ b/apps/dav/lib/CalDAV/Exception/UidConflict.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\CalDAV\Exception;
+
+use Sabre\DAV\Exception\Conflict;
+use Sabre\DAV\Server;
+
+/**
+ * Duplicate iCalendar UID in the target calendar collection.
+ *
+ * Reports the RFC 4791 (5.3.2.1) CALDAV:no-uid-conflict precondition with a
+ * DAV:href to the existing object, as 409 Conflict (RFC 4791 1.3: resolvable).
+ */
+class UidConflict extends Conflict {
+	public function __construct(
+		private readonly string $existingObjectUri,
+	) {
+		parent::__construct('Calendar object with uid already exists in this calendar collection.');
+	}
+
+	#[\Override]
+	public function serialize(Server $server, \DOMElement $errorNode) {
+		// The conflicting object lives in the same collection as the request.
+		[$collection] = \Sabre\Uri\split($server->getRequestUri());
+		$href = $server->getBaseUri() . $collection . '/' . $this->existingObjectUri;
+
+		$document = $errorNode->ownerDocument;
+		$conflict = $document->createElementNS('urn:ietf:params:xml:ns:caldav', 'cal:no-uid-conflict');
+		$hrefNode = $document->createElementNS('DAV:', 'd:href');
+		$hrefNode->appendChild($document->createTextNode($href));
+		$conflict->appendChild($hrefNode);
+		$errorNode->appendChild($conflict);
+	}
+}

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -264,7 +264,7 @@ EOD;
 	}
 
 	public function testMultipleCalendarObjectsWithSameUID(): void {
-		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
+		$this->expectException(\OCA\DAV\CalDAV\Exception\UidConflict::class);
 		$this->expectExceptionMessage('Calendar object with uid already exists in this calendar collection.');
 
 		$calendarId = $this->createTestCalendar();

--- a/apps/dav/tests/unit/CalDAV/Exception/UidConflictTest.php
+++ b/apps/dav/tests/unit/CalDAV/Exception/UidConflictTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\CalDAV\Exception;
+
+use OCA\DAV\CalDAV\Exception\UidConflict;
+use Sabre\DAV\Exception\Conflict;
+use Sabre\DAV\Server;
+use Test\TestCase;
+
+class UidConflictTest extends TestCase {
+	public function testHttpCodeIsConflict(): void {
+		$exception = new UidConflict('sabredav-1234.ics');
+
+		// Must stay a Conflict: CalendarImpl catches it for the OCP createFromString contract.
+		self::assertInstanceOf(Conflict::class, $exception);
+		self::assertSame(409, $exception->getHTTPCode());
+	}
+
+	public function testSerializeReportsNoUidConflictWithExistingHref(): void {
+		$server = $this->createMock(Server::class);
+		$server->method('getRequestUri')->willReturn('calendars/alice/personal/guessed.ics');
+		$server->method('getBaseUri')->willReturn('/remote.php/dav/');
+
+		$document = new \DOMDocument('1.0', 'utf-8');
+		$errorNode = $document->createElementNS('DAV:', 'd:error');
+		$document->appendChild($errorNode);
+
+		$exception = new UidConflict('sabredav-1234.ics');
+		$exception->serialize($server, $errorNode);
+
+		$conflict = $errorNode->getElementsByTagNameNS('urn:ietf:params:xml:ns:caldav', 'no-uid-conflict');
+		self::assertSame(1, $conflict->length);
+
+		$href = $errorNode->getElementsByTagNameNS('DAV:', 'href');
+		self::assertSame(1, $href->length);
+		self::assertSame(
+			'/remote.php/dav/calendars/alice/personal/sabredav-1234.ics',
+			$href->item(0)->textContent,
+		);
+	}
+}


### PR DESCRIPTION
* Re: https://github.com/nextcloud/server/issues/17915

## Summary

If a client attempts to create (PUT) a calendar object whose UID already exists in the target calendar, NC currently responds with a generic `400 Bad Request` ("Calendar object with uid already exists in this calendar collection."). RFC 4791 specifies a separate precondition for this exact case. This PR implements it:

`CalDavBackend::createCalendarObject` now throws `OCA\DAV\CalDAV\Exception\UidConflict` (inherits from `Sabre\DAV\Exception\Conflict` -> **409**), which satisfies the RFC 4791 precondition (Section [5.3.2.1](https://datatracker.ietf.org/doc/html/rfc4791#section-5.3.2.1)) `CALDAV:no-uid-conflict` with a `DAV:href` pointing to the existing object:

```xml
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>OCA\DAV\CalDAV\Exception\UidConflict</s:exception>
  <s:message>Calendar object with uid already exists in this calendar collection.</s:message>
  <cal:no-uid-conflict xmlns:cal="urn:ietf:params:xml:ns:caldav">
    <d:href xmlns:d="DAV:">/remote.php/dav/calendars/USER/personal/EXISTING.ics</d:href>
  </cal:no-uid-conflict>
</d:error>
```

This ensures the server is spec-compliant and provides the client with a machine-readable reference to the conflicting object, allowing the client to correct itself (by writing to the href or synchronizing).

**Status 409 instead of 403:** RFC 4791 Section 1.3 - the client CAN resolve the conflict and resend, hence 409 (not 403).

## Background / Motivation

If you accept an email event invitation from NC in Thunderbird and try to add it to the calendar of the same NC instance as the organizer before Thunderbird has synchronized its calendar with NC, Thunderbird will attempt to PUT the event using a UUID that already exists on the server.
This is **a client issue** (Thunderbird should sync before accepting) and is known as: Thunderbird Bug [1717401](https://bugzilla.mozilla.org/show_bug.cgi?id=1717401) ("Accepting invitation before calendar sync fails (Status 80004005)"). This PR **does not** resolve this issue in NC. It merely makes the server response more precise - providing a clean basis for a client (TB) to respond to.

## Testing

**Manuell live** (CalDAV-PUT gegen eine laufende Instanz):
- [x] Created an event in the web interface and saved the ICS file via export. Sent a PUT request to the same calendar with this ICS file using Curl and checked the response. -> `409 Conflict` with `cal:no-uid-conflict` + `d:href`

```bash
$ curl -s -w "\n--> %{http_code}\n" -u admin:admin -X PUT -H "Content-Type: text/calendar; charset=utf-8" --data-binary @event2.ics http://nextcloud-dev:8080/remote.php/dav/calendars/admin/personal/deposited.ics
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>OCA\DAV\CalDAV\Exception\UidConflict</s:exception>
  <s:message>Calendar object with uid already exists in this calendar collection.</s:message>
  <cal:no-uid-conflict xmlns:cal="urn:ietf:params:xml:ns:caldav">
    <d:href xmlns:d="DAV:">/remote.php/dav/calendars/admin/personal/8242054B-8CD2-42C9-BD92-543C5FF5BC0F.ics</d:href>
  </cal:no-uid-conflict>
</d:error>

--> 409
```

- [x] Confirmed with the real Thunderbird (152): TB now receive a `409 UidConflict` with `no-uid-conflict`/`href` during "accept-before-sync" instead of the generic 400 (see video)

https://github.com/user-attachments/assets/803c583a-e011-4c46-b14c-98e42fe285a3

### Duplicate-UID behavior across CalDAV servers

| Server | Status | Body |
|---|---|---|
| Nextcloud (before this PR) | 400 | Sabre text "…uid already exists…" |
| Nextcloud (with this PR)   | 409 | `CALDAV:no-uid-conflict` + `DAV:href` |
| Radicale 3.7.5               | 409 | `CALDAV:no-uid-conflict` (no href) |
| SOGo v5 Demo (2026-06-29)                 | 409 | `DAV:error` "Event UID already in use" |

## Note

Changing the exception class affects one catch site outside the diff: CalendarImpl::createFromStringInServer (catch (Conflict)) now wraps the duplicate-UID case into the contractual CalendarException instead of letting the former BadRequest escape uncaught. No other catch sites are affected.


## TODO

- [x] Accept the new RFC interpretation (409 vs 403 instead 400) 
- [x] Review the code

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
- Suggested code changes to me
- Wrote the unit test
