### PR TITLE
fix(docs): Fix sphinx lint check

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -332,7 +332,7 @@ $CONFIG = [
 	/**
 	 * Lifetime of logins where the user selected "Remember me", in seconds.
 	 *
-	 * A value >``0`` means "Remember me" is available.
+	 * A value > ``0`` means "Remember me" is available.
 	 * To make "Remember me" unavailable to users, set to ``0``.
 	 *
 	 * To avoid unexpected expiry, set this higher than ``session_lifetime``.


### PR DESCRIPTION
All PRs in docs repo are failing:

Error: admin_manual/configuration_server/config_sample_php_parameters.rst:712: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
Error: admin_manual/configuration_server/config_sample_php_parameters.rst:712: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
Error: admin_manual/configuration_server/config_sample_php_parameters.rst:712: missing space before default role: 'e >``0``'. (missing-space-before-default-role)
Error: Process completed with exit code 1.
