### PR TITLE
fix(files): release target lock when copy source is locked

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -955,12 +955,15 @@ class View {
 			}
 			$run = true;
 
-			$this->lockFile($target, ILockingProvider::LOCK_SHARED);
-			$this->lockFile($source, ILockingProvider::LOCK_SHARED);
+			$targetLocked = $this->lockFile($target, ILockingProvider::LOCK_SHARED);
+			$sourceLocked = false;
 			$lockTypePath1 = ILockingProvider::LOCK_SHARED;
 			$lockTypePath2 = ILockingProvider::LOCK_SHARED;
 
+			$operationException = null;
 			try {
+				$sourceLocked = $this->lockFile($source, ILockingProvider::LOCK_SHARED);
+
 				$exists = $this->file_exists($target);
 				if ($this->shouldEmitHooks($source) && $this->shouldEmitHooks($target)) {
 					\OC_Hook::emit(
@@ -1014,15 +1017,53 @@ class View {
 						$this->emit_file_hooks_post($exists, $target);
 					}
 				}
-			} catch (\Exception $e) {
-				$this->unlockFile($target, $lockTypePath2);
-				$this->unlockFile($source, $lockTypePath1);
+			} catch (\Throwable $e) {
+				$operationException = $e;
 				throw $e;
-			}
+			} finally {
+				$cleanupException = null;
 
-			$this->unlockFile($target, $lockTypePath2);
-			$this->unlockFile($source, $lockTypePath1);
+				// Preserve the prior target-then-source unlock order, but do not
+				// leave the source locked if releasing the target itself fails.
+				try {
+					if ($targetLocked) {
+						$this->unlockFile($target, $lockTypePath2);
+					}
+				} catch (\Throwable $unlockException) {
+					if ($operationException !== null) {
+						$this->logger->error('Failed to release target lock after copy operation', [
+							'app' => 'core',
+							'source' => $source,
+							'target' => $target,
+							'exception' => $unlockException,
+						]);
+					} else {
+						$cleanupException = $unlockException;
+					}
+				}
+
+				try {
+					if ($sourceLocked) {
+						$this->unlockFile($source, $lockTypePath1);
+					}
+				} catch (\Throwable $unlockException) {
+					if ($operationException !== null || $cleanupException !== null) {
+						$this->logger->error('Failed to release source lock after copy operation', [
+							'app' => 'core',
+							'source' => $source,
+							'target' => $target,
+							'exception' => $unlockException,
+						]);
+					} else {
+						$cleanupException = $unlockException;
+					}
+				}
+
+				if ($operationException === null && $cleanupException !== null) {
+					throw $cleanupException;
+			}
 		}
+
 		return $result;
 	}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -963,8 +963,8 @@ class View {
 			$operationException = null;
 			try {
 				$sourceLocked = $this->lockFile($source, ILockingProvider::LOCK_SHARED);
-
 				$exists = $this->file_exists($target);
+
 				if ($this->shouldEmitHooks($source) && $this->shouldEmitHooks($target)) {
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
@@ -977,6 +977,7 @@ class View {
 					);
 					$this->emit_file_hooks_pre($exists, $target, $run);
 				}
+
 				if ($run) {
 					$mount1 = $this->getMount($source);
 					$mount2 = $this->getMount($target);
@@ -1061,6 +1062,7 @@ class View {
 
 				if ($operationException === null && $cleanupException !== null) {
 					throw $cleanupException;
+				}
 			}
 		}
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2315,6 +2315,37 @@ class ViewTest extends \Test\TestCase {
 		}
 	}
 
+	public function testCopyUnlocksTargetWhenSourceLockCannotBeAcquired(): void {
+		$view = new View('/' . self::$user . '/files/');
+		$storage = new Temporary([]);
+
+		Filesystem::mount($storage, [], self::$user . '/');
+		$storage->mkdir('files');
+
+		$sourcePath = 'source.txt';
+		$targetPath = 'target.txt';
+		$view->file_put_contents($sourcePath, 'content');
+
+		$view->lockFile($sourcePath, ILockingProvider::LOCK_EXCLUSIVE);
+
+		try {
+			$view->copy($sourcePath, $targetPath);
+			$this->fail('Expected source-lock acquisition to fail');
+		} catch (LockedException) {
+			$this->assertNull(
+				$this->getFileLockType($view, $targetPath),
+				'The target lock acquired before the source lock must be released'
+			);
+			$this->assertSame(
+				ILockingProvider::LOCK_EXCLUSIVE,
+				$this->getFileLockType($view, $sourcePath),
+				'The pre-existing source lock must not be released by copy()'
+			);
+		} finally {
+			$view->unlockFile($sourcePath, ILockingProvider::LOCK_EXCLUSIVE);
+		}
+	}
+
 	/**
 	 * Test rename operation: unlock first path when second path was locked
 	 */


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Ensure `View::copy()` releases its target lock if acquiring the source lock fails.

Adds regression coverage for the partial lock-acquisition failure path.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
