### PR TITLE
chore(playwright): Wait for server response before checking sorting result

### DIFF
--- a/tests/playwright/support/sections/FilesListPage.ts
+++ b/tests/playwright/support/sections/FilesListPage.ts
@@ -106,7 +106,11 @@ export class FilesListPage {
 
 	/** Click a column header's sort button to toggle sorting by that column. */
 	async sortByColumn(name: string): Promise<void> {
+		const saved = this.page.waitForResponse((r) => r.request().method() === 'PUT' && r.url().includes('/index.php/apps/files/api/v1/views'))
+
 		await this.getColumnHeader(name).getByRole('button', { name }).click()
+
+		await saved
 	}
 
 	/** The per-row selection checkboxes. */


### PR DESCRIPTION
## Summary

This PR fixes a race condition that affects the playwright tests under high load on the CI runners. In case the race condition occurs, the tests fail with the following message:

```
Notice:   1 failed
    [chrome] › tests/playwright/e2e/files/files-sorting.spec.ts:138:2 › Files: Sorting the file list › Sorting works after switching view twice 
  43 passed (10.8m)

  1) [chrome] › tests/playwright/e2e/files/files-sorting.spec.ts:138:2 › Files: Sorting the file list › Sorting works after switching view twice 

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 3
    + Received  + 3

      Array [
        "folder",
    -   "1 tiny.txt",
    -   "welcome.txt",
    -   "a medium.txt",
        "z big.txt",
    +   "a medium.txt",
    +   "welcome.txt",
    +   "1 tiny.txt",
      ]

    Call Log:
    - Timeout 15000ms exceeded while waiting on the predicate

      158 | 		await filesListPage.sortByColumn('Size')
      159 | 		await expect(filesListPage.getColumnHeader('Size')).toHaveAttribute('aria-sort', 'ascending')
    > 160 | 		await expect.poll(() => filesListPage.getRowNames()).toEqual([
          | 		                                                     ^
      161 | 			'folder',
      162 | 			'1 tiny.txt',
      163 | 			'welcome.txt',
        at /home/runner/actions-runner/_work/server/server/tests/playwright/e2e/files/files-sorting.spec.ts:160:56

    Error Context: test-results/files-files-sorting-Files--46f65--after-switching-view-twice-chrome/error-context.md

```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
