### PR TITLE
fix(CalDav): Force trashbin deletion when re-creating item with same UID

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1552,7 +1552,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			if ($found !== false) {
 				// the object existed previously but has been deleted
 				// remove the trashbin entry and continue as if it was a new object
-				$this->deleteCalendarObject($calendarId, $found['uri']);
+				$this->deleteCalendarObject($calendarId, $found['uri'], $calendarType, true);
 			}
 
 			$query = $this->db->getQueryBuilder();

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -292,6 +292,46 @@ EOD;
 		$this->backend->createCalendarObject($calendarId, $uri1, $calData);
 	}
 
+	public function testCreateCalendarObjectWithSameUidAsObjectInTrashbin(): void {
+		$calendarId = $this->createTestCalendar();
+
+		$calData = <<<'EOD'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:ownCloud Calendar
+BEGIN:VEVENT
+CREATED;VALUE=DATE-TIME:20130910T125139Z
+UID:47d15e3ec8
+LAST-MODIFIED;VALUE=DATE-TIME:20130910T125139Z
+DTSTAMP;VALUE=DATE-TIME:20130910T125139Z
+SUMMARY:Test Event
+DTSTART;VALUE=DATE-TIME:20130912T130000Z
+DTEND;VALUE=DATE-TIME:20130912T140000Z
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+EOD;
+
+		$uri = static::getUniqueID('event') . '.ics';
+		$this->backend->createCalendarObject($calendarId, $uri, $calData);
+
+		// Soft-delete the object so it is moved to the trashbin but keeps its UID
+		$this->backend->deleteCalendarObject($calendarId, $uri);
+		$trashbinUri = str_replace('.ics', '-deleted.ics', $uri);
+		$trashedObject = $this->backend->getCalendarObject($calendarId, $trashbinUri);
+		$this->assertNotNull($trashedObject);
+
+		// Recreating an object with the same UID must purge the trashbin entry
+		// instead of violating the unique index on (calendarid, calendartype, uid)
+		$newUri = static::getUniqueID('event') . '.ics';
+		$this->backend->createCalendarObject($calendarId, $newUri, $calData);
+
+		$this->assertNull($this->backend->getCalendarObject($calendarId, $trashbinUri));
+		$newObject = $this->backend->getCalendarObject($calendarId, $newUri);
+		$this->assertNotNull($newObject);
+		$this->assertEquals($calData, $newObject['calendardata']);
+	}
+
 	public function testMultiCalendarObjects(): void {
 		$calendarId = $this->createTestCalendar();
 


### PR DESCRIPTION
* Resolves: #37577 

## Summary

When a calendar event is being deleted, but re-imported later on, the import currently fails as the trash-bin item isn't actually being deleted. That's fixed with this PR and a test to validate it is being added as well.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
