### PR TITLE
Optimize propagator

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -30,6 +30,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Exceptions\AbortedEventException;
+use OCP\Files\Cache\IPropagator;
 use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -937,21 +938,27 @@ class Trashbin implements IEventListener {
 		$size = 0;
 
 		if ($availableSpace <= 0) {
-			foreach ($files as $file) {
-				if ($availableSpace <= 0 && $expiration->isExpired($file['mtime'], true)) {
-					$tmp = self::delete($file['name'], $user, $file['mtime']);
-					Server::get(LoggerInterface::class)->info(
-						'remove "' . $file['name'] . '" (' . $tmp . 'B) to meet the limit of trash bin size (50% of available quota) for user "{user}"',
-						[
-							'app' => 'files_trashbin',
-							'user' => $user,
-						]
-					);
-					$availableSpace += $tmp;
-					$size += $tmp;
-				} else {
-					break;
+			$propagator = self::getUserStoragePropagator($user);
+			$propagator?->beginBatch();
+			try {
+				foreach ($files as $file) {
+					if ($availableSpace <= 0 && $expiration->isExpired($file['mtime'], true)) {
+						$tmp = self::delete($file['name'], $user, $file['mtime']);
+						Server::get(LoggerInterface::class)->info(
+							'remove "' . $file['name'] . '" (' . $tmp . 'B) to meet the limit of trash bin size (50% of available quota) for user "{user}"',
+							[
+								'app' => 'files_trashbin',
+								'user' => $user,
+							]
+						);
+						$availableSpace += $tmp;
+						$size += $tmp;
+					} else {
+						break;
+					}
 				}
+			} finally {
+				$propagator?->commitBatch();
 			}
 		}
 		return $size;
@@ -968,10 +975,17 @@ class Trashbin implements IEventListener {
 		$expiration = Server::get(Expiration::class);
 		$size = 0;
 		$count = 0;
-		foreach ($files as $file) {
-			$timestamp = $file['mtime'];
-			$filename = $file['name'];
-			if ($expiration->isExpired($timestamp)) {
+
+		$propagator = self::getUserStoragePropagator($user);
+		$propagator?->beginBatch();
+		try {
+			foreach ($files as $file) {
+				$timestamp = $file['mtime'];
+				$filename = $file['name'];
+				if (!$expiration->isExpired($timestamp)) {
+					break;
+				}
+
 				try {
 					$size += self::delete($filename, $user, $timestamp);
 					$count++;
@@ -991,12 +1005,20 @@ class Trashbin implements IEventListener {
 						'user' => $user,
 					],
 				);
-			} else {
-				break;
 			}
+		} finally {
+			$propagator?->commitBatch();
 		}
 
 		return [$size, $count];
+	}
+
+	private static function getUserStoragePropagator(string $user): ?IPropagator {
+		try {
+			return Server::get(IRootFolder::class)->getUserFolder($user)->getStorage()->getPropagator();
+		} catch (\Exception) {
+			return null;
+		}
 	}
 
 	/**

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -25,6 +25,7 @@ use OCA\Files_Versions\Versions\IVersionManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Command\IBus;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Cache\IPropagator;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
@@ -234,6 +235,14 @@ class Storage {
 			'filename' => $filename];
 	}
 
+	private static function getUserStoragePropagator(string $uid): ?IPropagator {
+		try {
+			return Server::get(IRootFolder::class)->getUserFolder($uid)->getStorage()->getPropagator();
+		} catch (\Exception) {
+			return null;
+		}
+	}
+
 	/**
 	 * delete the version from the storage and cache
 	 *
@@ -264,10 +273,16 @@ class Storage {
 
 			$versions = self::getVersions($uid, $filename);
 			if (!empty($versions)) {
-				foreach ($versions as $v) {
-					\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path . $v['version'], 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED]);
-					self::deleteVersion($view, $filename . '.v' . $v['version']);
-					\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path . $v['version'], 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED]);
+				$propagator = self::getUserStoragePropagator($uid);
+				$propagator?->beginBatch();
+				try {
+					foreach ($versions as $v) {
+						\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path . $v['version'], 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED]);
+						self::deleteVersion($view, $filename . '.v' . $v['version']);
+						\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path . $v['version'], 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED]);
+					}
+				} finally {
+					$propagator?->commitBatch();
 				}
 			}
 		}
@@ -619,21 +634,27 @@ class Storage {
 			return $version < $threshold;
 		});
 
-		foreach ($versions as $version) {
-			$internalPath = $version->getInternalPath();
-			\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $internalPath, 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
+		$propagator = self::getUserStoragePropagator($uid);
+		$propagator?->beginBatch();
+		try {
+			foreach ($versions as $version) {
+				$internalPath = $version->getInternalPath();
+				\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $internalPath, 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
 
-			$versionEntity = isset($versionEntities[$version->getId()]) ? $versionEntities[$version->getId()] : null;
-			if (!is_null($versionEntity)) {
-				$versionsMapper->delete($versionEntity);
-			}
+				$versionEntity = isset($versionEntities[$version->getId()]) ? $versionEntities[$version->getId()] : null;
+				if (!is_null($versionEntity)) {
+					$versionsMapper->delete($versionEntity);
+				}
 
-			try {
-				$version->delete();
-				\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $internalPath, 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
-			} catch (NotPermittedException $e) {
-				Server::get(LoggerInterface::class)->error("Missing permissions to delete version for user {$uid}: {$internalPath}", ['app' => 'files_versions', 'exception' => $e]);
+				try {
+					$version->delete();
+					\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $internalPath, 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
+				} catch (NotPermittedException $e) {
+					Server::get(LoggerInterface::class)->error("Missing permissions to delete version for user {$uid}: {$internalPath}", ['app' => 'files_versions', 'exception' => $e]);
+				}
 			}
+		} finally {
+			$propagator?->commitBatch();
 		}
 	}
 
@@ -935,47 +956,53 @@ class Storage {
 				$versionsSize = $versionsSize - $sizeOfDeletedVersions;
 			}
 
-			foreach ($toDelete as $key => $path) {
-				// Make sure to cleanup version table relations as expire does not pass deleteVersion
-				try {
-					/** @var VersionsMapper $versionsMapper */
-					$versionsMapper = Server::get(VersionsMapper::class);
-					$file = Server::get(IRootFolder::class)->getUserFolder($uid)->get($filename);
-					$pathparts = pathinfo($path);
-					$timestamp = (int)substr($pathparts['extension'] ?? '', 1);
-					$versionEntity = $versionsMapper->findVersionForFileId($file->getId(), $timestamp);
-					if ($versionEntity->getMetadataValue('label') !== null && $versionEntity->getMetadataValue('label') !== '') {
-						continue;
+			$propagator = self::getUserStoragePropagator($uid);
+			$propagator?->beginBatch();
+			try {
+				foreach ($toDelete as $key => $path) {
+					// Make sure to cleanup version table relations as expire does not pass deleteVersion
+					try {
+						/** @var VersionsMapper $versionsMapper */
+						$versionsMapper = Server::get(VersionsMapper::class);
+						$file = Server::get(IRootFolder::class)->getUserFolder($uid)->get($filename);
+						$pathparts = pathinfo($path);
+						$timestamp = (int)substr($pathparts['extension'] ?? '', 1);
+						$versionEntity = $versionsMapper->findVersionForFileId($file->getId(), $timestamp);
+						if ($versionEntity->getMetadataValue('label') !== null && $versionEntity->getMetadataValue('label') !== '') {
+							continue;
+						}
+						$versionsMapper->delete($versionEntity);
+					} catch (DoesNotExistException $e) {
 					}
-					$versionsMapper->delete($versionEntity);
-				} catch (DoesNotExistException $e) {
+
+					\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path, 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+					self::deleteVersion($versionsFileview, $path);
+					\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path, 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+					unset($allVersions[$key]); // update array with the versions we keep
+					$logger->info('Expire: ' . $path, ['app' => 'files_versions']);
 				}
 
-				\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path, 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
-				self::deleteVersion($versionsFileview, $path);
-				\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path, 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
-				unset($allVersions[$key]); // update array with the versions we keep
-				$logger->info('Expire: ' . $path, ['app' => 'files_versions']);
-			}
-
-			// Check if enough space is available after versions are rearranged.
-			// If not we delete the oldest versions until we meet the size limit for versions,
-			// but always keep the two latest versions
-			$numOfVersions = count($allVersions) - 2 ;
-			$i = 0;
-			// sort oldest first and make sure that we start at the first element
-			ksort($allVersions);
-			reset($allVersions);
-			while ($availableSpace < 0 && $i < $numOfVersions) {
-				$version = current($allVersions);
-				\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $version['path'] . '.v' . $version['version'], 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
-				self::deleteVersion($versionsFileview, $version['path'] . '.v' . $version['version']);
-				\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $version['path'] . '.v' . $version['version'], 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
-				$logger->info('running out of space! Delete oldest version: ' . $version['path'] . '.v' . $version['version'], ['app' => 'files_versions']);
-				$versionsSize -= $version['size'];
-				$availableSpace += $version['size'];
-				next($allVersions);
-				$i++;
+				// Check if enough space is available after versions are rearranged.
+				// If not we delete the oldest versions until we meet the size limit for versions,
+				// but always keep the two latest versions
+				$numOfVersions = count($allVersions) - 2 ;
+				$i = 0;
+				// sort oldest first and make sure that we start at the first element
+				ksort($allVersions);
+				reset($allVersions);
+				while ($availableSpace < 0 && $i < $numOfVersions) {
+					$version = current($allVersions);
+					\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $version['path'] . '.v' . $version['version'], 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+					self::deleteVersion($versionsFileview, $version['path'] . '.v' . $version['version']);
+					\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $version['path'] . '.v' . $version['version'], 'trigger' => self::DELETE_TRIGGER_QUOTA_EXCEEDED]);
+					$logger->info('running out of space! Delete oldest version: ' . $version['path'] . '.v' . $version['version'], ['app' => 'files_versions']);
+					$versionsSize -= $version['size'];
+					$availableSpace += $version['size'];
+					next($allVersions);
+					$i++;
+				}
+			} finally {
+				$propagator?->commitBatch();
 			}
 
 			return $versionsSize; // finally return the new size of the version history

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -195,6 +195,10 @@ class Propagator implements IPropagator {
 		// Ensure rows are always locked in the same order
 		uasort($this->batch, static fn (array $a, array $b) => $a['hash'] <=> $b['hash']);
 
+		// storages with reliable etags maintain their own etag, so don't churn one
+		// here on every batched row (matches the check in propagateChange())
+		$reliableEtag = $this->storage->instanceOfStorage(IReliableEtagStorage::class);
+
 		try {
 			$this->connection->beginTransaction();
 
@@ -219,17 +223,21 @@ class Propagator implements IPropagator {
 					$query = $this->connection->getQueryBuilder();
 					$query->update('filecache')
 						->set('mtime', $query->func()->greatest('mtime', $query->createParameter('time')))
-						->set('etag', $query->expr()->literal(uniqid()))
 						->where($query->expr()->eq('storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 						->andWhere($query->expr()->eq('fileid', $query->createParameter('fileid')));
+					if (!$reliableEtag) {
+						$query->set('etag', $query->expr()->literal(uniqid()));
+					}
 
 					$queryWithSize = $this->connection->getQueryBuilder();
 					$queryWithSize->update('filecache')
 						->set('mtime', $queryWithSize->func()->greatest('mtime', $queryWithSize->createParameter('time')))
-						->set('etag', $queryWithSize->expr()->literal(uniqid()))
 						->set('size', $queryWithSize->func()->add('size', $queryWithSize->createParameter('size')))
 						->where($queryWithSize->expr()->eq('storage', $queryWithSize->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 						->andWhere($queryWithSize->expr()->eq('fileid', $queryWithSize->createParameter('fileid')));
+					if (!$reliableEtag) {
+						$queryWithSize->set('etag', $queryWithSize->expr()->literal(uniqid()));
+					}
 
 					while ($row = $result->fetchAssociative()) {
 						$item = $this->batch[$row['path']];
@@ -250,17 +258,21 @@ class Propagator implements IPropagator {
 				$query = $this->connection->getQueryBuilder();
 				$query->update('filecache')
 					->set('mtime', $query->func()->greatest('mtime', $query->createParameter('time')))
-					->set('etag', $query->expr()->literal(uniqid()))
 					->where($query->expr()->eq('storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 					->andWhere($query->expr()->eq('path_hash', $query->createParameter('hash')));
+				if (!$reliableEtag) {
+					$query->set('etag', $query->expr()->literal(uniqid()));
+				}
 
 				$queryWithSize = $this->connection->getQueryBuilder();
 				$queryWithSize->update('filecache')
 					->set('mtime', $queryWithSize->func()->greatest('mtime', $queryWithSize->createParameter('time')))
-					->set('etag', $queryWithSize->expr()->literal(uniqid()))
 					->set('size', $queryWithSize->func()->add('size', $queryWithSize->createParameter('size')))
 					->where($queryWithSize->expr()->eq('storage', $queryWithSize->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 					->andWhere($queryWithSize->expr()->eq('path_hash', $queryWithSize->createParameter('hash')));
+				if (!$reliableEtag) {
+					$queryWithSize->set('etag', $queryWithSize->expr()->literal(uniqid()));
+				}
 
 				foreach ($this->batch as $item) {
 					if ($item['size']) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- Batch writes for the propagator in versions and trash backend 
- Don't update etags for IRelieableEtagStorage

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
