### PR TITLE
perf(workflow): Implement result cache for IP checks

### DIFF
--- a/apps/workflowengine/lib/Check/RequestRemoteAddress.php
+++ b/apps/workflowengine/lib/Check/RequestRemoteAddress.php
@@ -7,13 +7,13 @@
 
 namespace OCA\WorkflowEngine\Check;
 
+use OCP\Cache\CappedMemoryCache;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\WorkflowEngine\ICheck;
 
 class RequestRemoteAddress implements ICheck {
-	/** @var array<string, bool> */
-	protected array $checked = [];
+	protected CappedMemoryCache $checked;
 
 	/**
 	 * @param IL10N $l
@@ -23,6 +23,7 @@ class RequestRemoteAddress implements ICheck {
 		protected IL10N $l,
 		protected IRequest $request,
 	) {
+		$this->checked = new CappedMemoryCache();
 	}
 
 	/**

--- a/apps/workflowengine/lib/Check/RequestRemoteAddress.php
+++ b/apps/workflowengine/lib/Check/RequestRemoteAddress.php
@@ -12,6 +12,8 @@ use OCP\IRequest;
 use OCP\WorkflowEngine\ICheck;
 
 class RequestRemoteAddress implements ICheck {
+	/** @var array<string, bool> */
+	protected array $checked = [];
 
 	/**
 	 * @param IL10N $l
@@ -30,18 +32,24 @@ class RequestRemoteAddress implements ICheck {
 	 */
 	#[\Override]
 	public function executeCheck($operator, $value) {
+		$cacheKey = sha1($operator . $value);
+
+		if (isset($this->checked[$cacheKey])) {
+			return $this->checked[$cacheKey];
+		}
+
 		$actualValue = $this->request->getRemoteAddress();
 		$decodedValue = explode('/', $value);
 
-		if ($operator === 'matchesIPv4') {
-			return $this->matchIPv4($actualValue, $decodedValue[0], (int)$decodedValue[1]);
-		} elseif ($operator === '!matchesIPv4') {
-			return !$this->matchIPv4($actualValue, $decodedValue[0], (int)$decodedValue[1]);
-		} elseif ($operator === 'matchesIPv6') {
-			return $this->matchIPv6($actualValue, $decodedValue[0], (int)$decodedValue[1]);
-		} else {
-			return !$this->matchIPv6($actualValue, $decodedValue[0], (int)$decodedValue[1]);
-		}
+		$result = match ($operator) {
+			'matchesIPv4' => $this->matchIPv4($actualValue, $decodedValue[0], (int)$decodedValue[1]),
+			'!matchesIPv4' => !$this->matchIPv4($actualValue, $decodedValue[0], (int)$decodedValue[1]),
+			'matchesIPv6' => $this->matchIPv6($actualValue, $decodedValue[0], (int)$decodedValue[1]),
+			default => !$this->matchIPv6($actualValue, $decodedValue[0], (int)$decodedValue[1]),
+		};
+
+		$this->checked[$cacheKey] = $result;
+		return $result;
 	}
 
 	/**

--- a/apps/workflowengine/lib/Check/RequestTime.php
+++ b/apps/workflowengine/lib/Check/RequestTime.php
@@ -8,6 +8,7 @@
 namespace OCA\WorkflowEngine\Check;
 
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Cache\CappedMemoryCache;
 use OCP\IL10N;
 use OCP\WorkflowEngine\ICheck;
 
@@ -15,8 +16,7 @@ class RequestTime implements ICheck {
 	public const REGEX_TIME = '([0-1][0-9]|2[0-3]):([0-5][0-9])';
 	public const REGEX_TIMEZONE = '([a-zA-Z]+(?:\\/[a-zA-Z\-\_]+)+)';
 
-	/** @var bool[] */
-	protected $cachedResults;
+	protected CappedMemoryCache $cachedResults;
 
 	/**
 	 * @param ITimeFactory $timeFactory
@@ -25,6 +25,7 @@ class RequestTime implements ICheck {
 		protected IL10N $l,
 		protected ITimeFactory $timeFactory,
 	) {
+		$this->cachedResults = new CappedMemoryCache();
 	}
 
 	/**

--- a/apps/workflowengine/lib/Check/RequestTime.php
+++ b/apps/workflowengine/lib/Check/RequestTime.php
@@ -34,7 +34,7 @@ class RequestTime implements ICheck {
 	 */
 	#[\Override]
 	public function executeCheck($operator, $value) {
-		$valueHash = md5($value);
+		$valueHash = sha1($operator . $value);
 
 		if (isset($this->cachedResults[$valueHash])) {
 			return $this->cachedResults[$valueHash];
@@ -52,7 +52,10 @@ class RequestTime implements ICheck {
 			$in = $timestamp1 <= $timestamp || $timestamp <= $timestamp2;
 		}
 
-		return ($operator === 'in') ? $in : !$in;
+		$result = ($operator === 'in') ? $in : !$in;
+
+		$this->cachedResults[$valueHash] = $result;
+		return $result;
 	}
 
 	/**

--- a/apps/workflowengine/lib/Check/RequestURL.php
+++ b/apps/workflowengine/lib/Check/RequestURL.php
@@ -73,7 +73,7 @@ class RequestURL extends AbstractStringCheck {
 		if ($this->url === RequestURL::CLI) {
 			return false;
 		}
-		return substr($this->request->getScriptName(), 0 - strlen('/remote.php')) === '/remote.php' && (
+		return str_ends_with($this->request->getScriptName(), '/remote.php') && (
 			$this->request->getPathInfo() === '/webdav'
 			|| str_starts_with($this->request->getPathInfo() ?? '', '/webdav/')
 			|| $this->request->getPathInfo() === '/dav/files'


### PR DESCRIPTION
## Summary
- When the workflows are checked hundreds/thousands of times in the same request, the IP address as well as the time are not changing, so we can simply cache the result on a per operation+value level

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
