### PR TITLE
fix(UserPlugin): Don't return disabled users on user ID and mail match

### DIFF
--- a/build/integration/sharees_features/sharees.feature
+++ b/build/integration/sharees_features/sharees.feature
@@ -51,6 +51,24 @@ Feature: sharees
     And "exact remotes" sharees returned is empty
     And "remotes" sharees returned is empty
 
+  Scenario: Search without exact match does not return disabled users
+    Given As an "admin"
+    And assure user "Sharee1" is disabled
+    And As an "test"
+    When getting sharees for
+      | search | Sharee |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And "exact users" sharees returned is empty
+    And "users" sharees returned are
+      | Sharee2 | 0 | Sharee2 | sharee2@system.com |
+    And "exact groups" sharees returned is empty
+    And "groups" sharees returned are
+      | ShareeGroup | 1 | ShareeGroup |
+    And "exact remotes" sharees returned is empty
+    And "remotes" sharees returned is empty
+
   Scenario: Search only with group members - denied
     Given As an "test"
     And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
@@ -254,6 +272,22 @@ Feature: sharees
     Then "exact remotes" sharees returned is empty
     Then "remotes" sharees returned is empty
 
+  Scenario: Search with exact match does not return disabled users
+    Given As an "admin"
+    And assure user "Sharee1" is disabled
+    And As an "test"
+    When getting sharees for
+      | search | Sharee1 |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And "exact users" sharees returned is empty
+    And "users" sharees returned is empty
+    And "exact groups" sharees returned is empty
+    And "groups" sharees returned is empty
+    And "exact remotes" sharees returned is empty
+    And "remotes" sharees returned is empty
+
   Scenario: Search with exact match not-exact casing
     Given As an "test"
     When getting sharees for
@@ -361,6 +395,21 @@ Feature: sharees
     And "groups" sharees returned is empty
     And "exact remotes" sharees returned is empty
     And "remotes" sharees returned is empty
+    And "exact emails" sharees returned is empty
+    And "emails" sharees returned is empty
+
+  Scenario: Search user by system e-mail address does not return disabled users
+    Given As an "admin"
+    And assure user "Sharee2" is disabled
+    And As an "test"
+    When getting sharees for
+      | search    | sharee2@system.com |
+      | itemType  | file |
+      | shareType | 0 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And "exact users" sharees returned is empty
+    And "users" sharees returned is empty
     And "exact emails" sharees returned is empty
     And "emails" sharees returned is empty
 

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -124,7 +124,7 @@ readonly class UserPlugin implements ISearchPlugin {
 				// User backends may also resolve email addresses or other login names here
 				// (e.g. for login via email). Only an actual user id match counts as user id
 				// full match, everything else is governed by the email setting below.
-				if ($user !== null && mb_strtolower($user->getUID()) === $lowerSearch) {
+				if ($user !== null && $user->isEnabled() && mb_strtolower($user->getUID()) === $lowerSearch) {
 					$users[$user->getUID()] = ['exact', $user];
 				}
 			}
@@ -141,7 +141,10 @@ readonly class UserPlugin implements ISearchPlugin {
 					$uid = $row['uid'];
 					$email = $row['value'];
 					$isAdditional = $row['name'] === 'additional_mail';
-					$users[$uid] = ['exact', $this->userManager->get($uid), $isAdditional ? $email : null];
+					$user = $this->userManager->get($uid);
+					if ($user !== null && $user->isEnabled()) {
+						$users[$uid] = ['exact', $user, $isAdditional ? $email : null];
+					}
 				}
 				$result->closeCursor();
 			}


### PR DESCRIPTION
* Related: #58822

## Summary

Disabled users are supposed to be hidden when using the share API. This isn't the case right now for two code branches: user ID match and email address match.

This is being fixed by this PR to make the behavior consistent. I've also added integration tests to ensure it doesn't change in the future (until it's being changed on-purpose).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
