### PR TITLE
perf(dav): Optimize system tag permission checks for multi-mount file IDs

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -530,27 +530,40 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 	}
 
 	/**
-	 * Check if the user can update the tag for the given file ids
+	 * Check if the current user can update the tag assignment for all given file IDs.
+	 *
+	 * A file ID is considered updateable if the user can access at least one visible
+	 * occurrence of that file with {@see Constants::PERMISSION_UPDATE}. All file IDs
+	 * in the input list must satisfy that condition.
 	 *
 	 * @param list<string> $fileIds
-	 * @return bool
 	 */
 	private function canUpdateTagForFileIds(array $fileIds): bool {
 		$user = $this->userSession->getUser();
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 
+		// getFirstNodeById() is a cheap fast path, but it may return a read-only
+		// occurrence even when another visible occurrence of the same file ID is
+		// updateable. Fall back to getById() to preserve correct permission handling.
 		foreach ($fileIds as $fileId) {
 			try {
+				$node = $userFolder->getFirstNodeById((int)$fileId);
+				if ($node !== null && ($node->getPermissions() & Constants::PERMISSION_UPDATE) === Constants::PERMISSION_UPDATE) {
+					continue;
+				}
+				
 				$nodes = $userFolder->getById((int)$fileId);
 				if (empty($nodes)) {
 					return false;
 				}
 
 				foreach ($nodes as $node) {
-					if (($node->getPermissions() & Constants::PERMISSION_UPDATE) !== Constants::PERMISSION_UPDATE) {
-						return false;
+					if (($node->getPermissions() & Constants::PERMISSION_UPDATE) === Constants::PERMISSION_UPDATE) {
+						continue 2;
 					}
 				}
+
+				return false;
 			} catch (\Exception $e) {
 				return false;
 			}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Optimize `SystemTagPlugin::canUpdateTagForFileIds()` by using `getFirstNodeById()` as a fast path and falling back to `getById()` only when needed.

A file ID can be visible through multiple mounts or shares with different effective permissions. This change keeps the existing batch behavior that all requested file IDs must be authorized, while treating a file ID as updateable when at least one visible occurrence has `PERMISSION_UPDATE`.

- Aligns the permission check with similar logic in related DAV/system tag code
- Preserves correctness for multi-mount / multi-share edge cases
- Reduces work in the common case

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
