### PR TITLE
fix: silence unset password salt, secret warning

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -372,8 +372,8 @@ class Setup {
 			$dbType = 'sqlite3';
 		}
 
-		$salt = $options['passwordsalt'] ?: $this->random->generate(self::MIN_PASSWORD_SALT_LENGTH);
-		$secret = $options['secret'] ?: $this->random->generate(self::MIN_SECRET_LENGTH);
+		$salt = !empty($options['passwordsalt']) ? $options['passwordsalt'] : $this->random->generate(self::MIN_PASSWORD_SALT_LENGTH);
+		$secret = !empty($options['secret']) ? $options['secret'] : $this->random->generate(self::MIN_SECRET_LENGTH);
 
 		//write the config file
 		$newConfigValues = [


### PR DESCRIPTION
## Summary

A minor follow up to my earlier https://github.com/nextcloud/server/pull/57978#issuecomment-4957904567 PR. Silences a warning.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
