### PR TITLE
fix(files_sharing): skip unresolvable share recipients

### DIFF
--- a/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
+++ b/apps/files_sharing/lib/Listener/SharesUpdatedListener.php
@@ -26,6 +26,7 @@ use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareMovedEvent;
 use OCP\Share\Events\ShareTransferredEvent;
 use OCP\Share\IManager;
+use OCP\User\Exceptions\UserNotFoundException;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 
@@ -135,7 +136,14 @@ class SharesUpdatedListener implements IEventListener {
 		$elapsed = $now - $this->firstRun;
 
 		if ($this->cutOffMarkTime === -1.0 || $elapsed < $this->cutOffMarkTime) {
-			$callback();
+			try {
+				$callback();
+			} catch (UserNotFoundException $e) {
+				// A share recipient may reference a user id that no backend can resolve anymore
+				// (e.g. with LazyUser::getUID()) - like remnant / incorrectly removed user.
+				// Skip this recipient instead of aborting the share operation.
+				$this->logger->debug('Skipping share mount update for unresolvable user ' . $user->getUID(), ['exception' => $e]);
+			}
 		} else {
 			$this->markUserForRefresh($user);
 		}

--- a/apps/files_sharing/tests/SharesUpdatedListenerTest.php
+++ b/apps/files_sharing/tests/SharesUpdatedListenerTest.php
@@ -19,6 +19,7 @@ use OCP\Share\Events\BeforeShareDeletedEvent;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use OCP\User\Exceptions\UserNotFoundException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Clock\ClockInterface;
@@ -114,6 +115,33 @@ class SharesUpdatedListenerTest extends \Test\TestCase {
 				$this->assertEquals($share, $eventShare);
 			});
 
+		$this->sharesUpdatedListener->handle($event);
+	}
+
+	public function testShareAddedSkipsUnresolvableUser(): void {
+		$share = $this->createMock(IShare::class);
+		$user1 = $this->createUser('user1', '');
+		$user2 = $this->createUser('user2', '');
+
+		$this->manager->method('getUsersForShare')
+			->willReturn([$user1, $user2]);
+
+		$event = new ShareCreatedEvent($share);
+
+		// user1 is an orphaned recipient that no backend can resolve
+		$this->shareRecipientUpdater
+			->expects($this->exactly(2))
+			->method('updateForAddedShare')
+			->willReturnCallback(function (IUser $user) use ($user1): void {
+				if ($user === $user1) {
+					throw new UserNotFoundException('Backends provided no user object');
+				}
+			});
+
+		// the failure is logged, not thrown
+		$this->logger->expects($this->once())->method('debug');
+
+		// must not throw: user2 is still processed
 		$this->sharesUpdatedListener->handle($event);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/spreed/issues/18415

## Summary

in `SharesUpdatedListener`, a share recipient may reference a user id that no backend can resolve anymore (e.g. with LazyUser::getUID()) - like remnant / incorrectly removed user. 

Example: Talk application supplies LazyUsers from oc_talk_attendees table, which can get desynced from the user backend (e.g. LDAP entries)

Skip this recipient instead of aborting the share operation resolve the issue. As listener is running as a post-effect, and share is already created (at least to the room -> to the group), it should be a safe reason to catch and skip?

To test:
1. Easiest path: create a rogue entry in oc_talk_attendees, with non-existing id, omit capability 'conversation-subfolders' to utilize legacy share mechanism (each file is separate share), share a file to the room => POST request should fail with 500
2. Complicated path: find a way for LDAP to clear mapping / execute similar flow to leave a rogur entry, then same as in opt.1


## TODO

- [ ] Sanity check
- [ ] Possible side-effects?
- [ ] For backports - should use `OC\User\NoUserException` ?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
