### PR TITLE
fix(background-jobs): preserve Snowflake IDs as strings

### DIFF
--- a/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
+++ b/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
@@ -90,7 +90,7 @@ class UserStatusAutomation extends TimedJob {
 
 		$query->update('jobs')
 			->set('last_run', $query->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT))
-			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId())));
 		$query->executeStatement();
 
 		$this->logger->debug('Updated user status automation last_run to ' . $timestamp . ' for user ' . $userId);

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -116,7 +116,7 @@ class JobList implements IJobList {
 	public function removeById(string $id): void {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('jobs')
-			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($id)));
 		$query->executeStatement();
 	}
 
@@ -266,7 +266,7 @@ class JobList implements IJobList {
 				$reset->update('jobs')
 					->set('reserved_at', $reset->expr()->literal(0, IQueryBuilder::PARAM_INT))
 					->set('last_checked', $reset->createNamedParameter($this->timeFactory->getTime() + 12 * 3600, IQueryBuilder::PARAM_INT))
-					->where($reset->expr()->eq('id', $reset->createNamedParameter($row['id'], IQueryBuilder::PARAM_INT)));
+					->where($reset->expr()->eq('id', $reset->createNamedParameter($row['id'])));
 				$reset->executeStatement();
 
 				// Background job from disabled app, try again.
@@ -359,7 +359,7 @@ class JobList implements IJobList {
 		$query = $this->connection->getQueryBuilder();
 		$query->update('jobs')
 			->set('reserved_at', $query->expr()->literal(0, IQueryBuilder::PARAM_INT))
-			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId(), IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId())));
 		$query->executeStatement();
 	}
 
@@ -384,7 +384,7 @@ class JobList implements IJobList {
 		$query->update('jobs')
 			->set('execution_duration', $query->createNamedParameter($timeTaken, IQueryBuilder::PARAM_INT))
 			->set('reserved_at', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT))
-			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId(), IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId())));
 		$query->executeStatement();
 	}
 
@@ -394,7 +394,7 @@ class JobList implements IJobList {
 		$query->update('jobs')
 			->set('last_run', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT))
 			->set('reserved_at', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT))
-			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId()), IQueryBuilder::PARAM_INT));
+			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId())));
 		$query->executeStatement();
 	}
 

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -273,6 +273,26 @@ class JobListTest extends TestCase {
 		$this->assertLessThanOrEqual($timeEnd, $addedJob->getLastRun());
 	}
 
+	public function testRemoveByIdWithSnowflakeId(): void {
+		$this->instance->add(new TestJob(), 'remove-by-id');
+		$job = $this->instance->getJobs(null, 1, 0)[0];
+
+		$this->instance->removeById($job->getId());
+
+		$this->assertNull($this->instance->getById($job->getId()));
+	}
+
+	public function testResetBackgroundJobWithSnowflakeId(): void {
+		$this->instance->add(new TestJob(), 'reset');
+		$job = $this->instance->getJobs(null, 1, 0)[0];
+
+		$this->instance->resetBackgroundJob($job);
+
+		$row = $this->instance->getDetailsById($job->getId());
+		$this->assertSame('0', (string)$row['last_run']);
+		$this->assertSame('0', (string)$row['reserved_at']);
+	}
+
 	public function testHasReservedJobs(): void {
 		$this->clearJobsList();
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->
* Related: to #62381

## Summary

Bind background-job Snowflake IDs as strings instead of integers.

Snowflake IDs are represented as decimal strings. Binding them as integers can coerce the value and is immediately unsafe on 32-bit PHP; keeping them string-bound preserves the ID consistently across supported platforms. Technically also a bug in 64-bit, though it's less likely to be an immediate problem there (but still a correctness matter:  Binding them as `PARAM_INT` violates that API contract and can cause driver-dependent coercion).



Context: PR #57099 corrected string binding in `getDetailsById()` and `setLastRun()`, but other `jobs.id` bindings still used `PARAM_INT`. Also relevant: #56628

## Changes

- Fix remaining `JobList` `jobs.id` bindings.
- Fix `UserStatusAutomation`’s direct `jobs` update.
- Add regression coverage for string-bound Snowflake IDs.

## TODO

- [x] Determine which releases a backport is relevant to
- [x] Trigger backports to relevant releases

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
