### PR TITLE
fix: Use PHP_AUTH_PW for strict password confirmation

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -291,6 +291,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			'CONTENT_TYPE' => true,
 			'CONTENT_LENGTH' => true,
 			'REMOTE_ADDR' => true,
+			'PHP_AUTH_USER' => true,
+			'PHP_AUTH_PW' => true,
 		];
 
 		if (isset($specialKeys[$elementName]) && isset($this->server[$elementName])) {

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -77,11 +77,12 @@ class PasswordConfirmationMiddleware extends Middleware {
 
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 		if ($this->isPasswordConfirmationStrict($reflectionMethod)) {
-			$authHeader = $this->request->getHeader('Authorization');
-			if (!str_starts_with(strtolower($authHeader), 'basic ')) {
+			$password = $this->request->getHeader('PHP_AUTH_PW');
+
+			if ($password === '') {
 				throw new NotConfirmedException('Required authorization header missing');
 			}
-			[, $password] = explode(':', base64_decode(substr($authHeader, 6)), 2);
+
 			$loginName = $this->session->get('loginname');
 			$loginResult = $this->userManager->checkPassword($loginName, $password);
 			if ($loginResult === false) {

--- a/tests/lib/AppFramework/Middleware/Security/Mock/PasswordConfirmationMiddlewareController.php
+++ b/tests/lib/AppFramework/Middleware/Security/Mock/PasswordConfirmationMiddlewareController.php
@@ -35,4 +35,8 @@ class PasswordConfirmationMiddlewareController extends Controller {
 	#[PasswordConfirmationRequired]
 	public function testSSO() {
 	}
+
+	#[PasswordConfirmationRequired(strict: true)]
+	public function testAuthHeader() {
+	}
 }

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -205,4 +205,34 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 
 		$this->assertSame(false, $thrown);
 	}
+
+	public function testAuthHeader(): void {
+		$this->reflector->reflect($this->controller, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')
+			->willReturn('fictional_backend');
+		$this->userSession->method('getUser')
+			->willReturn($this->user);
+
+		$this->session->method('get')
+			->with('loginname')
+			->willReturn('user');
+
+		$this->request->method('getHeader')
+			->with('PHP_AUTH_PW')
+			->willReturn('password');
+
+		$this->userManager->expects($this->once())
+			->method('checkPassword')
+			->with('user', 'password');
+
+		$thrown = false;
+		try {
+			$this->middleware->beforeController($this->controller, __FUNCTION__);
+		} catch (NotConfirmedException) {
+			$thrown = true;
+		}
+
+		$this->assertSame(false, $thrown);
+	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #62190

## Summary

We already make sure that `AUTHORIZATION` headers are copied to `PHP_AUTH_USER` and `PHP_AUTH_PW`, so these should work in all cases.

https://github.com/nextcloud/server/blob/3541356d5ed57f4174a02da32306c15817b282ff/lib/OC.php#L1297-L1318

Please check if there's any reason to access the raw authorization header in that method, in that case we could use the `PHP_AUTH_*` ones as fallback.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
