### PR TITLE
refactor(files_sharing): clarify failed shared-storage cache handling

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -64,9 +64,13 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	private $initialized = false;
 
 	/**
-	 * @var ICacheEntry
+	 * The cache entry for the source node, or false when it cannot be found.
+	 *
+	 * `null` means the entry has not been resolved yet.
+	 *
+	 * @var ICacheEntry|false|null
 	 */
-	private $sourceRootInfo;
+	private ICacheEntry|false|null $sourceRootInfo = null;
 
 	/** @var string */
 	private $user;
@@ -120,18 +124,25 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	}
 
 	/**
-	 * @return ICacheEntry
+	 * Resolve the source node's cache entry.
+	 *
+	 * A failed storage supplies a synthetic root entry through FailedCache. Its
+	 * permissions do not include sharing, so isValid() safely denies access.
+	 *
+	 * @return ICacheEntry|false
 	 */
-	private function getSourceRootInfo() {
-		if (is_null($this->sourceRootInfo)) {
-			if (is_null($this->superShare->getNodeCacheEntry())) {
-				$this->init();
-				$this->sourceRootInfo = $this->nonMaskedStorage->getCache()->get($this->rootPath);
-			} else {
-				$this->sourceRootInfo = $this->superShare->getNodeCacheEntry();
-			}
+	private function getSourceRootInfo(): ICacheEntry|false {
+		if ($this->sourceRootInfo !== null) {
+			return $this->sourceRootInfo;
 		}
-		return $this->sourceRootInfo;
+
+		$sourceRootInfo = $this->superShare->getNodeCacheEntry();
+		if ($sourceRootInfo === null) {
+			$this->init();
+			$sourceRootInfo = $this->nonMaskedStorage->getCache()->get($this->rootPath);
+		}
+
+		return $this->sourceRootInfo = $sourceRootInfo;
 	}
 
 	/**
@@ -236,7 +247,9 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	}
 
 	private function isValid(): bool {
-		return $this->getSourceRootInfo() && ($this->getSourceRootInfo()->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE;
+		$sourceRootInfo = $this->getSourceRootInfo();
+		return $sourceRootInfo !== false
+			&& ($sourceRootInfo->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE;
 	}
 
 	#[\Override]
@@ -419,12 +432,19 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 		if ($this->cache) {
 			return $this->cache;
 		}
+
+		$this->init();
+		if ($this->cache) {
+			return $this->cache;
+		}
+
 		if (!$storage) {
 			$storage = $this;
 		}
+
 		$sourceRoot = $this->getSourceRootInfo();
-		if ($this->storage instanceof FailedStorage) {
-			return new FailedCache();
+		if ($sourceRoot === false) {
+			return $this->cache = new FailedCache();
 		}
 
 		$this->cache = new Cache(
@@ -433,6 +453,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 			$this->cacheDependencies,
 			$this->getShare()
 		);
+
 		return $this->cache;
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Failed shared storage uses `FailedCache`’s synthetic root entry and is denied through normal permission checks.

This change acknowledges that `ICache::get()` can return `false`, caches that result, and makes `isValid()` explicitly deny access in that case. This prevents a cache miss from becoming a method call on `false`, while documenting why the normal `FailedStorage` path remains safe.

Changes:

- Make source-root cache-entry handling explicit when a cache lookup returns `false`.
- Reuse the cache installed during failed storage initialization.
- Replace the missing-source test setup with a deterministic mocked `getById()` miss.
- Verify missing-source shares are inaccessible without errors.

Depends on/related to: PR #62484

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
