### PR TITLE
fix(files_sharing): don't abort share:list when orphaned shares exist

### DIFF
--- a/apps/files_sharing/lib/Command/ListShares.php
+++ b/apps/files_sharing/lib/Command/ListShares.php
@@ -72,11 +72,17 @@ class ListShares extends Base {
 		});
 		$shares = iterator_to_array($shares);
 		$data = array_map(function (IShare $share) {
+			try {
+				$sourcePath = $share->getNode()->getPath();
+			} catch (NotFoundException) {
+				// orphaned share, source file no longer exists
+				$sourcePath = null;
+			}
 			return [
 				'id' => $share->getId(),
 				'file' => $share->getNodeId(),
 				'target-path' => $share->getTarget(),
-				'source-path' => $share->getNode()->getPath(),
+				'source-path' => $sourcePath,
 				'owner' => $share->getShareOwner(),
 				'recipient' => $share->getSharedWith(),
 				'by' => $share->getSharedBy(),
@@ -140,19 +146,24 @@ class ListShares extends Base {
 				throw new \Exception("Parent {$parent->getPath()} is not a folder");
 			}
 			$recursive = $input->getOption('recursive');
-			if (!$recursive) {
-				$shareCacheEntry = $share->getNodeCacheEntry();
-				if (!$shareCacheEntry) {
-					$shareCacheEntry = $share->getNode();
+			try {
+				if (!$recursive) {
+					$shareCacheEntry = $share->getNodeCacheEntry();
+					if (!$shareCacheEntry) {
+						$shareCacheEntry = $share->getNode();
+					}
+					if ($shareCacheEntry->getParentId() !== $parent->getId()) {
+						return false;
+					}
+				} else {
+					$shareNode = $share->getNode();
+					if ($parent->getRelativePath($shareNode->getPath()) === null) {
+						return false;
+					}
 				}
-				if ($shareCacheEntry->getParentId() !== $parent->getId()) {
-					return false;
-				}
-			} else {
-				$shareNode = $share->getNode();
-				if ($parent->getRelativePath($shareNode->getPath()) === null) {
-					return false;
-				}
+			} catch (NotFoundException) {
+				// orphaned share, can't be inside the parent folder
+				return false;
 			}
 		}
 		if ($input->getOption('type') && $share->getShareType() !== $this->getShareType($input->getOption('type'))) {

--- a/apps/files_sharing/tests/Command/ListSharesTest.php
+++ b/apps/files_sharing/tests/Command/ListSharesTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Sharing\Tests\Command;
+
+use OCA\Files_Sharing\Command\ListShares;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Test\TestCase;
+
+class ListSharesTest extends TestCase {
+	private IManager&MockObject $shareManager;
+	private IRootFolder&MockObject $rootFolder;
+	private ListShares $command;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->shareManager = $this->createMock(IManager::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->command = new ListShares($this->shareManager, $this->rootFolder);
+	}
+
+	private function createShare(int $id, ?Node $node, ?ICacheEntry $cacheEntry = null): IShare {
+		$share = $this->createMock(IShare::class);
+		$share->method('getId')->willReturn((string)$id);
+		$share->method('getNodeId')->willReturn($id * 100);
+		$share->method('getTarget')->willReturn("/target-$id");
+		$share->method('getShareOwner')->willReturn('owner');
+		$share->method('getSharedWith')->willReturn('recipient');
+		$share->method('getSharedBy')->willReturn('owner');
+		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
+		$share->method('getNodeCacheEntry')->willReturn($cacheEntry);
+		if ($node === null) {
+			$share->method('getNode')->willThrowException(new NotFoundException('Node for share not found'));
+		} else {
+			$share->method('getNode')->willReturn($node);
+		}
+		return $share;
+	}
+
+	private function createNode(string $path, int $parentId = 0): Node {
+		$node = $this->createMock(Node::class);
+		$node->method('getPath')->willReturn($path);
+		$node->method('getParentId')->willReturn($parentId);
+		return $node;
+	}
+
+	private function createInput(array $options): InputInterface {
+		$options += [
+			'owner' => null,
+			'recipient' => null,
+			'by' => null,
+			'file' => null,
+			'parent' => null,
+			'recursive' => false,
+			'type' => null,
+			'status' => null,
+			'output' => 'json',
+		];
+		$input = $this->createMock(InputInterface::class);
+		$input->method('getOption')
+			->willReturnCallback(fn (string $name) => $options[$name] ?? null);
+		return $input;
+	}
+
+	public function testListIncludesOrphanShare(): void {
+		$shares = [
+			$this->createShare(1, $this->createNode('/owner/files/document.txt')),
+			$this->createShare(2, null),
+		];
+		$this->shareManager->method('getAllShares')
+			->willReturn(new \ArrayIterator($shares));
+
+		$output = new BufferedOutput();
+		$exitCode = $this->command->execute($this->createInput([]), $output);
+
+		$this->assertSame(0, $exitCode);
+		$rows = json_decode($output->fetch(), true);
+		$this->assertCount(2, $rows);
+		$this->assertSame('/owner/files/document.txt', $rows[0]['source-path']);
+		$this->assertNull($rows[1]['source-path']);
+	}
+
+	public function testParentFilterSkipsOrphanShare(): void {
+		$parent = $this->createMock(Folder::class);
+		$parent->method('getId')->willReturn(42);
+		$this->rootFolder->method('get')
+			->with('/owner/files/folder')
+			->willReturn($parent);
+
+		$cacheEntry = $this->createMock(ICacheEntry::class);
+		$cacheEntry->method('getParentId')->willReturn(42);
+		$shares = [
+			$this->createShare(1, $this->createNode('/owner/files/folder/document.txt'), $cacheEntry),
+			$this->createShare(2, null),
+		];
+		$this->shareManager->method('getAllShares')
+			->willReturn(new \ArrayIterator($shares));
+
+		$output = new BufferedOutput();
+		$exitCode = $this->command->execute($this->createInput(['parent' => '/owner/files/folder']), $output);
+
+		$this->assertSame(0, $exitCode);
+		$rows = json_decode($output->fetch(), true);
+		$this->assertCount(1, $rows);
+		$this->assertSame('1', $rows[0]['id']);
+	}
+
+	public function testRecursiveParentFilterSkipsOrphanShare(): void {
+		$parent = $this->createMock(Folder::class);
+		$parent->method('getId')->willReturn(42);
+		$parent->method('getRelativePath')
+			->willReturnCallback(fn (string $path) => str_starts_with($path, '/owner/files/folder/')
+				? substr($path, strlen('/owner/files/folder'))
+				: null);
+		$this->rootFolder->method('get')
+			->with('/owner/files/folder')
+			->willReturn($parent);
+
+		$shares = [
+			$this->createShare(1, $this->createNode('/owner/files/folder/sub/document.txt')),
+			$this->createShare(2, null),
+		];
+		$this->shareManager->method('getAllShares')
+			->willReturn(new \ArrayIterator($shares));
+
+		$output = new BufferedOutput();
+		$exitCode = $this->command->execute(
+			$this->createInput(['parent' => '/owner/files/folder', 'recursive' => true]),
+			$output,
+		);
+
+		$this->assertSame(0, $exitCode);
+		$rows = json_decode($output->fetch(), true);
+		$this->assertCount(1, $rows);
+		$this->assertSame('1', $rows[0]['id']);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/61949

## Summary

For several years I have been administering a server where 50–60 people work mainly with Nextcloud and Onlyoffice, and over the years they have created thousands of user shares.

When someone asked me to restore files from backup, in the cases involving shares between users they often could not tell me the exact origin of the shared file, and in two cases I wasted a lot of time because of that.

Since occ had no `share:list` command at the time, I had written an external script that generated a similar list every day, so that during a restore I could quickly find the origin of a share by looking at that list in a backup from a day when the share still existed.

Nextcloud 32 finally added `share:list` to occ, but unfortunately on that server (and I suppose in many other cases) it was unusable: some orphaned shares are always present, and a single one is enough to make the whole command abort.

I considered working around it by always deleting the orphaned shares first, but I don't want to lose the few cases where a restore can actually repair a share, nor risk needlessly removing shares because of temporary problems with the SMB file server or something else.

So I made this change so that the command also works when orphaned shares exist.

Note that orphaned shares are not skipped but included in the list, even though the most important piece of information (the source path) is missing and shown as empty/null. For cases like mine this still has some value: from the orphaned entries you can immediately tell whether a share with the exact name (or a similar one) mentioned by the user actually existed, and who it was shared with. This is already a small improvement over my old external script, which excluded orphaned shares, so I had to dig through several backups just to confirm that the share had existed at all and what it was called. I think keeping the orphaned entries visible where possible can be useful to others as well.

I also added unit tests to catch possible regressions; this command previously had no tests at all.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
