### PR TITLE
fix(SharingBackend): Call ISharePropertyTypeModifyValue::modifyValueOnSave when saving default value

### DIFF
--- a/apps/sharing/lib/SharingBackend.php
+++ b/apps/sharing/lib/SharingBackend.php
@@ -831,7 +831,7 @@ final readonly class SharingBackend implements ISharingBackend {
 						->values([
 							'share_id' => $qb->createNamedParameter($id),
 							'property_class' => $qb->createNamedParameter($propertyTypeClass),
-							'property_value' => $qb->createNamedParameter($value),
+							'property_value' => $qb->createNamedParameter($propertyType instanceof ISharePropertyTypeModifyValue ? $propertyType->modifyValueOnSave(null, $value) : $value),
 						])
 						->executeStatement();
 

--- a/lib/public/Sharing/Property/ISharePropertyType.php
+++ b/lib/public/Sharing/Property/ISharePropertyType.php
@@ -73,6 +73,8 @@ interface ISharePropertyType {
 	 *
 	 * A default value must be returned, if {@see self::isRequired()} returns true.
 	 *
+	 * If the class also implements {@see ISharePropertyTypeModifyValue}, {@see ISharePropertyTypeModifyValue::modifyValueOnSave()} will be called when the value is saved to the database, but the value will be returned to the user as-is.
+	 *
 	 * @since 35.0.0
 	 */
 	public function getDefaultValue(): ?string;

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -1370,9 +1370,63 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
 		$this->manager->addShareRecipient($accessContext, $id, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
-		$this->manager->getShare($accessContext, $id);
-		$this->manager->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'old-value'));
 
+		$this->dbConnection->commit();
+
+		$share = $this->getShare($accessContext, $id);
+		$this->assertEquals([
+			[
+				'class' => TestSharePropertyType1::class,
+				'display_name' => 'TestSharePropertyType1',
+				'hint' => 'hint TestSharePropertyType1',
+				'priority' => 1,
+				'advanced' => false,
+				'required' => false,
+				'value' => null,
+				'type' => 'enum',
+				'valid_values' => ['valid1'],
+			],
+			[
+				'class' => TestSharePropertyTypeModifyValue::class,
+				'display_name' => 'TestSharePropertyTypeModifyValue',
+				'hint' => 'hint TestSharePropertyTypeModifyValue',
+				'priority' => 1,
+				'advanced' => false,
+				'required' => false,
+				'value' => 'modify-on-save',
+				'type' => 'enum',
+				'valid_values' => ['old-value', 'modify-on-save-old-value', 'modify-on-save', 'modify-on-load'],
+			],
+		], $share['properties']);
+
+		$share = $this->getShare($accessContext, $id);
+		$this->assertEquals([
+			[
+				'class' => TestSharePropertyType1::class,
+				'display_name' => 'TestSharePropertyType1',
+				'hint' => 'hint TestSharePropertyType1',
+				'priority' => 1,
+				'advanced' => false,
+				'required' => false,
+				'value' => null,
+				'type' => 'enum',
+				'valid_values' => ['valid1'],
+			],
+			[
+				'class' => TestSharePropertyTypeModifyValue::class,
+				'display_name' => 'TestSharePropertyTypeModifyValue',
+				'hint' => 'hint TestSharePropertyTypeModifyValue',
+				'priority' => 1,
+				'advanced' => false,
+				'required' => false,
+				'value' => 'modified-on-save',
+				'type' => 'enum',
+				'valid_values' => ['old-value', 'modify-on-save-old-value', 'modify-on-save', 'modify-on-load'],
+			],
+		], $share['properties']);
+
+		$this->dbConnection->beginTransaction();
+		$this->manager->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'old-value'));
 		$this->dbConnection->commit();
 
 		$before = $this->manager->generateTimestamp();

--- a/tests/lib/Sharing/TestSharePropertyTypeModifyValue.php
+++ b/tests/lib/Sharing/TestSharePropertyTypeModifyValue.php
@@ -12,6 +12,12 @@ namespace Test\Sharing;
 use OCP\Sharing\Property\ISharePropertyTypeModifyValue;
 
 final class TestSharePropertyTypeModifyValue extends TestSharePropertyType1 implements ISharePropertyTypeModifyValue {
+
+	#[\Override]
+	public function getDefaultValue(): string {
+		return 'modify-on-save';
+	}
+
 	#[\Override]
 	public function modifyValueOnSave(?string $oldValue, ?string $newValue): ?string {
 		if ($newValue === 'modify-on-save') {


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/issues/51803

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
