### PR TITLE
feat(Sharing): Fallback to guest avatar if recipient provides no icon

### DIFF
--- a/lib/public/Sharing/Recipient/ShareRecipient.php
+++ b/lib/public/Sharing/Recipient/ShareRecipient.php
@@ -13,6 +13,7 @@ use OCP\AppFramework\Attribute\Consumable;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use OCP\Sharing\Icon\ShareIconURL;
 use OCP\Sharing\ISharingRegistry;
 use OCP\Sharing\Share;
 use OCP\Sharing\ShareUser;
@@ -77,12 +78,20 @@ final readonly class ShareRecipient {
 			);
 		}
 
+		$icon = $recipientType->getRecipientIcon($this->value);
+		if ($icon === null) {
+			$icon = new ShareIconURL(
+				$urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => $displayName, 'size' => 64]),
+				$urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => $displayName, 'size' => 64, 'darkTheme' => true]),
+			);
+		}
+
 		return [
 			'class' => $this->class,
 			'value' => $this->value,
 			'instance' => $this->instance,
 			'display_name' => $displayName,
-			'icon' => $recipientType->getRecipientIcon($this->value)?->format(),
+			'icon' => $icon->format(),
 			'secret' => $secret,
 			'initiator' => $this->initiator?->format($userManager),
 		];

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -2263,7 +2263,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 					'value' => 'secret',
 					'instance' => null,
 					'display_name' => 'secret',
-					'icon' => null,
+					'icon' => [
+						'light' => 'http://localhost/index.php/avatar/guest/secret/64',
+						'dark' => 'http://localhost/index.php/avatar/guest/secret/64?darkTheme=1',
+					],
 					'secret' => [
 						'updatable' => false,
 					],
@@ -2388,7 +2391,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 					'value' => 'secret',
 					'instance' => null,
 					'display_name' => 'secret',
-					'icon' => null,
+					'icon' => [
+						'light' => 'http://localhost/index.php/avatar/guest/secret/64',
+						'dark' => 'http://localhost/index.php/avatar/guest/secret/64?darkTheme=1',
+					],
 					'secret' => [
 						'updatable' => false,
 					],


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/issues/51803

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
