### PR TITLE
perf(group): Cache group membership in distributed cache

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -8,8 +8,6 @@
 
 namespace OCA\Files_Sharing\AppInfo;
 
-use OC\Group\DisplayNameCache as GroupDisplayNameCache;
-use OC\User\DisplayNameCache;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files\Event\LoadSidebar;
 use OCA\Files_Sharing\Capabilities;
@@ -50,7 +48,6 @@ use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\Events\Node\BeforeNodeReadEvent;
 use OCP\Files\Events\UserHomeSetupEvent;
 use OCP\Group\Events\BeforeGroupDeletedEvent;
-use OCP\Group\Events\GroupChangedEvent;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
@@ -62,8 +59,6 @@ use OCP\Share\Events\BeforeShareDeletedEvent;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareMovedEvent;
 use OCP\Share\Events\ShareTransferredEvent;
-use OCP\User\Events\UserChangedEvent;
-use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent as OldGenericEvent;
@@ -98,10 +93,6 @@ class Application extends App implements IBootstrap {
 		$context->registerCapability(Capabilities::class);
 
 		$context->registerNotifierService(Notifier::class);
-		$context->registerEventListener(UserChangedEvent::class, DisplayNameCache::class);
-		$context->registerEventListener(UserDeletedEvent::class, DisplayNameCache::class);
-		$context->registerEventListener(GroupChangedEvent::class, GroupDisplayNameCache::class);
-		$context->registerEventListener(GroupDeletedEvent::class, GroupDisplayNameCache::class);
 
 		// Sidebar and files scripts
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalListener::class);

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -129,7 +129,7 @@ class UsersController extends Controller {
 		} else {
 			if ($this->appManager->isEnabledForUser('user_ldap')) {
 				$isLDAPUsed
-					= $this->groupManager->isBackendUsed('\OCA\User_LDAP\Group_Proxy');
+					= $this->groupManager->isBackendUsed(\OCA\User_LDAP\Group_Proxy::class);
 				if ($isLDAPUsed) {
 					// LDAP user count can be slow, so we sort by group name here
 					$sortGroupsBy = MetaData::SORT_GROUPNAME;

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4129,12 +4129,6 @@
       <code><![CDATA[get]]></code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="lib/private/SubAdmin.php">
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[listen]]></code>
-      <code><![CDATA[listen]]></code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="lib/private/Support/Subscription/Registry.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[getSupportedApps]]></code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2874,6 +2874,11 @@
       <code><![CDATA[getSubject]]></code>
     </DeprecatedMethod>
   </file>
+  <file src="core/AppInfo/Application.php">
+    <DeprecatedClass>
+      <code><![CDATA[BeforeUserRemovedEvent::class]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php">
     <DeprecatedClass>
       <code><![CDATA[Files::rmdirr($dir)]]></code>

--- a/core/AppInfo/Application.php
+++ b/core/AppInfo/Application.php
@@ -9,6 +9,7 @@
 namespace OC\Core\AppInfo;
 
 use NCU\Sharing\ISharingRegistry;
+use OC\App\AppManager;
 use OC\Authentication\Events\RemoteWipeFinished;
 use OC\Authentication\Events\RemoteWipeStarted;
 use OC\Authentication\Listeners\RemoteWipeActivityListener;
@@ -42,6 +43,7 @@ use OC\Group\DisplayNameCache as GroupDisplayNameCache;
 use OC\Group\Manager as GroupManager;
 use OC\OCM\OCMDiscoveryHandler;
 use OC\OCM\OCMJwksHandler;
+use OC\SubAdmin;
 use OC\TagManager;
 use OC\User\DisplayNameCache;
 use OCP\AppFramework\App;
@@ -119,7 +121,9 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeGroupDeletedEvent::class, GroupManager::class);
 		$context->registerEventListener(BeforeUserAddedEvent::class, GroupManager::class);
 		$context->registerEventListener(BeforeUserRemovedEvent::class, GroupManager::class);
-		$context->registerEventListener(GroupDeletedEvent::class, GroupManager::class);
+		$context->registerEventListener(GroupDeletedEvent::class, AppManager::class);
+		$context->registerEventListener(GroupDeletedEvent::class, SubAdmin::class);
+		$context->registerEventListener(UserDeletedEvent::class, SubAdmin::class);
 
 		// Tags
 		$context->registerEventListener(UserDeletedEvent::class, TagManager::class);

--- a/core/AppInfo/Application.php
+++ b/core/AppInfo/Application.php
@@ -38,9 +38,12 @@ use OC\Core\Sharing\Recipient\GroupShareRecipientType;
 use OC\Core\Sharing\Recipient\TeamShareRecipientType;
 use OC\Core\Sharing\Recipient\TokenShareRecipientType;
 use OC\Core\Sharing\Recipient\UserShareRecipientType;
+use OC\Group\DisplayNameCache as GroupDisplayNameCache;
+use OC\Group\Manager as GroupManager;
 use OC\OCM\OCMDiscoveryHandler;
 use OC\OCM\OCMJwksHandler;
 use OC\TagManager;
+use OC\User\DisplayNameCache;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -49,12 +52,18 @@ use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\DB\Events\AddMissingPrimaryKeyEvent;
+use OCP\Group\Events\BeforeGroupDeletedEvent;
+use OCP\Group\Events\BeforeUserAddedEvent;
+use OCP\Group\Events\BeforeUserRemovedEvent;
+use OCP\Group\Events\GroupChangedEvent;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\IAppConfig;
 use OCP\Interaction\RestrictInteractionEvent;
 use OCP\Navigation\Events\LoadAdditionalEntriesEvent;
 use OCP\Server;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
+use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
 
@@ -102,6 +111,14 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedFilesCleanupListener::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedWebAuthnCleanupListener::class);
 		$context->registerEventListener(PasswordUpdatedEvent::class, PasswordUpdatedListener::class);
+
+		$context->registerEventListener(UserChangedEvent::class, DisplayNameCache::class);
+		$context->registerEventListener(UserDeletedEvent::class, DisplayNameCache::class);
+		$context->registerEventListener(GroupChangedEvent::class, GroupDisplayNameCache::class);
+		$context->registerEventListener(GroupDeletedEvent::class, GroupDisplayNameCache::class);
+		$context->registerEventListener(BeforeGroupDeletedEvent::class, GroupManager::class);
+		$context->registerEventListener(BeforeUserAddedEvent::class, GroupManager::class);
+		$context->registerEventListener(BeforeUserRemovedEvent::class, GroupManager::class);
 
 		// Tags
 		$context->registerEventListener(UserDeletedEvent::class, TagManager::class);

--- a/core/AppInfo/Application.php
+++ b/core/AppInfo/Application.php
@@ -119,6 +119,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeGroupDeletedEvent::class, GroupManager::class);
 		$context->registerEventListener(BeforeUserAddedEvent::class, GroupManager::class);
 		$context->registerEventListener(BeforeUserRemovedEvent::class, GroupManager::class);
+		$context->registerEventListener(GroupDeletedEvent::class, GroupManager::class);
 
 		// Tags
 		$context->registerEventListener(UserDeletedEvent::class, TagManager::class);

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -873,7 +873,6 @@ class OC {
 		self::registerResourceCollectionHooks();
 		self::registerFileReferenceEventListener();
 		self::registerRenderReferenceEventListener();
-		self::registerAppRestrictionsHooks();
 
 		// Make sure that the application class is not loaded before the database is setup
 		if ($systemConfig->getValue('installed', false)) {
@@ -1048,29 +1047,6 @@ class OC {
 		/** @var IEventDispatcher $dispatcher */
 		$dispatcher = Server::get(IEventDispatcher::class);
 		$dispatcher->addServiceListener(UserChangedEvent::class, \OC\Accounts\Hooks::class);
-	}
-
-	private static function registerAppRestrictionsHooks(): void {
-		/** @var \OC\Group\Manager $groupManager */
-		$groupManager = Server::get(\OCP\IGroupManager::class);
-		$groupManager->listen('\OC\Group', 'postDelete', function (\OCP\IGroup $group) {
-			$appManager = Server::get(\OCP\App\IAppManager::class);
-			$apps = $appManager->getEnabledAppsForGroup($group);
-			foreach ($apps as $appId) {
-				$restrictions = $appManager->getAppRestriction($appId);
-				if (empty($restrictions)) {
-					continue;
-				}
-				$key = array_search($group->getGID(), $restrictions, true);
-				unset($restrictions[$key]);
-				$restrictions = array_values($restrictions);
-				if (empty($restrictions)) {
-					$appManager->disableApp($appId);
-				} else {
-					$appManager->enableAppForGroups($appId, $restrictions);
-				}
-			}
-		});
 	}
 
 	private static function registerResourceCollectionHooks(): void {

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -27,7 +27,10 @@ use OCP\BackgroundJob\IJobList;
 use OCP\Collaboration\AutoComplete\IManager as IAutoCompleteManager;
 use OCP\Collaboration\Collaborators\ISearch as ICollaboratorSearch;
 use OCP\Diagnostics\IEventLogger;
+use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -45,8 +48,9 @@ use Psr\Log\LoggerInterface;
 
 /**
  * @psalm-import-type AppInfoDefinition from \OCP\App\AppInfoDefinition
+ * @template-implements IEventListener<GroupDeletedEvent>
  */
-class AppManager implements IAppManager {
+class AppManager implements IAppManager, IEventListener {
 	/**
 	 * Apps with these types can not be enabled for certain groups only
 	 * @var string[]
@@ -1275,5 +1279,29 @@ class AppManager implements IAppManager {
 		}
 		// run the steps
 		$r->run();
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!$event instanceof GroupDeletedEvent) {
+			return;
+		}
+
+		$group = $event->getGroup();
+		$apps = $this->getEnabledAppsForGroup($group);
+		foreach ($apps as $appId) {
+			$restrictions = $this->getAppRestriction($appId);
+			if (empty($restrictions)) {
+				continue;
+			}
+			$key = array_search($group->getGID(), $restrictions, true);
+			unset($restrictions[$key]);
+			$restrictions = array_values($restrictions);
+			if (empty($restrictions)) {
+				$this->disableApp($appId);
+			} else {
+				$this->enableAppForGroups($appId, $restrictions);
+			}
+		}
 	}
 }

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -8,7 +8,6 @@
 
 namespace OC\Group;
 
-use OC\Hooks\PublicEmitter;
 use OC\User\LazyUser;
 use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -48,7 +47,6 @@ class Group implements IGroup {
 		private array $backends,
 		private IEventDispatcher $dispatcher,
 		private IUserManager $userManager,
-		private ?PublicEmitter $emitter = null,
 		/** @var ?non-empty-string $displayName */
 		protected ?string $displayName = null,
 	) {
@@ -154,9 +152,6 @@ class Group implements IGroup {
 
 		$this->dispatcher->dispatchTyped(new BeforeUserAddedEvent($this, $user));
 
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\Group', 'preAddUser', [$this, $user]);
-		}
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::ADD_TO_GROUP)) {
 				/** @var IAddToGroupBackend $backend */
@@ -164,10 +159,6 @@ class Group implements IGroup {
 				$this->users[$user->getUID()] = $user;
 
 				$this->dispatcher->dispatchTyped(new UserAddedEvent($this, $user));
-
-				if ($this->emitter) {
-					$this->emitter->emit('\OC\Group', 'postAddUser', [$this, $user]);
-				}
 				return;
 			}
 		}
@@ -180,9 +171,6 @@ class Group implements IGroup {
 	public function removeUser(IUser $user): void {
 		$result = false;
 		$this->dispatcher->dispatchTyped(new BeforeUserRemovedEvent($this, $user));
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\Group', 'preRemoveUser', [$this, $user]);
-		}
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::REMOVE_FROM_GOUP) && $backend->inGroup($user->getUID(), $this->gid)) {
 				/** @var IRemoveFromGroupBackend $backend */
@@ -192,9 +180,6 @@ class Group implements IGroup {
 		}
 		if ($result) {
 			$this->dispatcher->dispatchTyped(new UserRemovedEvent($this, $user));
-			if ($this->emitter) {
-				$this->emitter->emit('\OC\Group', 'postRemoveUser', [$this, $user]);
-			}
 			if ($this->users) {
 				foreach ($this->users as $index => $groupUser) {
 					if ($groupUser->getUID() === $user->getUID()) {
@@ -323,9 +308,6 @@ class Group implements IGroup {
 
 		$result = false;
 		$this->dispatcher->dispatchTyped(new BeforeGroupDeletedEvent($this));
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\Group', 'preDelete', [$this]);
-		}
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::DELETE_GROUP)) {
 				/** @var IDeleteGroupBackend $backend */
@@ -334,9 +316,6 @@ class Group implements IGroup {
 		}
 		if ($result) {
 			$this->dispatcher->dispatchTyped(new GroupDeletedEvent($this));
-			if ($this->emitter) {
-				$this->emitter->emit('\OC\Group', 'postDelete', [$this]);
-			}
 		}
 		return $result;
 	}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -12,13 +12,19 @@ use OC\Hooks\PublicEmitter;
 use OC\Settings\AuthorizedGroupMapper;
 use OC\SubAdmin;
 use OCA\Settings\Settings\Admin\Users;
+use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\EventDispatcher\IEventListener;
 use OCP\Group\Backend\IBatchMethodsBackend;
 use OCP\Group\Backend\ICreateNamedGroupBackend;
 use OCP\Group\Backend\IGroupDetailsBackend;
 use OCP\Group\Events\BeforeGroupCreatedEvent;
+use OCP\Group\Events\BeforeGroupDeletedEvent;
+use OCP\Group\Events\BeforeUserAddedEvent;
+use OCP\Group\Events\BeforeUserRemovedEvent;
 use OCP\Group\Events\GroupCreatedEvent;
 use OCP\GroupInterface;
+use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\IGroup;
@@ -26,8 +32,6 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Security\Ip\IRemoteAddress;
 use OCP\Server;
-use Psr\Log\LoggerInterface;
-use function is_string;
 
 /**
  * Class Manager
@@ -42,15 +46,16 @@ use function is_string;
  * - preCreate(string $groupId)
  * - postCreate(\OC\Group\Group $group)
  *
- * @package OC\Group
+ * @template-implements IEventListener<BeforeGroupDeletedEvent|BeforeGroupCreatedEvent|BeforeUserAddedEvent|BeforeUserRemovedEvent>
  */
-class Manager extends PublicEmitter implements IGroupManager {
-	/** @var GroupInterface[] */
+class Manager extends PublicEmitter implements IGroupManager, IEventListener {
+	/** @var list<GroupInterface> */
 	private array $backends = [];
 	/** @var array<string, IGroup> */
 	private array $cachedGroups = [];
 	/** @var array<string, list<string>> */
-	private array $cachedUserGroups = [];
+	private array $cachedUserGroupsLocal = [];
+	private ICache $cachedUserGroups;
 	private ?SubAdmin $subAdmin = null;
 	private DisplayNameCache $displayNameCache;
 	private const MAX_GROUP_LENGTH = 255;
@@ -58,48 +63,20 @@ class Manager extends PublicEmitter implements IGroupManager {
 	public function __construct(
 		private \OC\User\Manager $userManager,
 		private IEventDispatcher $dispatcher,
-		private LoggerInterface $logger,
 		ICacheFactory $cacheFactory,
 		private IRemoteAddress $remoteAddress,
 	) {
 		$this->displayNameCache = new DisplayNameCache($cacheFactory, $this);
-
-		$this->listen('\OC\Group', 'preDelete', function (IGroup $group): void {
-			unset($this->cachedGroups[$group->getGID()]);
-			$this->cachedUserGroups = [];
-		});
-		$this->listen('\OC\Group', 'preAddUser', function (IGroup $group): void {
-			$this->cachedUserGroups = [];
-		});
-		$this->listen('\OC\Group', 'preRemoveUser', function (IGroup $group): void {
-			$this->cachedUserGroups = [];
-		});
+		$this->cachedUserGroups = $cacheFactory->createDistributed('user_groups_membership');
 	}
 
-	/**
-	 * Checks whether a given backend is used
-	 *
-	 * @param string $backendClass Full classname including complete namespace
-	 * @return bool
-	 */
 	#[\Override]
-	public function isBackendUsed($backendClass) {
-		$backendClass = strtolower(ltrim($backendClass, '\\'));
-
-		foreach ($this->backends as $backend) {
-			if (strtolower(get_class($backend)) === $backendClass) {
-				return true;
-			}
-		}
-
-		return false;
+	public function isBackendUsed(string $backendClass): bool {
+		return array_any($this->backends, fn (GroupInterface $backend): bool => $backend::class === $backendClass);
 	}
 
-	/**
-	 * @param GroupInterface $backend
-	 */
 	#[\Override]
-	public function addBackend($backend) {
+	public function addBackend(GroupInterface $backend): void {
 		$this->backends[] = $backend;
 		$this->clearCaches();
 	}
@@ -113,44 +90,31 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	#[\Override]
-	public function clearBackends() {
+	public function clearBackends(): void {
 		$this->backends = [];
 		$this->clearCaches();
 	}
 
-	/**
-	 * Get the active backends
-	 *
-	 * @return GroupInterface[]
-	 */
 	#[\Override]
-	public function getBackends() {
+	public function getBackends(): array {
 		return $this->backends;
 	}
 
-	protected function clearCaches() {
+	protected function clearCaches(): void {
 		$this->cachedGroups = [];
-		$this->cachedUserGroups = [];
+		$this->cachedUserGroups->clear();
+		$this->cachedUserGroupsLocal = [];
 	}
 
-	/**
-	 * @param string $gid
-	 * @return IGroup|null
-	 */
 	#[\Override]
-	public function get($gid) {
+	public function get(string $gid): ?IGroup {
 		if (isset($this->cachedGroups[$gid])) {
 			return $this->cachedGroups[$gid];
 		}
 		return $this->getGroupObject($gid);
 	}
 
-	/**
-	 * @param string $gid
-	 * @param string $displayName
-	 * @return IGroup|null
-	 */
-	protected function getGroupObject($gid, $displayName = null) {
+	protected function getGroupObject(string $gid, ?string $displayName = null): ?IGroup {
 		$backends = [];
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(Backend::GROUP_DETAILS)) {
@@ -231,22 +195,14 @@ class Manager extends PublicEmitter implements IGroupManager {
 		return $groups;
 	}
 
-	/**
-	 * @param string $gid
-	 * @return bool
-	 */
 	#[\Override]
-	public function groupExists($gid) {
+	public function groupExists(string $gid): bool {
 		return $this->get($gid) instanceof IGroup;
 	}
 
-	/**
-	 * @param string $gid
-	 * @return IGroup|null
-	 */
 	#[\Override]
-	public function createGroup($gid) {
-		if ($gid === '' || $gid === null) {
+	public function createGroup(string $gid): ?IGroup {
+		if ($gid === '') {
 			return null;
 		} elseif ($group = $this->get($gid)) {
 			return $group;
@@ -278,7 +234,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	#[\Override]
-	public function search(string $search, ?int $limit = null, ?int $offset = 0) {
+	public function search(string $search, ?int $limit = null, ?int $offset = 0): array {
 		$groups = [];
 		foreach ($this->backends as $backend) {
 			$groupIds = $backend->getGroups($search, $limit ?? -1, $offset ?? 0);
@@ -293,10 +249,6 @@ class Manager extends PublicEmitter implements IGroupManager {
 		return array_values($groups);
 	}
 
-	/**
-	 * @param IUser|null $user
-	 * @return array<string, IGroup>
-	 */
 	#[\Override]
 	public function getUserGroups(?IUser $user = null): array {
 		if (!$user instanceof IUser) {
@@ -316,18 +268,15 @@ class Manager extends PublicEmitter implements IGroupManager {
 
 	/**
 	 * Checks if a userId is in the admin group
-	 *
-	 * @param string $userId
-	 * @return bool if admin
 	 */
 	#[\Override]
-	public function isAdmin($userId) {
+	public function isAdmin(string $userId): bool {
 		if (!$this->remoteAddress->allowsAdminActions()) {
 			return false;
 		}
 
 		foreach ($this->backends as $backend) {
-			if (is_string($userId) && $backend->implementsActions(Backend::IS_ADMIN) && $backend->isAdmin($userId)) {
+			if ($backend->implementsActions(Backend::IS_ADMIN) && $backend->isAdmin($userId)) {
 				return true;
 			}
 		}
@@ -347,15 +296,8 @@ class Manager extends PublicEmitter implements IGroupManager {
 		return in_array(Users::class, $authorizedClasses, true);
 	}
 
-	/**
-	 * Checks if a userId is in a group
-	 *
-	 * @param string $userId
-	 * @param string $group
-	 * @return bool if in group
-	 */
 	#[\Override]
-	public function isInGroup($userId, $group) {
+	public function isInGroup(string $userId, string $group): bool {
 		return in_array($group, $this->getUserIdGroupIds($userId));
 	}
 
@@ -369,42 +311,31 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return list<string>
 	 */
 	private function getUserIdGroupIds(string $uid): array {
-		if (!isset($this->cachedUserGroups[$uid])) {
+		if (isset($this->cachedUserGroupsLocal[$uid])) {
+			return $this->cachedUserGroupsLocal[$uid];
+		}
+		$groups = $this->cachedUserGroups->get($uid);
+		if ($groups === null) {
 			$groups = [];
 			foreach ($this->backends as $backend) {
 				if ($groupIds = $backend->getUserGroups($uid)) {
 					$groups = array_merge($groups, $groupIds);
 				}
 			}
-			$this->cachedUserGroups[$uid] = $groups;
+			$this->cachedUserGroups->set($uid, $groups, 60 * 2); // 2min
+			$this->cachedUserGroupsLocal[$uid] = $groups;
 		}
 
-		return $this->cachedUserGroups[$uid];
+		return $groups;
 	}
 
-	/**
-	 * @param string $groupId
-	 * @return ?string
-	 */
 	#[\Override]
 	public function getDisplayName(string $groupId): ?string {
 		return $this->displayNameCache->getDisplayName($groupId);
 	}
 
-	/**
-	 * get an array of groupid and displayName for a user
-	 *
-	 * @param IUser $user
-	 * @return array ['displayName' => displayname]
-	 */
-	public function getUserGroupNames(IUser $user) {
-		return array_map(function ($group) {
-			return ['displayName' => $this->displayNameCache->getDisplayName($group->getGID())];
-		}, $this->getUserGroups($user));
-	}
-
 	#[\Override]
-	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+	public function displayNamesInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array {
 		$group = $this->get($gid);
 		if (is_null($group)) {
 			return [];
@@ -447,10 +378,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 		return $matchingUsers;
 	}
 
-	/**
-	 * @return SubAdmin
-	 */
-	public function getSubAdmin() {
+	public function getSubAdmin(): SubAdmin {
 		if (!$this->subAdmin) {
 			$this->subAdmin = new SubAdmin(
 				$this->userManager,
@@ -461,5 +389,19 @@ class Manager extends PublicEmitter implements IGroupManager {
 		}
 
 		return $this->subAdmin;
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if ($event instanceof BeforeGroupDeletedEvent) {
+			unset($this->cachedGroups[$event->getGroup()->getGID()]);
+			$this->cachedUserGroups->clear();
+			$this->cachedUserGroupsLocal = [];
+		}
+
+		if ($event instanceof BeforeUserAddedEvent || $event instanceof BeforeUserRemovedEvent) {
+			$this->cachedUserGroups->remove($event->getUser()->getUID());
+			unset($this->cachedUserGroupsLocal[$event->getUser()->getUID()]);
+		}
 	}
 }

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -22,7 +22,7 @@ use OCP\Group\Events\BeforeGroupDeletedEvent;
 use OCP\Group\Events\BeforeUserAddedEvent;
 use OCP\Group\Events\BeforeUserRemovedEvent;
 use OCP\Group\Events\GroupCreatedEvent;
-use OCP\Group\Events\GroupDeletedEvent;
+use OCP\Group\ISubAdmin;
 use OCP\GroupInterface;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -32,9 +32,11 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Security\Ip\IRemoteAddress;
 use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
- * @template-implements IEventListener<BeforeGroupDeletedEvent|BeforeGroupCreatedEvent|BeforeUserAddedEvent|BeforeUserRemovedEvent>
+ * @template-implements IEventListener<BeforeGroupDeletedEvent|BeforeUserAddedEvent|BeforeUserRemovedEvent>
  */
 class Manager implements IGroupManager, IEventListener {
 	/** @var list<GroupInterface> */
@@ -363,7 +365,11 @@ class Manager implements IGroupManager, IEventListener {
 		return $matchingUsers;
 	}
 
-	public function getSubAdmin(): SubAdmin {
+	/**
+	 * @throws ContainerExceptionInterface
+	 * @throws NotFoundExceptionInterface
+	 */
+	public function getSubAdmin(): ISubAdmin {
 		if (!$this->subAdmin) {
 			$this->subAdmin = new SubAdmin(
 				$this->userManager,
@@ -387,26 +393,6 @@ class Manager implements IGroupManager, IEventListener {
 		if ($event instanceof BeforeUserAddedEvent || $event instanceof BeforeUserRemovedEvent) {
 			$this->cachedUserGroups->remove($event->getUser()->getUID());
 			unset($this->cachedUserGroupsLocal[$event->getUser()->getUID()]);
-		}
-
-		if ($event instanceof GroupDeletedEvent) {
-			$group = $event->getGroup();
-			$appManager = Server::get(\OCP\App\IAppManager::class);
-			$apps = $appManager->getEnabledAppsForGroup($group);
-			foreach ($apps as $appId) {
-				$restrictions = $appManager->getAppRestriction($appId);
-				if (empty($restrictions)) {
-					continue;
-				}
-				$key = array_search($group->getGID(), $restrictions, true);
-				unset($restrictions[$key]);
-				$restrictions = array_values($restrictions);
-				if (empty($restrictions)) {
-					$appManager->disableApp($appId);
-				} else {
-					$appManager->enableAppForGroups($appId, $restrictions);
-				}
-			}
 		}
 	}
 }

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -8,7 +8,6 @@
 
 namespace OC\Group;
 
-use OC\Hooks\PublicEmitter;
 use OC\Settings\AuthorizedGroupMapper;
 use OC\SubAdmin;
 use OCA\Settings\Settings\Admin\Users;
@@ -23,6 +22,7 @@ use OCP\Group\Events\BeforeGroupDeletedEvent;
 use OCP\Group\Events\BeforeUserAddedEvent;
 use OCP\Group\Events\BeforeUserRemovedEvent;
 use OCP\Group\Events\GroupCreatedEvent;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\GroupInterface;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -34,21 +34,9 @@ use OCP\Security\Ip\IRemoteAddress;
 use OCP\Server;
 
 /**
- * Class Manager
- *
- * Hooks available in scope \OC\Group:
- * - preAddUser(\OC\Group\Group $group, \OC\User\User $user)
- * - postAddUser(\OC\Group\Group $group, \OC\User\User $user)
- * - preRemoveUser(\OC\Group\Group $group, \OC\User\User $user)
- * - postRemoveUser(\OC\Group\Group $group, \OC\User\User $user)
- * - preDelete(\OC\Group\Group $group)
- * - postDelete(\OC\Group\Group $group)
- * - preCreate(string $groupId)
- * - postCreate(\OC\Group\Group $group)
- *
  * @template-implements IEventListener<BeforeGroupDeletedEvent|BeforeGroupCreatedEvent|BeforeUserAddedEvent|BeforeUserRemovedEvent>
  */
-class Manager extends PublicEmitter implements IGroupManager, IEventListener {
+class Manager implements IGroupManager, IEventListener {
 	/** @var list<GroupInterface> */
 	private array $backends = [];
 	/** @var array<string, IGroup> */
@@ -134,7 +122,7 @@ class Manager extends PublicEmitter implements IGroupManager, IEventListener {
 			return null;
 		}
 		/** @var GroupInterface[] $backends */
-		$this->cachedGroups[$gid] = new Group($gid, $backends, $this->dispatcher, $this->userManager, $this, $displayName);
+		$this->cachedGroups[$gid] = new Group($gid, $backends, $this->dispatcher, $this->userManager, $displayName);
 		return $this->cachedGroups[$gid];
 	}
 
@@ -189,7 +177,7 @@ class Manager extends PublicEmitter implements IGroupManager, IEventListener {
 			if (count($backends[$gid]) === 0) {
 				continue;
 			}
-			$this->cachedGroups[$gid] = new Group($gid, $backends[$gid], $this->dispatcher, $this->userManager, $this, $displayNames[$gid]);
+			$this->cachedGroups[$gid] = new Group($gid, $backends[$gid], $this->dispatcher, $this->userManager, $displayNames[$gid]);
 			$groups[$gid] = $this->cachedGroups[$gid];
 		}
 		return $groups;
@@ -210,7 +198,6 @@ class Manager extends PublicEmitter implements IGroupManager, IEventListener {
 			throw new \Exception('Group name is limited to ' . self::MAX_GROUP_LENGTH . ' characters');
 		} else {
 			$this->dispatcher->dispatchTyped(new BeforeGroupCreatedEvent($gid));
-			$this->emit('\OC\Group', 'preCreate', [$gid]);
 			foreach ($this->backends as $backend) {
 				if ($backend->implementsActions(Backend::CREATE_GROUP)) {
 					if ($backend instanceof ICreateNamedGroupBackend) {
@@ -218,13 +205,11 @@ class Manager extends PublicEmitter implements IGroupManager, IEventListener {
 						if (($gid = $backend->createGroup($groupName)) !== null) {
 							$group = $this->getGroupObject($gid);
 							$this->dispatcher->dispatchTyped(new GroupCreatedEvent($group));
-							$this->emit('\OC\Group', 'postCreate', [$group]);
 							return $group;
 						}
 					} elseif ($backend->createGroup($gid)) {
 						$group = $this->getGroupObject($gid);
 						$this->dispatcher->dispatchTyped(new GroupCreatedEvent($group));
-						$this->emit('\OC\Group', 'postCreate', [$group]);
 						return $group;
 					}
 				}
@@ -402,6 +387,26 @@ class Manager extends PublicEmitter implements IGroupManager, IEventListener {
 		if ($event instanceof BeforeUserAddedEvent || $event instanceof BeforeUserRemovedEvent) {
 			$this->cachedUserGroups->remove($event->getUser()->getUID());
 			unset($this->cachedUserGroupsLocal[$event->getUser()->getUID()]);
+		}
+
+		if ($event instanceof GroupDeletedEvent) {
+			$group = $event->getGroup();
+			$appManager = Server::get(\OCP\App\IAppManager::class);
+			$apps = $appManager->getEnabledAppsForGroup($group);
+			foreach ($apps as $appId) {
+				$restrictions = $appManager->getAppRestriction($appId);
+				if (empty($restrictions)) {
+					continue;
+				}
+				$key = array_search($group->getGID(), $restrictions, true);
+				unset($restrictions[$key]);
+				$restrictions = array_values($restrictions);
+				if (empty($restrictions)) {
+					$appManager->disableApp($appId);
+				} else {
+					$appManager->enableAppForGroups($appId, $restrictions);
+				}
+			}
 		}
 	}
 }

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -168,7 +168,8 @@ class Manager implements IManager {
 			}
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			// We expect a valid group as sharedWith for group shares
-			if (!$this->groupManager->groupExists($share->getSharedWith())) {
+			$sharedWith = $share->getSharedWith();
+			if ($sharedWith === null || !$this->groupManager->groupExists($sharedWith)) {
 				throw new \InvalidArgumentException($this->l->t('Share recipient is not a valid group'));
 			}
 		} elseif ($share->getShareType() === IShare::TYPE_LINK) {

--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -9,7 +9,10 @@
 namespace OC;
 
 use OC\Hooks\PublicEmitter;
+use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\SubAdminAddedEvent;
 use OCP\Group\Events\SubAdminRemovedEvent;
 use OCP\Group\ISubAdmin;
@@ -18,27 +21,21 @@ use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\User\Events\UserDeletedEvent;
+use Override;
 
-class SubAdmin extends PublicEmitter implements ISubAdmin {
+/**
+ * @template-implements IEventListener<GroupDeletedEvent|UserDeletedEvent>
+ */
+class SubAdmin extends PublicEmitter implements ISubAdmin, IEventListener {
 	public function __construct(
-		private IUserManager $userManager,
-		private IGroupManager $groupManager,
-		private IDBConnection $dbConn,
-		private IEventDispatcher $eventDispatcher,
+		private readonly IUserManager $userManager,
+		private readonly IGroupManager $groupManager,
+		private readonly IDBConnection $dbConn,
+		private readonly IEventDispatcher $eventDispatcher,
 	) {
-		$this->userManager->listen('\OC\User', 'postDelete', function ($user): void {
-			$this->post_deleteUser($user);
-		});
-		$this->groupManager->listen('\OC\Group', 'postDelete', function ($group): void {
-			$this->post_deleteGroup($group);
-		});
 	}
 
-	/**
-	 * add a SubAdmin
-	 * @param IUser $user user to be SubAdmin
-	 * @param IGroup $group group $user becomes subadmin of
-	 */
 	#[\Override]
 	public function createSubAdmin(IUser $user, IGroup $group): void {
 		$qb = $this->dbConn->getQueryBuilder();
@@ -56,11 +53,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$this->eventDispatcher->dispatchTyped($event);
 	}
 
-	/**
-	 * delete a SubAdmin
-	 * @param IUser $user the user that is the SubAdmin
-	 * @param IGroup $group the group
-	 */
 	#[\Override]
 	public function deleteSubAdmin(IUser $user, IGroup $group): void {
 		$qb = $this->dbConn->getQueryBuilder();
@@ -76,11 +68,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$this->eventDispatcher->dispatchTyped($event);
 	}
 
-	/**
-	 * get groups of a SubAdmin
-	 * @param IUser $user the SubAdmin
-	 * @return IGroup[]
-	 */
 	#[\Override]
 	public function getSubAdminsGroups(IUser $user): array {
 		$groupIds = $this->getSubAdminsGroupIds($user);
@@ -129,11 +116,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		}, $this->getSubAdminsGroups($user));
 	}
 
-	/**
-	 * get SubAdmins of a group
-	 * @param IGroup $group the group
-	 * @return IUser[]
-	 */
 	#[\Override]
 	public function getGroupsSubAdmins(IGroup $group): array {
 		$qb = $this->dbConn->getQueryBuilder();
@@ -182,12 +164,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		return $subadmins;
 	}
 
-	/**
-	 * checks if a user is a SubAdmin of a group
-	 * @param IUser $user
-	 * @param IGroup $group
-	 * @return bool
-	 */
 	#[\Override]
 	public function isSubAdminOfGroup(IUser $user, IGroup $group): bool {
 		$qb = $this->dbConn->getQueryBuilder();
@@ -208,11 +184,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		return $result;
 	}
 
-	/**
-	 * checks if a user is a SubAdmin
-	 * @param IUser $user
-	 * @return bool
-	 */
 	#[\Override]
 	public function isSubAdmin(IUser $user): bool {
 		// Check if the user is already an admin
@@ -239,12 +210,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		return $isSubAdmin !== false;
 	}
 
-	/**
-	 * checks if a user is a accessible by a subadmin
-	 * @param IUser $subadmin
-	 * @param IUser $user
-	 * @return bool
-	 */
 	#[\Override]
 	public function isUserAccessible(IUser $subadmin, IUser $user): bool {
 		if ($subadmin->getUID() === $user->getUID()) {
@@ -267,10 +232,9 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 	}
 
 	/**
-	 * delete all SubAdmins by $user
-	 * @param IUser $user
+	 * Delete all SubAdmins by $user
 	 */
-	private function post_deleteUser(IUser $user) {
+	private function postDeleteUser(IUser $user): void {
 		$qb = $this->dbConn->getQueryBuilder();
 
 		$qb->delete('group_admin')
@@ -279,14 +243,24 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 	}
 
 	/**
-	 * delete all SubAdmins by $group
-	 * @param IGroup $group
+	 * Delete all SubAdmins by $group
 	 */
-	private function post_deleteGroup(IGroup $group) {
+	private function postDeleteGroup(IGroup $group): void {
 		$qb = $this->dbConn->getQueryBuilder();
 
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
 			->executeStatement();
+	}
+
+	#[Override]
+	public function handle(Event $event): void {
+		if ($event instanceof GroupDeletedEvent) {
+			$this->postDeleteGroup($event->getGroup());
+		}
+
+		if ($event instanceof UserDeletedEvent) {
+			$this->postDeleteUser($event->getUser());
+		}
 	}
 }

--- a/lib/public/Group/Backend/IAddToGroupBackend.php
+++ b/lib/public/Group/Backend/IAddToGroupBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 14.0.0
  */
+#[Implementable(since: '14.0.0')]
 interface IAddToGroupBackend {
 	/**
 	 * @since 14.0.0

--- a/lib/public/Group/Backend/IBatchMethodsBackend.php
+++ b/lib/public/Group/Backend/IBatchMethodsBackend.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @brief Optional interface for group backends
  * @since 28.0.0
  */
+#[Implementable(since: '28.0.0')]
 interface IBatchMethodsBackend {
 	/**
 	 * @brief Batch method to check if a list of groups exists

--- a/lib/public/Group/Backend/ICountDisabledInGroup.php
+++ b/lib/public/Group/Backend/ICountDisabledInGroup.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 14.0.0
  */
+#[Implementable(since: '14.0.0')]
 interface ICountDisabledInGroup {
 	/**
 	 * @since 14.0.0

--- a/lib/public/Group/Backend/ICountUsersBackend.php
+++ b/lib/public/Group/Backend/ICountUsersBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 14.0.0
  */
+#[Implementable(since: '14.0.0')]
 interface ICountUsersBackend {
 	/**
 	 * @since 14.0.0

--- a/lib/public/Group/Backend/ICreateGroupBackend.php
+++ b/lib/public/Group/Backend/ICreateGroupBackend.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 14.0.0
  * @deprecated 30.0.0 Use ICreateNamedGroupBackend instead
  */
+#[Implementable(since: '14.0.0')]
 interface ICreateGroupBackend {
 	/**
 	 * @since 14.0.0

--- a/lib/public/Group/Backend/ICreateNamedGroupBackend.php
+++ b/lib/public/Group/Backend/ICreateNamedGroupBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 30.0.0
  */
+#[Implementable(since: '30.0.0')]
 interface ICreateNamedGroupBackend {
 	/**
 	 * Tries to create a group from its name.

--- a/lib/public/Group/Backend/IDeleteGroupBackend.php
+++ b/lib/public/Group/Backend/IDeleteGroupBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 14.0.0
  */
+#[Implementable(since: '14.0.0')]
 interface IDeleteGroupBackend {
 	/**
 	 * @since 14.0.0

--- a/lib/public/Group/Backend/IGetDisplayNameBackend.php
+++ b/lib/public/Group/Backend/IGetDisplayNameBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 17.0.0
  */
+#[Implementable(since: '17.0.0')]
 interface IGetDisplayNameBackend {
 	/**
 	 * @param string $gid

--- a/lib/public/Group/Backend/IGroupDetailsBackend.php
+++ b/lib/public/Group/Backend/IGroupDetailsBackend.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @brief Optional interface for group backends
  * @since 14.0.0
  */
+#[Implementable(since: '14.0.0')]
 interface IGroupDetailsBackend {
 	/**
 	 * @brief Get additional details for a group, for example the display name.

--- a/lib/public/Group/Backend/IHideFromCollaborationBackend.php
+++ b/lib/public/Group/Backend/IHideFromCollaborationBackend.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 16.0.0
  *
  * Allow the backend to mark groups to be excluded from being shown in search dialogs
  */
+#[Implementable(since: '16.0.0')]
 interface IHideFromCollaborationBackend {
 	/**
 	 * Check if a group should be hidden from search dialogs

--- a/lib/public/Group/Backend/IIsAdminBackend.php
+++ b/lib/public/Group/Backend/IIsAdminBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 14.0.0
  */
+#[Implementable(since: '14.0.0')]
 interface IIsAdminBackend {
 	/**
 	 * @since 14.0.0

--- a/lib/public/Group/Backend/INamedBackend.php
+++ b/lib/public/Group/Backend/INamedBackend.php
@@ -7,9 +7,12 @@
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 22.0.0
  */
+#[Implementable(since: '22.0.0')]
 interface INamedBackend {
 	/**
 	 * Backend name to be shown in group management

--- a/lib/public/Group/Backend/IRemoveFromGroupBackend.php
+++ b/lib/public/Group/Backend/IRemoveFromGroupBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 14.0.0
  */
+#[Implementable(since: '14.0.0')]
 interface IRemoveFromGroupBackend {
 	/**
 	 * @since 14.0.0

--- a/lib/public/Group/Backend/ISearchableGroupBackend.php
+++ b/lib/public/Group/Backend/ISearchableGroupBackend.php
@@ -9,11 +9,13 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\IUser;
 
 /**
  * @since 27.0.0
  */
+#[Implementable(since: '27.0.0')]
 interface ISearchableGroupBackend {
 	/**
 	 * @brief Get a list of users matching the given search parameters.

--- a/lib/public/Group/Backend/ISetDisplayNameBackend.php
+++ b/lib/public/Group/Backend/ISetDisplayNameBackend.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace OCP\Group\Backend;
 
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * @since 18.0.0
  */
+#[Implementable(since: '18.0.0')]
 interface ISetDisplayNameBackend {
 	/**
 	 * @param string $gid

--- a/lib/public/Group/Events/BeforeGroupChangedEvent.php
+++ b/lib/public/Group/Events/BeforeGroupChangedEvent.php
@@ -9,49 +9,37 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 
 /**
  * @since 26.0.0
  */
+#[Implementable(since: '26.0.0')]
 class BeforeGroupChangedEvent extends Event {
-	private IGroup $group;
-	private string $feature;
-	/** @var mixed */
-	private $value;
-	/** @var mixed */
-	private $oldValue;
 
 	/**
 	 * @since 26.0.0
 	 */
-	public function __construct(IGroup $group,
-		string $feature,
-		$value,
-		$oldValue = null) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly string $feature,
+		private readonly mixed $value,
+		private readonly mixed $oldValue = null,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->feature = $feature;
-		$this->value = $value;
-		$this->oldValue = $oldValue;
 	}
 
 	/**
-	 *
 	 * @since 26.0.0
-	 *
-	 * @return IGroup
 	 */
 	public function getGroup(): IGroup {
 		return $this->group;
 	}
 
 	/**
-	 *
 	 * @since 26.0.0
-	 *
-	 * @return string
 	 */
 	public function getFeature(): string {
 		return $this->feature;
@@ -59,20 +47,15 @@ class BeforeGroupChangedEvent extends Event {
 
 	/**
 	 * @since 26.0.0
-	 *
-	 * @return mixed
 	 */
-	public function getValue() {
+	public function getValue(): mixed {
 		return $this->value;
 	}
 
 	/**
-	 *
 	 * @since 26.0.0
-	 *
-	 * @return mixed
 	 */
-	public function getOldValue() {
+	public function getOldValue(): mixed {
 		return $this->oldValue;
 	}
 }

--- a/lib/public/Group/Events/BeforeGroupCreatedEvent.php
+++ b/lib/public/Group/Events/BeforeGroupCreatedEvent.php
@@ -9,21 +9,21 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 
 /**
  * @since 18.0.0
  */
+#[Implementable(since: '18.0.0')]
 class BeforeGroupCreatedEvent extends Event {
-	/** @var string */
-	private $name;
-
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(string $name) {
+	public function __construct(
+		private readonly string $name,
+	) {
 		parent::__construct();
-		$this->name = $name;
 	}
 
 	/**

--- a/lib/public/Group/Events/BeforeGroupDeletedEvent.php
+++ b/lib/public/Group/Events/BeforeGroupDeletedEvent.php
@@ -9,26 +9,25 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 
 /**
  * @since 18.0.0
  */
+#[Implementable(since: '18.0.0')]
 class BeforeGroupDeletedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(IGroup $group) {
+	public function __construct(
+		private readonly IGroup $group,
+	) {
 		parent::__construct();
-		$this->group = $group;
 	}
 
 	/**
-	 * @return IGroup
 	 * @since 18.0.0
 	 */
 	public function getGroup(): IGroup {

--- a/lib/public/Group/Events/BeforeUserAddedEvent.php
+++ b/lib/public/Group/Events/BeforeUserAddedEvent.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Listenable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 use OCP\IUser;
@@ -16,24 +17,19 @@ use OCP\IUser;
 /**
  * @since 18.0.0
  */
+#[Listenable(since: '18.0.0')]
 class BeforeUserAddedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
-	/*** @var IUser */
-	private $user;
-
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(IGroup $group, IUser $user) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly IUser $user,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->user = $user;
 	}
 
 	/**
-	 * @return IGroup
 	 * @since 18.0.0
 	 */
 	public function getGroup(): IGroup {

--- a/lib/public/Group/Events/BeforeUserRemovedEvent.php
+++ b/lib/public/Group/Events/BeforeUserRemovedEvent.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 use OCP\IUser;
@@ -20,25 +21,20 @@ use OCP\IUser;
  * case please reach out in the issue tracker at
  * https://github.com/nextcloud/server/issues
  */
+#[Implementable(since: '18.0.0')]
 class BeforeUserRemovedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
-	/*** @var IUser */
-	private $user;
-
 	/**
 	 * @since 18.0.0
 	 * @deprecated 20.0.0
 	 */
-	public function __construct(IGroup $group, IUser $user) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly IUser $user,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->user = $user;
 	}
 
 	/**
-	 * @return IGroup
 	 * @since 18.0.0
 	 * @deprecated 20.0.0
 	 */
@@ -47,7 +43,6 @@ class BeforeUserRemovedEvent extends Event {
 	}
 
 	/**
-	 * @return IUser
 	 * @since 18.0.0
 	 * @deprecated 20.0.0
 	 */

--- a/lib/public/Group/Events/GroupChangedEvent.php
+++ b/lib/public/Group/Events/GroupChangedEvent.php
@@ -9,49 +9,36 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 
 /**
  * @since 26.0.0
  */
+#[Implementable(since: '21.0.0')]
 class GroupChangedEvent extends Event {
-	private IGroup $group;
-	private string $feature;
-	/** @var mixed */
-	private $value;
-	/** @var mixed */
-	private $oldValue;
-
 	/**
 	 * @since 26.0.0
 	 */
-	public function __construct(IGroup $group,
-		string $feature,
-		$value,
-		$oldValue = null) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly string $feature,
+		private readonly mixed $value,
+		private readonly mixed $oldValue = null,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->feature = $feature;
-		$this->value = $value;
-		$this->oldValue = $oldValue;
 	}
 
 	/**
-	 *
 	 * @since 26.0.0
-	 *
-	 * @return IGroup
 	 */
 	public function getGroup(): IGroup {
 		return $this->group;
 	}
 
 	/**
-	 *
 	 * @since 26.0.0
-	 *
-	 * @return string
 	 */
 	public function getFeature(): string {
 		return $this->feature;
@@ -59,20 +46,15 @@ class GroupChangedEvent extends Event {
 
 	/**
 	 * @since 26.0.0
-	 *
-	 * @return mixed
 	 */
-	public function getValue() {
+	public function getValue(): mixed {
 		return $this->value;
 	}
 
 	/**
-	 *
 	 * @since 26.0.0
-	 *
-	 * @return mixed
 	 */
-	public function getOldValue() {
+	public function getOldValue(): mixed {
 		return $this->oldValue;
 	}
 }

--- a/lib/public/Group/Events/GroupCreatedEvent.php
+++ b/lib/public/Group/Events/GroupCreatedEvent.php
@@ -9,26 +9,25 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 
 /**
  * @since 18.0.0
  */
+#[Implementable(since: '21.0.0')]
 class GroupCreatedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(IGroup $group) {
+	public function __construct(
+		private readonly IGroup $group,
+	) {
 		parent::__construct();
-		$this->group = $group;
 	}
 
 	/**
-	 * @return IGroup
 	 * @since 18.0.0
 	 */
 	public function getGroup(): IGroup {

--- a/lib/public/Group/Events/GroupDeletedEvent.php
+++ b/lib/public/Group/Events/GroupDeletedEvent.php
@@ -9,26 +9,25 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Listenable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 
 /**
  * @since 18.0.0
  */
+#[Listenable(since: '18.0.0')]
 class GroupDeletedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(IGroup $group) {
+	public function __construct(
+		private readonly IGroup $group,
+	) {
 		parent::__construct();
-		$this->group = $group;
 	}
 
 	/**
-	 * @return IGroup
 	 * @since 18.0.0
 	 */
 	public function getGroup(): IGroup {

--- a/lib/public/Group/Events/SubAdminAddedEvent.php
+++ b/lib/public/Group/Events/SubAdminAddedEvent.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 use OCP\IUser;
@@ -16,20 +17,16 @@ use OCP\IUser;
 /**
  * @since 21.0.0
  */
+#[Implementable(since: '21.0.0')]
 class SubAdminAddedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
-	/*** @var IUser */
-	private $user;
-
 	/**
 	 * @since 21.0.0
 	 */
-	public function __construct(IGroup $group, IUser $user) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly IUser $user,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->user = $user;
 	}
 
 	/**

--- a/lib/public/Group/Events/SubAdminRemovedEvent.php
+++ b/lib/public/Group/Events/SubAdminRemovedEvent.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 use OCP\IUser;
@@ -16,20 +17,16 @@ use OCP\IUser;
 /**
  * @since 21.0.0
  */
+#[Implementable(since: '21.0.0')]
 class SubAdminRemovedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
-	/*** @var IUser */
-	private $user;
-
 	/**
 	 * @since 21.0.0
 	 */
-	public function __construct(IGroup $group, IUser $user) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly IUser $user,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->user = $user;
 	}
 
 	/**

--- a/lib/public/Group/Events/UserAddedEvent.php
+++ b/lib/public/Group/Events/UserAddedEvent.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 use OCP\IUser;
@@ -16,24 +17,19 @@ use OCP\IUser;
 /**
  * @since 18.0.0
  */
+#[Implementable(since: '18.0.0')]
 class UserAddedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
-	/*** @var IUser */
-	private $user;
-
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(IGroup $group, IUser $user) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly IUser $user,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->user = $user;
 	}
 
 	/**
-	 * @return IGroup
 	 * @since 18.0.0
 	 */
 	public function getGroup(): IGroup {
@@ -41,7 +37,6 @@ class UserAddedEvent extends Event {
 	}
 
 	/**
-	 * @return IUser
 	 * @since 18.0.0
 	 */
 	public function getUser(): IUser {

--- a/lib/public/Group/Events/UserRemovedEvent.php
+++ b/lib/public/Group/Events/UserRemovedEvent.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCP\Group\Events;
 
+use OCP\AppFramework\Attribute\Implementable;
 use OCP\EventDispatcher\Event;
 use OCP\IGroup;
 use OCP\IUser;
@@ -16,24 +17,19 @@ use OCP\IUser;
 /**
  * @since 18.0.0
  */
+#[Implementable(since: '18.0.0')]
 class UserRemovedEvent extends Event {
-	/** @var IGroup */
-	private $group;
-
-	/*** @var IUser */
-	private $user;
-
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(IGroup $group, IUser $user) {
+	public function __construct(
+		private readonly IGroup $group,
+		private readonly IUser $user,
+	) {
 		parent::__construct();
-		$this->group = $group;
-		$this->user = $user;
 	}
 
 	/**
-	 * @return IGroup
 	 * @since 18.0.0
 	 */
 	public function getGroup(): IGroup {
@@ -41,7 +37,6 @@ class UserRemovedEvent extends Event {
 	}
 
 	/**
-	 * @return IUser
 	 * @since 18.0.0
 	 */
 	public function getUser(): IUser {

--- a/lib/public/Group/ISubAdmin.php
+++ b/lib/public/Group/ISubAdmin.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 
 namespace OCP\Group;
 
+use OCP\AppFramework\Attribute\Consumable;
 use OCP\IGroup;
 use OCP\IUser;
 
 /**
  * @since 16.0.0
  */
+#[Consumable(since: '16.0.0')]
 interface ISubAdmin {
 	/**
 	 * add a SubAdmin

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -11,17 +11,7 @@ namespace OCP;
 use OCP\AppFramework\Attribute\Consumable;
 
 /**
- * Class Manager
- *
- * Hooks available in scope \OC\Group:
- * - preAddUser(\OC\Group\Group $group, \OC\User\User $user)
- * - postAddUser(\OC\Group\Group $group, \OC\User\User $user)
- * - preRemoveUser(\OC\Group\Group $group, \OC\User\User $user)
- * - postRemoveUser(\OC\Group\Group $group, \OC\User\User $user)
- * - preDelete(\OC\Group\Group $group)
- * - postDelete(\OC\Group\Group $group)
- * - preCreate(string $groupId)
- * - postCreate(\OC\Group\Group $group)
+ * Group manager interface.
  *
  * @since 8.0.0
  */

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -8,6 +8,8 @@
 
 namespace OCP;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * Class Manager
  *
@@ -23,21 +25,20 @@ namespace OCP;
  *
  * @since 8.0.0
  */
+#[Consumable(since: '8.0.0')]
 interface IGroupManager {
 	/**
 	 * Checks whether a given backend is used
 	 *
-	 * @param string $backendClass Full classname including complete namespace
-	 * @return bool
+	 * @param class-string<GroupInterface> $backendClass Full classname including complete namespace
 	 * @since 8.1.0
 	 */
-	public function isBackendUsed($backendClass);
+	public function isBackendUsed(string $backendClass): bool;
 
 	/**
-	 * @param \OCP\GroupInterface $backend
 	 * @since 8.0.0
 	 */
-	public function addBackend($backend);
+	public function addBackend(GroupInterface $backend): void;
 
 	/**
 	 * @since 34.0.0
@@ -47,35 +48,35 @@ interface IGroupManager {
 	/**
 	 * @since 8.0.0
 	 */
-	public function clearBackends();
+	public function clearBackends(): void;
 
 	/**
 	 * Get the active backends
-	 * @return \OCP\GroupInterface[]
+	 * @return list<\OCP\GroupInterface>
 	 * @since 13.0.0
 	 */
-	public function getBackends();
+	public function getBackends(): array;
 
 	/**
 	 * @param string $gid
 	 * @return \OCP\IGroup|null
 	 * @since 8.0.0
 	 */
-	public function get($gid);
+	public function get(string $gid): ?IGroup;
 
 	/**
 	 * @param string $gid
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function groupExists($gid);
+	public function groupExists(string $gid): bool;
 
 	/**
 	 * @param string $gid
 	 * @return \OCP\IGroup|null
 	 * @since 8.0.0
 	 */
-	public function createGroup($gid);
+	public function createGroup(string $gid): ?IGroup;
 
 	/**
 	 * @param string $search
@@ -84,14 +85,14 @@ interface IGroupManager {
 	 * @return list<IGroup>
 	 * @since 8.0.0
 	 */
-	public function search(string $search, ?int $limit = null, ?int $offset = 0);
+	public function search(string $search, ?int $limit = null, ?int $offset = 0): array;
 
 	/**
 	 * @param \OCP\IUser|null $user
 	 * @return \OCP\IGroup[]
 	 * @since 8.0.0
 	 */
-	public function getUserGroups(?IUser $user = null);
+	public function getUserGroups(?IUser $user = null): array;
 
 	/**
 	 * @param \OCP\IUser $user
@@ -110,7 +111,7 @@ interface IGroupManager {
 	 * @return array<string, string> ['user id' => 'display name']
 	 * @since 8.0.0
 	 */
-	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0);
+	public function displayNamesInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array;
 
 	/**
 	 * Checks if a userId is in the admin group
@@ -118,7 +119,7 @@ interface IGroupManager {
 	 * @return bool if admin
 	 * @since 8.0.0
 	 */
-	public function isAdmin($userId);
+	public function isAdmin(string $userId): bool;
 
 	/**
 	 * Checks if a userId is eligible to users administration delegation
@@ -135,7 +136,7 @@ interface IGroupManager {
 	 * @return bool if in group
 	 * @since 8.0.0
 	 */
-	public function isInGroup($userId, $group);
+	public function isInGroup(string $userId, string $group): bool;
 
 	/**
 	 * Get the display name of a Nextcloud group

--- a/lib/public/User/Events/UserDeletedEvent.php
+++ b/lib/public/User/Events/UserDeletedEvent.php
@@ -9,27 +9,25 @@ declare(strict_types=1);
 
 namespace OCP\User\Events;
 
+use OCP\AppFramework\Attribute\Listenable;
 use OCP\EventDispatcher\Event;
 use OCP\IUser;
 
 /**
  * @since 18.0.0
  */
+#[Listenable(since: '18.0.0')]
 class UserDeletedEvent extends Event {
-	/** @var IUser */
-	private $user;
-
 	/**
-	 * @param IUser $user
 	 * @since 18.0.0
 	 */
-	public function __construct(IUser $user) {
+	public function __construct(
+		private readonly IUser $user,
+	) {
 		parent::__construct();
-		$this->user = $user;
 	}
 
 	/**
-	 * @return IUser
 	 * @since 18.0.0
 	 */
 	public function getUser(): IUser {

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -491,7 +491,7 @@ class GroupTest extends \Test\TestCase {
 			->with('group1', 'New Name')
 			->willReturn(true);
 
-		$group = new Group('group1', [$backend], $dispatcher, $userManager, null, 'Old Name');
+		$group = new Group('group1', [$backend], $dispatcher, $userManager, 'Old Name');
 		$this->assertTrue($group->setDisplayName('New Name'));
 	}
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -19,11 +19,11 @@ use OCP\Group\Backend\IGroupDetailsBackend;
 use OCP\Group\Backend\IRemoveFromGroupBackend;
 use OCP\Group\Backend\ISearchableGroupBackend;
 use OCP\GroupInterface;
+use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IUser;
 use OCP\Security\Ip\IRemoteAddress;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 abstract class TestBackend extends ABackend implements ISearchableGroupBackend, IAddToGroupBackend, ICreateGroupBackend, IGroupDetailsBackend, IRemoveFromGroupBackend, GroupInterface {
@@ -31,16 +31,11 @@ abstract class TestBackend extends ABackend implements ISearchableGroupBackend, 
 }
 
 class ManagerTest extends TestCase {
-	/** @var Manager|MockObject */
-	protected $userManager;
-	/** @var IEventDispatcher|MockObject */
-	protected $dispatcher;
-	/** @var LoggerInterface|MockObject */
-	protected $logger;
-	/** @var ICacheFactory|MockObject */
-	private $cache;
-	/** @var IRemoteAddress|MockObject */
-	private $remoteIpAddress;
+	protected Manager&MockObject $userManager;
+	protected IEventDispatcher&MockObject $dispatcher;
+	private ICacheFactory&MockObject $cache;
+	private ICache&MockObject $userGroupsCache;
+	private IRemoteAddress&MockObject $remoteIpAddress;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -48,14 +43,25 @@ class ManagerTest extends TestCase {
 
 		$this->userManager = $this->createMock(Manager::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->cache = $this->createMock(ICacheFactory::class);
+		$this->userGroupsCache = $this->createMock(ICache::class);
+		$this->cache->method('createDistributed')
+			->willReturnCallback(fn (string $prefix): ICache => $prefix === 'user_groups_membership'
+				? $this->userGroupsCache
+				: $this->createMock(ICache::class));
 
 		$this->remoteIpAddress = $this->createMock(IRemoteAddress::class);
 		$this->remoteIpAddress->method('allowsAdminActions')->willReturn(true);
 	}
 
-	private function getTestUser($userId) {
+	private function wireCacheInvalidation(\OC\Group\Manager $manager): void {
+		$this->dispatcher->method('dispatchTyped')
+			->willReturnCallback(function ($event) use ($manager): void {
+				$manager->handle($event);
+			});
+	}
+
+	private function getTestUser(string $userId): IUser&MockObject {
 		$mockUser = $this->createMock(IUser::class);
 		$mockUser->expects($this->any())
 			->method('getUID')
@@ -66,11 +72,7 @@ class ManagerTest extends TestCase {
 		return $mockUser;
 	}
 
-	/**
-	 * @param null|int $implementedActions
-	 * @return \PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function getTestBackend($implementedActions = null) {
+	private function getTestBackend(?int $implementedActions = null): TestBackend&MockObject {
 		if ($implementedActions === null) {
 			$implementedActions
 				= GroupInterface::ADD_TO_GROUP
@@ -107,16 +109,13 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGet(): void {
-		/**
-		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
-		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
 			->method('groupExists')
 			->with('group1')
 			->willReturn(true);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$group = $manager->get('group1');
@@ -125,22 +124,19 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetNoBackend(): void {
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 
 		$this->assertNull($manager->get('group1'));
 	}
 
 	public function testGetNotExists(): void {
-		/**
-		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
-		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
 			->method('groupExists')
 			->with('group1')
 			->willReturn(false);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$this->assertNull($manager->get('group1'));
@@ -150,8 +146,9 @@ class ManagerTest extends TestCase {
 		$backend = new \Test\Util\Group\Dummy();
 		$backend->createGroup('group1');
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
+		$this->wireCacheInvalidation($manager);
 
 		$group = $manager->get('group1');
 		$group->delete();
@@ -159,25 +156,19 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetMultipleBackends(): void {
-		/**
-		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend1
-		 */
 		$backend1 = $this->getTestBackend();
 		$backend1->expects($this->any())
 			->method('groupExists')
 			->with('group1')
 			->willReturn(false);
 
-		/**
-		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
-		 */
 		$backend2 = $this->getTestBackend();
 		$backend2->expects($this->any())
 			->method('groupExists')
 			->with('group1')
 			->willReturn(true);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
@@ -187,7 +178,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCreate(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Group\Backend $backend */
 		$backendGroupCreated = false;
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
@@ -203,7 +193,7 @@ class ManagerTest extends TestCase {
 				return true;
 			});
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$group = $manager->createGroup('group1');
@@ -211,7 +201,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCreateFailure(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Group\Backend $backend */
 		$backendGroupCreated = false;
 		$backend = $this->getTestBackend(
 			GroupInterface::ADD_TO_GROUP
@@ -232,7 +221,7 @@ class ManagerTest extends TestCase {
 			->method('getGroupDetails')
 			->willReturn([]);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$group = $manager->createGroup('group1');
@@ -240,8 +229,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCreateTooLong(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Group\Backend $backend */
-		$backendGroupCreated = false;
 		$backend = $this->getTestBackend(
 			GroupInterface::ADD_TO_GROUP
 			| GroupInterface::REMOVE_FROM_GOUP
@@ -256,7 +243,7 @@ class ManagerTest extends TestCase {
 			->with($groupName)
 			->willReturn(false);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$this->expectException(\Exception::class);
@@ -264,7 +251,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCreateExists(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Group\Backend $backend */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->any())
 			->method('groupExists')
@@ -273,7 +259,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('createGroup');
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$group = $manager->createGroup('group1');
@@ -281,9 +267,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testSearch(): void {
-		/**
-		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
-		 */
 		$backend = $this->getTestBackend();
 		$backend->expects($this->once())
 			->method('getGroups')
@@ -295,7 +278,7 @@ class ManagerTest extends TestCase {
 				['group1', ['displayName' => 'group1']],
 			]);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$groups = $manager->search('1');
@@ -305,9 +288,6 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testSearchMultipleBackends(): void {
-		/**
-		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend1
-		 */
 		$backend1 = $this->getTestBackend();
 		$backend1->expects($this->once())
 			->method('getGroups')
@@ -320,9 +300,6 @@ class ManagerTest extends TestCase {
 				['group12', []],
 			]);
 
-		/**
-		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend2
-		 */
 		$backend2 = $this->getTestBackend();
 		$backend2->expects($this->once())
 			->method('getGroups')
@@ -335,7 +312,7 @@ class ManagerTest extends TestCase {
 				['group1', ['displayName' => 'group1']],
 			]);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
@@ -382,7 +359,7 @@ class ManagerTest extends TestCase {
 				['group12', ['displayName' => 'group12']],
 			]);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
@@ -411,7 +388,7 @@ class ManagerTest extends TestCase {
 		/** @var \OC\User\Manager $userManager */
 		$userManager = $this->createMock(Manager::class);
 
-		$manager = new \OC\Group\Manager($userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$groups = $manager->search('1');
@@ -432,7 +409,7 @@ class ManagerTest extends TestCase {
 			->with('group1')
 			->willReturn(['displayName' => 'group1']);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$groups = $manager->getUserGroups($this->getTestUser('user1'));
@@ -450,7 +427,7 @@ class ManagerTest extends TestCase {
 			->with('myUID')
 			->willReturn(['123', 'abc']);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		/** @var User|\PHPUnit\Framework\MockObject\MockObject $user */
@@ -480,7 +457,7 @@ class ManagerTest extends TestCase {
 			->with(['group1'])
 			->willReturn(['group1' => []]);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		/** @var User|\PHPUnit\Framework\MockObject\MockObject $user */
@@ -506,7 +483,7 @@ class ManagerTest extends TestCase {
 			->method('groupExists')
 			->willReturn(true);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$this->assertTrue($manager->isInGroup('user1', 'group1'));
@@ -525,7 +502,7 @@ class ManagerTest extends TestCase {
 			->method('groupExists')
 			->willReturn(true);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$this->assertTrue($manager->isAdmin('user1'));
@@ -544,7 +521,7 @@ class ManagerTest extends TestCase {
 			->method('groupExists')
 			->willReturn(true);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$this->assertFalse($manager->isAdmin('user1'));
@@ -575,7 +552,7 @@ class ManagerTest extends TestCase {
 			->method('getGroupDetails')
 			->willReturnCallback(fn ($gid) => ['displayName' => $gid]);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
@@ -634,7 +611,7 @@ class ManagerTest extends TestCase {
 				}
 			});
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', 'user3');
@@ -694,7 +671,7 @@ class ManagerTest extends TestCase {
 				}
 			});
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', 'user3', 1);
@@ -758,7 +735,7 @@ class ManagerTest extends TestCase {
 				}
 			});
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', 'user3', 1, 1);
@@ -787,7 +764,7 @@ class ManagerTest extends TestCase {
 
 		$this->userManager->expects($this->never())->method('get');
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', '');
@@ -815,7 +792,7 @@ class ManagerTest extends TestCase {
 
 		$this->userManager->expects($this->never())->method('get');
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', '', 1);
@@ -843,7 +820,7 @@ class ManagerTest extends TestCase {
 
 		$this->userManager->expects($this->never())->method('get');
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', '', 1, 1);
@@ -875,8 +852,9 @@ class ManagerTest extends TestCase {
 			->with('group1')
 			->willReturn(['displayName' => 'group1']);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
+		$this->wireCacheInvalidation($manager);
 
 		// prime cache
 		$user1 = $this->getTestUser('user1');
@@ -918,8 +896,9 @@ class ManagerTest extends TestCase {
 			->method('removeFromGroup')
 			->willReturn(true);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
+		$this->wireCacheInvalidation($manager);
 
 		// prime cache
 		$user1 = $this->getTestUser('user1');
@@ -948,7 +927,7 @@ class ManagerTest extends TestCase {
 			->with('user1')
 			->willReturn(null);
 
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		$groups = $manager->getUserIdGroups('user1');
@@ -973,7 +952,7 @@ class ManagerTest extends TestCase {
 				['group1', ['gid' => 'group1', 'displayName' => 'Group One']],
 				['group2', ['gid' => 'group2']],
 			]);
-		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
+		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
 		// group with display name

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1205,9 +1205,8 @@ class ManagerTest extends \Test\TestCase {
 			['user1', $this->createMock(IUser::class)],
 		]);
 
-		$this->groupManager->method('groupExists')->willReturnMap([
-			['group0', true],
-		]);
+		$this->groupManager->method('groupExists')
+			->willReturnCallback(fn (string $group): bool => $group === 'group0');
 
 		$userFolder = $this->createMock(Folder::class);
 

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -502,8 +502,8 @@ class SystemTagManagerTest extends TestCase {
 
 	public static function allowedToCreateProvider(): array {
 		return [
-			[true, null, true],
-			[true, null, false],
+			[true, false, true],
+			[true, false, false],
 			[false, true, true],
 			[false, true, false],
 			[false, false, false],
@@ -511,7 +511,7 @@ class SystemTagManagerTest extends TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('allowedToCreateProvider')]
-	public function testAllowedToCreateTag(bool $isCli, ?bool $isAdmin, bool $isRestricted): void {
+	public function testAllowedToCreateTag(bool $isCli, bool $isAdmin, bool $isRestricted): void {
 		$oldCli = \OC::$CLI;
 		\OC::$CLI = $isCli;
 
@@ -539,15 +539,7 @@ class SystemTagManagerTest extends TestCase {
 		\OC::$CLI = $oldCli;
 	}
 
-	public static function disallowedToCreateProvider(): array {
-		return [
-			[false],
-			[null],
-		];
-	}
-
-	#[\PHPUnit\Framework\Attributes\DataProvider('disallowedToCreateProvider')]
-	public function testDisallowedToCreateTag(?bool $isAdmin): void {
+	public function testDisallowedToCreateTag(): void {
 		$oldCli = \OC::$CLI;
 		\OC::$CLI = false;
 
@@ -557,11 +549,11 @@ class SystemTagManagerTest extends TestCase {
 			->willReturn('test');
 		$this->userSession->expects($this->any())
 			->method('getUser')
-			->willReturn($isAdmin === null ? null : $user);
+			->willReturn($user);
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->with('test')
-			->willReturn($isAdmin);
+			->willReturn(false);
 		$this->appConfig->expects($this->any())
 			->method('getValueBool')
 			->with('systemtags', 'restrict_creation_to_admin')
@@ -573,11 +565,7 @@ class SystemTagManagerTest extends TestCase {
 		\OC::$CLI = $oldCli;
 	}
 
-	/**
-	 * @param ISystemTag $tag1
-	 * @param ISystemTag $tag2
-	 */
-	private function assertSameTag($tag1, $tag2) {
+	private function assertSameTag(ISystemTag $tag1, ISystemTag $tag2): void {
 		$this->assertEquals($tag1->getId(), $tag2->getId());
 		$this->assertEquals($tag1->getName(), $tag2->getName());
 		$this->assertEquals($tag1->isUserVisible(), $tag2->isUserVisible());

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -502,8 +502,8 @@ class SystemTagManagerTest extends TestCase {
 
 	public static function allowedToCreateProvider(): array {
 		return [
-			[true, false, true],
-			[true, false, false],
+			[true, null, true],
+			[true, null, false],
 			[false, true, true],
 			[false, true, false],
 			[false, false, false],
@@ -511,7 +511,7 @@ class SystemTagManagerTest extends TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('allowedToCreateProvider')]
-	public function testAllowedToCreateTag(bool $isCli, bool $isAdmin, bool $isRestricted): void {
+	public function testAllowedToCreateTag(bool $isCli, ?bool $isAdmin, bool $isRestricted): void {
 		$oldCli = \OC::$CLI;
 		\OC::$CLI = $isCli;
 
@@ -525,7 +525,7 @@ class SystemTagManagerTest extends TestCase {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->with('test')
-			->willReturn($isAdmin);
+			->willReturn($isAdmin ?? false);
 		$this->appConfig->expects($this->any())
 			->method('getValueBool')
 			->with('systemtags', 'restrict_creation_to_admin')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

And move the group management listener registration in the core app instead of the files_sharing app (which can be disabled).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
