### PR TITLE
fix(carddav): make paginated contact searches deterministic

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -1207,13 +1207,16 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * } $options
 	 * @return array
 	 */
-	private function searchByAddressBookIds(array $addressBookIds,
+	private function searchByAddressBookIds(
+		array $addressBookIds,
 		string $pattern,
 		array $searchProperties,
-		array $options = []): array {
+		array $options = [],
+	): array {
 		if (empty($addressBookIds)) {
 			return [];
 		}
+
 		$escapePattern = !\array_key_exists('escape_like_param', $options) || $options['escape_like_param'] !== false;
 		$useWildcards = !\array_key_exists('wildcard', $options) || $options['wildcard'] !== false;
 
@@ -1253,6 +1256,9 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			} else {
 				$query2->andWhere($query2->expr()->ilike('cp.value', $query2->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%')));
 			}
+		}
+		if (isset($options['limit']) || isset($options['offset'])) {
+			$query2->orderBy('cp.cardid', 'ASC');
 		}
 		if (isset($options['limit'])) {
 			$query2->setMaxResults($options['limit']);
@@ -1299,6 +1305,10 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$query->select('c.addressbookid', 'c.carddata', 'c.uri')
 			->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createParameter('matches')));
+
+		if (isset($options['limit']) || isset($options['offset'])) {
+			$query->orderBy('c.id', 'ASC');
+		}
 
 		foreach (array_chunk($matches, IQueryBuilder::MAX_IN_PARAMETERS) as $matchesChunk) {
 			$query->setParameter('matches', $matchesChunk, IQueryBuilder::PARAM_INT_ARRAY);

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -682,62 +682,7 @@ class CardDavBackendTest extends TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestSearch')]
 	public function testSearch(string $pattern, array $properties, array $options, array $expectedUris, array $expectedNeedles): void {
-		$vCards = [];
-
-		$vCards[0] = new VCard();
-		$vCards[0]->add(new Text($vCards[0], 'UID', 'uid-0'));
-		$vCards[0]->add(new Text($vCards[0], 'FN', 'John Doe'));
-		$vCards[0]->add(new Text($vCards[0], 'CLOUD', 'john@nextcloud.com'));
-
-		$vCards[1] = new VCard();
-		$vCards[1]->add(new Text($vCards[1], 'UID', 'uid-1'));
-		$vCards[1]->add(new Text($vCards[1], 'FN', 'John M. Doe'));
-
-		$vCards[2] = new VCard();
-		$vCards[2]->add(new Text($vCards[2], 'UID', 'uid-2'));
-		$vCards[2]->add(new Text($vCards[2], 'FN', 'find without options'));
-		$vCards[2]->add(new Text($vCards[2], 'CLOUD', 'peter_pan@nextcloud.com'));
-
-		$vCardIds = [];
-		$query = $this->db->getQueryBuilder();
-		for ($i = 0; $i < 3; $i++) {
-			$query->insert($this->dbCardsTable)
-				->values(
-					[
-						'addressbookid' => $query->createNamedParameter(0),
-						'carddata' => $query->createNamedParameter($vCards[$i]->serialize(), IQueryBuilder::PARAM_LOB),
-						'uri' => $query->createNamedParameter('uri' . $i),
-						'lastmodified' => $query->createNamedParameter(time()),
-						'etag' => $query->createNamedParameter('etag' . $i),
-						'size' => $query->createNamedParameter(120),
-					]
-				);
-			$query->executeStatement();
-			$vCardIds[] = $query->getLastInsertId();
-		}
-
-		$propertyRows = [
-			[$vCardIds[0], 'FN', 'John Doe'],
-			[$vCardIds[0], 'CLOUD', 'John@nextcloud.com'],
-			[$vCardIds[1], 'FN', 'John M. Doe'],
-			[$vCardIds[2], 'FN', 'find without options'],
-			[$vCardIds[2], 'CLOUD', 'peter_pan@nextcloud.com'],
-		];
-
-		foreach ($propertyRows as [$cardId, $name, $value]) {
-			$query = $this->db->getQueryBuilder();
-			$query->insert($this->dbCardsPropertiesTable)
-				->values(
-					[
-						'addressbookid' => $query->createNamedParameter(0),
-						'cardid' => $query->createNamedParameter($cardId),
-						'name' => $query->createNamedParameter($name),
-						'value' => $query->createNamedParameter($value),
-						'preferred' => $query->createNamedParameter(0),
-					]
-				);
-			$query->executeStatement();
-		}
+		$this->seedSearchCards();
 
 		$result = $this->backend->search(0, $pattern, $properties, $options);
 
@@ -759,6 +704,81 @@ class CardDavBackendTest extends TestCase {
 				strpos($row['carddata'], $expectedByUri[$row['uri']]),
 				'Returned carddata does not contain expected fragment for ' . $row['uri']
 			);
+		}
+	}
+
+	public function testSearchPaginationUsesCardIdOrder(): void {
+		$this->seedSearchCards();
+
+		$firstPage = $this->backend->search(0, 'john', ['FN'], [
+			'limit' => 1,
+			'offset' => 0,
+		]);
+		$secondPage = $this->backend->search(0, 'john', ['FN'], [
+			'limit' => 1,
+			'offset' => 1,
+		]);
+		$twoResults = $this->backend->search(0, 'john', ['FN'], [
+			'limit' => 2,
+		]);
+
+		self::assertSame(['uri0'], array_column($firstPage, 'uri'));
+		self::assertSame(['uri1'], array_column($secondPage, 'uri'));
+		self::assertSame(['uri0', 'uri1'], array_column($twoResults, 'uri'));
+	}
+
+	private function seedSearchCards(): void {
+		$vCards = [];
+
+		$vCards[0] = new VCard();
+		$vCards[0]->add(new Text($vCards[0], 'UID', 'uid-0'));
+		$vCards[0]->add(new Text($vCards[0], 'FN', 'John Doe'));
+		$vCards[0]->add(new Text($vCards[0], 'CLOUD', 'john@nextcloud.com'));
+
+		$vCards[1] = new VCard();
+		$vCards[1]->add(new Text($vCards[1], 'UID', 'uid-1'));
+		$vCards[1]->add(new Text($vCards[1], 'FN', 'John M. Doe'));
+
+		$vCards[2] = new VCard();
+		$vCards[2]->add(new Text($vCards[2], 'UID', 'uid-2'));
+		$vCards[2]->add(new Text($vCards[2], 'FN', 'find without options'));
+		$vCards[2]->add(new Text($vCards[2], 'CLOUD', 'peter_pan@nextcloud.com'));
+
+		$vCardIds = [];
+		$query = $this->db->getQueryBuilder();
+		for ($i = 0; $i < 3; $i++) {
+			$query->insert($this->dbCardsTable)
+				->values([
+					'addressbookid' => $query->createNamedParameter(0),
+					'carddata' => $query->createNamedParameter($vCards[$i]->serialize(), IQueryBuilder::PARAM_LOB),
+					'uri' => $query->createNamedParameter('uri' . $i),
+					'lastmodified' => $query->createNamedParameter(time()),
+					'etag' => $query->createNamedParameter('etag' . $i),
+					'size' => $query->createNamedParameter(120),
+				]);
+			$query->executeStatement();
+			$vCardIds[] = $query->getLastInsertId();
+		}
+
+		$propertyRows = [
+			[$vCardIds[0], 'FN', 'John Doe'],
+			[$vCardIds[0], 'CLOUD', 'John@nextcloud.com'],
+			[$vCardIds[1], 'FN', 'John M. Doe'],
+			[$vCardIds[2], 'FN', 'find without options'],
+			[$vCardIds[2], 'CLOUD', 'peter_pan@nextcloud.com'],
+		];
+
+		foreach ($propertyRows as [$cardId, $name, $value]) {
+			$query = $this->db->getQueryBuilder();
+			$query->insert($this->dbCardsPropertiesTable)
+				->values([
+					'addressbookid' => $query->createNamedParameter(0),
+					'cardid' => $query->createNamedParameter($cardId),
+					'name' => $query->createNamedParameter($name),
+					'value' => $query->createNamedParameter($value),
+					'preferred' => $query->createNamedParameter(0),
+				]);
+			$query->executeStatement();
 		}
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Make CardDAV contact search results deterministic when `limit` or `offset` is used.

The search query now orders matching card IDs before pagination and preserves that order when loading the matching cards. This avoids unstable limited search results across database backends.

Also add  test coverage for stable `limit`/`offset` pagination results and extract the shared CardDAV search fixture.

The existing general search test remains order-agnostic because unlimited searches do not promise a result order.

This was identified while investigating a failing PHPUnit MySQL job:
https://github.com/nextcloud/server/actions/runs/29437750990/job/87428653205?pr=62200

This change does not itself explain or fix the empty result from that job, but it fixes an independent issue with paginated search results.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
