### PR TITLE
fix(files): preserve encryptedVersion when copying cache entries

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -1254,6 +1254,9 @@ class Cache implements ICache {
 			&& $sourceCache->hasEncryptionWrapper()
 			&& !$this->shouldEncrypt($targetPath)) {
 			$data['encrypted'] = 0;
+			// normalizeData() prefers 'encryptedVersion' over 'encrypted' when both are
+			// set, so it has to be cleared too or the mark above gets ignored
+			unset($data['encryptedVersion']);
 		}
 
 		$fileId = $this->put($targetPath, $data);
@@ -1287,6 +1290,11 @@ class Cache implements ICache {
 		if ($entry instanceof CacheEntry && isset($entry['scan_permissions'])) {
 			$data['permissions'] = $entry['scan_permissions'];
 		}
+
+		if ($entry->isEncrypted() && isset($entry['encryptedVersion'])) {
+			$data['encryptedVersion'] = $entry['encryptedVersion'];
+		}
+
 		return $data;
 	}
 

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -541,6 +541,49 @@ class CacheTest extends \Test\TestCase {
 		$this->assertEquals($this->cache->getId(''), $this->cache->get('targetsub')->getParentId());
 	}
 
+	public function testCopyFromCachePreservesEncryptedVersion(): void {
+		$data = [
+			'size' => 100, 'mtime' => 50, 'mimetype' => 'foo/bar',
+			'encrypted' => true, 'encryptedVersion' => 3,
+		];
+		$this->cache->put('source', $data);
+		$sourceEntry = $this->cache->get('source');
+		$this->assertSame(3, $sourceEntry['encryptedVersion']);
+
+		$this->cache->copyFromCache($this->cache, $sourceEntry, 'target');
+
+		$targetEntry = $this->cache->get('target');
+		$this->assertTrue($targetEntry->isEncrypted());
+		$this->assertSame(3, $targetEntry['encryptedVersion']);
+	}
+
+	public function testCopyFromCacheClearsEncryptedVersionWhenCopyingToNonEncryptedStorage(): void {
+		$data = [
+			'size' => 100, 'mtime' => 50, 'mimetype' => 'foo/bar',
+			'encrypted' => true, 'encryptedVersion' => 3,
+		];
+		$this->cache2->put('source', $data);
+		$sourceEntry = $this->cache2->get('source');
+
+		$sourceCache = $this->getMockBuilder(Cache::class)
+			->setConstructorArgs([$this->storage2])
+			->onlyMethods(['hasEncryptionWrapper'])
+			->getMock();
+		$sourceCache->method('hasEncryptionWrapper')->willReturn(true);
+
+		$targetCache = $this->getMockBuilder(Cache::class)
+			->setConstructorArgs([$this->storage])
+			->onlyMethods(['shouldEncrypt'])
+			->getMock();
+		$targetCache->method('shouldEncrypt')->willReturn(false);
+
+		$targetCache->copyFromCache($sourceCache, $sourceEntry, 'target');
+
+		$targetEntry = $targetCache->get('target');
+		$this->assertFalse($targetEntry->isEncrypted());
+		$this->assertSame(0, $targetEntry['encryptedVersion']);
+	}
+
 	public function testGetIncomplete(): void {
 		$file1 = 'folder1';
 		$file2 = 'folder2';


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #61492 <!-- related github issue -->

## Summary
`Cache::copyFromCache()` rebuilt the target's cache row via `cacheEntryToArray()`, which only carried over a boolean `encrypted` flag and dropped the real `encryptedVersion` count. Since `View::copy()` unconditionally calls `copyFromCache()` after the storage copy completes, this silently overwrote the correct `encryptedVersion` that Encryption::updateEncryptedVersion() had just set, collapsing it back to 0/1 on every copy of a file whose `encryptedVersion` was above 1.

`cacheEntryToArray()` now includes the source entry's `encryptedVersion` when it is encrypted. The existing encrypted-to-non-encrypted-storage override in copyFromCache() also clears encryptedVersion alongside
`encrypted`, since normalizeData() prefers encryptedVersion over `encrypted` when both are present in the update data.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
