### PR TITLE
feat(files_sharing): fetch remote avatars for external shares

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1310,6 +1310,7 @@ return array(
     'OC\\Avatar\\AvatarManager' => $baseDir . '/lib/private/Avatar/AvatarManager.php',
     'OC\\Avatar\\GuestAvatar' => $baseDir . '/lib/private/Avatar/GuestAvatar.php',
     'OC\\Avatar\\PlaceholderAvatar' => $baseDir . '/lib/private/Avatar/PlaceholderAvatar.php',
+    'OC\\Avatar\\RemoteAvatar' => $baseDir . '/lib/private/Avatar/RemoteAvatar.php',
     'OC\\Avatar\\UserAvatar' => $baseDir . '/lib/private/Avatar/UserAvatar.php',
     'OC\\BackgroundJob\\JobClassesRegistry' => $baseDir . '/lib/private/BackgroundJob/JobClassesRegistry.php',
     'OC\\BackgroundJob\\JobList' => $baseDir . '/lib/private/BackgroundJob/JobList.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1351,6 +1351,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Avatar\\AvatarManager' => __DIR__ . '/../../..' . '/lib/private/Avatar/AvatarManager.php',
         'OC\\Avatar\\GuestAvatar' => __DIR__ . '/../../..' . '/lib/private/Avatar/GuestAvatar.php',
         'OC\\Avatar\\PlaceholderAvatar' => __DIR__ . '/../../..' . '/lib/private/Avatar/PlaceholderAvatar.php',
+        'OC\\Avatar\\RemoteAvatar' => __DIR__ . '/../../..' . '/lib/private/Avatar/RemoteAvatar.php',
         'OC\\Avatar\\UserAvatar' => __DIR__ . '/../../..' . '/lib/private/Avatar/UserAvatar.php',
         'OC\\BackgroundJob\\JobClassesRegistry' => __DIR__ . '/../../..' . '/lib/private/BackgroundJob/JobClassesRegistry.php',
         'OC\\BackgroundJob\\JobList' => __DIR__ . '/../../..' . '/lib/private/BackgroundJob/JobList.php',

--- a/lib/private/Avatar/AvatarManager.php
+++ b/lib/private/Avatar/AvatarManager.php
@@ -13,6 +13,7 @@ use OC\KnownUser\KnownUserService;
 use OC\User\Manager;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\PropertyDoesNotExistException;
+use OCP\Federation\ICloudIdManager;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -38,6 +39,7 @@ class AvatarManager implements IAvatarManager {
 		private IConfig $config,
 		private IAccountManager $accountManager,
 		private KnownUserService $knownUserService,
+		private ICloudIdManager $cloudIdManager,
 	) {
 	}
 
@@ -53,6 +55,10 @@ class AvatarManager implements IAvatarManager {
 	 */
 	#[\Override]
 	public function getAvatar(string $userId): IAvatar {
+		if ($this->cloudIdManager->isValidCloudId($userId)) {
+			return $this->getRemoteAvatar($userId);
+		}
+
 		$user = $this->userManager->get($userId);
 		if ($user === null) {
 			throw new \Exception('user does not exist');
@@ -133,5 +139,21 @@ class AvatarManager implements IAvatarManager {
 	#[\Override]
 	public function getGuestAvatar(string $name): IAvatar {
 		return new GuestAvatar($name, $this->config, $this->logger);
+	}
+
+	/**
+	 * Returns a RemoteAvatar
+	 *
+	 * @param string $userId The \OCP\Federation\ICloudId of the remote account, e.g. account@example.com
+	 */
+	private function getRemoteAvatar(string $userId): IAvatar {
+		try {
+			$remoteAvatarFolder = $this->appData->getFolder('__remote');
+		} catch (NotFoundException $e) {
+			$remoteAvatarFolder = $this->appData->newFolder('__remote');
+		}
+
+		$folder = $remoteAvatarFolder->getOrCreateFolder($userId);
+		return new RemoteAvatar($folder, $userId, $this->config, $this->logger);
 	}
 }

--- a/lib/private/Avatar/RemoteAvatar.php
+++ b/lib/private/Avatar/RemoteAvatar.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OC\Avatar;
+
+use OCP\Federation\ICloudId;
+use OCP\Federation\ICloudIdManager;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use Psr\Log\LoggerInterface;
+
+class RemoteAvatar extends Avatar {
+	private const IMAGE_CACHE_AGE = 60 * 60 * 24; // One day
+
+	private ICloudId $cloudId;
+
+	public function __construct(
+		protected readonly ISimpleFolder $folder,
+		protected readonly string $userId,
+		protected IConfig $config,
+		protected LoggerInterface $logger,
+	) {
+		parent::__construct($config, $logger);
+
+		$cloudIdManager = \OCP\Server::get(ICloudIdManager::class);
+		$this->cloudId = $cloudIdManager->resolveCloudId($userId);
+	}
+
+	#[\Override]
+	public function exists(): bool {
+		return true;
+	}
+
+	#[\Override]
+	public function getDisplayName(): string {
+		return $this->cloudId->getDisplayId();
+	}
+
+	/**
+	 * Setting avatars isn't implemented for remote accounts
+	 */
+	#[\Override]
+	public function set($data): void {
+	}
+
+	/**
+	 * Removing avatars isn't implemented for remote accounts
+	 */
+	#[\Override]
+	public function remove(bool $silent = false): void {
+	}
+
+	#[\Override]
+	public function getFile(int $size, bool $darkTheme = false): ISimpleFile {
+		if ($size === -1) {
+			$filename = 'avatar' . ($darkTheme ? '-dark' : '');
+		} else {
+			$filename = 'avatar' . ($darkTheme ? '-dark' : '') . '.' . $size;
+		}
+
+		$avatar = null;
+		$files = $this->folder->getDirectoryListing();
+		foreach ($files as $file) {
+			if (pathinfo($file->getName(), PATHINFO_FILENAME) === $filename) {
+				$avatar = $file;
+				break;
+			}
+		}
+
+		if ($avatar !== null) {
+			// check if a remote avatar is at least a day old, in case a new avatar was uploaded
+			$isAvatarOld = (time() - $avatar->getMTime()) >= self::IMAGE_CACHE_AGE;
+			if (!$isAvatarOld) {
+				return $avatar;
+			}
+		}
+
+		$url = rtrim($this->cloudId->getRemote(), '/') . '/index.php/avatar/' . rawurlencode($this->cloudId->getUser()) . '/' . $size;
+		if ($darkTheme) {
+			$url .= '/dark';
+		}
+
+		$clientService = \OCP\Server::get(IClientService::class);
+		$client = $clientService->newClient();
+		$response = $client->get($url, [
+			'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false)
+		]);
+
+		$contentType = $response->getHeader('Content-Type');
+		if (str_starts_with($contentType, 'image/') === false) {
+			throw new \Exception('Unknown filetype');
+		}
+
+		$avatar = $response->getBody();
+		if ($avatar === null) {
+			throw new \Exception('Failed to fetch remote avatar');
+		}
+
+		if (is_resource($avatar)) {
+			$avatar = stream_get_contents($avatar);
+			if ($avatar === false) {
+				throw new \Exception('Failed to fetch remote avatar');
+			}
+		}
+
+		$ext = match ($contentType) {
+			'image/png' => 'png',
+			'image/jpg', 'image/jpeg' => 'jpg',
+			'image/gif' => 'gif',
+			'image/webp' => 'webp',
+			default => 'png',
+		};
+		return $this->folder->newFile($filename . '.' . $ext, $avatar);
+	}
+
+	/**
+	 * Handling user changes isn't implemented for remote accounts
+	 */
+	#[\Override]
+	public function userChanged(string $feature, $oldValue, $newValue): void {
+	}
+
+	#[\Override]
+	public function isCustomAvatar(): bool {
+		return true;
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -605,7 +605,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(LoggerInterface::class),
 				$c->get(IConfig::class),
 				$c->get(IAccountManager::class),
-				$c->get(KnownUserService::class)
+				$c->get(KnownUserService::class),
+				$c->get(ICloudIdManager::class)
 			);
 		});
 

--- a/tests/lib/Avatar/AvatarManagerTest.php
+++ b/tests/lib/Avatar/AvatarManagerTest.php
@@ -10,6 +10,7 @@ namespace Test\Avatar;
 
 use OC\Avatar\AvatarManager;
 use OC\Avatar\PlaceholderAvatar;
+use OC\Avatar\RemoteAvatar;
 use OC\Avatar\UserAvatar;
 use OC\KnownUser\KnownUserService;
 use OC\User\Manager;
@@ -17,6 +18,8 @@ use OC\User\User;
 use OCP\Accounts\IAccount;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
+use OCP\Federation\ICloudId;
+use OCP\Federation\ICloudIdManager;
 use OCP\Files\IAppData;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;
@@ -47,6 +50,7 @@ class AvatarManagerTest extends \Test\TestCase {
 	private $avatarManager;
 	/** @var KnownUserService | \PHPUnit\Framework\MockObject\MockObject */
 	private $knownUserService;
+	private ICloudIdManager&\PHPUnit\Framework\MockObject\MockObject $cloudIdManager;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -60,6 +64,7 @@ class AvatarManagerTest extends \Test\TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->accountManager = $this->createMock(IAccountManager::class);
 		$this->knownUserService = $this->createMock(KnownUserService::class);
+		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
 
 		$this->avatarManager = new AvatarManager(
 			$this->userSession,
@@ -69,21 +74,9 @@ class AvatarManagerTest extends \Test\TestCase {
 			$this->logger,
 			$this->config,
 			$this->accountManager,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->cloudIdManager
 		);
-	}
-
-	public function testGetAvatarInvalidUser(): void {
-		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('user does not exist');
-
-		$this->userManager
-			->expects($this->once())
-			->method('get')
-			->with('invalidUser')
-			->willReturn(null);
-
-		$this->avatarManager->getAvatar('invalidUser');
 	}
 
 	public function testGetAvatarForSelf(): void {
@@ -275,5 +268,68 @@ class AvatarManagerTest extends \Test\TestCase {
 			$expected = new UserAvatar($folder, $this->l10n, $user, $this->logger, $this->config);
 		}
 		$this->assertEquals($expected, $this->avatarManager->getAvatar('valid-user'));
+	}
+
+	public function testGetAvatarInvalidUser(): void {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('user does not exist');
+
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('invalidUser')
+			->willReturn(null);
+
+		$this->avatarManager->getAvatar('invalidUser');
+	}
+
+	public function testGetAvatarForRemoteUser(): void {
+		$cloudId = 'user@https://remote.example.com';
+
+		$this->userManager
+			->expects($this->never())
+			->method('get');
+
+		$resolvedCloudId = $this->createMock(ICloudId::class);
+		$resolvedCloudId->method('getUser')->willReturn('user');
+		$resolvedCloudId->method('getRemote')->willReturn('https://remote.example.com');
+		$resolvedCloudId->method('getDisplayId')->willReturn('user@remote.example.com');
+
+		$this->cloudIdManager->expects($this->once())
+			->method('isValidCloudId')
+			->with($cloudId)
+			->willReturn(true);
+		$this->cloudIdManager->method('resolveCloudId')
+			->with($cloudId)
+			->willReturn($resolvedCloudId);
+		$this->overwriteService(ICloudIdManager::class, $this->cloudIdManager);
+
+		$this->appData->expects($this->once())->method('getFolder');
+		$this->accountManager->expects($this->never())->method('getAccount');
+
+		$avatar = $this->avatarManager->getAvatar($cloudId);
+
+		$this->assertInstanceOf(RemoteAvatar::class, $avatar);
+		$this->assertTrue($avatar->exists());
+		$this->assertTrue($avatar->isCustomAvatar());
+		$this->assertSame('user@remote.example.com', $avatar->getDisplayName());
+	}
+
+	public function testGetAvatarThrowsForUnknownUserThatIsNotACloudId(): void {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('user does not exist');
+
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('invalidUser')
+			->willReturn(null);
+
+		$this->cloudIdManager->expects($this->once())
+			->method('isValidCloudId')
+			->with('invalidUser')
+			->willReturn(false);
+
+		$this->avatarManager->getAvatar('invalidUser');
 	}
 }

--- a/tests/lib/Avatar/RemoteAvatarTest.php
+++ b/tests/lib/Avatar/RemoteAvatarTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Test\Avatar;
+
+use OC\Avatar\RemoteAvatar;
+use OCP\Federation\ICloudId;
+use OCP\Federation\ICloudIdManager;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class RemoteAvatarTest extends TestCase {
+	private const CLOUD_ID = 'user@https://remote.example.com';
+
+	private ISimpleFolder&MockObject $folder;
+	private IConfig&MockObject $config;
+	private LoggerInterface&MockObject $logger;
+	private ICloudIdManager&MockObject $cloudIdManager;
+	private IClientService&MockObject $clientService;
+	private RemoteAvatar $avatar;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$cloudId = $this->createMock(ICloudId::class);
+		$cloudId->method('getUser')->willReturn('user');
+		$cloudId->method('getRemote')->willReturn('https://remote.example.com');
+		$cloudId->method('getDisplayId')->willReturn('user@remote.example.com');
+
+		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
+		$this->cloudIdManager->method('resolveCloudId')
+			->with(self::CLOUD_ID)
+			->willReturn($cloudId);
+		$this->overwriteService(ICloudIdManager::class, $this->cloudIdManager);
+
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->overwriteService(IClientService::class, $this->clientService);
+
+		$this->folder = $this->createMock(ISimpleFolder::class);
+		$this->avatar = new RemoteAvatar($this->folder, self::CLOUD_ID, $this->config, $this->logger);
+	}
+
+	/**
+	 * Stubs the client returned by IClientService::newClient() to respond to
+	 * a single GET request, optionally asserting the requested URL/options.
+	 *
+	 * @param string|resource|false $body
+	 */
+	private function mockRemoteClient(string $contentType, string $body, ?string $expectedUrl = null, ?array $expectedOptions = null): void {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getHeader')->with('Content-Type')->willReturn($contentType);
+		$response->method('getBody')->willReturn($body);
+
+		$client = $this->createMock(IClient::class);
+		$matcher = $client->expects($this->once())->method('get');
+		if ($expectedUrl !== null) {
+			$matcher->with($expectedUrl, $expectedOptions ?? $this->anything());
+		}
+		$matcher->willReturn($response);
+
+		$this->clientService->method('newClient')->willReturn($client);
+	}
+
+	public function testExists(): void {
+		$this->assertTrue($this->avatar->exists());
+	}
+
+	public function testGetDisplayName(): void {
+		$this->assertSame('user@remote.example.com', $this->avatar->getDisplayName());
+	}
+
+	public function testGetFileFetchesAvatarFromRemoteInstance(): void {
+		$this->config->method('getSystemValueBool')
+			->with('sharing.federation.allowSelfSignedCertificates', false)
+			->willReturn(false);
+
+		$fileContents = 'png-bytes';
+
+		$this->mockRemoteClient(
+			'image/png',
+			$fileContents,
+			'https://remote.example.com/index.php/avatar/user/64',
+			['verify' => true],
+		);
+
+		$expectedFile = $this->createMock(ISimpleFile::class);
+		$expectedFile->expects($this->once())->method('getContent')->willReturn($fileContents);
+
+		$this->folder->expects($this->once())->method('newFile')->willReturn($expectedFile);
+
+		$file = $this->avatar->getFile(64);
+		$this->assertInstanceOf(ISimpleFile::class, $file);
+		$this->assertSame($fileContents, $file->getContent());
+	}
+
+	public function testGetFileFetchesAvatarFromCache(): void {
+		$this->config->method('getSystemValueBool')
+			->with('sharing.federation.allowSelfSignedCertificates', false)
+			->willReturn(false);
+
+		$fileContents = 'png-bytes';
+
+		$expectedFile = $this->createMock(ISimpleFile::class);
+		$expectedFile->expects($this->once())->method('getContent')->willReturn($fileContents);
+		$expectedFile->expects($this->once())->method('getMTime')->willReturn(time() + (60 * 60 * 24));
+		$expectedFile->expects($this->once())->method('getName')->willReturn('avatar.64.png');
+		$this->folder->expects($this->once())->method('getDirectoryListing')->willReturn([$expectedFile]);
+
+		$this->clientService->expects($this->never())->method('newClient');
+
+		$file = $this->avatar->getFile(64);
+		$this->assertInstanceOf(ISimpleFile::class, $file);
+		$this->assertSame($fileContents, $file->getContent());
+	}
+
+	public function testGetFileThrowsOnUnexpectedContentType(): void {
+		$this->mockRemoteClient('text/html', '<html></html>');
+
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Unknown filetype');
+
+		$this->avatar->getFile(64);
+	}
+
+	public function testIsCustomAvatar(): void {
+		$this->assertTrue($this->avatar->isCustomAvatar());
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Currently, external shares always show a `GuestAvatar` in the files list. This adds functionality to fetch the remote sharer's avatar.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
