### PR TITLE
fix: Don't add empty and broken ExternalShareScanJob on upgrade

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -35,7 +35,6 @@ Turning the feature off removes shared files and folders on the server for all s
 		<job>OCA\Files_Sharing\ExpireSharesJob</job>
 		<job>OCA\Files_Sharing\SharesReminderJob</job>
 		<job>OCA\Files_Sharing\BackgroundJob\FederatedSharesDiscoverJob</job>
-		<job>OCA\Files_Sharing\BackgroundJob\ExternalShareScanJob</job>
 	</background-jobs>
 
 	<repair-steps>

--- a/apps/files_sharing/lib/BackgroundJob/ExternalShareScanJob.php
+++ b/apps/files_sharing/lib/BackgroundJob/ExternalShareScanJob.php
@@ -35,6 +35,10 @@ class ExternalShareScanJob extends QueuedJob {
 		}
 
 		[$userId, $path] = $argument;
+		if ($userId === null || $userId === '') {
+			return;
+		}
+
 		try {
 			$this->rootFolder
 				->getUserFolder($userId)


### PR DESCRIPTION
This is added manually in
apps/files_sharing/lib/Controller/ExternalSharesController.php when needed and with arguments.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
