### PR TITLE
docs(config): clarify help menu/link configuration parameters (aka "knowledgebase")

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -281,15 +281,23 @@ $CONFIG = [
 	'default_timezone' => 'Europe/Berlin',
 
 	/**
-	 * ``true`` enables the Help menu item in the user menu (top right of the
-	 * Nextcloud Web interface).
-	 * ``false`` removes the Help item.
+	 * Controls the visibility of the "Help & privacy" navigation entry for
+	 * signed-in users. Set to ``false`` to hide it.
+	 *
+	 * Defaults to ``true``
 	 */
 	'knowledgebaseenabled' => true,
 
 	/**
-	 * ``true`` embeds the documentation in an iframe inside Nextcloud.
-	 * ``false`` only shows buttons to the online documentation.
+	 * Determines how documentation is displayed on the "Help & privacy" page.
+	 *
+	 * - ``true``: Embeds bundled documentation within an iframe.
+	 * - ``false``: Displays links to external documentation and other help and
+	 *   privacy resources.
+	 *
+	 * Custom themes may override the external documentation URLs.
+	 *
+	 * Defaults to ``false``
 	 */
 	'knowledgebase.embedded' => false,
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Clarify the documentation for the `knowledgebaseenabled` and `knowledgebase.embedded` system config options in `config.sample.php`.

## What changed

- clarified that `knowledgebaseenabled` controls the visibility of the **Help & privacy** navigation entry
- clarified that `knowledgebase.embedded` shows bundled documentation in an iframe when enabled
- noted that custom themes (old-style) may override the external documentation URLs when embedded mode is disabled

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
