### PR TITLE
perf(carddav): reduce disk usage of photocache

### DIFF
--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -24,8 +24,11 @@ use Sabre\VObject\Reader;
 class PhotoCache {
 	private ?IAppData $photoCacheAppData = null;
 
+	/** Maximum edge length (in pixels) for photos */
+	private const int MAX_SIZE = 2048;
+
 	/** @var array */
-	public const ALLOWED_CONTENT_TYPES = [
+	public const array ALLOWED_CONTENT_TYPES = [
 		'image/png' => 'png',
 		'image/jpeg' => 'jpg',
 		'image/gif' => 'gif',
@@ -98,6 +101,9 @@ class PhotoCache {
 	private function getFile(ISimpleFolder $folder, $size): ISimpleFile {
 		$ext = $this->getExtension($folder);
 
+		// cap the size
+		$size = (int)min($size, self::MAX_SIZE);
+
 		if ($size === -1) {
 			$path = 'photo.' . $ext;
 		} else {
@@ -122,9 +128,10 @@ class PhotoCache {
 			}
 
 			$size = (int)($size * $ratio);
-			if ($size !== -1) {
-				$photo->resize($size);
-			}
+			// cap the size
+			$size = min($size, self::MAX_SIZE);
+
+			$photo->resize($size);
 
 			try {
 				$file = $folder->newFile($path);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Reduce disk usage of photocache

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
