### PR TITLE
feat(occ): improve config:list help text/descriptions

### DIFF
--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -37,21 +37,46 @@ class ListConfigs extends Base {
 
 		$this
 			->setName('config:list')
-			->setDescription('List all configs')
+			->setDescription('List system and app configuration values')
 			->addArgument(
 				'app',
 				InputArgument::OPTIONAL,
-				'Name of the app ("system" to get the config.php values, "all" for all apps and system)',
+				'What to list: an app name, "system" for system configuration values, or "all" for system and all app configs',
 				'all'
 			)
 			->addOption(
 				'private',
 				null,
 				InputOption::VALUE_NONE,
-				'Use this option when you want to include sensitive configs like passwords, salts, ...'
+				'Include sensitive configuration values like passwords and secrets'
 			)
-			->addOption('migrate', null, InputOption::VALUE_NONE, 'Rename config keys of all enabled apps, based on ConfigLexicon')
-		;
+			->addOption(
+				'migrate',
+				null,
+				InputOption::VALUE_NONE,
+				'Migrate config keys using the ConfigLexicon before listing',
+			)
+			->setHelp(<<<'HELP'
+The <info>%command.name%</info> command lists system and app configuration values.
+
+For system, this shows the effective system configuration as loaded by
+Nextcloud. It may include values from <info>config.php</info>, additional <info>*.config.php</info>
+files, and <info>NC_*</info> environment variables.
+
+Examples:
+
+  <info>php occ config:list</info>
+    List all system and app configuration values
+
+  <info>php occ config:list system</info>
+    List only system configuration values
+
+  <info>php occ config:list files_sharing</info>
+    List configuration values for the files_sharing app
+
+  <info>php occ config:list --private</info>
+    List all system and app configuration values, including sensitive values
+HELP);
 	}
 
 	#[\Override]


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Make language more descriptive, precise, and consistent
- Add examples

### Before:

```console
root@90c0b61e2a5c:/var/www/html# ./occ config:list --help   
Description:
  List all configs

Usage:
  config:list [options] [--] [<app>]

Arguments:
  app                    Name of the app ("system" to get the config.php values, "all" for all apps and system) [default: "all"]

Options:
      --output[=OUTPUT]  Output format (plain, json or json_pretty, default is plain) [default: "json_pretty"]
      --private          Use this option when you want to include sensitive configs like passwords, salts, ...
      --migrate          Rename config keys of all enabled apps, based on ConfigLexicon
  -h, --help             Display help for the given command. When no command is given display help for the list command
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi|--no-ansi   Force (or disable --no-ansi) ANSI output
  -n, --no-interaction   Do not ask any interactive question
      --no-warnings      Skip global warnings, show command output only
  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  More extensive and thorough documentation may be found at https://docs.nextcloud.com
```
### After:

```console
root@55f7573a36fc:/var/www/html# ./occ config:list --help
Description:
  List system and app configuration values

Usage:
  config:list [options] [--] [<app>]

Arguments:
  app                    What to list: an app name, "system" for system configuration values, or "all" for system and all app configs [default: "all"]

Options:
      --output[=OUTPUT]  Output format (plain, json or json_pretty, default is plain) [default: "json_pretty"]
      --private          Include sensitive configuration values like passwords and secrets
      --migrate          Migrate config keys using the ConfigLexicon before listing
  -h, --help             Display help for the given command. When no command is given display help for the list command
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi|--no-ansi   Force (or disable --no-ansi) ANSI output
  -n, --no-interaction   Do not ask any interactive question
      --no-warnings      Skip global warnings, show command output only
  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The config:list command lists system and app configuration values.
  
  For system, this shows the effective system configuration as loaded by
  Nextcloud. It may include values from config.php, additional *.config.php
  files, and NC_* environment variables.
  
  Examples:
  
    php occ config:list
      List all system and app configuration values
  
    php occ config:list system
      List only system configuration values
  
    php occ config:list files_sharing
      List configuration values for the files_sharing app
  
    php occ config:list --private
      List all system and app configuration values, including sensitive values

```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
