### PR TITLE
perf(share): stop over-fetching grouped shared-with results

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -957,6 +957,9 @@ class DefaultShareProvider implements
 		} elseif ($shareType === IShare::TYPE_GROUP) {
 			$user = new LazyUser($userId, $this->userManager);
 			$allGroups = $this->groupManager->getUserGroupIds($user);
+			if ($allGroups === []) {
+				return [];
+			}
 
 			/** @var Share[] $shares2 */
 			$shares2 = [];
@@ -987,7 +990,11 @@ class DefaultShareProvider implements
 				}
 
 				if ($limit !== -1) {
-					$qb->setMaxResults($limit - count($shares));
+					$remaining = $limit + $offset - count($shares2);
+					if ($remaining <= 0) {
+						break;
+					}
+					$qb->setMaxResults($remaining);
 				}
 
 				// Filter by node if provided
@@ -1046,6 +1053,10 @@ class DefaultShareProvider implements
 					if ($this->isAccessibleResult($data)) {
 						$share = $this->createShare($data);
 						$shares2[$share->getId()] = $share;
+						if ($limit !== -1 && count($shares2) >= $limit + $offset) {
+							$cursor->closeCursor();
+							break 2;
+						}
 					}
 				}
 				$cursor->closeCursor();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->
* Helps with: #59779

## Summary

Fix the group branch so it uses the accumulated  grouped-share count and stop scanning once `offset + limit` unique shares are collected.

The previous logic used `count($shares)`, which stays empty until after group share resolution, so each chunk could query up to the full limit. This caused unnecessary DB work for users in many groups.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
