### PR TITLE
fix(security): reliably set Referrer-Policy: same-origin on the login page

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@
         # Avoid doubled headers by unsetting headers in "onsuccess" table,
         # then add headers to "always" table: https://github.com/nextcloud/server/pull/19002
 
-        <If "%{REQUEST_URI} =~ m#/login$#">
+        <If "%{THE_REQUEST} =~ m#\s/(index\.php/)?login/?[\s?]#">
             # Only on the login page we need any Origin or Referer header set.
             Header onsuccess unset Referrer-Policy
             Header always set Referrer-Policy "same-origin"


### PR DESCRIPTION
* Resolves: #60464

## Summary

The login page relies on the security-headers block in the root `.htaccess` to send `Referrer-Policy: same-origin` (every other path gets `no-referrer`):

```apache
<If "%{REQUEST_URI} =~ m#/login$#">
    Header always set Referrer-Policy "same-origin"
</If>
<Else>
    Header always set Referrer-Policy "no-referrer"
</Else>
```

`%{REQUEST_URI}` inside `<If>` is evaluated against the **post-rewrite** URI. Once the front-controller rewrite installed by `occ maintenance:update:htaccess` is active (`RewriteRule . index.php [PT,E=PATH_INFO:$1]`, added when `htaccess.RewriteBase` is set), the URI the expression sees is no longer `/login`, so the match fails and the request falls through to the `<Else>` branch — the login page ends up with `Referrer-Policy: no-referrer` instead of `same-origin`.

The same `m#/login$#` match also fails, independently of any rewrite, for:
- `/login/` (trailing slash — the exact form in the issue title), and
- `/index.php/login`.

There is no PHP-layer fallback: `LoginController` only injects an HTML `<meta name="referrer">` tag, and `<Else>`'s `Header always set` would override any header the PHP layer tried to set — so this must be fixed in `.htaccess`.

### Fix

Match against `%{THE_REQUEST}` — the original request line, which is **not** affected by mod_rewrite — and allow an optional `index.php/` prefix, an optional trailing slash, and a following query string:

```apache
<If "%{THE_REQUEST} =~ m#\s/(index\.php/)?login/?[\s?]#">
```

### Verification

Reproduced and verified against Apache 2.4 (mod_headers + mod_rewrite) with the current `.htaccess` plus the front-controller rewrite (i.e. the reporter's configuration), using a backend that sets no Referrer-Policy of its own:

| Request | before | after |
|---|---|---|
| `/login` | `no-referrer` ❌ | `same-origin` ✅ |
| `/login/` | `no-referrer` ❌ | `same-origin` ✅ |
| `/login?redirect_url=…` | `no-referrer` ❌ | `same-origin` ✅ |
| `/index.php/login` | `no-referrer` ❌ | `same-origin` ✅ |
| `/settings`, `/apps/files`, `/` | `no-referrer` ✅ | `no-referrer` ✅ |
| `/relogin`, `/apps/login` (no false match) | `no-referrer` ✅ | `no-referrer` ✅ |

`apachectl -t` reports `Syntax OK` with the change.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests are included — the `.htaccess`/Apache header behavior is not covered by the PHP test suite (the existing `SecurityHeaders` setup-check only probes the `heartbeat` route and accepts any valid Referrer-Policy value). Verified manually against Apache as shown above; happy to add coverage if maintainers can point to a suitable harness.
- [ ] Screenshots before/after for front-end changes — n/a
- [x] Documentation has been updated or is not required
- [ ] Backports requested where applicable — reproduces on stable branches (reported on v32/v33); can request backports if desired.
- [ ] Labels added where applicable
- [ ] Milestone added for target branch/version

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
