### PR TITLE
fix(UserPlugin): Don't return mail matches on user id search

### DIFF
--- a/build/integration/sharees_features/sharees.feature
+++ b/build/integration/sharees_features/sharees.feature
@@ -426,6 +426,40 @@ Feature: sharees
     And "exact emails" sharees returned is empty
     And "emails" sharees returned is empty
 
+  Scenario: Search user by system e-mail address with e-mail full match disabled
+    Given As an "test"
+    And parameter "shareapi_restrict_user_enumeration_full_match_email" of app "core" is set to "no"
+    When getting sharees for
+      | search    | sharee2@system.com |
+      | itemType  | file |
+      | shareType | 0 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And "exact users" sharees returned is empty
+    # With enumeration allowed the user is still found as non-exact match, as
+    # enumeration also searches in the e-mail address
+    And "users" sharees returned are
+      | Sharee2 | 0 | Sharee2 | sharee2@system.com |
+    And "exact emails" sharees returned is empty
+    And "emails" sharees returned is empty
+
+  Scenario: Search user by system e-mail address with e-mail full match and user enumeration disabled
+    Given As an "test"
+    And parameter "shareapi_restrict_user_enumeration_full_match_email" of app "core" is set to "no"
+    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+    When getting sharees for
+      | search    | sharee2@system.com |
+      | itemType  | file |
+      | shareType | 0 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # The user id full match must not resolve e-mail addresses through the user
+    # backends (login via e-mail address)
+    And "exact users" sharees returned is empty
+    And "users" sharees returned is empty
+    And "exact emails" sharees returned is empty
+    And "emails" sharees returned is empty
+
   Scenario: Search e-mail
     Given As an "test"
     When getting sharees for

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -118,7 +118,10 @@ readonly class UserPlugin implements ISearchPlugin {
 
 			if ($shareeEnumerationFullMatchUserId) {
 				$user = $this->userManager->get($search);
-				if ($user !== null) {
+				// User backends may also resolve email addresses or other login names here
+				// (e.g. for login via email). Only an actual user id match counts as user id
+				// full match, everything else is governed by the email setting below.
+				if ($user !== null && mb_strtolower($user->getUID()) === $lowerSearch) {
 					$users[$user->getUID()] = ['exact', $user];
 				}
 			}


### PR DESCRIPTION
* Resolves: #58858

## Summary

Since #47686 , the backend search not only returns matches by user ID, but also by their mail address. This is very confusing, as you would expect that to be impossible when the `shareapi_restrict_user_enumeration_full_match_email` setting is being set to `no`.

This PR fixes that by checking if the matched user in the user ID code branch was actually a match by user ID and not by something else (like the mail address) as well as adding integration tests to prevent that from happening in the future.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
