### PR TITLE
ci(dependabot): restore build/frontend dirs for stable33 npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -163,7 +163,10 @@ updates:
 # frontend dependencies
 - package-ecosystem: npm
   target-branch: stable33
-  directory: "/"
+  directories:
+    - "/"
+    - "/build/frontend"
+    - "/build/frontend-legacy"
   schedule:
     interval: weekly
     day: saturday


### PR DESCRIPTION
## Summary

When the config was updated for stable34 (4c697c78), the stable33 npm entry was rewritten from the older-stable template and lost the `/build/frontend` and `/build/frontend-legacy` directories — both of which still exist on `stable33`.

Because the config entry that created them no longer exists, Dependabot refuses to rebase or recreate its open PRs in those directories:

> The dependabot.yml entry that created this PR has been deleted so this PR can't be recreated. Please close the PR so Dependabot can create a new one with the current dependabot.yml.

(see #60050, which is stuck in a merge conflict for this reason)

This restores the two directories for the stable33 npm entry, matching the stable34 entry. `stable32` predates the frontend build split, so it is intentionally left untouched.

## Follow-up after merge

- Close #60050 and delete its branch
- Trigger a check via *Insights → Dependency graph → Dependabot → Recent update jobs → Check for updates* on the npm/stable33 entry (or wait for the Saturday schedule) — Dependabot will then open a fresh, conflict-free PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)