### PR TITLE
test(users): prevent flaky tests with hardcoded values

### DIFF
--- a/tests/playwright/e2e/users/users.spec.ts
+++ b/tests/playwright/e2e/users/users.spec.ts
@@ -12,22 +12,25 @@ import { handlePasswordConfirmation } from '../../support/utils/password-confirm
 
 test.describe('Settings: Create and delete accounts', () => {
 	test('can create a user with username and password', async ({ page }) => {
-		const settingsPage = new SettingsUsersPage(page)
-		await settingsPage.open()
+		const newUserId = crypto.randomUUID()
+		try {
+			const settingsPage = new SettingsUsersPage(page)
+			await settingsPage.open()
 
-		await settingsPage.openNewUserDialog()
+			await settingsPage.openNewUserDialog()
 
-		const dialog = settingsPage.newUserDialog()
-		await dialog.getByLabel(/Account name/).fill('newuser-basic')
-		await dialog.getByLabel(/Password/).and(page.locator('input')).fill('password123')
+			const dialog = settingsPage.newUserDialog()
+			await dialog.getByLabel(/Account name/).fill(newUserId)
+			await dialog.getByLabel(/Password/).and(page.locator('input')).fill('password123')
 
-		await dialog.getByRole('button', { name: 'Add new account' }).click()
-		await handlePasswordConfirmation(page)
-		await dialog.waitFor({ state: 'hidden' })
+			await dialog.getByRole('button', { name: 'Add new account' }).click()
+			await handlePasswordConfirmation(page)
+			await dialog.waitFor({ state: 'hidden' })
 
-		await expect(settingsPage.userRow('newuser-basic')).toContainText('newuser-basic')
-
-		await runOcc(['user:delete', 'newuser-basic'])
+			await expect(settingsPage.userRow(newUserId)).toContainText(newUserId)
+		} finally {
+			await runOcc(['user:delete', newUserId], { failOnError: false })
+		}
 	})
 
 	test('can create a user with display name and email', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Do not use hard coded user-id.
- Properly clean-up created user in `finally` clause

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
