### PR TITLE
Fix ldap:show-remnant sharer column when remnants are disabled

### DIFF
--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -188,7 +188,7 @@ class OfflineUser {
 				null,
 				false,
 				1,
-				onlyValid:false
+				onlyValid: false
 			);
 			if (!empty($shares)) {
 				$this->hasActiveShares = true;

--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -187,7 +187,8 @@ class OfflineUser {
 				$constantValue,
 				null,
 				false,
-				1
+				1,
+				onlyValid:false
 			);
 			if (!empty($shares)) {
 				$this->hasActiveShares = true;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1231,6 +1231,17 @@ class Manager implements IManager {
 			return [];
 		}
 
+		if ($onlyValid && $this->config->getAppValue('files_sharing', 'hide_disabled_user_shares', 'no') === 'yes') {
+			/*
+			 * If shares from disabled users are hidden, check user status first to avoid useless work.
+			 * Otherwise all shares would’ve been filtered out by checkShare anyway.
+			 */
+			$user = $this->userManager->get($userId);
+			if ($user?->isEnabled() === false) {
+				return [];
+			}
+		}
+
 		if ($path?->getMountPoint() instanceof IShareOwnerlessMount) {
 			$shares = array_filter($provider->getSharesByPath($path), static fn (IShare $share) => $share->getShareType() === $shareType);
 		} else {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1151,6 +1151,17 @@ class Manager implements IManager {
 			return [];
 		}
 
+		if ($onlyValid && $this->config->getAppValue('files_sharing', 'hide_disabled_user_shares', 'no') === 'yes') {
+			/*
+			 * If shares from disabled users are hidden, check user status first to avoid useless work.
+			 * Otherwise all shares would’ve been filtered out by checkShare anyway.
+			 */
+			$user = $this->userManager->get($userId);
+			if ($user?->isEnabled() === false) {
+				return [];
+			}
+		}
+
 		if ($path?->getMountPoint() instanceof IShareOwnerlessMount) {
 			$shares = array_filter($provider->getSharesByPath($path), static fn (IShare $share) => $share->getShareType() === $shareType);
 		} else {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

When Remnants are considered disabled (see markRemnantsAsDisabled) and shares by disabled users are hidden (see hide_disabled_user_shares) ldap:show-remnants would show all remnants as having no shares. It was also quite slow if users have a lot of shares as it was iterating over all shares from all remnants.
Now, validity of shares is not checked anymore by show-remnants. It’s a bit less accurate (a remnant may appear as a sharer even if all its shares are expired) but it’s faster.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
