### PR TITLE
perf(sharing): reduce share listing overhead

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -880,27 +880,30 @@ class ShareAPIController extends OCSController {
 		$nodes = $folder->getDirectoryListing();
 
 		/** @var IShare[] $shares */
-		$shares = array_reduce($nodes, function ($carry, $node) {
-			$carry = array_merge($carry, $this->getAllShares($node, true));
-			return $carry;
-		}, []);
-
-		// filter out duplicate shares
-		$known = [];
+		$shares = [];
+		foreach ($nodes as $node) {
+			foreach ($this->getAllShares($node, true) as $share) {
+				$shares[] = $share;
+			}
+		}
 
 		$formatted = $miniFormatted = [];
 		$resharingRight = false;
-		$known = [];
+		$knownIds = [];
+
 		foreach ($shares as $share) {
-			if (in_array($share->getId(), $known) || $share->getSharedWith() === $this->userId) {
+			$shareId = $share->getId();
+
+			if (isset($knownIds[$shareId]) || $share->getSharedWith() === $this->userId) {
 				continue;
 			}
 
 			try {
 				$format = $this->formatShare($share);
 
-				$known[] = $share->getId();
+				$knownIds[$shareId] = true; 
 				$formatted[] = $format;
+
 				if ($share->getSharedBy() === $this->userId) {
 					$miniFormatted[] = $format;
 				}
@@ -1058,8 +1061,10 @@ class ShareAPIController extends OCSController {
 
 		$shares = $this->getSharesFromNode($viewer, $node, $reShares);
 
-		$known = $formatted = $miniFormatted = [];
+		$formatted = $miniFormatted = [];
 		$resharingRight = false;
+		$knownIds = [];
+
 		foreach ($shares as $share) {
 			try {
 				$share->getNode();
@@ -1071,15 +1076,18 @@ class ShareAPIController extends OCSController {
 				continue;
 			}
 
-			if (in_array($share->getId(), $known)
+			$shareId = $share->getId();
+
+			if (isset($knownIds[$shareId])
 				|| ($share->getSharedWith() === $this->userId && $share->getShareType() === IShare::TYPE_USER)) {
 				continue;
 			}
 
-			$known[] = $share->getId();
 			try {
 				/** @var IShare $share */
 				$format = $this->formatShare($share, $node);
+
+				$knownIds[$shareId] = true;
 				$formatted[] = $format;
 
 				// let's also build a list of shares created

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1834,30 +1834,33 @@ class ShareAPIController extends OCSController {
 			IShare::TYPE_DECK,
 		];
 
-		// Should we assume that the (currentUser) viewer is the owner of the node !?
+		/** @var IShare[] $shares */
 		$shares = [];
+
 		foreach ($providers as $provider) {
 			if (!$this->shareManager->shareProviderExists($provider)) {
 				continue;
 			}
 
-			$providerShares
-				= $this->shareManager->getSharesBy($viewer, $provider, $node, $reShares, -1, 0);
-			$shares = array_merge($shares, $providerShares);
+			// Should we assume that the (currentUser) viewer is the owner of the node !?
+			$providerShares = $this->shareManager->getSharesBy($viewer, $provider, $node, $reShares, -1, 0);
+			if (!empty($providerShares)) {
+				array_push($shares, ...$providerShares);
+			}
 		}
 
 		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
-			$federatedShares = $this->shareManager->getSharesBy(
-				$this->userId, IShare::TYPE_REMOTE, $node, $reShares, -1, 0
-			);
-			$shares = array_merge($shares, $federatedShares);
+			$providerShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_REMOTE, $node, $reShares, -1, 0);
+			if (!empty($providerShares)) {
+				array_push($shares, ...$providerShares);
+			}
 		}
 
 		if ($this->shareManager->outgoingServer2ServerGroupSharesAllowed()) {
-			$federatedShares = $this->shareManager->getSharesBy(
-				$this->userId, IShare::TYPE_REMOTE_GROUP, $node, $reShares, -1, 0
-			);
-			$shares = array_merge($shares, $federatedShares);
+			$providerShares = $this->shareManager->getSharesBy($this->userId, IShare::TYPE_REMOTE_GROUP, $node, $reShares, -1, 0);
+			if (!empty($providerShares)) {
+				array_push($shares, ...$providerShares);
+			}
 		}
 
 		return $shares;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->
* May help with: #59779

## Summary

- avoid repeated `array_merge()` calls while building the share list
- avoid linear `in_array()` duplicate checks by tracking known share IDs in an `isset()`-backed lookup table

Reduces CPU and memory usage on folders containing a large number of files or shares

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
