### PR TITLE
fix(UserPlugin): Don't search for displayname when restricted

### DIFF
--- a/build/integration/features/bootstrap/ShareesContext.php
+++ b/build/integration/features/bootstrap/ShareesContext.php
@@ -27,6 +27,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 		$this->deleteServerConfig('core', 'shareapi_only_share_with_group_members');
 		$this->deleteServerConfig('core', 'shareapi_only_share_with_group_members_exclude_group_list');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match');
+		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_displayname');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_email');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_dn');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match_user_id');

--- a/build/integration/sharees_features/sharees_user.feature
+++ b/build/integration/sharees_features/sharees_user.feature
@@ -394,6 +394,40 @@ Feature: sharees_user
 			| Test One (Second displayname for user 1) | 0 | test1 | test1 |
 		And "users" sharees returned is empty
 
+	Scenario: Search for displayname returns nothing without sharee enumeration and without full match displayname enumeration
+		Given user "test" with displayname "foo" exists
+		And user "test1" with displayname "Test One" exists
+		And user "test2" with displayname "Test Two" exists
+		And group "groupA" exists
+		And user "test" belongs to group "groupA"
+		And user "test1" belongs to group "groupA"
+		And user "test2" belongs to group "groupA"
+		And As an "test"
+		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+		And parameter "shareapi_restrict_user_enumeration_full_match_displayname" of app "core" is set to "no"
+		When getting sharees for
+			| search   | Test One |
+			| itemType | file     |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned is empty
+
+	Scenario: Search for exact userid returns exact user without sharee enumeration and without full match displayname enumeration
+		Given user "test" with displayname "foo" exists
+		And user "test1" with displayname "Test One" exists
+		And As an "test"
+		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+		And parameter "shareapi_restrict_user_enumeration_full_match_displayname" of app "core" is set to "no"
+		When getting sharees for
+			| search   | test1 |
+			| itemType | file  |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned are
+			| Test One | 0 | test1 | test1 |
+		And "users" sharees returned is empty
+
 	Scenario: Search for exact userid with shared group returns exact user with sharee enumeration limited to group
 		Given user "test" with displayname "foo" exists
 		And user "test1" exists

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -105,14 +105,17 @@ readonly class UserPlugin implements ISearchPlugin {
 		$shareeEnumerationFullMatch = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match', 'yes') === 'yes';
 		if ($shareeEnumerationFullMatch && $search !== '') {
 			$shareeEnumerationFullMatchUserId = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_user_id', 'yes') === 'yes';
+			$shareeEnumerationFullMatchDisplayName = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_displayname', 'yes') === 'yes';
 			$shareeEnumerationFullMatchEmail = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_email', 'yes') === 'yes';
 			$shareeEnumerationFullMatchIgnoreSecondDisplayName = $this->appConfig->getValueString('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_dn', 'no') === 'yes';
 
-			// Re-use the results from earlier if possible
-			$usersByDisplayName ??= $this->userManager->searchDisplayName($search, $limit, $offset);
-			foreach ($usersByDisplayName as $user) {
-				if ($user->isEnabled() && (mb_strtolower($user->getDisplayName()) === $lowerSearch || ($shareeEnumerationFullMatchIgnoreSecondDisplayName && trim(mb_strtolower(preg_replace('/ \(.*\)$/', '', $user->getDisplayName()))) === $lowerSearch))) {
-					$users[$user->getUID()] = ['exact', $user];
+			if ($shareeEnumerationFullMatchDisplayName) {
+				// Re-use the results from earlier if possible
+				$usersByDisplayName ??= $this->userManager->searchDisplayName($search, $limit, $offset);
+				foreach ($usersByDisplayName as $user) {
+					if ($user->isEnabled() && (mb_strtolower($user->getDisplayName()) === $lowerSearch || ($shareeEnumerationFullMatchIgnoreSecondDisplayName && trim(mb_strtolower(preg_replace('/ \(.*\)$/', '', $user->getDisplayName()))) === $lowerSearch))) {
+						$users[$user->getUID()] = ['exact', $user];
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

In December 2025, @juliusknorr implemented the feature to block full matches on the display name when using the share API (PR https://github.com/nextcloud/server/pull/57041). That feature was unintentionally being dropped on the rewrite of the `UserPlugin` by @susnux, leaving a non-functional toggle in the UI (PR https://github.com/nextcloud/server/pull/57511).

This issue is being fixed with this PR, re-adding the necessary checks on backend side as well as adding integration tests to prevent that from happening in the future.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
