### PR TITLE
test(files): stabilize CachePermissionsMask tests

### DIFF
--- a/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
@@ -13,30 +13,24 @@ use OC\Files\Cache\Wrapper\CachePermissionsMask;
 use OCP\Constants;
 use Test\Files\Cache\CacheTest;
 
-/**
- * Class CachePermissionsMask
- *
- *
- * @package Test\Files\Cache\Wrapper
- */
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class CachePermissionsMaskTest extends CacheTest {
-	/**
-	 * @var Cache $sourceCache
-	 */
-	protected $sourceCache;
+	protected Cache $sourceCache;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->sourceCache = $this->cache;
-		$this->cache = $this->getMaskedCached(Constants::PERMISSION_ALL);
+		$this->cache = $this->getMaskedCache(Constants::PERMISSION_ALL);
 	}
 
-	protected function getMaskedCached($mask) {
+	protected function getMaskedCache(int $mask): CachePermissionsMask {
 		return new CachePermissionsMask($this->sourceCache, $mask);
 	}
 
+	/**
+	 * @return list<array{0: int}>
+	 */
 	public static function maskProvider(): array {
 		return [
 			[Constants::PERMISSION_ALL],
@@ -46,90 +40,81 @@ class CachePermissionsMaskTest extends CacheTest {
 		];
 	}
 
-	/**
-	 * @param int $mask
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
-	public function testGetMasked($mask): void {
-		$cache = $this->getMaskedCached($mask);
+	public function testGetMasked(int $mask): void {
+		$cache = $this->getMaskedCache($mask);
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain', 'permissions' => Constants::PERMISSION_ALL];
 		$this->sourceCache->put('foo', $data);
 		$result = $cache->get('foo');
-		$this->assertEquals($mask, $result['permissions']);
+		$this->assertSame($mask, $result['permissions']);
 
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain', 'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_DELETE];
 		$this->sourceCache->put('bar', $data);
 		$result = $cache->get('bar');
-		$this->assertEquals($mask & ~Constants::PERMISSION_DELETE, $result['permissions']);
+		$this->assertSame($mask & ~Constants::PERMISSION_DELETE, $result['permissions']);
 	}
 
-	/**
-	 * @param int $mask
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
-	public function testGetFolderContentMasked($mask): void {
+	public function testGetFolderContentMasked(int $mask): void {
 		$this->storage->mkdir('foo');
 		$this->storage->file_put_contents('foo/bar', 'asd');
 		$this->storage->file_put_contents('foo/asd', 'bar');
 		$this->storage->getScanner()->scan('');
 
-		$cache = $this->getMaskedCached($mask);
+		$cache = $this->getMaskedCache($mask);
 		$files = $cache->getFolderContents('foo');
 		$this->assertCount(2, $files);
 
 		foreach ($files as $file) {
-			$this->assertEquals($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
+			$this->assertSame($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
 		}
 	}
 
-	/**
-	 * @param int $mask
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
-	public function testSearchMasked($mask): void {
+	public function testSearchMasked(int $mask): void {
 		$this->storage->mkdir('foo');
 		$this->storage->file_put_contents('foo/bar', 'asd');
 		$this->storage->file_put_contents('foo/foobar', 'bar');
 		$this->storage->getScanner()->scan('');
 
-		$cache = $this->getMaskedCached($mask);
+		$cache = $this->getMaskedCache($mask);
 		$files = $cache->search('%bar');
 		$this->assertCount(2, $files);
 
 		foreach ($files as $file) {
-			$this->assertEquals($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
+			$this->assertSame($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
 		}
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
-	public function testGetScannedFileMasked($mask): void {
+	public function testGetScannedFileMasked(int $mask): void {
 		$this->storage->mkdir('foo');
 		$this->storage->file_put_contents('foo/bar', 'asd');
 		$this->storage->getScanner()->scan('');
 
-		$cache = $this->getMaskedCached($mask);
+		$cache = $this->getMaskedCache($mask);
 		$file = $cache->get('foo/bar');
 
 		$this->assertNotFalse($file);
-		$this->assertEquals($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
+		$this->assertSame($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
-	public function testGetScannedFolderMasked($mask): void {
+	public function testGetScannedFolderMasked(int $mask): void {
 		$this->storage->mkdir('foo');
 		$this->storage->file_put_contents('foo/bar', 'asd');
 		$this->storage->getScanner()->scan('');
 
-		$cache = $this->getMaskedCached($mask);
+		$cache = $this->getMaskedCache($mask);
 		$folder = $cache->get('foo');
 
 		$this->assertNotFalse($folder);
-		$this->assertEquals($mask, $folder['permissions']);
+		$this->assertSame($mask, $folder['permissions']);
 	}
 
 	public function testGetSetsScanPermissionsFromOriginalPermissions(): void {
 		$mask = Constants::PERMISSION_READ;
-		$cache = $this->getMaskedCached($mask);
+		$cache = $this->getMaskedCache($mask);
 
 		$data = [
 			'size' => 100,
@@ -141,13 +126,13 @@ class CachePermissionsMaskTest extends CacheTest {
 
 		$result = $cache->get('foo');
 
-		$this->assertEquals(Constants::PERMISSION_ALL, $result['scan_permissions']);
-		$this->assertEquals(Constants::PERMISSION_ALL & $mask, $result['permissions']);
+		$this->assertSame(Constants::PERMISSION_ALL, $result['scan_permissions']);
+		$this->assertSame(Constants::PERMISSION_ALL & $mask, $result['permissions']);
 	}
 
 	public function testGetDoesNotOverwriteExistingScanPermissions(): void {
 		$mask = Constants::PERMISSION_READ;
-		$cache = $this->getMaskedCached($mask);
+		$cache = $this->getMaskedCache($mask);
 
 		$data = [
 			'size' => 100,
@@ -160,7 +145,7 @@ class CachePermissionsMaskTest extends CacheTest {
 
 		$result = $cache->get('foo');
 
-		$this->assertEquals(Constants::PERMISSION_READ, $result['scan_permissions']);
-		$this->assertEquals(Constants::PERMISSION_ALL & $mask, $result['permissions']);
+		$this->assertSame(Constants::PERMISSION_READ, $result['scan_permissions']);
+		$this->assertSame(Constants::PERMISSION_ALL & $mask, $result['permissions']);
 	}
 }

--- a/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
@@ -100,4 +100,67 @@ class CachePermissionsMaskTest extends CacheTest {
 			$this->assertEquals($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
 		}
 	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
+	public function testGetScannedFileMasked($mask): void {
+		$this->storage->mkdir('foo');
+		$this->storage->file_put_contents('foo/bar', 'asd');
+		$this->storage->getScanner()->scan('');
+
+		$cache = $this->getMaskedCached($mask);
+		$file = $cache->get('foo/bar');
+
+		$this->assertNotFalse($file);
+		$this->assertEquals($mask & ~Constants::PERMISSION_CREATE, $file['permissions']);
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
+	public function testGetScannedFolderMasked($mask): void {
+		$this->storage->mkdir('foo');
+		$this->storage->file_put_contents('foo/bar', 'asd');
+		$this->storage->getScanner()->scan('');
+
+		$cache = $this->getMaskedCached($mask);
+		$folder = $cache->get('foo');
+
+		$this->assertNotFalse($folder);
+		$this->assertEquals($mask, $folder['permissions']);
+	}
+
+	public function testGetSetsScanPermissionsFromOriginalPermissions(): void {
+		$mask = Constants::PERMISSION_READ;
+		$cache = $this->getMaskedCached($mask);
+
+		$data = [
+			'size' => 100,
+			'mtime' => 50,
+			'mimetype' => 'text/plain',
+			'permissions' => Constants::PERMISSION_ALL,
+		];
+		$this->sourceCache->put('foo', $data);
+
+		$result = $cache->get('foo');
+
+		$this->assertEquals(Constants::PERMISSION_ALL, $result['scan_permissions']);
+		$this->assertEquals(Constants::PERMISSION_ALL & $mask, $result['permissions']);
+	}
+
+	public function testGetDoesNotOverwriteExistingScanPermissions(): void {
+		$mask = Constants::PERMISSION_READ;
+		$cache = $this->getMaskedCached($mask);
+
+		$data = [
+			'size' => 100,
+			'mtime' => 50,
+			'mimetype' => 'text/plain',
+			'permissions' => Constants::PERMISSION_ALL,
+			'scan_permissions' => Constants::PERMISSION_READ,
+		];
+		$this->sourceCache->put('foo', $data);
+
+		$result = $cache->get('foo');
+
+		$this->assertEquals(Constants::PERMISSION_READ, $result['scan_permissions']);
+		$this->assertEquals(Constants::PERMISSION_ALL & $mask, $result['permissions']);
+	}
 }

--- a/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
@@ -29,7 +29,6 @@ class CachePermissionsMaskTest extends CacheTest {
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
-		$this->storage->mkdir('foo');
 		$this->sourceCache = $this->cache;
 		$this->cache = $this->getMaskedCached(Constants::PERMISSION_ALL);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: (transient test/CI failures) # <!-- related github issue -->

## Summary

Remove the pre-created `foo` folder from `CachePermissionsMaskTest::setUp()` so inherited `CacheTest` cases still start with the default cache contents.

The test class intentionally changes the cache wrapper in `setUp()`, but storage fixtures should be (and already are) created in the individual tests that need them.

Also tighten permission masking coverage by:
- adding explicit coverage for direct `get()` on scanned file and folder entries
- verifying `scan_permissions` is populated from original permissions
- verifying existing `scan_permissions` values are not overwritten

This fixes a transient failure in inherited cache tests[^1] while keeping the wrapper-specific behavior covered and closing coverage gaps.

The final commit only cleans up and modernizes the test class.

[^1]: Example CI failure: https://github.com/nextcloud/server/actions/runs/28551681637/job/84737184657?pr=61707

## TODO

- [ ] Backport to at least v34

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
