### PR TITLE
fix(Sharing): Enable node download permission by default

### DIFF
--- a/apps/files/lib/Sharing/Permission/NodeDownloadSharePermissionType.php
+++ b/apps/files/lib/Sharing/Permission/NodeDownloadSharePermissionType.php
@@ -42,6 +42,6 @@ final readonly class NodeDownloadSharePermissionType implements ISharePermission
 
 	#[\Override]
 	public function isEnabledByDefault(): bool {
-		return false;
+		return true;
 	}
 }


### PR DESCRIPTION
https://github.com/nextcloud/server/issues/51803

To match the current behavior (and have the view preset selected by default for a new share on a fresh instance).