### PR TITLE
fix(share): do not re-accept rejected shares

### DIFF
--- a/apps/files_sharing/lib/Migration/SetAcceptedStatus.php
+++ b/apps/files_sharing/lib/Migration/SetAcceptedStatus.php
@@ -48,7 +48,8 @@ class SetAcceptedStatus implements IRepairStep {
 		$query
 			->update('share')
 			->set('accepted', $query->createNamedParameter(IShare::STATUS_ACCEPTED))
-			->where($query->expr()->in('share_type', $query->createNamedParameter([IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_USERGROUP], IQueryBuilder::PARAM_INT_ARRAY)));
+			->where($query->expr()->in('share_type', $query->createNamedParameter([IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_USERGROUP], IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($query->expr()->neq('accepted', $query->createNamedParameter(IShare::STATUS_REJECTED, IQueryBuilder::PARAM_INT)));
 		$query->executeStatement();
 	}
 


### PR DESCRIPTION
It seems owncloud is using the 'accepted' field on share_type=(0, 1, 2) to delete shares - instead of deleting the entry from `oc_share` like we do. This way, even user-to-user direct share can be restored via the 'Deleted shares' panel in Files.

Now, during the migration from oc to nc, we flatten the value to 1 forcing previously deleted shares to come back to life.

This patch will flatten value to 1 only on non-rejected shares.

This patch should be backport to 31 as migration can be initiated to 31