### PR TITLE
test: mark installation tests as slow

### DIFF
--- a/tests/playwright/e2e/core/setup.spec.ts
+++ b/tests/playwright/e2e/core/setup.spec.ts
@@ -105,6 +105,7 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 
 	test.describe('SQLite', { tag: '@db_sqlite' }, () => {
 		test('installs with SQLite', async ({ page, setupPage }) => {
+			test.slow()
 			await mockAppstore(page, 'skip')
 			await setupPage.open()
 
@@ -134,6 +135,7 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 	})
 
 	test('installs with MySQL', { tag: '@db_mysql' }, async ({ page, setupPage }) => {
+		test.slow()
 		await mockAppstore(page, 'skip')
 		await setupPage.open()
 
@@ -143,6 +145,7 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 	})
 
 	test('installs with MariaDB', { tag: '@db_mariadb' }, async ({ page, setupPage }) => {
+		test.slow()
 		await mockAppstore(page, 'skip')
 		await setupPage.open()
 
@@ -152,6 +155,7 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 	})
 
 	test('installs with PostgreSQL', { tag: '@db_postgres' }, async ({ page, setupPage }) => {
+		test.slow()
 		await mockAppstore(page, 'skip')
 		await setupPage.open()
 
@@ -161,8 +165,8 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 	})
 
 	test('installs with Oracle', { tag: '@db_oracle' }, async ({ page, setupPage }) => {
-		// Installing into Oracle (and the Oracle container itself) is slow
-		test.setTimeout(200_000)
+		test.slow()
+		test.setTimeout(200_000) // Oracle is slow to start up, so give it more time
 		// Oracle is only offered when the server allows all databases
 		await runExec(['cp', 'tests/databases-all-config.php', 'config/config.php'])
 


### PR DESCRIPTION
## Summary
Installing Nextcloud might take some time.
Marking those tests as slow to prevent flaky CI.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
