### PR TITLE
refactor(lock): simplify acquired lock tracking

### DIFF
--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -16,70 +16,79 @@ use OCP\Lock\ILockingProvider;
  * to release any leftover locks at the end of the request
  */
 abstract class AbstractLockingProvider implements ILockingProvider {
+	/**
+	 * @var array{
+	 *     shared: array<string, int>,
+	 *     exclusive: array<string, true>,
+	 * }
+	 */
 	protected array $acquiredLocks = [
 		'shared' => [],
-		'exclusive' => []
+		'exclusive' => [],
 	];
 
 	/**
-	 *
-	 * @param int $ttl how long until we clear stray locks in seconds
+	 * @param int $ttl How long until stray locks are cleared, in seconds.
 	 */
 	public function __construct(
 		protected int $ttl,
 	) {
 	}
 
-	/** @inheritDoc */
 	protected function hasAcquiredLock(string $path, int $type): bool {
 		if ($type === self::LOCK_SHARED) {
-			return isset($this->acquiredLocks['shared'][$path]) && $this->acquiredLocks['shared'][$path] > 0;
-		} else {
-			return isset($this->acquiredLocks['exclusive'][$path]) && $this->acquiredLocks['exclusive'][$path] === true;
+			return isset($this->acquiredLocks['shared'][$path])
+				&& $this->acquiredLocks['shared'][$path] > 0;
 		}
+
+		return $type === self::LOCK_EXCLUSIVE
+			&& isset($this->acquiredLocks['exclusive'][$path]);
 	}
 
-	/** @inheritDoc */
 	protected function markAcquire(string $path, int $targetType): void {
-		if ($targetType === self::LOCK_SHARED) {
-			if (!isset($this->acquiredLocks['shared'][$path])) {
-				$this->acquiredLocks['shared'][$path] = 0;
-			}
-			$this->acquiredLocks['shared'][$path]++;
-		} else {
+		if ($targetType === self::LOCK_EXCLUSIVE) {
 			$this->acquiredLocks['exclusive'][$path] = true;
+			return;
+		}
+
+		if ($targetType === self::LOCK_SHARED) {
+			$this->acquiredLocks['shared'][$path] ??= 0;
+			$this->acquiredLocks['shared'][$path]++;
 		}
 	}
 
-	/** @inheritDoc */
 	protected function markRelease(string $path, int $type): void {
-		if ($type === self::LOCK_SHARED) {
-			if (isset($this->acquiredLocks['shared'][$path]) && $this->acquiredLocks['shared'][$path] > 0) {
-				$this->acquiredLocks['shared'][$path]--;
-				if ($this->acquiredLocks['shared'][$path] === 0) {
-					unset($this->acquiredLocks['shared'][$path]);
-				}
-			}
-		} elseif ($type === self::LOCK_EXCLUSIVE) {
+		if ($type === self::LOCK_EXCLUSIVE) {
 			unset($this->acquiredLocks['exclusive'][$path]);
+			return;
+		}
+
+		if ($type === self::LOCK_SHARED) {
+			if (!isset($this->acquiredLocks['shared'][$path])) {
+				return;
+			}
+
+			$this->acquiredLocks['shared'][$path]--;
+			if ($this->acquiredLocks['shared'][$path] === 0) {
+				unset($this->acquiredLocks['shared'][$path]);
+			}
 		}
 	}
 
-	/** @inheritDoc */
 	protected function markChange(string $path, int $targetType): void {
+		if ($targetType === self::LOCK_EXCLUSIVE) {
+			$this->acquiredLocks['exclusive'][$path] = true;
+			unset($this->acquiredLocks['shared'][$path]);
+			return;
+		}
+
 		if ($targetType === self::LOCK_SHARED) {
 			unset($this->acquiredLocks['exclusive'][$path]);
-			if (!isset($this->acquiredLocks['shared'][$path])) {
-				$this->acquiredLocks['shared'][$path] = 0;
-			}
+			$this->acquiredLocks['shared'][$path] ??= 0;
 			$this->acquiredLocks['shared'][$path]++;
-		} elseif ($targetType === self::LOCK_EXCLUSIVE) {
-			$this->acquiredLocks['exclusive'][$path] = true;
-			$this->acquiredLocks['shared'][$path]--;
 		}
 	}
 
-	/** @inheritDoc */
 	#[\Override]
 	public function releaseAll(): void {
 		foreach ($this->acquiredLocks['shared'] as $path => $count) {
@@ -88,7 +97,7 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 			}
 		}
 
-		foreach ($this->acquiredLocks['exclusive'] as $path => $hasLock) {
+		foreach ($this->acquiredLocks['exclusive'] as $path => $_) {
 			$this->releaseLock($path, self::LOCK_EXCLUSIVE);
 		}
 	}

--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -35,6 +35,12 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 	) {
 	}
 
+	protected function assertValidLockType(int $type): void {
+		if ($type !== self::LOCK_SHARED && $type !== self::LOCK_EXCLUSIVE) {
+			throw new \InvalidArgumentException('Invalid lock type: ' . $type);
+		}
+	}
+
 	protected function hasAcquiredLock(string $path, int $type): bool {
 		if ($type === self::LOCK_SHARED) {
 			return isset($this->acquiredLocks['shared'][$path])


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Remove redundant inherited documentation
- Simplify acquired-lock bookkeeping
- Make the abstract tracking helpers consistently handle only shared and exclusive lock constants
- A a lock type validator to the abstract class for use in follow-on PR (see *Follow-up*)

The existing provider tests provide reasonable indirect coverage of this bookkeeping.

### Follow-up

This does not validate lock types at the provider boundaries. `DBLockingProvider::acquireLock()` and `MemcacheLockingProvider::acquireLock()` still treat any non-shared value as exclusive and an invalid value
can still flow through (though it will no longer be treated one way in `markChange()` and another by `markAcquire()`). This is already invalid per the contract, and can be addressed separately in the two provider implementations.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
