### PR TITLE
fix(files_sharing): only offer folders in file-request which are shareable

### DIFF
--- a/apps/files_sharing/src/components/NewFileRequestDialog.vue
+++ b/apps/files_sharing/src/components/NewFileRequestDialog.vue
@@ -197,11 +197,14 @@ export default defineComponent({
 	},
 
 	data() {
+		const destination = (this.context.permissions & Permission.SHARE)
+			? this.context.path
+			: '/'
 		return {
 			currentStep: STEP.FIRST,
 			loading: false,
 
-			destination: this.context.path || '/',
+			destination,
 			label: '',
 			note: '',
 

--- a/apps/files_sharing/src/components/NewFileRequestDialog/NewFileRequestDialogIntro.vue
+++ b/apps/files_sharing/src/components/NewFileRequestDialog/NewFileRequestDialogIntro.vue
@@ -73,10 +73,11 @@
 </template>
 
 <script lang="ts">
-import type { Folder, Node } from '@nextcloud/files'
+import type { Folder, INode } from '@nextcloud/files'
 import type { PropType } from 'vue'
 
 import { getFilePickerBuilder } from '@nextcloud/dialogs'
+import { Permission } from '@nextcloud/files'
 import { t } from '@nextcloud/l10n'
 import { defineComponent } from 'vue'
 import NcTextArea from '@nextcloud/vue/components/NcTextArea'
@@ -146,6 +147,7 @@ export default defineComponent({
 					callback: this.onPickedDestination,
 				})
 				.setFilter((node) => node.path !== '/')
+				.setCanPick((node) => Boolean(node.permissions & Permission.SHARE))
 				.startAt(this.destination)
 				.build()
 			try {
@@ -155,7 +157,7 @@ export default defineComponent({
 			}
 		},
 
-		onPickedDestination(nodes: Node[]) {
+		onPickedDestination(nodes: INode[]) {
 			const node = nodes[0]
 			if (node) {
 				this.$emit('update:destination', node.path)


### PR DESCRIPTION
## Summary
This resolves issues with e2ee where folders are not shareable so they must not be offered to be selected.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
