### PR TITLE
test(files): wait for actual requests when deleting files

### DIFF
--- a/tests/playwright/e2e/files/files-delete.spec.ts
+++ b/tests/playwright/e2e/files/files-delete.spec.ts
@@ -25,9 +25,10 @@ test.describe('Files: Delete', () => {
 	})
 
 	test('can delete multiple files', async ({ page, user, filesListPage }) => {
+		const files = Array.from({ length: 5 }, (_, i) => `file${i}.txt`)
 		await mkdir(page.request, user, '/root')
-		for (let i = 0; i < 5; i++) {
-			await uploadContent(page.request, user, Buffer.alloc(0), 'text/plain', `/root/file${i}.txt`)
+		for (const file of files) {
+			await uploadContent(page.request, user, Buffer.alloc(0), 'text/plain', `/root/${file}`)
 		}
 		await filesListPage.open()
 		await filesListPage.navigateToFolder('root')
@@ -35,9 +36,12 @@ test.describe('Files: Delete', () => {
 		// All 5 preview thumbnails must finish loading before we delete
 		await expect(page.locator('.files-list__row-icon-preview--loaded')).toHaveCount(5)
 
-		// Set up listeners for all 5 DELETE responses before triggering the action
-		const deleteResponses = Promise.all(Array.from({ length: 5 }, () => page.waitForResponse(
-			(r) => r.url().includes(`/remote.php/dav/files/${user.userId}/root/`) && r.request().method() === 'DELETE',
+		// One listener per file, registered before triggering the action. Each
+		// predicate matches its own file's URL — with identical predicates all
+		// listeners can resolve to the same first response, so distinct DELETE
+		// requests would never actually be verified.
+		const deleteResponses = Promise.all(files.map((file) => page.waitForResponse(
+			(r) => r.url().includes(`/remote.php/dav/files/${user.userId}/root/${file}`) && r.request().method() === 'DELETE',
 			{ timeout: 15000 },
 		)))
 
@@ -48,9 +52,12 @@ test.describe('Files: Delete', () => {
 			.getByRole('button', { name: 'Delete files' })
 			.click()
 
-		const responses = await deleteResponses
-		for (const response of responses) {
-			expect(response.status()).toBe(204)
+		await deleteResponses
+
+		// Assert the user-visible end state (rows gone) rather than raw response
+		// codes — a one-shot status check flakes on transient DAV lock responses.
+		for (const file of files) {
+			await expect(filesListPage.getRowForFile(file)).toHaveCount(0)
 		}
 	})
 })


### PR DESCRIPTION
## Summary
Otherwise one DELETE request can trigger all of the 5 promises. So wait for the proper filenames instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
