### PR TITLE
[stable33] test(settings): fix E2E selector for out of office replacement element

### DIFF
--- a/cypress/e2e/dav/availability.cy.ts
+++ b/cypress/e2e/dav/availability.cy.ts
@@ -94,7 +94,7 @@ describe('Calendar: Availability', { testIsolation: true }, () => {
 			.type('Happy holidays!')
 
 		cy.intercept('GET', '**/ocs/v2.php/apps/files_sharing/api/v1/sharees?*search=replacement*').as('userSearch')
-		cy.findByRole('searchbox')
+		cy.findByLabelText(/Out of office replacement/)
 			.should('be.visible')
 			.as('userSearchBox')
 			.click()
@@ -122,7 +122,8 @@ describe('Calendar: Availability', { testIsolation: true }, () => {
 			.should('have.value', 'Vacation')
 		cy.findByRole('textbox', { name: /Long absence/ })
 			.should('have.value', 'Happy holidays!')
-		cy.findByRole('combobox')
+		cy.findByLabelText(/Out of office replacement/)
+			.closest('.v-select')
 			.should('contain.text', 'replacement-user')
 	})
 })


### PR DESCRIPTION
Fixes failing test "dav/availability.cy.ts".
e.g., https://github.com/nextcloud/server/actions/runs/28765709876/job/85289776301?pr=61711

## Summary

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes (**not applicable**)
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is **not required**
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) **not required**
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
