### PR TITLE
fix(PasswordSharePropertyType): Generate default password when passwords are required

### DIFF
--- a/core/Sharing/Property/PasswordSharePropertyType.php
+++ b/core/Sharing/Property/PasswordSharePropertyType.php
@@ -10,20 +10,29 @@ declare(strict_types=1);
 namespace OC\Core\Sharing\Property;
 
 use OC\Core\AppInfo\Application;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\L10N\IFactory;
+use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\IHasher;
+use OCP\Security\ISecureRandom;
+use OCP\Security\PasswordContext;
 use OCP\Share\IManager;
 use OCP\Sharing\Property\APasswordSharePropertyType;
 use OCP\Sharing\Property\ISharePropertyTypeFilter;
 use OCP\Sharing\Share;
 use OCP\Sharing\ShareAccessContext;
+use Random\Randomizer;
 
 final class PasswordSharePropertyType extends APasswordSharePropertyType implements ISharePropertyTypeFilter {
+
+	private readonly Randomizer $randomizer;
 
 	public function __construct(
 		private readonly IManager $legacyManager,
 		private readonly IHasher $hasher,
+		private readonly IEventDispatcher $eventDispatcher,
 	) {
+		$this->randomizer = new Randomizer();
 	}
 
 	#[\Override]
@@ -54,7 +63,13 @@ final class PasswordSharePropertyType extends APasswordSharePropertyType impleme
 
 	#[\Override]
 	public function getDefaultValue(): ?string {
-		return null;
+		if (!$this->isRequired()) {
+			return null;
+		}
+
+		$event = new GenerateSecurePasswordEvent(PasswordContext::SHARING);
+		$this->eventDispatcher->dispatchTyped($event);
+		return $event->getPassword() ?? $this->randomizer->getBytesFromString(ISecureRandom::CHAR_ALPHANUMERIC, 20);
 	}
 
 	#[\Override]

--- a/tests/Core/Sharing/Property/PasswordSharePropertyTypeTest.php
+++ b/tests/Core/Sharing/Property/PasswordSharePropertyTypeTest.php
@@ -9,9 +9,13 @@ declare(strict_types=1);
 
 namespace Tests\Core\Sharing\Property;
 
+use OC\Core\AppInfo\Application;
+use OC\Core\AppInfo\ConfigLexicon;
 use OC\Core\Sharing\Property\PasswordSharePropertyType;
+use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\L10N\IFactory;
 use OCP\Security\IHasher;
 use OCP\Server;
 use OCP\Sharing\Property\ShareProperty;
@@ -62,6 +66,23 @@ final class PasswordSharePropertyTypeTest extends TestCase {
 			$properties,
 			[],
 		);
+	}
+
+	public function testGetDefaultValue(): void {
+		$appConfig = Server::get(IAppConfig::class);
+		$appConfig->deleteKey(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_ENFORCED);
+
+		$this->assertNull($this->propertyType->getDefaultValue());
+
+		$appConfig->setValueBool(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_ENFORCED, true);
+
+		$value = $this->propertyType->getDefaultValue();
+		$this->assertNotNull($value);
+		/** @psalm-suppress RedundantCastGivenDocblockType psalm:strict and rector:strict fight over the cast -_- */
+		$this->assertGreaterThan(1, strlen((string)$value));
+		$this->assertTrue($this->propertyType->validateValue(Server::get(IFactory::class), $value));
+
+		$appConfig->deleteKey(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_ENFORCED);
 	}
 
 	public function testIsFiltered(): void {


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/issues/51803

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
