### PR TITLE
feat:Add Dual Layer Server-Side Encryption via DSSE-KMS

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -135,6 +135,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\RandomnessSecure' => $baseDir . '/../lib/SetupChecks/RandomnessSecure.php',
     'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => $baseDir . '/../lib/SetupChecks/ReadOnlyConfig.php',
     'OCA\\Settings\\SetupChecks\\RepairSanitizeSystemTagsAvailable' => $baseDir . '/../lib/SetupChecks/RepairSanitizeSystemTagsAvailable.php',
+    'OCA\\Settings\\SetupChecks\\S3SseCEncryption' => $baseDir . '/../lib/SetupChecks/S3SseCEncryption.php',
     'OCA\\Settings\\SetupChecks\\SchedulingTableSize' => $baseDir . '/../lib/SetupChecks/SchedulingTableSize.php',
     'OCA\\Settings\\SetupChecks\\SecurityHeaders' => $baseDir . '/../lib/SetupChecks/SecurityHeaders.php',
     'OCA\\Settings\\SetupChecks\\ServerIdConfig' => $baseDir . '/../lib/SetupChecks/ServerIdConfig.php',

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -132,6 +132,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\RandomnessSecure' => $baseDir . '/../lib/SetupChecks/RandomnessSecure.php',
     'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => $baseDir . '/../lib/SetupChecks/ReadOnlyConfig.php',
     'OCA\\Settings\\SetupChecks\\RepairSanitizeSystemTagsAvailable' => $baseDir . '/../lib/SetupChecks/RepairSanitizeSystemTagsAvailable.php',
+    'OCA\\Settings\\SetupChecks\\S3SseCEncryption' => $baseDir . '/../lib/SetupChecks/S3SseCEncryption.php',
     'OCA\\Settings\\SetupChecks\\SchedulingTableSize' => $baseDir . '/../lib/SetupChecks/SchedulingTableSize.php',
     'OCA\\Settings\\SetupChecks\\SecurityHeaders' => $baseDir . '/../lib/SetupChecks/SecurityHeaders.php',
     'OCA\\Settings\\SetupChecks\\ServerIdConfig' => $baseDir . '/../lib/SetupChecks/ServerIdConfig.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -147,6 +147,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\RandomnessSecure' => __DIR__ . '/..' . '/../lib/SetupChecks/RandomnessSecure.php',
         'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ReadOnlyConfig.php',
         'OCA\\Settings\\SetupChecks\\RepairSanitizeSystemTagsAvailable' => __DIR__ . '/..' . '/../lib/SetupChecks/RepairSanitizeSystemTagsAvailable.php',
+        'OCA\\Settings\\SetupChecks\\S3SseCEncryption' => __DIR__ . '/..' . '/../lib/SetupChecks/S3SseCEncryption.php',
         'OCA\\Settings\\SetupChecks\\SchedulingTableSize' => __DIR__ . '/..' . '/../lib/SetupChecks/SchedulingTableSize.php',
         'OCA\\Settings\\SetupChecks\\SecurityHeaders' => __DIR__ . '/..' . '/../lib/SetupChecks/SecurityHeaders.php',
         'OCA\\Settings\\SetupChecks\\ServerIdConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ServerIdConfig.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -150,6 +150,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\RandomnessSecure' => __DIR__ . '/..' . '/../lib/SetupChecks/RandomnessSecure.php',
         'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ReadOnlyConfig.php',
         'OCA\\Settings\\SetupChecks\\RepairSanitizeSystemTagsAvailable' => __DIR__ . '/..' . '/../lib/SetupChecks/RepairSanitizeSystemTagsAvailable.php',
+        'OCA\\Settings\\SetupChecks\\S3SseCEncryption' => __DIR__ . '/..' . '/../lib/SetupChecks/S3SseCEncryption.php',
         'OCA\\Settings\\SetupChecks\\SchedulingTableSize' => __DIR__ . '/..' . '/../lib/SetupChecks/SchedulingTableSize.php',
         'OCA\\Settings\\SetupChecks\\SecurityHeaders' => __DIR__ . '/..' . '/../lib/SetupChecks/SecurityHeaders.php',
         'OCA\\Settings\\SetupChecks\\ServerIdConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ServerIdConfig.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -69,6 +69,7 @@ use OCA\Settings\SetupChecks\PushService;
 use OCA\Settings\SetupChecks\RandomnessSecure;
 use OCA\Settings\SetupChecks\ReadOnlyConfig;
 use OCA\Settings\SetupChecks\RepairSanitizeSystemTagsAvailable;
+use OCA\Settings\SetupChecks\S3SseCEncryption;
 use OCA\Settings\SetupChecks\SchedulingTableSize;
 use OCA\Settings\SetupChecks\SecurityHeaders;
 use OCA\Settings\SetupChecks\ServerIdConfig;
@@ -212,6 +213,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(RandomnessSecure::class);
 		$context->registerSetupCheck(ReadOnlyConfig::class);
 		$context->registerSetupCheck(RepairSanitizeSystemTagsAvailable::class);
+		$context->registerSetupCheck(S3SseCEncryption::class);
 		$context->registerSetupCheck(SecurityHeaders::class);
 		$context->registerSetupCheck(ServerIdConfig::class);
 		$context->registerSetupCheck(SchedulingTableSize::class);

--- a/apps/settings/lib/SetupChecks/S3SseCEncryption.php
+++ b/apps/settings/lib/SetupChecks/S3SseCEncryption.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+/**
+ * Warns when the primary or multibucket S3 object store is configured to use SSE-C
+ * (customer-provided key) server-side encryption, deprecated since Nextcloud 34.
+ *
+ * Not to be confused with LegacySSEKeyFormat, which checks Nextcloud's own
+ * server-side-encryption app's legacy key file format and is unrelated to S3.
+ */
+class S3SseCEncryption implements ISetupCheck {
+	public function __construct(
+		private IL10N $l10n,
+		private IConfig $config,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l10n->t('S3 SSE-C encryption');
+	}
+
+	#[\Override]
+	public function getCategory(): string {
+		return 'security';
+	}
+
+	/**
+	 * @param array $arguments the 'arguments' of an 'objectstore'/'objectstore_multibucket' config
+	 */
+	private function isSseCInEffect(array $arguments): bool {
+		$sse = $arguments['sse'] ?? '';
+		if ($sse !== '') {
+			return $sse === 'sse-c';
+		}
+
+		// No explicit 'sse' argument: matches the precedence in
+		// OC\Files\ObjectStore\S3ConnectionTrait::parseEncryptionParams() -- the legacy
+		// 'sse_c_key' argument wins over 'sse_kms_enabled' whenever both are set.
+		return !empty($arguments['sse_c_key']);
+	}
+
+	#[\Override]
+	public function run(): SetupResult {
+		foreach (['objectstore', 'objectstore_multibucket'] as $key) {
+			$objectStore = $this->config->getSystemValue($key, null);
+			if (!is_array($objectStore) || ($objectStore['class'] ?? null) !== 'OC\\Files\\ObjectStore\\S3') {
+				continue;
+			}
+
+			if ($this->isSseCInEffect($objectStore['arguments'] ?? [])) {
+				return SetupResult::warning(
+					$this->l10n->t('This instance uses S3 SSE-C (customer-provided key) encryption, deprecated since Nextcloud 34: Amazon S3 disabled SSE-C by default for new buckets in April 2026. Migrate to SSE-KMS instead.'),
+					$this->urlGenerator->linkToDocs('admin-s3-sse-c'),
+				);
+			}
+		}
+
+		return SetupResult::success($this->l10n->t('No deprecated S3 SSE-C encryption configuration found.'));
+	}
+}

--- a/apps/settings/tests/SetupChecks/S3SseCEncryptionTest.php
+++ b/apps/settings/tests/SetupChecks/S3SseCEncryptionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\Tests\SetupChecks;
+
+use OCA\Settings\SetupChecks\S3SseCEncryption;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\SetupResult;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class S3SseCEncryptionTest extends TestCase {
+	private IL10N&MockObject $l10n;
+	private IConfig&MockObject $config;
+	private IURLGenerator&MockObject $urlGenerator;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')
+			->willReturnCallback(function ($message, array $replace = []) {
+				return vsprintf($message, $replace);
+			});
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+	}
+
+	public static function dataRun(): array {
+		$s3 = static fn (array $arguments): array => ['class' => 'OC\\Files\\ObjectStore\\S3', 'arguments' => $arguments];
+
+		return [
+			'no objectstore configured' => [null, null, SetupResult::SUCCESS],
+			'non-S3 objectstore class' => [['class' => 'OC\\Files\\ObjectStore\\Swift', 'arguments' => ['sse_c_key' => 'x']], null, SetupResult::SUCCESS],
+			'S3 with no sse* arguments' => [$s3([]), null, SetupResult::SUCCESS],
+			'S3 with sse-kms' => [$s3(['sse' => 'sse-kms']), null, SetupResult::SUCCESS],
+			'S3 with sse-kms-dsse' => [$s3(['sse' => 'sse-kms-dsse']), null, SetupResult::SUCCESS],
+			'S3 with legacy sse_c_key only' => [$s3(['sse_c_key' => 'x']), null, SetupResult::WARNING],
+			'S3 with explicit sse => sse-c' => [$s3(['sse' => 'sse-c', 'sse_c_key' => 'x']), null, SetupResult::WARNING],
+			'S3 with both legacy keys set (sse_c_key wins by precedence)' => [$s3(['sse_c_key' => 'x', 'sse_kms_enabled' => true]), null, SetupResult::WARNING],
+			'S3 with explicit sse overriding legacy sse_c_key' => [$s3(['sse' => 'sse-kms', 'sse_c_key' => 'x']), null, SetupResult::SUCCESS],
+			'multibucket S3 with legacy sse_c_key only' => [null, $s3(['sse_c_key' => 'x']), SetupResult::WARNING],
+			'multibucket S3 with sse-kms' => [null, $s3(['sse' => 'sse-kms']), SetupResult::SUCCESS],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRun')]
+	public function testRun(?array $objectStore, ?array $objectStoreMultibucket, string $expected): void {
+		$this->urlGenerator->method('linkToDocs')->willReturn('admin-s3-sse-c');
+
+		$this->config->method('getSystemValue')
+			->willReturnCallback(function (string $key, $default = null) use ($objectStore, $objectStoreMultibucket) {
+				return match ($key) {
+					'objectstore' => $objectStore ?? $default,
+					'objectstore_multibucket' => $objectStoreMultibucket ?? $default,
+					default => $default,
+				};
+			});
+
+		$check = new S3SseCEncryption($this->l10n, $this->config, $this->urlGenerator);
+
+		$result = $check->run();
+		$this->assertEquals($expected, $result->getSeverity());
+	}
+}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2116,6 +2116,31 @@ $CONFIG = [
 			// using Amazon S3 (or any other implementation that supports it) we recommend enabling it by using "when_supported".
 			'request_checksum_calculation' => 'when_required',
 			'response_checksum_validation' => 'when_required',
+			// optional: Server-side encryption of objects at rest.
+			// Valid values are:
+			//  - '' (default): no server-side encryption requested by Nextcloud
+			//  - 'sse-s3': S3-managed AES256 key
+			//  - 'sse-c': customer-provided key, see 'sse_c_key' below
+			//  - 'sse-kms': single layer of AWS KMS-managed encryption
+			//  - 'sse-kms-dsse': dual layer of AWS KMS-managed encryption (DSSE-KMS), higher cost
+			//    and latency than 'sse-kms' but required by some compliance standards
+			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
+			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingDSSEncryption.html
+			'sse' => '',
+			// optional: customer-provided key for 'sse' => 'sse-c', base64 encoded
+			'sse_c_key' => '',
+			// optional: ARN of the AWS KMS key to use for 'sse-kms' / 'sse-kms-dsse'.
+			// If omitted, the bucket's default KMS key (or the AWS-managed 'aws/s3' key) is used.
+			// The key must be a symmetric key in the same AWS region as the bucket.
+			'sse_kms_key_id' => '',
+			// optional: 'sse-kms' / 'sse-kms-dsse' only. Additional AWS KMS encryption context,
+			// e.g. to scope key usage to a tenant via a matching kms:EncryptionContext condition
+			// on the key policy. This is stored alongside the object and visible in AWS CloudTrail,
+			// so it must not contain secrets.
+			'sse_kms_encryption_context' => [],
+			// optional: 'sse-kms' only, not supported for 'sse-kms-dsse'. Enables S3 Bucket Keys,
+			// which can reduce AWS KMS request costs by up to 99% for SSE-KMS.
+			'sse_kms_bucket_key' => false,
 		],
 	],
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2120,14 +2120,16 @@ $CONFIG = [
 			// Valid values are:
 			//  - '' (default): no server-side encryption requested by Nextcloud
 			//  - 'sse-s3': S3-managed AES256 key
-			//  - 'sse-c': customer-provided key, see 'sse_c_key' below
+			//  - 'sse-c': customer-provided key, see 'sse_c_key' below (deprecated, see below)
 			//  - 'sse-kms': single layer of AWS KMS-managed encryption
 			//  - 'sse-kms-dsse': dual layer of AWS KMS-managed encryption (DSSE-KMS), higher cost
 			//    and latency than 'sse-kms' but required by some compliance standards
 			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
 			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingDSSEncryption.html
 			'sse' => '',
-			// optional: customer-provided key for 'sse' => 'sse-c', base64 encoded
+			// optional: customer-provided key for 'sse' => 'sse-c', base64 encoded.
+			// Deprecated since Nextcloud 34: Amazon S3 disabled SSE-C by default for new
+			// buckets in April 2026. Use 'sse' => 'sse-kms' or 'sse-kms-dsse' instead.
 			'sse_c_key' => '',
 			// optional: ARN of the AWS KMS key to use for 'sse-kms' / 'sse-kms-dsse'.
 			// If omitted, the bucket's default KMS key (or the AWS-managed 'aws/s3' key) is used.

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2159,6 +2159,31 @@ $CONFIG = [
 			// using Amazon S3 (or any other implementation that supports it) we recommend enabling it by using "when_supported".
 			'request_checksum_calculation' => 'when_required',
 			'response_checksum_validation' => 'when_required',
+			// optional: Server-side encryption of objects at rest.
+			// Valid values are:
+			//  - '' (default): no server-side encryption requested by Nextcloud
+			//  - 'sse-s3': S3-managed AES256 key
+			//  - 'sse-c': customer-provided key, see 'sse_c_key' below
+			//  - 'sse-kms': single layer of AWS KMS-managed encryption
+			//  - 'sse-kms-dsse': dual layer of AWS KMS-managed encryption (DSSE-KMS), higher cost
+			//    and latency than 'sse-kms' but required by some compliance standards
+			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
+			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingDSSEncryption.html
+			'sse' => '',
+			// optional: customer-provided key for 'sse' => 'sse-c', base64 encoded
+			'sse_c_key' => '',
+			// optional: ARN of the AWS KMS key to use for 'sse-kms' / 'sse-kms-dsse'.
+			// If omitted, the bucket's default KMS key (or the AWS-managed 'aws/s3' key) is used.
+			// The key must be a symmetric key in the same AWS region as the bucket.
+			'sse_kms_key_id' => '',
+			// optional: 'sse-kms' / 'sse-kms-dsse' only. Additional AWS KMS encryption context,
+			// e.g. to scope key usage to a tenant via a matching kms:EncryptionContext condition
+			// on the key policy. This is stored alongside the object and visible in AWS CloudTrail,
+			// so it must not contain secrets.
+			'sse_kms_encryption_context' => [],
+			// optional: 'sse-kms' only, not supported for 'sse-kms-dsse'. Enables S3 Bucket Keys,
+			// which can reduce AWS KMS request costs by up to 99% for SSE-KMS.
+			'sse_kms_bucket_key' => false,
 		],
 	],
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2163,14 +2163,16 @@ $CONFIG = [
 			// Valid values are:
 			//  - '' (default): no server-side encryption requested by Nextcloud
 			//  - 'sse-s3': S3-managed AES256 key
-			//  - 'sse-c': customer-provided key, see 'sse_c_key' below
+			//  - 'sse-c': customer-provided key, see 'sse_c_key' below (deprecated, see below)
 			//  - 'sse-kms': single layer of AWS KMS-managed encryption
 			//  - 'sse-kms-dsse': dual layer of AWS KMS-managed encryption (DSSE-KMS), higher cost
 			//    and latency than 'sse-kms' but required by some compliance standards
 			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
 			// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingDSSEncryption.html
 			'sse' => '',
-			// optional: customer-provided key for 'sse' => 'sse-c', base64 encoded
+			// optional: customer-provided key for 'sse' => 'sse-c', base64 encoded.
+			// Deprecated since Nextcloud 34: Amazon S3 disabled SSE-C by default for new
+			// buckets in April 2026. Use 'sse' => 'sse-kms' or 'sse-kms-dsse' instead.
 			'sse_c_key' => '',
 			// optional: ARN of the AWS KMS key to use for 'sse-kms' / 'sse-kms-dsse'.
 			// If omitted, the bucket's default KMS key (or the AWS-managed 'aws/s3' key) is used.

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1889,6 +1889,7 @@ return array(
     'OC\\Files\\ObjectStore\\S3' => $baseDir . '/lib/private/Files/ObjectStore/S3.php',
     'OC\\Files\\ObjectStore\\S3ConfigTrait' => $baseDir . '/lib/private/Files/ObjectStore/S3ConfigTrait.php',
     'OC\\Files\\ObjectStore\\S3ConnectionTrait' => $baseDir . '/lib/private/Files/ObjectStore/S3ConnectionTrait.php',
+    'OC\\Files\\ObjectStore\\S3EncryptionMode' => $baseDir . '/lib/private/Files/ObjectStore/S3EncryptionMode.php',
     'OC\\Files\\ObjectStore\\S3ObjectTrait' => $baseDir . '/lib/private/Files/ObjectStore/S3ObjectTrait.php',
     'OC\\Files\\ObjectStore\\S3Signature' => $baseDir . '/lib/private/Files/ObjectStore/S3Signature.php',
     'OC\\Files\\ObjectStore\\StorageObjectStore' => $baseDir . '/lib/private/Files/ObjectStore/StorageObjectStore.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1944,6 +1944,7 @@ return array(
     'OC\\Files\\ObjectStore\\S3' => $baseDir . '/lib/private/Files/ObjectStore/S3.php',
     'OC\\Files\\ObjectStore\\S3ConfigTrait' => $baseDir . '/lib/private/Files/ObjectStore/S3ConfigTrait.php',
     'OC\\Files\\ObjectStore\\S3ConnectionTrait' => $baseDir . '/lib/private/Files/ObjectStore/S3ConnectionTrait.php',
+    'OC\\Files\\ObjectStore\\S3EncryptionMode' => $baseDir . '/lib/private/Files/ObjectStore/S3EncryptionMode.php',
     'OC\\Files\\ObjectStore\\S3ObjectTrait' => $baseDir . '/lib/private/Files/ObjectStore/S3ObjectTrait.php',
     'OC\\Files\\ObjectStore\\S3Signature' => $baseDir . '/lib/private/Files/ObjectStore/S3Signature.php',
     'OC\\Files\\ObjectStore\\StorageObjectStore' => $baseDir . '/lib/private/Files/ObjectStore/StorageObjectStore.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1930,6 +1930,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Files\\ObjectStore\\S3' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3.php',
         'OC\\Files\\ObjectStore\\S3ConfigTrait' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3ConfigTrait.php',
         'OC\\Files\\ObjectStore\\S3ConnectionTrait' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3ConnectionTrait.php',
+        'OC\\Files\\ObjectStore\\S3EncryptionMode' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3EncryptionMode.php',
         'OC\\Files\\ObjectStore\\S3ObjectTrait' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3ObjectTrait.php',
         'OC\\Files\\ObjectStore\\S3Signature' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3Signature.php',
         'OC\\Files\\ObjectStore\\StorageObjectStore' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/StorageObjectStore.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1985,6 +1985,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Files\\ObjectStore\\S3' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3.php',
         'OC\\Files\\ObjectStore\\S3ConfigTrait' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3ConfigTrait.php',
         'OC\\Files\\ObjectStore\\S3ConnectionTrait' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3ConnectionTrait.php',
+        'OC\\Files\\ObjectStore\\S3EncryptionMode' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3EncryptionMode.php',
         'OC\\Files\\ObjectStore\\S3ObjectTrait' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3ObjectTrait.php',
         'OC\\Files\\ObjectStore\\S3Signature' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3Signature.php',
         'OC\\Files\\ObjectStore\\StorageObjectStore' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/StorageObjectStore.php',

--- a/lib/private/Files/ObjectStore/S3ConfigTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConfigTrait.php
@@ -50,4 +50,7 @@ trait S3ConfigTrait {
 	protected ?string $sseKmsEncryptionContext = null;
 
 	protected bool $sseKmsBucketKey = false;
+
+	/** @var string[] Non-fatal `sse*` configuration issues found by parseEncryptionParams(), logged by logEncryptionWarnings() */
+	protected array $encryptionWarnings = [];
 }

--- a/lib/private/Files/ObjectStore/S3ConfigTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConfigTrait.php
@@ -41,4 +41,13 @@ trait S3ConfigTrait {
 	private bool $useMultipartCopy = true;
 
 	protected int $retriesMaxAttempts;
+
+	protected S3EncryptionMode $sseMode = S3EncryptionMode::None;
+
+	protected ?string $sseKmsKeyId = null;
+
+	/** Already base64-encoded JSON, ready to hand to the AWS SDK */
+	protected ?string $sseKmsEncryptionContext = null;
+
+	protected bool $sseKmsBucketKey = false;
 }

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -38,6 +38,9 @@ trait S3ConnectionTrait {
 	private ?ICache $existingBucketsCache = null;
 	private bool $usePresignedUrl = false;
 
+	/** @var array<string, true> Deduplicates encryption warnings across instances/calls, keyed by message */
+	private static array $loggedEncryptionWarnings = [];
+
 	protected function parseParams($params) {
 		if (empty($params['bucket'])) {
 			throw new \Exception('Bucket has to be configured.');
@@ -96,6 +99,8 @@ trait S3ConnectionTrait {
 		if ($this->connection !== null) {
 			return $this->connection;
 		}
+
+		$this->logEncryptionWarnings();
 
 		if ($this->existingBucketsCache === null) {
 			$this->existingBucketsCache = Server::get(ICacheFactory::class)
@@ -341,14 +346,19 @@ trait S3ConnectionTrait {
 	 * Resolve and validate the `sse*` objectstore arguments into `$this->sseMode` and friends.
 	 *
 	 * `sse_c_key` and `sse_kms_enabled` are kept as deprecated aliases for `sse` set to
-	 * `sse-c` / `sse-kms` respectively, so existing configurations keep working unchanged.
-	 * Conflicting combinations are rejected rather than silently resolved, since a config
-	 * that requests one encryption mode but silently gets another (or none) is worse than
-	 * a startup error.
+	 * `sse-c` / `sse-kms` respectively, so existing configurations keep working unchanged. An
+	 * explicit `sse` always wins over both. If neither is set and both deprecated keys are,
+	 * `sse_c_key` (SSE-C) takes precedence, matching the behaviour Nextcloud 34 shipped with.
 	 *
-	 * @throws \Exception on invalid or conflicting `sse*` configuration
+	 * Configuration that can be deterministically resolved never blocks boot: it is instead
+	 * recorded in `$this->encryptionWarnings` for `logEncryptionWarnings()` to log once a
+	 * connection is actually made. Only configuration with no reasonable resolution throws.
+	 *
+	 * @throws \Exception on `sse*` configuration with no reasonable resolution
 	 */
 	private function parseEncryptionParams(array $params): void {
+		$this->encryptionWarnings = [];
+
 		$explicitMode = null;
 		if (isset($params['sse']) && $params['sse'] !== '') {
 			$explicitMode = S3EncryptionMode::tryFrom($params['sse']);
@@ -364,39 +374,51 @@ trait S3ConnectionTrait {
 		$hasLegacySseC = !empty($params['sse_c_key']);
 		$hasLegacySseKms = !empty($params['sse_kms_enabled']);
 
-		if ($hasLegacySseC && $hasLegacySseKms) {
-			throw new \Exception("The 'sse_c_key' and 'sse_kms_enabled' objectstore arguments are mutually exclusive, use the 'sse' argument to select a single encryption mode.");
-		}
-
 		if ($explicitMode !== null) {
-			if ($hasLegacySseC && $explicitMode !== S3EncryptionMode::SseC) {
-				throw new \Exception("The 'sse_c_key' objectstore argument requires 'sse' to be 'sse-c' (or unset).");
-			}
-			if ($hasLegacySseKms && !$explicitMode->isKms()) {
-				throw new \Exception("The 'sse_kms_enabled' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse' (or unset).");
-			}
 			$mode = $explicitMode;
-		} elseif ($hasLegacySseC) {
-			$mode = S3EncryptionMode::SseC;
-		} elseif ($hasLegacySseKms) {
-			$mode = S3EncryptionMode::SseKms;
+			if ($hasLegacySseC && $mode !== S3EncryptionMode::SseC) {
+				$this->encryptionWarnings[] = "Ignoring the 'sse_c_key' objectstore argument: 'sse' is explicitly set to '{$mode->value}'.";
+			}
+			if ($hasLegacySseKms && !$mode->isKms()) {
+				$this->encryptionWarnings[] = "Ignoring the 'sse_kms_enabled' objectstore argument: 'sse' is explicitly set to '{$mode->value}'.";
+			}
+		} elseif ($hasLegacySseC || $hasLegacySseKms) {
+			if ($hasLegacySseC && $hasLegacySseKms) {
+				// This is the Nextcloud 34 behaviour: SSE-C silently took precedence over
+				// SSE-KMS whenever both were configured. Kept for backward compatibility,
+				// but no longer silent.
+				$this->encryptionWarnings[] = "Both 'sse_c_key' and 'sse_kms_enabled' are set; 'sse_c_key' (SSE-C) takes precedence, as it did in Nextcloud 34. Set the 'sse' objectstore argument to select a single encryption mode explicitly.";
+			}
+			$mode = $hasLegacySseC ? S3EncryptionMode::SseC : S3EncryptionMode::SseKms;
+			$deprecatedKey = $hasLegacySseC ? 'sse_c_key' : 'sse_kms_enabled';
+			$this->encryptionWarnings[] = "The '{$deprecatedKey}' objectstore argument is deprecated, use 'sse' => '{$mode->value}' instead.";
 		} else {
 			$mode = S3EncryptionMode::None;
+		}
+
+		if ($mode === S3EncryptionMode::SseC) {
+			// SSE-C is a supported mode, not merely a deprecated way to reach one, so this
+			// warning is intentionally emitted regardless of how 'sse-c' was selected.
+			$this->encryptionWarnings[] = "SSE-C ('sse' => 'sse-c') requires you to manage and distribute the encryption key yourself. Consider 'sse' => 'sse-kms' or 'sse-kms-dsse' instead, which let AWS KMS manage the key.";
+			if (empty($params['sse_c_key'])) {
+				// Unlike a merely redundant option, this cannot be resolved: silently falling
+				// back to no encryption would defeat an explicit request for SSE-C.
+				throw new \Exception("The 'sse' objectstore argument is set to 'sse-c' but no 'sse_c_key' is configured.");
+			}
 		}
 
 		$this->sseMode = $mode;
 
 		$keyId = (isset($params['sse_kms_key_id']) && $params['sse_kms_key_id'] !== '') ? (string)$params['sse_kms_key_id'] : null;
 		if ($keyId !== null && !$mode->isKms()) {
-			throw new \Exception("The 'sse_kms_key_id' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
+			$this->encryptionWarnings[] = "Ignoring the 'sse_kms_key_id' objectstore argument: it only applies when 'sse' is 'sse-kms' or 'sse-kms-dsse'.";
+			$keyId = null;
 		}
 		$this->sseKmsKeyId = $keyId;
 
 		$context = $params['sse_kms_encryption_context'] ?? null;
 		if ($context !== null) {
-			if (!$mode->isKms()) {
-				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
-			}
+			// A structurally invalid context can never be resolved, regardless of mode.
 			if (!is_array($context)) {
 				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
 			}
@@ -405,19 +427,47 @@ trait S3ConnectionTrait {
 					throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
 				}
 			}
-			$this->sseKmsEncryptionContext = base64_encode(json_encode($context, JSON_THROW_ON_ERROR));
-		} else {
-			$this->sseKmsEncryptionContext = null;
+			if (!$mode->isKms()) {
+				$this->encryptionWarnings[] = "Ignoring the 'sse_kms_encryption_context' objectstore argument: it only applies when 'sse' is 'sse-kms' or 'sse-kms-dsse'.";
+				$context = null;
+			}
 		}
+		$this->sseKmsEncryptionContext = $context !== null ? base64_encode(json_encode($context, JSON_THROW_ON_ERROR)) : null;
 
 		$bucketKey = (bool)($params['sse_kms_bucket_key'] ?? false);
 		if ($bucketKey && $mode !== S3EncryptionMode::SseKms) {
+			// Merely redundant, not impossible: verified against a real bucket that S3
+			// accepts BucketKeyEnabled alongside 'aws:kms:dsse' and simply does not apply
+			// it (HeadObject afterwards shows no BucketKeyEnabled), rather than rejecting
+			// the request outright, despite AWS's own documentation describing S3 Bucket
+			// Keys as unsupported for DSSE-KMS.
 			$reason = $mode === S3EncryptionMode::SseKmsDsse
-				? "S3 Bucket Keys are not supported for DSSE-KMS ('sse' => 'sse-kms-dsse')"
-				: "'sse_kms_bucket_key' requires 'sse' to be 'sse-kms'";
-			throw new \Exception("The 'sse_kms_bucket_key' objectstore argument cannot be enabled: {$reason}.");
+				? "S3 Bucket Keys are not applied for DSSE-KMS ('sse' => 'sse-kms-dsse')"
+				: "it only applies when 'sse' is 'sse-kms'";
+			$this->encryptionWarnings[] = "Ignoring the 'sse_kms_bucket_key' objectstore argument: {$reason}.";
+			$bucketKey = false;
 		}
 		$this->sseKmsBucketKey = $bucketKey;
+	}
+
+	/**
+	 * Log any warnings recorded by `parseEncryptionParams()`, once a connection is actually
+	 * made, deduplicated by message so a long-lived request/worker doesn't repeat the same
+	 * warning on every call.
+	 */
+	private function logEncryptionWarnings(): void {
+		if ($this->encryptionWarnings === []) {
+			return;
+		}
+
+		$logger = Server::get(LoggerInterface::class);
+		foreach ($this->encryptionWarnings as $warning) {
+			if (isset(self::$loggedEncryptionWarnings[$warning])) {
+				continue;
+			}
+			self::$loggedEncryptionWarnings[$warning] = true;
+			$logger->warning($warning, ['app' => 'objectstore']);
+		}
 	}
 
 	/**

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -397,9 +397,12 @@ trait S3ConnectionTrait {
 		}
 
 		if ($mode === S3EncryptionMode::SseC) {
-			// SSE-C is a supported mode, not merely a deprecated way to reach one, so this
-			// warning is intentionally emitted regardless of how 'sse-c' was selected.
-			$this->encryptionWarnings[] = "SSE-C ('sse' => 'sse-c') requires you to manage and distribute the encryption key yourself. Consider 'sse' => 'sse-kms' or 'sse-kms-dsse' instead, which let AWS KMS manage the key.";
+			// SSE-C itself is deprecated since Nextcloud 34, not just the legacy 'sse_c_key'
+			// argument shape, so this warning is emitted regardless of how 'sse-c' was
+			// selected. Amazon S3 disabled SSE-C by default for new buckets in April 2026
+			// (https://aws.amazon.com/blogs/storage/advanced-notice-amazon-s3-to-disable-the-use-of-sse-c-encryption-by-default-for-all-new-buckets-and-select-existing-buckets-in-april-2026/),
+			// which is why this also requires managing and distributing the key yourself.
+			$this->encryptionWarnings[] = "SSE-C ('sse' => 'sse-c') is deprecated since Nextcloud 34: Amazon S3 disabled SSE-C by default for new buckets in April 2026, and it requires you to manage the encryption key yourself. Use 'sse' => 'sse-kms' or 'sse-kms-dsse' instead, which let AWS KMS manage the key.";
 			if (empty($params['sse_c_key'])) {
 				// Unlike a merely redundant option, this cannot be resolved: silently falling
 				// back to no encryption would defeat an explicit request for SSE-C.

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -62,6 +62,7 @@ trait S3ConnectionTrait {
 		$this->copySizeLimit = $params['copySizeLimit'] ?? 5242880000;
 		$this->useMultipartCopy = (bool)($params['useMultipartCopy'] ?? true);
 		$this->retriesMaxAttempts = $params['retriesMaxAttempts'] ?? 5;
+		$this->parseEncryptionParams($params);
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.' . $params['region'] . '.amazonaws.com' : $params['hostname'];
 		$params['s3-accelerate'] = $params['hostname'] === 's3-accelerate.amazonaws.com' || $params['hostname'] === 's3-accelerate.dualstack.amazonaws.com';
@@ -337,77 +338,129 @@ trait S3ConnectionTrait {
 	}
 
 	/**
-	 * Get SSE-KMS key ID from configuration
-	 * @return string|null KMS key ARN/ID or null for bucket default key
+	 * Resolve and validate the `sse*` objectstore arguments into `$this->sseMode` and friends.
+	 *
+	 * `sse_c_key` and `sse_kms_enabled` are kept as deprecated aliases for `sse` set to
+	 * `sse-c` / `sse-kms` respectively, so existing configurations keep working unchanged.
+	 * Conflicting combinations are rejected rather than silently resolved, since a config
+	 * that requests one encryption mode but silently gets another (or none) is worse than
+	 * a startup error.
+	 *
+	 * @throws \Exception on invalid or conflicting `sse*` configuration
 	 */
-	protected function getSSEKMSKeyId(): ?string {
-		if (isset($this->params['sse_kms_key_id']) && !empty($this->params['sse_kms_key_id'])) {
-			return $this->params['sse_kms_key_id'];
+	private function parseEncryptionParams(array $params): void {
+		$explicitMode = null;
+		if (isset($params['sse']) && $params['sse'] !== '') {
+			$explicitMode = S3EncryptionMode::tryFrom($params['sse']);
+			if ($explicitMode === null) {
+				$valid = implode(', ', array_map(
+					static fn (S3EncryptionMode $mode): string => "'{$mode->value}'",
+					array_filter(S3EncryptionMode::cases(), static fn (S3EncryptionMode $mode): bool => $mode !== S3EncryptionMode::None)
+				));
+				throw new \Exception("Invalid 'sse' objectstore argument '{$params['sse']}', expected one of: {$valid}.");
+			}
 		}
-		return null;
+
+		$hasLegacySseC = !empty($params['sse_c_key']);
+		$hasLegacySseKms = !empty($params['sse_kms_enabled']);
+
+		if ($hasLegacySseC && $hasLegacySseKms) {
+			throw new \Exception("The 'sse_c_key' and 'sse_kms_enabled' objectstore arguments are mutually exclusive, use the 'sse' argument to select a single encryption mode.");
+		}
+
+		if ($explicitMode !== null) {
+			if ($hasLegacySseC && $explicitMode !== S3EncryptionMode::SseC) {
+				throw new \Exception("The 'sse_c_key' objectstore argument requires 'sse' to be 'sse-c' (or unset).");
+			}
+			if ($hasLegacySseKms && !$explicitMode->isKms()) {
+				throw new \Exception("The 'sse_kms_enabled' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse' (or unset).");
+			}
+			$mode = $explicitMode;
+		} elseif ($hasLegacySseC) {
+			$mode = S3EncryptionMode::SseC;
+		} elseif ($hasLegacySseKms) {
+			$mode = S3EncryptionMode::SseKms;
+		} else {
+			$mode = S3EncryptionMode::None;
+		}
+
+		$this->sseMode = $mode;
+
+		$keyId = (isset($params['sse_kms_key_id']) && $params['sse_kms_key_id'] !== '') ? (string)$params['sse_kms_key_id'] : null;
+		if ($keyId !== null && !$mode->isKms()) {
+			throw new \Exception("The 'sse_kms_key_id' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
+		}
+		$this->sseKmsKeyId = $keyId;
+
+		$context = $params['sse_kms_encryption_context'] ?? null;
+		if ($context !== null) {
+			if (!$mode->isKms()) {
+				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
+			}
+			if (!is_array($context)) {
+				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
+			}
+			foreach ($context as $contextKey => $contextValue) {
+				if (!is_string($contextKey) || !is_string($contextValue)) {
+					throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
+				}
+			}
+			$this->sseKmsEncryptionContext = base64_encode(json_encode($context, JSON_THROW_ON_ERROR));
+		} else {
+			$this->sseKmsEncryptionContext = null;
+		}
+
+		$bucketKey = (bool)($params['sse_kms_bucket_key'] ?? false);
+		if ($bucketKey && $mode !== S3EncryptionMode::SseKms) {
+			$reason = $mode === S3EncryptionMode::SseKmsDsse
+				? "S3 Bucket Keys are not supported for DSSE-KMS ('sse' => 'sse-kms-dsse')"
+				: "'sse_kms_bucket_key' requires 'sse' to be 'sse-kms'";
+			throw new \Exception("The 'sse_kms_bucket_key' objectstore argument cannot be enabled: {$reason}.");
+		}
+		$this->sseKmsBucketKey = $bucketKey;
 	}
 
 	/**
-	 * Check if SSE-KMS is enabled
-	 * @return bool
-	 */
-	protected function isSSEKMSEnabled(): bool {
-		return !empty($this->params['sse_kms_enabled']) && $this->params['sse_kms_enabled'] === true;
-	}
-
-	/**
-	 * Get SSE-KMS parameters for S3 operations
+	 * Get SSE-KMS / DSSE-KMS parameters for S3 operations.
 	 *
-	 * When SSE-KMS is enabled, AWS S3 encrypts objects server-side using
-	 * AWS Key Management Service (KMS) keys. This provides:
-	 * - Centralized key management via AWS KMS
-	 * - Audit trail of key usage
-	 * - No client-side encryption overhead
-	 * - Automatic key rotation support
-	 *
-	 * @param bool $copy Whether this is for a copy operation (unused for KMS)
 	 * @return array Parameters to merge into S3 API calls
 	 */
-	protected function getSSEKMSParameters(bool $copy = false): array {
-		if (!$this->isSSEKMSEnabled()) {
-			return [];
-		}
-
+	private function getSSEKMSParameters(): array {
 		$params = [
-			'ServerSideEncryption' => 'aws:kms',
+			'ServerSideEncryption' => $this->sseMode === S3EncryptionMode::SseKmsDsse ? 'aws:kms:dsse' : 'aws:kms',
 		];
 
-		// Add specific KMS key if configured, otherwise use bucket default key
-		$keyId = $this->getSSEKMSKeyId();
-		if ($keyId !== null) {
-			$params['SSEKMSKeyId'] = $keyId;
+		// Add specific KMS key if configured, otherwise use the bucket default key
+		if ($this->sseKmsKeyId !== null) {
+			$params['SSEKMSKeyId'] = $this->sseKmsKeyId;
 		}
 
-		// Note: For copy operations, S3 re-encrypts with the destination key
-		// No special source parameters needed (unlike SSE-C)
+		if ($this->sseKmsEncryptionContext !== null) {
+			$params['SSEKMSEncryptionContext'] = $this->sseKmsEncryptionContext;
+		}
+
+		if ($this->sseKmsBucketKey) {
+			$params['BucketKeyEnabled'] = true;
+		}
 
 		return $params;
 	}
 
 	/**
-	 * Get unified server-side encryption parameters
+	 * Get server-side encryption parameters for S3 operations, for whichever `sse` mode is configured.
 	 *
-	 * Supports both SSE-C (customer-provided keys) and SSE-KMS (AWS-managed keys).
-	 * SSE-C takes precedence if both are configured (for backward compatibility
-	 * during migration from SSE-C to SSE-KMS).
-	 *
-	 * @param bool $copy Whether this is for a copy operation
+	 * @param bool $copy Whether this is for a copy operation (only relevant for SSE-C)
 	 * @return array Encryption parameters to merge into S3 API calls
 	 */
 	protected function getServerSideEncryptionParameters(bool $copy = false): array {
-		// SSE-C takes precedence for backward compatibility during migration
-		$sseC = $this->getSSECParameters($copy);
-		if (!empty($sseC)) {
-			return $sseC;
-		}
-
-		// Fall back to SSE-KMS if enabled
-		return $this->getSSEKMSParameters($copy);
+		return match ($this->sseMode) {
+			S3EncryptionMode::None => [],
+			S3EncryptionMode::SseS3 => ['ServerSideEncryption' => 'AES256'],
+			S3EncryptionMode::SseC => $this->getSSECParameters($copy),
+			// Unlike SSE-C, KMS/DSSE-KMS have no CopySource* variant: on CopyObject these
+			// headers describe the destination object only, so $copy is not needed here.
+			S3EncryptionMode::SseKms, S3EncryptionMode::SseKmsDsse => $this->getSSEKMSParameters(),
+		};
 	}
 
 	public function isUsePresignedUrl(): bool {

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -62,6 +62,7 @@ trait S3ConnectionTrait {
 		$this->copySizeLimit = $params['copySizeLimit'] ?? 5242880000;
 		$this->useMultipartCopy = (bool)($params['useMultipartCopy'] ?? true);
 		$this->retriesMaxAttempts = $params['retriesMaxAttempts'] ?? 5;
+		$this->parseEncryptionParams($params);
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.' . $params['region'] . '.amazonaws.com' : $params['hostname'];
 		$params['key'] = $params['key'] ?? '';
@@ -337,77 +338,129 @@ trait S3ConnectionTrait {
 	}
 
 	/**
-	 * Get SSE-KMS key ID from configuration
-	 * @return string|null KMS key ARN/ID or null for bucket default key
+	 * Resolve and validate the `sse*` objectstore arguments into `$this->sseMode` and friends.
+	 *
+	 * `sse_c_key` and `sse_kms_enabled` are kept as deprecated aliases for `sse` set to
+	 * `sse-c` / `sse-kms` respectively, so existing configurations keep working unchanged.
+	 * Conflicting combinations are rejected rather than silently resolved, since a config
+	 * that requests one encryption mode but silently gets another (or none) is worse than
+	 * a startup error.
+	 *
+	 * @throws \Exception on invalid or conflicting `sse*` configuration
 	 */
-	protected function getSSEKMSKeyId(): ?string {
-		if (isset($this->params['sse_kms_key_id']) && !empty($this->params['sse_kms_key_id'])) {
-			return $this->params['sse_kms_key_id'];
+	private function parseEncryptionParams(array $params): void {
+		$explicitMode = null;
+		if (isset($params['sse']) && $params['sse'] !== '') {
+			$explicitMode = S3EncryptionMode::tryFrom($params['sse']);
+			if ($explicitMode === null) {
+				$valid = implode(', ', array_map(
+					static fn (S3EncryptionMode $mode): string => "'{$mode->value}'",
+					array_filter(S3EncryptionMode::cases(), static fn (S3EncryptionMode $mode): bool => $mode !== S3EncryptionMode::None)
+				));
+				throw new \Exception("Invalid 'sse' objectstore argument '{$params['sse']}', expected one of: {$valid}.");
+			}
 		}
-		return null;
+
+		$hasLegacySseC = !empty($params['sse_c_key']);
+		$hasLegacySseKms = !empty($params['sse_kms_enabled']);
+
+		if ($hasLegacySseC && $hasLegacySseKms) {
+			throw new \Exception("The 'sse_c_key' and 'sse_kms_enabled' objectstore arguments are mutually exclusive, use the 'sse' argument to select a single encryption mode.");
+		}
+
+		if ($explicitMode !== null) {
+			if ($hasLegacySseC && $explicitMode !== S3EncryptionMode::SseC) {
+				throw new \Exception("The 'sse_c_key' objectstore argument requires 'sse' to be 'sse-c' (or unset).");
+			}
+			if ($hasLegacySseKms && !$explicitMode->isKms()) {
+				throw new \Exception("The 'sse_kms_enabled' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse' (or unset).");
+			}
+			$mode = $explicitMode;
+		} elseif ($hasLegacySseC) {
+			$mode = S3EncryptionMode::SseC;
+		} elseif ($hasLegacySseKms) {
+			$mode = S3EncryptionMode::SseKms;
+		} else {
+			$mode = S3EncryptionMode::None;
+		}
+
+		$this->sseMode = $mode;
+
+		$keyId = (isset($params['sse_kms_key_id']) && $params['sse_kms_key_id'] !== '') ? (string)$params['sse_kms_key_id'] : null;
+		if ($keyId !== null && !$mode->isKms()) {
+			throw new \Exception("The 'sse_kms_key_id' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
+		}
+		$this->sseKmsKeyId = $keyId;
+
+		$context = $params['sse_kms_encryption_context'] ?? null;
+		if ($context !== null) {
+			if (!$mode->isKms()) {
+				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
+			}
+			if (!is_array($context)) {
+				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
+			}
+			foreach ($context as $contextKey => $contextValue) {
+				if (!is_string($contextKey) || !is_string($contextValue)) {
+					throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
+				}
+			}
+			$this->sseKmsEncryptionContext = base64_encode(json_encode($context, JSON_THROW_ON_ERROR));
+		} else {
+			$this->sseKmsEncryptionContext = null;
+		}
+
+		$bucketKey = (bool)($params['sse_kms_bucket_key'] ?? false);
+		if ($bucketKey && $mode !== S3EncryptionMode::SseKms) {
+			$reason = $mode === S3EncryptionMode::SseKmsDsse
+				? "S3 Bucket Keys are not supported for DSSE-KMS ('sse' => 'sse-kms-dsse')"
+				: "'sse_kms_bucket_key' requires 'sse' to be 'sse-kms'";
+			throw new \Exception("The 'sse_kms_bucket_key' objectstore argument cannot be enabled: {$reason}.");
+		}
+		$this->sseKmsBucketKey = $bucketKey;
 	}
 
 	/**
-	 * Check if SSE-KMS is enabled
-	 * @return bool
-	 */
-	protected function isSSEKMSEnabled(): bool {
-		return !empty($this->params['sse_kms_enabled']) && $this->params['sse_kms_enabled'] === true;
-	}
-
-	/**
-	 * Get SSE-KMS parameters for S3 operations
+	 * Get SSE-KMS / DSSE-KMS parameters for S3 operations.
 	 *
-	 * When SSE-KMS is enabled, AWS S3 encrypts objects server-side using
-	 * AWS Key Management Service (KMS) keys. This provides:
-	 * - Centralized key management via AWS KMS
-	 * - Audit trail of key usage
-	 * - No client-side encryption overhead
-	 * - Automatic key rotation support
-	 *
-	 * @param bool $copy Whether this is for a copy operation (unused for KMS)
 	 * @return array Parameters to merge into S3 API calls
 	 */
-	protected function getSSEKMSParameters(bool $copy = false): array {
-		if (!$this->isSSEKMSEnabled()) {
-			return [];
-		}
-
+	private function getSSEKMSParameters(): array {
 		$params = [
-			'ServerSideEncryption' => 'aws:kms',
+			'ServerSideEncryption' => $this->sseMode === S3EncryptionMode::SseKmsDsse ? 'aws:kms:dsse' : 'aws:kms',
 		];
 
-		// Add specific KMS key if configured, otherwise use bucket default key
-		$keyId = $this->getSSEKMSKeyId();
-		if ($keyId !== null) {
-			$params['SSEKMSKeyId'] = $keyId;
+		// Add specific KMS key if configured, otherwise use the bucket default key
+		if ($this->sseKmsKeyId !== null) {
+			$params['SSEKMSKeyId'] = $this->sseKmsKeyId;
 		}
 
-		// Note: For copy operations, S3 re-encrypts with the destination key
-		// No special source parameters needed (unlike SSE-C)
+		if ($this->sseKmsEncryptionContext !== null) {
+			$params['SSEKMSEncryptionContext'] = $this->sseKmsEncryptionContext;
+		}
+
+		if ($this->sseKmsBucketKey) {
+			$params['BucketKeyEnabled'] = true;
+		}
 
 		return $params;
 	}
 
 	/**
-	 * Get unified server-side encryption parameters
+	 * Get server-side encryption parameters for S3 operations, for whichever `sse` mode is configured.
 	 *
-	 * Supports both SSE-C (customer-provided keys) and SSE-KMS (AWS-managed keys).
-	 * SSE-C takes precedence if both are configured (for backward compatibility
-	 * during migration from SSE-C to SSE-KMS).
-	 *
-	 * @param bool $copy Whether this is for a copy operation
+	 * @param bool $copy Whether this is for a copy operation (only relevant for SSE-C)
 	 * @return array Encryption parameters to merge into S3 API calls
 	 */
 	protected function getServerSideEncryptionParameters(bool $copy = false): array {
-		// SSE-C takes precedence for backward compatibility during migration
-		$sseC = $this->getSSECParameters($copy);
-		if (!empty($sseC)) {
-			return $sseC;
-		}
-
-		// Fall back to SSE-KMS if enabled
-		return $this->getSSEKMSParameters($copy);
+		return match ($this->sseMode) {
+			S3EncryptionMode::None => [],
+			S3EncryptionMode::SseS3 => ['ServerSideEncryption' => 'AES256'],
+			S3EncryptionMode::SseC => $this->getSSECParameters($copy),
+			// Unlike SSE-C, KMS/DSSE-KMS have no CopySource* variant: on CopyObject these
+			// headers describe the destination object only, so $copy is not needed here.
+			S3EncryptionMode::SseKms, S3EncryptionMode::SseKmsDsse => $this->getSSEKMSParameters(),
+		};
 	}
 
 	public function isUsePresignedUrl(): bool {

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -38,6 +38,9 @@ trait S3ConnectionTrait {
 	private ?ICache $existingBucketsCache = null;
 	private bool $usePresignedUrl = false;
 
+	/** @var array<string, true> Deduplicates encryption warnings across instances/calls, keyed by message */
+	private static array $loggedEncryptionWarnings = [];
+
 	protected function parseParams($params) {
 		if (empty($params['bucket'])) {
 			throw new \Exception('Bucket has to be configured.');
@@ -98,6 +101,8 @@ trait S3ConnectionTrait {
 		if ($this->connection !== null) {
 			return $this->connection;
 		}
+
+		$this->logEncryptionWarnings();
 
 		if ($this->existingBucketsCache === null) {
 			$this->existingBucketsCache = Server::get(ICacheFactory::class)
@@ -341,14 +346,19 @@ trait S3ConnectionTrait {
 	 * Resolve and validate the `sse*` objectstore arguments into `$this->sseMode` and friends.
 	 *
 	 * `sse_c_key` and `sse_kms_enabled` are kept as deprecated aliases for `sse` set to
-	 * `sse-c` / `sse-kms` respectively, so existing configurations keep working unchanged.
-	 * Conflicting combinations are rejected rather than silently resolved, since a config
-	 * that requests one encryption mode but silently gets another (or none) is worse than
-	 * a startup error.
+	 * `sse-c` / `sse-kms` respectively, so existing configurations keep working unchanged. An
+	 * explicit `sse` always wins over both. If neither is set and both deprecated keys are,
+	 * `sse_c_key` (SSE-C) takes precedence, matching the behaviour Nextcloud 34 shipped with.
 	 *
-	 * @throws \Exception on invalid or conflicting `sse*` configuration
+	 * Configuration that can be deterministically resolved never blocks boot: it is instead
+	 * recorded in `$this->encryptionWarnings` for `logEncryptionWarnings()` to log once a
+	 * connection is actually made. Only configuration with no reasonable resolution throws.
+	 *
+	 * @throws \Exception on `sse*` configuration with no reasonable resolution
 	 */
 	private function parseEncryptionParams(array $params): void {
+		$this->encryptionWarnings = [];
+
 		$explicitMode = null;
 		if (isset($params['sse']) && $params['sse'] !== '') {
 			$explicitMode = S3EncryptionMode::tryFrom($params['sse']);
@@ -364,39 +374,51 @@ trait S3ConnectionTrait {
 		$hasLegacySseC = !empty($params['sse_c_key']);
 		$hasLegacySseKms = !empty($params['sse_kms_enabled']);
 
-		if ($hasLegacySseC && $hasLegacySseKms) {
-			throw new \Exception("The 'sse_c_key' and 'sse_kms_enabled' objectstore arguments are mutually exclusive, use the 'sse' argument to select a single encryption mode.");
-		}
-
 		if ($explicitMode !== null) {
-			if ($hasLegacySseC && $explicitMode !== S3EncryptionMode::SseC) {
-				throw new \Exception("The 'sse_c_key' objectstore argument requires 'sse' to be 'sse-c' (or unset).");
-			}
-			if ($hasLegacySseKms && !$explicitMode->isKms()) {
-				throw new \Exception("The 'sse_kms_enabled' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse' (or unset).");
-			}
 			$mode = $explicitMode;
-		} elseif ($hasLegacySseC) {
-			$mode = S3EncryptionMode::SseC;
-		} elseif ($hasLegacySseKms) {
-			$mode = S3EncryptionMode::SseKms;
+			if ($hasLegacySseC && $mode !== S3EncryptionMode::SseC) {
+				$this->encryptionWarnings[] = "Ignoring the 'sse_c_key' objectstore argument: 'sse' is explicitly set to '{$mode->value}'.";
+			}
+			if ($hasLegacySseKms && !$mode->isKms()) {
+				$this->encryptionWarnings[] = "Ignoring the 'sse_kms_enabled' objectstore argument: 'sse' is explicitly set to '{$mode->value}'.";
+			}
+		} elseif ($hasLegacySseC || $hasLegacySseKms) {
+			if ($hasLegacySseC && $hasLegacySseKms) {
+				// This is the Nextcloud 34 behaviour: SSE-C silently took precedence over
+				// SSE-KMS whenever both were configured. Kept for backward compatibility,
+				// but no longer silent.
+				$this->encryptionWarnings[] = "Both 'sse_c_key' and 'sse_kms_enabled' are set; 'sse_c_key' (SSE-C) takes precedence, as it did in Nextcloud 34. Set the 'sse' objectstore argument to select a single encryption mode explicitly.";
+			}
+			$mode = $hasLegacySseC ? S3EncryptionMode::SseC : S3EncryptionMode::SseKms;
+			$deprecatedKey = $hasLegacySseC ? 'sse_c_key' : 'sse_kms_enabled';
+			$this->encryptionWarnings[] = "The '{$deprecatedKey}' objectstore argument is deprecated, use 'sse' => '{$mode->value}' instead.";
 		} else {
 			$mode = S3EncryptionMode::None;
+		}
+
+		if ($mode === S3EncryptionMode::SseC) {
+			// SSE-C is a supported mode, not merely a deprecated way to reach one, so this
+			// warning is intentionally emitted regardless of how 'sse-c' was selected.
+			$this->encryptionWarnings[] = "SSE-C ('sse' => 'sse-c') requires you to manage and distribute the encryption key yourself. Consider 'sse' => 'sse-kms' or 'sse-kms-dsse' instead, which let AWS KMS manage the key.";
+			if (empty($params['sse_c_key'])) {
+				// Unlike a merely redundant option, this cannot be resolved: silently falling
+				// back to no encryption would defeat an explicit request for SSE-C.
+				throw new \Exception("The 'sse' objectstore argument is set to 'sse-c' but no 'sse_c_key' is configured.");
+			}
 		}
 
 		$this->sseMode = $mode;
 
 		$keyId = (isset($params['sse_kms_key_id']) && $params['sse_kms_key_id'] !== '') ? (string)$params['sse_kms_key_id'] : null;
 		if ($keyId !== null && !$mode->isKms()) {
-			throw new \Exception("The 'sse_kms_key_id' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
+			$this->encryptionWarnings[] = "Ignoring the 'sse_kms_key_id' objectstore argument: it only applies when 'sse' is 'sse-kms' or 'sse-kms-dsse'.";
+			$keyId = null;
 		}
 		$this->sseKmsKeyId = $keyId;
 
 		$context = $params['sse_kms_encryption_context'] ?? null;
 		if ($context !== null) {
-			if (!$mode->isKms()) {
-				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument requires 'sse' to be 'sse-kms' or 'sse-kms-dsse'.");
-			}
+			// A structurally invalid context can never be resolved, regardless of mode.
 			if (!is_array($context)) {
 				throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
 			}
@@ -405,19 +427,47 @@ trait S3ConnectionTrait {
 					throw new \Exception("The 'sse_kms_encryption_context' objectstore argument must be an array of string key-value pairs.");
 				}
 			}
-			$this->sseKmsEncryptionContext = base64_encode(json_encode($context, JSON_THROW_ON_ERROR));
-		} else {
-			$this->sseKmsEncryptionContext = null;
+			if (!$mode->isKms()) {
+				$this->encryptionWarnings[] = "Ignoring the 'sse_kms_encryption_context' objectstore argument: it only applies when 'sse' is 'sse-kms' or 'sse-kms-dsse'.";
+				$context = null;
+			}
 		}
+		$this->sseKmsEncryptionContext = $context !== null ? base64_encode(json_encode($context, JSON_THROW_ON_ERROR)) : null;
 
 		$bucketKey = (bool)($params['sse_kms_bucket_key'] ?? false);
 		if ($bucketKey && $mode !== S3EncryptionMode::SseKms) {
+			// Merely redundant, not impossible: verified against a real bucket that S3
+			// accepts BucketKeyEnabled alongside 'aws:kms:dsse' and simply does not apply
+			// it (HeadObject afterwards shows no BucketKeyEnabled), rather than rejecting
+			// the request outright, despite AWS's own documentation describing S3 Bucket
+			// Keys as unsupported for DSSE-KMS.
 			$reason = $mode === S3EncryptionMode::SseKmsDsse
-				? "S3 Bucket Keys are not supported for DSSE-KMS ('sse' => 'sse-kms-dsse')"
-				: "'sse_kms_bucket_key' requires 'sse' to be 'sse-kms'";
-			throw new \Exception("The 'sse_kms_bucket_key' objectstore argument cannot be enabled: {$reason}.");
+				? "S3 Bucket Keys are not applied for DSSE-KMS ('sse' => 'sse-kms-dsse')"
+				: "it only applies when 'sse' is 'sse-kms'";
+			$this->encryptionWarnings[] = "Ignoring the 'sse_kms_bucket_key' objectstore argument: {$reason}.";
+			$bucketKey = false;
 		}
 		$this->sseKmsBucketKey = $bucketKey;
+	}
+
+	/**
+	 * Log any warnings recorded by `parseEncryptionParams()`, once a connection is actually
+	 * made, deduplicated by message so a long-lived request/worker doesn't repeat the same
+	 * warning on every call.
+	 */
+	private function logEncryptionWarnings(): void {
+		if ($this->encryptionWarnings === []) {
+			return;
+		}
+
+		$logger = Server::get(LoggerInterface::class);
+		foreach ($this->encryptionWarnings as $warning) {
+			if (isset(self::$loggedEncryptionWarnings[$warning])) {
+				continue;
+			}
+			self::$loggedEncryptionWarnings[$warning] = true;
+			$logger->warning($warning, ['app' => 'objectstore']);
+		}
 	}
 
 	/**

--- a/lib/private/Files/ObjectStore/S3EncryptionMode.php
+++ b/lib/private/Files/ObjectStore/S3EncryptionMode.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Files\ObjectStore;
+
+/**
+ * Server-side encryption mode for the S3 object store, configured via the
+ * `sse` objectstore argument.
+ */
+enum S3EncryptionMode: string {
+	/** No server-side encryption requested by Nextcloud (bucket defaults, if any, still apply) */
+	case None = '';
+	/** SSE-S3: S3-managed AES256 key */
+	case SseS3 = 'sse-s3';
+	/** SSE-C: customer-provided key, see `sse_c_key` */
+	case SseC = 'sse-c';
+	/** SSE-KMS: single layer of AWS KMS-managed encryption */
+	case SseKms = 'sse-kms';
+	/** DSSE-KMS: dual layer of AWS KMS-managed encryption */
+	case SseKmsDsse = 'sse-kms-dsse';
+
+	public function isKms(): bool {
+		return $this === self::SseKms || $this === self::SseKmsDsse;
+	}
+}

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -77,6 +77,10 @@ class SystemConfig {
 				'key' => true,
 				'secret' => true,
 				'sse_c_key' => true,
+				// SSE-KMS encryption context may carry tenant identifiers and is marked
+				// sensitive by the AWS SDK itself (visible in CloudTrail, but not a secret
+				// we want dumped in support requests)
+				'sse_kms_encryption_context' => true,
 				// Swift v2
 				'username' => true,
 				'password' => true,
@@ -98,6 +102,8 @@ class SystemConfig {
 				// S3
 				'key' => true,
 				'secret' => true,
+				'sse_c_key' => true,
+				'sse_kms_encryption_context' => true,
 				// Swift v2
 				'username' => true,
 				'password' => true,

--- a/tests/lib/Files/ObjectStore/S3EncryptionModesLiveTest.php
+++ b/tests/lib/Files/ObjectStore/S3EncryptionModesLiveTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Files\ObjectStore;
+
+use Aws\S3\Exception\S3Exception;
+use OC\Files\ObjectStore\S3;
+use OCP\IConfig;
+use OCP\Server;
+use Test\TestCase;
+
+/**
+ * Live permutation matrix for the S3 `sse*` encryption modes against a real AWS S3 bucket
+ * and KMS key, including cross-mode reads (an object written under one mode, read back by
+ * an instance configured for a different mode). Unlike S3SSEKMSTest, which is scoped to a
+ * single mode taken from the configured primary objectstore, this constructs several S3
+ * instances per test with different `sse*` overrides, so it cannot extend
+ * ObjectStoreTestCase (one getInstance() per test class).
+ *
+ * Requires a bucket + KMS setup that actually supports SSE-KMS/DSSE-KMS (i.e. AWS, not
+ * MinIO/Ceph) and a real symmetric CMK. Skips unless NC_TEST_S3_KMS_KEY_ID is set, so
+ * upstream's MinIO-based CI (.github/workflows/object-storage-s3.yml) skips this cleanly.
+ */
+#[\PHPUnit\Framework\Attributes\Group('PRIMARY-s3')]
+#[\PHPUnit\Framework\Attributes\Group('S3-AWS-KMS')]
+class S3EncryptionModesLiveTest extends TestCase {
+	private static array $baseArguments = [];
+	private static string $kmsKeyId = '';
+
+	/** @var string[] urns to delete in tearDown, across every instance created by makeS3() */
+	private array $cleanupUrns = [];
+
+	#[\Override]
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		$config = Server::get(IConfig::class)->getSystemValue('objectstore');
+		if (!is_array($config) || $config['class'] !== S3::class) {
+			self::markTestSkipped('S3 primary storage not configured');
+		}
+
+		$keyId = getenv('NC_TEST_S3_KMS_KEY_ID');
+		if (!$keyId) {
+			self::markTestSkipped('Set NC_TEST_S3_KMS_KEY_ID to a real AWS KMS key ARN to run the live sse* permutation matrix');
+		}
+
+		self::$baseArguments = $config['arguments'] ?? [];
+		self::$kmsKeyId = $keyId;
+	}
+
+	#[\Override]
+	protected function tearDown(): void {
+		// Any instance from makeS3() can delete any urn: they all share one bucket.
+		if ($this->cleanupUrns !== []) {
+			$s3 = $this->makeS3([]);
+			foreach ($this->cleanupUrns as $urn) {
+				try {
+					$s3->deleteObject($urn);
+				} catch (\Exception) {
+					// already gone, or never actually got written
+				}
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	private function cleanupAfter(string $urn): string {
+		$this->cleanupUrns[] = $urn;
+		return $urn;
+	}
+
+	/**
+	 * @param array $overrides 'sse*' (and other) arguments overriding the configured primary
+	 *                         objectstore for this one instance; every other test in this
+	 *                         file starts from a clean slate, with no 'sse*' carried over.
+	 */
+	private function makeS3(array $overrides): S3 {
+		$arguments = array_filter(
+			self::$baseArguments,
+			static fn (string $key): bool => !str_starts_with($key, 'sse'),
+			ARRAY_FILTER_USE_KEY,
+		);
+		return new S3($overrides + $arguments);
+	}
+
+	private function stringToStream(string $data) {
+		$stream = fopen('php://temp', 'w+');
+		fwrite($stream, $data);
+		rewind($stream);
+		return $stream;
+	}
+
+	private function headObject(S3 $s3, string $urn): array {
+		return $s3->getConnection()->headObject([
+			'Bucket' => $s3->getBucket(),
+			'Key' => $urn,
+		])->toArray();
+	}
+
+	/**
+	 * Some AWS accounts/buckets are configured to reject any upload that requests SSE-C
+	 * outright ("this bucket has blocked upload requests that specify Server Side Encryption
+	 * with Customer provided keys"), independent of anything Nextcloud does. That is a
+	 * deliberate security control, not a bug to route around, so SSE-C tests skip on this
+	 * specific error rather than failing -- and still run for real on a bucket without it.
+	 */
+	private function writeObjectOrSkipIfSseCBlocked(S3 $s3, string $urn, string $data): void {
+		try {
+			$s3->writeObject($urn, $this->stringToStream($data));
+		} catch (S3Exception $e) {
+			if ($e->getAwsErrorCode() === 'AccessDenied' && str_contains($e->getAwsErrorMessage() ?? '', 'Customer provided keys')) {
+				self::markTestSkipped('This bucket/account blocks SSE-C uploads by policy: ' . $e->getAwsErrorMessage());
+			}
+			throw $e;
+		}
+	}
+
+	/**
+	 * Asserts that reading $urn throws, the way S3ObjectTrait::readObject() does for a GetObject
+	 * error response (e.g. missing/wrong SSE-C key). Mirrors ObjectStoreTestCase::testReadNonExisting's
+	 * pattern of tolerating the incidental fopen() PHP warning SeekableHttpStream raises alongside it.
+	 */
+	private function assertReadFails(S3 $s3, string $urn): void {
+		$warnings = [];
+		try {
+			set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+				if ($errno === E_DEPRECATED || $errno === E_USER_DEPRECATED) {
+					return true;
+				}
+				$warnings[] = $errstr;
+				return true;
+			});
+			stream_get_contents($s3->readObject($urn));
+			$this->fail("Expected reading '$urn' to fail");
+		} catch (\Exception) {
+			foreach ($warnings as $warning) {
+				$this->assertStringStartsWith('fopen(', $warning);
+			}
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+	// --- Per-mode matrix -----------------------------------------------------------------
+
+	public function testNoEncryption(): void {
+		$urn = $this->cleanupAfter('live-sse-none');
+		$s3 = $this->makeS3(['sse' => '']);
+		$s3->writeObject($urn, $this->stringToStream('none'));
+
+		// AWS applies its own bucket-default encryption (AES256) even when Nextcloud sends
+		// no encryption headers at all; what matters here is that Nextcloud didn't ask for
+		// KMS, not that the object ends up with literally no encryption.
+		$head = $this->headObject($s3, $urn);
+		$this->assertNotEquals('aws:kms', $head['ServerSideEncryption'] ?? null);
+		$this->assertNotEquals('aws:kms:dsse', $head['ServerSideEncryption'] ?? null);
+		$this->assertSame('none', stream_get_contents($s3->readObject($urn)));
+	}
+
+	public function testSseS3(): void {
+		$urn = $this->cleanupAfter('live-sse-s3');
+		$s3 = $this->makeS3(['sse' => 'sse-s3']);
+		$s3->writeObject($urn, $this->stringToStream('sse-s3'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('AES256', $head['ServerSideEncryption']);
+		$this->assertSame('sse-s3', stream_get_contents($s3->readObject($urn)));
+	}
+
+	public function testSseC(): void {
+		$urn = $this->cleanupAfter('live-sse-c');
+		$key = base64_encode(random_bytes(32));
+		$s3 = $this->makeS3(['sse' => 'sse-c', 'sse_c_key' => $key]);
+		$this->writeObjectOrSkipIfSseCBlocked($s3, $urn, 'sse-c');
+
+		$this->assertSame('sse-c', stream_get_contents($s3->readObject($urn)));
+
+		// Genuinely differs from SSE-KMS/SSE-S3/none: reading without the customer key fails.
+		$this->assertReadFails($this->makeS3(['sse' => '']), $urn);
+	}
+
+	public function testSseKmsBucketDefaultKey(): void {
+		$urn = $this->cleanupAfter('live-sse-kms-default');
+		$s3 = $this->makeS3(['sse' => 'sse-kms']);
+		$s3->writeObject($urn, $this->stringToStream('sse-kms'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms', $head['ServerSideEncryption']);
+		$this->assertSame('sse-kms', stream_get_contents($s3->readObject($urn)));
+	}
+
+	public function testSseKmsWithKeyId(): void {
+		$urn = $this->cleanupAfter('live-sse-kms-keyid');
+		$s3 = $this->makeS3(['sse' => 'sse-kms', 'sse_kms_key_id' => self::$kmsKeyId]);
+		$s3->writeObject($urn, $this->stringToStream('sse-kms-keyid'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms', $head['ServerSideEncryption']);
+		$this->assertSame(self::$kmsKeyId, $head['SSEKMSKeyId']);
+	}
+
+	public function testSseKmsWithEncryptionContext(): void {
+		// Verified live: unlike ServerSideEncryption/SSEKMSKeyId, S3 does not echo the
+		// encryption context back on HeadObject/GetObject -- it's write-only, used for KMS
+		// authorization at PutObject/CopyObject/CreateMultipartUpload time. Confirming it was
+		// actually applied would require reading the kms:EncryptionContext condition off a
+		// CloudTrail Decrypt event, which is out of scope here; this just proves AWS accepts
+		// the header (rather than erroring) and the object still round-trips normally.
+		$urn = $this->cleanupAfter('live-sse-kms-context');
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms',
+			'sse_kms_key_id' => self::$kmsKeyId,
+			'sse_kms_encryption_context' => ['tenant' => 'acme'],
+		]);
+		$s3->writeObject($urn, $this->stringToStream('sse-kms-context'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms', $head['ServerSideEncryption']);
+		$this->assertSame('sse-kms-context', stream_get_contents($s3->readObject($urn)));
+	}
+
+	public function testSseKmsWithBucketKey(): void {
+		$urn = $this->cleanupAfter('live-sse-kms-bucketkey');
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms',
+			'sse_kms_key_id' => self::$kmsKeyId,
+			'sse_kms_bucket_key' => true,
+		]);
+		$s3->writeObject($urn, $this->stringToStream('sse-kms-bucketkey'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms', $head['ServerSideEncryption']);
+		$this->assertTrue($head['BucketKeyEnabled'] ?? false);
+	}
+
+	public function testSseKmsDsseWithKeyId(): void {
+		$urn = $this->cleanupAfter('live-sse-dsse-keyid');
+		$s3 = $this->makeS3(['sse' => 'sse-kms-dsse', 'sse_kms_key_id' => self::$kmsKeyId]);
+		$s3->writeObject($urn, $this->stringToStream('sse-dsse-keyid'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms:dsse', $head['ServerSideEncryption']);
+		$this->assertSame(self::$kmsKeyId, $head['SSEKMSKeyId']);
+	}
+
+	public function testSseKmsDsseWithEncryptionContext(): void {
+		// See testSseKmsWithEncryptionContext(): the context is not echoed back by S3.
+		$urn = $this->cleanupAfter('live-sse-dsse-context');
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms-dsse',
+			'sse_kms_key_id' => self::$kmsKeyId,
+			'sse_kms_encryption_context' => ['tenant' => 'acme'],
+		]);
+		$s3->writeObject($urn, $this->stringToStream('sse-dsse-context'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms:dsse', $head['ServerSideEncryption']);
+		$this->assertSame('sse-dsse-context', stream_get_contents($s3->readObject($urn)));
+	}
+
+	public function testSseKmsDsseBucketKeyIsIgnoredByAws(): void {
+		// Matches S3ServerSideEncryptionTest::testSseKmsDsseBucketKeyIsWarnedAndIgnored:
+		// verified live that AWS accepts the request and simply doesn't apply the bucket
+		// key, rather than rejecting it, despite documenting it as unsupported.
+		$urn = $this->cleanupAfter('live-sse-dsse-bucketkey');
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms-dsse',
+			'sse_kms_key_id' => self::$kmsKeyId,
+			'sse_kms_bucket_key' => true,
+		]);
+		$s3->writeObject($urn, $this->stringToStream('sse-dsse-bucketkey'));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms:dsse', $head['ServerSideEncryption']);
+		$this->assertFalse($head['BucketKeyEnabled'] ?? false);
+	}
+
+	// --- Cross-mode reads, the ones that catch real bugs ----------------------------------
+
+	public function testDsseObjectReadableWithNoEncryptionHeaders(): void {
+		// Proves the read path needs no encryption headers for KMS/DSSE-KMS: AWS rejects
+		// GET/HEAD requests that carry SSE-KMS headers with an HTTP 400, so if Nextcloud's
+		// read path ever started sending them, this would fail instead of silently working.
+		$urn = $this->cleanupAfter('live-cross-dsse-write-plain-read');
+		$writer = $this->makeS3(['sse' => 'sse-kms-dsse', 'sse_kms_key_id' => self::$kmsKeyId]);
+		$writer->writeObject($urn, $this->stringToStream('cross-mode'));
+
+		$reader = $this->makeS3(['sse' => '']);
+		$this->assertTrue($reader->objectExists($urn));
+		$this->assertSame('cross-mode', stream_get_contents($reader->readObject($urn)));
+	}
+
+	public function testSseKmsObjectReadableByDsseInstanceAndViceVersa(): void {
+		$kmsUrn = $this->cleanupAfter('live-cross-kms-write');
+		$dsseUrn = $this->cleanupAfter('live-cross-dsse-write');
+
+		$kms = $this->makeS3(['sse' => 'sse-kms', 'sse_kms_key_id' => self::$kmsKeyId]);
+		$dsse = $this->makeS3(['sse' => 'sse-kms-dsse', 'sse_kms_key_id' => self::$kmsKeyId]);
+
+		$kms->writeObject($kmsUrn, $this->stringToStream('written-as-kms'));
+		$dsse->writeObject($dsseUrn, $this->stringToStream('written-as-dsse'));
+
+		$this->assertSame('written-as-kms', stream_get_contents($dsse->readObject($kmsUrn)));
+		$this->assertSame('written-as-dsse', stream_get_contents($kms->readObject($dsseUrn)));
+	}
+
+	public function testSseCObjectNotReadableWithoutCustomerKey(): void {
+		// The negative-path counterpart to testSseC(), kept as its own cross-mode case:
+		// a plain reader must not be able to read an SSE-C object.
+		$urn = $this->cleanupAfter('live-cross-ssec-negative');
+		$key = base64_encode(random_bytes(32));
+		$writer = $this->makeS3(['sse' => 'sse-c', 'sse_c_key' => $key]);
+		$this->writeObjectOrSkipIfSseCBlocked($writer, $urn, 'ssec-negative');
+
+		$this->assertReadFails($this->makeS3(['sse' => '']), $urn);
+	}
+
+	public function testMultipartUploadUnderDsse(): void {
+		// Parts inherit their encryption from CreateMultipartUpload, not from UploadPart;
+		// this is the case that would catch a regression there. putSizeLimit is lowered so
+		// a modest 6 MB body actually exercises the multipart path (default is 100 MB).
+		$urn = $this->cleanupAfter('live-dsse-multipart');
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms-dsse',
+			'sse_kms_key_id' => self::$kmsKeyId,
+			'putSizeLimit' => 5 * 1024 * 1024,
+		]);
+
+		$data = str_repeat('M', 6 * 1024 * 1024);
+		$s3->writeObject($urn, $this->stringToStream($data));
+
+		$head = $this->headObject($s3, $urn);
+		$this->assertSame('aws:kms:dsse', $head['ServerSideEncryption']);
+		$this->assertSame($data, stream_get_contents($s3->readObject($urn)));
+	}
+}

--- a/tests/lib/Files/ObjectStore/S3SSEKMSTest.php
+++ b/tests/lib/Files/ObjectStore/S3SSEKMSTest.php
@@ -10,22 +10,24 @@ declare(strict_types=1);
 namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\S3;
+use OC\Files\ObjectStore\S3EncryptionMode;
 use OCP\IConfig;
 use OCP\Server;
 
 /**
- * Test suite for AWS SSE-KMS (Server-Side Encryption with Key Management Service).
+ * Test suite for AWS SSE-KMS and DSSE-KMS (Server-Side Encryption with Key Management Service).
  *
- * SSE-KMS provides:
- * - AWS-managed server-side encryption
+ * SSE-KMS / DSSE-KMS provide:
+ * - AWS-managed server-side encryption (DSSE-KMS applies two independent layers)
  * - Centralized key management via AWS KMS
  * - Audit trail of key usage via CloudTrail
  * - No client-side encryption overhead
  * - Automatic key rotation support
  *
  * Configuration options:
- * - sse_kms_enabled: true - Enable SSE-KMS
+ * - sse: 'sse-kms' or 'sse-kms-dsse' - Enable single- or dual-layer KMS encryption
  * - sse_kms_key_id: (optional) Specific KMS key ARN, or use bucket default
+ * - sse_kms_enabled: true - deprecated alias for sse => 'sse-kms'
  */
 #[\PHPUnit\Framework\Attributes\Group('PRIMARY-s3')]
 #[\PHPUnit\Framework\Attributes\Group('SSE-KMS')]
@@ -43,8 +45,10 @@ class S3SSEKMSTest extends ObjectStoreTestCase {
 		}
 
 		$arguments = $config['arguments'] ?? [];
-		if (empty($arguments['sse_kms_enabled'])) {
-			self::markTestSkipped('SSE-KMS not enabled. Set sse_kms_enabled=true in objectstore config');
+		$sse = S3EncryptionMode::tryFrom($arguments['sse'] ?? '');
+		$isKmsEnabled = ($sse !== null && $sse->isKms()) || !empty($arguments['sse_kms_enabled']);
+		if (!$isKmsEnabled) {
+			self::markTestSkipped("SSE-KMS not enabled. Set sse => 'sse-kms' or 'sse-kms-dsse' in the objectstore config");
 		}
 	}
 
@@ -55,6 +59,17 @@ class S3SSEKMSTest extends ObjectStoreTestCase {
 			$this->instance = new S3($config['arguments']);
 		}
 		return $this->instance;
+	}
+
+	/**
+	 * The `ServerSideEncryption` value expected on objects, given the configured `sse` mode
+	 * (or its deprecated `sse_kms_enabled` alias, which always maps to single-layer SSE-KMS).
+	 */
+	private function getExpectedServerSideEncryption(): string {
+		$config = Server::get(IConfig::class)->getSystemValue('objectstore');
+		$arguments = $config['arguments'] ?? [];
+		$sse = S3EncryptionMode::tryFrom($arguments['sse'] ?? '');
+		return $sse === S3EncryptionMode::SseKmsDsse ? 'aws:kms:dsse' : 'aws:kms';
 	}
 
 	/**
@@ -212,7 +227,7 @@ class S3SSEKMSTest extends ObjectStoreTestCase {
 		]);
 
 		// Verify SSE is KMS
-		$this->assertEquals('aws:kms', $result->get('ServerSideEncryption'),
+		$this->assertEquals($this->getExpectedServerSideEncryption(), $result->get('ServerSideEncryption'),
 			'Object should have SSE-KMS encryption');
 
 		// If specific key configured, verify it's used
@@ -252,7 +267,7 @@ class S3SSEKMSTest extends ObjectStoreTestCase {
 
 		$this->assertEquals(0, $metadata->get('ContentLength'),
 			'Zero-byte file should have ContentLength of 0');
-		$this->assertEquals('aws:kms', $metadata->get('ServerSideEncryption'),
+		$this->assertEquals($this->getExpectedServerSideEncryption(), $metadata->get('ServerSideEncryption'),
 			'Zero-byte file should still have SSE-KMS encryption');
 	}
 
@@ -285,7 +300,7 @@ class S3SSEKMSTest extends ObjectStoreTestCase {
 			'Key' => $urn,
 		]);
 
-		$this->assertEquals('aws:kms', $metadata->get('ServerSideEncryption'),
+		$this->assertEquals($this->getExpectedServerSideEncryption(), $metadata->get('ServerSideEncryption'),
 			"Object should have SSE-KMS encryption for size $size");
 		$this->assertEquals($size, $metadata->get('ContentLength'),
 			"Size should match for $size byte file");
@@ -324,7 +339,7 @@ class S3SSEKMSTest extends ObjectStoreTestCase {
 			'Key' => 'kms-test-multipart-copy-target',
 		]);
 
-		$this->assertEquals('aws:kms', $metadata->get('ServerSideEncryption'),
+		$this->assertEquals($this->getExpectedServerSideEncryption(), $metadata->get('ServerSideEncryption'),
 			'Copied object should have SSE-KMS encryption');
 	}
 
@@ -393,7 +408,7 @@ class S3SSEKMSTest extends ObjectStoreTestCase {
 			'Key' => 'kms-test-overwrite',
 		]);
 
-		$this->assertEquals('aws:kms', $metadata->get('ServerSideEncryption'),
+		$this->assertEquals($this->getExpectedServerSideEncryption(), $metadata->get('ServerSideEncryption'),
 			'Overwritten object should still have SSE-KMS encryption');
 	}
 }

--- a/tests/lib/Files/ObjectStore/S3ServerSideEncryptionTest.php
+++ b/tests/lib/Files/ObjectStore/S3ServerSideEncryptionTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\S3;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 /**
@@ -20,6 +21,18 @@ use Test\TestCase;
  * it never opens a connection.
  */
 class S3ServerSideEncryptionTest extends TestCase {
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		// S3ConnectionTrait::$loggedEncryptionWarnings is a static, class-wide dedup cache
+		// (intentionally: it survives across the many S3 instances a long-lived
+		// request/worker constructs). Reset it so tests asserting a warning IS logged don't
+		// depend on which other test using an identical message ran first in this process.
+		$property = new \ReflectionProperty(S3::class, 'loggedEncryptionWarnings');
+		$property->setValue(null, []);
+	}
+
 	private function makeS3(array $arguments): S3 {
 		return new S3(['bucket' => 'test-bucket'] + $arguments);
 	}
@@ -32,14 +45,24 @@ class S3ServerSideEncryptionTest extends TestCase {
 		return $method->invoke($s3, $copy);
 	}
 
+	/**
+	 * @return string[] Warnings recorded by parseEncryptionParams(), not yet flushed to the logger
+	 */
+	private function getEncryptionWarnings(S3 $s3): array {
+		$property = new \ReflectionProperty($s3, 'encryptionWarnings');
+		return $property->getValue($s3);
+	}
+
 	public function testNoEncryptionByDefault(): void {
 		$s3 = $this->makeS3([]);
 		$this->assertSame([], $this->getServerSideEncryptionParameters($s3));
+		$this->assertSame([], $this->getEncryptionWarnings($s3));
 	}
 
 	public function testSseS3(): void {
 		$s3 = $this->makeS3(['sse' => 'sse-s3']);
 		$this->assertSame(['ServerSideEncryption' => 'AES256'], $this->getServerSideEncryptionParameters($s3));
+		$this->assertSame([], $this->getEncryptionWarnings($s3));
 	}
 
 	public function testSseC(): void {
@@ -57,6 +80,20 @@ class S3ServerSideEncryptionTest extends TestCase {
 			'CopySourceSSECustomerKey' => $rawKey,
 			'CopySourceSSECustomerKeyMD5' => md5($rawKey, true),
 		], $this->getServerSideEncryptionParameters($s3, true));
+
+		// SSE-C is warned about in every form, including this explicit, non-deprecated one:
+		// it is a supported mode, not merely a deprecated way to reach one.
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('SSE-C', $warnings[0]);
+	}
+
+	public function testSseCWithoutKeyIsRejected(): void {
+		// Unlike a merely redundant option, this cannot be resolved: silently falling back
+		// to no encryption would defeat an explicit request for SSE-C.
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage("no 'sse_c_key' is configured");
+		$this->makeS3(['sse' => 'sse-c']);
 	}
 
 	public function testSseCLegacyAliasWithoutExplicitSse(): void {
@@ -69,11 +106,19 @@ class S3ServerSideEncryptionTest extends TestCase {
 			'SSECustomerKey' => $rawKey,
 			'SSECustomerKeyMD5' => md5($rawKey, true),
 		], $this->getServerSideEncryptionParameters($s3));
+
+		// Both the deprecated-key warning and the generic SSE-C warning apply.
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertCount(2, $warnings);
+		$this->assertStringContainsString('sse_c_key', $warnings[0]);
+		$this->assertStringContainsString('deprecated', $warnings[0]);
+		$this->assertStringContainsString('SSE-C', $warnings[1]);
 	}
 
 	public function testSseKms(): void {
 		$s3 = $this->makeS3(['sse' => 'sse-kms']);
 		$this->assertSame(['ServerSideEncryption' => 'aws:kms'], $this->getServerSideEncryptionParameters($s3));
+		$this->assertSame([], $this->getEncryptionWarnings($s3));
 	}
 
 	public function testSseKmsWithKeyId(): void {
@@ -85,6 +130,7 @@ class S3ServerSideEncryptionTest extends TestCase {
 			'ServerSideEncryption' => 'aws:kms',
 			'SSEKMSKeyId' => 'arn:aws:kms:us-east-1:123456789012:key/test-key',
 		], $this->getServerSideEncryptionParameters($s3));
+		$this->assertSame([], $this->getEncryptionWarnings($s3));
 	}
 
 	public function testSseKmsWithEncryptionContext(): void {
@@ -98,6 +144,7 @@ class S3ServerSideEncryptionTest extends TestCase {
 			// must base64-encode the JSON itself; the SDK does not do this automatically.
 			'SSEKMSEncryptionContext' => base64_encode(json_encode(['tenant' => 'acme'])),
 		], $this->getServerSideEncryptionParameters($s3));
+		$this->assertSame([], $this->getEncryptionWarnings($s3));
 	}
 
 	public function testSseKmsWithBucketKey(): void {
@@ -106,6 +153,7 @@ class S3ServerSideEncryptionTest extends TestCase {
 			'ServerSideEncryption' => 'aws:kms',
 			'BucketKeyEnabled' => true,
 		], $this->getServerSideEncryptionParameters($s3));
+		$this->assertSame([], $this->getEncryptionWarnings($s3));
 	}
 
 	public function testSseKmsDsse(): void {
@@ -114,13 +162,20 @@ class S3ServerSideEncryptionTest extends TestCase {
 			'ServerSideEncryption' => 'aws:kms:dsse',
 			'SSEKMSKeyId' => 'arn:aws:kms:us-east-1:123456789012:key/test-key',
 		], $this->getServerSideEncryptionParameters($s3));
+		$this->assertSame([], $this->getEncryptionWarnings($s3));
 	}
 
-	public function testSseKmsDsseRejectsBucketKey(): void {
-		// S3 Bucket Keys are not supported for DSSE-KMS.
-		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('not supported for DSSE-KMS');
-		$this->makeS3(['sse' => 'sse-kms-dsse', 'sse_kms_bucket_key' => true]);
+	public function testSseKmsDsseBucketKeyIsWarnedAndIgnored(): void {
+		// AWS documents S3 Bucket Keys as unsupported for DSSE-KMS, but verified against a
+		// real bucket: S3 accepts BucketKeyEnabled alongside 'aws:kms:dsse' and simply does
+		// not apply it, rather than rejecting the request. Matches every other redundant
+		// 'sse_kms_*' option: warn and drop, don't block boot over something S3 itself tolerates.
+		$s3 = $this->makeS3(['sse' => 'sse-kms-dsse', 'sse_kms_bucket_key' => true]);
+		$this->assertSame(['ServerSideEncryption' => 'aws:kms:dsse'], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('sse_kms_bucket_key', $warnings[0]);
 	}
 
 	/**
@@ -143,20 +198,69 @@ class S3ServerSideEncryptionTest extends TestCase {
 		];
 	}
 
-	public function testConflictingLegacyKeysAreRejected(): void {
-		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('mutually exclusive');
-		$this->makeS3(['sse_c_key' => base64_encode(random_bytes(32)), 'sse_kms_enabled' => true]);
+	public function testLegacySseKmsEnabledAloneWarnsOnlyAboutDeprecation(): void {
+		$s3 = $this->makeS3(['sse_kms_enabled' => true]);
+		$this->assertSame(['ServerSideEncryption' => 'aws:kms'], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('sse_kms_enabled', $warnings[0]);
+		$this->assertStringContainsString('deprecated', $warnings[0]);
 	}
 
-	public function testExplicitSseConflictingWithLegacySseCKeyIsRejected(): void {
-		$this->expectException(\Exception::class);
-		$this->makeS3(['sse' => 'sse-kms', 'sse_c_key' => base64_encode(random_bytes(32))]);
+	public function testBothLegacyKeysResolveToSseCByPrecedence(): void {
+		// Matches the Nextcloud 34 behaviour: SSE-C silently took precedence over SSE-KMS
+		// whenever both were configured. That precedence is kept, but is no longer silent.
+		$rawKey = random_bytes(32);
+		$s3 = $this->makeS3(['sse_c_key' => base64_encode($rawKey), 'sse_kms_enabled' => true]);
+
+		$this->assertSame([
+			'SSECustomerAlgorithm' => 'AES256',
+			'SSECustomerKey' => $rawKey,
+			'SSECustomerKeyMD5' => md5($rawKey, true),
+		], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertGreaterThanOrEqual(1, count($warnings));
+		$this->assertTrue(
+			(bool)array_filter($warnings, static fn (string $w): bool => str_contains($w, 'precedence')),
+			'Expected a precedence warning, got: ' . implode(' | ', $warnings)
+		);
 	}
 
-	public function testExplicitSseConflictingWithLegacyKmsEnabledIsRejected(): void {
-		$this->expectException(\Exception::class);
-		$this->makeS3(['sse' => 'sse-c', 'sse_kms_enabled' => true]);
+	public function testExplicitSseKmsOverridesLegacySseCKey(): void {
+		// An explicit 'sse' always wins, even over the deprecated key that would otherwise
+		// take precedence under the Nextcloud 34 rule.
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms',
+			'sse_c_key' => base64_encode(random_bytes(32)),
+		]);
+
+		$this->assertSame(['ServerSideEncryption' => 'aws:kms'], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('sse_c_key', $warnings[0]);
+		$this->assertStringContainsString('Ignoring', $warnings[0]);
+	}
+
+	public function testExplicitSseCOverridesLegacyKmsEnabled(): void {
+		$rawKey = random_bytes(32);
+		$s3 = $this->makeS3([
+			'sse' => 'sse-c',
+			'sse_c_key' => base64_encode($rawKey),
+			'sse_kms_enabled' => true,
+		]);
+
+		$this->assertSame([
+			'SSECustomerAlgorithm' => 'AES256',
+			'SSECustomerKey' => $rawKey,
+			'SSECustomerKeyMD5' => md5($rawKey, true),
+		], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$ignoreWarnings = array_filter($warnings, static fn (string $w): bool => str_contains($w, 'sse_kms_enabled') && str_contains($w, 'Ignoring'));
+		$this->assertNotEmpty($ignoreWarnings, 'Expected an "ignoring sse_kms_enabled" warning, got: ' . implode(' | ', $warnings));
 	}
 
 	public function testInvalidSseValueIsRejected(): void {
@@ -165,14 +269,34 @@ class S3ServerSideEncryptionTest extends TestCase {
 		$this->makeS3(['sse' => 'sse-does-not-exist']);
 	}
 
-	public function testKmsKeyIdWithoutKmsModeIsRejected(): void {
-		$this->expectException(\Exception::class);
-		$this->makeS3(['sse' => 'sse-s3', 'sse_kms_key_id' => 'arn:aws:kms:us-east-1:123456789012:key/test-key']);
+	public function testKmsKeyIdWithoutKmsModeIsWarnedAndIgnored(): void {
+		$s3 = $this->makeS3(['sse' => 'sse-s3', 'sse_kms_key_id' => 'arn:aws:kms:us-east-1:123456789012:key/test-key']);
+		$this->assertSame(['ServerSideEncryption' => 'AES256'], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('sse_kms_key_id', $warnings[0]);
 	}
 
-	public function testEncryptionContextWithoutKmsModeIsRejected(): void {
-		$this->expectException(\Exception::class);
-		$this->makeS3(['sse' => 'sse-c', 'sse_c_key' => base64_encode(random_bytes(32)), 'sse_kms_encryption_context' => ['tenant' => 'acme']]);
+	public function testEncryptionContextWithoutKmsModeIsWarnedAndIgnored(): void {
+		$rawKey = random_bytes(32);
+		$s3 = $this->makeS3([
+			'sse' => 'sse-c',
+			'sse_c_key' => base64_encode($rawKey),
+			'sse_kms_encryption_context' => ['tenant' => 'acme'],
+		]);
+
+		$this->assertSame([
+			'SSECustomerAlgorithm' => 'AES256',
+			'SSECustomerKey' => $rawKey,
+			'SSECustomerKeyMD5' => md5($rawKey, true),
+		], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertTrue(
+			(bool)array_filter($warnings, static fn (string $w): bool => str_contains($w, 'sse_kms_encryption_context')),
+			'Expected a warning about sse_kms_encryption_context, got: ' . implode(' | ', $warnings)
+		);
 	}
 
 	public function testEncryptionContextRejectsNonStringValues(): void {
@@ -180,8 +304,81 @@ class S3ServerSideEncryptionTest extends TestCase {
 		$this->makeS3(['sse' => 'sse-kms', 'sse_kms_encryption_context' => ['tenant' => 123]]);
 	}
 
-	public function testBucketKeyWithoutSseKmsModeIsRejected(): void {
+	public function testMalformedEncryptionContextIsRejectedRegardlessOfMode(): void {
+		// A structurally invalid context can never be resolved, even for a mode where the
+		// context itself would otherwise just be redundant and warned-about.
 		$this->expectException(\Exception::class);
-		$this->makeS3(['sse' => 'sse-s3', 'sse_kms_bucket_key' => true]);
+		$this->makeS3([
+			'sse' => 'sse-c',
+			'sse_c_key' => base64_encode(random_bytes(32)),
+			'sse_kms_encryption_context' => 'not-an-array',
+		]);
+	}
+
+	public function testBucketKeyWithoutSseKmsModeIsWarnedAndIgnored(): void {
+		$s3 = $this->makeS3(['sse' => 'sse-s3', 'sse_kms_bucket_key' => true]);
+		$this->assertSame(['ServerSideEncryption' => 'AES256'], $this->getServerSideEncryptionParameters($s3));
+
+		$warnings = $this->getEncryptionWarnings($s3);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('sse_kms_bucket_key', $warnings[0]);
+	}
+
+	/**
+	 * Unlike the other tests here, this exercises getConnection() (with verify_bucket_exists
+	 * disabled, so it makes no network call) to prove parseEncryptionParams()'s warnings
+	 * actually reach the logger.
+	 */
+	public function testWarningsAreLoggedViaGetConnection(): void {
+		$rawKey = random_bytes(32);
+		$s3 = $this->makeS3([
+			'sse_c_key' => base64_encode($rawKey),
+			'verify_bucket_exists' => false,
+		]);
+
+		$expectedWarnings = $this->getEncryptionWarnings($s3);
+		$this->assertNotEmpty($expectedWarnings);
+
+		$loggedMessages = [];
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('warning')
+			->willReturnCallback(function (string $message, array $context = []) use (&$loggedMessages): void {
+				$loggedMessages[] = $message;
+			});
+		$this->overwriteService(LoggerInterface::class, $logger);
+
+		$s3->getConnection();
+
+		$this->assertSame($expectedWarnings, $loggedMessages);
+	}
+
+	/**
+	 * The dedup is keyed on message text and static across instances (a long-lived
+	 * request/worker constructs the primary object storage repeatedly), so a second,
+	 * distinct S3 instance with the same 'sse*' configuration must not log again.
+	 */
+	public function testIdenticalWarningsAreNotLoggedTwiceAcrossInstances(): void {
+		$rawKey = random_bytes(32);
+		$makeIdenticallyConfiguredS3 = fn (): S3 => $this->makeS3([
+			'sse_c_key' => base64_encode($rawKey),
+			'verify_bucket_exists' => false,
+		]);
+
+		$loggedMessages = [];
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('warning')
+			->willReturnCallback(function (string $message, array $context = []) use (&$loggedMessages): void {
+				$loggedMessages[] = $message;
+			});
+		$this->overwriteService(LoggerInterface::class, $logger);
+
+		$first = $makeIdenticallyConfiguredS3();
+		$expectedWarnings = $this->getEncryptionWarnings($first);
+		$first->getConnection();
+		$this->assertSame($expectedWarnings, $loggedMessages, 'First instance should log its warnings');
+
+		$second = $makeIdenticallyConfiguredS3();
+		$second->getConnection();
+		$this->assertSame($expectedWarnings, $loggedMessages, 'Second instance with the same warnings should not log them again');
 	}
 }

--- a/tests/lib/Files/ObjectStore/S3ServerSideEncryptionTest.php
+++ b/tests/lib/Files/ObjectStore/S3ServerSideEncryptionTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Files\ObjectStore;
+
+use OC\Files\ObjectStore\S3;
+use Test\TestCase;
+
+/**
+ * Pure unit tests for the `sse*` objectstore argument parsing and resulting
+ * S3 API parameters in S3ConnectionTrait::parseEncryptionParams() /
+ * getServerSideEncryptionParameters(). Unlike S3SSEKMSTest, these do not
+ * require a live S3 bucket: S3::__construct() only calls parseParams(),
+ * it never opens a connection.
+ */
+class S3ServerSideEncryptionTest extends TestCase {
+	private function makeS3(array $arguments): S3 {
+		return new S3(['bucket' => 'test-bucket'] + $arguments);
+	}
+
+	/**
+	 * @return array Parameters S3 would merge into an S3 API call
+	 */
+	private function getServerSideEncryptionParameters(S3 $s3, bool $copy = false): array {
+		$method = new \ReflectionMethod($s3, 'getServerSideEncryptionParameters');
+		return $method->invoke($s3, $copy);
+	}
+
+	public function testNoEncryptionByDefault(): void {
+		$s3 = $this->makeS3([]);
+		$this->assertSame([], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseS3(): void {
+		$s3 = $this->makeS3(['sse' => 'sse-s3']);
+		$this->assertSame(['ServerSideEncryption' => 'AES256'], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseC(): void {
+		$rawKey = random_bytes(32);
+		$s3 = $this->makeS3(['sse' => 'sse-c', 'sse_c_key' => base64_encode($rawKey)]);
+
+		$this->assertSame([
+			'SSECustomerAlgorithm' => 'AES256',
+			'SSECustomerKey' => $rawKey,
+			'SSECustomerKeyMD5' => md5($rawKey, true),
+		], $this->getServerSideEncryptionParameters($s3));
+
+		$this->assertSame([
+			'CopySourceSSECustomerAlgorithm' => 'AES256',
+			'CopySourceSSECustomerKey' => $rawKey,
+			'CopySourceSSECustomerKeyMD5' => md5($rawKey, true),
+		], $this->getServerSideEncryptionParameters($s3, true));
+	}
+
+	public function testSseCLegacyAliasWithoutExplicitSse(): void {
+		// Configs from before the 'sse' argument existed must keep working unchanged.
+		$rawKey = random_bytes(32);
+		$s3 = $this->makeS3(['sse_c_key' => base64_encode($rawKey)]);
+
+		$this->assertSame([
+			'SSECustomerAlgorithm' => 'AES256',
+			'SSECustomerKey' => $rawKey,
+			'SSECustomerKeyMD5' => md5($rawKey, true),
+		], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseKms(): void {
+		$s3 = $this->makeS3(['sse' => 'sse-kms']);
+		$this->assertSame(['ServerSideEncryption' => 'aws:kms'], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseKmsWithKeyId(): void {
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms',
+			'sse_kms_key_id' => 'arn:aws:kms:us-east-1:123456789012:key/test-key',
+		]);
+		$this->assertSame([
+			'ServerSideEncryption' => 'aws:kms',
+			'SSEKMSKeyId' => 'arn:aws:kms:us-east-1:123456789012:key/test-key',
+		], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseKmsWithEncryptionContext(): void {
+		$s3 = $this->makeS3([
+			'sse' => 'sse-kms',
+			'sse_kms_encryption_context' => ['tenant' => 'acme'],
+		]);
+		$this->assertSame([
+			'ServerSideEncryption' => 'aws:kms',
+			// SSEKMSEncryptionContext is a plain string shape in the AWS SDK, so Nextcloud
+			// must base64-encode the JSON itself; the SDK does not do this automatically.
+			'SSEKMSEncryptionContext' => base64_encode(json_encode(['tenant' => 'acme'])),
+		], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseKmsWithBucketKey(): void {
+		$s3 = $this->makeS3(['sse' => 'sse-kms', 'sse_kms_bucket_key' => true]);
+		$this->assertSame([
+			'ServerSideEncryption' => 'aws:kms',
+			'BucketKeyEnabled' => true,
+		], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseKmsDsse(): void {
+		$s3 = $this->makeS3(['sse' => 'sse-kms-dsse', 'sse_kms_key_id' => 'arn:aws:kms:us-east-1:123456789012:key/test-key']);
+		$this->assertSame([
+			'ServerSideEncryption' => 'aws:kms:dsse',
+			'SSEKMSKeyId' => 'arn:aws:kms:us-east-1:123456789012:key/test-key',
+		], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public function testSseKmsDsseRejectsBucketKey(): void {
+		// S3 Bucket Keys are not supported for DSSE-KMS.
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('not supported for DSSE-KMS');
+		$this->makeS3(['sse' => 'sse-kms-dsse', 'sse_kms_bucket_key' => true]);
+	}
+
+	/**
+	 * @dataProvider dataTruthyLegacyKmsEnabled
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTruthyLegacyKmsEnabled')]
+	public function testSseKmsLegacyAliasAcceptsAnyTruthyValue(mixed $value): void {
+		// Prior to this change, 'sse_kms_enabled' required a strict `=== true` check, so
+		// e.g. 1 or 'true' from an environment-driven config would silently disable encryption.
+		$s3 = $this->makeS3(['sse_kms_enabled' => $value]);
+		$this->assertSame(['ServerSideEncryption' => 'aws:kms'], $this->getServerSideEncryptionParameters($s3));
+	}
+
+	public static function dataTruthyLegacyKmsEnabled(): array {
+		return [
+			'bool true' => [true],
+			'int 1' => [1],
+			'string "true"' => ['true'],
+			'string "1"' => ['1'],
+		];
+	}
+
+	public function testConflictingLegacyKeysAreRejected(): void {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('mutually exclusive');
+		$this->makeS3(['sse_c_key' => base64_encode(random_bytes(32)), 'sse_kms_enabled' => true]);
+	}
+
+	public function testExplicitSseConflictingWithLegacySseCKeyIsRejected(): void {
+		$this->expectException(\Exception::class);
+		$this->makeS3(['sse' => 'sse-kms', 'sse_c_key' => base64_encode(random_bytes(32))]);
+	}
+
+	public function testExplicitSseConflictingWithLegacyKmsEnabledIsRejected(): void {
+		$this->expectException(\Exception::class);
+		$this->makeS3(['sse' => 'sse-c', 'sse_kms_enabled' => true]);
+	}
+
+	public function testInvalidSseValueIsRejected(): void {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage("Invalid 'sse'");
+		$this->makeS3(['sse' => 'sse-does-not-exist']);
+	}
+
+	public function testKmsKeyIdWithoutKmsModeIsRejected(): void {
+		$this->expectException(\Exception::class);
+		$this->makeS3(['sse' => 'sse-s3', 'sse_kms_key_id' => 'arn:aws:kms:us-east-1:123456789012:key/test-key']);
+	}
+
+	public function testEncryptionContextWithoutKmsModeIsRejected(): void {
+		$this->expectException(\Exception::class);
+		$this->makeS3(['sse' => 'sse-c', 'sse_c_key' => base64_encode(random_bytes(32)), 'sse_kms_encryption_context' => ['tenant' => 'acme']]);
+	}
+
+	public function testEncryptionContextRejectsNonStringValues(): void {
+		$this->expectException(\Exception::class);
+		$this->makeS3(['sse' => 'sse-kms', 'sse_kms_encryption_context' => ['tenant' => 123]]);
+	}
+
+	public function testBucketKeyWithoutSseKmsModeIsRejected(): void {
+		$this->expectException(\Exception::class);
+		$this->makeS3(['sse' => 'sse-s3', 'sse_kms_bucket_key' => true]);
+	}
+}


### PR DESCRIPTION
* Related: #57623 (the SSE-KMS PR this extends; not tracked by an open issue)
* Related: nextcloud/documentation#15375 (Documentation to deprecate SSE-C usage)

## Summary

Extends the SSE-KMS support merged in #57623 with [AWS DSSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingDSSEncryption.html), and replaces the two
booleans that PR introduced (`sse_c_key`, `sse_kms_enabled`) with a single `sse` mode
argument (`''` / `sse-s3` / `sse-c` / `sse-kms` / `sse-kms-dsse`), since a third mode
couldn't be added to that config shape without either a second mutually-exclusive
boolean or a discriminator.

- New `sse` objectstore argument selects the encryption mode explicitly. `sse_c_key`
  and `sse_kms_enabled` remain as deprecated aliases — existing configs keep working
  unchanged, resolved by the same precedence Nextcloud 34 already shipped (SSE-C wins
  if both are set), but the fallback is now logged instead of silent.
- Adds `sse_kms_encryption_context` and `sse_kms_bucket_key`, the two SSE-KMS features
  that make it useful for the multi-tenant case #57623 described (encryption context
  for `kms:EncryptionContext` policy conditions on a shared bucket; bucket keys for
  KMS request cost reduction).
- Corrects SSE-C's status: it's deprecated since Nextcloud 34 — Amazon S3 disabled
  SSE-C by default for new buckets in April 2026, which we hit directly during live
  testing against a fresh bucket. Adds a `SetupCheck` (Settings → Overview) so this is
  actually visible to admins, not just a log line.
- A docs PR is already open covering the original SSE-KMS/SSE-C-deprecation baseline
  from #57623: nextcloud/documentation#15375. It predates the `sse` argument, DSSE-KMS,
  encryption context, and bucket keys added here, so it'll need a follow-up once this
  merges.

Tested against a real AWS bucket + KMS key (all `sse` modes, cross-mode reads, SSE-C
negative-read path, multipart under DSSE) and against MinIO for the non-AWS regression
path.

## TODO

- [ ] Register the `admin-s3-sse-c` `linkToDocs()` redirect key once nextcloud/documentation#15375's `s3-sse-c` anchor exists
- [ ] Follow-up docs PR for `sse`, `sse-kms-dsse`, `sse_kms_encryption_context`, `sse_kms_bucket_key`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes — n/a, no front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required — partially: nextcloud/documentation#15375 is open but predates this PR's additions, see Summary
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) — n/a
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
