### PR TITLE
Fix/caldav option forgiving

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2325,7 +2325,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		}
 
 		$calendarObjects = array_map(function ($o) use ($options) {
-			$calendarData = Reader::read($o['calendardata']);
+			$calendarData = Reader::read($o['calendardata'], $this->getReaderOptions());
 
 			// Expand recurrences if an explicit time range is requested
 			if ($calendarData instanceof VCalendar
@@ -3392,7 +3392,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @return array
 	 */
 	public function getDenormalizedData(string $calendarData): array {
-		$vObject = Reader::read($calendarData);
+		$vObject = Reader::read($calendarData, $this->getReaderOptions());
 		$vEvents = [];
 		$componentType = null;
 		$component = null;
@@ -3843,7 +3843,13 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @return VCalendar
 	 */
 	protected function readCalendarData($objectData) {
-		return Reader::read($objectData);
+		return Reader::read($objectData, $this->getReaderOptions());
+	}
+
+	private function getReaderOptions(): int {
+		return $this->config->getSystemValueBool('dav.forgiving_ical_parser', false)
+			? Reader::OPTION_FORGIVING
+			: 0;
 	}
 
 	/**

--- a/apps/dav/lib/CalDAV/Import/ImportService.php
+++ b/apps/dav/lib/CalDAV/Import/ImportService.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\CalendarImpl;
 use OCP\Calendar\CalendarImportOptions;
+use OCP\IConfig;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Node;
 use Sabre\VObject\Reader;
@@ -26,6 +27,7 @@ class ImportService {
 
 	public function __construct(
 		private CalDavBackend $backend,
+		private IConfig $config,
 	) {
 	}
 
@@ -83,7 +85,7 @@ class ImportService {
 		foreach ($structure['VTIMEZONE'] as $tid => $collection) {
 			$instance = $collection[0];
 			$sObjectContents = $importer->extract((int)$instance[2], (int)$instance[3]);
-			$vObject = Reader::read($sObjectPrefix . $sObjectContents . $sObjectSuffix);
+			$vObject = Reader::read($sObjectPrefix . $sObjectContents . $sObjectSuffix, $this->getReaderOptions());
 			$timezones[$tid] = clone $vObject->VTIMEZONE;
 		}
 		// calendar components
@@ -98,7 +100,7 @@ class ImportService {
 					$sObjectContents .= $importer->extract($instance[2], $instance[3]);
 				}
 				/** @var VCalendar $vObject */
-				$vObject = Reader::read($sObjectPrefix . $sObjectContents . $sObjectSuffix);
+				$vObject = Reader::read($sObjectPrefix . $sObjectContents . $sObjectSuffix, $this->getReaderOptions());
 				// add time zones to object
 				foreach ($this->findTimeZones($vObject) as $zone) {
 					if (isset($timezones[$zone])) {
@@ -341,5 +343,11 @@ class ImportService {
 		}
 
 		return $result;
+	}
+
+	private function getReaderOptions(): int {
+		return $this->config->getSystemValueBool('dav.forgiving_ical_parser', false)
+			? Reader::OPTION_FORGIVING
+			: 0;
 	}
 }

--- a/apps/dav/lib/CalDAV/Plugin.php
+++ b/apps/dav/lib/CalDAV/Plugin.php
@@ -8,8 +8,19 @@
 
 namespace OCA\DAV\CalDAV;
 
+use OCP\IConfig;
+use Sabre\CalDAV\Exception\InvalidComponentType;
+use Sabre\DAV;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\Uri;
+use Sabre\VObject;
+
 class Plugin extends \Sabre\CalDAV\Plugin {
 	public const SYSTEM_CALENDAR_ROOT = 'system-calendars';
+
+	public function __construct(private ?IConfig $config = null) {
+	}
 
 	/**
 	 * Returns the path to a principal's calendar home.
@@ -35,5 +46,120 @@ class Plugin extends \Sabre\CalDAV\Plugin {
 			[, $principalId] = \Sabre\Uri\split($principalUrl);
 			return self::SYSTEM_CALENDAR_ROOT . '/calendar-rooms/' . $principalId;
 		}
+	}
+
+	#[\Override]
+	protected function validateICalendar(&$data, $path, &$modified, RequestInterface $request, ResponseInterface $response, $isNew) {
+		if (is_resource($data)) {
+			$data = stream_get_contents($data);
+		}
+
+		$before = $data;
+
+		try {
+			if ('[' === substr($data, 0, 1)) {
+				$vobj = VObject\Reader::readJson($data);
+				$data = $vobj->serialize();
+				$modified = true;
+			} else {
+				$vobj = VObject\Reader::read($data, $this->getReaderOptions());
+			}
+		} catch (VObject\ParseException $e) {
+			throw new DAV\Exception\UnsupportedMediaType('This resource only supports valid iCalendar 2.0 data. Parse error: ' . $e->getMessage());
+		}
+
+		if ('VCALENDAR' !== $vobj->name) {
+			throw new DAV\Exception\UnsupportedMediaType('This collection can only support iCalendar objects.');
+		}
+
+		$sCCS = '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set';
+
+		list($parentPath) = Uri\split($path);
+		$calendarProperties = $this->server->getProperties($parentPath, [$sCCS]);
+
+		if (isset($calendarProperties[$sCCS])) {
+			$supportedComponents = $calendarProperties[$sCCS]->getValue();
+		} else {
+			$supportedComponents = ['VJOURNAL', 'VTODO', 'VEVENT'];
+		}
+
+		$foundType = null;
+
+		foreach ($vobj->getComponents() as $component) {
+			switch ($component->name) {
+				case 'VTIMEZONE':
+					continue 2;
+				case 'VEVENT':
+				case 'VTODO':
+				case 'VJOURNAL':
+					$foundType = $component->name;
+					break;
+			}
+		}
+
+		if (!$foundType || !in_array($foundType, $supportedComponents)) {
+			throw new InvalidComponentType('iCalendar objects must at least have a component of type ' . implode(', ', $supportedComponents));
+		}
+
+		$options = VObject\Node::PROFILE_CALDAV;
+		$prefer = $this->server->getHTTPPrefer();
+
+		if ('strict' !== $prefer['handling']) {
+			$options |= VObject\Node::REPAIR;
+		}
+
+		$messages = $vobj->validate($options);
+
+		$highestLevel = 0;
+		$warningMessage = null;
+
+		foreach ($messages as $message) {
+			if ($message['level'] > $highestLevel) {
+				$highestLevel = $message['level'];
+				$warningMessage = $message['message'];
+			}
+			switch ($message['level']) {
+				case 1:
+					$modified = true;
+					break;
+				case 2:
+					break;
+				case 3:
+					throw new DAV\Exception\UnsupportedMediaType('Validation error in iCalendar: ' . $message['message']);
+			}
+		}
+
+		if ($warningMessage) {
+			$response->setHeader('X-Sabre-Ew-Gross', 'iCalendar validation warning: ' . $warningMessage);
+		}
+
+		$subModified = false;
+
+		$this->server->emit(
+			'calendarObjectChange',
+			[
+				$request,
+				$response,
+				$vobj,
+				$parentPath,
+				&$subModified,
+				$isNew,
+			]
+		);
+
+		if ($modified || $subModified) {
+			$data = $vobj->serialize();
+			if (!$modified && 0 !== strcmp($data, $before)) {
+				$modified = true;
+			}
+		}
+
+		$vobj->destroy();
+	}
+
+	private function getReaderOptions(): int {
+		return $this->config?->getSystemValueBool('dav.forgiving_ical_parser', false)
+			? VObject\Reader::OPTION_FORGIVING
+			: 0;
 	}
 }

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -205,7 +205,7 @@ class Server {
 		// calendar plugins
 		if ($this->requestIsForSubtree(['calendars', 'public-calendars', 'system-calendars', 'principals'])) {
 			$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OCP\Server::get(IRequest::class), \OCP\Server::get(IConfig::class), \OCP\Server::get(RateLimiting::class)));
-			$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
+			$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin(\OCP\Server::get(IConfig::class)));
 			$this->server->addPlugin(new ICSExportPlugin(\OCP\Server::get(IConfig::class), $logger));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OCP\Server::get(IConfig::class), \OCP\Server::get(LoggerInterface::class), \OCP\Server::get(DefaultCalendarValidator::class)));
 

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -52,7 +52,7 @@ abstract class AbstractCalDavBackend extends TestCase {
 	protected IGroupManager&MockObject $groupManager;
 	protected IEventDispatcher&MockObject $dispatcher;
 	private LoggerInterface&MockObject $logger;
-	private IConfig&MockObject $config;
+	protected IConfig&MockObject $config;
 	private ISecureRandom $random;
 	protected SharingBackend $sharingBackend;
 	protected IDBConnection $db;

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -2104,4 +2104,24 @@ EOD;
 		// Clean up
 		$this->backend->deleteCalendar($calendars[0]['id'], true);
 	}
+
+	private const ICS_ENTOURAGE = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nBEGIN:VEVENT\r\nDTSTART:20260715T100000Z\r\nDTEND:20260715T110000Z\r\nSUMMARY:Test\r\nUID:test-uid-123\r\nX-ENTOURAGE_UUID:test-uid-123\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+	public function testGetDenormalizedDataRejectsNonStandardPropertyWhenFlagDisabled(): void {
+		$this->config->method('getSystemValueBool')
+			->with('dav.forgiving_ical_parser', false)
+			->willReturn(false);
+
+		$this->expectException(\Sabre\VObject\ParseException::class);
+		$this->backend->getDenormalizedData(self::ICS_ENTOURAGE);
+	}
+
+	public function testGetDenormalizedDataAcceptsNonStandardPropertyWhenFlagEnabled(): void {
+		$this->config->method('getSystemValueBool')
+			->with('dav.forgiving_ical_parser', false)
+			->willReturn(true);
+
+		$result = $this->backend->getDenormalizedData(self::ICS_ENTOURAGE);
+		$this->assertSame('test-uid-123', $result['uid']);
+	}
 }

--- a/apps/dav/tests/unit/CalDAV/Import/ImportServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Import/ImportServiceTest.php
@@ -11,22 +11,29 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\CalendarImpl;
 use OCA\DAV\CalDAV\Import\ImportService;
 use OCP\Calendar\CalendarImportOptions;
+use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VEvent;
+use Sabre\VObject\ParseException;
 
 class ImportServiceTest extends \Test\TestCase {
 
 	private ImportService $service;
 	private CalendarImpl|MockObject $calendar;
 	private CalDavBackend|MockObject $backend;
+	private IConfig|MockObject $config;
 	private array $importResults = [];
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->backend = $this->createMock(CalDavBackend::class);
-		$this->service = new ImportService($this->backend);
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->method('getSystemValueBool')
+			->with('dav.forgiving_ical_parser', false)
+			->willReturn(false);
+		$this->service = new ImportService($this->backend, $this->config);
 		$this->calendar = $this->createMock(CalendarImpl::class);
 
 	}
@@ -147,5 +154,31 @@ class ImportServiceTest extends \Test\TestCase {
 		$this->assertCount(1, $result, 'Import result should contain one item');
 		$this->assertArrayHasKey($longUID, $result);
 		$this->assertEquals('created', $result[$longUID]['outcome']);
+	}
+
+	private const ICS_ENTOURAGE = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nBEGIN:VEVENT\r\nDTSTART:20260715T100000Z\r\nDTEND:20260715T110000Z\r\nSUMMARY:Test\r\nUID:test-uid-123\r\nX-ENTOURAGE_UUID:test-uid-123\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+	public function testImportTextRejectsNonStandardPropertyWhenFlagDisabled(): void {
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, self::ICS_ENTOURAGE);
+		rewind($stream);
+
+		$this->expectException(ParseException::class);
+		iterator_to_array($this->service->importText($stream));
+	}
+
+	public function testImportTextAcceptsNonStandardPropertyWhenFlagEnabled(): void {
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->method('getSystemValueBool')
+			->with('dav.forgiving_ical_parser', false)
+			->willReturn(true);
+		$this->service = new ImportService($this->backend, $this->config);
+
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, self::ICS_ENTOURAGE);
+		rewind($stream);
+
+		$objects = iterator_to_array($this->service->importText($stream));
+		$this->assertCount(1, $objects);
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/PluginTest.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\CalDAV;
 
 use OCA\DAV\CalDAV\Plugin;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Exception\UnsupportedMediaType;
+use Sabre\DAV\Server as SabreServer;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
 class PluginTest extends TestCase {
@@ -44,5 +50,57 @@ class PluginTest extends TestCase {
 
 	public function testGetCalendarHomeForUnknownPrincipal(): void {
 		$this->assertNull($this->plugin->getCalendarHomeForPrincipal('FOO/BAR/BLUB'));
+	}
+
+	private const ICS_ENTOURAGE = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nBEGIN:VEVENT\r\nDTSTART:20260715T100000Z\r\nDTEND:20260715T110000Z\r\nSUMMARY:Test\r\nUID:test-uid-123\r\nX-ENTOURAGE_UUID:test-uid-123\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+	private function makePlugin(bool $forgiving): Plugin {
+		/** @var IConfig&MockObject $config */
+		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValueBool')
+			->with('dav.forgiving_ical_parser', false)
+			->willReturn($forgiving);
+
+		$plugin = new class($config) extends Plugin {
+			public function exposeValidateICalendar(string &$data, string $path, bool &$modified, RequestInterface $request, ResponseInterface $response, bool $isNew): void {
+				$this->validateICalendar($data, $path, $modified, $request, $response, $isNew);
+			}
+		};
+
+		/** @var SabreServer&MockObject $server */
+		$server = $this->createMock(SabreServer::class);
+		$server->method('getProperties')->willReturn([]);
+		$server->method('getHTTPPrefer')->willReturn(['handling' => 'lenient']);
+		$server->method('emit')->willReturn(true);
+
+		// Inject server without calling initialize() to avoid its side effects on xml/resourceTypeMapping
+		$prop = new \ReflectionProperty(\Sabre\CalDAV\Plugin::class, 'server');
+		$prop->setValue($plugin, $server);
+
+		return $plugin;
+	}
+
+	public function testValidateICalendarRejectsNonStandardPropertyWhenFlagDisabled(): void {
+		$plugin = $this->makePlugin(false);
+		$data = self::ICS_ENTOURAGE;
+		$modified = false;
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->expectException(UnsupportedMediaType::class);
+		$plugin->exposeValidateICalendar($data, 'calendars/admin/personal/test.ics', $modified, $request, $response, true);
+	}
+
+	public function testValidateICalendarAcceptsNonStandardPropertyWhenFlagEnabled(): void {
+		$plugin = $this->makePlugin(true);
+		$data = self::ICS_ENTOURAGE;
+		$modified = false;
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
+		$response->expects($this->once())
+			->method('setHeader')
+			->with('X-Sabre-Ew-Gross', $this->stringContains('X-ENTOURAGE_UUID'));
+
+		$plugin->exposeValidateICalendar($data, 'calendars/admin/personal/test.ics', $modified, $request, $response, true);
 	}
 }

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -388,6 +388,16 @@ $CONFIG = [
 	'carddav_sync_request_truncation' => 2500,
 
 	/**
+	 * Enable ``Sabre\VObject\Reader::OPTION_FORGIVING`` for CalDAV parsing.
+	 * When set to ``true``, the iCalendar parser accepts property names that do
+	 * not conform to RFC 5545 §3.2, such as ``X-ENTOURAGE_UUID`` produced by
+	 * Outlook for Mac (underscores are invalid in property names).
+	 *
+	 * Defaults to ``false``.
+	 */
+	'dav.forgiving_ical_parser' => false,
+
+	/**
 	 * ``true`` enables a relaxed session timeout, where the session timeout would no longer be
 	 * handled by Nextcloud but by either the PHP garbage collection or the expiration of
 	 * potential other session backends like Redis.


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
* Resolves: #45574 
* Resolves: https://github.com/nextcloud/server/issues/16679
* May help also in  https://github.com/nextcloud/server/issues/17915


## Summary

This is a self-contained PR that adds support for using SabreDAV's `OPTION_FORGIVING` when `dav.forigiving_ical_parser` config option is set to allow non-standard ICS events parsed instead of giving error.  

For example, Outlook on Mac, under certain conditions, generates ICS events that have invalid key `X-ENTOURAGE_UID` (underscore should be dash) which get rejected by Nextcloud/SabreDAV's strict parser by default.

This PR requires no changes to SabreDAV unlike the closed PR https://github.com/nextcloud/3rdparty/pull/902 which got subsequently pushed to SabreDAV (https://github.com/sabre-io/dav/pull/1563)

This PR includes unit tests and all DAV tests pass with the changes.

A bit problematic part of this PR is that overriding  `\Sabre\CalDAV\Plugin::validateICalendar()` just to replace the  `VObject\Reader::read()` call which is prone to error if SabreDAV changes their  `validateICalendar()`. A better approach would be to refactor   `\Sabre\CalDAV\Plugin` to allow overriding only the `VObject\Reader::read()` invocationa arguments with a hook  but that would require changes on SabreDAV side whereas this is fully self-contained to Nextcloud.

## TODO

- [ ] Add documentation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
