### PR TITLE
fix(view): implement partial lock cleanup in lockFile

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2171,27 +2171,62 @@ class View {
 	}
 
 	/**
-	 * Lock a path and all its parents up to the root of the view
+	 * Lock a path and its parent directories up to the view root.	
 	 *
-	 * @param string $path the path of the file to lock relative to the view
-	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
-	 * @param bool $lockMountPoint true to lock the mount point, false to lock the attached mount/storage
+	 * The target path is locked using `$lockMountPoint`; parent directories are
+	 * always locked on their attached storage. If acquiring a parent lock fails,
+	 * locks already acquired by this method are released on a best-effort basis
+	 * before the acquisition failure is rethrown.
 	 *
-	 * @return bool False if the path is excluded from locking, true otherwise
-	 * @throws LockedException
+	 * @param string $path Path relative to the view
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or
+	 *                  \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param bool $lockMountPoint Whether to lock the target mount point instead
+	 *                             of its attached mount/storage
+	 *
+	 * @return bool False if the target path is excluded from locking; true otherwise
+	 * @throws LockedException If locking the target path or a parent directory fails
 	 */
-	public function lockFile($path, $type, $lockMountPoint = false) {
+	public function lockFile(
+		string $path,
+		int $type,
+		bool $lockMountPoint = false
+	): bool {
 		$absolutePath = $this->getAbsolutePath($path);
 		$absolutePath = Filesystem::normalizePath($absolutePath);
 		if (!$this->shouldLockFile($absolutePath)) {
 			return false;
 		}
 
-		$this->lockPath($path, $type, $lockMountPoint);
+		/** @var array<array{string, int, bool}> $acquiredLocks */
+		$acquiredLocks = [];
+		try {
+			$this->lockPath($path, $type, $lockMountPoint);
+			$acquiredLocks[] = [$path, $type, $lockMountPoint];
 
-		$parents = $this->getParents($path);
-		foreach ($parents as $parent) {
-			$this->lockPath($parent, ILockingProvider::LOCK_SHARED);
+			$parents = $this->getParents($path);
+			foreach ($parents as $parent) {
+				$this->lockPath($parent, ILockingProvider::LOCK_SHARED);
+				$acquiredLocks[] = [$parent, ILockingProvider::LOCK_SHARED, false];
+			}
+		} catch (\Throwable $e) {
+			// Undo only locks which were acquired successfully. Reverse order mirrors
+			// stack-style acquisition and avoids retaining parent locks after failure.
+			foreach (array_reverse($acquiredLocks) as [$lockedPath, $lockedType, $lockedMountPoint]) {
+				try {
+					$this->unlockPath($lockedPath, $lockedType, $lockedMountPoint);
+				} catch (\Throwable $unlockException) {
+					// Do not replace the acquisition failure with a cleanup failure.
+					// The provider may still need its normal TTL/request cleanup as a fallback.
+					$this->logger->warning('Failed to release a partially acquired file lock', [
+						'app' => 'core',
+						'path' => $lockedPath,
+						'exception' => $unlockException,
+					]);
+				}
+			}
+
+			throw $e;
 		}
 
 		return true;

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2171,7 +2171,7 @@ class View {
 	}
 
 	/**
-	 * Lock a path and its parent directories up to the view root.	
+	 * Lock a path and its parent directories up to the view root.
 	 *
 	 * The target path is locked using `$lockMountPoint`; parent directories are
 	 * always locked on their attached storage. If acquiring a parent lock fails,
@@ -2190,7 +2190,7 @@ class View {
 	public function lockFile(
 		string $path,
 		int $type,
-		bool $lockMountPoint = false
+		bool $lockMountPoint = false,
 	): bool {
 		$absolutePath = $this->getAbsolutePath($path);
 		$absolutePath = Filesystem::normalizePath($absolutePath);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Make `View::lockFile()` roll back locks it has already acquired when acquiring a later parent lock fails.

Previously, `lockFile()` could leave the target path and earlier parent locks held after a later parent-lock acquisition failed. The method now tracks successful acquisitions and releases them in reverse order before rethrowing the original failure. Rollback is best-effort: cleanup failures are logged without masking the acquisition failure.

This complements the cache-refresh cleanup change (#62345) by ensuring `lockFile()` does not leave a partial lock set behind when acquisition itself fails.


## TODO

- [ ] Add test:  parent-lock acquisition failure releases the file and already-acquired parents
- [ ] Add test:  a rollback unlock failure does not replace the acquisition exception

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
