### PR TITLE
fix(files_sharing): validate input in PublicPreviewController#getPreview

### DIFF
--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -17,8 +17,10 @@ use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\PublicShareController;
 use OCP\Constants;
+use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\ISession;
@@ -29,8 +31,7 @@ use OCP\Share\IShare;
 
 class PublicPreviewController extends PublicShareController {
 
-	/** @var IShare */
-	private $share;
+	private IShare $share;
 
 	public function __construct(
 		string $appName,
@@ -64,10 +65,13 @@ class PublicPreviewController extends PublicShareController {
 	}
 
 	/**
-	 * Get a preview for a shared file
+	 * Get a preview for a public share
+	 *
+	 * For shares pointing to a single file, the file parameter is ignored.
+	 * For folder shares, file must be the relative path to a file inside the shared folder.
 	 *
 	 * @param string $token Token of the share
-	 * @param string $file File in the share
+	 * @param string $file Relative path to a file inside a shared folder; ignored for single-file shares
 	 * @param int $x Width of the preview
 	 * @param int $y Height of the preview
 	 * @param bool $a Whether to not crop the preview
@@ -122,27 +126,43 @@ class PublicPreviewController extends PublicShareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		$previewFile = null;
+
 		try {
-			$node = $share->getNode();
-			if ($node instanceof Folder) {
-				$file = $node->get($file);
+			$shareNode = $share->getNode();
+			if ($shareNode instanceof Folder) {
+				if ($file === '') {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
+
+				$previewFile = $shareNode->get($file);
+				if ($previewFile instanceof Folder) {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
 			} else {
-				$file = $node;
+				$previewFile = $shareNode;
 			}
 
-			$f = $this->previewManager->getPreview($file, $x, $y, !$a);
-			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$preview = $this->previewManager->getPreview($previewFile, $x, $y, !$a);
+			$response = new FileDisplayResponse(
+				$preview,
+				Http::STATUS_OK,
+				['Content-Type' => $preview->getMimeType()]
+			);
+
 			$response->cacheFor($cacheForSeconds);
 			return $response;
-		} catch (NotFoundException $e) {
-			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($file instanceof \OCP\Files\File && $mimeFallback) {
-				if ($url = $this->mimeIconProvider->getMimeIconUrl($file->getMimeType())) {
+		} catch (NotFoundException) {
+			// If a preview could not be generated for a resolved file, we can redirect to the mime icon if any
+			if ($mimeFallback && $previewFile instanceof File) {
+				if ($url = $this->mimeIconProvider->getMimeIconUrl($previewFile->getMimeType())) {
 					return new RedirectResponse($url);
 				}
 			}
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
-		} catch (\InvalidArgumentException $e) {
+		} catch (NotPermittedException) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		} catch (\InvalidArgumentException) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 	}
@@ -200,8 +220,10 @@ class PublicPreviewController extends PublicShareController {
 			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
 			$response->cacheFor(3600 * 24);
 			return $response;
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (NotPermittedException) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		} catch (\InvalidArgumentException $e) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}

--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -20,6 +20,7 @@ use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\ISession;
@@ -30,8 +31,7 @@ use OCP\Share\IShare;
 
 class PublicPreviewController extends PublicShareController {
 
-	/** @var IShare */
-	private $share;
+	private IShare $share;
 
 	public function __construct(
 		string $appName,
@@ -65,10 +65,13 @@ class PublicPreviewController extends PublicShareController {
 	}
 
 	/**
-	 * Get a preview for a shared file
+	 * Get a preview for a public share
+	 *
+	 * For shares pointing to a single file, the file parameter is ignored.
+	 * For folder shares, file must be the relative path to a file inside the shared folder.
 	 *
 	 * @param string $token Token of the share
-	 * @param string $file File in the share
+	 * @param string $file Relative path to a file inside a shared folder; ignored for single-file shares
 	 * @param int $x Width of the preview
 	 * @param int $y Height of the preview
 	 * @param bool $a Whether to not crop the preview
@@ -123,27 +126,43 @@ class PublicPreviewController extends PublicShareController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		$previewFile = null;
+
 		try {
-			$node = $share->getNode();
-			if ($node instanceof Folder) {
-				$file = $node->get($file);
+			$shareNode = $share->getNode();
+			if ($shareNode instanceof Folder) {
+				if ($file === '') {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
+
+				$previewFile = $shareNode->get($file);
+				if ($previewFile instanceof Folder) {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
 			} else {
-				$file = $node;
+				$previewFile = $shareNode;
 			}
 
-			$f = $this->previewManager->getPreview($file, $x, $y, !$a);
-			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$preview = $this->previewManager->getPreview($previewFile, $x, $y, !$a);
+			$response = new FileDisplayResponse(
+				$preview,
+				Http::STATUS_OK,
+				['Content-Type' => $preview->getMimeType()]
+			);
+
 			$response->cacheFor($cacheForSeconds);
 			return $response;
-		} catch (NotFoundException $e) {
-			// If we have no preview enabled, we can redirect to the mime icon if any
-			if ($file instanceof File && $mimeFallback) {
-				if ($url = $this->mimeIconProvider->getMimeIconUrl($file->getMimeType())) {
+		} catch (NotFoundException) {
+			// If a preview could not be generated for a resolved file, we can redirect to the mime icon if any
+			if ($mimeFallback && $previewFile instanceof File) {
+				if ($url = $this->mimeIconProvider->getMimeIconUrl($previewFile->getMimeType())) {
 					return new RedirectResponse($url);
 				}
 			}
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
-		} catch (\InvalidArgumentException $e) {
+		} catch (NotPermittedException) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
+		} catch (\InvalidArgumentException) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 	}
@@ -201,8 +220,10 @@ class PublicPreviewController extends PublicShareController {
 			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
 			$response->cacheFor(3600 * 24);
 			return $response;
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		} catch (NotPermittedException) {
+			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		} catch (\InvalidArgumentException $e) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -1474,7 +1474,8 @@
         "/index.php/apps/files_sharing/publicpreview/{token}": {
             "get": {
                 "operationId": "public_preview-get-preview",
-                "summary": "Get a preview for a shared file",
+                "summary": "Get a preview for a public share",
+                "description": "For shares pointing to a single file, the file parameter is ignored. For folder shares, file must be the relative path to a file inside the shared folder.",
                 "tags": [
                     "public_preview"
                 ],
@@ -1500,7 +1501,7 @@
                     {
                         "name": "file",
                         "in": "query",
-                        "description": "File in the share",
+                        "description": "Relative path to a file inside a shared folder; ignored for single-file shares",
                         "schema": {
                             "type": "string",
                             "default": ""

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -11,6 +11,7 @@ use OCA\Files_Sharing\Controller\PublicPreviewController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
 use OCP\Files\File;
@@ -33,6 +34,7 @@ class PublicPreviewControllerTest extends TestCase {
 	private IManager&MockObject $shareManager;
 	private ITimeFactory&MockObject $timeFactory;
 	private IRequest&MockObject $request;
+	private IMimeIconProvider&MockObject $mimeIconProvider;
 
 	private PublicPreviewController $controller;
 
@@ -43,6 +45,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->request = $this->createMock(IRequest::class);
+		$this->mimeIconProvider = $this->createMock(IMimeIconProvider::class);
 
 		$this->timeFactory->method('getTime')
 			->willReturn(1337);
@@ -55,7 +58,7 @@ class PublicPreviewControllerTest extends TestCase {
 			$this->shareManager,
 			$this->createMock(ISession::class),
 			$this->previewManager,
-			$this->createMock(IMimeIconProvider::class),
+			$this->mimeIconProvider,
 		);
 	}
 
@@ -154,7 +157,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(15 * 60);
 		$this->assertEquals($expected, $res);
@@ -190,7 +193,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
@@ -222,7 +225,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
@@ -248,8 +251,120 @@ class PublicPreviewControllerTest extends TestCase {
 			->with($this->equalTo('file'))
 			->willThrowException(new NotFoundException());
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderEmptyFileReturnsBadRequest(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$res = $this->controller->getPreview('token', '', 10, 10, false, false);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderSubfolderReturnsBadRequest(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$subfolder = $this->createMock(Folder::class);
+		$folder->method('get')
+			->with($this->equalTo('nested'))
+			->willReturn($subfolder);
+
+		$res = $this->controller->getPreview('token', 'nested', 10, 10, false, false);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderInvalidFileWithMimeFallbackReturnsNotFound(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$folder->method('get')
+			->with($this->equalTo('file'))
+			->willThrowException(new NotFoundException());
+
+		$this->mimeIconProvider->expects($this->never())
+			->method('getMimeIconUrl');
+
+		$res = $this->controller->getPreview('token', 'file', 10, 10, false, true);
+		$expected = new DataResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $res);
+	}
+
+	public function testPreviewFolderValidFileMimeFallbackRedirectsWhenPreviewMissing(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$file = $this->createMock(File::class);
+		$folder->method('get')
+			->with($this->equalTo('file'))
+			->willReturn($file);
+
+		$file->method('getMimeType')
+			->willReturn('text/plain');
+
+		$this->previewManager->method('getPreview')
+			->with($this->equalTo($file), 10, 10, true)
+			->willThrowException(new NotFoundException());
+
+		$this->mimeIconProvider->method('getMimeIconUrl')
+			->with('text/plain')
+			->willReturn('/icon-url');
+
+		$res = $this->controller->getPreview('token', 'file', 10, 10, false, true);
+		$expected = new RedirectResponse('/icon-url');
 		$this->assertEquals($expected, $res);
 	}
 
@@ -284,7 +399,7 @@ class PublicPreviewControllerTest extends TestCase {
 		$preview->method('getMimeType')
 			->willReturn('myMime');
 
-		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
+		$res = $this->controller->getPreview('token', 'file', 10, 10, true, false);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
 		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);

--- a/openapi.json
+++ b/openapi.json
@@ -26400,7 +26400,8 @@
         "/index.php/apps/files_sharing/publicpreview/{token}": {
             "get": {
                 "operationId": "files_sharing-public_preview-get-preview",
-                "summary": "Get a preview for a shared file",
+                "summary": "Get a preview for a public share",
+                "description": "For shares pointing to a single file, the file parameter is ignored. For folder shares, file must be the relative path to a file inside the shared folder.",
                 "tags": [
                     "files_sharing/public_preview"
                 ],
@@ -26426,7 +26427,7 @@
                     {
                         "name": "file",
                         "in": "query",
-                        "description": "File in the share",
+                        "description": "Relative path to a file inside a shared folder; ignored for single-file shares",
                         "schema": {
                             "type": "string",
                             "default": ""

--- a/openapi.json
+++ b/openapi.json
@@ -25989,7 +25989,8 @@
         "/index.php/apps/files_sharing/publicpreview/{token}": {
             "get": {
                 "operationId": "files_sharing-public_preview-get-preview",
-                "summary": "Get a preview for a shared file",
+                "summary": "Get a preview for a public share",
+                "description": "For shares pointing to a single file, the file parameter is ignored. For folder shares, file must be the relative path to a file inside the shared folder.",
                 "tags": [
                     "files_sharing/public_preview"
                 ],
@@ -26015,7 +26016,7 @@
                     {
                         "name": "file",
                         "in": "query",
-                        "description": "File in the share",
+                        "description": "Relative path to a file inside a shared folder; ignored for single-file shares",
                         "schema": {
                             "type": "string",
                             "default": ""


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Fixes #59229

## Summary

Local version of https://github.com/nextcloud/server/pull/59253

Return 400 Bad Request when the file parameter is empty and the shared node is a folder, instead of passing the folder itself to getPreview which triggers an internal server error.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
