### PR TITLE
feat: allow specifying applicable users and groups in the files_external:create command

### DIFF
--- a/apps/files_external/lib/Command/Create.php
+++ b/apps/files_external/lib/Command/Create.php
@@ -19,6 +19,7 @@ use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\AppFramework\Http;
+use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\User\Exceptions\UserNotFoundException;
@@ -35,6 +36,7 @@ class Create extends Base {
 		private IUserManager $userManager,
 		private IUserSession $userSession,
 		private BackendService $backendService,
+		private IGroupManager $groupManager,
 	) {
 		parent::__construct();
 	}
@@ -76,6 +78,18 @@ class Create extends Base {
 				'',
 				InputOption::VALUE_NONE,
 				'Don\'t save the created mount, only list the new mount'
+			)
+			->addOption(
+				'applicable-user',
+				'',
+				InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+				'Add a user as applicable to the newly created mount'
+			)
+			->addOption(
+				'applicable-group',
+				'',
+				InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+				'Add a group as applicable to the newly created mount'
 			);
 		parent::configure();
 	}
@@ -87,6 +101,8 @@ class Create extends Base {
 		$storageIdentifier = $input->getArgument('storage_backend');
 		$authIdentifier = $input->getArgument('authentication_backend');
 		$configInput = $input->getOption('config');
+		$applicableUsers = $input->getOption('applicable-user');
+		$applicableGroups = $input->getOption('applicable-group');
 
 		$storageBackend = $this->backendService->getBackend($storageIdentifier);
 		$authBackend = $this->backendService->getAuthMechanism($authIdentifier);
@@ -128,6 +144,19 @@ class Create extends Base {
 		$mount->setBackend($storageBackend);
 		$mount->setAuthMechanism($authBackend);
 		$mount->setBackendOptions($config);
+
+		foreach ($applicableUsers as $applicableUser) {
+			if (!$this->userManager->userExists($applicableUser)) {
+				$output->writeln('<error>Unknown user "' . $applicableUser . '"</error>');
+			}
+		}
+		foreach ($applicableGroups as $applicableGroup) {
+			if (!$this->groupManager->groupExists($applicableGroup)) {
+				$output->writeln('<error>Unknown group "' . $applicableGroup . '"</error>');
+			}
+		}
+		$mount->setApplicableUsers($applicableUsers);
+		$mount->setApplicableGroups($applicableGroups);
 
 		if ($user) {
 			if (!$this->userManager->userExists($user)) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Just as you can also specify config flags.

This allows creating external storages for a user/group without having it in an "applicable to everyone" state in between the `files_external:create` and `files_exteranal:applicable` commands.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
