### PR TITLE
fix(jobs): compute memory usage after clean-up

### DIFF
--- a/core/Service/CronService.php
+++ b/core/Service/CronService.php
@@ -226,21 +226,33 @@ class CronService {
 					['app' => 'cron']
 				);
 			}
-
-			if ($memoryIncrease > 50 * 1024 * 1024) {
-				$message = 'Memory leak detected after executing job ' . $jobDetails . '. Memory usage grew by ' . Util::humanFileSize($memoryIncrease) . '.';
+			if ($jobMemoryPeak > (300 * 1024 * 1024)) {
+				$message
+					= 'Cron job used more than 300 MiB of RAM after executing job '
+					. $jobDetails
+					. ': '
+					. Util::humanFileSize($jobMemoryPeak)
+					. ')';
 				$this->logger->warning($message, ['app' => 'cron']);
 				$this->verboseOutput($message);
 			}
-			if ($jobMemoryPeak > 300 * 1024 * 1024) {
-				$message = 'Cron job used more than 300 MiB of RAM after executing job ' . $jobDetails . ': ' . Util::humanFileSize($jobMemoryPeak) . ')';
-				$this->logger->warning($message, ['app' => 'cron']);
-				$this->verboseOutput($message);
-			}
 
-			// clean up after unclean jobs
+			// Clean-up
 			$this->setupManager->tearDown();
 			$this->tempManager->clean();
+
+			if ($memoryIncrease > (50 * 1024 * 1024)) {
+				$message
+					= 'Memory leak detected after executing job '
+					. $jobDetails
+					. '. Memory usage grew by '
+					. Util::humanFileSize($memoryIncrease)
+					. '.';
+				$this->logger->warning($message, ['app' => 'cron']);
+				$this->verboseOutput($message);
+			}
+
+			// Check forgotten transaction
 			if ($this->connection->inTransaction()) {
 				$this->connection->rollBack();
 				$message = 'Cron job left a transaction opened after executing job ' . $jobDetails . '. The transaction was rolled back.';


### PR DESCRIPTION
## Summary

Memory leak detection should happen after the teardown

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
