### PR TITLE
chore(tests): Fix flaky nodb tests due to `AlgorithmTest`

### DIFF
--- a/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
+++ b/tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php
@@ -182,15 +182,30 @@ class AlgorithmTest extends TestCase {
 		$priv = '';
 		openssl_pkey_export($pkey, $priv);
 		$details = openssl_pkey_get_details($pkey);
+		$coordinateSize = $opensslCurve === 'prime256v1' ? 32 : 48;
+		[$x, $y] = self::zeroPadCoordinates($details['ec']['x'], $details['ec']['y'], $coordinateSize);
 		$key = JWK::parseKey([
 			'kty' => 'EC',
 			'crv' => $jwkCurve,
 			'kid' => 'k',
 			'alg' => $joseAlg,
-			'x' => self::b64url($details['ec']['x']),
-			'y' => self::b64url($details['ec']['y']),
+			'x' => self::b64url($x),
+			'y' => self::b64url($y),
 		], $joseAlg);
 		return [$priv, $key];
+	}
+
+	/**
+	 * openssl strips leading zero bytes from EC coordinates; JWK requires them
+	 * zero-padded to the full field size (RFC 7518 §6.2.1.2).
+	 *
+	 * @return array{0: string, 1: string}
+	 */
+	private static function zeroPadCoordinates(string $x, string $y, int $coordinateSize): array {
+		return [
+			str_pad($x, $coordinateSize, "\x00", STR_PAD_LEFT),
+			str_pad($y, $coordinateSize, "\x00", STR_PAD_LEFT),
+		];
 	}
 
 	private static function b64url(string $bin): string {


### PR DESCRIPTION
## Summary (AI generated)

The failing test `AlgorithmTest::testEcdsaP256RoundTrip` is a **random flake**. The chain:

1. The test helper `ecKeyPair()` generates a fresh EC key each run and builds a JWK from `openssl_pkey_get_details()['ec']['x']/['y']`.
2. PHP returns those coordinates via `BN_bn2bin()`, which strips leading zero bytes — so ~1 in 256 coordinates comes back 31 bytes instead of 32.
3. firebase/php-jwt's `JWK::parseKey()` concatenates the decoded coordinates directly into the uncompressed EC point (`0x04 || x || y`), which OpenSSL requires to be exactly 65 bytes for P-256. A short coordinate produces a malformed point → the warning `openssl_verify(): Supplied key param cannot be coerced into a public key` → verify returns `false`.

RFC 7518 §6.2.1.2 requires JWK coordinates zero-padded to the full field size. Production code already does this correctly (`OCMSignatoryManager::buildEcdsaP256JwkArray`) — only the test helper forgot.

### Why "only on PHP 8.3"?

It actually isn't version-specific — that run was just unlucky. I checked php-src: both PHP 8.3 and 8.5 use the same unpadded `BN_bn2bin` in `openssl_pkey_get_details()`. I then ran a 2000-iteration repro in both `php:8.3-cli` and `php:8.5-rc-cli` containers: both produced short coordinates at the expected ~0.5–0.9% rate, and every short coordinate failed verification. Each CI job generates its own random keys, so with roughly a 1–3% failure chance per job, the 8.3 job happened to draw a bad key while the 8.5 job didn't. A re-run could just as well have failed on 8.5.

### The fix

In `tests/lib/Security/Signature/Rfc9421/AlgorithmTest.php`, `ecKeyPair()` now pads both coordinates via a new `zeroPadCoordinates()` helper (as you suggested) — 32 bytes for P-256, 48 for P-384. Verified: 100 consecutive runs of the ECDSA tests in the dev container, all green, and the repro loop shows zero failures with padding on both PHP versions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
