### PR TITLE
fix(Sharing): Don't break cache entry by setting path to null

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -135,7 +135,11 @@ class Cache extends CacheJail {
 	protected function formatCacheEntry($entry, $path = null) {
 		if (is_null($path)) {
 			$path = $entry['path'] ?? '';
-			$entry['path'] = $this->getJailedPath($path);
+			$jailedPath = $this->getJailedPath($path);
+			if ($jailedPath === null) {
+				return false;
+			}
+			$entry['path'] = $jailedPath;
 		} else {
 			$entry['path'] = $path;
 		}


### PR DESCRIPTION
see #58676

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
