### PR TITLE
fix: Mark some parameters as sensitive

### DIFF
--- a/lib/private/Security/CredentialsManager.php
+++ b/lib/private/Security/CredentialsManager.php
@@ -12,6 +12,7 @@ namespace OC\Security;
 use OCP\IDBConnection;
 use OCP\Security\ICredentialsManager;
 use OCP\Security\ICrypto;
+use SensitiveParameter;
 
 /**
  * Store and retrieve credentials for external services
@@ -34,7 +35,12 @@ class CredentialsManager implements ICredentialsManager {
 	 * @param mixed $credentials
 	 */
 	#[\Override]
-	public function store(string $userId, string $identifier, $credentials): void {
+	public function store(
+		string $userId,
+		string $identifier,
+		#[SensitiveParameter]
+		$credentials,
+	): void {
 		$value = $this->crypto->encrypt(json_encode($credentials));
 
 		$this->dbConnection->setValues(self::DB_TABLE, [

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -14,6 +14,7 @@ use OCP\IConfig;
 use OCP\Security\ICrypto;
 use phpseclib\Crypt\AES;
 use phpseclib\Crypt\Hash;
+use SensitiveParameter;
 
 /**
  * Class Crypto provides a high-level encryption layer using AES-CBC. If no key has been provided
@@ -41,7 +42,11 @@ class Crypto implements ICrypto {
 	 * @return string Calculated HMAC
 	 */
 	#[\Override]
-	public function calculateHMAC(string $message, string $password = ''): string {
+	public function calculateHMAC(
+		string $message,
+		#[SensitiveParameter]
+		string $password = '',
+	): string {
 		if ($password === '') {
 			$password = $this->config->getSystemValueString('secret');
 		}
@@ -63,7 +68,11 @@ class Crypto implements ICrypto {
 	 * @throws Exception if encrypting the data failed
 	 */
 	#[\Override]
-	public function encrypt(string $plaintext, string $password = ''): string {
+	public function encrypt(
+		string $plaintext,
+		#[SensitiveParameter]
+		string $password = '',
+	): string {
 		if ($password === '') {
 			$password = $this->config->getSystemValueString('secret');
 		}
@@ -93,7 +102,11 @@ class Crypto implements ICrypto {
 	 * @throws Exception If the decryption failed
 	 */
 	#[\Override]
-	public function decrypt(string $authenticatedCiphertext, string $password = ''): string {
+	public function decrypt(
+		string $authenticatedCiphertext,
+		#[SensitiveParameter]
+		string $password = '',
+	): string {
 		$secret = $this->config->getSystemValue('secret');
 		try {
 			if ($password === '') {

--- a/lib/public/Security/Events/GenerateSecurePasswordEvent.php
+++ b/lib/public/Security/Events/GenerateSecurePasswordEvent.php
@@ -11,6 +11,7 @@ namespace OCP\Security\Events;
 
 use OCP\EventDispatcher\Event;
 use OCP\Security\PasswordContext;
+use SensitiveParameter;
 
 /**
  * Event to request a secure password to be generated
@@ -50,7 +51,10 @@ class GenerateSecurePasswordEvent extends Event {
 	 * This is used by password generators to set the generated password.
 	 * @since 18.0.0
 	 */
-	public function setPassword(string $password): void {
+	public function setPassword(
+		#[SensitiveParameter]
+		string $password,
+	): void {
 		$this->password = $password;
 	}
 

--- a/lib/public/Security/Events/ValidatePasswordPolicyEvent.php
+++ b/lib/public/Security/Events/ValidatePasswordPolicyEvent.php
@@ -11,6 +11,7 @@ namespace OCP\Security\Events;
 
 use OCP\EventDispatcher\Event;
 use OCP\Security\PasswordContext;
+use SensitiveParameter;
 
 /**
  * This event can be emitted to request a validation of a password.
@@ -26,6 +27,7 @@ class ValidatePasswordPolicyEvent extends Event {
 	 * @since 31.0.0 - $context parameter added
 	 */
 	public function __construct(
+		#[SensitiveParameter]
 		private string $password,
 		private PasswordContext $context = PasswordContext::ACCOUNT,
 	) {

--- a/lib/public/Security/ICredentialsManager.php
+++ b/lib/public/Security/ICredentialsManager.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCP\Security;
 
+use SensitiveParameter;
+
 /**
  * Store and retrieve credentials for external services
  *
@@ -23,7 +25,12 @@ interface ICredentialsManager {
 	 * @param mixed $credentials
 	 * @since 8.2.0
 	 */
-	public function store(string $userId, string $identifier, $credentials): void;
+	public function store(
+		string $userId,
+		string $identifier,
+		#[SensitiveParameter]
+		$credentials,
+	): void;
 
 	/**
 	 * Retrieve a set of credentials

--- a/lib/public/Security/ICrypto.php
+++ b/lib/public/Security/ICrypto.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCP\Security;
 
+use SensitiveParameter;
+
 /**
  * Class Crypto provides a high-level encryption layer using AES-CBC. If no key has been provided
  * it will use the secret defined in config.php as key. Additionally the message will be HMAC'd.
@@ -26,7 +28,11 @@ interface ICrypto {
 	 * @return string Calculated HMAC
 	 * @since 8.0.0
 	 */
-	public function calculateHMAC(string $message, string $password = ''): string;
+	public function calculateHMAC(
+		string $message,
+		#[SensitiveParameter]
+		string $password = '',
+	): string;
 
 	/**
 	 * Encrypts a value and adds an HMAC (Encrypt-Then-MAC)
@@ -35,7 +41,11 @@ interface ICrypto {
 	 * @return string Authenticated ciphertext
 	 * @since 8.0.0
 	 */
-	public function encrypt(string $plaintext, string $password = ''): string;
+	public function encrypt(
+		string $plaintext,
+		#[SensitiveParameter]
+		string $password = '',
+	): string;
 
 	/**
 	 * Decrypts a value and verifies the HMAC (Encrypt-Then-Mac)
@@ -46,5 +56,9 @@ interface ICrypto {
 	 * @throws \Exception If the decryption failed
 	 * @since 8.0.0
 	 */
-	public function decrypt(string $authenticatedCiphertext, string $password = ''): string;
+	public function decrypt(
+		string $authenticatedCiphertext,
+		#[SensitiveParameter]
+		string $password = '',
+	): string;
 }

--- a/lib/public/Security/VerificationToken/IVerificationToken.php
+++ b/lib/public/Security/VerificationToken/IVerificationToken.php
@@ -15,7 +15,7 @@ use OCP\IUser;
  */
 interface IVerificationToken {
 	/**
-	 * Checks whether the a provided tokent matches a stored token and its
+	 * Checks whether a provided token matches a stored token and its
 	 * constraints. An InvalidTokenException is thrown on issues, otherwise
 	 * the check is successful.
 	 *


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
