### PR TITLE
refactor(Interaction): Allow multiple resources and receivers in a single event

### DIFF
--- a/apps/files/lib/Listener/RestrictInteractionListener.php
+++ b/apps/files/lib/Listener/RestrictInteractionListener.php
@@ -36,8 +36,10 @@ final readonly class RestrictInteractionListener implements IEventListener {
 	 */
 	#[\Override]
 	public function handle(Event $event): void {
-		if ($event->resource instanceof NodeResource && ($event->resource->getNodePermissions() & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ) {
-			throw new InteractionRestrictedException('No read permission on the node.', $this->l10n->t('No read permission on file.'));
+		foreach ($event->resources as $resource) {
+			if ($resource instanceof NodeResource && ($resource->getNodePermissions() & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ) {
+				throw new InteractionRestrictedException('No read permission on the node.', $this->l10n->t('No read permission on file.'));
+			}
 		}
 	}
 }

--- a/apps/files/tests/Listener/RestrictInteractionListenerTest.php
+++ b/apps/files/tests/Listener/RestrictInteractionListenerTest.php
@@ -53,7 +53,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$folderNode->getStorage()->getCache()->update($folderNode->getId(), ['permissions' => Constants::PERMISSION_ALL & ~Constants::PERMISSION_READ]);
 
 		foreach ([$fileNode, $folderNode] as $node) {
-			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), null, null);
+			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($node->getId(), $this->user->getUID(), $node)], null, []);
 			$this->assertEquals('No read permission on file.', $event->isInteractionRestricted());
 		}
 	}

--- a/apps/files_sharing/lib/Listener/RestrictInteractionListener.php
+++ b/apps/files_sharing/lib/Listener/RestrictInteractionListener.php
@@ -45,43 +45,47 @@ final class RestrictInteractionListener implements IEventListener {
 	 */
 	#[\Override]
 	public function handle(Event $event): void {
-		if ($event->resource instanceof NodeResource && $event->action instanceof ShareAction) {
-			if (!$event->resource->getNode()->isShareable()) {
-				throw new InteractionRestrictedException('Node is not shareable.', $this->l10n->t('You are not allowed to share "%s".', [$event->resource->getNode()->getName()]));
-			}
+		foreach ($event->resources as $resource) {
+			if ($resource instanceof NodeResource && $event->action instanceof ShareAction) {
+				if (!$resource->getNode()->isShareable()) {
+					throw new InteractionRestrictedException('Node is not shareable.', $this->l10n->t('You are not allowed to share "%s".', [$resource->getNode()->getName()]));
+				}
 
-			$userFolder = $this->rootFolder->getUserFolder($event->userId);
-			if ($event->resource->nodeId === $userFolder->getId()) {
-				throw new InteractionRestrictedException('Cannot share home folder node.', $this->l10n->t('You cannot share your home folder.'));
-			}
+				$userFolder = $this->rootFolder->getUserFolder($event->userId);
+				if ($resource->nodeId === $userFolder->getId()) {
+					throw new InteractionRestrictedException('Cannot share home folder node.', $this->l10n->t('You cannot share your home folder.'));
+				}
 
-			if ($event->action->filesSharingPermissions !== null) {
-				if ($event->resource->getNode() instanceof File) {
-					if (($event->action->filesSharingPermissions & Constants::PERMISSION_DELETE) === Constants::PERMISSION_DELETE) {
-						throw new InteractionRestrictedException('Cannot share file node with delete permission.', $this->l10n->t('File cannot be shared with delete permission.'));
+				if ($event->action->filesSharingPermissions !== null) {
+					if ($resource->getNode() instanceof File) {
+						if (($event->action->filesSharingPermissions & Constants::PERMISSION_DELETE) === Constants::PERMISSION_DELETE) {
+							throw new InteractionRestrictedException('Cannot share file node with delete permission.', $this->l10n->t('File cannot be shared with delete permission.'));
+						}
+
+						if (($event->action->filesSharingPermissions & Constants::PERMISSION_CREATE) === Constants::PERMISSION_CREATE) {
+							throw new InteractionRestrictedException('Cannot share file node with create permission.', $this->l10n->t('File cannot be shared with create permission.'));
+						}
 					}
 
-					if (($event->action->filesSharingPermissions & Constants::PERMISSION_CREATE) === Constants::PERMISSION_CREATE) {
-						throw new InteractionRestrictedException('Cannot share file node with create permission.', $this->l10n->t('File cannot be shared with create permission.'));
+					foreach ($event->receivers as $receiver) {
+						if (!$receiver instanceof LinkReceiver
+							&& !$receiver instanceof EmailReceiver
+							&& ($event->action->filesSharingPermissions & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ) {
+							throw new InteractionRestrictedException('No read permission on the share.', $this->l10n->t('File share needs at least read permission.'));
+						}
+
+						if (($receiver instanceof LinkReceiver || $receiver instanceof EmailReceiver)
+							&& $resource->getNode() instanceof Folder
+							&& ($event->action->filesSharingPermissions & (Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE)) !== 0
+							&& !$this->manager->shareApiLinkAllowPublicUpload()) {
+							throw new InteractionRestrictedException('Public upload is not allowed.', $this->l10n->t('Public upload is not allowed.'));
+						}
 					}
-				}
 
-				if (!$event->receiver instanceof LinkReceiver
-					&& !$event->receiver instanceof EmailReceiver
-					&& ($event->action->filesSharingPermissions & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ) {
-					throw new InteractionRestrictedException('No read permission on the share.', $this->l10n->t('File share needs at least read permission.'));
-				}
-
-				if (($event->receiver instanceof LinkReceiver || $event->receiver instanceof EmailReceiver)
-					&& $event->resource->getNode() instanceof Folder
-					&& ($event->action->filesSharingPermissions & (Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE)) !== 0
-					&& !$this->manager->shareApiLinkAllowPublicUpload()) {
-					throw new InteractionRestrictedException('Public upload is not allowed.', $this->l10n->t('Public upload is not allowed.'));
-				}
-
-				if (($event->action->filesSharingPermissions & ~$event->resource->getNodePermissions()) !== 0) {
-					$path = $userFolder->getRelativePath($event->resource->getNode()->getPath());
-					throw new InteractionRestrictedException('Cannot share node with more permissions than the node already has.', $this->l10n->t('You cannot share "%s" with more permission than you have yourself.', [$path]));
+					if (($event->action->filesSharingPermissions & ~$resource->getNodePermissions()) !== 0) {
+						$path = $userFolder->getRelativePath($resource->getNode()->getPath());
+						throw new InteractionRestrictedException('Cannot share node with more permissions than the node already has.', $this->l10n->t('You cannot share "%s" with more permission than you have yourself.', [$path]));
+					}
 				}
 			}
 		}

--- a/apps/files_sharing/tests/Listener/RestrictInteractionListenerTest.php
+++ b/apps/files_sharing/tests/Listener/RestrictInteractionListenerTest.php
@@ -68,7 +68,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$this->assertNotNull($folderNode);
 
 		foreach ([$fileNode, $folderNode] as $node) {
-			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(), null);
+			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($node->getId(), $this->user->getUID(), $node)], new ShareAction(), []);
 			$this->assertEquals('You are not allowed to share "' . $node->getName() . '".', $event->isInteractionRestricted());
 		}
 	}
@@ -76,7 +76,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 	public function testNodeResourceShareActionNotHomeFolder(): void {
 		$userFolder = Server::get(IRootFolder::class)->getUserFolder($this->user->getUID());
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($userFolder->getId(), $this->user->getUID(), $userFolder), new ShareAction(), null);
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($userFolder->getId(), $this->user->getUID(), $userFolder)], new ShareAction(), []);
 		$this->assertEquals('You cannot share your home folder.', $event->isInteractionRestricted());
 	}
 
@@ -90,7 +90,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$folderNode->getStorage()->getCache()->update($folderNode->getId(), ['permissions' => Constants::PERMISSION_READ | Constants::PERMISSION_SHARE]);
 
 		foreach ([$fileNode, $folderNode] as $node) {
-			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_UPDATE), null);
+			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($node->getId(), $this->user->getUID(), $node)], new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_UPDATE), []);
 			$this->assertEquals('You cannot share "/' . $node->getName() . '" with more permission than you have yourself.', $event->isInteractionRestricted());
 		}
 	}
@@ -101,7 +101,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$node = $userFolder->newFile('foo.txt', 'bar');
 		$node->getStorage()->getCache()->update($node->getId(), ['permissions' => Constants::PERMISSION_READ | Constants::PERMISSION_SHARE]);
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_DELETE), null);
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($node->getId(), $this->user->getUID(), $node)], new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_DELETE), []);
 		$this->assertEquals('File cannot be shared with delete permission.', $event->isInteractionRestricted());
 	}
 
@@ -111,7 +111,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$node = $userFolder->newFile('foo.txt', 'bar');
 		$node->getStorage()->getCache()->update($node->getId(), ['permissions' => Constants::PERMISSION_READ | Constants::PERMISSION_SHARE]);
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_CREATE), null);
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($node->getId(), $this->user->getUID(), $node)], new ShareAction(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE | Constants::PERMISSION_CREATE), []);
 		$this->assertEquals('File cannot be shared with create permission.', $event->isInteractionRestricted());
 	}
 
@@ -121,7 +121,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$node = $userFolder->newFile('foo.txt', 'bar');
 		$node->getStorage()->getCache()->update($node->getId(), ['permissions' => Constants::PERMISSION_ALL]);
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(Constants::PERMISSION_DELETE), null);
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($node->getId(), $this->user->getUID(), $node)], new ShareAction(Constants::PERMISSION_DELETE), []);
 		$this->assertEquals('File cannot be shared with delete permission.', $event->isInteractionRestricted());
 	}
 
@@ -131,7 +131,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$node = $userFolder->newFile('foo.txt', 'bar');
 		$node->getStorage()->getCache()->update($node->getId(), ['permissions' => Constants::PERMISSION_ALL]);
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, new NodeResource($node->getId(), $this->user->getUID(), $node), new ShareAction(Constants::PERMISSION_CREATE), null);
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [new NodeResource($node->getId(), $this->user->getUID(), $node)], new ShareAction(Constants::PERMISSION_CREATE), []);
 		$this->assertEquals('File cannot be shared with create permission.', $event->isInteractionRestricted());
 	}
 
@@ -157,7 +157,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 			new RoomReceiver(''),
 			new UserReceiver(''),
 		] as $receiver) {
-			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, $resource, new ShareAction(Constants::PERMISSION_ALL & ~Constants::PERMISSION_READ), $receiver);
+			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [$resource], new ShareAction(Constants::PERMISSION_ALL & ~Constants::PERMISSION_READ), [$receiver]);
 			$this->assertEquals('File share needs at least read permission.', $event->isInteractionRestricted());
 		}
 
@@ -185,7 +185,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 				Constants::PERMISSION_UPDATE,
 				Constants::PERMISSION_DELETE,
 			] as $permissions) {
-				$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, $resource, new ShareAction($permissions), $receiver);
+				$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [$resource], new ShareAction($permissions), [$receiver]);
 				$this->assertEquals('Public upload is not allowed.', $event->isInteractionRestricted());
 			}
 		}

--- a/core/Listener/RestrictInteractionListener.php
+++ b/core/Listener/RestrictInteractionListener.php
@@ -54,39 +54,41 @@ final class RestrictInteractionListener implements IEventListener {
 				throw new InteractionRestrictedException('Sharing is not allowed for the user.', $this->l10n->t('Sharing is not allowed for you.'));
 			}
 
-			if ($this->manager->shareWithGroupMembersOnly()) {
-				if ($event->receiver instanceof UserReceiver) {
-					$groups = array_intersect(
-						$this->groupManager->getUserGroupIds($event->getUser()),
-						$this->groupManager->getUserGroupIds($event->receiver->getUser()),
-					);
+			foreach ($event->receivers as $receiver) {
+				if ($this->manager->shareWithGroupMembersOnly()) {
+					if ($receiver instanceof UserReceiver) {
+						$groups = array_intersect(
+							$this->groupManager->getUserGroupIds($event->getUser()),
+							$this->groupManager->getUserGroupIds($receiver->getUser()),
+						);
 
-					$groups = array_diff($groups, $this->manager->shareWithGroupMembersOnlyExcludeGroupsList());
+						$groups = array_diff($groups, $this->manager->shareWithGroupMembersOnlyExcludeGroupsList());
 
-					if ($groups === []) {
-						throw new InteractionRestrictedException('Sharing is only allowed with group members.', $this->l10n->t('Sharing is only allowed with group members.'));
+						if ($groups === []) {
+							throw new InteractionRestrictedException('Sharing is only allowed with group members.', $this->l10n->t('Sharing is only allowed with group members.'));
+						}
+					}
+
+					if ($receiver instanceof GroupReceiver && (!$receiver->getGroup()->inGroup($event->getUser()) || in_array($receiver->getGroup()->getGID(), $this->manager->shareWithGroupMembersOnlyExcludeGroupsList(), true))) {
+						throw new InteractionRestrictedException('Sharing is only allowed to the groups the user is a member of.', $this->l10n->t('Sharing is only allowed within your own groups.'));
 					}
 				}
 
-				if ($event->receiver instanceof GroupReceiver && (!$event->receiver->getGroup()->inGroup($event->getUser()) || in_array($event->receiver->getGroup()->getGID(), $this->manager->shareWithGroupMembersOnlyExcludeGroupsList(), true))) {
-					throw new InteractionRestrictedException('Sharing is only allowed to the groups the user is a member of.', $this->l10n->t('Sharing is only allowed within your own groups.'));
+				if ($receiver instanceof GroupReceiver && !$this->manager->allowGroupSharing()) {
+					throw new InteractionRestrictedException('Group sharing is not allowed.', $this->l10n->t('Group sharing is not allowed.'));
 				}
-			}
 
-			if ($event->receiver instanceof GroupReceiver && !$this->manager->allowGroupSharing()) {
-				throw new InteractionRestrictedException('Group sharing is not allowed.', $this->l10n->t('Group sharing is not allowed.'));
-			}
+				if (($receiver instanceof LinkReceiver || $receiver instanceof EmailReceiver) && !$this->manager->shareApiAllowLinks($event->getUser())) {
+					throw new InteractionRestrictedException('Public link sharing is not allowed.', $this->l10n->t('Public link sharing is not allowed.'));
+				}
 
-			if (($event->receiver instanceof LinkReceiver || $event->receiver instanceof EmailReceiver) && !$this->manager->shareApiAllowLinks($event->getUser())) {
-				throw new InteractionRestrictedException('Public link sharing is not allowed.', $this->l10n->t('Public link sharing is not allowed.'));
-			}
+				if ($receiver instanceof RemoteUserReceiver && !$this->manager->outgoingServer2ServerSharesAllowed()) {
+					throw new InteractionRestrictedException('Sharing to remote users is not allowed.', $this->l10n->t('Sharing to remote users is not allowed.'));
+				}
 
-			if ($event->receiver instanceof RemoteUserReceiver && !$this->manager->outgoingServer2ServerSharesAllowed()) {
-				throw new InteractionRestrictedException('Sharing to remote users is not allowed.', $this->l10n->t('Sharing to remote users is not allowed.'));
-			}
-
-			if ($event->receiver instanceof RemoteGroupReceiver && !$this->manager->outgoingServer2ServerGroupSharesAllowed()) {
-				throw new InteractionRestrictedException('Sharing to remote groups is not allowed.', $this->l10n->t('Sharing to remote groups is not allowed.'));
+				if ($receiver instanceof RemoteGroupReceiver && !$this->manager->outgoingServer2ServerGroupSharesAllowed()) {
+					throw new InteractionRestrictedException('Sharing to remote groups is not allowed.', $this->l10n->t('Sharing to remote groups is not allowed.'));
+				}
 			}
 		}
 	}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -261,7 +261,7 @@ class Manager implements IManager {
 
 		foreach ($users as $user) {
 			$resource = new NodeResource($share->getNodeId(), $user->getUID());
-			$event = new RestrictInteractionEvent($user->getUID(), $user, $resource, $action, $receiver);
+			$event = new RestrictInteractionEvent($user->getUID(), $user, [$resource], $action, [$receiver]);
 			try {
 				$isRestricted = $event->isInteractionRestricted();
 				if ($isRestricted !== false) {

--- a/lib/public/Interaction/RestrictInteractionEvent.php
+++ b/lib/public/Interaction/RestrictInteractionEvent.php
@@ -19,8 +19,8 @@ use OCP\Server;
 use RuntimeException;
 
 /**
- * This event can be emitted to check if a user is allowed to perform an action, such that the receiver would become aware of the resource.
- * If the resource has a distinction between an owner and a initiator, the event must be emitted for both.
+ * This event can be emitted to check if a user is allowed to perform an action, such that the receivers would become aware of the resources.
+ * If the resources have a distinction between an owner and a initiator, the event must be emitted for each separately.
  * Emitters may omit one or multiple properties, if they are not known.
  * Emitters must call {@see isInteractionRestricted} instead of dispatching the event manually, to ensure exception handling and audit logging is done correctly.
  * Listeners may ignore any of the properties and only check the ones that are relevant to them.
@@ -36,9 +36,11 @@ final class RestrictInteractionEvent extends Event {
 	public function __construct(
 		public readonly string $userId,
 		private ?IUser $user,
-		public readonly ?InteractionResource $resource,
+		/** @var list<InteractionResource> $resources */
+		public readonly array $resources,
 		public readonly ?InteractionAction $action,
-		public readonly ?InteractionReceiver $receiver,
+		/** @var list<InteractionReceiver> $receivers */
+		public readonly array $receivers,
 	) {
 		parent::__construct();
 	}
@@ -69,22 +71,22 @@ final class RestrictInteractionEvent extends Event {
 		$params = [
 			$this->action instanceof InteractionAction ? $this->action::class : '?',
 			$this->userId,
-			$this->resource?->getID() ?? '?',
-			$this->receiver?->getID() ?? '?',
+			$this->resources === [] ? '?' : implode(', ', array_map(static fn (InteractionResource $resource): string => $resource->getID(), $this->resources)),
+			$this->receivers === [] ? '?' : implode(', ', array_map(static fn (InteractionReceiver $receiver): string => $receiver->getID() ?? $receiver::class, $this->receivers)),
 		];
 
 		try {
 			$eventDispatcher->dispatchTyped($this);
 
 			$eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent(
-				'Interaction "%s" from user "%s" on "%s" to "%s" is allowed.',
+				'Interaction %s from user %s on %s to %s is allowed.',
 				$params,
 			));
 
 			return false;
 		} catch (InteractionRestrictedException $interactionRestrictedException) {
 			$eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent(
-				'Interaction "%s" from user "%s" on "%s" to "%s" is restricted: ' . $interactionRestrictedException->getMessage(),
+				'Interaction %s from user %s on %s to %s is restricted: ' . $interactionRestrictedException->getMessage(),
 				$params,
 			));
 

--- a/tests/Core/Listener/RestrictInteractionListenerTest.php
+++ b/tests/Core/Listener/RestrictInteractionListenerTest.php
@@ -61,7 +61,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('core', 'shareapi_enabled', 'no');
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), null);
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), []);
 		$this->assertEquals('Sharing is not allowed.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('core', 'shareapi_enabled');
@@ -77,7 +77,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config->setAppValue('core', 'shareapi_exclude_groups', 'yes');
 		$config->setAppValue('core', 'shareapi_exclude_groups_list', json_encode([$group->getGID()], JSON_THROW_ON_ERROR));
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), null);
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), []);
 		$this->assertEquals('Sharing is not allowed for you.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('core', 'shareapi_exclude_groups');
@@ -98,7 +98,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('core', 'shareapi_only_share_with_group_members', 'yes');
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), new UserReceiver($user2->getUID(), $user2));
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [new UserReceiver($user2->getUID(), $user2)]);
 		$this->assertEquals('Sharing is only allowed with group members.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('core', 'shareapi_only_share_with_group_members');
@@ -121,7 +121,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config->setAppValue('core', 'shareapi_only_share_with_group_members', 'yes');
 		$config->setAppValue('core', 'shareapi_only_share_with_group_members_exclude_group_list', json_encode([$group->getGID()], JSON_THROW_ON_ERROR));
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), new UserReceiver($user2->getUID(), $user2));
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [new UserReceiver($user2->getUID(), $user2)]);
 		$this->assertEquals('Sharing is only allowed with group members.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('core', 'shareapi_only_share_with_group_members');
@@ -139,7 +139,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('core', 'shareapi_only_share_with_group_members', 'yes');
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), new GroupReceiver($group->getGID(), $group));
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [new GroupReceiver($group->getGID(), $group)]);
 		$this->assertEquals('Sharing is only allowed within your own groups.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('core', 'shareapi_only_share_with_group_members');
@@ -157,7 +157,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config->setAppValue('core', 'shareapi_only_share_with_group_members', 'yes');
 		$config->setAppValue('core', 'shareapi_only_share_with_group_members_exclude_group_list', json_encode([$group->getGID()], JSON_THROW_ON_ERROR));
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), new GroupReceiver($group->getGID(), $group));
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [new GroupReceiver($group->getGID(), $group)]);
 		$this->assertEquals('Sharing is only allowed within your own groups.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('core', 'shareapi_only_share_with_group_members');
@@ -175,7 +175,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('core', 'shareapi_allow_group_sharing', 'no');
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), new GroupReceiver($group->getGID(), $group));
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [new GroupReceiver($group->getGID(), $group)]);
 		$this->assertEquals('Group sharing is not allowed.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('core', 'shareapi_allow_group_sharing');
@@ -192,7 +192,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 			new LinkReceiver(),
 			new EmailReceiver(''),
 		] as $receiver) {
-			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), $receiver);
+			$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [$receiver]);
 			$this->assertEquals('Public link sharing is not allowed.', $event->isInteractionRestricted());
 		}
 
@@ -204,7 +204,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'no');
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), new RemoteUserReceiver(''));
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [new RemoteUserReceiver('')]);
 		$this->assertEquals('Sharing to remote users is not allowed.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('files_sharing', 'outgoing_server2server_share_enabled');
@@ -215,7 +215,7 @@ final class RestrictInteractionListenerTest extends TestCase {
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('files_sharing', 'outgoing_server2server_group_share_enabled', 'no');
 
-		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, null, new ShareAction(), new RemoteGroupReceiver(''));
+		$event = new RestrictInteractionEvent($this->user->getUID(), $this->user, [], new ShareAction(), [new RemoteGroupReceiver('')]);
 		$this->assertEquals('Sharing to remote groups is not allowed.', $event->isInteractionRestricted());
 
 		$config->deleteAppValue('files_sharing', 'outgoing_server2server_group_share_enabled');

--- a/tests/lib/Interaction/RestrictInteractionEventTest.php
+++ b/tests/lib/Interaction/RestrictInteractionEventTest.php
@@ -55,24 +55,34 @@ final class RestrictInteractionEventTest extends TestCase {
 			->method('getUID')
 			->willReturn('my-uid');
 
-		$resource = $this->createMock(InteractionResource::class);
-		$resource
+		$resource1 = $this->createMock(InteractionResource::class);
+		$resource1
 			->method('getID')
-			->willReturn('my-resource');
+			->willReturn('my-resource1');
+
+		$resource2 = $this->createMock(InteractionResource::class);
+		$resource2
+			->method('getID')
+			->willReturn('my-resource2');
 
 		$action = $this->createStub(InteractionAction::class);
 
-		$receiver = $this->createMock(InteractionReceiver::class);
-		$receiver
+		$receiver1 = $this->createMock(InteractionReceiver::class);
+		$receiver1
 			->method('getID')
-			->willReturn('my-receiver');
+			->willReturn('my-receiver1');
+
+		$receiver2 = $this->createMock(InteractionReceiver::class);
+		$receiver2
+			->method('getID')
+			->willReturn('my-receiver2');
 
 		$event = new RestrictInteractionEvent(
 			$user->getUID(),
 			$user,
-			$resource,
+			[$resource1, $resource2],
 			$action,
-			$receiver,
+			[$receiver1, $receiver2],
 		);
 
 		if ($isRestricted) {
@@ -84,13 +94,13 @@ final class RestrictInteractionEventTest extends TestCase {
 		$this->assertEquals([
 			new CriticalActionPerformedEvent(
 				$isRestricted
-					? 'Interaction "%s" from user "%s" on "%s" to "%s" is restricted: my restriction message'
-					: 'Interaction "%s" from user "%s" on "%s" to "%s" is allowed.',
+					? 'Interaction %s from user %s on %s to %s is restricted: my restriction message'
+					: 'Interaction %s from user %s on %s to %s is allowed.',
 				[
 					$action::class,
 					'my-uid',
-					'my-resource',
-					'my-receiver',
+					'my-resource1, my-resource2',
+					'my-receiver1, my-receiver2',
 				],
 			),
 		], $auditEvents);


### PR DESCRIPTION
For Unified Sharing some checks will need to check several resources and receivers at once, so this is needed to avoid breaking changes once it is released in 34.0.2.