### PR TITLE
docs(lock): clarify ILockingProvider contract and lock behavior

### DIFF
--- a/lib/public/Lock/ILockingProvider.php
+++ b/lib/public/Lock/ILockingProvider.php
@@ -10,54 +10,98 @@ declare(strict_types=1);
 namespace OCP\Lock;
 
 /**
- * This interface allows locking and unlocking filesystem paths
+ * Contract for providers of shared and exclusive locks for server resources.
  *
- * This interface should be used directly and not implemented by an application.
- * The implementation is provided by the server.
+ * This low-level interface provides the short-lived locks used for concurrency
+ * control by Nextcloud storage implementations and, through them, by the Files
+ * Node and View APIs.
+ *
+ * While primarily used by storage implementations, this interface is generic
+ * and may also coordinate access to other server resources.
+ *
+ * This is an underlying primitive, not the high-level VFS API used for locking
+ * filesystem paths during normal Files Node or View operations.
+ *
+ * This interface is distinct from the OCP\Files\Lock APIs, which provide
+ * user, application, and collaborative-editor locks for files.
  *
  * @since 8.1.0
  */
 interface ILockingProvider {
 	/**
+	 * A shared lock. Multiple shared locks may coexist, but they prevent an
+	 * exclusive lock from being acquired.
+	 *
 	 * @since 8.1.0
 	 */
 	public const LOCK_SHARED = 1;
+
 	/**
+	 * An exclusive lock. It prevents shared and exclusive locks from being
+	 * acquired.
+	 *
 	 * @since 8.1.0
 	 */
 	public const LOCK_EXCLUSIVE = 2;
 
 	/**
-	 * @psalm-param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $type
+	 * Check whether a lock of the requested type exists for a resource.
+	 *
+	 * This does not determine whether acquiring the requested type would
+	 * succeed. For example, an existing shared lock prevents an exclusive
+	 * acquisition, while this method returns false for LOCK_EXCLUSIVE.
+	 *
+	 * @param string $path Identifier of the resource to check.
+	 * @param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $type Lock type to check.
+	 * @return bool True when a lock of the requested type exists.
 	 * @since 8.1.0
 	 */
 	public function isLocked(string $path, int $type): bool;
 
 	/**
-	 * @psalm-param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $type
-	 * @param ?string $readablePath A human-readable path to use in error messages, since 20.0.0
-	 * @throws LockedException
+	 * Acquire a shared or exclusive lock for a resource.
+	 *
+	 * A shared lock cannot be acquired while an exclusive lock exists. An
+	 * exclusive lock cannot be acquired while any lock exists.
+	 *
+	 * @param string $path Identifier of the resource to lock.
+	 * @param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $type Lock type to acquire.
+	 * @param ?string $readablePath Optional human-readable representation of
+	 *        `$path` to include in error messages.
+	 * @throws LockedException If the requested lock cannot be acquired.
 	 * @since 8.1.0
 	 */
 	public function acquireLock(string $path, int $type, ?string $readablePath = null): void;
 
 	/**
-	 * @psalm-param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $type
+	 * Release one acquisition of the requested lock type for a resource.
+	 *
+	 * Repeated shared-lock acquisitions must be released separately.
+	 *
+	 * @param string $path Identifier of the resource to unlock.
+	 * @param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $type Lock type to release.
 	 * @since 8.1.0
 	 */
 	public function releaseLock(string $path, int $type): void;
 
 	/**
-	 * Change the target type of an existing lock
+	 * Convert an existing lock to another type.
 	 *
-	 * @psalm-param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $targetType
-	 * @throws LockedException
+	 * Converting a shared lock to an exclusive lock succeeds only when the
+	 * shared lock is the only shared lock. An exclusive lock can be converted
+	 * to a shared lock.
+	 *
+	 * @param string $path Identifier of the resource whose lock to change.
+	 * @param self::LOCK_SHARED|self::LOCK_EXCLUSIVE $targetType Lock type to
+	 *        convert to.
+	 * @throws LockedException If the existing lock cannot be converted.
 	 * @since 8.1.0
 	 */
 	public function changeLock(string $path, int $targetType): void;
 
 	/**
-	 * Release all lock acquired by this instance
+	 * Release all locks acquired and tracked by this provider instance.
+	 *
 	 * @since 8.1.0
 	 */
 	public function releaseAll(): void;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Clarify the public `ILockingProvider` documentation to better describe its role in Nextcloud's locking architecture.

## Changes

- Clarify that the provider is a low-level primitive primarily used by storage implementations and indirectly by the Files Node and View APIs
- Document shared and exclusive lock behavior
- Distinguish it from the VFS-level Node/View locking APIs used during normal file operations
- Distinguish it from the `OCP\Files\Lock` APIs used for user, application, and collaborative-editor file locks (i.e. via the `files_app`)
- Document that it can also coordinate access to non-file server resources; for example, the `encryption` app uses it to prevent concurrent key-generation operations
- Add method-level descriptions, clean up docblock parameter typing, and improve existing wording

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
