### PR TITLE
perf: Don't fetch full group object in AuthorizedGroupMapper

### DIFF
--- a/lib/private/Settings/AuthorizedGroupMapper.php
+++ b/lib/private/Settings/AuthorizedGroupMapper.php
@@ -15,7 +15,6 @@ use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
-use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Server;
@@ -36,15 +35,15 @@ class AuthorizedGroupMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 
 		$groupManager = Server::get(IGroupManager::class);
-		$groups = $groupManager->getUserGroups($user);
-		if (count($groups) === 0) {
+		$groupIds = $groupManager->getUserGroupIds($user);
+		if (count($groupIds) === 0) {
 			return [];
 		}
 
 		/** @var list<string> $rows */
 		$rows = $qb->select('class')
 			->from($this->getTableName(), 'auth')
-			->where($qb->expr()->in('group_id', array_map(static fn (IGroup $group) => $qb->createNamedParameter($group->getGID()), $groups), IQueryBuilder::PARAM_STR))
+			->where($qb->expr()->in('group_id', $qb->createNamedParameter($groupIds, IQueryBuilder::PARAM_STR_ARRAY)))
 			->executeQuery()
 			->fetchFirstColumn();
 


### PR DESCRIPTION
## Summary

This is very expensive when multiple group backends are enabled as we don't cache which groups is included in which backend unlike in the User Manager.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
