### PR TITLE
fix(files): release locks after failed stream uploads

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -617,66 +617,70 @@ class View {
 	 * @throws LockedException
 	 */
 	public function file_put_contents($path, $data) {
-		if (is_resource($data)) { //not having to deal with streams in file_put_contents makes life easier
-			$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
-			if (Filesystem::isValidPath($path)
-				&& !Filesystem::isFileBlacklisted($path)
-			) {
-				$path = $this->getRelativePath($absolutePath);
-				if ($path === null) {
-					throw new InvalidPathException("Path $absolutePath is not in the expected root");
-				}
+		// not having to deal with streams in file_put_contents makes life easier
+		if (!is_resource($data)) {
+ 			$hooks = $this->file_exists($path) ? ['update', 'write'] : ['create', 'write'];
+ 			return $this->basicOperation('file_put_contents', $path, $hooks, $data);
+ 		}
 
-				$this->lockFile($path, ILockingProvider::LOCK_SHARED);
+		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
+		if (!Filesystem::isValidPath($path)
+			|| Filesystem::isFileBlacklisted($path)
+		) {
+			return false;
+		}
+		
+		$path = $this->getRelativePath($absolutePath);
+		if ($path === null) {
+			throw new InvalidPathException("Path $absolutePath is not in the expected root");
+		}
 
-				$exists = $this->file_exists($path);
-				if ($this->shouldEmitHooks($path)) {
-					$run = true;
-					$this->emit_file_hooks_pre($exists, $path, $run);
-					if (!$run) {
-						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-						return false;
-					}
-				}
+		$this->lockFile($path, ILockingProvider::LOCK_SHARED);
+		$lockType = ILockingProvider::LOCK_SHARED;
 
-				try {
-					$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
-				} catch (\Exception $e) {
-					// Release the shared lock before throwing.
-					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-					throw $e;
-				}
-
-				/** @var Storage $storage */
-				[$storage, $internalPath] = $this->resolvePath($path);
-				$target = $storage->fopen($internalPath, 'w');
-				if ($target) {
-					$result = stream_copy_to_stream($data, $target);
-					if ($result !== false) {
-						$result = true;
-					}
-					fclose($target);
-					fclose($data);
-
-					$this->writeUpdate($storage, $internalPath);
-
-					$this->changeLock($path, ILockingProvider::LOCK_SHARED);
-
-					if ($this->shouldEmitHooks($path) && $result !== false) {
-						$this->emit_file_hooks_post($exists, $path);
-					}
-					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-					return $result;
-				} else {
-					$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
+		try {
+			$exists = $this->file_exists($path);
+			if ($this->shouldEmitHooks($path)) {
+				$run = true;
+				$this->emit_file_hooks_pre($exists, $path, $run);
+				if (!$run) {
 					return false;
 				}
-			} else {
+			}
+
+			$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
+			$lockType = ILockingProvider::LOCK_EXCLUSIVE;
+
+			/** @var Storage $storage */
+			[$storage, $internalPath] = $this->resolvePath($path);
+			$target = $storage->fopen($internalPath, 'w');
+			if (!$target) {
 				return false;
 			}
-		} else {
-			$hooks = $this->file_exists($path) ? ['update', 'write'] : ['create', 'write'];
-			return $this->basicOperation('file_put_contents', $path, $hooks, $data);
+
+			try {
+				$result = stream_copy_to_stream($data, $target);
+			} finally {
+				fclose($target);
+				fclose($data);
+			}
+
+			if ($result !== false) {
+				$result = true;
+			}
+
+			$this->writeUpdate($storage, $internalPath);
+
+			$this->changeLock($path, ILockingProvider::LOCK_SHARED);
+			$lockType = ILockingProvider::LOCK_SHARED;
+
+			if ($this->shouldEmitHooks($path) && $result !== false) {
+				$this->emit_file_hooks_post($exists, $path);
+			}
+
+			return $result;
+		} finally {
+			$this->unlockFile($path, $lockType);
 		}
 	}
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2017,6 +2017,41 @@ class ViewTest extends \Test\TestCase {
 		$this->assertNull($this->getFileLockType($view, $path));
 	}
 
+	public function testLockFilePutContentsWithStreamUnlocksAfterStorageException(): void {
+		$view = new View('/' . self::$user . '/files/');
+		$path = 'failed-stream-upload.txt';
+
+		/** @var Temporary&MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
+			->onlyMethods(['fopen'])
+			->getMock();
+
+		Filesystem::mount($storage, [], self::$user . '/');
+		$storage->mkdir('files');
+
+		$storage->expects($this->once())
+			->method('fopen')
+			->willThrowException(new \Exception('Simulated stream upload failure'));
+
+		$source = fopen('php://temp', 'r+');
+
+		try {
+			$view->file_put_contents($path, $source);
+			$this->fail('Expected the storage exception to be rethrown');
+		} catch (\Exception $e) {
+			$this->assertSame('Simulated stream upload failure', $e->getMessage());
+		} finally {
+			if (is_resource($source)) {
+				fclose($source);
+			}
+		}
+
+		$this->assertNull(
+			$this->getFileLockType($view, $path),
+			'The stream-upload lock must be released after a storage exception'
+		);
+	}
+
 	/**
 	 * Test locks for fopen with fclose at the end
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Stream-based `View::file_put_contents()` uploads can retain an exclusive lock if the storage backend throws after lock escalation.

This PR ensures cleanup releases the currently held lock on all failure path and adds regression coverage for a destination-storage `fopen()` exception. Also includes minor refactoring of the function to flatten it by using early guards to improve readability.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI [tests in particular]
