### PR TITLE
fix(redis): properly clear keys from cluster

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -100,16 +100,29 @@ class Redis extends Cache implements IMemcacheTTL {
 
 	#[\Override]
 	public function clear($prefix = '') {
-		// TODO: this is slow and would fail with Redis cluster
-		$prefix = $this->getPrefix() . $prefix . '*';
-		/** @var list<string>|false -- we are not in MULTI mode, so we can cast the return value here */
-		$keys = $this->getCache()->keys($prefix);
-		if ($keys === false) {
-			return false;
-		}
+		$pattern = $this->getPrefix() . $prefix . '*';
+		$deletedTotal = 0;
+		$expectedTotal = 0;
+		$iterator = null;
+		while (true) {
+			$keys = $this->getCache()->scan($iterator, $pattern, 1000);
+			if ($keys === false) {
+				break;
+			}
 
-		$deleted = $this->getCache()->del($keys);
-		return count($keys) === $deleted;
+			if (!empty($keys)) {
+				$expectedTotal += count($keys);
+				$result = $this->getCache()->del($keys);
+				if (is_int($result)) {
+					$deletedTotal += $result;
+				}
+			}
+
+			if ($iterator === 0) {
+				break;
+			}
+		}
+		return $deletedTotal === $expectedTotal;
 	}
 
 	#[\Override]


### PR DESCRIPTION
- chained on https://github.com/nextcloud/server/pull/62121

## Summary

Adjust code to also work with redis in cluster mode when trying to clear all keys with a prefix.
Also fixes performance issues with normal single-server setups as SCAN is non-blocking.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
