### PR TITLE
docs(config): fix unbalanced inline literal in remember-me sample com…

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -332,7 +332,7 @@ $CONFIG = [
 	/**
 	 * Lifetime of logins where the user selected "Remember me", in seconds.
 	 *
-	 * A value >``0`` means "Remember me" is available.
+	 * A value > ``0`` means "Remember me" is available.
 	 * To make "Remember me" unavailable to users, set to ``0``.
 	 *
 	 * To avoid unexpected expiry, set this higher than ``session_lifetime``.


### PR DESCRIPTION
Fixes the documentation RST linter.

The `remember_login_cookie_lifetime` comment introduced in #58792 wrote `A value >``0``` with no space before the inline
literal. The documentation repo auto-generates `config_sample_php_parameters.rst` from `config.sample.php`, so the
malformed literal breaks sphinx-lint there:

```
config_sample_php_parameters.rst:712: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
config_sample_php_parameters.rst:712: missing space before default role: 'e >0'. (missing-space-before-default-role)
```

## Notes:
- Failing run: https://github.com/nextcloud/documentation/actions/runs/28579553982
- AI-assisted (ClaudeCode:claude-opus-4-8).