### PR TITLE
perf(db): drop redundant db-side migrations version sorting 

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -94,7 +94,12 @@ class MigrationService {
 	}
 
 	/**
-	 * @codeCoverageIgnore - this will implicitly tested on installation
+	 * Ensures the `migrations` table exists with the expected schema.
+	 *
+	 * Creates the table if missing, or recreates it if the existing one is incompatible.
+	 *
+	 * @return bool True if the table was created or recreated; false otherwise.
+	 * @codeCoverageIgnore This is exercised implicitly during installation.
 	 */
 	private function createMigrationTable(): bool {
 		if ($this->migrationTableCreated) {
@@ -109,8 +114,9 @@ class MigrationService {
 		$schema = new SchemaWrapper($this->connection);
 
 		/**
-		 * We drop the table when it has different columns or the definition does not
-		 * match. E.g. ownCloud uses a length of 177 for app and 14 for version.
+		 * Recreate the `migrations` table when the existing schema is incompatible.
+		 * For example, older ownCloud installations used shorter column lengths
+		 * for `app` (177) and `version` (14).
 		 */
 		try {
 			$table = $schema->getTable('migrations');
@@ -131,19 +137,19 @@ class MigrationService {
 				}
 
 				if (!$schemaMismatch) {
-					// Table exists and schema matches: return back!
+					// The existing table matches the expected schema; nothing to do.
 					$this->migrationTableCreated = true;
 					return false;
 				}
 			}
 
-			// Drop the table, when it didn't match our expectations.
+			// Drop the table because it does not match the expected schema.
 			$this->connection->dropTable('migrations');
 
-			// Recreate the schema after the table was dropped.
+			// Recreate the schema wrapper after dropping the table.
 			$schema = new SchemaWrapper($this->connection);
 		} catch (SchemaException $e) {
-			// Table not found, no need to panic, we will create it.
+			// The table does not exist; it will be created below.
 		}
 
 		$table = $schema->createTable('migrations');

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -170,14 +170,13 @@ class MigrationService {
 	 * @return list<string>
 	 * @codeCoverageIgnore - no need to test this
 	 */
-	public function getMigratedVersions() {
+	public function getMigratedVersions(): array {
 		$this->createMigrationTable();
 		$qb = $this->connection->getQueryBuilder();
 
 		$qb->select('version')
 			->from('migrations')
-			->where($qb->expr()->eq('app', $qb->createNamedParameter($this->getApp())))
-			->orderBy('version');
+			->where($qb->expr()->eq('app', $qb->createNamedParameter($this->getApp())));
 
 		$result = $qb->executeQuery();
 		$rows = $result->fetchAll(\PDO::FETCH_COLUMN);

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -252,7 +252,7 @@ class MigrationService {
 	 * @param string $to
 	 * @return string[]
 	 */
-	private function getMigrationsToExecute($to) {
+	private function getMigrationsToExecute($to): array {
 		$knownMigrations = $this->getMigratedVersions();
 		$availableMigrations = $this->getAvailableVersions();
 
@@ -274,7 +274,7 @@ class MigrationService {
 	 * @param string[] $knownMigrations
 	 * @return bool
 	 */
-	private function shallBeExecuted($m, $knownMigrations) {
+	private function shallBeExecuted($m, $knownMigrations): bool {
 		if (in_array($m, $knownMigrations)) {
 			return false;
 		}
@@ -294,28 +294,22 @@ class MigrationService {
 
 	/**
 	 * Returns the name of the table which holds the already applied versions
-	 *
-	 * @return string
 	 */
-	public function getMigrationsTableName() {
+	public function getMigrationsTableName(): string {
 		return $this->connection->getPrefix() . 'migrations';
 	}
 
 	/**
 	 * Returns the namespace of the version classes
-	 *
-	 * @return string
 	 */
-	public function getMigrationsNamespace() {
+	public function getMigrationsNamespace(): string {
 		return $this->migrationsNamespace;
 	}
 
 	/**
 	 * Returns the directory which holds the versions
-	 *
-	 * @return string
 	 */
-	public function getMigrationsDirectory() {
+	public function getMigrationsDirectory(): string {
 		return $this->migrationsPath;
 	}
 
@@ -457,7 +451,7 @@ class MigrationService {
 	 * @param string $to
 	 * @return string[] [$name => $description]
 	 */
-	public function describeMigrationStep($to = 'latest') {
+	public function describeMigrationStep(string $to = 'latest'): array {
 		$toBeExecuted = $this->getMigrationsToExecute($to);
 		$description = [];
 		foreach ($toBeExecuted as $version) {
@@ -470,11 +464,9 @@ class MigrationService {
 	}
 
 	/**
-	 * @param string $version
-	 * @return IMigrationStep
 	 * @throws \InvalidArgumentException
 	 */
-	public function createInstance($version) {
+	public function createInstance(string $version): IMigrationStep {
 		/** @psalm-var class-string<IMigrationStep> $class */
 		$class = $this->getClass($version);
 		try {
@@ -496,11 +488,9 @@ class MigrationService {
 	/**
 	 * Executes one explicit version
 	 *
-	 * @param string $version
-	 * @param bool $schemaOnly
 	 * @throws \InvalidArgumentException
 	 */
-	public function executeStep($version, $schemaOnly = false): void {
+	public function executeStep(string $version, bool $schemaOnly = false): void {
 		$instance = $this->createInstance($version);
 
 		if (!$schemaOnly) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Since we sort in PHP in the way we want to, the db-side sorting is just extra CPU burn.

Notes:

- The only real change here is line 179
  - Related historical context: #47515
- The other changes are just some tech debt/cleanup:
  - the addition of runtime typing (that was partially missing throughout the class).
  - updating of the comments for `createMigrationTable()` since it has some serious side effects worth knowing about.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
