### PR TITLE
[stable34] build(deps): Composer audit updates

### DIFF
--- a/build/integration/features/bootstrap/FilesDropContext.php
+++ b/build/integration/features/bootstrap/FilesDropContext.php
@@ -25,8 +25,8 @@ class FilesDropContext implements Context, SnippetAcceptingContext {
 			$token = $this->lastShareData->data[0]->token;
 		}
 
-		$base = substr($this->baseUrl, 0, -4);
-		$fullUrl = str_replace('//', '/', $base . "/public.php/dav/files/$token/$path");
+		$base = rtrim(substr($this->baseUrl, 0, -4), '/');
+		$fullUrl = $base . str_replace('//', '/', "/public.php/dav/files/$token/$path");
 
 		$options['headers'] = [
 			'X-REQUESTED-WITH' => 'XMLHttpRequest',
@@ -66,8 +66,8 @@ class FilesDropContext implements Context, SnippetAcceptingContext {
 			$token = $this->lastShareData->data[0]->token;
 		}
 
-		$base = substr($this->baseUrl, 0, -4);
-		$fullUrl = str_replace('//', '/', $base . "/public.php/dav/files/$token/$folder");
+		$base = rtrim(substr($this->baseUrl, 0, -4), '/');
+		$fullUrl = $base . str_replace('//', '/', "/public.php/dav/files/$token/$folder");
 
 		$options['headers'] = [
 			'X-REQUESTED-WITH' => 'XMLHttpRequest',

--- a/tests/lib/Files/ObjectStore/ObjectStoreTestCase.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTestCase.php
@@ -85,6 +85,9 @@ abstract class ObjectStoreTestCase extends TestCase {
 		try {
 			set_error_handler(
 				function (int $errno, string $errstr) use (&$warnings): void {
+					if ($errno === E_DEPRECATED || $errno === E_USER_DEPRECATED) {
+						return;
+					}
 					$warnings[] = $errstr;
 				},
 			);
@@ -105,6 +108,9 @@ abstract class ObjectStoreTestCase extends TestCase {
 		try {
 			set_error_handler(
 				function (int $errno, string $errstr) use (&$warnings): void {
+					if ($errno === E_DEPRECATED || $errno === E_USER_DEPRECATED) {
+						return;
+					}
 					$warnings[] = $errstr;
 				},
 			);

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -117,6 +117,9 @@ class S3Test extends ObjectStoreTestCase {
 		$warnings = [];
 		set_error_handler(
 			function (int $errno, string $errstr) use (&$warnings): void {
+				if ($errno === E_DEPRECATED || $errno === E_USER_DEPRECATED) {
+					return;
+				}
 				$warnings[] = $errstr;
 			},
 		);


### PR DESCRIPTION
- [x] https://github.com/nextcloud/3rdparty/pull/2498

| Prod Packages                 | Operation | Base    | Target  |
|-------------------------------|-----------|---------|---------|
| guzzlehttp/guzzle             | Upgraded  | 7.10.0  | 7.13.1  |
| guzzlehttp/promises           | Upgraded  | 2.3.0   | 2.5.0   |
| guzzlehttp/psr7               | Upgraded  | 2.9.0   | 2.12.3  |
| masterminds/html5             | Upgraded  | 2.9.0   | 2.10.1  |
| mtdowling/jmespath.php        | Upgraded  | 2.8.0   | 2.9.1   |
| phpseclib/phpseclib           | Upgraded  | 2.0.54  | 2.0.55  |
| symfony/deprecation-contracts | Upgraded  | v3.7.0  | v3.7.1  |
| symfony/dom-crawler           | Upgraded  | v6.4.32 | v7.4.12 |
| symfony/http-foundation       | Upgraded  | v6.4.41 | v6.4.42 |

