### PR TITLE
fix(user_ldap): skip non-string elements from ldap_explode_dn in getDomainDNFromDN

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -397,6 +397,9 @@ class Access extends LDAPUtility {
 		$domainParts = [];
 		$dcFound = false;
 		foreach ($allParts as $part) {
+			if (!is_string($part)) {
+				continue;
+			}
 			if (!$dcFound && str_starts_with($part, 'dc=')) {
 				$dcFound = true;
 			}

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -204,6 +204,25 @@ class AccessTest extends TestCase {
 		$this->assertSame($expected, $this->access->getDomainDNFromDN($inputDN));
 	}
 
+	public function testGetDomainDNFromDNSkipsCountElement(): void {
+		$inputDN = 'cn=John,dc=example,dc=com';
+		// ldap_explode_dn() returns array with a 'count' key
+		$allParts = [
+			0 => 'cn=John',
+			1 => 'dc=example',
+			2 => 'dc=com',
+			'count' => 3,
+		];
+		$expected = 'dc=example,dc=com';
+
+		$this->ldap->expects($this->once())
+			->method('explodeDN')
+			->with($inputDN, 0)
+			->willReturn($allParts);
+
+		$this->assertSame($expected, $this->access->getDomainDNFromDN($inputDN));
+	}
+
 	public static function dnInputDataProvider(): array {
 		return [
 			[


### PR DESCRIPTION
## Summary

Fixes a bug in `getDomainDNFromDN()` where `ldap_explode_dn()` returns an array that includes a `count` key with an integer value. The foreach loop did not skip this non-string element, causing the integer to be appended to the domain DN (e.g. `dc=example,dc=com,4`), which produces an invalid DN and causes `ldap_read` to fail with "Invalid DN syntax".

## Root Cause

`ldap_explode_dn("cn=John Doe,ou=staff,dc=example,dc=com", 0)` returns:
```php
[
  0 => "cn=John Doe",
  1 => "ou=staff",
  2 => "dc=example",
  3 => "dc=com",
  "count" => 4
]
```

The `count` integer was being appended to `$domainParts` because the loop did not filter non-string elements.

## Fix

Added `if (!is_string($part)) continue;` at the top of the foreach loop to skip the `count` integer (and any other non-string elements).

## Changes

- **apps/user_ldap/lib/Access.php**: One-line fix in `getDomainDNFromDN()`
- **apps/user_ldap/tests/AccessTest.php**: New test `testGetDomainDNFromDNSkipsCountElement` that reproduces the bug with a `count`-containing array

Closes: #61446

## AI Assistance

This contribution was made with the help of DeepSeek V4 Pro. The AI assisted with code analysis and framing, but all code has been reviewed and understood by the author.

Assisted-by: DeepSeek:V4-Pro