### PR TITLE
docs(ratelimit): add missing @param documentation

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php
@@ -131,6 +131,7 @@ class RateLimitingMiddleware extends Middleware {
 	 * @param string $methodName
 	 * @param string $annotationName
 	 * @param class-string<T> $attributeClass
+	 * @param string $overwriteKey
 	 * @return ?ARateLimit
 	 */
 	protected function readLimitFromAnnotationOrAttribute(Controller $controller, string $methodName, string $annotationName, string $attributeClass, string $overwriteKey): ?ARateLimit {


### PR DESCRIPTION
## Summary

This PR adds missing `@param` documentation for the `$overwriteKey` parameter in the `readLimitFromAnnotationOrAttribute` method of `RateLimitingMiddleware`. The parameter was present in the method signature but was not documented in the PHPDoc comment block.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests are not required (documentation-only change)
- [x] Screenshots not applicable (backend documentation change)
- [x] Documentation not required (inline PHPDoc improvement)
- [x] Backports not required (minor documentation improvement)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] Milestone to be set by maintainers

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

**AI Tool Disclosure:** 