### PR TITLE
fix(systemtags): correct @since tag for sanitizeWordsAndEmojis

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -638,7 +638,7 @@ class Util {
 	 *
 	 * @param string $input The input string to sanitize
 	 * @return string The sanitized string
-	 * @since 35.0.0
+	 * @since 34.0.2
 	 */
 	public static function sanitizeWordsAndEmojis(string $input): string {
 		// Remove control characters and other invisible separators, but keep everything else.


### PR DESCRIPTION
Since it got backported to stable34, let's adjust 
https://github.com/nextcloud/server/pull/61965


---

*This change was AI-assisted (Claude Code).*
