### PR TITLE
fix(caldav): url-encode owner/user in activity event links

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -72,13 +72,13 @@ class Event extends Base {
 				$linkData = $eventData['link'];
 				$calendarUri = $this->urlencodeLowerHex($linkData['calendar_uri']);
 				if ($affectedUser === $linkData['owner']) {
-					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $calendarUri . '/' . $linkData['object_uri']);
+					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . rawurlencode($linkData['owner']) . '/' . $calendarUri . '/' . $linkData['object_uri']);
 				} else {
 					// Can't use the "real" owner and calendar names here because we create a custom
 					// calendar for incoming shares with the name "<calendar>_shared_by_<sharer>".
 					// Hack: Fix the link by generating it for the incoming shared calendar instead,
 					//       as seen from the affected user.
-					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $affectedUser . '/' . $calendarUri . '_shared_by_' . $linkData['owner'] . '/' . $linkData['object_uri']);
+					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . rawurlencode($affectedUser) . '/' . $calendarUri . '_shared_by_' . rawurlencode($linkData['owner']) . '/' . $linkData['object_uri']);
 				}
 				$params['link'] = $this->url->linkToRouteAbsolute('calendar.view.indexdirect.edit', [
 					'objectId' => $objectId,

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -146,11 +146,29 @@ class EventTest extends TestCase {
 				],
 				base64_encode('/remote.php/dav/calendars/sharee/Umlaut_%c3%a4%c3%bc%c3%b6%c3%9f/someuuid.ics'),
 			],
+			[ // Owned calendar, uid contains a space
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'personal',
+					'owner' => 'Elisa Ciria'
+				],
+				base64_encode('/remote.php/dav/calendars/Elisa%20Ciria/personal/someuuid.ics'),
+				'Elisa Ciria',
+			],
+			[ // Shared calendar, owner and affected user uids both contain a space
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'personal',
+					'owner' => 'Elisa Ciria'
+				],
+				base64_encode('/remote.php/dav/calendars/John%20Doe/personal_shared_by_Elisa%20Ciria/someuuid.ics'),
+				'John Doe',
+			],
 		];
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'generateObjectParameterLinkEncodingDataProvider')]
-	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId): void {
+	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId, string $affectedUser = 'sharee'): void {
 		$generatedLink = [
 			'objectId' => $objectId,
 		];
@@ -171,7 +189,7 @@ class EventTest extends TestCase {
 			'name' => 'calendar',
 			'link' => 'fullLink',
 		];
-		$this->assertEquals($result, $this->invokePrivate($this->provider, 'generateObjectParameter', [$objectParameter, 'sharee']));
+		$this->assertEquals($result, $this->invokePrivate($this->provider, 'generateObjectParameter', [$objectParameter, $affectedUser]));
 	}
 
 	public static function dataGenerateObjectParameterThrows(): array {


### PR DESCRIPTION
Fixes #61738.

Activity links break when a uid has a space, since owner/affectedUser weren't url-encoded the way calendar_uri already is. Wrapped both in rawurlencode(), same fix @joshtrichards okayed on the issue.

Added two test cases for uids with spaces and confirmed they fail without the fix, pass with it. Ran the full EventTest suite locally (13 tests, 55 assertions, all passing).

Assisted with Claude Code.