### PR TITLE
fix(files): report new files as new in the files:scan summary

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -208,7 +208,7 @@ class Scanner extends PublicEmitter {
 			});
 			$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function ($path, $storageId, $data, $fileId) use ($storage): void {
 				$this->triggerPropagator($storage, $path);
-				if ($fileId !== -1) {
+				if ($fileId > 0) {
 					$this->eventDispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
 				} else {
 					$this->eventDispatcher->dispatchTyped(new NodeAddedToCache($storage, $path));

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -208,7 +208,7 @@ class Scanner extends PublicEmitter {
 			});
 			$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function ($path, $storageId, $data, $fileId) use ($storage): void {
 				$this->triggerPropagator($storage, $path);
-				if ($fileId) {
+				if ($fileId !== -1) {
 					$this->eventDispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
 				} else {
 					$this->eventDispatcher->dispatchTyped(new NodeAddedToCache($storage, $path));

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -18,6 +18,8 @@ use OC\Files\Utils\Scanner;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\Events\FileCacheUpdated;
+use OCP\Files\Events\NodeAddedToCache;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IDBConnection;
 use OCP\IUser;
@@ -207,6 +209,53 @@ class ScannerTest extends TestCase {
 		$newRoot = $cache->get('');
 
 		$this->assertNotEquals($oldRoot->getEtag(), $newRoot->getEtag());
+	}
+
+	public function testScanDispatchesAddedForNewAndUpdatedForChangedEntries(): void {
+		$storage = new Temporary([]);
+		$mount = new MountPoint($storage, '');
+		Filesystem::getMountManager()->addMount($mount);
+
+		$storage->mkdir('folder');
+		$storage->file_put_contents('folder/bar.txt', 'qwerty');
+		$storage->touch('folder/bar.txt', time() - 200);
+
+		/** @var list<object> $events */
+		$events = [];
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')
+			->willReturnCallback(function (object $event) use (&$events): void {
+				$events[] = $event;
+			});
+
+		$scanner = new TestScanner(
+			Server::get(IUserManager::class)->get(''),
+			Server::get(IDBConnection::class),
+			$dispatcher,
+			Server::get(LoggerInterface::class),
+			Server::get(SetupManager::class),
+		);
+		$scanner->addMount($mount);
+
+		$pathsForEvents = function (string $class) use (&$events): array {
+			return array_values(array_map(
+				static fn (object $event): string => $event->getPath(),
+				array_filter($events, static fn (object $event): bool => $event instanceof $class),
+			));
+		};
+
+		// first scan: everything is new, nothing is updated
+		$scanner->scan('');
+		$this->assertContains('folder/bar.txt', $pathsForEvents(NodeAddedToCache::class));
+		$this->assertContains('folder', $pathsForEvents(NodeAddedToCache::class));
+		$this->assertSame([], $pathsForEvents(FileCacheUpdated::class));
+
+		// re-scan after modifying the file: updated, not new
+		$events = [];
+		$storage->file_put_contents('folder/bar.txt', 'qwerty asdf');
+		$scanner->scan('');
+		$this->assertContains('folder/bar.txt', $pathsForEvents(FileCacheUpdated::class));
+		$this->assertSame([], $pathsForEvents(NodeAddedToCache::class));
 	}
 
 	public function testShallow(): void {


### PR DESCRIPTION
## Summary

`occ files:scan` has reported every new file as "Updated" (never "New")
since the summary table was introduced in 292c0e53f8a.

Root cause: the addToCache listener decides between `NodeAddedToCache` and
`FileCacheUpdated` by checking `if ($fileId)`, but `Cache\Scanner` emits
`$fileId = -1` for newly inserted entries, which is truthy. As a result,
the `NodeAddedToCache` branch was unreachable.

## What it does

- Checks for the actual `-1` sentinel instead, so newly inserted entries
  dispatch `NodeAddedToCache` and existing entries dispatch
  `FileCacheUpdated`
- Adds a regression test asserting that a first scan dispatches
  `NodeAddedToCache` and a re-scan of a modified file dispatches
  `FileCacheUpdated`

## How I verified

Setup: Nextcloud master, MariaDB, an S3 (MinIO) external storage mount with
100 files in 35 folders, mounted at `/legacy` for user `demo01`.

Before each scan I cleared the mount's rows from the file cache so every
entry the scan finds is guaranteed new:

```sql
DELETE FROM oc_filecache WHERE storage = <numeric_id of the mount>;
```

**On master** — all 135 entries were just deleted, so all of them are new,
yet the summary reports none:

```
$ occ files:scan demo01 --path=/demo01/files/legacy
Starting scan for user 1 out of 1 (demo01)
+---------+-------+-----+---------+---------+--------+--------------+
| Folders | Files | New | Updated | Removed | Errors | Elapsed time |
+---------+-------+-----+---------+---------+--------+--------------+
| 35      | 100   | 0   | 135     | 0       | 0      | 00:00:00     |
+---------+-------+-----+---------+---------+--------+--------------+
```

**On this branch** — identical steps:

```
$ occ files:scan demo01 --path=/demo01/files/legacy
Starting scan for user 1 out of 1 (demo01)
+---------+-------+-----+---------+---------+--------+--------------+
| Folders | Files | New | Updated | Removed | Errors | Elapsed time |
+---------+-------+-----+---------+---------+--------+--------------+
| 35      | 100   | 135 | 0       | 0       | 0      | 00:00:00     |
+---------+-------+-----+---------+---------+--------+--------------+
```

The included regression test also fails against master and passes with the
fix (first scan must dispatch `NodeAddedToCache`, re-scan of a modified
file must dispatch `FileCacheUpdated`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
