### PR TITLE
feat(federation): implement minimal federation user backend

### DIFF
--- a/apps/federation/composer/composer/autoload_classmap.php
+++ b/apps/federation/composer/composer/autoload_classmap.php
@@ -23,4 +23,5 @@ return array(
     'OCA\\Federation\\SyncFederationAddressBooks' => $baseDir . '/../lib/SyncFederationAddressBooks.php',
     'OCA\\Federation\\SyncJob' => $baseDir . '/../lib/SyncJob.php',
     'OCA\\Federation\\TrustedServers' => $baseDir . '/../lib/TrustedServers.php',
+    'OCA\\Federation\\User\\Backend' => $baseDir . '/../lib/User/Backend.php',
 );

--- a/apps/federation/composer/composer/autoload_static.php
+++ b/apps/federation/composer/composer/autoload_static.php
@@ -38,6 +38,7 @@ class ComposerStaticInitFederation
         'OCA\\Federation\\SyncFederationAddressBooks' => __DIR__ . '/..' . '/../lib/SyncFederationAddressBooks.php',
         'OCA\\Federation\\SyncJob' => __DIR__ . '/..' . '/../lib/SyncJob.php',
         'OCA\\Federation\\TrustedServers' => __DIR__ . '/..' . '/../lib/TrustedServers.php',
+        'OCA\\Federation\\User\\Backend' => __DIR__ . '/..' . '/../lib/User/Backend.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/apps/federation/lib/AppInfo/Application.php
+++ b/apps/federation/lib/AppInfo/Application.php
@@ -11,11 +11,13 @@ namespace OCA\Federation\AppInfo;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\Federation\Listener\SabrePluginAuthInitListener;
 use OCA\Federation\Listener\TrustedServerRemovedListener;
+use OCA\Federation\User\Backend;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
+use OCP\IUserManager;
 
 class Application extends App implements IBootstrap {
 
@@ -36,5 +38,6 @@ class Application extends App implements IBootstrap {
 
 	#[\Override]
 	public function boot(IBootContext $context): void {
+		$context->injectFn(fn (IUserManager $userManager, Backend $backend) => $userManager->registerBackend($backend));
 	}
 }

--- a/apps/federation/lib/User/Backend.php
+++ b/apps/federation/lib/User/Backend.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Federation\User;
+
+use OCP\Federation\ICloudIdManager;
+use OCP\User\Backend\ABackend;
+use OCP\User\Backend\IGetDisplayNameBackend;
+
+class Backend extends ABackend implements IGetDisplayNameBackend {
+	public function __construct(
+		private ICloudIdManager $cloudIdManager,
+	) {
+	}
+
+	#[\Override]
+	public function getBackendName() {
+		return 'federation';
+	}
+
+	#[\Override]
+	public function deleteUser($uid) {
+		return false;
+	}
+
+	#[\Override]
+	public function getUsers($search = '', $limit = null, $offset = null) {
+		return [];
+	}
+
+	/**
+	 * Check if a user exists. Assume that the user with valid cloud id exists since the account is for a remote user
+	 */
+	#[\Override]
+	public function userExists($uid) {
+		return $this->cloudIdManager->isValidCloudId($uid);
+	}
+
+	#[\Override]
+	public function getDisplayName($uid): string {
+		return $this->cloudIdManager->resolveCloudId($uid)->getDisplayId();
+	}
+
+	#[\Override]
+	public function getDisplayNames($search = '', $limit = null, $offset = null) {
+		return [];
+	}
+
+	#[\Override]
+	public function hasUserListings() {
+		return false;
+	}
+}

--- a/apps/federation/tests/User/BackendTest.php
+++ b/apps/federation/tests/User/BackendTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Federation\Tests\User;
+
+use OC\User\Backend as Base;
+use OCA\Federation\User\Backend;
+use OCP\Server;
+use Test\TestCase;
+
+#[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
+class BackendTest extends TestCase {
+	private Backend $backend;
+	private string $userId;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->backend = Server::get(Backend::class);
+		$this->userId = 'foo@example.com';
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function testGetBackendName(): void {
+		$this->assertEquals($this->backend->getBackendName(), 'federation');
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestImplementsActions')]
+	public function testImplementsActions(int $action, bool $implemented): void {
+		$this->assertEquals($this->backend->implementsActions($action), $implemented);
+	}
+
+	public static function dataTestImplementsActions(): array {
+		return [
+			[Base::CREATE_USER, false],
+			[Base::SET_PASSWORD, false],
+			[Base::CHECK_PASSWORD, false],
+			[Base::GET_HOME, false],
+			[Base::GET_DISPLAYNAME, true],
+			[Base::SET_DISPLAYNAME, false],
+			[Base::PROVIDE_AVATAR, false],
+			[Base::COUNT_USERS, false],
+		];
+	}
+
+	public function testDeleteUser(): void {
+		$this->assertFalse($this->backend->deleteUser($this->userId));
+	}
+
+	public function testGetUsers(): void {
+		$this->assertEquals($this->backend->getUsers(), []);
+	}
+
+	public function testUserExists(): void {
+		$this->assertTrue($this->backend->userExists($this->userId));
+		$this->assertFalse($this->backend->userExists('foo'));
+	}
+
+	public function testGetDisplayName(): void {
+		$this->assertEquals($this->backend->getDisplayName($this->userId), $this->userId);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->backend->getDisplayName('foo');
+	}
+
+	public function testGetDisplayNames(): void {
+		$this->assertEquals($this->backend->getDisplayNames(), []);
+	}
+
+	public function testHasUserListings(): void {
+		$this->assertFalse($this->backend->hasUserListings());
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
This adds a minimal user backend for federation that can continue to be built upon.

This was inspired by and fixes an issue where the "Deleted by" column in the trashbin is shown as "Unknown" if a file shared externally was deleted by a remote user. The "Deleted by" column will now correctly show the federated user as the deleter (e.g. bob@example.com)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
