### PR TITLE
fix(chunkingUpload): sliding expiration based on upload activity

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -51,6 +51,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 	private ?string $uploadId = null;
 	private ?string $uploadPath = null;
+	private ?int $uploadTargetId = null;
 
 	private const TEMP_TARGET = '.target';
 
@@ -60,6 +61,17 @@ class ChunkingV2Plugin extends ServerPlugin {
 	public const UPLOAD_ID = 'upload-id';
 
 	private const DESTINATION_HEADER = 'Destination';
+
+	/**
+	 * Lifetime of the chunked upload session metadata in the distributed cache.
+	 *
+	 * The TTL is refreshed on every successful chunk upload (sliding
+	 * expiration), so it acts as an inactivity timeout rather than a hard
+	 * wall-clock limit. Without the refresh an upload whose total duration
+	 * exceeds this value would fail with "Missing metadata for chunked upload"
+	 * even while chunks are still actively being uploaded.
+	 */
+	private const UPLOAD_SESSION_TTL = 24 * 60 * 60;
 
 	public function __construct(ICacheFactory $cacheFactory) {
 		$this->cache = $cacheFactory->createDistributed(self::CACHE_KEY);
@@ -130,12 +142,9 @@ class ChunkingV2Plugin extends ServerPlugin {
 		[$storage, $storagePath] = $this->getUploadStorage($this->uploadPath);
 
 		$this->uploadId = $storage->startChunkedWrite($storagePath);
+		$this->uploadTargetId = $targetFile->getId();
 
-		$this->cache->set($this->uploadFolder->getName(), [
-			self::UPLOAD_ID => $this->uploadId,
-			self::UPLOAD_TARGET_PATH => $this->uploadPath,
-			self::UPLOAD_TARGET_ID => $targetFile->getId(),
-		], 86400);
+		$this->storeUploadSession();
 
 		$response->setStatus(Http::STATUS_CREATED);
 		return true;
@@ -176,6 +185,12 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 		$stream = $request->getBodyAsStream();
 		$storage->putChunkedWritePart($storagePath, $this->uploadId, (string)$partId, $stream, $additionalSize);
+
+		// Refresh the session metadata TTL on every successful chunk so an
+		// actively progressing upload is not garbage-collected purely on
+		// wall-clock age (sliding expiration). See afterMkcol() for the
+		// initial write.
+		$this->storeUploadSession();
 
 		$storage->getCache()->update($uploadFile->getId(), ['size' => $uploadFile->getSize() + $additionalSize]);
 		if ($tempTargetFile) {
@@ -317,6 +332,25 @@ class ChunkingV2Plugin extends ServerPlugin {
 		$uploadMetadata = $this->cache->get($this->uploadFolder->getName());
 		$this->uploadId = $uploadMetadata[self::UPLOAD_ID] ?? null;
 		$this->uploadPath = $uploadMetadata[self::UPLOAD_TARGET_PATH] ?? null;
+		$this->uploadTargetId = $uploadMetadata[self::UPLOAD_TARGET_ID] ?? null;
+	}
+
+	/**
+	 * Persist the chunked upload session metadata in the distributed cache and
+	 * (re)set its TTL. Called once when the session is created in afterMkcol()
+	 * and again after every successful chunk in beforePut() to provide a
+	 * sliding expiration based on activity rather than a fixed lifetime.
+	 */
+	private function storeUploadSession(): void {
+		if ($this->uploadId === null || $this->uploadPath === null || $this->uploadTargetId === null) {
+			return;
+		}
+
+		$this->cache->set($this->uploadFolder->getName(), [
+			self::UPLOAD_ID => $this->uploadId,
+			self::UPLOAD_TARGET_PATH => $this->uploadPath,
+			self::UPLOAD_TARGET_ID => $this->uploadTargetId,
+		], self::UPLOAD_SESSION_TTL);
 	}
 
 	private function completeChunkedWrite(string $targetAbsolutePath): void {

--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -52,6 +52,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 	private ?string $uploadId = null;
 	private ?string $uploadPath = null;
+	private ?int $uploadTargetId = null;
 
 	private const string TEMP_TARGET = '.target';
 
@@ -61,6 +62,17 @@ class ChunkingV2Plugin extends ServerPlugin {
 	public const UPLOAD_ID = 'upload-id';
 
 	private const string DESTINATION_HEADER = 'Destination';
+
+	/**
+	 * Lifetime of the chunked upload session metadata in the distributed cache.
+	 *
+	 * The TTL is refreshed on every successful chunk upload (sliding
+	 * expiration), so it acts as an inactivity timeout rather than a hard
+	 * wall-clock limit. Without the refresh an upload whose total duration
+	 * exceeds this value would fail with "Missing metadata for chunked upload"
+	 * even while chunks are still actively being uploaded.
+	 */
+	private const UPLOAD_SESSION_TTL = 24 * 60 * 60;
 
 	public function __construct(ICacheFactory $cacheFactory) {
 		$this->cache = $cacheFactory->createDistributed(self::CACHE_KEY);
@@ -155,12 +167,9 @@ class ChunkingV2Plugin extends ServerPlugin {
 		[$storage, $storagePath] = $this->getUploadStorage($this->uploadPath);
 
 		$this->uploadId = $storage->startChunkedWrite($storagePath);
+		$this->uploadTargetId = $targetFile->getId();
 
-		$this->cache->set($this->uploadFolder->getName(), [
-			self::UPLOAD_ID => $this->uploadId,
-			self::UPLOAD_TARGET_PATH => $this->uploadPath,
-			self::UPLOAD_TARGET_ID => $targetFile->getId(),
-		], 86400);
+		$this->storeUploadSession();
 
 		$response->setStatus(Http::STATUS_CREATED);
 		return true;
@@ -201,6 +210,9 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 		$stream = $request->getBodyAsStream();
 		$storage->putChunkedWritePart($storagePath, $this->uploadId, (string)$partId, $stream, $additionalSize);
+
+		// Refresh the session metadata TTL on every successful chunk
+		$this->storeUploadSession();
 
 		$storage->getCache()->update($uploadFile->getId(), ['size' => $uploadFile->getSize() + $additionalSize]);
 		if ($tempTargetFile) {
@@ -342,6 +354,23 @@ class ChunkingV2Plugin extends ServerPlugin {
 		$uploadMetadata = $this->cache->get($this->uploadFolder->getName());
 		$this->uploadId = $uploadMetadata[self::UPLOAD_ID] ?? null;
 		$this->uploadPath = $uploadMetadata[self::UPLOAD_TARGET_PATH] ?? null;
+		$this->uploadTargetId = $uploadMetadata[self::UPLOAD_TARGET_ID] ?? null;
+	}
+
+	/**
+	 * Persist the chunked upload session metadata in the distributed cache and
+	 * (re)set its TTL to provide a sliding expiration based on activity rather than a fixed lifetime.
+	 */
+	private function storeUploadSession(): void {
+		if ($this->uploadId === null || $this->uploadPath === null || $this->uploadTargetId === null) {
+			return;
+		}
+
+		$this->cache->set($this->uploadFolder->getName(), [
+			self::UPLOAD_ID => $this->uploadId,
+			self::UPLOAD_TARGET_PATH => $this->uploadPath,
+			self::UPLOAD_TARGET_ID => $this->uploadTargetId,
+		], self::UPLOAD_SESSION_TTL);
 	}
 
 	private function completeChunkedWrite(string $targetAbsolutePath): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/61604

## Summary

Fixes the reported issue: a continuously-progressing upload never expires, regardless of total duration. It also aligns the cache's expiry model with the sibling `UploadCleanup` job, which already expires on inactivity (mtime), not creation age.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
