### PR TITLE
[stable29] chore: Fix psalm CI on stable29

### DIFF
--- a/lib/public/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/public/Collaboration/Reference/LinkReferenceProvider.php
@@ -240,6 +240,8 @@ class LinkReferenceProvider implements IReferenceProvider {
 	 *
 	 * XSLT transformations in SVG files can cause memory exhaustion
 	 * in Chromium based browsers when rendered.
+	 *
+	 * @since 29.0.16.16
 	 */
 	private function containsXslt(string $xmlContent): bool {
 		set_error_handler(function (int $code, string $message): bool {


### PR DESCRIPTION
* Related to: https://github.com/nextcloud/server/pull/59840
* Related to: https://github.com/nextcloud/server/pull/61321

## Summary

Since #59840, the static code analysis from psalm is broken in our CI. To make the CI pipeline green again, I've added the correct `@since` attribute to the function.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
