### PR TITLE
chore(tests): Fix broken rector run due to conflict with psalm

### DIFF
--- a/build/rector-strict.php
+++ b/build/rector-strict.php
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector;
@@ -68,4 +69,8 @@ return (require __DIR__ . '/rector-shared.php')
 			$nextcloudDir . '/core/Listener/RestrictInteractionListener.php',
 			$nextcloudDir . '/apps/files_sharing/lib/Listener/RestrictInteractionListener.php',
 		],
+		// `@return $this` is more specific than the native `: self` on a
+		// non-final type; removing it breaks psalm's
+		// LessSpecificImplementedReturnType check (psalm-strict).
+		RemoveDuplicatedReturnSelfDocblockRector::class,
 	]);


### PR DESCRIPTION
## Summary

The CI pipeline against master is currently failing because `rector:strict` is failing. The attempted changes can't be made, as they conflict with the psalm rules. Therefore, I've decided to add the error message to the exception list.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
