### PR TITLE
fix(NavigationManager): do not warn when an unknown entry is requested

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -312,7 +312,7 @@ class NavigationManager implements INavigationManager {
 	#[Override]
 	public function get(string $id): ?array {
 		$this->resolveAppNavigationEntries();
-		return $this->entries[$id];
+		return $this->entries[$id] ?? null;
 	}
 
 	#[Override]

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -171,6 +171,13 @@ class NavigationManagerTest extends TestCase {
 		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists after clear()');
 	}
 
+	public function testGetUnknownEntryReturnsNull(): void {
+		// Requesting an entry no app has registered must return null without
+		// emitting an "Undefined array key" warning, e.g. when an app without
+		// a navigation entry renders a public page
+		$this->assertNull($this->navigationManager->get('unknown'));
+	}
+
 	public function testAddArrayClearGetAll(): void {
 		$entry = [
 			'id' => 'entry id',


### PR DESCRIPTION
* Resolves: reported downstream in arnowelzel/drawio-nextcloud#35

## Summary

`NavigationManager::get()` is declared `?array` and all of its callers handle `null`: `TemplateLayout` even branches on `$currentAppData === null` for `RENDER_AS_PUBLIC`. The lookup itself does not guard against a missing key.

So every public page rendered by an app that registers **no** navigation entry (typical for files-integration apps) logs one PHP warning per anonymous page view:

```
Undefined array key "drawio" at /var/www/nextcloud/lib/private/NavigationManager.php#432
```

Reproduction on 33.0.6: share a file handled by such an app (e.g. drawio) as a public link, open the link in a private window. The page renders fine (the layout receives `null` and shows an empty app list), only the log noise is the problem.

A unit test locks the contract (`get('unknown')` returns `null`); before the fix it surfaces the `Undefined array key` warning.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version

## AI (if applicable)

- [x] The test of this PR was partly or fully generated using AI