### PR TITLE
chore(settings): make 32bit warning more serious

### DIFF
--- a/apps/settings/lib/SetupChecks/SystemIs64bit.php
+++ b/apps/settings/lib/SetupChecks/SystemIs64bit.php
@@ -44,7 +44,7 @@ class SystemIs64bit implements ISetupCheck {
 		if ($this->is64bit()) {
 			return SetupResult::success($this->l10n->t('64-bit'));
 		} else {
-			return SetupResult::warning(
+			return SetupResult::error(
 				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud\'s 32-bit support will run out in the foreseeable future. Please upgrade your OS and PHP to 64-bit!'),
 				$this->urlGenerator->linkToDocs('admin-system-requirements')
 			);

--- a/apps/settings/lib/SetupChecks/SystemIs64bit.php
+++ b/apps/settings/lib/SetupChecks/SystemIs64bit.php
@@ -45,7 +45,7 @@ class SystemIs64bit implements ISetupCheck {
 			return SetupResult::success($this->l10n->t('64-bit'));
 		} else {
 			return SetupResult::warning(
-				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit!'),
+				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud\'s 32-bit support will run out in the foreseeable future. Please upgrade your OS and PHP to 64-bit!'),
 				$this->urlGenerator->linkToDocs('admin-system-requirements')
 			);
 		}


### PR DESCRIPTION
## Summary


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
