### PR TITLE
fix(view): release cache refresh locks on errors

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1383,48 +1383,76 @@ class View {
 	}
 
 	/**
-	 * Get file info from cache
+	 * Get cached metadata for a storage path.
 	 *
-	 * If the file is not in cached it will be scanned
-	 * If the file has changed on storage the cache will be updated
+	 * Scans the path if it is not cached, or refreshes cached metadata when it has
+	 * changed on storage. If refreshing cached metadata requires a lock that cannot
+	 * be acquired, the existing cached metadata is returned instead.
 	 *
-	 * @param Storage $storage
-	 * @param string $internalPath
-	 * @param string $relativePath
-	 * @return ICacheEntry|bool
+	 * @param Storage $storage Storage containing the path
+	 * @param string $internalPath Path relative to the storage root
+	 * @param string $relativePath Path relative to this view
+	 * @return ICacheEntry|false Cached metadata, or false if the path does not
+	 *                            exist or cannot be scanned due to a lock
 	 */
 	private function getCacheEntry($storage, $internalPath, $relativePath) {
 		$cache = $storage->getCache($internalPath);
 		$data = $cache->get($internalPath);
 		$watcher = $storage->getWatcher($internalPath);
 
-		try {
-			// if the file is not in the cache or needs to be updated, trigger the scanner and reload the data
-			if (!$data || (isset($data['size']) && $data['size'] === -1)) {
-				if (!$storage->file_exists($internalPath)) {
-					return false;
-				}
-				// don't need to get a lock here since the scanner does it's own locking
+		if (!$data || (isset($data['size']) && $data['size'] === -1)) {
+			// Populate missing or incomplete cache entries. The scanner handles locking.
+			if (!$storage->file_exists($internalPath)) {
+				return false;
+			}
+
+			try {
 				$scanner = $storage->getScanner($internalPath);
 				$scanner->scan($internalPath, Scanner::SCAN_SHALLOW);
 				$data = $cache->get($internalPath);
-			} elseif (!Scanner::isPartialFile($internalPath) && $watcher->needsUpdate($internalPath, $data)) {
+			} catch (LockedException $e) {
+				// If the path cannot be scanned because it is locked, return the existing cache result.
+			}
+		} elseif (!Scanner::isPartialFile($internalPath) && $watcher->needsUpdate($internalPath, $data)) {
+			// Refresh metadata when storage has changed and propagate changes. Handle locking.
+			try {
 				$this->lockFile($relativePath, ILockingProvider::LOCK_SHARED);
-				$cacheDataBefore = $data instanceof CacheEntry ? $data->getData() : false;
+			} catch (LockedException $e) {
+				// Refreshing cache metadata is best-effort; use the existing cache entry.
+				return $data;
+			}
+
+			$refreshException = null;
+			try {
+				$cachedDataBeforeUpdate = $data instanceof CacheEntry ? $data->getData() : false;
 				$watcher->update($internalPath, $data);
 				$data = $cache->get($internalPath);
-				$cacheDataAfter = $data instanceof CacheEntry ? $data->getData() : false;
+				$cachedDataAfterUpdate = $data instanceof CacheEntry ? $data->getData() : false;
 
-				// Only propagate mtime change to parent folders if the scanner actually changed the cached metadata,
-				// to avoid updating folder mtimes on every read for backends that conservatively report directories as updated (e.g. S3)
-				if ($cacheDataAfter !== $cacheDataBefore) {
+				// Propagate only actual metadata changes, avoiding mtime updates on every
+				// read for backends that conservatively report directories as updated (e.g. S3).
+				if ($cachedDataAfterUpdate !== $cachedDataBeforeUpdate) {
 					$storage->getPropagator()->propagateChange($internalPath, time());
 					$data = $cache->get($internalPath);
 				}
-				$this->unlockFile($relativePath, ILockingProvider::LOCK_SHARED);
+			} catch (\Throwable $e) {
+				$refreshException = $e;
+				throw $e;
+			} finally {
+				try {
+					$this->unlockFile($relativePath, ILockingProvider::LOCK_SHARED);
+				} catch (\Throwable $unlockException) {
+					if ($refreshException !== null) {
+						$this->logger->error('Failed to release cache refresh lock', [
+							'app' => 'core',
+							'path' => $relativePath,
+							'exception' => $unlockException,
+						]);
+					} else {
+						throw $unlockException;
+					}
+				}
 			}
-		} catch (LockedException $e) {
-			// if the file is locked we just use the old cache info
 		}
 
 		return $data;

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1392,10 +1392,13 @@ class View {
 	 * @param Storage $storage Storage containing the path
 	 * @param string $internalPath Path relative to the storage root
 	 * @param string $relativePath Path relative to this view
-	 * @return ICacheEntry|false Cached metadata, or false if the path does not
-	 *                            exist or cannot be scanned due to a lock
+	 * @return ICacheEntry|false Cached metadata, or false if the path does not exist or cannot be scanned due to a lock
 	 */
-	private function getCacheEntry($storage, $internalPath, $relativePath) {
+	private function getCacheEntry(
+		Storage $storage,
+		string $internalPath,
+		string $relativePath,
+	): ICacheEntry|false {
 		$cache = $storage->getCache($internalPath);
 		$data = $cache->get($internalPath);
 		$watcher = $storage->getWatcher($internalPath);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -22,7 +22,6 @@ use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
-use OCP\Files\Cache\IPropagator;
 use OCP\Files\Cache\IWatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IMountProviderCollection;

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -21,6 +21,9 @@ use OC\Share20\ShareDisableChecker;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Cache\IPropagator;
+use OCP\Files\Cache\IWatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Config\IUserMountCache;
@@ -88,6 +91,49 @@ class TemporaryNoLocal extends Temporary {
 class TemporaryAlwaysUpdated extends Temporary {
 	public function hasUpdated(string $path, int $time): bool {
 		return true;
+	}
+}
+
+class TemporaryWatcherUpdateThrows extends TemporaryAlwaysUpdated {
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher {
+		return new class(parent::getWatcher($path, $storage)) implements IWatcher {
+			public function __construct(
+				private readonly IWatcher $watcher,
+			) {
+			}
+
+			public function setPolicy($policy): void {
+				$this->watcher->setPolicy($policy);
+			}
+
+			public function setCheckFilter(?string $filter): void {
+				$this->watcher->setCheckFilter($filter);
+			}
+
+			public function getPolicy() {
+				return $this->watcher->getPolicy();
+			}
+
+			public function checkUpdate($path, $cachedEntry = null) {
+				return $this->watcher->checkUpdate($path, $cachedEntry);
+			}
+
+			public function update($path, $cachedData): void {
+				throw new \RuntimeException('Simulated watcher update failure');
+			}
+
+			public function needsUpdate($path, $cachedData): bool {
+				return $this->watcher->needsUpdate($path, $cachedData);
+			}
+
+			public function cleanFolder($path): void {
+				$this->watcher->cleanFolder($path);
+			}
+
+			public function onUpdate(callable $callback): void {
+				$this->watcher->onUpdate($callback);
+			}
+		};
 	}
 }
 
@@ -490,6 +536,55 @@ class ViewTest extends \Test\TestCase {
 			$rootMtimeAfter,
 			'Root folder mtime must not be updated when the watcher fires but cached metadata has not changed'
 		);
+	}
+
+	public function testWatcherRefreshFailureReleasesFileAndParentLocks(): void {
+		$storage = $this->getTestStorage(true, TemporaryWatcherUpdateThrows::class);
+		Filesystem::mount($storage, [], '/' . self::$user . '/files');
+
+		$view = new View('/' . self::$user . '/files');
+		$storage->getWatcher()->setPolicy(Watcher::CHECK_ALWAYS);
+
+		try {
+			$view->getFileInfo('folder/bar.txt');
+			$this->fail('Expected the watcher update failure to be rethrown');
+		} catch (\RuntimeException $e) {
+			$this->assertSame('Simulated watcher update failure', $e->getMessage());
+		}
+
+		$this->assertFalse(
+			$this->isFileLocked($view, 'folder/bar.txt', ILockingProvider::LOCK_SHARED),
+			'The refreshed file lock must be released after a watcher failure',
+		);
+		$this->assertFalse(
+			$this->isFileLocked($view, 'folder', ILockingProvider::LOCK_SHARED),
+			'The parent refresh lock must be released after a watcher failure',
+		);
+		$this->assertFalse(
+			$this->isFileLocked($view, '/', ILockingProvider::LOCK_SHARED),
+			'The root refresh lock must be released after a watcher failure',
+		);
+	}
+
+	public function testWatcherRefreshUsesCachedEntryWhenRefreshLockCannotBeAcquired(): void {
+		$storage = $this->getTestStorage(true, TemporaryAlwaysUpdated::class);
+		Filesystem::mount($storage, [], '/' . self::$user . '/files');
+
+		$view = new View('/' . self::$user . '/files');
+		$storage->getWatcher()->setPolicy(Watcher::CHECK_ALWAYS);
+
+		$cachedEntry = $storage->getCache()->get('folder/bar.txt');
+		$this->assertInstanceOf(ICacheEntry::class, $cachedEntry);
+
+		$view->lockFile('folder/bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
+		try {
+			$info = $view->getFileInfo('folder/bar.txt');
+
+			$this->assertNotFalse($info);
+			$this->assertSame($cachedEntry->getId(), $info->getId());
+		} finally {
+			$view->unlockFile('folder/bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
+		}
 	}
 
 	public function testCopyBetweenStorageNoCross(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fix `View::getCacheEntry()` so that, after `lockFile()` succeeds, release of its file and parent-directory refresh locks is attempted in `finally`.

Previously, the broad `LockedException` fallback also caught failures during refresh or lock release. That could skip cleanup and return cached metadata, leaving locks held until request shutdown and obscuring the cause of later lock contention.

Lock contention during shallow scanning or initial lock acquisition remains best-effort and returns the existing cache entry. Once `lockFile()` succeeds, however, `getCacheEntry()` owns the file and parent-directory refresh locks. A subsequent failure during refresh work or cleanup is no longer treated as initial lock contention: the method attempts release in `finally` and propagates the failure.

## Follow-up ideas:

- `lockFile()` does not roll back locks already acquired if acquiring a parent lock fails. Addressing that partial-acquisition cleanup remains out of scope. (Edit: implemented via #62349)
- `basicOperation()` has similar lock-cleanup responsibilities and could probably benefit from a similar approach. In particular, its current cleanup is inside a `catch`, so an `unlockFile()` failure could obscure the original storage exception.

## TODO

- [x] Check existing test assumptions
- [x] Consider expanding existing coverage
- [ ] Decide about backporting: worthiness + risk(s)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI [tests]
