### PR TITLE
fix(DeclarativeManager): Fix admin delegation

### DIFF
--- a/lib/private/Settings/DeclarativeManager.php
+++ b/lib/private/Settings/DeclarativeManager.php
@@ -147,8 +147,10 @@ class DeclarativeManager implements IDeclarativeManager {
 				if ($section !== null && $schema['section_id'] !== $section) {
 					continue;
 				}
-				// If listing all fields skip the admin fields which a non-admin user has no access to
-				if ($type === null && $schema['section_type'] === 'admin' && !$isAdmin) {
+				// Skip admin declarative forms for non-admin users. They have no access to
+				// these fields even when they are allowed to view the section through admin
+				// delegation, which only covers non-declarative settings.
+				if ($schema['section_type'] === DeclarativeSettingsTypes::SECTION_TYPE_ADMIN && !$isAdmin) {
 					continue;
 				}
 

--- a/tests/lib/Settings/DeclarativeManagerTest.php
+++ b/tests/lib/Settings/DeclarativeManagerTest.php
@@ -556,8 +556,15 @@ class DeclarativeManagerTest extends TestCase {
 		$schema = self::validSchemaAllFields;
 		$this->declarativeManager->registerSchema($app, $schema);
 
+		// A non-admin user must not receive admin declarative forms, but this must not
+		// throw: it would abort rendering of a section a user can legitimately access
+		// through admin delegation (which only covers non-declarative settings).
+		$forms = $this->declarativeManager->getFormsWithValues($this->user, $schema['section_type'], $schema['section_id']);
+		$this->assertEmpty($forms);
+
+		// Writing to an admin declarative form is still forbidden for a non-admin user.
 		$this->expectException(\Exception::class);
-		$this->declarativeManager->getFormsWithValues($this->user, $schema['section_type'], $schema['section_id']);
+		$this->declarativeManager->setValue($this->user, $app, $schema['id'], 'some_real_setting', '120m');
 	}
 
 	/**


### PR DESCRIPTION
## The bug
- As admin, go to Settings → Admin Delegation
- Assign a group the following delegated sections: Basic Settings → Background Jobs and Basic Settings → Email Server
- Log in as a non-admin user who is a member of that group
- The navigation item "Basic Settings" appears in the admin menu

#### Expected behavior:
- The user can access the delegated admin sections.

#### Actual behavior:
- Navigating to /settings/admin returns "Access Denied". The navigation entry is rendered but the route does not grant access based on delegation permissions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
