### PR TITLE
perf(ShareUser): Only fetch display name instead of user object

### DIFF
--- a/lib/public/Sharing/Recipient/ShareRecipient.php
+++ b/lib/public/Sharing/Recipient/ShareRecipient.php
@@ -52,6 +52,11 @@ final readonly class ShareRecipient {
 			throw new RuntimeException('The recipient type is not registered: ' . $this->class);
 		}
 
+		if ($this->instance !== null) {
+			// TODO: Support federation
+			throw new RuntimeException('Currently only local recipients are supported.');
+		}
+
 		$displayName = $recipientType->getRecipientDisplayName($this->value) ?? $this->value;
 		if (!$isUnique) {
 			$displayName .= ' (' . $recipientType->getDisplayName($l10nFactory) . ': ' . $this->value . ')';

--- a/lib/public/Sharing/ShareUser.php
+++ b/lib/public/Sharing/ShareUser.php
@@ -51,15 +51,15 @@ final readonly class ShareUser {
 			throw new RuntimeException('Currently only local users are supported.');
 		}
 
-		$ownerUser = $userManager->get($this->userId);
-		if ($ownerUser === null) {
-			throw new RuntimeException('The userId does not exist: ' . $this->userId);
+		$displayName = $userManager->getDisplayName($this->userId);
+		if ($displayName === null) {
+			throw new RuntimeException('No display name for user ' . $this->userId);
 		}
 
 		return [
 			'user_id' => $this->userId,
 			'instance' => $this->instance,
-			'display_name' => $ownerUser->getDisplayName(),
+			'display_name' => $displayName,
 			'icon' => (new ShareIconURL(
 				$userManager->getAvatarUrlLight($this->userId, 64),
 				$userManager->getAvatarUrlDark($this->userId, 64),

--- a/lib/public/Sharing/ShareUser.php
+++ b/lib/public/Sharing/ShareUser.php
@@ -46,6 +46,11 @@ final readonly class ShareUser {
 	 * @since 35.0.0
 	 */
 	public function format(IUserManager $userManager): array {
+		if ($this->instance !== null) {
+			// TODO: Support federation
+			throw new RuntimeException('Currently only local users are supported.');
+		}
+
 		$ownerUser = $userManager->get($this->userId);
 		if ($ownerUser === null) {
 			throw new RuntimeException('The userId does not exist: ' . $this->userId);


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/issues/51803
https://github.com/nextcloud/server/pull/62241#discussion_r3595544833

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
