### PR TITLE
fix(jobs): resolve portability issues with background job cleanup

### DIFF
--- a/core/BackgroundJobs/CleanupBackgroundJobsJob.php
+++ b/core/BackgroundJobs/CleanupBackgroundJobsJob.php
@@ -47,11 +47,9 @@ class CleanupBackgroundJobsJob extends TimedJob {
 			if ($job->serverId !== $currentServerId) {
 				continue;
 			}
-			$output = [];
-			$result = 0;
-			exec('ps -p ' . escapeshellarg((string)$job->pid) . ' -o cmd', $output, $result);
-			if (count($output) === 1 && current($output) === 'CMD' && $result === 1) {
-				// Process doesn't exists anymore
+			$processExists = posix_kill($job->pid, 0) || posix_get_last_error() === 1 /* EPERM */;
+			if (!$processExists) {
+				// Process doesn't exist anymore
 				$maxDuration = (new DateTimeImmutable())->diff($job->startedAt);
 				$maxDuration
 					= ($maxDuration->days * 24 * 60 * 60 * 1000)

--- a/lib/private/BackgroundJob/JobRuns.php
+++ b/lib/private/BackgroundJob/JobRuns.php
@@ -64,7 +64,6 @@ final readonly class JobRuns implements IJobRuns {
 
 	public function deleteBefore(int $timestamp): int {
 		$beforeSnowflake = $this->snowflakeGenerator->minForTimeId($timestamp);
-		$beforeSnowflake = '91480652934574081';
 		$qb = $this->connection->getQueryBuilder();
 		$result = $qb
 			->delete(self::TABLE)


### PR DESCRIPTION
* Resolves: #61635

## Summary

This PR resolves two issues with background job cleanup introduced recently:

### Portability of cleanup on Alpine, BSD and macOS

The previous implementation executes "ps" with flags -p and -o to check whether a job process was still running. This approach has portability issues regarding e.g.
* BusyBox ps (Alpine Linux) where `ps -p` fails
```
ps: unrecognized option: p
BusyBox v1.37.0 (2026-01-10 15:38:28 UTC) multi-call binary.

Usage: ps [-o COL1,COL2=HEADER] [-T]

Show list of processes

	-o COL1,COL2=HEADER	Select columns for display
	-T			Show threads
```
(this affects the official "fpm-alpine" Docker image)
* BSD/macOS where `ps -o` fails
```
ps: cmd: keyword not found
ps: no valid keywords; valid keywords:
```

Replace with `posix_kill($pid, 0)`, the standard POSIX way to probe process existence without delivering a signal. `EPERM` is treated as "process exists but not owned by current user". This should be available on all supported platforms.

### Hardcoded snowflake ID prevents `background_jobs_expiration_days`

Snowflake ID in `JobRuns:deleteBefore()` is computed from given timestamp, but immediately overwritten by a literal value making the expiration setting have no effect.

This looks like a leftover artifact from development that should be cleaned up. Remove the hardcoded ID to restore the desired behavior.

Both fixes suggested by @mmdevl in the linked issue.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
