### PR TITLE
fix(caldav): url-encode owner/user in activity event links

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -72,13 +72,13 @@ class Event extends Base {
 				$linkData = $eventData['link'];
 				$calendarUri = $this->urlencodeLowerHex($linkData['calendar_uri']);
 				if ($affectedUser === $linkData['owner']) {
-					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $calendarUri . '/' . $linkData['object_uri']);
+					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . rawurlencode($linkData['owner']) . '/' . $calendarUri . '/' . $linkData['object_uri']);
 				} else {
 					// Can't use the "real" owner and calendar names here because we create a custom
 					// calendar for incoming shares with the name "<calendar>_shared_by_<sharer>".
 					// Hack: Fix the link by generating it for the incoming shared calendar instead,
 					//       as seen from the affected user.
-					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $affectedUser . '/' . $calendarUri . '_shared_by_' . $linkData['owner'] . '/' . $linkData['object_uri']);
+					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . rawurlencode($affectedUser) . '/' . $calendarUri . '_shared_by_' . rawurlencode($linkData['owner']) . '/' . $linkData['object_uri']);
 				}
 				$params['link'] = $this->url->linkToRouteAbsolute('calendar.view.indexdirect.edit', [
 					'objectId' => $objectId,

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -146,11 +146,29 @@ class EventTest extends TestCase {
 				],
 				base64_encode('/remote.php/dav/calendars/sharee/Umlaut_%c3%a4%c3%bc%c3%b6%c3%9f/someuuid.ics'),
 			],
+			[ // Owned calendar, uid contains a space
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'personal',
+					'owner' => 'Elisa Ciria'
+				],
+				base64_encode('/remote.php/dav/calendars/Elisa%20Ciria/personal/someuuid.ics'),
+				'Elisa Ciria',
+			],
+			[ // Shared calendar, owner and affected user uids both contain a space
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'personal',
+					'owner' => 'Elisa Ciria'
+				],
+				base64_encode('/remote.php/dav/calendars/John%20Doe/personal_shared_by_Elisa%20Ciria/someuuid.ics'),
+				'John Doe',
+			],
 		];
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'generateObjectParameterLinkEncodingDataProvider')]
-	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId): void {
+	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId, string $affectedUser = 'sharee'): void {
 		$generatedLink = [
 			'objectId' => $objectId,
 		];
@@ -171,7 +189,7 @@ class EventTest extends TestCase {
 			'name' => 'calendar',
 			'link' => 'fullLink',
 		];
-		$this->assertEquals($result, $this->invokePrivate($this->provider, 'generateObjectParameter', [$objectParameter, 'sharee']));
+		$this->assertEquals($result, $this->invokePrivate($this->provider, 'generateObjectParameter', [$objectParameter, $affectedUser]));
 	}
 
 	public static function dataGenerateObjectParameterThrows(): array {


### PR DESCRIPTION
Assisted-by: ClaudeCode:claude-sonnet-5

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/61738

## Summary
- Re-created community PR to pass CI https://github.com/nextcloud/server/pull/61973

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
