### PR TITLE
occ file command enhancements

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -46,6 +46,7 @@
 		<command>OCA\Files\Command\Delete</command>
 		<command>OCA\Files\Command\Copy</command>
 		<command>OCA\Files\Command\Move</command>
+		<command>OCA\Files\Command\Mkdir</command>
 		<command>OCA\Files\Command\SanitizeFilenames</command>
 		<command>OCA\Files\Command\Mount\Refresh</command>
 		<command>OCA\Files\Command\Mount\ListMounts</command>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -47,6 +47,7 @@
 		<command>OCA\Files\Command\Copy</command>
 		<command>OCA\Files\Command\Move</command>
 		<command>OCA\Files\Command\Mkdir</command>
+		<command>OCA\Files\Command\Touch</command>
 		<command>OCA\Files\Command\SanitizeFilenames</command>
 		<command>OCA\Files\Command\Mount\Refresh</command>
 		<command>OCA\Files\Command\Mount\ListMounts</command>

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -50,6 +50,7 @@ return array(
     'OCA\\Files\\Command\\SanitizeFilenames' => $baseDir . '/../lib/Command/SanitizeFilenames.php',
     'OCA\\Files\\Command\\Scan' => $baseDir . '/../lib/Command/Scan.php',
     'OCA\\Files\\Command\\ScanAppData' => $baseDir . '/../lib/Command/ScanAppData.php',
+    'OCA\\Files\\Command\\Touch' => $baseDir . '/../lib/Command/Touch.php',
     'OCA\\Files\\Command\\TransferOwnership' => $baseDir . '/../lib/Command/TransferOwnership.php',
     'OCA\\Files\\Command\\WindowsCompatibleFilenames' => $baseDir . '/../lib/Command/WindowsCompatibleFilenames.php',
     'OCA\\Files\\ConfigLexicon' => $baseDir . '/../lib/ConfigLexicon.php',

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -32,6 +32,7 @@ return array(
     'OCA\\Files\\Command\\Delete' => $baseDir . '/../lib/Command/Delete.php',
     'OCA\\Files\\Command\\DeleteOrphanedFiles' => $baseDir . '/../lib/Command/DeleteOrphanedFiles.php',
     'OCA\\Files\\Command\\Get' => $baseDir . '/../lib/Command/Get.php',
+    'OCA\\Files\\Command\\Mkdir' => $baseDir . '/../lib/Command/Mkdir.php',
     'OCA\\Files\\Command\\Mount\\ListMounts' => $baseDir . '/../lib/Command/Mount/ListMounts.php',
     'OCA\\Files\\Command\\Mount\\Refresh' => $baseDir . '/../lib/Command/Mount/Refresh.php',
     'OCA\\Files\\Command\\Move' => $baseDir . '/../lib/Command/Move.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -47,6 +47,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Command\\Delete' => __DIR__ . '/..' . '/../lib/Command/Delete.php',
         'OCA\\Files\\Command\\DeleteOrphanedFiles' => __DIR__ . '/..' . '/../lib/Command/DeleteOrphanedFiles.php',
         'OCA\\Files\\Command\\Get' => __DIR__ . '/..' . '/../lib/Command/Get.php',
+        'OCA\\Files\\Command\\Mkdir' => __DIR__ . '/..' . '/../lib/Command/Mkdir.php',
         'OCA\\Files\\Command\\Mount\\ListMounts' => __DIR__ . '/..' . '/../lib/Command/Mount/ListMounts.php',
         'OCA\\Files\\Command\\Mount\\Refresh' => __DIR__ . '/..' . '/../lib/Command/Mount/Refresh.php',
         'OCA\\Files\\Command\\Move' => __DIR__ . '/..' . '/../lib/Command/Move.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -65,6 +65,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Command\\SanitizeFilenames' => __DIR__ . '/..' . '/../lib/Command/SanitizeFilenames.php',
         'OCA\\Files\\Command\\Scan' => __DIR__ . '/..' . '/../lib/Command/Scan.php',
         'OCA\\Files\\Command\\ScanAppData' => __DIR__ . '/..' . '/../lib/Command/ScanAppData.php',
+        'OCA\\Files\\Command\\Touch' => __DIR__ . '/..' . '/../lib/Command/Touch.php',
         'OCA\\Files\\Command\\TransferOwnership' => __DIR__ . '/..' . '/../lib/Command/TransferOwnership.php',
         'OCA\\Files\\Command\\WindowsCompatibleFilenames' => __DIR__ . '/..' . '/../lib/Command/WindowsCompatibleFilenames.php',
         'OCA\\Files\\ConfigLexicon' => __DIR__ . '/..' . '/../lib/ConfigLexicon.php',

--- a/apps/files/lib/Command/Delete.php
+++ b/apps/files/lib/Command/Delete.php
@@ -10,6 +10,7 @@ namespace OCA\Files\Command;
 
 use OC\Core\Command\Info\FileUtils;
 use OCA\Files_Sharing\SharedStorage;
+use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Files\Folder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -21,7 +22,8 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class Delete extends Command {
 	public function __construct(
-		private FileUtils $fileUtils,
+		private readonly FileUtils $fileUtils,
+		private readonly ITrashManager $trashManager,
 	) {
 		parent::__construct();
 	}
@@ -32,7 +34,8 @@ class Delete extends Command {
 			->setName('files:delete')
 			->setDescription('Delete a file or folder')
 			->addArgument('file', InputArgument::REQUIRED, 'File id or path')
-			->addOption('force', 'f', InputOption::VALUE_NONE, "Don't ask for configuration and don't output any warnings");
+			->addOption('force', 'f', InputOption::VALUE_NONE, "Don't ask for configuration and don't output any warnings")
+			->addOption('skip-trash', null, InputOption::VALUE_NONE, 'Bypass the trashbin when deleting the file or folder');
 	}
 
 	#[\Override]
@@ -40,6 +43,7 @@ class Delete extends Command {
 		$fileInput = $input->getArgument('file');
 		$inputIsId = is_numeric($fileInput);
 		$force = $input->getOption('force');
+		$skipTrash = $input->getOption('skip-trash');
 		$node = $this->fileUtils->getNode($fileInput);
 
 		if (!$node) {
@@ -90,6 +94,10 @@ class Delete extends Command {
 
 		if ($deleteConfirmed) {
 			if ($node->isDeletable()) {
+				if ($skipTrash && $this->trashManager) {
+					$this->trashManager->pauseTrash();
+				}
+
 				$node->delete();
 			} else {
 				$output->writeln('<error>File cannot be deleted, insufficient permissions.</error>');

--- a/apps/files/lib/Command/Delete.php
+++ b/apps/files/lib/Command/Delete.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 class Delete extends Command {
 	public function __construct(
 		private readonly FileUtils $fileUtils,
-		private readonly ITrashManager $trashManager,
+		private readonly ?ITrashManager $trashManager = null,
 	) {
 		parent::__construct();
 	}

--- a/apps/files/lib/Command/Mkdir.php
+++ b/apps/files/lib/Command/Mkdir.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files\Command;
+
+use OC\Core\Command\Info\FileUtils;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Mkdir extends Command {
+	public function __construct(
+		private readonly FileUtils $fileUtils,
+		private readonly IRootFolder $rootFolder,
+	) {
+		parent::__construct();
+	}
+
+	#[\Override]
+	protected function configure(): void {
+		$this
+			->setName('files:mkdir')
+			->setDescription('Create a new directory')
+			->addArgument('path', InputArgument::REQUIRED, 'Target Nextcloud path for the new folder');
+	}
+
+	#[\Override]
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$path = $input->getArgument('path');
+		$node = $this->fileUtils->getNode($path);
+
+		if ($node instanceof Folder) {
+			$output->writeln("<info>$path already exists</info>");
+			return self::SUCCESS;
+		}
+		if ($node instanceof File) {
+			$output->writeln("<error>$path is a file</error>");
+			return self::FAILURE;
+		}
+
+		$this->rootFolder->newFolder($path);
+
+		return self::SUCCESS;
+	}
+}

--- a/apps/files/lib/Command/Put.php
+++ b/apps/files/lib/Command/Put.php
@@ -62,6 +62,11 @@ class Put extends Command {
 			}
 			stream_copy_to_stream($source, $target);
 		} else {
+			$parentPath = dirname($fileOutput);
+			if (!$this->rootFolder->nodeExists($parentPath)) {
+				$this->rootFolder->newFolder($parentPath);
+			}
+
 			$this->rootFolder->newFile($fileOutput, $source);
 		}
 		return self::SUCCESS;

--- a/apps/files/lib/Command/Touch.php
+++ b/apps/files/lib/Command/Touch.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files\Command;
+
+use DateTimeImmutable;
+use OC\Core\Command\Info\FileUtils;
+use OCP\Files\IRootFolder;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Touch extends Command {
+	public function __construct(
+		private readonly FileUtils $fileUtils,
+		private readonly IRootFolder $rootFolder,
+		private readonly ClockInterface $clock,
+	) {
+		parent::__construct();
+	}
+
+	#[\Override]
+	protected function configure(): void {
+		$this
+			->setName('files:touch')
+			->setDescription('Update the last modified date of a file or folder, or create an empty file')
+			->addArgument('file', InputArgument::REQUIRED, 'Nextcloud path or fileid for the file or folder to change the modified date of')
+			->addOption('date', 'd', InputOption::VALUE_REQUIRED, 'Time to use as modified date instead of the current time. Acceptable formats are: ISO8601, "YYYY-MM-DD" and Unix time in seconds.')
+			->addOption('no-create', 'c', InputOption::VALUE_NONE, 'Don\'t create an empty file if the target path doesn\'t exist');
+	}
+
+	#[\Override]
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$fileInput = $input->getArgument('file');
+		$node = $this->fileUtils->getNode($fileInput);
+		$date = $input->getOption('date');
+		$noCreate = $input->getOption('no-create');
+
+		if (!$node) {
+			if ($noCreate || is_numeric($fileInput)) {
+				$output->writeln("<error>$fileInput doesn't exist</error>");
+				return self::FAILURE;
+			}
+			$node = $this->rootFolder->newFile($fileInput);
+		}
+
+
+		if ($date) {
+			$mtime = $this->parseDateOption($date);
+			if (!$mtime) {
+				$output->writeln("<error>Invalid date format '$date'. Acceptable formats are: ISO8601, \"YYYY-MM-DD\" and Unix time in seconds.</error>");
+			}
+		} else {
+			$mtime = $this->clock->now();
+		}
+		$node->touch($mtime->getTimestamp());
+
+		return self::SUCCESS;
+	}
+
+	/**
+	 * @return \DateTimeImmutable|false
+	 */
+	protected function parseDateOption(string $input) {
+		$date = false;
+
+		// Handle Unix timestamp
+		if (filter_var($input, FILTER_VALIDATE_INT)) {
+			return new DateTimeImmutable('@' . $input);
+		}
+
+		// ISO8601
+		$date = DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $input);
+		if ($date) {
+			return $date;
+		}
+		// With fractions
+		$date = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $input);
+		if ($date) {
+			return $date;
+		}
+
+		// YYYY-MM-DD
+		return DateTimeImmutable::createFromFormat('!Y-m-d', $input);
+	}
+}

--- a/apps/files/lib/Command/Touch.php
+++ b/apps/files/lib/Command/Touch.php
@@ -52,7 +52,6 @@ class Touch extends Command {
 			$node = $this->rootFolder->newFile($fileInput);
 		}
 
-
 		if ($date) {
 			$mtime = $this->parseDateOption($date);
 			if (!$mtime) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- add `occ files:mkdir`
- add `occ files:touch`
- create missing parent folders for `occ files:put`
- add option to skip trashbin for `occ files:delete`

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
