### PR TITLE
feat(files_sharing): schedule external share scan job when accepted

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -35,6 +35,7 @@ Turning the feature off removes shared files and folders on the server for all s
 		<job>OCA\Files_Sharing\ExpireSharesJob</job>
 		<job>OCA\Files_Sharing\SharesReminderJob</job>
 		<job>OCA\Files_Sharing\BackgroundJob\FederatedSharesDiscoverJob</job>
+		<job>OCA\Files_Sharing\BackgroundJob\ExternalShareScanJob</job>
 	</background-jobs>
 
 	<repair-steps>

--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -20,6 +20,7 @@ return array(
     'OCA\\Files_Sharing\\Activity\\Settings\\ShareActivitySettings' => $baseDir . '/../lib/Activity/Settings/ShareActivitySettings.php',
     'OCA\\Files_Sharing\\Activity\\Settings\\Shared' => $baseDir . '/../lib/Activity/Settings/Shared.php',
     'OCA\\Files_Sharing\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\Files_Sharing\\BackgroundJob\\ExternalShareScanJob' => $baseDir . '/../lib/BackgroundJob/ExternalShareScanJob.php',
     'OCA\\Files_Sharing\\BackgroundJob\\FederatedSharesDiscoverJob' => $baseDir . '/../lib/BackgroundJob/FederatedSharesDiscoverJob.php',
     'OCA\\Files_Sharing\\Cache' => $baseDir . '/../lib/Cache.php',
     'OCA\\Files_Sharing\\Capabilities' => $baseDir . '/../lib/Capabilities.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -35,6 +35,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Activity\\Settings\\ShareActivitySettings' => __DIR__ . '/..' . '/../lib/Activity/Settings/ShareActivitySettings.php',
         'OCA\\Files_Sharing\\Activity\\Settings\\Shared' => __DIR__ . '/..' . '/../lib/Activity/Settings/Shared.php',
         'OCA\\Files_Sharing\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\Files_Sharing\\BackgroundJob\\ExternalShareScanJob' => __DIR__ . '/..' . '/../lib/BackgroundJob/ExternalShareScanJob.php',
         'OCA\\Files_Sharing\\BackgroundJob\\FederatedSharesDiscoverJob' => __DIR__ . '/..' . '/../lib/BackgroundJob/FederatedSharesDiscoverJob.php',
         'OCA\\Files_Sharing\\Cache' => __DIR__ . '/..' . '/../lib/Cache.php',
         'OCA\\Files_Sharing\\Capabilities' => __DIR__ . '/..' . '/../lib/Capabilities.php',

--- a/apps/files_sharing/lib/BackgroundJob/ExternalShareScanJob.php
+++ b/apps/files_sharing/lib/BackgroundJob/ExternalShareScanJob.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Files_Sharing\BackgroundJob;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\Files\IRootFolder;
+use OCP\IConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Scans an external share with a specific path
+ */
+class ExternalShareScanJob extends QueuedJob {
+	public function __construct(
+		private readonly IConfig $config,
+		private readonly IRootFolder $rootFolder,
+		private readonly LoggerInterface $logger,
+		ITimeFactory $time,
+	) {
+		parent::__construct($time);
+	}
+
+	#[\Override]
+	protected function run($argument): void {
+		if ($this->config->getSystemValueBool('files_no_background_scan', false)) {
+			return;
+		}
+
+		[$userId, $path] = $argument;
+		try {
+			$this->rootFolder
+				->getUserFolder($userId)
+				->get($path)
+				->getStorage()
+				->getScanner()
+				->scan('');
+		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), [ 'exception' => $e ]);
+		}
+	}
+}

--- a/apps/files_sharing/lib/Controller/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controller/ExternalSharesController.php
@@ -8,10 +8,12 @@
 
 namespace OCA\Files_Sharing\Controller;
 
+use OCA\Files_Sharing\BackgroundJob\ExternalShareScanJob;
 use OCA\Files_Sharing\External\Manager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\BackgroundJob\IJobList;
 use OCP\IRequest;
 
 /**
@@ -24,6 +26,7 @@ class ExternalSharesController extends Controller {
 		string $appName,
 		IRequest $request,
 		private readonly Manager $externalManager,
+		private IJobList $jobList,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -44,6 +47,7 @@ class ExternalSharesController extends Controller {
 		$externalShare = $this->externalManager->getShare($id);
 		if ($externalShare !== false) {
 			$this->externalManager->acceptShare($externalShare);
+			$this->jobList->add(ExternalShareScanJob::class, [$externalShare->getUser(), $externalShare->getMountpoint()]);
 		}
 		return new JSONResponse();
 	}

--- a/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
@@ -12,6 +12,7 @@ use OCA\Files_Sharing\Controller\ExternalSharesController;
 use OCA\Files_Sharing\External\ExternalShare;
 use OCA\Files_Sharing\External\Manager;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\BackgroundJob\IJobList;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -23,11 +24,13 @@ use PHPUnit\Framework\MockObject\MockObject;
 class ExternalShareControllerTest extends \Test\TestCase {
 	private IRequest&MockObject $request;
 	private Manager&MockObject $externalManager;
+	private IJobList&MockObject $jobList;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->request = $this->createMock(IRequest::class);
 		$this->externalManager = $this->createMock(Manager::class);
+		$this->jobList = $this->createMock(IJobList::class);
 	}
 
 	public function getExternalShareController(): ExternalSharesController {
@@ -35,6 +38,7 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			'files_sharing',
 			$this->request,
 			$this->externalManager,
+			$this->jobList,
 		);
 	}
 
@@ -58,6 +62,9 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('acceptShare')
 			->with($share);
+		$this->jobList
+			->expects($this->once())
+			->method('add');
 
 		$this->assertEquals(new JSONResponse(), $this->getExternalShareController()->create('4'));
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Schedule a scan job on an external share when an account accepts it to make file information available (e.g. size) without having to interact with the share.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
