### PR TITLE
fix: unreachable LDAP backend must not block local/DB account login

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -235,7 +235,7 @@ class Manager extends PublicEmitter implements IUserManager {
 				try {
 					$uid = $backend->checkPassword($loginName, $password);
 				} catch (ServerNotAvailableException $e) {
-					$this->logger->warning('Unable to check password against user backend', ['exception' => $e]);
+					$this->logger->warning('Unable to check password against user backend: ' . ($backend instanceof IUserBackend ? $backend->getBackendName() : get_class($backend)), ['exception' => $e]);
 					continue;
 				}
 				if ($uid !== false) {
@@ -255,7 +255,7 @@ class Manager extends PublicEmitter implements IUserManager {
 				try {
 					$uid = $backend->checkPassword($loginName, $password);
 				} catch (ServerNotAvailableException $e) {
-					$this->logger->warning('Unable to check password against user backend', ['exception' => $e]);
+					$this->logger->warning('Unable to check password against user backend: ' . ($backend instanceof IUserBackend ? $backend->getBackendName() : get_class($backend)), ['exception' => $e]);
 					continue;
 				}
 				if ($uid !== false) {

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -9,6 +9,7 @@ namespace OC\User;
 
 use OC\Hooks\PublicEmitter;
 use OC\Memcache\WithLocalCache;
+use OC\ServerNotAvailableException;
 use OCP\Config\IUserConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -231,7 +232,12 @@ class Manager extends PublicEmitter implements IUserManager {
 		foreach ($backends as $backend) {
 			if ($backend instanceof ICheckPasswordBackend || $backend->implementsActions(Backend::CHECK_PASSWORD)) {
 				/** @var ICheckPasswordBackend $backend */
-				$uid = $backend->checkPassword($loginName, $password);
+				try {
+					$uid = $backend->checkPassword($loginName, $password);
+				} catch (ServerNotAvailableException $e) {
+					$this->logger->warning('Unable to check password against user backend', ['exception' => $e]);
+					continue;
+				}
 				if ($uid !== false) {
 					return $this->getUserObject($uid, $backend);
 				}
@@ -246,7 +252,12 @@ class Manager extends PublicEmitter implements IUserManager {
 		foreach ($backends as $backend) {
 			if ($backend instanceof ICheckPasswordBackend || $backend->implementsActions(Backend::CHECK_PASSWORD)) {
 				/** @var ICheckPasswordBackend|UserInterface $backend */
-				$uid = $backend->checkPassword($loginName, $password);
+				try {
+					$uid = $backend->checkPassword($loginName, $password);
+				} catch (ServerNotAvailableException $e) {
+					$this->logger->warning('Unable to check password against user backend', ['exception' => $e]);
+					continue;
+				}
 				if ($uid !== false) {
 					return $this->getUserObject($uid, $backend);
 				}

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -9,6 +9,7 @@
 namespace Test\User;
 
 use OC\AllConfig;
+use OC\ServerNotAvailableException;
 use OC\USER\BACKEND;
 use OC\User\Database;
 use OC\User\Manager;
@@ -163,6 +164,56 @@ class ManagerTest extends TestCase {
 
 		$user = $manager->checkPassword('foo', 'bar');
 		$this->assertTrue($user instanceof User);
+	}
+
+	public function testCheckPasswordNoLoggingContinuesAfterUnavailableBackend(): void {
+		$exception = new ServerNotAvailableException();
+		$unavailableBackend = $this->createMock(\Test\Util\User\Dummy::class);
+		$unavailableBackend->expects($this->once())
+			->method('checkPassword')
+			->with('foo', 'bar')
+			->willThrowException($exception);
+		$unavailableBackend->method('implementsActions')
+			->with(BACKEND::CHECK_PASSWORD)
+			->willReturn(true);
+
+		$databaseBackend = $this->createMock(Database::class);
+		$databaseBackend->expects($this->once())
+			->method('checkPassword')
+			->with('foo', 'bar')
+			->willReturn('foo');
+
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with('Unable to check password against user backend', ['exception' => $exception]);
+
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager->registerBackend($unavailableBackend);
+		$manager->registerBackend($databaseBackend);
+
+		$user = $manager->checkPasswordNoLogging('foo', 'bar');
+		$this->assertInstanceOf(User::class, $user);
+		$this->assertSame('foo', $user->getUID());
+	}
+
+	public function testCheckPasswordNoLoggingReturnsFalseForUnavailableBackend(): void {
+		$exception = new ServerNotAvailableException();
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->method('checkPassword')
+			->with('foo', 'bar')
+			->willThrowException($exception);
+		$backend->method('implementsActions')
+			->with(BACKEND::CHECK_PASSWORD)
+			->willReturn(true);
+
+		$this->logger->expects($this->atLeastOnce())
+			->method('warning')
+			->with('Unable to check password against user backend', ['exception' => $exception]);
+
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager->registerBackend($backend);
+
+		$this->assertFalse($manager->checkPasswordNoLogging('foo', 'bar'));
 	}
 
 	public function testCheckPasswordNotSupported(): void {

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -176,6 +176,8 @@ class ManagerTest extends TestCase {
 		$unavailableBackend->method('implementsActions')
 			->with(BACKEND::CHECK_PASSWORD)
 			->willReturn(true);
+		$unavailableBackend->method('getBackendName')
+			->willReturn('Dummy');
 
 		$databaseBackend = $this->createMock(Database::class);
 		$databaseBackend->expects($this->once())
@@ -185,7 +187,7 @@ class ManagerTest extends TestCase {
 
 		$this->logger->expects($this->once())
 			->method('warning')
-			->with('Unable to check password against user backend', ['exception' => $exception]);
+			->with('Unable to check password against user backend: Dummy', ['exception' => $exception]);
 
 		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($unavailableBackend);
@@ -205,10 +207,12 @@ class ManagerTest extends TestCase {
 		$backend->method('implementsActions')
 			->with(BACKEND::CHECK_PASSWORD)
 			->willReturn(true);
+		$backend->method('getBackendName')
+			->willReturn('Dummy');
 
 		$this->logger->expects($this->atLeastOnce())
 			->method('warning')
-			->with('Unable to check password against user backend', ['exception' => $exception]);
+			->with('Unable to check password against user backend: Dummy', ['exception' => $exception]);
 
 		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
 		$manager->registerBackend($backend);


### PR DESCRIPTION
* Resolves: #36281

## Summary

In `OC\User\Manager::checkPasswordNoLogging()` the two `foreach ($backends ...)` loops call `$backend->checkPassword()` directly; when the LDAP backend (`OCA\User_LDAP\User_Proxy`) cannot reach the server it throws `OC\ServerNotAvailableException`, which propagates uncaught out of `Session::loginWithPassword()` (the login command chain catches only Session/Token exceptions), surfacing as the reported 500 and preventing any later backend (the local `OC\User\Database` backend that would authenticate the local admin) from being tried. Wrap each per-backend `checkPassword()` call in a `try/catch (\OC\ServerNotAvailableException $e)` that logs a warning via the injected logger and `continue`s to the next backend, so an unavailable backend degrades gracefully instead of blocking login for users of other backends. The exception is logged (not silently swallowed) to preserve diagnosability, and credential validation for every backend is unchanged, so this is a purely defensive hardening with no authentication-bypass surface. Add `use OC\ServerNotAvailableException;` (or fully-qualify) since `Manager` lives in the `OC\User` namespace.

## Checklist

- Code is properly formatted
- Sign-off message is added to all commits
- [x] Tests are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [ ] Backports requested where applicable
- [ ] Labels added where applicable
- [ ] Milestone added for target branch/version

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
