### PR TITLE
[stable32] chore(psalm): Fix broken CI due to missing changes in psalm-baseline.xml

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3934,7 +3934,6 @@
   </file>
   <file src="lib/private/Group/Manager.php">
     <LessSpecificReturnStatement>
-      <code><![CDATA[$groups]]></code>
       <code><![CDATA[array_values($groups)]]></code>
       <code><![CDATA[array_values($groups)]]></code>
     </LessSpecificReturnStatement>


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/pull/61934 made changes to the group manager file that needs to be reflected in the `psalm-baseline.xml` as well. [This didn't happen during the PR](https://github.com/nextcloud/server/actions/runs/29014025641/job/86104381984), which left the `stable32` with a broken `static-code-analysis` workflow. That's being fixed with this PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
