### PR TITLE
[stable30] chore: adjust for old PHP

### DIFF
--- a/tests/lib/Preview/Provider.php
+++ b/tests/lib/Preview/Provider.php
@@ -9,7 +9,9 @@
 namespace Test\Preview;
 
 use OC\Files\Node\File;
+use OC\Preview\Provider as PreviewProvider;
 use OCP\Files\IRootFolder;
+use OCP\Preview\IProviderV2;
 
 abstract class Provider extends \Test\TestCase {
 	/** @var string */
@@ -18,7 +20,7 @@ abstract class Provider extends \Test\TestCase {
 	protected $width;
 	/** @var int */
 	protected $height;
-	/** @var \OC\Preview\Provider */
+	/** @var IProviderV2|PreviewProvider */
 	protected $provider;
 	/** @var int */
 	protected $maxWidth = 1024;
@@ -126,7 +128,9 @@ abstract class Provider extends \Test\TestCase {
 	 */
 	private function getPreview($provider) {
 		$file = new File(\OC::$server->get(IRootFolder::class), $this->rootView, $this->imgPath);
-		$preview = $provider->getThumbnail($file, $this->maxWidth, $this->maxHeight, $this->scalingUp);
+		$preview = ($provider instanceof PreviewProvider)
+			? $provider->getThumbnail($file, $this->maxWidth, $this->maxHeight, $this->scalingUp, $this->rootView)
+			: $provider->getThumbnail($file, $this->maxWidth, $this->maxHeight, $this->scalingUp);
 
 		if (get_class($this) === BitmapTest::class && $preview === null) {
 			$this->markTestSkipped('An error occured while operating with Imagick.');

--- a/tests/lib/Preview/SVGTest.php
+++ b/tests/lib/Preview/SVGTest.php
@@ -8,6 +8,8 @@
 
 namespace Test\Preview;
 
+use OCP\Files\File;
+
 /**
  * Class SVGTest
  *
@@ -53,15 +55,17 @@ class SVGTest extends Provider {
 </svg>');
 		rewind($handle);
 
-		$file = $this->createMock(\OCP\Files\File::class);
+		$file = $this->createMock(File::class);
 		$file->method('fopen')
 			->willReturn($handle);
 
 		self::assertNull($this->provider->getThumbnail($file, 512, 512));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetThumbnailSVGHrefNamespace')]
-	#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('imagick')]
+	/**
+	 * @dataProvider dataGetThumbnailSVGHrefNamespace
+	 * @requires extension imagick
+	 */
 	public function testGetThumbnailSvgHrefNamespace(string $namespace): void {
 		$handle = fopen('php://temp', 'w+');
 		fwrite($handle, '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:' . $namespace . '="http://www.w3.org/1999/xlink">
@@ -87,8 +91,10 @@ class SVGTest extends Provider {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetThumbnailSvgEncoded')]
-	#[\PHPUnit\Framework\Attributes\RequiresPhpExtension('imagick')]
+	/**
+	 * @dataProvider dataGetThumbnailSvgEncoded
+	 * @requires extension imagick
+	 */
 	public function testGetThumbnailSvgEncoded(string $content): void {
 		$handle = fopen('php://temp', 'w+');
 		fwrite($handle, $content);


### PR DESCRIPTION
Fix failing tests from https://github.com/nextcloud/server/actions/runs/29891791018/job/88833549981?pr=62383

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
