### PR TITLE
feat(occ): Cache command list to speed up occ

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -19,6 +19,7 @@ use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\ITempManager;
 use OCP\Server;
 use OCP\ServerVersion;
 use OCP\Util;
@@ -42,6 +43,7 @@ class Application {
 		private MemoryInfo $memoryInfo,
 		private IAppManager $appManager,
 		private Defaults $defaults,
+		private ITempManager $tempManager,
 	) {
 		$this->application = new SymfonyApplication($defaults->getName(), $serverVersion->getVersionString());
 	}
@@ -79,6 +81,16 @@ class Application {
 				'<comment>The current PHP memory limit '
 				. 'is below the recommended value of 512MB.</comment>'
 			);
+		}
+
+		$cacheFilePath = $this->tempManager->getTempBaseDir() . '/nextcloud_commands.json';
+		if (file_exists($cacheFilePath)) {
+			$commandsCache = json_decode(file_get_contents($cacheFilePath), associative:true);
+			$firstArg = $input->getFirstArgument();
+			if (isset($commandsCache[$firstArg])) {
+				$this->application->add(Server::get($commandsCache[$firstArg]));
+				return;
+			}
 		}
 
 		try {
@@ -161,6 +173,19 @@ class Application {
 				throw new \Exception('Environment not properly prepared.');
 			}
 		}
+		$commands = $this->application->all();
+		$cache = [];
+		foreach ($commands as $command) {
+			$name = $command->getName();
+			if ($name !== null) {
+				$cache[$name] = $command::class;
+			}
+
+			foreach ($command->getAliases() as $alias) {
+				$cache[$alias] = $command::class;
+			}
+		}
+		file_put_contents($cacheFilePath, json_encode($cache));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This is a rough draft to track the idea and challenges.

## TODO

- [ ] Only enable cache if instance is installed, maintenance is off and no upgrade required
- [ ] Cache in a PHP file for best performance
- [ ] Ideally add a PHP caching system we can re-use for autoloaders
- [ ] Reset cache on application install/removal/update
- [ ] Find out how to not break https://github.com/nextcloud/app_api/blob/main/appinfo/register_command.php

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
