### PR TITLE
fix(Session): Don't updateLastLoginTimestamp when logging in via token

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -351,7 +351,7 @@ class Session implements IUserSession, Emitter {
 		if ($isToken) {
 			$this->setToken($loginDetails['token']->getId());
 			$this->lockdownManager->setToken($loginDetails['token']);
-			$user->updateLastLoginTimestamp();
+			// don't updateLastLoginTimestamp here, since $firstTimeLogin would never ever be true in the future
 			$firstTimeLogin = false;
 		} else {
 			$this->setToken(null);


### PR DESCRIPTION
This fixes a bug where for users logging in for the first time via a client that uses tokens, no `<user>/files/` subdir is created. 

Note: I'm not sure if this is the best possible fix.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
