### PR TITLE
perf(tags): reduce repeated query setup in hot loops

### DIFF
--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -402,6 +402,8 @@ class Tags implements ITags {
 				'type' => $qb->createParameter('type'),
 			]);
 
+		$qb->setParameter('type', $this->type, IQueryBuilder::PARAM_STR);
+
 		// Loop through temporarily cached objectid/tagname pairs
 		// and save relations.
 		foreach ($this->relations as $relation) {
@@ -410,7 +412,6 @@ class Tags implements ITags {
 			if ($tagId) {
 				$qb->setParameter('objid', $relation['objid'], IQueryBuilder::PARAM_INT);
 				$qb->setParameter('categoryid', $tagId, IQueryBuilder::PARAM_INT);
-				$qb->setParameter('type', $this->type, IQueryBuilder::PARAM_STR);
 
 				try {
 					$qb->executeStatement();

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -159,16 +159,16 @@ class Tags implements ITags {
 				->where($qb->expr()->eq('uid', $qb->createParameter('uid')))
 				->andWhere($qb->expr()->eq('r.type', $qb->createParameter('type')))
 				->andWhere($qb->expr()->in('objid', $qb->createParameter('chunk')));
+
+			$qb->setParameter('uid', $this->user, IQueryBuilder::PARAM_STR);
+			$qb->setParameter('type', $this->type, IQueryBuilder::PARAM_STR);
+
 			foreach ($chunks as $chunk) {
-				$qb->setParameter('uid', $this->user, IQueryBuilder::PARAM_STR);
-				$qb->setParameter('type', $this->type, IQueryBuilder::PARAM_STR);
 				$qb->setParameter('chunk', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 				$result = $qb->executeQuery();
 				while ($row = $result->fetch()) {
 					$objId = (int)$row['objid'];
-					if (!isset($entries[$objId])) {
-						$entries[$objId] = [];
-					}
+					$entries[$objId] ??= [];
 					$entries[$objId][] = $row['category'];
 				}
 				$result->closeCursor();
@@ -393,19 +393,25 @@ class Tags implements ITags {
 		// reload tags to get the proper ids.
 		$this->tags = $this->mapper->loadTags($this->owners, $this->type);
 		$this->logger->debug(__METHOD__ . 'tags' . print_r($this->tags, true), ['app' => 'core']);
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->insert(self::RELATION_TABLE)
+			->values([
+				'objid' => $qb->createParameter('objid'),
+				'categoryid' => $qb->createParameter('categoryid'),
+				'type' => $qb->createParameter('type'),
+			]);
+
 		// Loop through temporarily cached objectid/tagname pairs
 		// and save relations.
 		foreach ($this->relations as $relation) {
 			$tagId = $this->getTagId($relation['tag']);
 			$this->logger->debug(__METHOD__ . 'catid ' . $relation['tag'] . ' ' . $tagId, ['app' => 'core']);
 			if ($tagId) {
-				$qb = $this->db->getQueryBuilder();
-				$qb->insert(self::RELATION_TABLE)
-					->values([
-						'objid' => $qb->createNamedParameter($relation['objid'], IQueryBuilder::PARAM_INT),
-						'categoryid' => $qb->createNamedParameter($tagId, IQueryBuilder::PARAM_INT),
-						'type' => $qb->createNamedParameter($this->type),
-					]);
+				$qb->setParameter('objid', $relation['objid'], IQueryBuilder::PARAM_INT);
+				$qb->setParameter('categoryid', $tagId, IQueryBuilder::PARAM_INT);
+				$qb->setParameter('type', $this->type, IQueryBuilder::PARAM_STR);
+
 				try {
 					$qb->executeStatement();
 				} catch (Exception $e) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Reduce a bit of repeated query setup and parameter binding in `OC\Tags`.

- bind the invariant `uid` and `type` parameters once in `getTagsForObjects()`; loop only updates the chunk parameter
- reuse a single relation-insert query builder in `save()`
- bind the invariant relation `type` parameter once in `save()`; the loop only updates `objid` and `categoryid`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
