### PR TITLE
chore(Memcached): Fix flaky tests

### DIFF
--- a/tests/lib/Memcache/MemcachedTest.php
+++ b/tests/lib/Memcache/MemcachedTest.php
@@ -30,6 +30,13 @@ class MemcachedTest extends Cache {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->instance = new Memcached($this->getUniqueID());
+		// Flush the shared \Memcached singleton so that its internal result
+		// code is reset to RES_SUCCESS before the first get() of each test.
+		// Without this, a prior test that ended with a successful set/get
+		// leaves RES_SUCCESS in the singleton, and if the underlying library
+		// then returns false+RES_SUCCESS for a missing key the get() wrapper
+		// cannot tell the difference from a stored false value.
+		$this->instance->clear();
 	}
 
 	#[\Override]


### PR DESCRIPTION
## Summary

The unit tests for `memcached` are [a bit flaky](https://github.com/nextcloud/server/actions?query=workflow%3A%22PHPUnit+memcached%22+is%3Afailure). They sometimes fail on different methods with the same `Failed asserting that false is null.` error. This is an attempt to fix the issue and make sure that the return value on the beginning of a test is always the same.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
