### PR TITLE
fix(files_sharing): preserve unmasked permissions as scan_permissions

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -146,6 +146,9 @@ class Cache extends CacheJail {
 
 		try {
 			if (isset($entry['permissions'])) {
+				// keep the unmasked permissions so a future scan or cross-storage
+				// copy doesn't persist the share-masked permissions in the cache
+				$entry['scan_permissions'] ??= $entry['permissions'];
 				$entry['permissions'] &= $this->share->getPermissions();
 			} else {
 				$entry['permissions'] = $this->storage->getPermissions($entry['path']);

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -556,6 +556,55 @@ class CacheTest extends TestCase {
 		$this->assertCount(1, $results);
 	}
 
+	public function testSingleFileShareKeepsUnmaskedPermissionsAsScanPermissions(): void {
+		$sourceEntry = $this->ownerCache->get('files/container/shared single file.txt');
+
+		/** @var SharedStorage $sharedStorage */
+		[$sharedStorage] = $this->user2View->resolvePath('shared single file.txt');
+		$entry = $sharedStorage->getCache()->get('');
+
+		$mask = Constants::PERMISSION_ALL & ~(Constants::PERMISSION_CREATE | Constants::PERMISSION_DELETE);
+		$this->assertEquals($sourceEntry->getPermissions() & $mask, $entry->getPermissions());
+		$this->assertEquals($sourceEntry->getPermissions(), $entry['scan_permissions']);
+	}
+
+	public function testFolderShareKeepsUnmaskedPermissionsAsScanPermissions(): void {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('container');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(IShare::TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE);
+		$share = $this->shareManager->createShare($share);
+		$share->setStatus(IShare::STATUS_ACCEPTED);
+		$this->shareManager->updateShare($share);
+		Server::get(ISetupManager::class)->tearDown();
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		/** @var SharedStorage $sharedStorage */
+		[$sharedStorage] = $this->user2View->resolvePath('container');
+		$sharedCache = $sharedStorage->getCache();
+		$mask = Constants::PERMISSION_READ | Constants::PERMISSION_SHARE;
+
+		$entry = $sharedCache->get('shareddir/bar.txt');
+		$sourceEntry = $this->ownerCache->get('files/container/shareddir/bar.txt');
+		$this->assertEquals($sourceEntry->getPermissions() & $mask, $entry->getPermissions());
+		$this->assertEquals($sourceEntry->getPermissions(), $entry['scan_permissions']);
+
+		$children = $sharedCache->getFolderContents('shareddir');
+		$this->assertNotEmpty($children);
+		foreach ($children as $child) {
+			$sourceChild = $this->ownerCache->get('files/container/shareddir/' . $child->getName());
+			$this->assertEquals($sourceChild->getPermissions() & $mask, $child->getPermissions());
+			$this->assertEquals($sourceChild->getPermissions(), $child['scan_permissions']);
+		}
+	}
+
 	public function testWatcherRootChange(): void {
 		$sourceStorage = new Temporary();
 		$sourceStorage->mkdir('shared');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/groupfolders/issues/4867

## Summary

`Cache::formatCacheEntry` now preserves the unmasked permissions in `scan_permissions` before applying the share mask, exactly like `CachePermissionsMask` and the `PermissionsMask` storage wrapper already do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
