### PR TITLE
fix: only retry urldecoded password when decoding changes it (LDAP badPwdCount double-increment)

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -241,12 +241,18 @@ class Manager extends PublicEmitter implements IUserManager {
 		// since http basic auth doesn't provide a standard way of handling non ascii password we allow password to be urlencoded
 		// we only do this decoding after using the plain password fails to maintain compatibility with any password that happens
 		// to contain urlencoded patterns by "accident".
-		$password = urldecode($password);
+		$decodedPassword = urldecode($password);
+		if ($decodedPassword === $password) {
+			// decoding the password did not change it, so retrying with the
+			// decoded value would just be a redundant duplicate authentication
+			// attempt (e.g. a second LDAP bind that double-increments badPwdCount).
+			return false;
+		}
 
 		foreach ($backends as $backend) {
 			if ($backend instanceof ICheckPasswordBackend || $backend->implementsActions(Backend::CHECK_PASSWORD)) {
 				/** @var ICheckPasswordBackend|UserInterface $backend */
-				$uid = $backend->checkPassword($loginName, $password);
+				$uid = $backend->checkPassword($loginName, $decodedPassword);
 				if ($uid !== false) {
 					return $this->getUserObject($uid, $backend);
 				}

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -180,6 +180,55 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($manager->checkPassword('foo', 'bar'));
 	}
 
+	public function testCheckPasswordWrongPasswordCallsBackendOnce(): void {
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->expects($this->once())
+			->method('checkPassword')
+			->with($this->equalTo('foo'), $this->equalTo('wrongpass'))
+			->willReturn(false);
+
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->willReturnCallback(function ($actions) {
+				if ($actions === BACKEND::CHECK_PASSWORD) {
+					return true;
+				} else {
+					return false;
+				}
+			});
+
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager->registerBackend($backend);
+
+		$this->assertFalse($manager->checkPassword('foo', 'wrongpass'));
+	}
+
+	public function testCheckPasswordUrlencodedRetriesWithDecodedValue(): void {
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->expects($this->exactly(2))
+			->method('checkPassword')
+			->willReturnMap([
+				['foo', '%C3%A9', false],
+				['foo', urldecode('%C3%A9'), 'foo'],
+			]);
+
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->willReturnCallback(function ($actions) {
+				if ($actions === BACKEND::CHECK_PASSWORD) {
+					return true;
+				} else {
+					return false;
+				}
+			});
+
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager->registerBackend($backend);
+
+		$user = $manager->checkPassword('foo', '%C3%A9');
+		$this->assertTrue($user instanceof User);
+	}
+
 	public function testGetOneBackendExists(): void {
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())


### PR DESCRIPTION
* Resolves: #33657

## Summary

When a wrong password is entered for an LDAP or Active Directory user, the directory's failed-login counter is increased by two instead of one. Administrators who lock accounts after three failed attempts therefore find users locked out after only two mistakes, which causes avoidable lockouts and support load.

The cause is in the password check inside the user manager. After the first authentication attempt with the plain password fails, the method decodes the password and then tries every backend a second time. That second pass exists so that non-ASCII passwords sent over HTTP basic auth, which arrive percent-encoded, can still be verified. The problem is that the second pass ran unconditionally, even when the password contained nothing to decode, so an ordinary wrong password produced two identical authentication attempts and two directory binds for a single login.

This change performs the second attempt only when decoding actually changes the password. When decoding leaves the password unchanged, the method now returns right after the first attempt, so one wrong password results in exactly one directory bind and one counter increment. The compatibility path for genuinely percent-encoded passwords is preserved: when decoding does change the value, the second attempt still runs against the decoded password.

Two unit tests were added. The first checks that a wrong password with nothing to decode reaches the backend exactly once. The second checks that a percent-encoded password still triggers a second attempt with the decoded value and authenticates when the decoded form is accepted.

Fixes #33657

## TODO

Nothing outstanding. The change is self-contained and covered by the added tests.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

AI was used for assistance.
