### PR TITLE
fix(lock): valid lock types and modernize locking providers

### DIFF
--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -12,13 +13,13 @@ use OC\DB\QueryBuilder\Literal;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
-use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 
 /**
- * Locking provider that stores the locks in the database
+ * Locking provider that stores locks in the database.
  */
 class DBLockingProvider extends AbstractLockingProvider {
+	/** @var array<string, bool> */
 	private array $sharedLocks = [];
 
 	public function __construct(
@@ -31,47 +32,49 @@ class DBLockingProvider extends AbstractLockingProvider {
 	}
 
 	/**
-	 * Check if we have an open shared lock for a path
+	 * Whether this request tracks a shared lock retained in the database.
 	 */
 	protected function isLocallyLocked(string $path): bool {
-		return isset($this->sharedLocks[$path]) && $this->sharedLocks[$path];
+		return $this->sharedLocks[$path] ?? false;
 	}
 
-	/** @inheritDoc */
 	#[\Override]
 	protected function markAcquire(string $path, int $targetType): void {
 		parent::markAcquire($path, $targetType);
-		if ($this->cacheSharedLocks) {
-			if ($targetType === self::LOCK_SHARED) {
-				$this->sharedLocks[$path] = true;
-			}
+
+		if (!$this->cacheSharedLocks) {
+			return;
+		}
+
+		if ($targetType === self::LOCK_SHARED) {
+			$this->sharedLocks[$path] = true;
 		}
 	}
 
-	/**
-	 * Change the type of an existing tracked lock
-	 */
 	#[\Override]
 	protected function markChange(string $path, int $targetType): void {
 		parent::markChange($path, $targetType);
-		if ($this->cacheSharedLocks) {
-			if ($targetType === self::LOCK_SHARED) {
-				$this->sharedLocks[$path] = true;
-			} elseif ($targetType === self::LOCK_EXCLUSIVE) {
-				$this->sharedLocks[$path] = false;
-			}
+
+		if (!$this->cacheSharedLocks) {
+			return;
+		}
+
+		if ($targetType === self::LOCK_SHARED) {
+			$this->sharedLocks[$path] = true;
+		} elseif ($targetType === self::LOCK_EXCLUSIVE) {
+			$this->sharedLocks[$path] = false;
 		}
 	}
 
 	/**
-	 * Insert a file locking row if it does not exists.
+	 * Insert a file-lock row if it does not already exist.
 	 */
 	protected function initLockField(string $path, int $lock = 0): int {
 		$expire = $this->getExpireTime();
 		return $this->connection->insertIgnoreConflict('file_locks', [
 			'key' => $path,
 			'lock' => $lock,
-			'ttl' => $expire
+			'ttl' => $expire,
 		]);
 	}
 
@@ -79,39 +82,43 @@ class DBLockingProvider extends AbstractLockingProvider {
 		return $this->timeFactory->getTime() + $this->ttl;
 	}
 
-	/** @inheritDoc */
 	#[\Override]
 	public function isLocked(string $path, int $type): bool {
+		$this->assertValidLockType($type);
+
 		if ($this->hasAcquiredLock($path, $type)) {
 			return true;
 		}
+
 		$query = $this->connection->getQueryBuilder();
 		$query->select('lock')
 			->from('file_locks')
 			->where($query->expr()->eq('key', $query->createNamedParameter($path)));
+
 		$result = $query->executeQuery();
 		$lockValue = (int)$result->fetchOne();
+
 		if ($type === self::LOCK_SHARED) {
-			if ($this->isLocallyLocked($path)) {
-				// if we have a shared lock we kept open locally but it's released we always have at least 1 shared lock in the db
-				return $lockValue > 1;
-			} else {
-				return $lockValue > 0;
-			}
-		} elseif ($type === self::LOCK_EXCLUSIVE) {
-			return $lockValue === -1;
-		} else {
-			return false;
+			// A shared lock retained for this request remains in the database after it is
+			// released from active bookkeeping.
+			return $this->isLocallyLocked($path)
+				? $lockValue > 1
+				: $lockValue > 0;
 		}
+
+		return $lockValue === -1;
 	}
 
-	/** @inheritDoc */
 	#[\Override]
 	public function acquireLock(string $path, int $type, ?string $readablePath = null): void {
+		$this->assertValidLockType($type);
+
 		$expire = $this->getExpireTime();
+
 		if ($type === self::LOCK_SHARED) {
 			if (!$this->isLocallyLocked($path)) {
 				$result = $this->initLockField($path, 1);
+
 				if ($result <= 0) {
 					$query = $this->connection->getQueryBuilder();
 					$query->update('file_locks')
@@ -124,12 +131,20 @@ class DBLockingProvider extends AbstractLockingProvider {
 			} else {
 				$result = 1;
 			}
-		} else {
+		} elseif ($type === self::LOCK_EXCLUSIVE) {
 			$existing = 0;
-			if ($this->hasAcquiredLock($path, ILockingProvider::LOCK_SHARED) === false && $this->isLocallyLocked($path)) {
+
+			// A shared lock retained for this request may remain in the database after it
+			// has been released from active bookkeeping.
+			if (
+				$this->hasAcquiredLock($path, self::LOCK_SHARED) === false
+				&& $this->isLocallyLocked($path)
+			) {
 				$existing = 1;
 			}
+
 			$result = $this->initLockField($path, -1);
+
 			if ($result <= 0) {
 				$query = $this->connection->getQueryBuilder();
 				$query->update('file_locks')
@@ -140,85 +155,94 @@ class DBLockingProvider extends AbstractLockingProvider {
 				$result = $query->executeStatement();
 			}
 		}
+
 		if ($result !== 1) {
 			throw new LockedException($path, null, null, $readablePath);
 		}
+
 		$this->markAcquire($path, $type);
 	}
 
-	/** @inheritDoc */
 	#[\Override]
 	public function releaseLock(string $path, int $type): void {
+		$this->assertValidLockType($type);
+
 		$this->markRelease($path, $type);
 
-		// we keep shared locks till the end of the request so we can re-use them
+		// Shared locks remain in the database until the end of the request so they
+		// can be reused.
 		if ($type === self::LOCK_EXCLUSIVE) {
-			$qb = $this->connection->getQueryBuilder();
-			$qb->update('file_locks')
-				->set('lock', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT))
-				->where($qb->expr()->eq('key', $qb->createNamedParameter($path)))
-				->andWhere($qb->expr()->eq('lock', $qb->createNamedParameter(-1, IQueryBuilder::PARAM_INT)));
-			$qb->executeStatement();
+			$query = $this->connection->getQueryBuilder();
+			$query->update('file_locks')
+				->set('lock', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+				->where($query->expr()->eq('key', $query->createNamedParameter($path)))
+				->andWhere($query->expr()->eq('lock', $query->createNamedParameter(-1, IQueryBuilder::PARAM_INT)));
+			$query->executeStatement();
 		} elseif (!$this->cacheSharedLocks) {
-			$qb = $this->connection->getQueryBuilder();
-			$qb->update('file_locks')
-				->set('lock', $qb->func()->subtract('lock', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
-				->where($qb->expr()->eq('key', $qb->createNamedParameter($path)))
-				->andWhere($qb->expr()->gt('lock', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
-			$qb->executeStatement();
+			$query = $this->connection->getQueryBuilder();
+			$query->update('file_locks')
+				->set('lock', $query->func()->subtract('lock', $query->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
+				->where($query->expr()->eq('key', $query->createNamedParameter($path)))
+				->andWhere($query->expr()->gt('lock', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+			$query->executeStatement();
 		}
 	}
 
-	/** @inheritDoc */
 	#[\Override]
 	public function changeLock(string $path, int $targetType): void {
+		$this->assertValidLockType($targetType);
+
 		$expire = $this->getExpireTime();
+
 		if ($targetType === self::LOCK_SHARED) {
-			$qb = $this->connection->getQueryBuilder();
-			$result = $qb->update('file_locks')
-				->set('lock', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT))
-				->set('ttl', $qb->createNamedParameter($expire, IQueryBuilder::PARAM_INT))
-				->where($qb->expr()->andX(
-					$qb->expr()->eq('key', $qb->createNamedParameter($path)),
-					$qb->expr()->eq('lock', $qb->createNamedParameter(-1, IQueryBuilder::PARAM_INT))
-				))->executeStatement();
-		} else {
-			// since we only keep one shared lock in the db we need to check if we have more than one shared lock locally manually
-			if (isset($this->acquiredLocks['shared'][$path]) && $this->acquiredLocks['shared'][$path] > 1) {
+			$query = $this->connection->getQueryBuilder();
+			$query->update('file_locks')
+				->set('lock', $query->createNamedParameter(1, IQueryBuilder::PARAM_INT))
+				->set('ttl', $query->createNamedParameter($expire, IQueryBuilder::PARAM_INT))
+				->where($query->expr()->andX(
+					$query->expr()->eq('key', $query->createNamedParameter($path)),
+					$query->expr()->eq('lock', $query->createNamedParameter(-1, IQueryBuilder::PARAM_INT))));
+			$result = $query->executeStatement();
+		} elseif ($targetType === self::LOCK_EXCLUSIVE) {
+			// The database retains one shared lock per request, so an upgrade is only
+			// possible when this request holds exactly one shared lock.
+			if ($this->getOwnSharedLockCount($path) > 1) {
 				throw new LockedException($path);
 			}
-			$qb = $this->connection->getQueryBuilder();
-			$result = $qb->update('file_locks')
-				->set('lock', $qb->createNamedParameter(-1, IQueryBuilder::PARAM_INT))
-				->set('ttl', $qb->createNamedParameter($expire, IQueryBuilder::PARAM_INT))
-				->where($qb->expr()->andX(
-					$qb->expr()->eq('key', $qb->createNamedParameter($path)),
-					$qb->expr()->eq('lock', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT))
-				))->executeStatement();
+
+			$query = $this->connection->getQueryBuilder();
+			$query->update('file_locks')
+				->set('lock', $query->createNamedParameter(-1, IQueryBuilder::PARAM_INT))
+				->set('ttl', $query->createNamedParameter($expire, IQueryBuilder::PARAM_INT))
+				->where($query->expr()->andX(
+					$query->expr()->eq('key', $query->createNamedParameter($path)),
+					$query->expr()->eq('lock', $query->createNamedParameter(1, IQueryBuilder::PARAM_INT))));
+			$result = $query->executeStatement();
 		}
+
 		if ($result !== 1) {
 			throw new LockedException($path);
 		}
+
 		$this->markChange($path, $targetType);
 	}
 
-	/** @inheritDoc */
 	public function cleanExpiredLocks(): void {
 		$expire = $this->timeFactory->getTime();
+
 		try {
-			$qb = $this->connection->getQueryBuilder();
-			$qb->delete('file_locks')
-				->where($qb->expr()->lt('ttl', $qb->createNamedParameter($expire, IQueryBuilder::PARAM_INT)))
-				->executeStatement();
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('file_locks')
+				->where($query->expr()->lt('ttl', $query->createNamedParameter($expire, IQueryBuilder::PARAM_INT)));
+			$query->executeStatement();
 		} catch (\Exception $e) {
-			// If the table is missing, the clean up was successful
+			// If the table is missing, cleanup was successful.
 			if ($this->connection->tableExists('file_locks')) {
 				throw $e;
 			}
 		}
 	}
 
-	/** @inheritDoc */
 	#[\Override]
 	public function releaseAll(): void {
 		parent::releaseAll();
@@ -226,23 +250,20 @@ class DBLockingProvider extends AbstractLockingProvider {
 		if (!$this->cacheSharedLocks) {
 			return;
 		}
-		// since we keep shared locks we need to manually clean those
-		$lockedPaths = array_keys($this->sharedLocks);
-		$lockedPaths = array_filter($lockedPaths, function ($path) {
-			return $this->sharedLocks[$path];
-		});
 
+		// Shared locks remain in the database until the end of the request.
+		$lockedPaths = array_keys(array_filter($this->sharedLocks));
 		$chunkedPaths = array_chunk($lockedPaths, 100);
 
-		$qb = $this->connection->getQueryBuilder();
-		$qb->update('file_locks')
-			->set('lock', $qb->func()->subtract('lock', $qb->expr()->literal(1)))
-			->where($qb->expr()->in('key', $qb->createParameter('chunk')))
-			->andWhere($qb->expr()->gt('lock', new Literal(0)));
+		$query = $this->connection->getQueryBuilder();
+		$query->update('file_locks')
+			->set('lock', $query->func()->subtract('lock', $query->expr()->literal(1)))
+			->where($query->expr()->in('key', $query->createParameter('chunk')))
+			->andWhere($query->expr()->gt('lock', new Literal(0)));
 
 		foreach ($chunkedPaths as $chunk) {
-			$qb->setParameter('chunk', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
-			$qb->executeStatement();
+			$query->setParameter('chunk', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
+			$query->executeStatement();
 		}
 	}
 }

--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -14,7 +14,12 @@ use OCP\IMemcache;
 use OCP\IMemcacheTTL;
 use OCP\Lock\LockedException;
 
+/**
+ * Locking provider that stores locks in memcache.
+ */
 class MemcacheLockingProvider extends AbstractLockingProvider {
+	private const EXCLUSIVE_LOCK_VALUE = 'exclusive';
+
 	/** @var array<string, array{time: int, ttl: int}> */
 	private array $oldTTLs = [];
 
@@ -27,78 +32,93 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	}
 
 	private function setTTL(string $path, ?int $ttl = null, mixed $compare = null): void {
-		if (is_null($ttl)) {
+		if ($ttl === null) {
 			$ttl = $this->ttl;
 		}
-		if ($this->memcache instanceof IMemcacheTTL) {
-			if ($compare !== null) {
-				$this->memcache->compareSetTTL($path, $compare, $ttl);
-			} else {
-				$this->memcache->setTTL($path, $ttl);
-			}
+
+		if (!$this->memcache instanceof IMemcacheTTL) {
+			return;
 		}
+
+		if ($compare !== null) {
+			$this->memcache->compareSetTTL($path, $compare, $ttl);
+			return;
+		}
+
+		$this->memcache->setTTL($path, $ttl);
 	}
 
+	/**
+	 * @return int Actual TTL, or -1 when TTL support is unavailable or no TTL is returned
+	 */
 	private function getTTL(string $path): int {
-		if ($this->memcache instanceof IMemcacheTTL) {
-			$ttl = $this->memcache->getTTL($path);
-			return $ttl === false ? -1 : $ttl;
-		} else {
+		if (!$this->memcache instanceof IMemcacheTTL) {
 			return -1;
 		}
+
+		$ttl = $this->memcache->getTTL($path);
+		return $ttl === false ? -1 : $ttl;
 	}
 
 	#[\Override]
 	public function isLocked(string $path, int $type): bool {
+		$this->assertValidLockType($type);
+
 		$lockValue = $this->memcache->get($path);
-		if ($type === self::LOCK_SHARED) {
-			return is_int($lockValue) && $lockValue > 0;
-		} elseif ($type === self::LOCK_EXCLUSIVE) {
-			return $lockValue === 'exclusive';
-		} else {
-			return false;
-		}
+
+		return match ($type) {
+			self::LOCK_SHARED => is_int($lockValue) && $lockValue > 0,
+			self::LOCK_EXCLUSIVE => $lockValue === self::EXCLUSIVE_LOCK_VALUE,
+		};
 	}
 
 	#[\Override]
 	public function acquireLock(string $path, int $type, ?string $readablePath = null): void {
+		$this->assertValidLockType($type);
+
 		if ($type === self::LOCK_SHARED) {
-			// save the old TTL to for `restoreTTL`
+			// Save the previous TTL for restoreTTL().
 			$this->oldTTLs[$path] = [
 				'ttl' => $this->getTTL($path),
-				'time' => $this->timeFactory->getTime()
+				'time' => $this->timeFactory->getTime(),
 			];
 			if (!$this->memcache->inc($path)) {
 				throw new LockedException($path, null, $this->getExistingLockForException($path), $readablePath);
 			}
-		} else {
-			// when getting exclusive locks, we know there are no old TTLs to restore
+		} elseif ($type === self::LOCK_EXCLUSIVE) {
+			// An exclusive lock has no TTL to restore.
 			$this->memcache->add($path, 0);
-			// ttl is updated automatically when the `set` succeeds
-			if (!$this->memcache->cas($path, 0, 'exclusive')) {
+			// The TTL is updated automatically when the compare-and-set succeeds.
+			if (!$this->memcache->cas($path, 0, self::EXCLUSIVE_LOCK_VALUE)) {
 				throw new LockedException($path, null, $this->getExistingLockForException($path), $readablePath);
 			}
 			unset($this->oldTTLs[$path]);
 		}
+
 		$this->setTTL($path);
 		$this->markAcquire($path, $type);
 	}
 
 	#[\Override]
 	public function releaseLock(string $path, int $type): void {
+		$this->assertValidLockType($type);
+
 		if ($type === self::LOCK_SHARED) {
 			$ownSharedLockCount = $this->getOwnSharedLockCount($path);
 			$newValue = 0;
-			if ($ownSharedLockCount === 0) { // if we are not holding the lock, don't try to release it
+			// If we do not hold the lock, do not try to release it.
+			if ($ownSharedLockCount === 0) {
 				return;
 			}
+			// If we own the only shared lock, remove it atomically.
 			if ($ownSharedLockCount === 1) {
-				$removed = $this->memcache->cad($path, 1); // if we're the only one having a shared lock we can remove it in one go
-				if (!$removed) { //someone else also has a shared lock, decrease only
+				$removed = $this->memcache->cad($path, 1);
+				if (!$removed) {
+					// Another owner holds a shared lock; decrement only our share.
 					$newValue = $this->memcache->dec($path);
 				}
 			} else {
-				// if we own more than one lock ourselves just decrease
+				// If we hold more than one shared lock, decrement only our count.
 				$newValue = $this->memcache->dec($path);
 			}
 
@@ -108,79 +128,91 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 				unset($this->oldTTLs[$path]);
 			}
 
-			// if we somehow release more locks then exists, reset the lock
+			// If we (somehow) release more locks than exist, reset the lock.
 			if ($newValue < 0) {
 				$this->memcache->cad($path, $newValue);
 			}
 		} elseif ($type === self::LOCK_EXCLUSIVE) {
-			$this->memcache->cad($path, 'exclusive');
+			$this->memcache->cad($path, self::EXCLUSIVE_LOCK_VALUE);
 		}
+
 		$this->markRelease($path, $type);
 	}
 
 	#[\Override]
 	public function changeLock(string $path, int $targetType): void {
+		$this->assertValidLockType($targetType);
+
 		if ($targetType === self::LOCK_SHARED) {
-			if (!$this->memcache->cas($path, 'exclusive', 1)) {
+			if (!$this->memcache->cas($path, self::EXCLUSIVE_LOCK_VALUE, 1)) {
 				throw new LockedException($path, null, $this->getExistingLockForException($path));
 			}
 		} elseif ($targetType === self::LOCK_EXCLUSIVE) {
-			// we can only change a shared lock to an exclusive if there's only a single owner of the shared lock
-			if (!$this->memcache->cas($path, 1, 'exclusive')) {
+			// A shared lock can only be upgraded to exclusive when the shared lock has a single owner.
+			if (!$this->memcache->cas($path, 1, self::EXCLUSIVE_LOCK_VALUE)) {
 				$this->restoreTTL($path);
 				throw new LockedException($path, null, $this->getExistingLockForException($path));
 			}
 			unset($this->oldTTLs[$path]);
 		}
+
 		$this->setTTL($path);
 		$this->markChange($path, $targetType);
 	}
 
 	/**
-	 * With shared locks, each time the lock is acquired, the ttl for the path is reset.
+	 * With shared locks, each acquisition resets the path's TTL.
 	 *
-	 * Due to this "ttl extension" when a shared lock isn't freed correctly for any reason
-	 * the lock won't expire until no shared locks are required for the path for 1h.
-	 * This can lead to a client repeatedly trying to upload a file, and failing forever
-	 * because the lock never gets the opportunity to expire.
+	 * A side effect of this automatic TTL extension is that a shared lock not
+	 * released for any reason may never expire if shared locks continue to be
+	 * acquired for the path. With the default one-hour TTL, a client repeatedly
+	 * trying to upload a file can therefore fail indefinitely because the lock
+	 * never has an opportunity to expire.
 	 *
-	 * To help the lock expire in this case, we lower the TTL back to what it was before we
-	 * took the shared lock *only* if nobody else got a shared lock after we did.
+	 * To help the lock expire in this case, restore the path's previous TTL, but
+	 * only if no other concurrent owner, such as another request, acquired a
+	 * shared lock after this one.
 	 *
-	 * This doesn't handle all cases where multiple requests are acquiring shared locks
-	 * but it should handle some of the more common ones and not hurt things further
+	 * This does not cover every concurrent shared-lock scenario, but mitigates
+	 * common cases without making them worse.
 	 */
 	private function restoreTTL(string $path): void {
-		if (isset($this->oldTTLs[$path])) {
-			$saved = $this->oldTTLs[$path];
-			$elapsed = $this->timeFactory->getTime() - $saved['time'];
+		if (!isset($this->oldTTLs[$path])) {
+			return;
+		}
 
-			// old value to compare to when setting ttl in case someone else changes the lock in the middle of this function
-			$value = $this->memcache->get($path);
+		$saved = $this->oldTTLs[$path];
+		$elapsed = $this->timeFactory->getTime() - $saved['time'];
 
-			$currentTtl = $this->getTTL($path);
+		// Value to compare when updating the TTL in case another request changes the lock.
+		$value = $this->memcache->get($path);
 
-			// what the old ttl would be given the time elapsed since we acquired the lock
-			// note that if this gets negative the key will be expired directly when we set the ttl
-			$remainingOldTtl = $saved['ttl'] - $elapsed;
-			// what the currently ttl would be if nobody else acquired a lock since we did (+1 to cover rounding errors)
-			$expectedTtl = $this->ttl - $elapsed + 1;
+		$currentTtl = $this->getTTL($path);
 
-			// check if another request has acquired a lock (and didn't release it yet)
-			if ($currentTtl <= $expectedTtl) {
-				$this->setTTL($path, $remainingOldTtl, $value);
-			}
+		// Account for elapsed time since acquiring the shared lock.
+		$remainingOldTtl = $saved['ttl'] - $elapsed;
+
+		// Allow one second for rounding when detecting a concurrent acquisition.
+		$expectedTtl = $this->ttl - $elapsed + 1;
+
+		// Restore the TTL only if no other request has acquired the lock since.
+		if ($currentTtl <= $expectedTtl) {
+			// A negative remaining TTL expires the key.
+			$this->setTTL($path, $remainingOldTtl, $value);
 		}
 	}
 
 	private function getExistingLockForException(string $path): string {
 		$existing = $this->memcache->get($path);
+
 		if (!$existing) {
 			return 'none';
-		} elseif ($existing === 'exclusive') {
-			return $existing;
-		} else {
-			return $existing . ' shared locks';
 		}
+
+		if ($existing === self::EXCLUSIVE_LOCK_VALUE) {
+			return $existing;
+		}
+
+		return $existing . ' shared locks';
 	}
 }

--- a/tests/lib/Lock/LockingProvider.php
+++ b/tests/lib/Lock/LockingProvider.php
@@ -240,4 +240,28 @@ abstract class LockingProvider extends TestCase {
 		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
 		$this->instance->releaseLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
+
+	public function testIsLockedWithInvalidType(): void {
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->instance->isLocked('foo', 0);
+	}
+
+	public function testAcquireLockWithInvalidType(): void {
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->instance->acquireLock('foo', 0);
+	}
+
+	public function testReleaseLockWithInvalidType(): void {
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->instance->releaseLock('foo', 0);
+	}
+
+	public function testChangeLockWithInvalidType(): void {
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->instance->changeLock('foo', 0);
+	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

# NOTE: #62374 is a dependency for this PR; review/merge that one first then rebase this one

## Summary

- Simplify and clarify shared-lock bookkeeping in `DBLockingProvider`.
- Improve readability of database query construction and lock lifecycle comments.
- Replace Memcache’s exclusive-lock magic value with a named constant.
- Simplify Memcache TTL helper control flow and tidy the shared-lock TTL restoration behavior note.
- Validate supported lock types before either provider reads or mutates its backing store (note: depends on #62374)

## Details

Both providers now explicitly accept only `LOCK_SHARED` and `LOCK_EXCLUSIVE`. Previously, an invalid value passed to `acquireLock()` could follow the exclusive-acquisition path before request-local lock tracking occurred. The validation is performed before backend mutation, preventing an untracked lock from being created.

The DB provider retains its existing per-request shared-lock reuse behavior: a shared database lock may remain after it is released from active request bookkeeping and is cleaned up by `releaseAll()`.

The Memcache provider retains its existing conditional TTL restoration logic. The cleanup makes the compare-and-set intent and the concurrent shared-lock failure mode easier to follow without changing its behavior.

## Testing

- Existing `LockingProvider` contract tests cover shared/exclusive acquisition, release, conversion, and `releaseAll()` behavior through both concrete providers.
- Existing DB-specific tests cover cached shared-lock reuse and cleanup.
- Added invalid lock-type coverage in the shared contract suite

## TODO

- [ ] Merge #62374 
- [ ] Rebase after #62374 is merged

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
