### PR TITLE
fix(KeyValueCache): allow negative TTL for file locking

### DIFF
--- a/lib/private/Memcache/KeyValueCache.php
+++ b/lib/private/Memcache/KeyValueCache.php
@@ -232,7 +232,7 @@ class KeyValueCache extends Cache implements IMemcacheTTL {
 	 * so fall back to the default and cap it to the maximum.
 	 */
 	private function normalizeTtl(int $ttl): int {
-		if ($ttl <= 0) {
+		if ($ttl === 0) { // we need to allow negative TTL for file locking
 			$ttl = self::DEFAULT_TTL;
 		}
 		return min($ttl, self::MAX_TTL);


### PR DESCRIPTION
## Summary
file locking uses negative TTL, returning the default will break.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
