### PR TITLE
fix: embed Nextcloud logo directly into SMTP notifications

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -296,6 +296,16 @@ class ThemingDefaults extends \OC_Defaults {
 		return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => 'logo', 'useSvg' => $useSvg, 'v' => $cacheBusterCounter ]);
 	}
 
+	#[\Override]
+	public function getLogoImage(): ?array {
+		try {
+			$file = $this->imageManager->getImage('logo', false);
+			return ['content' => $file->getContent(), 'mimeType' => $file->getMimeType()];
+		} catch (\Exception $e) {
+			return parent::getLogoImage();
+		}
+	}
+
 	/**
 	 * Themed background image url
 	 *

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -34,6 +34,8 @@ class EMailTemplate implements IEMailTemplate {
 	protected bool $bodyListOpened = false;
 	/** indicated if the footer is added */
 	protected bool $footerAdded = false;
+	/** @var array<array{name: string, content: string, mimeType: string}> images to embed inline, referenced via cid: */
+	protected array $inlineImages = [];
 
 	protected string $head = <<<EOF
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -355,8 +357,25 @@ EOF;
 			$logoSizeDimensions = ' width="' . $this->logoWidth . '" height="' . $this->logoHeight . '"';
 		}
 
-		$logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false));
-		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getDefaultColorPrimary(), $logoUrl, $this->themingDefaults->getName(), $logoSizeDimensions]);
+		$logoImage = $this->themingDefaults->getLogoImage();
+		if ($logoImage !== null) {
+			// Embed the logo directly in the message instead of linking to it, so mail
+			// clients don't have to fetch it from the internet (some (e.g. gmail) block that).
+			$logoSrc = 'cid:logo';
+			$this->inlineImages[] = ['name' => 'logo'] + $logoImage;
+		} else {
+			$logoSrc = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false));
+		}
+		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getDefaultColorPrimary(), $logoSrc, $this->themingDefaults->getName(), $logoSizeDimensions]);
+	}
+
+	/**
+	 * Images that must be embedded inline in the message, referenced via `cid:<name>` in the HTML body
+	 *
+	 * @return array<array{name: string, content: string, mimeType: string}>
+	 */
+	public function getInlineImages(): array {
+		return $this->inlineImages;
 	}
 
 	/**

--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -292,6 +292,11 @@ class Message implements IMessage {
 		$this->setPlainBody($emailTemplate->renderText());
 		if (!$this->plainTextOnly) {
 			$this->setHtmlBody($emailTemplate->renderHtml());
+			if ($emailTemplate instanceof EMailTemplate) {
+				foreach ($emailTemplate->getInlineImages() as $image) {
+					$this->attachInline($image['content'], $image['name'], $image['mimeType']);
+				}
+			}
 		}
 		return $this;
 	}

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -321,6 +321,24 @@ class OC_Defaults {
 		return $logo . '?v=' . hash('sha1', implode('.', Util::getVersion()));
 	}
 
+	/**
+	 * Raw logo image data (raster, not SVG) for embedding directly into emails,
+	 * so mail clients don't have to fetch it from the internet.
+	 *
+	 * @return array{content: string, mimeType: string}|null null when unavailable
+	 */
+	public function getLogoImage(): ?array {
+		if ($this->themeExist('getLogoImage')) {
+			return $this->theme->getLogoImage();
+		}
+
+		$content = @file_get_contents(\OC::$SERVERROOT . '/core/img/logo/logo.png');
+		if ($content === false) {
+			return null;
+		}
+		return ['content' => $content, 'mimeType' => 'image/png'];
+	}
+
 	public function getTextColorPrimary() {
 		if ($this->themeExist('getTextColorPrimary')) {
 			return $this->theme->getTextColorPrimary();

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -174,6 +174,16 @@ class Defaults {
 	}
 
 	/**
+	 * Raw logo image data (raster) for embedding directly into emails
+	 *
+	 * @return array{content: string, mimeType: string}|null null when unavailable
+	 * @since 35.0.0
+	 */
+	public function getLogoImage(): ?array {
+		return $this->defaults->getLogoImage();
+	}
+
+	/**
 	 * Returns primary color
 	 * @return string
 	 * @since 12.0.0

--- a/tests/lib/Mail/EMailTemplateTest.php
+++ b/tests/lib/Mail/EMailTemplateTest.php
@@ -217,4 +217,20 @@ class EMailTemplateTest extends TestCase {
 		$expectedTXT = file_get_contents(\OC::$SERVERROOT . '/tests/data/emails/new-account-email-custom-text-alternative.txt');
 		$this->assertSame($expectedTXT, $this->emailTemplate->renderText());
 	}
+
+	public function testEMailTemplateEmbedsLogo(): void {
+		$this->defaults->method('getDefaultColorPrimary')->willReturn('#0082c9');
+		$this->defaults->method('getName')->willReturn('TestCloud');
+		$this->defaults->method('getLogoImage')
+			->willReturn(['content' => 'PNGDATA', 'mimeType' => 'image/png']);
+		$this->urlGenerator->expects($this->never())->method('getAbsoluteURL');
+
+		$this->emailTemplate->addHeader();
+
+		$this->assertStringContainsString('src="cid:logo"', $this->emailTemplate->renderHtml());
+		$this->assertSame(
+			[['name' => 'logo', 'content' => 'PNGDATA', 'mimeType' => 'image/png']],
+			$this->emailTemplate->getInlineImages()
+		);
+	}
 }


### PR DESCRIPTION
## Summary

This embeds the Nextcloud logo directly into the email (SMTP notification). Before the nextcloud logo would not show up when the instance is not public accessibly:
<img width="605" height="411" alt="image" src="https://github.com/user-attachments/assets/ee8b8098-ce28-4564-8dfc-aff6a54cc744" />

After:

<img width="650" height="287" alt="image" src="https://github.com/user-attachments/assets/248b05ca-d708-4308-89fe-e9c0e2a278a5" />
<img width="844" height="434" alt="image" src="https://github.com/user-attachments/assets/c9b09161-ce00-4178-9468-1599c97f06fa" />



Same as https://github.com/seerr-team/seerr/issues/3034 (see https://github.com/seerr-team/seerr/issues/3034#issuecomment-4458425409)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI