### PR TITLE
fix(dav): release part-file lock when an upload fails

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -125,11 +125,16 @@ class Directory extends Node implements
 			$node->acquireLock(ILockingProvider::LOCK_SHARED);
 			$this->fileView->lockFile($this->path . '/' . $name . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
 
-			$result = $node->put($data);
-
-			$this->fileView->unlockFile($this->path . '/' . $name . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
-			$node->releaseLock(ILockingProvider::LOCK_SHARED);
-			return $result;
+			try {
+				return $node->put($data);
+			} finally {
+				// Always release the locks, even when the upload failed or was
+				// interrupted. Otherwise a failed attempt leaves the exclusive
+				// part-file lock behind and every later upload to the same path
+				// keeps getting rejected with 423 until the lock TTL expires.
+				$this->fileView->unlockFile($this->path . '/' . $name . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
+				$node->releaseLock(ILockingProvider::LOCK_SHARED);
+			}
 		} catch (StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage(), $e->getCode(), $e);
 		} catch (InvalidPathException $ex) {

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -25,6 +25,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Lock\ILockingProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\NotFound;
 use Test\Traits\UserTrait;
@@ -171,6 +172,47 @@ class DirectoryTest extends \Test\TestCase {
 
 		$dir = $this->getDir('sub');
 		$dir->delete();
+	}
+
+	/**
+	 * A failed or interrupted upload must not leave the exclusive part-file
+	 * lock behind. Otherwise every later upload to the same path keeps getting
+	 * rejected with "423 Locked" until the lock TTL expires (up to an hour),
+	 * createFile() therefore releases the locks in a finally block.
+	 */
+	public function testCreateFileReleasesPartFileLockOnFailure(): void {
+		$name = 'foo.txt';
+
+		$this->view->method('getRelativePath')->willReturnArgument(0);
+		$this->view->method('getAbsolutePath')->willReturnArgument(0);
+		$this->view->method('isCreatable')->willReturn(true);
+		// the target does not exist yet
+		$this->view->method('getFileInfo')->willReturn(false);
+		// make File::put() fail right after the locks have been acquired
+		$this->view->method('resolvePath')->willReturn([null, null]);
+
+		$released = [];
+		$this->view->method('unlockFile')
+			->willReturnCallback(function (string $path, int $type) use (&$released): bool {
+				$released[] = [$path, $type];
+				return true;
+			});
+
+		$dir = new Directory($this->view, $this->info);
+		$partLockPath = $dir->getPath() . '/' . $name . '.upload.part';
+
+		try {
+			$dir->createFile($name, 'test data');
+			$this->fail('Expected the failing upload to throw');
+		} catch (\Sabre\DAV\Exception\ServiceUnavailable) {
+			// expected: File::put() cannot resolve the storage
+		}
+
+		$this->assertContains(
+			[$partLockPath, ILockingProvider::LOCK_EXCLUSIVE],
+			$released,
+			'The exclusive .upload.part lock must be released after a failed upload',
+		);
 	}
 
 	public function testGetChildren(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`Directory::createFile()` takes a shared lock on the target file and an **exclusive** lock on the `<name>.upload.part` path before calling `File::put()`, but only released them on the success path. If the upload throws or is interrupted, both locks are left behind.

A leftover exclusive part-file lock causes every later upload to the same path to fail with `423 Locked`. Because it persists until the request-scoped cleanup runs, or up to the lock TTL (default 1h) if the PHP worker is killed mid-request, one failed upload can block that file for a long time. The web uploader retries `423`, so it just keeps hitting the same lock.

This wraps `put()` in `try/finally` so the locks are always released.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
