### PR TITLE
fix(files_sharing): Fail on sharing file with create or delete permission before failing on increased permissions

### DIFF
--- a/apps/files_sharing/lib/Listener/RestrictInteractionListener.php
+++ b/apps/files_sharing/lib/Listener/RestrictInteractionListener.php
@@ -56,11 +56,6 @@ final class RestrictInteractionListener implements IEventListener {
 			}
 
 			if ($event->action->filesSharingPermissions !== null) {
-				if (($event->action->filesSharingPermissions & ~$event->resource->getNodePermissions()) !== 0) {
-					$path = $userFolder->getRelativePath($event->resource->getNode()->getPath());
-					throw new InteractionRestrictedException('Cannot share node with more permissions than the node already has.', $this->l10n->t('You cannot share "%s" with more permission than you have yourself.', [$path]));
-				}
-
 				if ($event->resource->getNode() instanceof File) {
 					if (($event->action->filesSharingPermissions & Constants::PERMISSION_DELETE) === Constants::PERMISSION_DELETE) {
 						throw new InteractionRestrictedException('Cannot share file node with delete permission.', $this->l10n->t('File cannot be shared with delete permission.'));
@@ -82,6 +77,11 @@ final class RestrictInteractionListener implements IEventListener {
 					&& ($event->action->filesSharingPermissions & (Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE)) !== 0
 					&& !$this->manager->shareApiLinkAllowPublicUpload()) {
 					throw new InteractionRestrictedException('Public upload is not allowed.', $this->l10n->t('Public upload is not allowed.'));
+				}
+
+				if (($event->action->filesSharingPermissions & ~$event->resource->getNodePermissions()) !== 0) {
+					$path = $userFolder->getRelativePath($event->resource->getNode()->getPath());
+					throw new InteractionRestrictedException('Cannot share node with more permissions than the node already has.', $this->l10n->t('You cannot share "%s" with more permission than you have yourself.', [$path]));
 				}
 			}
 		}

--- a/apps/files_sharing/tests/Listener/RestrictInteractionListenerTest.php
+++ b/apps/files_sharing/tests/Listener/RestrictInteractionListenerTest.php
@@ -95,6 +95,26 @@ final class RestrictInteractionListenerTest extends TestCase {
 		}
 	}
 
+	public function testNodeResourceShareActionIncreasePermissionFileDelete(): void {
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder($this->user->getUID());
+
+		$node = $userFolder->newFile('foo.txt', 'bar');
+		$node->getStorage()->getCache()->update($node->getId(), ['permissions' => Constants::PERMISSION_READ | Constants::PERMISSION_SHARE]);
+
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_DELETE), null);
+		$this->assertEquals('File cannot be shared with delete permission.', $event->isInteractionRestricted());
+	}
+
+	public function testNodeResourceShareActionIncreasePermissionFileCreate(): void {
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder($this->user->getUID());
+
+		$node = $userFolder->newFile('foo.txt', 'bar');
+		$node->getStorage()->getCache()->update($node->getId(), ['permissions' => Constants::PERMISSION_READ | Constants::PERMISSION_SHARE]);
+
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_CREATE), null);
+		$this->assertEquals('File cannot be shared with create permission.', $event->isInteractionRestricted());
+	}
+
 	public function testNodeResourceShareActionFileHasDeletePermission(): void {
 		$userFolder = Server::get(IRootFolder::class)->getUserFolder($this->user->getUID());
 


### PR DESCRIPTION
In this order the error message is less confusing to users.