### PR TITLE
fix(memcache): restrict Redis evalSha fallback to NOSCRIPT

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -234,6 +234,10 @@ class Redis extends Cache implements IMemcacheTTL {
 			return $cache->eval($script[0], $args, count($keys));
 		}
 
+		if ($error !== null && str_starts_with($error, 'WRONGTYPE')) {
+			return false;
+		}
+
 		if ($error !== null) {
 			throw new \RuntimeException('Redis EVALSHA failed: ' . $error);
 		}

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -39,6 +39,8 @@ class Redis extends Cache implements IMemcacheTTL {
 
 	private const MAX_TTL = 30 * 24 * 60 * 60; // 1 month
 
+	private const NO_SCRIPT_ERROR_MESSAGE_PREFIX = 'NOSCRIPT';
+
 	private \Redis|\RedisCluster|null $cache = null;
 
 	public function __construct($prefix = '', string $logFile = '') {
@@ -218,12 +220,25 @@ class Redis extends Cache implements IMemcacheTTL {
 		$args = array_merge($keys, $args);
 		$script = self::LUA_SCRIPTS[$scriptName];
 
-		$result = $this->getCache()->evalSha($script[1], $args, count($keys));
-		if ($result === false) {
-			$result = $this->getCache()->eval($script[0], $args, count($keys));
+		$cache = $this->getCache();
+		$cache->clearLastError();
+
+		$result = $cache->evalSha($script[1], $args, count($keys));
+		if ($result !== false) {
+			return $result;
 		}
 
-		return $result;
+		$error = $cache->getLastError();
+		if ($error !== null && str_starts_with($error, self::NO_SCRIPT_ERROR_MESSAGE_PREFIX)) {
+			$cache->clearLastError();
+			return $cache->eval($script[0], $args, count($keys));
+		}
+
+		if ($error !== null) {
+			throw new \RuntimeException('Redis EVALSHA failed: ' . $error);
+		}
+
+		return false;
 	}
 
 	protected static function encodeValue(mixed $value): string {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Adjust `OC\Memcache\Redis::evalLua()` to only fall back from `EVALSHA` to `EVAL` when Redis reports `NOSCRIPT`.

The current implementation retries with the full Lua script whenever `evalSha()` returns `false`. This makes the fallback broader than necessary and can treat unrelated Redis failures the same as a missing cached script.

Restricting the fallback to `NOSCRIPT` keeps the existing behavior for missing script SHAs while allowing other failures to surface normally.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
