### PR TITLE
fix(rector): Don't use AddSeeTestAnnotationRector in rector strict

### DIFF
--- a/build/rector-strict.php
+++ b/build/rector-strict.php
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector;
+
 $nextcloudDir = dirname(__DIR__);
 
 return (require __DIR__ . '/rector-shared.php')
@@ -46,4 +48,6 @@ return (require __DIR__ . '/rector-shared.php')
 		symfonyConfigs: true,
 	)->withPhpSets(
 		php82: true,
-	);
+	)->withSkip([
+		AddSeeTestAnnotationRector::class,
+	]);


### PR DESCRIPTION

## Summary

This should make the CI green again


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
