### PR TITLE
test(files): make watcher propagation mtime regression test deterministic

### DIFF
--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -473,23 +473,33 @@ class ViewTest extends \Test\TestCase {
 
 		$rootView = new View('');
 
-		// Note the root mtime right after the initial scan.
-		$rootMtimeBefore = $storage->getCache()->get('')['mtime'];
+		// Use an mtime that cannot accidentally equal the current timestamp. This makes
+		// the test fail reliably if propagateChange() is called during this request.
+		$rootEntry = $storage->getCache()->get('');
+		$storage->getCache()->update($rootEntry->getId(), [
+			'mtime' => 1,
+			'etag' => 'unchanged-root-etag',
+		]);
 
 		// Access a subfolder. The watcher will fire (hasUpdated always returns true),
 		// but the scanner leaves the cached metadata for 'folder' unchanged.
 		// getCacheEntry must therefore NOT call propagateChange('folder', time()),
-		// which would update the root entry's mtime to the current timestamp.
+		// which would update the root entry's mtime and etag.
 		$rootView->getFileInfo('folder');
 
-		// Read the root mtime directly from the cache to avoid triggering another watcher cycle.
-		$rootMtimeAfter = $storage->getCache()->get('')['mtime'];
+		// Read the root entry directly from the cache to avoid triggering another watcher cycle.
+		$rootEntryAfter = $storage->getCache()->get('');
 
-		$this->assertEquals(
-			$rootMtimeBefore,
-			$rootMtimeAfter,
-			'Root folder mtime must not be updated when the watcher fires but cached metadata has not changed'
+		$this->assertSame(
+			1,
+			$rootEntryAfter->getMTime(),
+			'Root folder mtime must not change when the watcher finds no metadata change'
 		);
+		$this->assertSame(
+			'unchanged-root-etag',
+			$rootEntryAfter->getEtag(),
+			'Root folder etag must not change when the watcher finds no metadata change'
+ 		);
 	}
 
 	public function testCopyBetweenStorageNoCross(): void {

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -493,13 +493,13 @@ class ViewTest extends \Test\TestCase {
 		$this->assertSame(
 			1,
 			$rootEntryAfter->getMTime(),
-			'Root folder mtime must not change when the watcher finds no metadata change'
+			'Root folder mtime must not change when the watcher finds no metadata change',
 		);
 		$this->assertSame(
 			'unchanged-root-etag',
 			$rootEntryAfter->getEtag(),
-			'Root folder etag must not change when the watcher finds no metadata change'
- 		);
+			'Root folder etag must not change when the watcher finds no metadata change',
+		);
 	}
 
 	public function testCopyBetweenStorageNoCross(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- The existing watcher regression test could pass if the cached mtime and request timestamp land in the same second.
- The test now uses a fixed root mtime and etag before accessing the folder.
- Checking the etag as well is valid, because an unwanted propagation can invalidate ancestor etags.

Related/context: #59539

Assisted-by: GitHubCopilot:GPT-5

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
