### PR TITLE
feat(TaskProcessing): add TextToTextImprove to improve or iterate on text

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -958,6 +958,7 @@ return array(
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextChatWithTools' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextChatWithTools.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextFormalization' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextHeadline' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php',
+    'OCP\\TaskProcessing\\TaskTypes\\TextToTextImprove' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextImprove.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextProofread' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextProofread.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformatParagraphs' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformulation' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -999,6 +999,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextChatWithTools' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextChatWithTools.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextFormalization' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextHeadline' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php',
+        'OCP\\TaskProcessing\\TaskTypes\\TextToTextImprove' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextImprove.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextProofread' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextProofread.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformatParagraphs' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformatParagraphs.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextReformulation' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php',

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -87,6 +87,7 @@ use OCP\TaskProcessing\TaskTypes\TextToTextChat;
 use OCP\TaskProcessing\TaskTypes\TextToTextChatWithTools;
 use OCP\TaskProcessing\TaskTypes\TextToTextFormalization;
 use OCP\TaskProcessing\TaskTypes\TextToTextHeadline;
+use OCP\TaskProcessing\TaskTypes\TextToTextImprove;
 use OCP\TaskProcessing\TaskTypes\TextToTextProofread;
 use OCP\TaskProcessing\TaskTypes\TextToTextReformatParagraphs;
 use OCP\TaskProcessing\TaskTypes\TextToTextReformulation;
@@ -687,6 +688,7 @@ class Manager implements IManager {
 			TextToTextChat::ID => Server::get(TextToTextChat::class),
 			TextToTextTranslate::ID => Server::get(TextToTextTranslate::class),
 			TextToTextReformulation::ID => Server::get(TextToTextReformulation::class),
+			TextToTextImprove::ID => Server::get(TextToTextImprove::class),
 			TextToImage::ID => Server::get(TextToImage::class),
 			AudioToText::ID => Server::get(AudioToText::class),
 			AudioToTextSubtitles::ID => Server::get(AudioToTextSubtitles::class),

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextImprove.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextImprove.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\TaskProcessing\TaskTypes;
+
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\ShapeDescriptor;
+
+/**
+ * This is the task processing task type for improving text
+ * @since 35.0.0
+ */
+class TextToTextImprove implements ITaskType {
+	/**
+	 * @since 35.0.0
+	 */
+	public const ID = 'core:text2text:improve';
+
+	private IL10N $l;
+
+	/**
+	 * @param IFactory $l10nFactory
+	 * @since 35.0.0
+	 */
+	public function __construct(
+		IFactory $l10nFactory,
+	) {
+		$this->l = $l10nFactory->get('lib');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getName(): string {
+		return $this->l->t('Improve text');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getDescription(): string {
+		return $this->l->t('Takes a text and improves it based on instructions');
+	}
+
+	/**
+	 * @return string
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getId(): string {
+		return self::ID;
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getInputShape(): array {
+		return [
+			'input' => new ShapeDescriptor(
+				$this->l->t('Input text'),
+				$this->l->t('Write a text that you want the assistant to improve'),
+				EShapeType::Text
+			),
+			'instructions' => new ShapeDescriptor(
+				$this->l->t('Instructions'),
+				$this->l->t('Describe how the assistant should improve the text'),
+				EShapeType::Text
+			),
+		];
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 35.0.0
+	 */
+	#[\Override]
+	public function getOutputShape(): array {
+		return [
+			'output' => new ShapeDescriptor(
+				$this->l->t('Improved text'),
+				$this->l->t('The improved text'),
+				EShapeType::Text
+			),
+		];
+	}
+}


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Adds TextToTextImprove to allow for iteration on text

## TODO

- [ ] Create documentation
- [x] Implement provider for openai integration (https://github.com/nextcloud/integration_openai/pull/392)
- [ ] Implement improve button for assistant (https://github.com/nextcloud/assistant/pull/596)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
