### PR TITLE
feat(bruteforce): improve bruteforce protection command output

### DIFF
--- a/core/Command/Security/BruteforceAttempts.php
+++ b/core/Command/Security/BruteforceAttempts.php
@@ -60,6 +60,9 @@ class BruteforceAttempts extends Base {
 				(string)$input->getArgument('action'),
 			),
 		];
+		if ($input->getOption('output') === 'plain') {
+			$data['delay'] = $data['delay'] . ' ms';
+		}
 
 		$this->writeArrayInOutputFormat($input, $output, $data);
 

--- a/core/Command/Security/BruteforceAttempts.php
+++ b/core/Command/Security/BruteforceAttempts.php
@@ -12,6 +12,7 @@ use OC\Core\Command\Base;
 use OCP\Security\Bruteforce\IThrottler;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class BruteforceAttempts extends Base {
@@ -37,12 +38,20 @@ class BruteforceAttempts extends Base {
 				InputArgument::OPTIONAL,
 				'Only count attempts for the given action',
 			)
+			->addOption(
+				'interval',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Interval in hours to count attempts for (max 48)',
+				12,
+			)
 		;
 	}
 
 	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$ip = $input->getArgument('ipaddress');
+		$interval = (float)$input->getOption('interval');
 
 		if (!filter_var($ip, FILTER_VALIDATE_IP)) {
 			$output->writeln('<error>"' . $ip . '" is not a valid IP address</error>');
@@ -54,6 +63,7 @@ class BruteforceAttempts extends Base {
 			'attempts' => $this->throttler->getAttempts(
 				$ip,
 				(string)$input->getArgument('action'),
+				$interval,
 			),
 			'delay' => $this->throttler->getDelay(
 				$ip,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Add hint on the delay output that it's in milliseconds
- Add "interval" option to the command

## TODO

- [x] ~~It feels like the command might be used in a script. Should the key change be avoided and done differently? Or perhaps documented as a breaking change? ... Does not need to be explicit in the first place?~~

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
