### PR TITLE
ci(e2e): raise timeouts in Cypress setup tests

### DIFF
--- a/cypress/e2e/core/setup.ts
+++ b/cypress/e2e/core/setup.ts
@@ -158,7 +158,7 @@ function sharedSetup(mode: RecommendedAppsMode = 'skip') {
 		.within(() => {
 			cy.findByRole('heading', { name: 'Recommended apps' })
 				.should('be.visible')
-			cy.findByRole('button', { name: 'Skip' })
+			cy.findByRole('button', { name: 'Skip', timeout: 10000 })
 				.should('be.visible')
 			cy.findByRole('button', { name: 'Install recommended apps' })
 				.should('be.visible')
@@ -184,7 +184,7 @@ function sharedSetup(mode: RecommendedAppsMode = 'skip') {
 
 	// The strict password-confirmation dialog must appear and must result in a
 	// Basic auth header on the enable request.
-	cy.findByRole('dialog', { name: 'Authentication required' })
+	cy.findByRole('dialog', { name: 'Authentication required', timeout: 10000 })
 		.should('be.visible')
 	handlePasswordConfirmation(randAdmin)
 	cy.wait('@enableApps')


### PR DESCRIPTION
Raise timeouts to avoid:

- `4000ms: Unable to find an accessible element with the role "button" and name "Skip"`
- `4000ms: Unable to find an accessible element with the role "dialog" and name "Authentication required"`

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
