### PR TITLE
rate limiting for creating federated shares

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -7,6 +7,7 @@
 
 namespace OCA\CloudFederationAPI\Controller;
 
+use OC\AppFramework\Http\Attributes\FederationRateLimit;
 use OC\Authentication\Token\PublicKeyTokenProvider;
 use OC\OCM\OCMSignatoryManager;
 use OCA\CloudFederationAPI\Config;
@@ -107,6 +108,7 @@ class RequestHandlerController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[BruteForceProtection(action: 'receiveFederatedShare')]
+	#[FederationRateLimit(limit: 5, period: 1200)]
 	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
 		if (!$this->appConfig->getValueBool('core', OCMSignatoryManager::APPCONFIG_SIGN_DISABLED, lazy: true)) {
 			try {

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -8,6 +8,7 @@
 
 namespace OCA\FederatedFileSharing\Controller;
 
+use OC\AppFramework\Http\Attributes\FederationRateLimit;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
@@ -30,7 +31,6 @@ use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\Log\Audit\CriticalActionPerformedEvent;
 use OCP\Server;
-use OCP\Share;
 use OCP\Share\Exceptions\ShareNotFound;
 use Psr\Log\LoggerInterface;
 
@@ -70,6 +70,7 @@ class RequestHandlerController extends OCSController {
 	 */
 	#[NoCSRFRequired]
 	#[PublicPage]
+	#[FederationRateLimit(limit: 5, period: 1200)]
 	public function createShare(
 		?string $remote = null,
 		?string $token = null,

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1127,6 +1127,7 @@ return array(
     'OC\\AppFramework\\Bootstrap\\ServiceRegistration' => $baseDir . '/lib/private/AppFramework/Bootstrap/ServiceRegistration.php',
     'OC\\AppFramework\\DependencyInjection\\DIContainer' => $baseDir . '/lib/private/AppFramework/DependencyInjection/DIContainer.php',
     'OC\\AppFramework\\Http' => $baseDir . '/lib/private/AppFramework/Http.php',
+    'OC\\AppFramework\\Http\\Attributes\\FederationRateLimit' => $baseDir . '/lib/private/AppFramework/Http/Attributes/FederationRateLimit.php',
     'OC\\AppFramework\\Http\\Attributes\\TwoFactorSetUpDoneRequired' => $baseDir . '/lib/private/AppFramework/Http/Attributes/TwoFactorSetUpDoneRequired.php',
     'OC\\AppFramework\\Http\\Dispatcher' => $baseDir . '/lib/private/AppFramework/Http/Dispatcher.php',
     'OC\\AppFramework\\Http\\Output' => $baseDir . '/lib/private/AppFramework/Http/Output.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1168,6 +1168,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\AppFramework\\Bootstrap\\ServiceRegistration' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/ServiceRegistration.php',
         'OC\\AppFramework\\DependencyInjection\\DIContainer' => __DIR__ . '/../../..' . '/lib/private/AppFramework/DependencyInjection/DIContainer.php',
         'OC\\AppFramework\\Http' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http.php',
+        'OC\\AppFramework\\Http\\Attributes\\FederationRateLimit' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Attributes/FederationRateLimit.php',
         'OC\\AppFramework\\Http\\Attributes\\TwoFactorSetUpDoneRequired' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Attributes/TwoFactorSetUpDoneRequired.php',
         'OC\\AppFramework\\Http\\Dispatcher' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Dispatcher.php',
         'OC\\AppFramework\\Http\\Output' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Output.php',

--- a/lib/private/AppFramework/Http/Attributes/FederationRateLimit.php
+++ b/lib/private/AppFramework/Http/Attributes/FederationRateLimit.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\AppFramework\Http\Attributes;
+
+use Attribute;
+use OC\OCM\OCMDiscoveryService;
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\IRequest;
+use OCP\Server;
+
+/**
+ * Attribute for controller methods that want to limit the times a not logged-in
+ * guest can call the endpoint in a given time period.
+ *
+ * Unlike regular AnonRateLimit, signed requests from trusted servers are excluded from the rate limit.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+class FederationRateLimit extends AnonRateLimit {
+	private readonly OCMDiscoveryService $discoveryService;
+	private readonly ?TrustedServers $trustedServers;
+
+	public function __construct(int $limit, int $period) {
+		parent::__construct($limit, $period);
+
+		$this->discoveryService = Server::get(OCMDiscoveryService::class);
+		$this->trustedServers = Server::get(TrustedServers::class);
+	}
+
+	#[\Override]
+	public function shouldApply(IRequest $request): bool {
+		if ($this->trustedServers === null) {
+			return true;
+		}
+
+		try {
+			$signedRequest = $this->discoveryService->getIncomingSignedRequest();
+			if (!$signedRequest) {
+				return true;
+			}
+			$signedRequest->verify();
+			return !$this->trustedServers->isTrustedServer($signedRequest->getOrigin());
+		} catch (\Exception) {
+			// no or invalid signature
+			return true;
+		}
+	}
+}

--- a/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php
@@ -89,6 +89,10 @@ class RateLimitingMiddleware extends Middleware {
 			);
 
 			if ($rateLimit !== null) {
+				if (!$rateLimit->shouldApply($this->request)) {
+					return;
+				}
+
 				if ($this->appConfig->getValueBool('bruteforcesettings', 'apply_allowlist_to_ratelimit')
 					&& $this->bruteForceAllowList->isBypassListed($this->request->getRemoteAddress())) {
 					return;
@@ -115,6 +119,10 @@ class RateLimitingMiddleware extends Middleware {
 		);
 
 		if ($rateLimit !== null) {
+			if (!$rateLimit->shouldApply($this->request)) {
+				return;
+			}
+
 			$this->limiter->registerAnonRequest(
 				$rateLimitIdentifier,
 				$rateLimit->getLimit(),
@@ -174,7 +182,7 @@ class RateLimitingMiddleware extends Middleware {
 		}
 
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
-		$attributes = $reflectionMethod->getAttributes($attributeClass);
+		$attributes = $reflectionMethod->getAttributes($attributeClass, \ReflectionAttribute::IS_INSTANCEOF);
 		$attribute = current($attributes);
 
 		if ($attribute !== false) {

--- a/lib/public/AppFramework/Http/Attribute/ARateLimit.php
+++ b/lib/public/AppFramework/Http/Attribute/ARateLimit.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework\Http\Attribute;
 
+use OCP\IRequest;
+
 /**
  * Attribute for controller methods that want to limit the times a logged-in
  * user can call the endpoint in a given time period.
@@ -39,5 +41,12 @@ abstract class ARateLimit {
 	 */
 	public function getPeriod(): int {
 		return $this->period;
+	}
+
+	/**
+	 * @since 35.0.0
+	 */
+	public function shouldApply(IRequest $request): bool {
+		return true;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Allow apps to use custom subclasses for ratelimit definitions
- Allow disabling rate limiting on a per-request basis
- Add rate limiting on creating federated shares for non-trusted server

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
