### PR TITLE
fix: correct spelling errors in comments

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -49,8 +49,8 @@ $CONFIG = [
 	 *
 	 * Value must be an integer, comprised between 0 and 511.
 	 *
-	 * When config.php is shared between different servers, this value should be overriden with "NC_serverid=<int>" on each server.
-	 * Note that it must be overriden for CLI and for your webserver.
+	 * When config.php is shared between different servers, this value should be overridden with "NC_serverid=<int>" on each server.
+	 * Note that it must be overridden for CLI and for your webserver.
 	 *
 	 * Example for CLI: NC_serverid=42 occ config:list system
 	 */

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -333,7 +333,7 @@ class Comment implements IComment {
 	#[\Override]
 	public function getCreationDateTime(): \DateTime {
 		if (!isset($this->data['creationDT'])) {
-			throw new \LogicException('Cannot get creation date before setting one or writting to database');
+			throw new \LogicException('Cannot get creation date before setting one or writing to database');
 		}
 		return $this->data['creationDT'];
 	}

--- a/lib/public/BackgroundJob/JobStatus.php
+++ b/lib/public/BackgroundJob/JobStatus.php
@@ -23,7 +23,7 @@ enum JobStatus: int {
 	case RUNNING = 0;
 
 	/**
-	 * Background job completed sucessfully
+	 * Background job completed successfully
 	 *
 	 * @since 34.0.0
 	 */


### PR DESCRIPTION
## Summary

Fixes three spelling errors in code comments and configuration documentation.

## Changes

| File | Correction |
|---|---|
| `lib/private/Comments/Comment.php` | `writting` → `writing` |
| `config/config.sample.php` | `overriden` → `overridden` (2 occurrences) |
| `lib/public/BackgroundJob/JobStatus.php` | `sucessfully` → `successfully` |

All changes are limited to comments/documentation only — no functional impact.

## AI Assistance

This contribution was made with the help of DeepSeek V4 Pro.

Assisted-by: DeepSeek:V4-Pro