### PR TITLE
fix(memcache): preserve float values in Redis-based cache backends

### DIFF
--- a/lib/private/Memcache/KeyValueCache.php
+++ b/lib/private/Memcache/KeyValueCache.php
@@ -242,13 +242,13 @@ class KeyValueCache extends Cache implements IMemcacheTTL {
 	 * Serialize a value for storage in the key-value store.
 	 */
 	protected static function encodeValue(mixed $value): string {
-		return is_int($value) ? (string)$value : json_encode($value, JSON_THROW_ON_ERROR);
+		return is_int($value) ? (string)$value : json_encode($value, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
 	}
 
 	/**
 	 * Unserialize a value from the key-value store.
 	 */
 	protected static function decodeValue(string $value): mixed {
-		return is_numeric($value) ? (int)$value : json_decode($value, true);
+		return json_decode($value, true, 512, JSON_THROW_ON_ERROR);
 	}
 }

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -233,10 +233,10 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	protected static function encodeValue(mixed $value): string {
-		return is_int($value) ? (string)$value : json_encode($value);
+		return is_int($value) ? (string)$value : json_encode($value, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
 	}
 
 	protected static function decodeValue(string $value): mixed {
-		return is_numeric($value) ? (int)$value : json_decode($value, true);
+		return json_decode($value, true, 512, JSON_THROW_ON_ERROR);
 	}
 }

--- a/tests/lib/Memcache/Cache.php
+++ b/tests/lib/Memcache/Cache.php
@@ -16,6 +16,40 @@ abstract class Cache extends \Test\Cache\TestCache {
 	 */
 	protected $instance;
 
+	/**
+	 * @return array<string, array{0: mixed}>
+ 	*/
+	public static function roundtripValuesProvider(): array {
+		return [
+			'string' => ['some string value'],
+			'empty string' => [''],
+			'numeric string' => ['0123'],
+			'float-like string' => ['3.14'],
+			'scientific notation string' => ['1e3'],
+			'integer' => [1234],
+			'zero' => [0],
+			'negative integer' => [-42],
+			'float' => [3.14],
+			'zero-fraction float' => [1.0],
+			'negative float' => [-2.75],
+			'scientific notation float' => [1.2e3],
+			'boolean true' => [true],
+			'boolean false' => [false],
+			'null' => [null],
+			'list' => [['a', 'b', 'c']],
+			'associative array' => [['foo' => 'bar', 'baz' => 42]],
+			'mixed nested array' => [[
+				'int' => 7,
+				'float' => 3.14,
+				'whole-float' => 1.0,
+				'string' => '3.14',
+				'bool' => true,
+				'null' => null,
+				'list' => [1, 2.5, '3'],
+			]],
+		];
+	}
+
 	public function testExistsAfterSet(): void {
 		$this->assertFalse($this->instance->hasKey('foo'));
 		$this->instance->set('foo', 'bar');
@@ -32,6 +66,15 @@ abstract class Cache extends \Test\Cache\TestCache {
 		$this->assertNull($this->instance->get('foo'));
 		$this->instance->set('foo', ['bar']);
 		$this->assertEquals(['bar'], $this->instance->get('foo'));
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('roundtripValuesProvider')]
+	public function testStoreAndReadBack(mixed $value): void {
+		$this->assertNull($this->instance->get('roundtrip'), 'key should be empty before storing');
+
+		$this->assertNotFalse($this->instance->set('roundtrip', $value), 'value should be stored');
+		$this->assertTrue($this->instance->hasKey('roundtrip'), 'stored key should exist');
+		$this->assertSame($value, $this->instance->get('roundtrip'), 'stored value should be read back unchanged');
 	}
 
 	public function testDoesNotExistAfterRemove(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue --> (hard to say)

## Summary

Preserve float values in Redis/Valkey-backed memcache backends.

This updates `Redis` and `KeyValueCache` to:
- decode values via `json_decode(...)` instead of coercing all numeric payloads to `int`
- encode floats with `JSON_PRESERVE_ZERO_FRACTION` so `1.0` stays distinct from `1`

It also adds shared round-trip test coverage in `tests/lib/Memcache/Cache.php`, including floats and numeric edge cases.

## Before / after

### Before
- `3.14` → `3`
- `1.0` → `1`

### After
- `3.14` → `3.14`
- `1.0` → `1.0`

## Notes

This slightly changes the cache format for values like `1.0`, so older entries may not compare equal in Redis-side CAS/Lua operations until they expire and are rewritten.

Down the road we may want to consider using `_pack` / `_unpack` (at least for phpredis; not sure about predis).

## TODO

- [ ] Drop redundant round-trip tests from `KeyValueCacheTest` once deciding what to do about the embedded comments there

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
