### PR TITLE
test(TestCase): restore unregistered services correctly

### DIFF
--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -96,7 +96,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 					return $oldService;
 				});
 			} else {
-				unset($container[$oldService]);
+				// The service was not registered before the test override.
+				// Remove the test registration so the container returns to its prior state.
+				unset($container[$name]);
 			}
 
 			unset($this->services[$name]);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fix `Test\TestCase::restoreService()` to remove a temporary DI-container registration when the service did not exist before `overwriteService()` was called.

Previously, restoration attempted to unset the saved service value (`false`) instead of the service name, leaving the test override registered and potentially leaking it into subsequent tests.

Related/introduced in #53523

Possible follow-up: May be worth adding test coverage for more for of our test infrastructure; particularly this base class. Leaving out of scope since that deserves its own PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
