### PR TITLE
feat: Fetch groups in batch in getUserGroups

### DIFF
--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -310,18 +310,8 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return array<string, IGroup>
 	 */
 	public function getUserIdGroups(string $uid): array {
-		$groups = [];
-
-		foreach ($this->getUserIdGroupIds($uid) as $groupId) {
-			$aGroup = $this->get($groupId);
-			if ($aGroup instanceof IGroup) {
-				$groups[$groupId] = $aGroup;
-			} else {
-				$this->logger->debug('User "' . $uid . '" belongs to deleted group: "' . $groupId . '"', ['app' => 'core']);
-			}
-		}
-
-		return $groups;
+		$groupIds = $this->getUserIdGroupIds($uid);
+		return $this->getGroupsObjects($groupIds);
 	}
 
 	/**

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -428,9 +428,9 @@ class ManagerTest extends TestCase {
 			->with('user1')
 			->willReturn(['group1']);
 		$backend->expects($this->any())
-			->method('groupExists')
+			->method('getGroupDetails')
 			->with('group1')
-			->willReturn(true);
+			->willReturn(['displayName' => 'group1']);
 
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
@@ -476,9 +476,9 @@ class ManagerTest extends TestCase {
 			->with('user1')
 			->willReturn(['group1']);
 		$backend->expects($this->any())
-			->method('groupExists')
-			->with('group1')
-			->willReturn(false);
+			->method('getGroupsDetails')
+			->with(['group1'])
+			->willReturn(['group1' => []]);
 
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
@@ -560,8 +560,8 @@ class ManagerTest extends TestCase {
 			->with('user1')
 			->willReturn(['group1']);
 		$backend1->expects($this->any())
-			->method('groupExists')
-			->willReturn(true);
+			->method('getGroupDetails')
+			->willReturnCallback(fn ($gid) => $gid === 'group1' ? ['displayName' => 'group1'] : []);
 
 		/**
 		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
@@ -571,9 +571,9 @@ class ManagerTest extends TestCase {
 			->method('getUserGroups')
 			->with('user1')
 			->willReturn(['group1', 'group2']);
-		$backend1->expects($this->any())
-			->method('groupExists')
-			->willReturn(true);
+		$backend2->expects($this->any())
+			->method('getGroupDetails')
+			->willReturnCallback(fn ($gid) => ['displayName' => $gid]);
 
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend1);
@@ -870,6 +870,10 @@ class ManagerTest extends TestCase {
 			->method('groupExists')
 			->with('group1')
 			->willReturn(true);
+		$backend->expects($this->any())
+			->method('getGroupDetails')
+			->with('group1')
+			->willReturn(['displayName' => 'group1']);
 
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
@@ -904,9 +908,9 @@ class ManagerTest extends TestCase {
 				return $expectedGroups;
 			});
 		$backend->expects($this->any())
-			->method('groupExists')
+			->method('getGroupDetails')
 			->with('group1')
-			->willReturn(true);
+			->willReturn(['displayName' => 'group1']);
 		$backend->expects($this->once())
 			->method('inGroup')
 			->willReturn(true);


### PR DESCRIPTION
## Summary

Alternative to #61871 

Will need https://github.com/nextcloud/user_saml/pull/1161 working

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
