### PR TITLE
fix: don't rely on constraint for filecache_extended "upsert" when in transaction

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -322,17 +322,7 @@ class Cache implements ICache {
 			if ($builder->executeStatement()) {
 				$fileId = $builder->getLastInsertId();
 
-				if (count($extensionValues)) {
-					$query = $this->getQueryBuilder();
-					$query->insert('filecache_extended');
-					$query->hintShardKey('storage', $storageId);
-
-					$query->setValue('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT));
-					foreach ($extensionValues as $column => $value) {
-						$query->setValue($column, $query->createNamedParameter($value));
-					}
-					$query->executeStatement();
-				}
+				$this->setExtensionValues($fileId, $extensionValues, true);
 
 				$event = new CacheEntryInsertedEvent($this->storage, $file, $fileId, $storageId);
 				$this->eventDispatcher->dispatch(CacheEntryInsertedEvent::class, $event);
@@ -400,40 +390,7 @@ class Cache implements ICache {
 			$query->executeStatement();
 		}
 
-		if (count($extensionValues)) {
-			try {
-				$query = $this->getQueryBuilder();
-				$query->insert('filecache_extended');
-				$query->hintShardKey('storage', $this->getNumericStorageId());
-
-				$query->setValue('fileid', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT));
-				foreach ($extensionValues as $column => $value) {
-					$query->setValue($column, $query->createNamedParameter($value));
-				}
-
-				$query->executeStatement();
-			} catch (Exception $e) {
-				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-					throw $e;
-				}
-				$query = $this->getQueryBuilder();
-				$query->update('filecache_extended')
-					->whereFileId($id)
-					->hintShardKey('storage', $this->getNumericStorageId())
-					->andWhere($query->expr()->orX(...array_map(function ($key, $value) use ($query) {
-						return $query->expr()->orX(
-							$query->expr()->neq($key, $query->createNamedParameter($value)),
-							$query->expr()->isNull($key)
-						);
-					}, array_keys($extensionValues), array_values($extensionValues))));
-
-				foreach ($extensionValues as $key => $value) {
-					$query->set($key, $query->createNamedParameter($value));
-				}
-
-				$query->executeStatement();
-			}
-		}
+		$this->setExtensionValues($id, $extensionValues, false);
 
 		$path = $this->getPathById($id);
 		// path can still be null if the file doesn't exist
@@ -441,6 +398,73 @@ class Cache implements ICache {
 			$event = new CacheEntryUpdatedEvent($this->storage, $path, $id, $this->getNumericStorageId());
 			$this->eventDispatcher->dispatchTyped($event);
 		}
+	}
+
+	private function hasExtensionValues(int $id) {
+		$query = $this->getQueryBuilder();
+		$query->select('fileid')
+			->from('filecache_extended')
+			->whereFileId($id);
+
+		return $query->executeQuery()->fetchOne() !== false;
+	}
+
+	private function setExtensionValues(int $id, array $extensionValues, bool $newFile) {
+		if (!$extensionValues) {
+			return;
+		}
+
+		// a failed insert in a transaction aborts the transactions on some platforms, so we can't rely on
+		// that behavior to to an "upsert"
+		// for new files, we can safely assume that there won't be a conflict, since the fileid is new
+		if (!$newFile && $this->connection->inTransaction()) {
+			if ($this->hasExtensionValues($id)) {
+				$this->updateExtensionValues($id, $extensionValues);
+			} else {
+				$this->insertExtensionValues($id, $extensionValues);
+			}
+		} else {
+			try {
+				$this->insertExtensionValues($id, $extensionValues);
+			} catch (Exception $e) {
+				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					throw $e;
+				}
+				$this->updateExtensionValues($id, $extensionValues);
+			}
+		}
+	}
+
+	private function insertExtensionValues(int $id, array $extensionValues) {
+		$query = $this->getQueryBuilder();
+		$query->insert('filecache_extended');
+		$query->hintShardKey('storage', $this->getNumericStorageId());
+
+		$query->setValue('fileid', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT));
+		foreach ($extensionValues as $column => $value) {
+			$query->setValue($column, $query->createNamedParameter($value));
+		}
+
+		$query->executeStatement();
+	}
+
+	private function updateExtensionValues(int $id, array $extensionValues) {
+		$query = $this->getQueryBuilder();
+		$query->update('filecache_extended')
+			->whereFileId($id)
+			->hintShardKey('storage', $this->getNumericStorageId())
+			->andWhere($query->expr()->orX(...array_map(function ($key, $value) use ($query) {
+				return $query->expr()->orX(
+					$query->expr()->neq($key, $query->createNamedParameter($value)),
+					$query->expr()->isNull($key)
+				);
+			}, array_keys($extensionValues), array_values($extensionValues))));
+
+		foreach ($extensionValues as $key => $value) {
+			$query->set($key, $query->createNamedParameter($value));
+		}
+
+		$query->executeStatement();
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Postgresql aborts the transaction on the constraint violation, so instead we need to manually check if we need to do an update or insert when in a transaction.

In the long term we really need a proper "upsert" or "insert ignore" in the query builder to make use of the various tools that databases offer for this

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
