### PR TITLE
fix(dav): return RFC 4791 no-uid-conflict on duplicate calendar UID

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -317,6 +317,7 @@ return array(
     'OCA\\DAV\\Events\\SubscriptionUpdatedEvent' => $baseDir . '/../lib/Events/SubscriptionUpdatedEvent.php',
     'OCA\\DAV\\Exception\\ExampleEventException' => $baseDir . '/../lib/Exception/ExampleEventException.php',
     'OCA\\DAV\\Exception\\ServerMaintenanceMode' => $baseDir . '/../lib/Exception/ServerMaintenanceMode.php',
+    'OCA\\DAV\\Exception\\UidConflict' => $baseDir . '/../lib/Exception/UidConflict.php',
     'OCA\\DAV\\Exception\\UnsupportedLimitOnInitialSyncException' => $baseDir . '/../lib/Exception/UnsupportedLimitOnInitialSyncException.php',
     'OCA\\DAV\\Files\\BrowserErrorPagePlugin' => $baseDir . '/../lib/Files/BrowserErrorPagePlugin.php',
     'OCA\\DAV\\Files\\FileSearchBackend' => $baseDir . '/../lib/Files/FileSearchBackend.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitDAV
 {
     public static $prefixLengthsPsr4 = array (
-        'O' =>
+        'O' => 
         array (
             'OCA\\DAV\\' => 8,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\DAV\\' =>
+        'OCA\\DAV\\' => 
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),
@@ -332,6 +332,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Events\\SubscriptionUpdatedEvent' => __DIR__ . '/..' . '/../lib/Events/SubscriptionUpdatedEvent.php',
         'OCA\\DAV\\Exception\\ExampleEventException' => __DIR__ . '/..' . '/../lib/Exception/ExampleEventException.php',
         'OCA\\DAV\\Exception\\ServerMaintenanceMode' => __DIR__ . '/..' . '/../lib/Exception/ServerMaintenanceMode.php',
+        'OCA\\DAV\\Exception\\UidConflict' => __DIR__ . '/..' . '/../lib/Exception/UidConflict.php',
         'OCA\\DAV\\Exception\\UnsupportedLimitOnInitialSyncException' => __DIR__ . '/..' . '/../lib/Exception/UnsupportedLimitOnInitialSyncException.php',
         'OCA\\DAV\\Files\\BrowserErrorPagePlugin' => __DIR__ . '/..' . '/../lib/Files/BrowserErrorPagePlugin.php',
         'OCA\\DAV\\Files\\FileSearchBackend' => __DIR__ . '/..' . '/../lib/Files/FileSearchBackend.php',

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -32,6 +32,7 @@ use OCA\DAV\Events\CalendarUpdatedEvent;
 use OCA\DAV\Events\SubscriptionCreatedEvent;
 use OCA\DAV\Events\SubscriptionDeletedEvent;
 use OCA\DAV\Events\SubscriptionUpdatedEvent;
+use OCA\DAV\Exception\UidConflict;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\Calendar\CalendarExportOptions;
 use OCP\Calendar\Events\CalendarObjectCreatedEvent;
@@ -1499,6 +1500,35 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	/**
+	 * Find an existing calendar object that already carries the given UID in a calendar collection
+	 *
+	 * @param int $calendarId
+	 * @param string $uid
+	 * @param int $calendarType
+	 * @param bool|null $deleted Whether to match trashed objects: false for live objects only, true for trashed only, null for any
+	 * @return array|null The existing object, or null when no match is found
+	 */
+	public function findCalendarObjectByUid(int $calendarId, string $uid, int $calendarType = self::CALENDAR_TYPE_CALENDAR, ?bool $deleted = false): ?array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('calendarobjects')
+			->where($qb->expr()->eq('calendarid', $qb->createNamedParameter($calendarId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('calendartype', $qb->createNamedParameter($calendarType, IQueryBuilder::PARAM_INT)))
+			->setMaxResults(1);
+		if ($deleted === false) {
+			$qb->andWhere($qb->expr()->isNull('deleted_at'));
+		} elseif ($deleted === true) {
+			$qb->andWhere($qb->expr()->isNotNull('deleted_at'));
+		}
+		$result = $qb->executeQuery();
+		$row = $result->fetchAssociative();
+		$result->closeCursor();
+
+		return $row === false ? null : $this->rowToCalendarObject($row);
+	}
+
+	/**
 	 * Creates a new calendar object.
 	 *
 	 * The object uri is only the basename, or filename and not a full path.
@@ -1523,35 +1553,15 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$extraData = $this->getDenormalizedData($calendarData);
 
 		return $this->atomic(function () use ($calendarId, $objectUri, $calendarData, $extraData, $calendarType) {
-			// Try to detect duplicates
-			$qb = $this->db->getQueryBuilder();
-			$qb->select($qb->func()->count('*'))
-				->from('calendarobjects')
-				->where($qb->expr()->eq('calendarid', $qb->createNamedParameter($calendarId)))
-				->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($extraData['uid'])))
-				->andWhere($qb->expr()->eq('calendartype', $qb->createNamedParameter($calendarType)))
-				->andWhere($qb->expr()->isNull('deleted_at'));
-			$result = $qb->executeQuery();
-			$count = (int)$result->fetchOne();
-			$result->closeCursor();
-
-			if ($count !== 0) {
-				throw new BadRequest('Calendar object with uid already exists in this calendar collection.');
+			// Try to detect duplicate uids in the target collection
+			$existing = $this->findCalendarObjectByUid($calendarId, $extraData['uid'], $calendarType);
+			if ($existing !== null) {
+				// RFC 4791 no-uid-conflict (409) reporting the existing object's href.
+				throw UidConflict::forCalendar($existing['uri']);
 			}
-			// For a more specific error message we also try to explicitly look up the UID but as a deleted entry
-			$qbDel = $this->db->getQueryBuilder();
-			$qbDel->select('*')
-				->from('calendarobjects')
-				->where($qbDel->expr()->eq('calendarid', $qbDel->createNamedParameter($calendarId)))
-				->andWhere($qbDel->expr()->eq('uid', $qbDel->createNamedParameter($extraData['uid'])))
-				->andWhere($qbDel->expr()->eq('calendartype', $qbDel->createNamedParameter($calendarType)))
-				->andWhere($qbDel->expr()->isNotNull('deleted_at'));
-			$result = $qbDel->executeQuery();
-			$found = $result->fetchAssociative();
-			$result->closeCursor();
-			if ($found !== false) {
-				// the object existed previously but has been deleted
-				// remove the trashbin entry and continue as if it was a new object
+			// The UID may still belong to a trashed object; delete it and replace it with the new object.
+			$found = $this->findCalendarObjectByUid($calendarId, $extraData['uid'], $calendarType, true);
+			if ($found !== null) {
 				$this->deleteCalendarObject($calendarId, $found['uri'], $calendarType, true);
 			}
 
@@ -1702,6 +1712,13 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 			$sourceCalendarId = $object['calendarid'];
 			$sourceObjectUri = $object['uri'];
+			$sourceObjectUid = $object['uid'];
+
+			// Try to detect duplicate uids in the target collection
+			$existing = $this->findCalendarObjectByUid($targetCalendarId, $sourceObjectUid, $calendarType);
+			if ($existing !== null) {
+				throw UidConflict::forCalendar($existing['uri']);
+			}
 
 			$query = $this->db->getQueryBuilder();
 			$query->update('calendarobjects')
@@ -2659,7 +2676,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 	public function getCalendarObjectById(string $principalUri, int $id): ?array {
 		$query = $this->db->getQueryBuilder();
-		$query->select(['co.id', 'co.uri', 'co.lastmodified', 'co.etag', 'co.calendarid', 'co.size', 'co.calendardata', 'co.componenttype', 'co.classification', 'co.deleted_at'])
+		$query->select(['co.id', 'co.uri', 'co.uid', 'co.lastmodified', 'co.etag', 'co.calendarid', 'co.size', 'co.calendardata', 'co.componenttype', 'co.classification', 'co.deleted_at'])
 			->selectAlias('c.uri', 'calendaruri')
 			->from('calendarobjects', 'co')
 			->join('co', 'calendars', 'c', $query->expr()->eq('c.id', 'co.calendarid', IQueryBuilder::PARAM_INT))
@@ -2676,6 +2693,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		return [
 			'id' => $row['id'],
 			'uri' => $row['uri'],
+			'uid' => $row['uid'],
 			'lastmodified' => $row['lastmodified'],
 			'etag' => '"' . $row['etag'] . '"',
 			'calendarid' => $row['calendarid'],

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -20,6 +20,7 @@ use OCA\DAV\Events\CardCreatedEvent;
 use OCA\DAV\Events\CardDeletedEvent;
 use OCA\DAV\Events\CardMovedEvent;
 use OCA\DAV\Events\CardUpdatedEvent;
+use OCA\DAV\Exception\UidConflict;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -546,6 +547,37 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	}
 
 	/**
+	 * Returns a card that already has a given UID in an address book collection.
+	 *
+	 * @param int $addressBookId
+	 * @param string $uid
+	 * @return array|null The existing card, or null when the UID is free
+	 */
+	public function getCardByUid(int $addressBookId, string $uid): ?array {
+		$q = $this->db->getQueryBuilder();
+		$q->select('*')
+			->from($this->dbCardsTable)
+			->where($q->expr()->eq('addressbookid', $q->createNamedParameter($addressBookId, IQueryBuilder::PARAM_INT)))
+			->andWhere($q->expr()->eq('uid', $q->createNamedParameter($uid, IQueryBuilder::PARAM_STR)))
+			->setMaxResults(1);
+		$result = $q->executeQuery();
+		$row = $result->fetchAssociative();
+		$result->closeCursor();
+		if ($row === false) {
+			return null;
+		}
+
+		$row['etag'] = '"' . $row['etag'] . '"';
+		$modified = false;
+		$row['carddata'] = $this->readBlob($row['carddata'], $modified);
+		if ($modified) {
+			$row['size'] = strlen($row['carddata']);
+		}
+
+		return $row;
+	}
+
+	/**
 	 * Returns a list of cards.
 	 *
 	 * This method should work identical to getCard, but instead return all the
@@ -615,26 +647,20 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @param mixed $addressBookId
 	 * @param string $cardUri
 	 * @param string $cardData
-	 * @param bool $checkAlreadyExists
+	 * @param bool $checkUidConflict
 	 * @return string
 	 */
 	#[\Override]
-	public function createCard($addressBookId, $cardUri, $cardData, bool $checkAlreadyExists = true) {
+	public function createCard($addressBookId, $cardUri, $cardData, bool $checkUidConflict = true) {
 		$etag = md5($cardData);
 		$uid = $this->getUID($cardData);
-		return $this->atomic(function () use ($addressBookId, $cardUri, $cardData, $checkAlreadyExists, $etag, $uid) {
-			if ($checkAlreadyExists) {
-				$q = $this->db->getQueryBuilder();
-				$q->select('uid')
-					->from($this->dbCardsTable)
-					->where($q->expr()->eq('addressbookid', $q->createNamedParameter($addressBookId)))
-					->andWhere($q->expr()->eq('uid', $q->createNamedParameter($uid)))
-					->setMaxResults(1);
-				$result = $q->executeQuery();
-				$count = (bool)$result->fetchOne();
-				$result->closeCursor();
-				if ($count) {
-					throw new \Sabre\DAV\Exception\BadRequest('VCard object with uid already exists in this addressbook collection.');
+		return $this->atomic(function () use ($addressBookId, $cardUri, $cardData, $checkUidConflict, $etag, $uid) {
+			// Try to detect duplicate uids in the target collection
+			if ($checkUidConflict) {
+				$existing = $this->getCardByUid($addressBookId, $uid);
+				if ($existing !== null) {
+					// RFC 6352 no-uid-conflict (409) reporting the existing object's href.
+					throw UidConflict::forAddressBook($existing['uri']);
 				}
 			}
 
@@ -738,6 +764,12 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 				return false;
 			}
 			$sourceObjectId = (int)$card['id'];
+
+			// Try to detect duplicate uids in the target collection
+			$existing = $this->getCardByUid($targetAddressBookId, $card['uid']);
+			if ($existing !== null) {
+				throw UidConflict::forAddressBook($existing['uri']);
+			}
 
 			$query = $this->db->getQueryBuilder();
 			$query->update('cards')

--- a/apps/dav/lib/Exception/UidConflict.php
+++ b/apps/dav/lib/Exception/UidConflict.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Exception;
+
+use Sabre\CalDAV\Plugin as CalDAVPlugin;
+use Sabre\CardDAV\Plugin as CardDAVPlugin;
+use Sabre\DAV\Exception\Conflict;
+use Sabre\DAV\Server;
+
+/**
+ * Duplicate iCalendar or vCard UID in the target collection.
+ *
+ * Reports the no-uid-conflict precondition with a DAV:href to the existing
+ * object, as 409 Conflict (resolvable by the client):
+ * - CALDAV:no-uid-conflict for calendar collections (RFC 4791 5.3.2.1)
+ * - CARDDAV:no-uid-conflict for address book collections (RFC 6352 6.3.2.1)
+ */
+class UidConflict extends Conflict {
+	private function __construct(
+		private readonly string $namespace,
+		private readonly string $prefix,
+		private readonly string $existingObjectUri,
+		string $message,
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * RFC 4791 CALDAV:no-uid-conflict for a calendar object collection.
+	 */
+	public static function forCalendar(string $existingObjectUri): self {
+		return new self(
+			CalDAVPlugin::NS_CALDAV,
+			'cal',
+			$existingObjectUri,
+			'Calendar object with uid already exists in this calendar collection.',
+		);
+	}
+
+	/**
+	 * RFC 6352 CARDDAV:no-uid-conflict for an address book collection.
+	 */
+	public static function forAddressBook(string $existingObjectUri): self {
+		return new self(
+			CardDAVPlugin::NS_CARDDAV,
+			'card',
+			$existingObjectUri,
+			'VCard object with uid already exists in this addressbook collection.',
+		);
+	}
+
+	#[\Override]
+	public function serialize(Server $server, \DOMElement $errorNode) {
+		// The conflicting object lives in the collection the resource is written
+		// to. For PUT that is the request collection; for COPY and MOVE it is the
+		// collection referenced by the Destination header.
+		$method = $server->httpRequest->getMethod();
+		if (($method === 'COPY' || $method === 'MOVE')
+			&& $server->httpRequest->getHeader('Destination') !== null) {
+			$targetPath = $server->calculateUri($server->httpRequest->getHeader('Destination'));
+		} else {
+			$targetPath = $server->getRequestUri();
+		}
+		[$collection] = \Sabre\Uri\split($targetPath);
+		$href = $server->getBaseUri() . $collection . '/' . $this->existingObjectUri;
+
+		$document = $errorNode->ownerDocument;
+		$conflict = $document->createElementNS($this->namespace, $this->prefix . ':no-uid-conflict');
+		$hrefNode = $document->createElementNS('DAV:', 'd:href');
+		$hrefNode->appendChild($document->createTextNode($href));
+		$conflict->appendChild($hrefNode);
+		$errorNode->appendChild($conflict);
+	}
+}

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -264,7 +264,7 @@ EOD;
 	}
 
 	public function testMultipleCalendarObjectsWithSameUID(): void {
-		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
+		$this->expectException(\OCA\DAV\Exception\UidConflict::class);
 		$this->expectExceptionMessage('Calendar object with uid already exists in this calendar collection.');
 
 		$calendarId = $this->createTestCalendar();
@@ -330,6 +330,82 @@ EOD;
 		$newObject = $this->backend->getCalendarObject($calendarId, $newUri);
 		$this->assertNotNull($newObject);
 		$this->assertEquals($calData, $newObject['calendardata']);
+	}
+
+	public function testMoveCalendarObjectToCollectionWithSameUID(): void {
+		$this->dispatcher->expects(self::any())->method('dispatchTyped');
+
+		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Source', []);
+		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Target', []);
+		$calendars = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER);
+		$sourceCalendarId = (int)$calendars[0]['id'];
+		$targetCalendarId = (int)$calendars[1]['id'];
+
+		$calData = <<<'EOD'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:ownCloud Calendar
+BEGIN:VEVENT
+CREATED;VALUE=DATE-TIME:20130910T125139Z
+UID:move-conflict-1
+LAST-MODIFIED;VALUE=DATE-TIME:20130910T125139Z
+DTSTAMP;VALUE=DATE-TIME:20130910T125139Z
+SUMMARY:Test Event
+DTSTART;VALUE=DATE-TIME:20130912T130000Z
+DTEND;VALUE=DATE-TIME:20130912T140000Z
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+EOD;
+
+		// Same UID in two different collections is allowed; moving the source
+		// into the target must then be rejected with the no-uid-conflict error.
+		$this->backend->createCalendarObject($sourceCalendarId, 'source.ics', $calData);
+		$this->backend->createCalendarObject($targetCalendarId, 'target.ics', $calData);
+		$sourceObject = $this->backend->getCalendarObject($sourceCalendarId, 'source.ics');
+
+		$this->expectException(\OCA\DAV\Exception\UidConflict::class);
+		$this->backend->moveCalendarObject(
+			self::UNIT_TEST_USER,
+			(int)$sourceObject['id'],
+			self::UNIT_TEST_USER,
+			$targetCalendarId,
+			'moved.ics',
+		);
+	}
+
+	public function testRecreateCalendarObjectReclaimsTrashedUid(): void {
+		$this->dispatcher->expects(self::any())->method('dispatchTyped');
+		$calendarId = $this->createTestCalendar();
+
+		$calData = <<<'EOD'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:ownCloud Calendar
+BEGIN:VEVENT
+CREATED;VALUE=DATE-TIME:20130910T125139Z
+UID:reclaim-1
+LAST-MODIFIED;VALUE=DATE-TIME:20130910T125139Z
+DTSTAMP;VALUE=DATE-TIME:20130910T125139Z
+SUMMARY:Test Event
+DTSTART;VALUE=DATE-TIME:20130912T130000Z
+DTEND;VALUE=DATE-TIME:20130912T140000Z
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+EOD;
+
+		$this->backend->createCalendarObject($calendarId, 'first.ics', $calData);
+		// Soft-delete moves the object to the trashbin (deleted_at is set).
+		$this->backend->deleteCalendarObject($calendarId, 'first.ics');
+		self::assertCount(0, $this->backend->getCalendarObjects($calendarId));
+
+		// Re-creating the same UID must reclaim the trashed entry instead of
+		// raising a no-uid-conflict.
+		$this->backend->createCalendarObject($calendarId, 'second.ics', $calData);
+		$objects = $this->backend->getCalendarObjects($calendarId);
+		self::assertCount(1, $objects);
+		self::assertSame('second.ics', $objects[0]['uri']);
 	}
 
 	public function testMultiCalendarObjects(): void {

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -18,6 +18,7 @@ use OCA\DAV\CardDAV\Sharing\Service;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCA\DAV\DAV\RemoteUserPrincipalBackend;
 use OCA\DAV\DAV\Sharing\SharingMapper;
+use OCA\DAV\Exception\UidConflict;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -378,6 +379,28 @@ class CardDavBackendTest extends TestCase {
 		$this->backend->createCard($bookId1, $uri1, $this->vcardTest0);
 	}
 
+	public function testMoveCardToCollectionWithSameUID(): void {
+		$this->backend = $this->getMockBuilder(CardDavBackend::class)
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->dispatcher, $this->sharingBackend, $this->config])
+			->onlyMethods(['updateProperties'])
+			->getMock();
+
+		$this->backend->createAddressBook(self::UNIT_TEST_USER, 'Source', []);
+		$this->backend->createAddressBook(self::UNIT_TEST_USER, 'Target', []);
+		$books = $this->backend->getAddressBooksForUser(self::UNIT_TEST_USER);
+		$sourceBookId = (int)$books[0]['id'];
+		$targetBookId = (int)$books[1]['id'];
+
+		// Same UID in two different collections is allowed; moving the source
+		// into the target must then be rejected with the no-uid-conflict error.
+		$this->backend->createCard($sourceBookId, 'source.vcf', $this->vcardTest0);
+		$this->backend->createCard($targetBookId, 'target.vcf', $this->vcardTest0);
+
+		$this->expectException(UidConflict::class);
+		$this->expectExceptionMessage('VCard object with uid already exists in this addressbook collection.');
+		$this->backend->moveCard($sourceBookId, 'source.vcf', $targetBookId, 'moved.vcf');
+	}
+
 	public function testMultipleUIDDenied(): void {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
 			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->dispatcher, $this->sharingBackend, $this->config])
@@ -396,7 +419,8 @@ class CardDavBackendTest extends TestCase {
 
 		// create another card with same uid
 		$uri1 = $this->getUniqueID('card');
-		$this->expectException(BadRequest::class);
+		$this->expectException(UidConflict::class);
+		$this->expectExceptionMessage('VCard object with uid already exists in this addressbook collection.');
 		$test = $this->backend->createCard($bookId, $uri1, $this->vcardTest0);
 	}
 

--- a/apps/dav/tests/unit/Exception/UidConflictTest.php
+++ b/apps/dav/tests/unit/Exception/UidConflictTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\Exception;
+
+use OCA\DAV\Exception\UidConflict;
+use Sabre\DAV\Exception\Conflict;
+use Sabre\DAV\Server;
+use Sabre\HTTP\RequestInterface;
+use Test\TestCase;
+
+class UidConflictTest extends TestCase {
+	public function testHttpCodeIsConflict(): void {
+		// Must stay a Conflict: CalendarImpl/AddressBookImpl rely on it for the
+		// OCP createFromString contract.
+		self::assertInstanceOf(Conflict::class, UidConflict::forCalendar('sabredav-1234.ics'));
+		self::assertSame(409, UidConflict::forCalendar('sabredav-1234.ics')->getHTTPCode());
+		self::assertInstanceOf(Conflict::class, UidConflict::forAddressBook('sabredav-1234.vcf'));
+		self::assertSame(409, UidConflict::forAddressBook('sabredav-1234.vcf')->getHTTPCode());
+	}
+
+	public function testSerializeReportsCalDavNoUidConflictWithExistingHref(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getMethod')->willReturn('PUT');
+		$server = $this->createMock(Server::class);
+		$server->httpRequest = $request;
+		$server->method('getRequestUri')->willReturn('calendars/alice/personal/guessed.ics');
+		$server->method('getBaseUri')->willReturn('/remote.php/dav/');
+
+		$errorNode = $this->serialize(UidConflict::forCalendar('sabredav-1234.ics'), $server);
+
+		$conflict = $errorNode->getElementsByTagNameNS('urn:ietf:params:xml:ns:caldav', 'no-uid-conflict');
+		self::assertSame(1, $conflict->length);
+		self::assertSame(
+			'/remote.php/dav/calendars/alice/personal/sabredav-1234.ics',
+			$this->hrefOf($errorNode),
+		);
+	}
+
+	public function testSerializeReportsCardDavNoUidConflictWithExistingHref(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getMethod')->willReturn('PUT');
+		$server = $this->createMock(Server::class);
+		$server->httpRequest = $request;
+		$server->method('getRequestUri')->willReturn('addressbooks/users/alice/contacts/guessed.vcf');
+		$server->method('getBaseUri')->willReturn('/remote.php/dav/');
+
+		$errorNode = $this->serialize(UidConflict::forAddressBook('sabredav-1234.vcf'), $server);
+
+		$conflict = $errorNode->getElementsByTagNameNS('urn:ietf:params:xml:ns:carddav', 'no-uid-conflict');
+		self::assertSame(1, $conflict->length);
+		self::assertSame(
+			'/remote.php/dav/addressbooks/users/alice/contacts/sabredav-1234.vcf',
+			$this->hrefOf($errorNode),
+		);
+	}
+
+	public function testSerializeUsesDestinationCollectionForMove(): void {
+		// On MOVE the request URI is the source object; the conflicting object
+		// lives in the destination collection referenced by the header.
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getMethod')->willReturn('MOVE');
+		$request->method('getHeader')->with('Destination')
+			->willReturn('https://cloud.example.com/remote.php/dav/calendars/alice/work/moved.ics');
+		$server = $this->createMock(Server::class);
+		$server->httpRequest = $request;
+		$server->method('calculateUri')->willReturn('calendars/alice/work/moved.ics');
+		$server->method('getBaseUri')->willReturn('/remote.php/dav/');
+
+		$errorNode = $this->serialize(UidConflict::forCalendar('sabredav-1234.ics'), $server);
+
+		self::assertSame(
+			'/remote.php/dav/calendars/alice/work/sabredav-1234.ics',
+			$this->hrefOf($errorNode),
+		);
+	}
+
+	private function serialize(UidConflict $exception, Server $server): \DOMElement {
+		$document = new \DOMDocument('1.0', 'utf-8');
+		$errorNode = $document->createElementNS('DAV:', 'd:error');
+		$document->appendChild($errorNode);
+		$exception->serialize($server, $errorNode);
+		return $errorNode;
+	}
+
+	private function hrefOf(\DOMElement $errorNode): string {
+		$href = $errorNode->getElementsByTagNameNS('DAV:', 'href');
+		self::assertSame(1, $href->length);
+		return $href->item(0)->textContent;
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
- Original Community PR: https://github.com/nextcloud/server/pull/61640
- Modified the CalDAV and CardDAV backend create to use new serializable exception type that returns a dav response as per RFC
- Modified the CalDAV and CardDAV backend move to use new serializable exception type that returns a dav response as per RFC
- RFC 4791 (CalDAV) defines the CALDAV:no-uid-conflict precondition. It ensures that within a calendar collection, there cannot be two different resources containing iCalendar objects with the same UID.
- RFC 6352 (CardDAV) defines the analogous CARDDAV:no-uid-conflict precondition for address books. It ensures that within an address book collection, there cannot be two different vCard resources with the same UID.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
