### PR TITLE
perf: Replace more calls from getUserGroups to getUserGroupIds

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserDataOCSController.php
+++ b/apps/provisioning_api/lib/Controller/AUserDataOCSController.php
@@ -275,10 +275,11 @@ abstract class AUserDataOCSController extends OCSController {
 		$groupIds = array_unique($groupIds);
 		sort($groupIds);
 
-		return array_map(function ($groupId) {
-			$displayname = $this->groupDisplayNameCache->getDisplayName($groupId) ?? $groupId;
-			return ['id' => $groupId, 'displayname' => $displayname];
-		}, $groupIds);
+		$info = [];
+		foreach ($this->groupDisplayNameCache->getDisplayNames($groupIds) as $groupId => $displayName) {
+			$info[] = ['id' => $groupId, 'displayname' => $displayName ?? $groupId];
+		}
+		return $info;
 	}
 
 	/**

--- a/apps/provisioning_api/lib/Controller/AUserDataOCSController.php
+++ b/apps/provisioning_api/lib/Controller/AUserDataOCSController.php
@@ -106,11 +106,7 @@ abstract class AUserDataOCSController extends OCSController {
 
 		// Get groups data
 		$userAccount = $this->accountManager->getAccount($targetUserObject);
-		$groups = $this->groupManager->getUserGroups($targetUserObject);
-		$gids = [];
-		foreach ($groups as $group) {
-			$gids[] = $group->getGID();
-		}
+		$gids = $this->groupManager->getUserGroupIds($targetUserObject);
 
 		if ($isAdmin || $isDelegatedAdmin) {
 			try {

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -1080,8 +1080,7 @@ class UsersController extends AUserDataOCSController {
 		}
 
 		if ($groups !== null) {
-			$currentGroups = $this->groupManager->getUserGroups($targetUser);
-			$currentGroupIds = array_map(fn (IGroup $g) => $g->getGID(), $currentGroups);
+			$currentGroupIds = $this->groupManager->getUserGroupIds($targetUser);
 			foreach (array_diff($currentGroupIds, $groups) as $gid) {
 				$this->groupManager->get($gid)?->removeUser($targetUser);
 			}

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -495,9 +495,9 @@ class GroupsControllerTest extends \Test\TestCase {
 			->willReturn([]);
 
 		$this->groupDisplayNameCache
-			->method('getDisplayName')
-			->with('ncg1')
-			->willReturn('Group One');
+			->method('getDisplayNames')
+			->with(['ncg1'])
+			->willReturn(['ncg1' => 'Group One']);
 
 		$result = $this->api->getGroupUsersDetails($gid);
 
@@ -550,9 +550,9 @@ class GroupsControllerTest extends \Test\TestCase {
 			->willReturn([]);
 
 		$this->groupDisplayNameCache
-			->method('getDisplayName')
-			->with('Department A/B C/D')
-			->willReturn('Department A/B C/D-name');
+			->method('getDisplayNames')
+			->with(['Department A/B C/D'])
+			->willReturn(['Department A/B C/D' => 'Department A/B C/D-name']);
 
 		$result = $this->api->getGroupUsersDetails(urlencode($gid));
 

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -483,8 +483,8 @@ class GroupsControllerTest extends \Test\TestCase {
 			->with($gid)
 			->willReturn($group);
 		$this->groupManager->expects($this->any())
-			->method('getUserGroups')
-			->willReturn([$group]);
+			->method('getUserGroupIds')
+			->willReturn(['ncg1']);
 
 		/** @var MockObject */
 		$this->subAdminManager->expects($this->any())
@@ -538,8 +538,8 @@ class GroupsControllerTest extends \Test\TestCase {
 			->with($gid)
 			->willReturn($group);
 		$this->groupManager->expects($this->any())
-			->method('getUserGroups')
-			->willReturn([$group]);
+			->method('getUserGroupIds')
+			->willReturn(['Department A/B C/D']);
 
 		/** @var MockObject */
 		$this->subAdminManager->expects($this->any())

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -1196,8 +1196,8 @@ class UsersControllerTest extends TestCase {
 			->willReturn(true);
 		$this->groupManager
 			->expects($this->any())
-			->method('getUserGroups')
-			->willReturn([$group0, $group1, $group2]);
+			->method('getUserGroupIds')
+			->willReturn(['group0', 'group1', 'group2']);
 		$this->groupManager
 			->expects($this->once())
 			->method('getSubAdmin')
@@ -1206,15 +1206,6 @@ class UsersControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getSubAdminsGroups')
 			->willReturn([$group3]);
-		$group0->expects($this->exactly(1))
-			->method('getGID')
-			->willReturn('group0');
-		$group1->expects($this->exactly(1))
-			->method('getGID')
-			->willReturn('group1');
-		$group2->expects($this->exactly(1))
-			->method('getGID')
-			->willReturn('group2');
 		$group3->expects($this->once())
 			->method('getGID')
 			->willReturn('group3');
@@ -2759,7 +2750,7 @@ class UsersControllerTest extends TestCase {
 		$newGroup = $this->createMock(IGroup::class);
 		$newGroup->method('getGID')->willReturn('newgroup');
 
-		$this->groupManager->method('getUserGroups')->willReturn([$oldGroup]);
+		$this->groupManager->method('getUserGroupIds')->willReturn(['oldgroup']);
 		$this->groupManager->method('groupExists')->willReturn(true);
 		$this->groupManager->method('get')->willReturnMap([
 			['newgroup', $newGroup],

--- a/lib/private/Group/DisplayNameCache.php
+++ b/lib/private/Group/DisplayNameCache.php
@@ -83,7 +83,7 @@ class DisplayNameCache implements IEventListener {
 		$groups = $groupManager->getGroupsObjects($missing);
 		$stillMissingGroups = array_diff($missing, array_keys($groups));
 		foreach ($groups as $groupId => $group) {
-			$displayName = $group->getDisplayName() ?? $group->getGID();
+			$displayName = $group->getDisplayName();
 			$this->cache[$groupId] = $displayName;
 			$this->memCache->set($groupId, $displayName, 60 * 10); // 10 minutes
 			$result[$groupId] = $displayName;

--- a/lib/private/Group/DisplayNameCache.php
+++ b/lib/private/Group/DisplayNameCache.php
@@ -57,6 +57,45 @@ class DisplayNameCache implements IEventListener {
 		return $displayName;
 	}
 
+	/**
+	 * @param list<string> $groupIds
+	 * @return array<string, ?string>
+	 */
+	public function getDisplayNames(array $groupIds): array {
+		$result = [];
+		$missing = [];
+		foreach ($groupIds as $groupId) {
+			if (isset($this->cache[$groupId])) {
+				$result[$groupId] = $this->cache[$groupId];
+			} else {
+				$displayName = $this->memCache->get($groupId);
+				if ($displayName) {
+					$this->cache[$groupId] = $displayName;
+					$result[$groupId] = $displayName;
+				} else {
+					$missing[] = $groupId;
+				}
+			}
+		}
+
+		/** @var Manager $groupManager */
+		$groupManager = $this->groupManager;
+		$groups = $groupManager->getGroupsObjects($missing);
+		$stillMissingGroups = array_diff($missing, array_keys($groups));
+		foreach ($groups as $groupId => $group) {
+			$displayName = $group->getDisplayName() ?? $group->getGID();
+			$this->cache[$groupId] = $displayName;
+			$this->memCache->set($groupId, $displayName, 60 * 10); // 10 minutes
+			$result[$groupId] = $displayName;
+		}
+
+		foreach ($stillMissingGroups as $groupId) {
+			$result[$groupId] = null;
+		}
+
+		return $result;
+	}
+
 	public function clear(): void {
 		$this->cache = new CappedMemoryCache();
 		$this->memCache->clear();

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -181,7 +181,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @param array<string, string> $displayNames Array containing already know display name for a groupId
 	 * @return array<string, IGroup>
 	 */
-	protected function getGroupsObjects(array $gids, array $displayNames = []): array {
+	public function getGroupsObjects(array $gids, array $displayNames = []): array {
 		$backends = [];
 		$groups = [];
 		foreach ($gids as $gid) {


### PR DESCRIPTION
## Summary

Faster as we only need the gid and not the full group objects

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
