### PR TITLE
perf(files_sharing): simplify tag population in ShareAPIController

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -2227,29 +2227,30 @@ class ShareAPIController extends OCSController {
 	 * @return list<T> file list populated with tags
 	 */
 	private function populateTags(array $fileList): array {
+		if ($fileList === []) {
+			return [];
+		}
+
 		$tagger = $this->tagManager->load('files');
-		$tags = $tagger->getTagsForObjects(array_map(static fn (array $fileData) => $fileData['file_source'], $fileList));
+		$tags = $tagger->getTagsForObjects(array_map(
+			static fn (array $fileData) => $fileData['file_source'],
+			$fileList
+		));
 
 		if (!is_array($tags)) {
 			throw new \UnexpectedValueException('$tags must be an array');
 		}
 
-		// Set empty tag array
-		foreach ($fileList as &$fileData) {
-			$fileData['tags'] = [];
+		$index = [];
+		foreach ($fileList as $i => $fileData) {
+			$fileList[$i]['tags'] = [];
+			// Multiple share rows can point to the same file_source, so store all positions.
+			$index[$fileData['file_source']][] = $i;
 		}
-		unset($fileData);
 
-		if (!empty($tags)) {
-			foreach ($tags as $fileId => $fileTags) {
-				foreach ($fileList as &$fileData) {
-					if ($fileId !== $fileData['file_source']) {
-						continue;
-					}
-
-					$fileData['tags'] = $fileTags;
-				}
-				unset($fileData);
+		foreach ($tags as $fileSource => $fileTags) {
+			foreach ($index[$fileSource] ?? [] as $i) {
+				$fileList[$i]['tags'] = $fileTags;
 			}
 		}
 

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -2224,7 +2224,7 @@ class ShareAPIController extends OCSController {
 	 *
 	 * @psalm-template T of array{tags?: list<string>, file_source: int, ...array<string, mixed>}
 	 * @param list<T> $fileList
-	 * @return list<T> file list populated with tags
+	 * @return list<T&array{tags: list<string>}> file list populated with tags
 	 */
 	private function populateTags(array $fileList): array {
 		if ($fileList === []) {

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -5257,6 +5257,31 @@ class ShareAPIControllerTest extends TestCase {
 		], $result);
 	}
 
+	public function testPopulateTagsWithDuplicateFileSource(): void {
+		$tagger = $this->createMock(ITags::class);
+		$this->tagManager->method('load')
+			->with('files')
+			->willReturn($tagger);
+		$data = [
+			['file_source' => 42, 'foo' => 'bar'],
+			['file_source' => 10],
+			['file_source' => 42, 'x' => 'y'],
+		];
+		$tags = [
+			42 => ['tag1', 'tag2'],
+		];
+		$tagger->method('getTagsForObjects')
+			->with([42, 10, 42])
+			->willReturn($tags);
+
+		$result = self::invokePrivate($this->ocs, 'populateTags', [$data]);
+		$this->assertSame([
+			['file_source' => 42, 'foo' => 'bar', 'tags' => ['tag1', 'tag2']],
+			['file_source' => 10, 'tags' => []],
+			['file_source' => 42, 'x' => 'y', 'tags' => ['tag1', 'tag2']],
+		], $result);
+	}
+
 	public static function trustedServerProvider(): array {
 		return [
 			'Trusted server' => [true, true],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->
* May help with: #59779

## Summary

Build an index in `ShareAPIController::populateTags()` instead of scanning the full result list for each tagged file.

## Notes

Multiple formatted share entries can refer to the same `file_source`, so the index keeps all matching positions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
