### PR TITLE
[stable32] fix(files_sharing): reject custom share tokens longer than the db column

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -76,6 +76,9 @@ use Psr\Log\LoggerInterface;
  */
 class ShareAPIController extends OCSController {
 
+	/** Maximum length of a custom share token, matching the oc_share.token database column. */
+	private const TOKEN_MAX_LENGTH = 32;
+
 	private ?Node $lockedNode = null;
 	/** @var array<bool> $trustedServerCache */
 	private array $trustedServerCache = [];
@@ -1385,7 +1388,7 @@ class ShareAPIController extends OCSController {
 					throw new OCSForbiddenException($this->l->t('Custom share link tokens have been disabled by the administrator'));
 				}
 				if (!$this->validateToken($token)) {
-					throw new OCSBadRequestException($this->l->t('Tokens must contain at least 1 character and may only contain letters, numbers, or a hyphen'));
+					throw new OCSBadRequestException($this->l->t('Tokens must be between 1 and %s characters long and may only contain letters, numbers, or a hyphen', [self::TOKEN_MAX_LENGTH]));
 				}
 				$share->setToken($token);
 			}
@@ -1424,7 +1427,7 @@ class ShareAPIController extends OCSController {
 	}
 
 	private function validateToken(string $token): bool {
-		if (mb_strlen($token) === 0) {
+		if (mb_strlen($token) === 0 || mb_strlen($token) > self::TOKEN_MAX_LENGTH) {
 			return false;
 		}
 		if (!preg_match('/^[a-z0-9-]+$/i', $token)) {

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1427,7 +1427,8 @@ class ShareAPIController extends OCSController {
 	}
 
 	private function validateToken(string $token): bool {
-		if (mb_strlen($token) === 0 || mb_strlen($token) > self::TOKEN_MAX_LENGTH) {
+		$length = mb_strlen($token);
+		if ($length === 0 || $length > self::TOKEN_MAX_LENGTH) {
 			return false;
 		}
 		if (!preg_match('/^[a-z0-9-]+$/i', $token)) {

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -5602,6 +5602,7 @@ class ShareAPIControllerTest extends TestCase {
 			'letters numbers and hyphen' => ['abc-123', true],
 			'invalid character' => ['abc_123', false],
 			'32 characters (oc_share.token column limit)' => [str_repeat('a', 32), true],
+			'32 non-ascii characters' => [str_repeat('é', 32), false],
 			'33 characters (exceeds oc_share.token column limit)' => [str_repeat('a', 33), false],
 		];
 	}

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -5594,4 +5594,20 @@ class ShareAPIControllerTest extends TestCase {
 
 		$this->invokePrivate($ocs, 'checkInheritedAttributes', [$share]);
 	}
+
+	public static function dataValidateToken(): array {
+		return [
+			'empty token' => ['', false],
+			'single character' => ['a', true],
+			'letters numbers and hyphen' => ['abc-123', true],
+			'invalid character' => ['abc_123', false],
+			'32 characters (oc_share.token column limit)' => [str_repeat('a', 32), true],
+			'33 characters (exceeds oc_share.token column limit)' => [str_repeat('a', 33), false],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateToken')]
+	public function testValidateToken(string $token, bool $expected): void {
+		$this->assertSame($expected, $this->invokePrivate($this->ocs, 'validateToken', [$token]));
+	}
 }


### PR DESCRIPTION
Backport of #61630 to stable32 (fixes #61416 there).

stable32 still ships the custom share link token feature but not the length validation: `validateToken()` only checks for an empty string and the character set, so a token longer than 32 characters passes validation and then fails at the database layer (`oc_share.token` is varchar(32)) with the generic *"Failed to update share."* instead of a clear validation message.

The fix is already merged to master (#61630) and stable34 (#61676); the stable33 backport is pending in #61675. stable32 was never requested, so this closes the gap for the remaining supported branch.

Both original commits are cherry-picked with authorship and sign-offs preserved (`-x` annotations included). One adaptation was needed: the test uses the fully qualified `#[\PHPUnit\Framework\Attributes\DataProvider]` attribute, matching the conventions in stable32's `ShareAPIControllerTest.php` (the bare `DataProvider` import and the surrounding `mockTalkController` helper from master do not exist on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
