### PR TITLE
fix(s3): trim multiple spaces to single space in original path header

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -501,7 +501,7 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 		$metadata = [
 			'mimetype' => $mimetype,
 			'original-storage' => $this->getId(),
-			'original-path' => $path,
+			'original-path' => preg_replace('/\s+/', ' ', $path) ?? $path,
 		];
 		if ($size) {
 			$metadata['size'] = $size;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
The S3 API spec defines that `x-amz-meta-original-path` header needs spaces to be trimmed and multiple spaces need to be converted to a single space. This is to comply with the spec and fix it for some storage hosts that return a `SignatureDoesNotMatch` error.

The reference to the documentation can be found [here](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html) in Task 1.4

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
