### PR TITLE
perf(share): Collapse filtering and formatting into a single loop in getSharedWithMe()

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -858,20 +858,18 @@ class ShareAPIController extends OCSController {
 		$roomShares = $this->shareManager->getSharedWith($this->userId, IShare::TYPE_ROOM, $node, -1, 0);
 		$deckShares = $this->shareManager->getSharedWith($this->userId, IShare::TYPE_DECK, $node, -1, 0);
 
-		$shares = array_merge($userShares, $groupShares, $circleShares, $roomShares, $deckShares);
-
-		$filteredShares = array_filter($shares, function (IShare $share) {
-			return $share->getShareOwner() !== $this->userId && $share->getSharedBy() !== $this->userId;
-		});
-
 		$formatted = [];
-		foreach ($filteredShares as $share) {
-			if ($this->canAccessShare($share)) {
-				try {
-					$formatted[] = $this->formatShare($share);
-				} catch (NotFoundException $e) {
-					// Ignore this share
-				}
+		foreach (array_merge($userShares, $groupShares, $circleShares, $roomShares, $deckShares) as $share) {
+			if ($share->getShareOwner() === $this->userId || $share->getSharedBy() === $this->userId) {
+				continue;
+			}
+			if (!$this->canAccessShare($share)) {
+				continue;
+			}
+			try {
+				$formatted[] = $this->formatShare($share);
+			} catch (NotFoundException $e) {
+				// Ignore this share
 			}
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fuse merge/filter/format into one pass. 

Instead of:

- merge all arrays
- filter to $filteredShares
- loop again

do one pass over all shares.

Cheap win in terms of CPU/memory usage.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
