### PR TITLE
test(files): wait for PUT before continue with tests

### DIFF
--- a/tests/playwright/e2e/files/files-settings.spec.ts
+++ b/tests/playwright/e2e/files/files-settings.spec.ts
@@ -21,11 +21,15 @@ test.describe('files: Set default view', () => {
 		await filesListPage.open()
 
 		const dialog = await filesNavigation.openSettings()
+		// The next page load only honors the new default once the config PUT has
+		// been persisted, so wait for it before re-navigating.
+		const saved = page.waitForResponse((r) => r.url().includes('/apps/files/api/v1/config/default_view'))
 		// The radio input is `hidden-visually` and can sit below the dialog fold, so
 		// clicking its visible label is more reliable than checking the input.
 		await dialog.getByRole('group', { name: 'Default view' })
 			.getByText('Personal files', { exact: true })
 			.click()
+		await saved
 		await expect(dialog.getByRole('group', { name: 'Default view' }).getByRole('radio', { name: 'Personal files' })).toBeChecked()
 		await filesNavigation.closeSettings()
 


### PR DESCRIPTION
## Summary
As described in the code comment we need to await the PUT otherwise this can get flaky.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
