### PR TITLE
[stable33]: perf: Don't fetch all the trash items when deleting a single item

### DIFF
--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -12,6 +12,7 @@ use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\IMimeTypeDetector;
+use OCP\Files\Mount\IMountPoint;
 use OCP\Server;
 
 class Helper {
@@ -26,9 +27,6 @@ class Helper {
 	 * @return \OCP\Files\FileInfo[]
 	 */
 	public static function getTrashFiles($dir, $user, $sortAttribute = '', $sortDescending = false) {
-		$result = [];
-		$timestamp = null;
-
 		$view = new View('/' . $user . '/files_trashbin/files');
 
 		if (ltrim($dir, '/') !== '' && !$view->is_dir($dir)) {
@@ -39,56 +37,62 @@ class Helper {
 		$storage = $mount->getStorage();
 		$absoluteDir = $view->getAbsolutePath($dir);
 		$internalPath = $mount->getInternalPath($absoluteDir);
-
 		$extraData = Trashbin::getExtraData($user);
+
+		$result = [];
+		$timestamp = null;
 		$dirContent = $storage->getCache()->getFolderContents($mount->getInternalPath($view->getAbsolutePath($dir)));
 		foreach ($dirContent as $entry) {
-			$entryName = $entry->getName();
-			$name = $entryName;
-			if ($dir === '' || $dir === '/') {
-				$pathparts = pathinfo($entryName);
-				$timestamp = substr($pathparts['extension'], 1);
-				$name = $pathparts['filename'];
-			} elseif ($timestamp === null) {
-				// for subfolders we need to calculate the timestamp only once
-				$parts = explode('/', ltrim($dir, '/'));
-				$timestamp = substr(pathinfo($parts[0], PATHINFO_EXTENSION), 1);
-			}
-			$originalPath = '';
-			$originalName = substr($entryName, 0, -strlen($timestamp) - 2);
-			if (isset($extraData[$originalName][$timestamp]['location'])) {
-				$originalPath = $extraData[$originalName][$timestamp]['location'];
-				if (substr($originalPath, -1) === '/') {
-					$originalPath = substr($originalPath, 0, -1);
-				}
-			}
-			$type = $entry->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE ? 'dir' : 'file';
-			$i = [
-				'name' => $name,
-				'mtime' => $timestamp,
-				'mimetype' => $type === 'dir' ? 'httpd/unix-directory' : Server::get(IMimeTypeDetector::class)->detectPath($name),
-				'type' => $type,
-				'directory' => ($dir === '/') ? '' : $dir,
-				'size' => $entry->getSize(),
-				'etag' => '',
-				'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE,
-				'fileid' => $entry->getId(),
-			];
-			if ($originalPath) {
-				if ($originalPath !== '.') {
-					$i['extraData'] = $originalPath . '/' . $originalName;
-				} else {
-					$i['extraData'] = $originalName;
-				}
-			}
-			$i['deletedBy'] = $extraData[$originalName][$timestamp]['deletedBy'] ?? null;
-			$result[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i, $mount);
+			$result[] = self::buildFileInfo($entry, $dir, $timestamp, $extraData, $storage, $absoluteDir, $internalPath, $mount);
 		}
 
 		if ($sortAttribute !== '') {
 			return \OCA\Files\Helper::sortFiles($result, $sortAttribute, $sortDescending);
 		}
 		return $result;
+	}
+
+	private static function buildFileInfo(ICacheEntry $entry, string $dir, ?string &$timestamp, array $extraData, $storage, string $absoluteDir, string $internalPath, IMountPoint $mount): FileInfo {
+		$entryName = $entry->getName();
+		$name = $entryName;
+		if ($dir === '' || $dir === '/') {
+			$pathparts = pathinfo($entryName);
+			$timestamp = substr($pathparts['extension'], 1);
+			$name = $pathparts['filename'];
+		} elseif ($timestamp === null) {
+			// for subfolders we need to calculate the timestamp only once
+			$parts = explode('/', ltrim($dir, '/'));
+			$timestamp = substr(pathinfo($parts[0], PATHINFO_EXTENSION), 1);
+		}
+		$originalPath = '';
+		$originalName = substr($entryName, 0, -strlen($timestamp) - 2);
+		if (isset($extraData[$originalName][$timestamp]['location'])) {
+			$originalPath = $extraData[$originalName][$timestamp]['location'];
+			if (substr($originalPath, -1) === '/') {
+				$originalPath = substr($originalPath, 0, -1);
+			}
+		}
+		$type = $entry->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE ? 'dir' : 'file';
+		$i = [
+			'name' => $name,
+			'mtime' => $timestamp,
+			'mimetype' => $type === 'dir' ? 'httpd/unix-directory' : Server::get(IMimeTypeDetector::class)->detectPath($name),
+			'type' => $type,
+			'directory' => ($dir === '/') ? '' : $dir,
+			'size' => $entry->getSize(),
+			'etag' => '',
+			'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE,
+			'fileid' => $entry->getId(),
+		];
+		if ($originalPath) {
+			if ($originalPath !== '.') {
+				$i['extraData'] = $originalPath . '/' . $originalName;
+			} else {
+				$i['extraData'] = $originalName;
+			}
+		}
+		$i['deletedBy'] = $extraData[$originalName][$timestamp]['deletedBy'] ?? null;
+		return new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i, $mount);
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -52,6 +52,30 @@ class Helper {
 		return $result;
 	}
 
+	public static function getTrashFile(string $dir, string $user, string $name): ?FileInfo {
+		$timestamp = null;
+
+		$view = new View('/' . $user . '/files_trashbin/files');
+
+		if (ltrim($dir, '/') !== '' && !$view->is_dir($dir)) {
+			throw new \Exception('Directory does not exists');
+		}
+
+		$mount = $view->getMount($dir);
+		$storage = $mount->getStorage();
+		$absoluteDir = $view->getAbsolutePath($dir);
+		$internalPath = $mount->getInternalPath($absoluteDir);
+
+		$extraData = Trashbin::getExtraData($user);
+		$entry = $storage->getCache()->get($mount->getInternalPath($view->getAbsolutePath($dir . '/' . $name)));
+		if ($entry === false) {
+			return null;
+		}
+
+		$timestamp = null;
+		return self::buildFileInfo($entry, $dir, $timestamp, $extraData, $storage, $absoluteDir, $internalPath, $mount);
+	}
+
 	private static function buildFileInfo(ICacheEntry $entry, string $dir, ?string &$timestamp, array $extraData, $storage, string $absoluteDir, string $internalPath, IMountPoint $mount): FileInfo {
 		$entryName = $entry->getName();
 		$name = $entryName;

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -118,21 +118,4 @@ class Helper {
 		$i['deletedBy'] = $extraData[$originalName][$timestamp]['deletedBy'] ?? null;
 		return new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i, $mount);
 	}
-
-	/**
-	 * Format file infos for JSON
-	 *
-	 * @param \OCP\Files\FileInfo[] $fileInfos file infos
-	 */
-	public static function formatFileInfos($fileInfos) {
-		$files = [];
-		foreach ($fileInfos as $i) {
-			$entry = \OCA\Files\Helper::formatFileInfo($i);
-			$entry['id'] = $i->getId();
-			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
-			$entry['permissions'] = Constants::PERMISSION_READ;
-			$files[] = $entry;
-		}
-		return $files;
-	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -14,15 +14,17 @@ use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\FileInfo;
 use OCP\IUser;
+use RuntimeException;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
+use Sabre\DAV\INode;
 
 class TrashRoot implements ICollection {
 
 	public function __construct(
-		private IUser $user,
-		private ITrashManager $trashManager,
+		private readonly IUser $user,
+		private readonly ITrashManager $trashManager,
 	) {
 	}
 
@@ -56,12 +58,7 @@ class TrashRoot implements ICollection {
 	public function getChildren(): array {
 		$entries = $this->trashManager->listTrashRoot($this->user);
 
-		return array_map(function (ITrashItem $entry): TrashFile|TrashFolder {
-			if ($entry->getType() === FileInfo::TYPE_FOLDER) {
-				return new TrashFolder($this->trashManager, $entry);
-			}
-			return new TrashFile($this->trashManager, $entry);
-		}, $entries);
+		return array_map($this->trashItemToTrashNode(...), $entries);
 	}
 
 	public function getChild($name): ITrash {
@@ -71,10 +68,7 @@ class TrashRoot implements ICollection {
 			throw new NotFound();
 		}
 
-		if ($entry->getType() === FileInfo::TYPE_FOLDER) {
-			return new TrashFolder($this->trashManager, $entry);
-		}
-		return new TrashFile($this->trashManager, $entry);
+		return $this->trashItemToTrashNode($entry);
 	}
 
 	public function childExists($name): bool {
@@ -83,5 +77,13 @@ class TrashRoot implements ICollection {
 
 	public function getLastModified(): int {
 		return 0;
+	}
+
+	private function trashItemToTrashNode(ITrashItem $entry): ITrash&INode {
+		return match ($entry->getType()) {
+			FileInfo::TYPE_FOLDER => new TrashFolder($this->trashManager, $entry),
+			FileInfo::TYPE_FILE => new TrashFile($this->trashManager, $entry),
+			default => throw new RuntimeException("Invalid FileInfo object"),
+		};
 	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -56,35 +56,29 @@ class TrashRoot implements ICollection {
 	public function getChildren(): array {
 		$entries = $this->trashManager->listTrashRoot($this->user);
 
-		$children = array_map(function (ITrashItem $entry) {
+		return array_map(function (ITrashItem $entry): TrashFile|TrashFolder {
 			if ($entry->getType() === FileInfo::TYPE_FOLDER) {
 				return new TrashFolder($this->trashManager, $entry);
 			}
 			return new TrashFile($this->trashManager, $entry);
 		}, $entries);
-
-		return $children;
 	}
 
 	public function getChild($name): ITrash {
-		$entries = $this->getChildren();
+		$entry = $this->trashManager->getTrashRootItem($this->user, $name);
 
-		foreach ($entries as $entry) {
-			if ($entry->getName() === $name) {
-				return $entry;
-			}
+		if ($entry === null) {
+			throw new NotFound();
 		}
 
-		throw new NotFound();
+		if ($entry->getType() === FileInfo::TYPE_FOLDER) {
+			return new TrashFolder($this->trashManager, $entry);
+		}
+		return new TrashFile($this->trashManager, $entry);
 	}
 
 	public function childExists($name): bool {
-		try {
-			$this->getChild($name);
-			return true;
-		} catch (NotFound $e) {
-			return false;
-		}
+		return $this->trashManager->getTrashRootItem($this->user, $name) !== null;
 	}
 
 	public function getLastModified(): int {

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -83,7 +83,7 @@ class TrashRoot implements ICollection {
 		return match ($entry->getType()) {
 			FileInfo::TYPE_FOLDER => new TrashFolder($this->trashManager, $entry),
 			FileInfo::TYPE_FILE => new TrashFile($this->trashManager, $entry),
-			default => throw new RuntimeException("Invalid FileInfo object"),
+			default => throw new RuntimeException('Invalid FileInfo object'),
 		};
 	}
 }

--- a/apps/files_trashbin/lib/Trash/ITrashManager.php
+++ b/apps/files_trashbin/lib/Trash/ITrashManager.php
@@ -32,7 +32,7 @@ interface ITrashManager extends ITrashBackend {
 	 *
 	 * @param IUser $user
 	 * @return ?ITrashItem
-	 * @since 35.0.0
+	 * @since 33.0.7
 	 */
 	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem;
 

--- a/apps/files_trashbin/lib/Trash/ITrashManager.php
+++ b/apps/files_trashbin/lib/Trash/ITrashManager.php
@@ -28,6 +28,15 @@ interface ITrashManager extends ITrashBackend {
 	public function listTrashRoot(IUser $user): array;
 
 	/**
+	 * Get a specific item in the root of the trashbin
+	 *
+	 * @param IUser $user
+	 * @return ?ITrashItem
+	 * @since 35.0.0
+	 */
+	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem;
+
+	/**
 	 * Temporally prevent files from being moved to the trash
 	 *
 	 * @since 15.0.0

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -29,38 +29,31 @@ class LegacyTrashBackend implements ITrashBackend {
 	) {
 	}
 
-	/**
-	 * @param array $items
-	 * @param IUser $user
-	 * @param ITrashItem $parent
-	 * @return ITrashItem[]
-	 */
-	private function mapTrashItems(array $items, IUser $user, ?ITrashItem $parent = null): array {
+	private function mapTrashItem(FileInfo $file, IUser $user, ?ITrashItem $parent = null): ITrashItem {
 		$parentTrashPath = ($parent instanceof ITrashItem) ? $parent->getTrashPath() : '';
 		$isRoot = $parent === null;
-		return array_map(function (FileInfo $file) use ($parent, $parentTrashPath, $isRoot, $user) {
-			$originalLocation = $isRoot ? $file['extraData'] : $parent->getOriginalLocation() . '/' . $file->getName();
-			if (!$originalLocation) {
-				$originalLocation = $file->getName();
-			}
-			/** @psalm-suppress UndefinedInterfaceMethod */
-			$deletedBy = $this->userManager->get($file['deletedBy']) ?? $parent?->getDeletedBy();
-			$trashFilename = Trashbin::getTrashFilename($file->getName(), $file->getMtime());
-			return new TrashItem(
-				$this,
-				$originalLocation,
-				$file->getMTime(),
-				$parentTrashPath . '/' . ($isRoot ? $trashFilename : $file->getName()),
-				$file,
-				$user,
-				$deletedBy,
-			);
-		}, $items);
+
+		$originalLocation = $isRoot ? $file['extraData'] : $parent->getOriginalLocation() . '/' . $file->getName();
+		if (!$originalLocation) {
+			$originalLocation = $file->getName();
+		}
+		/** @psalm-suppress UndefinedInterfaceMethod */
+		$deletedBy = $this->userManager->get($file['deletedBy']) ?? $parent?->getDeletedBy();
+		$trashFilename = Trashbin::getTrashFilename($file->getName(), $file->getMtime());
+		return new TrashItem(
+			$this,
+			$originalLocation,
+			$file->getMTime(),
+			$parentTrashPath . '/' . ($isRoot ? $trashFilename : $file->getName()),
+			$file,
+			$user,
+			$deletedBy,
+		);
 	}
 
 	public function listTrashRoot(IUser $user): array {
 		$entries = Helper::getTrashFiles('/', $user->getUID());
-		return $this->mapTrashItems($entries, $user);
+		return array_map(fn (FileInfo $fileInfo): ITrashItem => $this->mapTrashItem($fileInfo, $user), $entries);
 	}
 
 	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem {
@@ -68,13 +61,13 @@ class LegacyTrashBackend implements ITrashBackend {
 		if ($entry === null) {
 			return null;
 		}
-		return $this->mapTrashItems([$entry], $user)[0];
+		return $this->mapTrashItem($entry, $user);
 	}
 
 	public function listTrashFolder(ITrashItem $folder): array {
 		$user = $folder->getUser();
 		$entries = Helper::getTrashFiles($folder->getTrashPath(), $user->getUID());
-		return $this->mapTrashItems($entries, $user, $folder);
+		return array_map(fn (FileInfo $fileInfo): ITrashItem => $this->mapTrashItem($fileInfo, $user, $folder), $entries);
 	}
 
 	public function restoreItem(ITrashItem $item) {

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -63,6 +63,14 @@ class LegacyTrashBackend implements ITrashBackend {
 		return $this->mapTrashItems($entries, $user);
 	}
 
+	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem {
+		$entry = Helper::getTrashFile('/', $user->getUID(), $name);
+		if ($entry === null) {
+			return null;
+		}
+		return $this->mapTrashItems([$entry], $user)[0];
+	}
+
 	public function listTrashFolder(ITrashItem $folder): array {
 		$user = $folder->getUser();
 		$entries = Helper::getTrashFiles($folder->getTrashPath(), $user->getUID());

--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -36,6 +36,26 @@ class TrashManager implements ITrashManager {
 		return $items;
 	}
 
+	#[\Override]
+	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem {
+		foreach ($this->getBackends() as $backend) {
+			if (method_exists($backend, 'getTrashRootItem')) {
+				$item = $backend->getTrashRootItem($user, $name);
+				if ($item !== null) {
+					return $item;
+				}
+			} else {
+				$items = $backend->listTrashRoot($user);
+				foreach ($items as $item) {
+					if ($item->getName() === $name) {
+						return $item;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
 	private function getBackendForItem(ITrashItem $item) {
 		return $item->getTrashBackend();
 	}

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1784,12 +1784,18 @@
   <file src="apps/files_trashbin/lib/Helper.php">
     <InternalClass>
       <code><![CDATA[new View('/' . $user . '/files_trashbin/files')]]></code>
+      <code><![CDATA[new View('/' . $user . '/files_trashbin/files')]]></code>
     </InternalClass>
     <InternalMethod>
       <code><![CDATA[getAbsolutePath]]></code>
       <code><![CDATA[getAbsolutePath]]></code>
+      <code><![CDATA[getAbsolutePath]]></code>
+      <code><![CDATA[getAbsolutePath]]></code>
+      <code><![CDATA[getMount]]></code>
       <code><![CDATA[getMount]]></code>
       <code><![CDATA[is_dir]]></code>
+      <code><![CDATA[is_dir]]></code>
+      <code><![CDATA[new View('/' . $user . '/files_trashbin/files')]]></code>
       <code><![CDATA[new View('/' . $user . '/files_trashbin/files')]]></code>
     </InternalMethod>
   </file>
@@ -1821,14 +1827,6 @@
     <MismatchingDocblockReturnType>
       <code><![CDATA[INode]]></code>
     </MismatchingDocblockReturnType>
-  </file>
-  <file src="apps/files_trashbin/lib/Sabre/TrashRoot.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$entry]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[ITrash]]></code>
-    </InvalidReturnType>
   </file>
   <file src="apps/files_trashbin/lib/Sabre/TrashbinPlugin.php">
     <InternalMethod>


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/61906

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
