### PR TITLE
feat(webauthn): Skip 2FA for user verified logins

### DIFF
--- a/core/Controller/WebAuthnController.php
+++ b/core/Controller/WebAuthnController.php
@@ -77,7 +77,7 @@ class WebAuthnController extends Controller {
 		// Obtain the publicKeyCredentialOptions from when we started the registration
 		$publicKeyCredentialRequestOptions = PublicKeyCredentialRequestOptions::createFromString($this->session->get(self::WEBAUTHN_LOGIN));
 		$uid = $this->session->get(self::WEBAUTHN_LOGIN_UID);
-		$this->webAuthnManger->finishAuthentication($publicKeyCredentialRequestOptions, $data, $uid);
+		$authenticatorData = $this->webAuthnManger->finishAuthentication($publicKeyCredentialRequestOptions, $data, $uid);
 
 		//TODO: add other parameters
 		$loginData = new LoginData(
@@ -85,6 +85,7 @@ class WebAuthnController extends Controller {
 			$uid,
 			''
 		);
+		$loginData->setWebAuthnUserVerified($authenticatorData->isUserVerified());
 		$this->webAuthnChain->process($loginData);
 
 		return new JSONResponse([

--- a/lib/private/Authentication/Login/LoginData.php
+++ b/lib/private/Authentication/Login/LoginData.php
@@ -16,6 +16,13 @@ class LoginData {
 	/** @var IUser|false|null */
 	private $user = null;
 
+	/**
+	 * True when this login was performed via WebAuthn *and* the authenticator
+	 * verified the user (PIN, biometrics, …), which makes the login itself a
+	 * multi-factor authentication.
+	 */
+	private bool $webAuthnUserVerified = false;
+
 	public function __construct(
 		private IRequest $request,
 		private string $username,
@@ -75,5 +82,13 @@ class LoginData {
 
 	public function isRememberLogin(): bool {
 		return $this->rememberLogin;
+	}
+
+	public function setWebAuthnUserVerified(bool $webAuthnUserVerified): void {
+		$this->webAuthnUserVerified = $webAuthnUserVerified;
+	}
+
+	public function isWebAuthnUserVerified(): bool {
+		return $this->webAuthnUserVerified;
 	}
 }

--- a/lib/private/Authentication/Login/TwoFactorCommand.php
+++ b/lib/private/Authentication/Login/TwoFactorCommand.php
@@ -25,7 +25,10 @@ class TwoFactorCommand extends ALoginCommand {
 
 	#[\Override]
 	public function process(LoginData $loginData): LoginResult {
-		if (!$this->twoFactorManager->isTwoFactorAuthenticated($loginData->getUser())) {
+		// A WebAuthn login with user verification combines possession of the
+		// authenticator with a PIN or a biometric, so it is a second factor already
+		if ($loginData->isWebAuthnUserVerified()
+			|| !$this->twoFactorManager->isTwoFactorAuthenticated($loginData->getUser())) {
 			return $this->processNextOrFinishSuccessfully($loginData);
 		}
 

--- a/lib/private/Authentication/WebAuthn/Manager.php
+++ b/lib/private/Authentication/WebAuthn/Manager.php
@@ -27,6 +27,7 @@ use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorData;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialDescriptor;
@@ -168,7 +169,7 @@ class Manager {
 		);
 	}
 
-	public function finishAuthentication(PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions, string $data, string $uid) {
+	public function finishAuthentication(PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions, string $data, string $uid): AuthenticatorData {
 		$attestationStatementSupportManager = new AttestationStatementSupportManager();
 		$attestationStatementSupportManager->add(new NoneAttestationStatementSupport());
 
@@ -216,7 +217,7 @@ class Manager {
 			throw $e;
 		}
 
-		return true;
+		return $response->authenticatorData;
 	}
 
 	public function deleteRegistration(IUser $user, int $id): void {

--- a/tests/lib/Authentication/Login/TwoFactorCommandTest.php
+++ b/tests/lib/Authentication/Login/TwoFactorCommandTest.php
@@ -56,6 +56,41 @@ class TwoFactorCommandTest extends ALoginTestCommand {
 		$this->assertTrue($result->isSuccess());
 	}
 
+	public function testSkippedForVerifiedWebAuthnLogin(): void {
+		$data = $this->getLoggedInLoginData();
+		$data->setWebAuthnUserVerified(true);
+		$this->twoFactorManager->expects($this->never())
+			->method('prepareTwoFactorLogin');
+
+		$result = $this->cmd->process($data);
+
+		$this->assertTrue($result->isSuccess());
+		$this->assertNull($result->getRedirectUrl());
+	}
+
+	public function testNotSkippedForWebAuthnLoginWithoutUserVerification(): void {
+		$data = $this->getLoggedInLoginData();
+		$data->setWebAuthnUserVerified(false);
+		$this->twoFactorManager->expects($this->once())
+			->method('isTwoFactorAuthenticated')
+			->willReturn(true);
+		$this->twoFactorManager->expects($this->once())
+			->method('prepareTwoFactorLogin');
+		$this->twoFactorManager->expects($this->once())
+			->method('getProviderSet')
+			->willReturn(new ProviderSet([], false));
+		$this->twoFactorManager->expects($this->once())
+			->method('getLoginSetupProviders')
+			->willReturn([]);
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->willReturn('two/factor/url');
+
+		$result = $this->cmd->process($data);
+
+		$this->assertEquals('two/factor/url', $result->getRedirectUrl());
+	}
+
 	public function testProcessOneActiveProvider(): void {
 		$data = $this->getLoggedInLoginData();
 		$this->twoFactorManager->expects($this->once())


### PR DESCRIPTION
A WebAuthn login with user verification is already a second factor, so do not ask for an additional 2FA challenge

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #21215

## Summary

WebAuthn optionally performs user verification: a PIN or a fingerprint is checked on the device itself. That is effectively MFA, something the user has plus something the user knows.

This PR skips the 2FA challenge for those logins. Keys without user verification still go through the usual challenge.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
