### PR TITLE
chore(playwright): Rewrite password confirmation handler to avoid race conditions

### DIFF
--- a/tests/playwright/support/utils/password-confirmation.ts
+++ b/tests/playwright/support/utils/password-confirmation.ts
@@ -16,19 +16,18 @@ export async function handlePasswordConfirmation(page: Page, password = 'admin')
 
 	try {
 		// Check if the dialog exists within a short timeout
-		const dialogVisible = await dialog.isVisible({ timeout: 500 }).catch(() => false)
-
-		if (dialogVisible) {
-			// Fill the password field
-			await dialog.locator('input[type="password"]').fill(password)
-
-			// Click the confirm button
-			await dialog.getByRole('button', { name: 'Confirm' }).click()
-
-			// Wait for the dialog to disappear
-			await dialog.waitFor({ state: 'hidden' })
-		}
+		await dialog.waitFor({ state: 'visible', timeout: 500 })
 	} catch {
 		// Dialog didn't appear, which is fine - some operations might not require confirmation
+		return
 	}
+
+	// Fill the password field
+	await dialog.locator('input[type="password"]').fill(password)
+
+	// Click the confirm button
+	await dialog.getByRole('button', { name: 'Confirm' }).click()
+
+	// Wait for the dialog to disappear
+	await dialog.waitFor({ state: 'hidden' })
 }


### PR DESCRIPTION
## Summary

The password confirmation handler on playwright is using a timeout on `isVisible`. That is [deprecated and isn't being considered anymore](https://playwright.dev/docs/api/class-locator#locator-is-visible), which lead to several issues during our playwright tests (especially under high load on our CI runners).

When that issue occurs, the following error can be seen in the playwright tests. The timeout was raised to 90 seconds here and the issue still happened, as the whole test just stuck because of the login never being done.

```
Notice:   1 failed
    [admin-settings] › tests/playwright/e2e/appstore/admin-settings-apps.spec.ts:159:2 › Settings: App management › Limit app usage to group 
  43 passed (11.2m)

  1) [admin-settings] › tests/playwright/e2e/appstore/admin-settings-apps.spec.ts:159:2 › Settings: App management › Limit app usage to group 

    Test timeout of 90000ms exceeded.

    Error: expect(locator).toHaveCount(expected) failed

    Locator:  locator('#app-sidebar-vue').getByRole('list', { name: 'Limited to groups' })
    Expected: 0
    Received: undefined


      206 |
      207 | 		// Verify the "Limited to groups" list is no longer visible
    > 208 | 		await expect(appstorePage.limitedToGroupsList()).toHaveCount(0)
          | 		                                                 ^
      209 | 	})
      210 | })
      211 |
        at /home/runner/actions-runner/_work/server/server/tests/playwright/e2e/appstore/admin-settings-apps.spec.ts:208:52

    Error Context: test-results/appstore-admin-settings-ap-4ce9a-nt-Limit-app-usage-to-group-admin-settings/error-context.md
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
