### PR TITLE
fix: throw better error message if a user doesn't have a key even though it should have

### DIFF
--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -1171,7 +1171,10 @@ class UserConfig implements IUserConfig {
 		}
 
 		$oldValue = null;
+		$updateReason = '';
 		if ($this->hasKey($userId, $app, $key, $lazy)) {
+			$updateReason = 'key exists';
+
 			/**
 			 * no update if key is already known with set lazy status and value is
 			 * not different, unless sensitivity is switched from false to true.
@@ -1206,6 +1209,7 @@ class UserConfig implements IUserConfig {
 					// TODO: throw exception or just log and returns false !?
 					throw $e;
 				}
+				$updateReason = 'insert raised a duplicate contraint';
 			}
 		}
 
@@ -1216,7 +1220,11 @@ class UserConfig implements IUserConfig {
 			$currType = $this->valueDetails[$userId][$app][$key]['type'] ?? null;
 			if ($currType === null) { // this might happen when switching lazy loading status
 				$this->loadConfigAll($userId);
-				$currType = $this->valueDetails[$userId][$app][$key]['type'];
+
+				if (!isset($this->valueDetails[$userId][$app][$key])) {
+					throw new UnknownKeyException("unknown key $app $key for $userId even though $updateReason");
+				}
+				$currType = $this->valueDetails[$userId][$app][$key]['type'] ?? null;
 			}
 
 			/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Raise a proper error instead of just having array access errors later on

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
