### PR TITLE
fix(navigation): Missing logout entry

### DIFF
--- a/core/AppInfo/Application.php
+++ b/core/AppInfo/Application.php
@@ -170,21 +170,23 @@ class Application extends App implements IBootstrap {
 		IURLGenerator $urlGenerator,
 		IFactory $factory,
 	): void {
-		if (!$userSession->isLoggedIn()) {
-			return;
-		}
+		$navigationManager->add(function () use ($userSession, $factory, $urlGenerator): ?array {
+			if (!$userSession->isLoggedIn()) {
+				return null;
+			}
 
-		$l = $factory->get('core');
+			$l = $factory->get('core');
 
-		// Register the logout button in the user settings
-		$logoutUrl = $urlGenerator->getLogoutUrl();
-		$navigationManager->add([
-			'type' => 'settings',
-			'id' => 'logout',
-			'order' => 99999,
-			'href' => $logoutUrl,
-			'name' => $l->t('Log out'),
-			'icon' => $urlGenerator->imagePath('core', 'actions/logout.svg'),
-		]);
+			// Register the logout button in the user settings
+			$logoutUrl = $urlGenerator->getLogoutUrl();
+			return [
+				'type' => 'settings',
+				'id' => 'logout',
+				'order' => 99999,
+				'href' => $logoutUrl,
+				'name' => $l->t('Log out'),
+				'icon' => $urlGenerator->imagePath('core', 'actions/logout.svg'),
+			];
+		});
 	}
 }

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -30,7 +30,7 @@ use Psr\Log\LoggerInterface;
 class NavigationManager implements INavigationManager {
 	/** @var array<string, NavigationEntryOutput> */
 	protected array $entries = [];
-	/** @var list<callable(): NavigationEntry> */
+	/** @var list<callable(): ?NavigationEntry> */
 	protected array $closureEntries = [];
 	protected ?string $activeEntry = null;
 	protected array $unreadCounters = [];
@@ -208,7 +208,10 @@ class NavigationManager implements INavigationManager {
 	private function resolveAppNavigationEntries(): void {
 		// Resolve app navigation closures
 		while ($c = array_pop($this->closureEntries)) {
-			$this->add($c());
+			$entry = $c();
+			if ($entry !== null) {
+				$this->add($entry);
+			}
 		}
 
 		// Resolve dynamically added navigation entries via event listeners

--- a/lib/public/INavigationManager.php
+++ b/lib/public/INavigationManager.php
@@ -63,9 +63,9 @@ interface INavigationManager {
 	/**
 	 * Creates a new navigation entry
 	 *
-	 * @param NavigationEntry|callable():NavigationEntry $entry If a menu entry (type = 'link') is added, you shall also set app to the app that
-	 *                                                          added the entry. The use of a closure is preferred, because it will avoid loading
-	 *                                                          the routing of your app, unless required.
+	 * @param NavigationEntry|callable():?NavigationEntry $entry If a menu entry (type = 'link') is added, you shall also set app to the app that
+	 *                                                           added the entry. The use of a closure is preferred, because it will avoid loading
+	 *                                                           the routing of your app, unless required.
 	 * @return void
 	 * @since 6.0.0
 	 */


### PR DESCRIPTION
When using some other user backends like the one from global scale, the user session is not yet available in the boot process which makes IUserSession::isLoggedIn fail.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
