### PR TITLE
fix(view): make removeMount locking cleanup exception-safe

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -241,31 +241,63 @@ class View {
 	 * @param string $path relative to data/
 	 */
 	protected function removeMount($mount, $path): bool {
-		if ($mount instanceof IMovableMount) {
-			// cut of /user/files to get the relative path to data/user/files
-			$pathParts = explode('/', $path, 4);
-			$relPath = '/' . $pathParts[3];
-			$this->lockFile($relPath, ILockingProvider::LOCK_SHARED, true);
+		if (!$mount instanceof IMovableMount) {
+			// do not allow deleting the storage's root / the mount point
+			// because for some storages it might delete the whole contents
+			// but isn't supposed to work that way
+			return false;
+		}
+
+		// cut of /user/files to get the relative path to data/user/files
+		$pathParts = explode('/', $path, 4);
+		$relPath = '/' . $pathParts[3];
+
+		$this->lockFile($relPath, ILockingProvider::LOCK_SHARED, true);
+		$lockType = ILockingProvider::LOCK_SHARED;
+
+		$operationException = null;
+
+		try {
 			\OC_Hook::emit(
 				Filesystem::CLASSNAME, 'umount',
-				[Filesystem::signal_param_path => $relPath]
+				[Filesystem::signal_param_path => $relPath],
 			);
+
 			$this->changeLock($relPath, ILockingProvider::LOCK_EXCLUSIVE, true);
+			$lockType = ILockingProvider::LOCK_EXCLUSIVE;
+
 			$result = $mount->removeMount();
+
 			$this->changeLock($relPath, ILockingProvider::LOCK_SHARED, true);
+			$lockType = ILockingProvider::LOCK_SHARED;
+
 			if ($result) {
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME, 'post_umount',
 					[Filesystem::signal_param_path => $relPath]
 				);
 			}
-			$this->unlockFile($relPath, ILockingProvider::LOCK_SHARED, true);
 			return $result;
-		} else {
-			// do not allow deleting the storage's root / the mount point
-			// because for some storages it might delete the whole contents
-			// but isn't supposed to work that way
-			return false;
+		} catch (\Throwable $e) {
+			$operationException = $e;
+			throw $e;
+		} finally {
+			try {
+				$this->unlockFile($relPath, $lockType, true);
+			} catch (\Throwable $unlockException) {
+				if ($operationException === null) {
+					throw $unlockException;
+				}
+
+				$this->logger->error(
+					'Failed to release mount-point lock while handling a mount removal failure',
+					[
+						'app' => 'core',
+						'exception' => $unlockException,
+						'operationException' => $operationException,
+					]
+				);
+			}
 		}
 	}
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2644,6 +2644,43 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals('foo', $view->rmdir('mount'));
 	}
 
+	public function testRemoveMovableMountPointUnlocksAfterException(): void {
+		$mountPoint = '/' . self::$user . '/files/mount/';
+		$view = new View('/' . self::$user . '/files');
+
+		/** @var TestMoveableMountPoint&MockObject $mount */
+		$mount = $this->createMock(TestMoveableMountPoint::class);
+		$mount->method('getMountPoint')
+			->willReturn($mountPoint);
+		$mount->method('getInternalPath')
+			->willReturn('');
+		$mount->expects($this->once())
+			->method('removeMount')
+			->willReturnCallback(function () use ($view): never {
+				$this->assertSame(
+					ILockingProvider::LOCK_EXCLUSIVE,
+					$this->getFileLockType($view, 'mount', true),
+					'The mount point must be exclusively locked during removal'
+				);
+
+				throw new \RuntimeException('Simulated mount removal failure');
+			});
+
+		Filesystem::getMountManager()->addMount($mount);
+
+		try {
+			$view->rmdir('mount');
+			$this->fail('Expected the mount removal exception to be rethrown');
+		} catch (\RuntimeException $e) {
+			$this->assertSame('Simulated mount removal failure', $e->getMessage());
+		}
+
+		$this->assertNull(
+			$this->getFileLockType($view, 'mount', true),
+			'The mount-point lock must be released after a failed mount removal'
+		);
+	}
+
 	public static function mimeFilterProvider(): array {
 		return [
 			[null, ['test1.txt', 'test2.txt', 'test3.md', 'test4.png']],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Continuing my efforts to eliminate more "lock acquired, then an exception bypasses cleanup" pattern from another spot in the code base.

Make `removeMount()` release its lock on every exit. 

This protects against exceptions from the `umount` hook, `changeLock()`, `IMovableMount::removeMount()`, or `post_umount` hook.

Also preserves non-cleanup exceptions and passes them on.

### Why

`removeMount()` / movable-mount cleanup is not exception-safe:

- `removeMount()` acquires a shared mount-point lock, emits an `umount` hook, promotes the lock to exclusive, calls `removeMount()`, downgrades, emits the post-hook, then unlocks.
- If a hook, `changeLock()`, or the mount’s `removeMount()` implementation throws, neither the downgrade nor unlock is guaranteed. A `try/finally` should protect that sequence.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
