### PR TITLE
test(db): add regression test for string to text column conversion

### DIFF
--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -244,6 +244,47 @@ class MigratorTest extends \Test\TestCase {
 		$this->addToAssertionCount(1);
 	}
 
+	/**
+	 * Changing a populated string column to text maps to VARCHAR2 -> CLOB
+	 * on Oracle, which cannot be altered in-place (ORA-22858). This is what
+	 * core Version34000Date20260318095645 does to oc_jobs.argument.
+	 */
+	public function testChangeStringToText(): void {
+		$startSchema = new Schema([], [], $this->getSchemaConfig());
+		$table = $startSchema->createTable($this->tableName);
+		$table->addColumn('id', Types::BIGINT);
+		$table->addColumn('argument', Types::STRING, [
+			'notnull' => true,
+			'length' => 4000,
+		]);
+		$table->addIndex(['id'], $this->tableName . '_id');
+
+		$migrator = $this->getMigrator();
+		$migrator->migrate($startSchema);
+
+		$shortValue = '{"foo":"bar"}';
+		$longValue = json_encode(['data' => str_repeat('x', 3900)]);
+		$this->connection->insert($this->tableName, ['id' => 1, 'argument' => $shortValue]);
+		$this->connection->insert($this->tableName, ['id' => 2, 'argument' => $longValue]);
+
+		$endSchema = new Schema([], [], $this->getSchemaConfig());
+		$table = $endSchema->createTable($this->tableName);
+		$table->addColumn('id', Types::BIGINT);
+		$table->addColumn('argument', Types::TEXT, [
+			'notnull' => true,
+		]);
+		$table->addIndex(['id'], $this->tableName . '_id');
+
+		$migrator->migrate($endSchema);
+
+		$result = $this->connection->executeQuery(
+			'SELECT ' . $this->connection->quoteIdentifier('argument')
+			. ' FROM ' . $this->connection->quoteIdentifier($this->tableName)
+			. ' ORDER BY ' . $this->connection->quoteIdentifier('id') . ' ASC'
+		);
+		$this->assertSame([$shortValue, $longValue], $result->fetchFirstColumn());
+	}
+
 	public function testAddingForeignKey(): void {
 		$startSchema = new Schema([], [], $this->getSchemaConfig());
 		$table = $startSchema->createTable($this->tableName);


### PR DESCRIPTION
This is just to test against CI.

On Oracle, converting a populated string column to text maps to VARCHAR2 -> CLOB, which cannot be done with an in-place ALTER TABLE and fails with ORA-22858. Core migration Version34000Date20260318095645 (oc_jobs.argument, shipped in 32.0.7+, 33.0.1+ and 34) triggers this during occ upgrade. The test asserts column data survives the conversion.

Assisted-by: ClaudeCode:claude-fable-5

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
