### PR TITLE
fix(Sharing): Remove faulty check if required properties have a defaut value

### DIFF
--- a/apps/sharing/tests/CapabilitiesTest.php
+++ b/apps/sharing/tests/CapabilitiesTest.php
@@ -11,12 +11,14 @@ use OCA\Sharing\AppInfo\Application;
 use OCA\Sharing\Capabilities;
 use OCP\Server;
 use OCP\Sharing\ISharingRegistry;
+use PHPUnit\Framework\Attributes\Group;
 use Test\Sharing\TestSharePermissionPreset1;
 use Test\Sharing\TestSharePermissionPreset2;
 use Test\Sharing\TestShareSourceType1;
 use Test\Sharing\TestShareSourceType2;
 use Test\TestCase;
 
+#[Group(name: 'DB')]
 final class CapabilitiesTest extends TestCase {
 	private ISharingRegistry $registry;
 

--- a/lib/private/Sharing/SharingRegistry.php
+++ b/lib/private/Sharing/SharingRegistry.php
@@ -175,10 +175,6 @@ final class SharingRegistry implements ISharingRegistry {
 	public function registerPropertyType(ISharePropertyType $propertyType): void {
 		$class = $propertyType::class;
 
-		if ($propertyType->isRequired() && $propertyType->getDefaultValue() === null) {
-			throw new RuntimeException('Share property type ' . $class . ' is required, but has no default value.');
-		}
-
 		if (isset($this->propertyTypes[$class])) {
 			throw new RuntimeException('Share property type ' . $class . ' is already registered');
 		}


### PR DESCRIPTION
https://github.com/nextcloud/server/issues/51803

Because both are computed, the result depends on the server configuration. If there is a logic mistake in either of them, we might not detect it and admins with a specific config would be affected. It's much better to accidentally not provide a default value than to brick sharing (and possibly more).