### PR TITLE
chore(e2e): Replace deprecated buildjet with native github cache

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -105,29 +105,19 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
         run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
-
-      - name: Restore npm cache
-        uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
-        with:
-          path: ~/.npm
-          key: node-${{ steps.versions.outputs.nodeVersion }}-npm-${{ steps.versions.outputs.npmVersion }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install node dependencies & build app
         run: |
           npm ci
           TESTING=true npm run build --if-present
 
-      - name: Save npm cache
-        uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
-        with:
-          path: ~/.npm
-          key: node-${{ steps.versions.outputs.nodeVersion }}-npm-${{ steps.versions.outputs.npmVersion }}-${{ hashFiles('**/package-lock.json') }}
-
       - name: Save context
-        uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: cypress-context-${{ github.run_id }}
           path: ./
@@ -196,7 +186,7 @@ jobs:
     steps:
       - name: Restore context
         id: cache
-        uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: cypress-context-${{ github.run_id }}
           path: ./
@@ -224,6 +214,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ needs.init.outputs.nodeVersion }}
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Set up npm ${{ needs.init.outputs.npmVersion }}
         run: npm i -g 'npm@${{ needs.init.outputs.npmVersion }}'
@@ -287,6 +279,10 @@ jobs:
           path: data.tar
 
   summary:
+    permissions:
+      contents: none
+      pull-requests: none
+      actions: write
     runs-on: ubuntu-latest-low
     needs: [init, cypress]
 
@@ -298,8 +294,8 @@ jobs:
       - name: Summary status
         run: if ${{ needs.init.result != 'success' || ( needs.cypress.result != 'success' && needs.cypress.result != 'skipped' ) }}; then exit 1; fi
 
-      - name: Delete cache on success
-        uses: buildjet/cache-delete@7184288b8396c4492a56728c47dd286fbd1e96ae # v1
+      - name: Delete context on success
+        uses: snnaplab/delete-branch-cache-action@20f7992a7b8b51aa719420d11b32c9d34a5eb362 # v1.0.0
         if: needs.init.result == 'success' && needs.cypress.result == 'success'
         with:
-          cache_key: cypress-context-${{ github.run_id }}
+          key: cypress-context-${{ github.run_id }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,6 +62,8 @@ jobs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ steps.versions.outputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
     - name: Set up npm
       run: npm i -g 'npm@${{ steps.versions.outputs.package-manager-version }}'
     - name: Install dependencies and build
@@ -69,7 +71,7 @@ jobs:
         npm ci
         npm run build --if-present
     - name: Save context
-      uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: playwright-context-${{ github.run_id }}
         path: ./
@@ -91,7 +93,7 @@ jobs:
     steps:
     - name: Restore context
       id: cache
-      uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: playwright-context-${{ github.run_id }}
         path: ./
@@ -112,6 +114,8 @@ jobs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ steps.versions.outputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
 
     - name: Set up npm
       if: steps.cache.outputs.cache-hit != 'true'
@@ -150,13 +154,16 @@ jobs:
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
     if: ${{ !cancelled() }}
+    permissions:
+      contents: none
+      actions: write
     needs: [gate, playwright-tests]
 
     runs-on: ubuntu-latest-low
     steps:
     - name: Restore context
       id: cache
-      uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: playwright-context-${{ github.run_id }}
         path: ./
@@ -170,6 +177,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       with:
         node-version: ${{ needs.playwright-tests.outputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
 
     - name: Set up npm
       if: steps.cache.outputs.cache-hit != 'true'
@@ -201,6 +210,12 @@ jobs:
         echo 'To view the report:'
         echo '  1. Extract the folder from the zip file'
         echo '  2. run "npx playwright show-report name-of-my-extracted-playwright-report"'
+
+    - name: Delete context on success
+      uses: snnaplab/delete-branch-cache-action@20f7992a7b8b51aa719420d11b32c9d34a5eb362 # v1.0.0
+      if: needs.playwright-tests.result == 'success'
+      with:
+        key: playwright-context-${{ github.run_id }}
 
   summary:
     permissions:


### PR DESCRIPTION
## Summary

The cypress and playwright workflows use buildjet for caching. This service isn't being maintained anymore for GitHub Actions (see https://buildjet.com/for-github-actions/blog/we-are-shutting-down ). It works for the moment, but having in mind that it's being officially shut down end of March... It's only a matter of time until our e2e tests will fall apart if we keep using it.

Keep in mind that this change was [made in the template repository months ago](https://github.com/nextcloud/.github/pull/698) and could have been synced automatically, if the used workflows here wouldn't have diverged quite a bit from the templates. It wouldn't be bad if we could bring those together again or at least have a mechanism to add modifications to workflows during the sync process.

As the scope of GitHub caches are limited to [the own branch and their parents](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache) (e.g., master), it might make sense to run it on master and stable branches regularly to keep a suitable cached copy for more runs. That would be an equivalent strategy like we do for CodeQL ([this workflow file](https://github.com/nextcloud/server/blob/master/.github/workflows/codeql.yml) is creating all those `codeql-overlay-base-database` caches [listed here](https://github.com/nextcloud/server/actions/caches)).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
