### PR TITLE
perf: Ensure encryption wrapper is only setup when needed

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3661,11 +3661,6 @@
       <code><![CDATA[null]]></code>
     </NullArgument>
   </file>
-  <file src="lib/private/Encryption/Manager.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[bool]]></code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="lib/private/Federation/CloudFederationProviderManager.php">
     <ParamNameMismatch>
       <code><![CDATA[$providerId]]></code>

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -45,13 +45,9 @@ class EncryptionWrapper {
 	/**
 	 * Wraps the given storage when it is not a shared storage
 	 *
-	 * @param string $mountPoint
-	 * @param IStorage $storage
-	 * @param IMountPoint $mount
 	 * @param bool $force apply the wrapper even if the storage normally has encryption disabled, helpful for repair steps
-	 * @return Encryption|IStorage
 	 */
-	public function wrapStorage(string $mountPoint, IStorage $storage, IMountPoint $mount, bool $force = false) {
+	public function wrapStorage(string $mountPoint, IStorage $storage, IMountPoint $mount, bool $force = false): Encryption|IStorage {
 		$parameters = [
 			'storage' => $storage,
 			'mountPoint' => $mountPoint,

--- a/lib/private/Encryption/Manager.php
+++ b/lib/private/Encryption/Manager.php
@@ -206,7 +206,7 @@ class Manager implements IManager {
 	 */
 	public function setupStorage(): void {
 		// If encryption is disabled and there are no loaded modules it makes no sense to load the wrapper
-		if (!empty($this->encryptionModules) || $this->isEnabled()) {
+		if ($this->encryptionModules !== [] && $this->isEnabled()) {
 			$encryptionWrapper = new EncryptionWrapper($this->arrayCache, $this, $this->logger);
 			Filesystem::addStorageWrapper('oc_encryption', $encryptionWrapper->wrapStorage(...), 2);
 		}

--- a/lib/private/Encryption/Manager.php
+++ b/lib/private/Encryption/Manager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -12,55 +14,53 @@ use OC\Encryption\Exceptions\ModuleAlreadyExistsException;
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
 use OC\Encryption\Keys\Storage;
 use OC\Files\Filesystem;
-use OC\Files\View;
+use OC\Files\Storage\Wrapper\Encryption;
 use OC\Memcache\ArrayCache;
 use OC\ServiceUnavailableException;
 use OCP\Encryption\IEncryptionModule;
 use OCP\Encryption\IManager;
+use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IStorage;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class Manager implements IManager {
+	/**
+	 * @var array<string, array{callback: callable(): IEncryptionModule, displayName: string, id: string}>
+	 */
 	protected array $encryptionModules;
 
 	public function __construct(
-		protected IConfig $config,
-		protected LoggerInterface $logger,
-		protected IL10N $l,
-		protected View $rootView,
-		protected Util $util,
-		protected ArrayCache $arrayCache,
+		protected readonly IConfig $config,
+		protected readonly IAppConfig $appConfig,
+		protected readonly LoggerInterface $logger,
+		protected readonly IL10N $l,
+		protected readonly IRootFolder $rootFolder,
+		protected readonly Util $util,
+		protected readonly ArrayCache $arrayCache,
 	) {
 		$this->encryptionModules = [];
 	}
 
-	/**
-	 * Check if encryption is enabled
-	 *
-	 * @return bool true if enabled, false if not
-	 */
 	#[\Override]
-	public function isEnabled() {
+	public function isEnabled(): bool {
 		$installed = $this->config->getSystemValueBool('installed', false);
 		if (!$installed) {
 			return false;
 		}
 
-		return Server::get(IAppConfig::class)->getValueBool('core', 'encryption_enabled');
+		return $this->appConfig->getValueBool('core', 'encryption_enabled');
 	}
 
 	/**
-	 * check if new encryption is ready
+	 * Check if new encryption is ready
 	 *
-	 * @return bool
 	 * @throws ServiceUnavailableException
 	 */
-	public function isReady() {
+	public function isReady(): bool {
 		if ($this->isKeyStorageReady() === false) {
 			throw new ServiceUnavailableException('Key Storage is not ready');
 		}
@@ -68,10 +68,7 @@ class Manager implements IManager {
 		return true;
 	}
 
-	/**
-	 * @param string $user
-	 */
-	public function isReadyForUser($user) {
+	public function isReadyForUser(string $user): bool {
 		if (!$this->isReady()) {
 			return false;
 		}
@@ -87,16 +84,8 @@ class Manager implements IManager {
 		return true;
 	}
 
-	/**
-	 * Registers an callback function which must return an encryption module instance
-	 *
-	 * @param string $id
-	 * @param string $displayName
-	 * @param callable $callback
-	 * @throws Exceptions\ModuleAlreadyExistsException
-	 */
 	#[\Override]
-	public function registerEncryptionModule($id, $displayName, callable $callback) {
+	public function registerEncryptionModule(string $id, string $displayName, callable $callback): void {
 		if (isset($this->encryptionModules[$id])) {
 			throw new ModuleAlreadyExistsException($id, $displayName);
 		}
@@ -114,35 +103,18 @@ class Manager implements IManager {
 		}
 	}
 
-	/**
-	 * Unregisters an encryption module
-	 *
-	 * @param string $moduleId
-	 */
 	#[\Override]
-	public function unregisterEncryptionModule($moduleId) {
+	public function unregisterEncryptionModule(string $moduleId): void {
 		unset($this->encryptionModules[$moduleId]);
 	}
 
-	/**
-	 * get a list of all encryption modules
-	 *
-	 * @return array [id => ['id' => $id, 'displayName' => $displayName, 'callback' => callback]]
-	 */
 	#[\Override]
-	public function getEncryptionModules() {
+	public function getEncryptionModules(): array {
 		return $this->encryptionModules;
 	}
 
-	/**
-	 * get a specific encryption module
-	 *
-	 * @param string $moduleId
-	 * @return IEncryptionModule
-	 * @throws Exceptions\ModuleDoesNotExistsException
-	 */
 	#[\Override]
-	public function getEncryptionModule($moduleId = '') {
+	public function getEncryptionModule(string $moduleId = ''): IEncryptionModule {
 		if (empty($moduleId)) {
 			return $this->getDefaultEncryptionModule();
 		}
@@ -155,12 +127,11 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * get default encryption module
+	 * Get default encryption module
 	 *
-	 * @return IEncryptionModule
 	 * @throws Exceptions\ModuleDoesNotExistsException
 	 */
-	protected function getDefaultEncryptionModule() {
+	protected function getDefaultEncryptionModule(): IEncryptionModule {
 		$defaultModuleId = $this->getDefaultEncryptionModuleId();
 		if (empty($defaultModuleId)) {
 			$message = 'No default encryption module defined';
@@ -173,32 +144,21 @@ class Manager implements IManager {
 		throw new ModuleDoesNotExistsException($message);
 	}
 
-	/**
-	 * set default encryption module Id
-	 *
-	 * @param string $moduleId
-	 * @return bool
-	 */
 	#[\Override]
-	public function setDefaultEncryptionModule($moduleId) {
+	public function setDefaultEncryptionModule(string $moduleId): bool {
 		try {
 			$this->getEncryptionModule($moduleId);
 		} catch (\Exception $e) {
 			return false;
 		}
 
-		$this->config->setAppValue('core', 'default_encryption_module', $moduleId);
+		$this->appConfig->setValueString('core', 'default_encryption_module', $moduleId);
 		return true;
 	}
 
-	/**
-	 * get default encryption module Id
-	 *
-	 * @return string
-	 */
 	#[\Override]
-	public function getDefaultEncryptionModuleId() {
-		return $this->config->getAppValue('core', 'default_encryption_module');
+	public function getDefaultEncryptionModuleId(): string {
+		return $this->appConfig->getValueString('core', 'default_encryption_module');
 	}
 
 	/**
@@ -212,17 +172,15 @@ class Manager implements IManager {
 		}
 	}
 
-	public function forceWrapStorage(IMountPoint $mountPoint, IStorage $storage) {
+	public function forceWrapStorage(IMountPoint $mountPoint, IStorage $storage): Encryption|IStorage {
 		$encryptionWrapper = new EncryptionWrapper($this->arrayCache, $this, $this->logger);
 		return $encryptionWrapper->wrapStorage($mountPoint->getMountPoint(), $storage, $mountPoint, true);
 	}
 
 	/**
-	 * check if key storage is ready
-	 *
-	 * @return bool
+	 * Check if key storage is ready
 	 */
-	protected function isKeyStorageReady() {
+	protected function isKeyStorageReady(): bool {
 		$rootDir = $this->util->getKeyStorageRoot();
 
 		// the default root is always valid
@@ -231,10 +189,6 @@ class Manager implements IManager {
 		}
 
 		// check if key storage is mounted correctly
-		if ($this->rootView->file_exists($rootDir . '/' . Storage::KEY_STORAGE_MARKER)) {
-			return true;
-		}
-
-		return false;
+		return $this->rootFolder->nodeExists($rootDir . '/' . Storage::KEY_STORAGE_MARKER);
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -347,9 +347,10 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(Encryption\Manager::class, function (Server $c): Encryption\Manager {
 			return new Encryption\Manager(
 				$c->get(IConfig::class),
+				$c->get(IAppConfig::class),
 				$c->get(LoggerInterface::class),
 				$c->get(IFactory::class)->get('core'),
-				$c->get(View::class),
+				$c->get(IRootFolder::class),
 				$c->get(Encryption\Util::class),
 				new ArrayCache()
 			);

--- a/lib/public/Encryption/IManager.php
+++ b/lib/public/Encryption/IManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -10,12 +12,14 @@ namespace OCP\Encryption;
 
 use OC\Encryption\Exceptions\ModuleAlreadyExistsException;
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * This class provides access to files encryption apps.
  *
  * @since 8.1.0
  */
+#[Consumable(since: '8.1.0')]
 interface IManager {
 	/**
 	 * Check if encryption is available (at least one encryption module needs to be enabled)
@@ -23,59 +27,54 @@ interface IManager {
 	 * @return bool true if enabled, false if not
 	 * @since 8.1.0
 	 */
-	public function isEnabled();
+	public function isEnabled(): bool;
 
 	/**
-	 * Registers an callback function which must return an encryption module instance
+	 * Registers a callback function which must return an encryption module instance
 	 *
 	 * @param string $id
 	 * @param string $displayName
-	 * @param callable $callback
+	 * @param callable(): IEncryptionModule $callback
 	 * @throws ModuleAlreadyExistsException
 	 * @since 8.1.0
 	 */
-	public function registerEncryptionModule($id, $displayName, callable $callback);
+	public function registerEncryptionModule(string $id, string $displayName, callable $callback): void;
 
 	/**
 	 * Unregisters an encryption module
 	 *
-	 * @param string $moduleId
 	 * @since 8.1.0
 	 */
-	public function unregisterEncryptionModule($moduleId);
+	public function unregisterEncryptionModule(string $moduleId): void;
 
 	/**
-	 * get a list of all encryption modules
+	 * Get a list of all encryption modules.
 	 *
-	 * @return array [id => ['id' => $id, 'displayName' => $displayName, 'callback' => callback]]
+	 * @return array<string, array{id: string, displayName: string, callback: (callable():IEncryptionModule)}>
 	 * @since 8.1.0
 	 */
-	public function getEncryptionModules();
+	public function getEncryptionModules(): array;
 
 	/**
-	 * get a specific encryption module
+	 * Get a specific encryption module.
 	 *
 	 * @param string $moduleId Empty to get the default module
-	 * @return IEncryptionModule
 	 * @throws ModuleDoesNotExistsException
 	 * @since 8.1.0
 	 */
-	public function getEncryptionModule($moduleId = '');
+	public function getEncryptionModule(string $moduleId = ''): IEncryptionModule;
 
 	/**
-	 * get default encryption module Id
+	 * Get default encryption module Id
 	 *
-	 * @return string
 	 * @since 8.1.0
 	 */
-	public function getDefaultEncryptionModuleId();
+	public function getDefaultEncryptionModuleId(): string;
 
 	/**
-	 * set default encryption module Id
+	 * Set default encryption module Id.
 	 *
-	 * @param string $moduleId
-	 * @return string
 	 * @since 8.1.0
 	 */
-	public function setDefaultEncryptionModule($moduleId);
+	public function setDefaultEncryptionModule(string $moduleId): bool;
 }

--- a/tests/lib/Encryption/ManagerTest.php
+++ b/tests/lib/Encryption/ManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -12,48 +14,37 @@ use OC\Encryption\Exceptions\ModuleAlreadyExistsException;
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
 use OC\Encryption\Manager;
 use OC\Encryption\Util;
-use OC\Files\View;
 use OC\Memcache\ArrayCache;
 use OCP\Encryption\IEncryptionModule;
+use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
-	/** @var Manager */
-	private $manager;
-
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	private $logger;
-
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10n;
-
-	/** @var View|\PHPUnit\Framework\MockObject\MockObject */
-	private $view;
-
-	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
-	private $util;
-
-	/** @var ArrayCache|\PHPUnit\Framework\MockObject\MockObject */
-	private $arrayCache;
+	private Manager $manager;
+	private IConfig&MockObject $config;
+	private IAppConfig&MockObject $appConfig;
+	private LoggerInterface&MockObject $logger;
+	private IL10N&MockObject $l10n;
+	private IRootFolder&MockObject $rootFolder;
+	private Util&MockObject $util;
+	private ArrayCache&MockObject $arrayCache;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->l10n = $this->createMock(IL10N::class);
-		$this->view = $this->createMock(View::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->util = $this->createMock(Util::class);
 		$this->arrayCache = $this->createMock(ArrayCache::class);
-		$this->manager = new Manager($this->config, $this->logger, $this->l10n, $this->view, $this->util, $this->arrayCache);
+		$this->manager = new Manager($this->config, $this->appConfig, $this->logger, $this->l10n, $this->rootFolder, $this->util, $this->arrayCache);
 	}
 
 	public function testManagerIsDisabled(): void {
@@ -76,20 +67,17 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($this->manager->isEnabled());
 	}
 
-	#[Group(name: 'DB')]
 	public function testManagerIsEnabled(): void {
-		$appConfig = Server::get(IAppConfig::class);
-		$appConfig->setValueBool('core', 'encryption_enabled', true);
+		$this->appConfig->expects($this->any())->method('getValueBool')->with('core', 'encryption_enabled')->willReturn(true);
 
 		$this->config->expects($this->any())->method('getSystemValueBool')->willReturn(true);
 		$result = $this->manager->isEnabled();
 
-		$appConfig->deleteKey('core', 'encryption_enabled');
 		$this->assertTrue($result);
 	}
 
 	public function testModuleRegistration() {
-		$this->config->expects($this->any())->method('getAppValue')->willReturn('yes');
+		$this->appConfig->expects($this->any())->method('getValueBool')->willReturn(true);
 
 		$this->addNewEncryptionModule($this->manager, 0);
 		$this->assertCount(1, $this->manager->getEncryptionModules());
@@ -106,7 +94,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testModuleUnRegistration(): void {
-		$this->config->expects($this->any())->method('getAppValue')->willReturn(true);
+		$this->appConfig->expects($this->any())->method('getValueBool')->willReturn(true);
 		$this->addNewEncryptionModule($this->manager, 0);
 		$this->assertCount(1, $this->manager->getEncryptionModules());
 
@@ -118,7 +106,7 @@ class ManagerTest extends TestCase {
 		$this->expectException(ModuleDoesNotExistsException::class);
 		$this->expectExceptionMessage('Module with ID: unknown does not exist.');
 
-		$this->config->expects($this->any())->method('getAppValue')->willReturn(true);
+		$this->appConfig->expects($this->any())->method('getValueBool')->willReturn(true);
 		$this->addNewEncryptionModule($this->manager, 0);
 		$this->assertCount(1, $this->manager->getEncryptionModules());
 		$this->manager->getEncryptionModule('unknown');
@@ -126,10 +114,10 @@ class ManagerTest extends TestCase {
 
 	public function testGetEncryptionModuleEmpty(): void {
 		global $defaultId;
-		$defaultId = null;
+		$defaultId = '';
 
-		$this->config->expects($this->any())
-			->method('getAppValue')
+		$this->appConfig->expects($this->any())
+			->method('getValueString')
 			->with('core', 'default_encryption_module')
 			->willReturnCallback(function () {
 				global $defaultId;
@@ -150,10 +138,10 @@ class ManagerTest extends TestCase {
 
 	public function testGetEncryptionModule(): void {
 		global $defaultId;
-		$defaultId = null;
+		$defaultId = '';
 
-		$this->config->expects($this->any())
-			->method('getAppValue')
+		$this->appConfig->expects($this->any())
+			->method('getValueString')
 			->with('core', 'default_encryption_module')
 			->willReturnCallback(function () {
 				global $defaultId;
@@ -175,10 +163,10 @@ class ManagerTest extends TestCase {
 
 	public function testSetDefaultEncryptionModule(): void {
 		global $defaultId;
-		$defaultId = null;
+		$defaultId = '';
 
-		$this->config->expects($this->any())
-			->method('getAppValue')
+		$this->appConfig->expects($this->any())
+			->method('getValueString')
 			->with('core', 'default_encryption_module')
 			->willReturnCallback(function () {
 				global $defaultId;
@@ -195,8 +183,8 @@ class ManagerTest extends TestCase {
 		$this->assertEquals('ID0', $this->manager->getDefaultEncryptionModuleId());
 
 		// Set to an existing module
-		$this->config->expects($this->once())
-			->method('setAppValue')
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
 			->with('core', 'default_encryption_module', 'ID1');
 		$this->assertTrue($this->manager->setDefaultEncryptionModule('ID1'));
 		$defaultId = 'ID1';

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -19,7 +19,6 @@ use OCP\App\IAppManager;
 use OCP\Encryption\IManager;
 use OCP\Files\ISetupManager;
 use OCP\IAppConfig;
-use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Server;
@@ -42,11 +41,6 @@ trait EncryptionTrait {
 
 	private IUserManager $userManagerEncTrait;
 	private ISetupManager $setupManagerEncTrait;
-
-	/**
-	 * @var IConfig
-	 */
-	private $config;
 
 	private IAppConfig $appConfig;
 
@@ -110,20 +104,19 @@ trait EncryptionTrait {
 
 		$this->encryptionApp = new Application([], $isReady);
 
-		$this->config = Server::get(IConfig::class);
 		$this->appConfig = Server::get(IAppConfig::class);
 		$this->encryptionWasEnabled = $this->appConfig->getValueBool('core', 'encryption_enabled');
-		$this->originalEncryptionModule = $this->config->getAppValue('core', 'default_encryption_module');
-		$this->config->setAppValue('core', 'default_encryption_module', Encryption::ID);
+		$this->originalEncryptionModule = $this->appConfig->getValueString('core', 'default_encryption_module');
+		$this->appConfig->setValueString('core', 'default_encryption_module', Encryption::ID);
 		$this->appConfig->setValueBool('core', 'encryption_enabled', true);
 		$this->assertTrue(Server::get(\OCP\Encryption\IManager::class)->isEnabled());
 	}
 
 	protected function tearDownEncryptionTrait() {
-		if ($this->config) {
+		if ($this->appConfig) {
 			$this->appConfig->setValueBool('core', 'encryption_enabled', $this->encryptionWasEnabled);
-			$this->config->setAppValue('core', 'default_encryption_module', $this->originalEncryptionModule);
-			$this->config->deleteAppValue('encryption', 'useMasterKey');
+			$this->appConfig->setValueBool('core', 'default_encryption_module', $this->originalEncryptionModule);
+			$this->appConfig->deleteKey('encryption', 'useMasterKey');
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The app needs to be enabled and the settings need to be on.

And second commit

refactor: Cleanup encryption manager
    
- Port to IAppConfig
- Port to IRootFolder
- Add typing
- Add Consumable attribute to OCP interface

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
