### PR TITLE
Don't fill the pagination cache if there are no extra items

### DIFF
--- a/apps/dav/lib/Paginate/LimitedCopyIterator.php
+++ b/apps/dav/lib/Paginate/LimitedCopyIterator.php
@@ -20,6 +20,7 @@ namespace OCA\DAV\Paginate;
 class LimitedCopyIterator extends \AppendIterator {
 	private array $skipped = [];
 	private array $copy = [];
+	private readonly bool $hasOthers;
 
 	public function __construct(\Traversable $iterator, int $count, int $offset = 0) {
 		parent::__construct();
@@ -29,17 +30,17 @@ class LimitedCopyIterator extends \AppendIterator {
 		}
 		$iterator = new \NoRewindIterator($iterator);
 
-		$i = 0;
-		while ($iterator->valid() && ++$i <= $offset) {
-			$this->skipped[] = $iterator->current();
+		while ($iterator->valid() && count($this->skipped) < $offset) {
+			$this->skipped[$iterator->key()] = $iterator->current();
 			$iterator->next();
 		}
 
 		while ($iterator->valid() && count($this->copy) < $count) {
-			$this->copy[] = $iterator->current();
+			$this->copy[$iterator->key()] = $iterator->current();
 			$iterator->next();
 		}
 
+		$this->hasOthers = $iterator->valid() || count($this->skipped) > 0;
 		$this->append(new \ArrayIterator($this->skipped));
 		$this->append($this->getRequestedItems());
 		$this->append($iterator);
@@ -47,5 +48,12 @@ class LimitedCopyIterator extends \AppendIterator {
 
 	public function getRequestedItems(): \Iterator {
 		return new \ArrayIterator($this->copy);
+	}
+
+	/**
+	 * Are there any other items in the iterator aside from the requested ones
+	 */
+	public function hasOthers(): bool {
+		return $this->hasOthers;
 	}
 }

--- a/apps/dav/lib/Paginate/PaginatePlugin.php
+++ b/apps/dav/lib/Paginate/PaginatePlugin.php
@@ -59,17 +59,21 @@ class PaginatePlugin extends ServerPlugin {
 			$offset = (int)$request->getHeader(self::PAGINATE_OFFSET_HEADER);
 
 			$copyIterator = new LimitedCopyIterator($fileProperties, $pageSize, $offset);
-			// wrap the iterator with another that renders XML, this way we
-			// cache XML, but we keep the first $pageSize elements as objects
-			// to use for the response of the first page.
-			$rendererGenerator = $this->getXmlRendererGenerator($copyIterator);
-			['token' => $token, 'count' => $count] = $this->cache->store($url, $rendererGenerator);
+
+			if ($copyIterator->hasOthers()) {
+				// wrap the iterator with another that renders XML, this way we
+				// cache XML, but we keep the first $pageSize elements as objects
+				// to use for the response of the first page.
+				$rendererGenerator = $this->getXmlRendererGenerator($copyIterator);
+				['token' => $token, 'count' => $count] = $this->cache->store($url, $rendererGenerator);
+
+				$this->server->httpResponse->addHeader(self::PAGINATE_HEADER, 'true');
+				$this->server->httpResponse->addHeader(self::PAGINATE_TOKEN_HEADER, $token);
+				$this->server->httpResponse->addHeader(self::PAGINATE_TOTAL_HEADER, (string)$count);
+				$request->setHeader(self::PAGINATE_TOKEN_HEADER, $token);
+			}
 
 			$fileProperties = $copyIterator->getRequestedItems();
-			$this->server->httpResponse->addHeader(self::PAGINATE_HEADER, 'true');
-			$this->server->httpResponse->addHeader(self::PAGINATE_TOKEN_HEADER, $token);
-			$this->server->httpResponse->addHeader(self::PAGINATE_TOTAL_HEADER, (string)$count);
-			$request->setHeader(self::PAGINATE_TOKEN_HEADER, $token);
 		}
 	}
 

--- a/apps/dav/tests/unit/Paginate/LimitedCopyIteratorTest.php
+++ b/apps/dav/tests/unit/Paginate/LimitedCopyIteratorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\Paginate;
+
+use OCA\DAV\Paginate\LimitedCopyIterator;
+use Test\TestCase;
+
+class LimitedCopyIteratorTest extends TestCase {
+	public function testBasic() {
+		$data = [1, 2, 3, 4, 5, 6, 7];
+
+		$copy = new LimitedCopyIterator(new \ArrayIterator($data), 5, 0);
+		$this->assertEquals([1, 2, 3, 4, 5], iterator_to_array($copy->getRequestedItems()));
+		$this->assertTrue($copy->hasOthers());
+		$this->assertEquals($data, iterator_to_array($copy));
+
+		$copy = new LimitedCopyIterator(new \ArrayIterator($data), 15, 0);
+		$this->assertEquals([1, 2, 3, 4, 5, 6, 7], iterator_to_array($copy->getRequestedItems()));
+		$this->assertFalse($copy->hasOthers());
+		$this->assertEquals($data, iterator_to_array($copy));
+
+		$copy = new LimitedCopyIterator(new \ArrayIterator($data), 15, 1);
+		$this->assertEquals([1 => 2, 3, 4, 5, 6, 7], iterator_to_array($copy->getRequestedItems()));
+		$this->assertTrue($copy->hasOthers());
+		$this->assertEquals($data, iterator_to_array($copy));
+	}
+
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Only store paginated items and return pagination headers if the requested folder has more than 1 page worth of items.

This prevents needlessly caching items in redis

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
