### PR TITLE
fix(core): handle parameter limits in files metadata deletion

### DIFF
--- a/lib/private/FilesMetadata/Service/MetadataRequestService.php
+++ b/lib/private/FilesMetadata/Service/MetadataRequestService.php
@@ -155,7 +155,7 @@ class MetadataRequestService {
 		foreach ($chunks as $chunk) {
 			$qb = $this->dbConnection->getQueryBuilder();
 			$qb->delete(self::TABLE_METADATA)
-				->where($qb->expr()->in('file_id', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)))
+				->where($qb->expr()->in('file_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)))
 				->hintShardKey('storage', $storage);
 			$qb->executeStatement();
 		}

--- a/tests/lib/FilesMetadata/FilesMetadataManagerTest.php
+++ b/tests/lib/FilesMetadata/FilesMetadataManagerTest.php
@@ -94,4 +94,37 @@ class FilesMetadataManagerTest extends TestCase {
 		$this->assertEquals($file->getId(), $retrieved->getFileId());
 		$this->assertEquals('yes', $retrieved->getString('istest'));
 	}
+
+	public function testDropMetadataForFilesChunking(): void {
+		$connection = $this->createMock(IDBConnection::class);
+		$qb = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+		$expr = $this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class);
+
+		$connection->method('getQueryBuilder')->willReturn($qb);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('delete')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('hintShardKey')->willReturnSelf();
+
+		$fileIds = range(1, \OCP\DB\QueryBuilder\IQueryBuilder::MAX_IN_PARAMETERS * 2 + 1);
+		$expectedChunks = array_chunk($fileIds, \OCP\DB\QueryBuilder\IQueryBuilder::MAX_IN_PARAMETERS);
+		$boundChunks = [];
+
+		$qb->expects($this->exactly(count($expectedChunks)))
+			->method('createNamedParameter')
+			->willReturnCallback(function (array $chunk, $type) use (&$boundChunks): string {
+				$this->assertSame(\OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT_ARRAY, $type);
+				$boundChunks[] = $chunk;
+				return ':param';
+			});
+
+		$qb->expects($this->exactly(count($expectedChunks)))
+			->method('executeStatement')
+			->willReturn(1);
+
+		$service = new MetadataRequestService($connection, $this->logger);
+		$service->dropMetadataForFiles(123, $fileIds);
+
+		$this->assertSame($expectedChunks, $boundChunks);
+	}
 }


### PR DESCRIPTION
* Resolves: #62325

## Summary

`dropMetadataForFiles()` was already intended to split file IDs into chunks using `IQueryBuilder::MAX_IN_PARAMETERS`, but the DELETE query mistakenly bound the original `$fileIds` array instead of the current `$chunk`. As a result, every query still contained the full ID list and could exceed database parameter limits.

This PR passes `$chunk` to each query and adds regression coverage that verifies the exact chunks sent to the query builder.

## Testing

Added a regression test using more than two parameter-limit batches. It verifies that every ID is bound exactly once, in order, and no query receives more than `MAX_IN_PARAMETERS` IDs.

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI