### PR TITLE
fix(sharing): Hide Allow download and sync option for federated

### DIFF
--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -183,7 +183,7 @@
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch
-						v-else
+						v-else-if="canShowDownloadPermission"
 						v-model="canDownload"
 						:disabled="!canSetDownload"
 						data-cy-files-sharing-share-permissions-checkbox="download">
@@ -694,6 +694,10 @@ export default {
 			// the share still has the permission, and the resharer is still
 			// allowed to revoke it too (but not to grant it again).
 			return (this.fileInfo.canDownload() || this.canDownload)
+		},
+
+		canShowDownloadPermission() {
+			return !this.isPublicShare && !this.isRemoteShare
 		},
 
 		canRemoveReadPermission() {

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -181,7 +181,7 @@
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch
-						v-else
+						v-else-if="canShowDownloadPermission"
 						v-model="canDownload"
 						:disabled="!canSetDownload"
 						data-cy-files-sharing-share-permissions-checkbox="download">
@@ -699,6 +699,10 @@ export default {
 			// the share still has the permission, and the resharer is still
 			// allowed to revoke it too (but not to grant it again).
 			return (this.fileInfo.canDownload() || this.canDownload)
+		},
+
+		canShowDownloadPermission() {
+			return !this.isPublicShare && !this.isRemoteShare
 		},
 
 		canRemoveReadPermission() {


### PR DESCRIPTION
Hide the “Allow download and sync” option for federated user/group shares because the setting is not enforced end to end for remote recipients.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
