### PR TITLE
feat(files_sharing): unified sharing sidebar and dialog

### DIFF
--- a/apps/files_sharing/lib/Config/ConfigLexicon.php
+++ b/apps/files_sharing/lib/Config/ConfigLexicon.php
@@ -26,6 +26,7 @@ class ConfigLexicon implements ILexicon {
 	public const EXCLUDE_RESHARE_FROM_EDIT = 'shareapi_exclude_reshare_from_edit';
 	public const UPDATE_CUTOFF_TIME = 'update_cutoff_time';
 	public const USER_NEEDS_SHARE_REFRESH = 'user_needs_share_refresh';
+	public const SHARING_DIALOG_ENABLED = 'sharing_dialog_enabled';
 
 	#[\Override]
 	public function getStrictness(): Strictness {
@@ -40,6 +41,10 @@ class ConfigLexicon implements ILexicon {
 			new Entry(self::EXCLUDE_RESHARE_FROM_EDIT, ValueType::BOOL, false, 'Exclude reshare permission from "Allow editing" bundled permissions'),
 
 			new Entry(self::UPDATE_CUTOFF_TIME, ValueType::FLOAT, 3.0, 'Maximum time in second during which we update the share data immediately before switching to only marking the user'),
+
+			// Hidden killswitch: enables the new unified sharing dialog UI in the sidebar.
+			// Set to false to temporarily restore the legacy sharing inputs and menus.
+			new Entry(self::SHARING_DIALOG_ENABLED, ValueType::BOOL, true, 'Use the new unified sharing dialog in the files sidebar instead of the legacy inline UI', true),
 		];
 	}
 

--- a/apps/files_sharing/lib/Listener/LoadSidebarListener.php
+++ b/apps/files_sharing/lib/Listener/LoadSidebarListener.php
@@ -38,6 +38,10 @@ class LoadSidebarListener implements IEventListener {
 			return;
 		}
 		Util::addScript(Application::APP_ID, 'files_sharing_tab', 'files');
+		// Vue 3 bridge exposing the unified sharing dialog on OCA.Sharing for the
+		// (Vue 2) sidebar to trigger without bundling Vue 3.
+		Util::addStyle(Application::APP_ID, 'sharing-dialog');
+		Util::addScript(Application::APP_ID, 'sharing-dialog', 'files');
 
 		$appConfig = Server::get(IAppConfig::class);
 		$gsConfig = Server::get(IConfig::class);

--- a/apps/files_sharing/lib/Listener/LoadSidebarListener.php
+++ b/apps/files_sharing/lib/Listener/LoadSidebarListener.php
@@ -47,8 +47,11 @@ class LoadSidebarListener implements IEventListener {
 		$showExternalSharing = $appConfig->getValueBool('files_sharing', 'outgoing_server2server_share_enabled', true)
 			|| $appConfig->getValueBool('core', 'shareapi_allow_links', true);
 
+		$sharingDialogEnabled = $appConfig->getValueBool('files_sharing', ConfigLexicon::SHARING_DIALOG_ENABLED, true);
+
 		$this->initialState->provideInitialState('showFederatedSharesAsInternal', $showFederatedAsInternal);
 		$this->initialState->provideInitialState('showFederatedSharesToTrustedServersAsInternal', $showFederatedToTrustedAsInternal);
 		$this->initialState->provideInitialState('showExternalSharing', $showExternalSharing);
+		$this->initialState->provideInitialState('sharingDialogEnabled', $sharingDialogEnabled);
 	}
 }

--- a/apps/files_sharing/src/components/AvatarStack.vue
+++ b/apps/files_sharing/src/components/AvatarStack.vue
@@ -1,0 +1,72 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="avatar-stack">
+		<span
+			v-for="(recipient, index) in displayed"
+			:key="recipient.class + recipient.value"
+			class="avatar-stack__item"
+			:style="{ zIndex: displayed.length - index }">
+			<NcAvatar
+				:size="32"
+				:isNoUser="isNoUserRecipient(recipient)"
+				:user="isNoUserRecipient(recipient) ? undefined : recipient.value"
+				:displayName="recipient.display_name"
+				disableMenu
+				disableTooltip />
+		</span>
+		<span v-if="overflow > 0" class="avatar-stack__overflow" :aria-hidden="true">
+			+{{ overflow }}
+		</span>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { SharingRecipient } from '../types/unifiedSharing.ts'
+
+import { computed } from 'vue'
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
+import { isNoUserRecipient } from '../lib/unifiedSharing.ts'
+
+const props = defineProps<{
+	recipients: SharingRecipient[]
+}>()
+
+const MAX_AVATARS = 3
+
+const displayed = computed(() => props.recipients.slice(0, MAX_AVATARS))
+const overflow = computed(() => Math.max(0, props.recipients.length - MAX_AVATARS))
+</script>
+
+<style lang="scss" scoped>
+.avatar-stack {
+	display: flex;
+	align-items: center;
+
+	// Wrapper we own, so the ring cannot be overridden by the avatar's own styles.
+	&__item {
+		display: flex;
+		border-radius: 50%;
+		// Ring in the main background colour separates overlapping avatars. Using
+		// a box-shadow (not a border) keeps the avatar exactly 32px, matching the
+		// avatars in the other entries.
+		box-shadow: 0 0 0 2px var(--color-main-background);
+		// Each avatar sits under the previous one (first on top); z-index is set
+		// inline, descending, so the ring overlaps correctly.
+		position: relative;
+
+		&:not(:first-child) {
+			margin-inline-start: -12px;
+		}
+	}
+
+	&__overflow {
+		margin-inline-start: 4px;
+		color: var(--color-text-maxcontrast);
+		font-size: 12px;
+	}
+}
+</style>

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -62,7 +62,7 @@
 				class="sharing-entry__action"
 				:aria-label="t('files_sharing', 'Delete share')"
 				variant="tertiary"
-				@click="onDelete">
+				@click="confirmDelete">
 				<template #icon>
 					<DeleteIcon :size="20" />
 				</template>
@@ -72,6 +72,7 @@
 </template>
 
 <script>
+import { DialogBuilder } from '@nextcloud/dialogs'
 import { ShareType } from '@nextcloud/sharing'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -168,6 +169,41 @@ export default {
 				await openShareEditDialog(this.share.id, this.fileInfo.node)
 			} catch (error) {
 				logger.error('Failed to open the sharing dialog', { error })
+			}
+		},
+
+		/**
+		 * Ask for confirmation before deleting the share.
+		 */
+		async confirmDelete() {
+			let confirmed = false
+			const dialog = (new DialogBuilder())
+				.setName(t('files_sharing', 'Delete share'))
+				.setText(t('files_sharing', 'Are you sure you want to delete this share? This operation cannot be undone.'))
+				.setButtons([
+					{
+						label: t('files_sharing', 'Cancel'),
+						variant: 'secondary',
+						callback: () => {},
+					},
+					{
+						label: t('files_sharing', 'Delete'),
+						variant: 'error',
+						callback: () => {
+							confirmed = true
+						},
+					},
+				])
+				.build()
+
+			try {
+				await dialog.show()
+			} catch (error) {
+				logger.debug('Delete confirmation dialog closed', { error })
+			}
+
+			if (confirmed) {
+				this.onDelete()
 			}
 		},
 

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -28,13 +28,14 @@
 				</span>
 			</component>
 			<SharingEntryQuickShareSelect
+				v-if="!config.sharingDialogEnabled"
 				:share="share"
 				:file-info="fileInfo"
 				@open-sharing-details="openShareDetailsForCustomSettings(share)" />
 		</div>
 		<ShareExpiryTime v-if="share && share.expireDate" :share="share" />
 		<NcButton
-			v-if="share.canEdit"
+			v-if="share.canEdit && !config.sharingDialogEnabled"
 			class="sharing-entry__action"
 			data-cy-files-sharing-share-actions
 			:aria-label="t('files_sharing', 'Open Sharing Details')"
@@ -44,6 +45,29 @@
 				<DotsHorizontalIcon :size="20" />
 			</template>
 		</NcButton>
+		<!-- Unified dialog: edit + delete as a simple dual button -->
+		<template v-else-if="config.sharingDialogEnabled">
+			<NcButton
+				v-if="share.canEdit"
+				class="sharing-entry__action"
+				:aria-label="t('files_sharing', 'Edit share')"
+				variant="tertiary"
+				@click="openEditDialog">
+				<template #icon>
+					<PencilIcon :size="20" />
+				</template>
+			</NcButton>
+			<NcButton
+				v-if="share.canDelete"
+				class="sharing-entry__action"
+				:aria-label="t('files_sharing', 'Delete share')"
+				variant="tertiary"
+				@click="onDelete">
+				<template #icon>
+					<DeleteIcon :size="20" />
+				</template>
+			</NcButton>
+		</template>
 	</li>
 </template>
 
@@ -52,11 +76,15 @@ import { ShareType } from '@nextcloud/sharing'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
+import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
+import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import ShareExpiryTime from './ShareExpiryTime.vue'
 import SharingEntryQuickShareSelect from './SharingEntryQuickShareSelect.vue'
 import ShareDetails from '../mixins/ShareDetails.js'
 import SharesMixin from '../mixins/SharesMixin.js'
+import { openShareEditDialog } from '../services/SharingDialog.ts'
+import logger from '../services/logger.ts'
 
 export default {
 	name: 'SharingEntry',
@@ -64,7 +92,9 @@ export default {
 	components: {
 		NcButton,
 		NcAvatar,
+		DeleteIcon,
 		DotsHorizontalIcon,
+		PencilIcon,
 		NcSelect,
 		ShareExpiryTime,
 		SharingEntryQuickShareSelect,
@@ -130,6 +160,17 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Open the unified sharing dialog to edit this share.
+		 */
+		async openEditDialog() {
+			try {
+				await openShareEditDialog(this.share.id, this.fileInfo.node)
+			} catch (error) {
+				logger.error('Failed to open the sharing dialog', { error })
+			}
+		},
+
 		/**
 		 * Save potential changed data on menu close
 		 */

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -21,7 +21,7 @@
 					{{ subtitle }}
 				</p>
 				<SharingEntryQuickShareSelect
-					v-if="share && share.permissions !== undefined"
+					v-if="share && share.permissions !== undefined && !config.sharingDialogEnabled"
 					:share="share"
 					:file-info="fileInfo"
 					@open-sharing-details="openShareDetailsForCustomSettings(share)" />
@@ -151,9 +151,20 @@
 			<template v-if="share">
 				<template v-if="share.canEdit && canReshare">
 					<NcActionButton
+						v-if="!config.sharingDialogEnabled"
 						:disabled="saving"
 						:close-after-click="true"
 						@click.prevent="openSharingDetails">
+						<template #icon>
+							<Tune :size="20" />
+						</template>
+						{{ t('files_sharing', 'Customize link') }}
+					</NcActionButton>
+					<NcActionButton
+						v-else
+						:disabled="saving"
+						:close-after-click="true"
+						@click.prevent="openEditDialog">
 						<template #icon>
 							<Tune :size="20" />
 						</template>
@@ -279,6 +290,7 @@ import ShareDetails from '../mixins/ShareDetails.js'
 import SharesMixin from '../mixins/SharesMixin.js'
 import Share from '../models/Share.ts'
 import logger from '../services/logger.ts'
+import { openShareEditDialog } from '../services/SharingDialog.ts'
 import GeneratePassword from '../utils/GeneratePassword.ts'
 
 export default {
@@ -600,6 +612,17 @@ export default {
 
 	methods: {
 		/**
+		 * Open the unified sharing dialog to edit this link share.
+		 */
+		async openEditDialog() {
+			try {
+				await openShareEditDialog(this.share.id, this.fileInfo.node)
+			} catch (error) {
+				logger.error('Failed to open the sharing dialog', { error })
+			}
+		},
+
+		/**
 		 * Check if the share requires review
 		 *
 		 * @param {boolean} shareReviewComplete if the share was reviewed
@@ -866,6 +889,7 @@ export default {
 		justify-content: space-between;
 		flex: 1 0;
 		min-width: 0;
+		align-items: center;
 	}
 
 		&__desc {

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -21,7 +21,7 @@
 					{{ subtitle }}
 				</p>
 				<SharingEntryQuickShareSelect
-					v-if="share && share.permissions !== undefined"
+					v-if="share && share.permissions !== undefined && !config.sharingDialogEnabled"
 					:share="share"
 					:file-info="fileInfo"
 					@open-sharing-details="openShareDetailsForCustomSettings(share)" />
@@ -152,9 +152,20 @@
 			<template v-if="share">
 				<template v-if="share.canEdit && canReshare">
 					<NcActionButton
+						v-if="!config.sharingDialogEnabled"
 						:disabled="saving"
 						:close-after-click="true"
 						@click.prevent="openSharingDetails">
+						<template #icon>
+							<Tune :size="20" />
+						</template>
+						{{ t('files_sharing', 'Customize link') }}
+					</NcActionButton>
+					<NcActionButton
+						v-else
+						:disabled="saving"
+						:close-after-click="true"
+						@click.prevent="openEditDialog">
 						<template #icon>
 							<Tune :size="20" />
 						</template>
@@ -279,6 +290,7 @@ import SidebarTabExternalActionLegacy from './SidebarTabExternal/SidebarTabExter
 import ShareDetails from '../mixins/ShareDetails.js'
 import SharesMixin from '../mixins/SharesMixin.js'
 import Share from '../models/Share.ts'
+import { openShareEditDialog } from '../services/SharingDialog.ts'
 import logger from '../services/logger.ts'
 import GeneratePassword from '../utils/GeneratePassword.ts'
 
@@ -628,6 +640,17 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Open the unified sharing dialog to edit this link share.
+		 */
+		async openEditDialog() {
+			try {
+				await openShareEditDialog(this.share.id, this.fileInfo.node)
+			} catch (error) {
+				logger.error('Failed to open the sharing dialog', { error })
+			}
+		},
+
 		/**
 		 * Check if the share requires review
 		 *

--- a/apps/files_sharing/src/components/SharingEntrySimple.vue
+++ b/apps/files_sharing/src/components/SharingEntrySimple.vue
@@ -12,11 +12,14 @@
 				{{ subtitle }}
 			</p>
 		</div>
+		<!-- Standalone action(s) shown before the overflow menu (e.g. a caret) -->
+		<slot name="action" />
 		<NcActions
 			v-if="$slots['default']"
 			ref="actionsComponent"
 			class="sharing-entry__actions"
 			menu-align="right"
+			:force-menu="forceMenu"
 			:aria-expanded="ariaExpandedValue">
 			<slot />
 		</NcActions>
@@ -52,6 +55,13 @@ export default {
 		ariaExpanded: {
 			type: Boolean,
 			default: null,
+		},
+
+		// Force the overflow menu even with a single action (keeps destructive
+		// actions in a menu instead of rendering them inline).
+		forceMenu: {
+			type: Boolean,
+			default: false,
 		},
 	},
 

--- a/apps/files_sharing/src/components/UnifiedShareEntry.spec.ts
+++ b/apps/files_sharing/src/components/UnifiedShareEntry.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import UnifiedShareEntry from './UnifiedShareEntry.vue'
+import { openShareEditDialog } from '../services/SharingDialog.ts'
+import { deleteShare, removeRecipient } from '../services/unifiedShares.ts'
+
+vi.mock('../services/SharingDialog.ts', () => ({
+	openShareEditDialog: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../services/unifiedShares.ts', () => ({
+	deleteShare: vi.fn().mockResolvedValue(undefined),
+	removeRecipient: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../services/logger.ts', () => ({
+	default: { error: vi.fn(), debug: vi.fn() },
+}))
+
+// Confirm dialog: answers with the last button ("Delete") by default; set
+// `confirmation.declined` to answer with the first one ("Cancel") instead.
+const confirmation = vi.hoisted(() => ({ declined: false }))
+
+vi.mock('@nextcloud/dialogs', () => ({
+	DialogBuilder: class {
+		buttons: { callback: () => void }[] = []
+		setName() {
+			return this
+		}
+
+		setText() {
+			return this
+		}
+
+		setButtons(buttons: { callback: () => void }[]) {
+			this.buttons = buttons
+			return this
+		}
+
+		build() {
+			const { buttons } = this
+			return {
+				show: async () => (confirmation.declined ? buttons.at(0) : buttons.at(-1))?.callback(),
+			}
+		}
+	},
+}))
+
+function recipient(value: string) {
+	return {
+		class: 'UserRecipient',
+		value,
+		instance: null,
+		display_name: value,
+		icon: null,
+		secret: { updatable: false },
+		initiator: null,
+		permissions: [],
+	}
+}
+
+function share(recipients = [recipient('bob')]) {
+	return {
+		id: '42',
+		state: 'active',
+		recipients,
+		permissions: [],
+		permission_preset: null,
+		owner: { user_id: 'alice', display_name: 'Alice', instance: null },
+	}
+}
+
+function mountEntry(data = share()) {
+	return mount(UnifiedShareEntry, {
+		propsData: { share: data, fileInfo: { node: { fileid: 1 } } },
+		stubs: {
+			NcAvatar: true,
+			AvatarStack: true,
+			// The actions live in a menu that only renders its content once opened.
+			NcActions: { template: '<div><slot /></div>' },
+		},
+	})
+}
+
+/** Trigger a row action by its label, as clicking the menu entry would. */
+async function triggerAction(wrapper: ReturnType<typeof mountEntry>, label: string) {
+	const action = wrapper.findAllComponents({ name: 'NcActionButton' })
+		.wrappers.find((button) => button.text().includes(label))
+	expect(action, `the "${label}" action is rendered`).toBeDefined()
+	action!.vm.$emit('click')
+	await new Promise((resolve) => setTimeout(resolve))
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	confirmation.declined = false
+})
+
+describe('editing', () => {
+	it('refreshes the list once the dialog closes', async () => {
+		const wrapper = mountEntry()
+		await triggerAction(wrapper, 'Edit share')
+		expect(openShareEditDialog).toHaveBeenCalledWith('42', { fileid: 1 })
+		expect(wrapper.emitted('refresh')).toHaveLength(1)
+	})
+
+	it('still refreshes when the dialog fails', async () => {
+		vi.mocked(openShareEditDialog).mockRejectedValueOnce(new Error('nope'))
+		const wrapper = mountEntry()
+		await triggerAction(wrapper, 'Edit share')
+		// The dialog writes straight to the backend, so it may have applied
+		// changes before it errored.
+		expect(wrapper.emitted('refresh')).toHaveLength(1)
+	})
+})
+
+describe('deleting the share', () => {
+	it('deletes it and refreshes once confirmed', async () => {
+		const wrapper = mountEntry()
+		await triggerAction(wrapper, 'Delete share')
+		expect(deleteShare).toHaveBeenCalledWith('42')
+		expect(wrapper.emitted('refresh')).toHaveLength(1)
+	})
+
+	it('does not delete it when the confirmation is declined', async () => {
+		confirmation.declined = true
+		const wrapper = mountEntry()
+		await triggerAction(wrapper, 'Delete share')
+		expect(deleteShare).not.toHaveBeenCalled()
+		expect(wrapper.emitted('refresh')).toBeUndefined()
+	})
+
+	it('does not refresh when the deletion fails', async () => {
+		vi.mocked(deleteShare).mockRejectedValueOnce(new Error('nope'))
+		const wrapper = mountEntry()
+		await triggerAction(wrapper, 'Delete share')
+		expect(wrapper.emitted('refresh')).toBeUndefined()
+	})
+})
+
+describe('removing a participant', () => {
+	it('removes the recipient of the row it was triggered on', async () => {
+		const wrapper = mountEntry(share([recipient('bob'), recipient('carol')]))
+		await triggerAction(wrapper, 'Remove participant')
+		expect(removeRecipient).toHaveBeenCalledWith('42', 'UserRecipient', 'bob', null)
+		expect(wrapper.emitted('refresh')).toHaveLength(1)
+	})
+
+	it('does not refresh when the removal fails', async () => {
+		vi.mocked(removeRecipient).mockRejectedValueOnce(new Error('nope'))
+		const wrapper = mountEntry(share([recipient('bob'), recipient('carol')]))
+		await triggerAction(wrapper, 'Remove participant')
+		expect(wrapper.emitted('refresh')).toBeUndefined()
+	})
+})

--- a/apps/files_sharing/src/components/UnifiedShareEntry.vue
+++ b/apps/files_sharing/src/components/UnifiedShareEntry.vue
@@ -1,0 +1,222 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<ul class="unified-share">
+		<!-- Single-recipient share: one row -->
+		<SharingEntrySimple
+			v-if="isSingle"
+			:title="recipients[0].display_name"
+			:subtitle="recipientPermissionLabel(share, recipients[0])">
+			<template #avatar>
+				<NcAvatar
+					:size="32"
+					:isNoUser="isNoUserRecipient(recipients[0])"
+					:user="isNoUserRecipient(recipients[0]) ? undefined : recipients[0].value"
+					:displayName="recipients[0].display_name" />
+			</template>
+			<NcActionButton :aria-label="t('files_sharing', 'Edit share')" @click="openEditDialog">
+				<template #icon>
+					<PencilIcon :size="20" />
+				</template>
+				{{ t('files_sharing', 'Edit share') }}
+			</NcActionButton>
+			<NcActionButton :aria-label="t('files_sharing', 'Delete share')" @click="confirmDeleteShare">
+				<template #icon>
+					<DeleteIcon :size="20" />
+				</template>
+				{{ t('files_sharing', 'Delete share') }}
+			</NcActionButton>
+		</SharingEntrySimple>
+
+		<!-- Multi-recipient share: collapsible group -->
+		<template v-else>
+			<SharingEntrySimple
+				:title="summaryTitle"
+				:subtitle="reshareLine"
+				:aria-expanded="expanded">
+				<template #avatar>
+					<!-- Collapsed: show the stack; expanded: avatars live in the list -->
+					<AvatarStack v-if="!expanded" :recipients="recipients" />
+				</template>
+				<template #action>
+					<NcButton
+						variant="tertiary"
+						:aria-label="t('files_sharing', 'Toggle recipients')"
+						:aria-expanded="expanded"
+						@click="expanded = !expanded">
+						<template #icon>
+							<ChevronDownIcon v-if="expanded" :size="20" />
+							<ChevronRightIcon v-else :size="20" />
+						</template>
+					</NcButton>
+				</template>
+				<NcActionButton :aria-label="t('files_sharing', 'Edit share')" @click="openEditDialog">
+					<template #icon>
+						<PencilIcon :size="20" />
+					</template>
+					{{ t('files_sharing', 'Edit share') }}
+				</NcActionButton>
+				<NcActionButton :aria-label="t('files_sharing', 'Delete share')" @click="confirmDeleteShare">
+					<template #icon>
+						<DeleteIcon :size="20" />
+					</template>
+					{{ t('files_sharing', 'Delete share') }}
+				</NcActionButton>
+			</SharingEntrySimple>
+
+			<SharingEntrySimple
+				v-for="recipient in recipients"
+				v-show="expanded"
+				:key="recipient.class + recipient.value"
+				class="unified-share__recipient"
+				:title="recipient.display_name"
+				:subtitle="recipientPermissionLabel(share, recipient)"
+				forceMenu>
+				<template #avatar>
+					<NcAvatar
+						:size="32"
+						:isNoUser="isNoUserRecipient(recipient)"
+						:user="isNoUserRecipient(recipient) ? undefined : recipient.value"
+						:displayName="recipient.display_name" />
+				</template>
+				<NcActionButton :aria-label="t('files_sharing', 'Remove participant')" @click="removeOne(recipient)">
+					<template #icon>
+						<DeleteIcon :size="20" />
+					</template>
+					{{ t('files_sharing', 'Remove participant') }}
+				</NcActionButton>
+			</SharingEntrySimple>
+		</template>
+	</ul>
+</template>
+
+<script setup lang="ts">
+import type { SharingRecipient, SharingShare } from '../types/unifiedSharing.ts'
+
+import { DialogBuilder } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
+import { computed, ref } from 'vue'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import AvatarStack from './AvatarStack.vue'
+import SharingEntrySimple from './SharingEntrySimple.vue'
+import { isNoUserRecipient, recipientPermissionLabel, recipientSummary, reshareSubtitle } from '../lib/unifiedSharing.ts'
+import logger from '../services/logger.ts'
+import { openShareEditDialog } from '../services/SharingDialog.ts'
+import { deleteShare, removeRecipient } from '../services/unifiedShares.ts'
+
+const props = defineProps<{
+	share: SharingShare
+	fileInfo: { node?: unknown }
+}>()
+
+const emit = defineEmits<{
+	(e: 'refresh'): void
+}>()
+
+// Expanded by default; collapse is optional (e.g. long lists).
+const expanded = ref(true)
+
+const recipients = computed(() => props.share.recipients)
+const isSingle = computed(() => recipients.value.length === 1)
+const summaryTitle = computed(() => recipientSummary(recipients.value))
+const reshareLine = computed(() => reshareSubtitle(props.share))
+
+/**
+ * Show a confirmation dialog and resolve to the user's choice.
+ *
+ * @param text The confirmation prompt
+ */
+async function confirm(text: string): Promise<boolean> {
+	let confirmed = false
+	const dialog = (new DialogBuilder())
+		.setName(t('files_sharing', 'Delete share'))
+		.setText(text)
+		.setButtons([
+			{
+				label: t('files_sharing', 'Cancel'),
+				variant: 'secondary',
+				callback: () => {},
+			},
+			{
+				label: t('files_sharing', 'Delete'),
+				variant: 'error',
+				callback: () => {
+					confirmed = true
+				},
+			},
+		])
+		.build()
+	try {
+		await dialog.show()
+	} catch (error) {
+		logger.debug('Delete confirmation dialog closed', { error })
+	}
+	return confirmed
+}
+
+/**
+ * Open the unified sharing dialog to edit this share.
+ */
+async function openEditDialog(): Promise<void> {
+	try {
+		await openShareEditDialog(props.share.id, props.fileInfo.node)
+	} catch (error) {
+		logger.error('Failed to open the sharing dialog', { error })
+	} finally {
+		// Refresh even if the dialog errored, it may still have applied
+		// changes (recipients, permissions) before closing.
+		emit('refresh')
+	}
+}
+
+/**
+ * Ask for confirmation, then delete the whole share.
+ */
+async function confirmDeleteShare(): Promise<void> {
+	if (!await confirm(t('files_sharing', 'Are you sure you want to delete this share? This operation cannot be undone.'))) {
+		return
+	}
+	try {
+		await deleteShare(props.share.id)
+		emit('refresh')
+	} catch (error) {
+		logger.error('Failed to delete share', { error })
+	}
+}
+
+/**
+ * Remove a single recipient from the share.
+ *
+ * @param recipient The recipient to remove
+ */
+async function removeOne(recipient: SharingRecipient): Promise<void> {
+	try {
+		await removeRecipient(props.share.id, recipient.class, recipient.value, recipient.instance)
+		emit('refresh')
+	} catch (error) {
+		logger.error('Failed to remove recipient', { error })
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+.unified-share {
+	// Unify every share row to 52px.
+	:deep(.sharing-entry) {
+		min-height: 52px;
+	}
+
+	&__recipient {
+		padding-inline-start: 24px;
+	}
+}
+</style>

--- a/apps/files_sharing/src/components/UnifiedShareList.vue
+++ b/apps/files_sharing/src/components/UnifiedShareList.vue
@@ -1,0 +1,34 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="unified-share-list">
+		<UnifiedShareEntry
+			v-for="share in sortedShares"
+			:key="share.id"
+			:share="share"
+			:fileInfo="fileInfo"
+			@refresh="$emit('refresh')" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { SharingShare } from '../types/unifiedSharing.ts'
+
+import { computed } from 'vue'
+import UnifiedShareEntry from './UnifiedShareEntry.vue'
+import { sortSharesByPermission } from '../lib/unifiedSharing.ts'
+
+const props = defineProps<{
+	shares: SharingShare[]
+	fileInfo: object
+}>()
+
+defineEmits<{
+	(e: 'refresh'): void
+}>()
+
+const sortedShares = computed(() => sortSharesByPermission(props.shares))
+</script>

--- a/apps/files_sharing/src/components/UnifiedShareListSkeleton.vue
+++ b/apps/files_sharing/src/components/UnifiedShareListSkeleton.vue
@@ -1,0 +1,85 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<ul class="share-skeleton" aria-hidden="true">
+		<li v-for="i in count" :key="i" class="share-skeleton__row">
+			<span class="share-skeleton__avatar" />
+			<span class="share-skeleton__lines">
+				<span class="share-skeleton__line share-skeleton__line--title" />
+				<span class="share-skeleton__line share-skeleton__line--subtitle" />
+			</span>
+		</li>
+	</ul>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{
+	/** How many placeholder rows to render. */
+	count?: number
+}>(), {
+	count: 3,
+})
+</script>
+
+<style lang="scss" scoped>
+.share-skeleton {
+	&__row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		min-height: 52px;
+	}
+
+	&__avatar {
+		flex: 0 0 auto;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+	}
+
+	&__lines {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		flex: 1 1 auto;
+	}
+
+	&__line {
+		height: 12px;
+		border-radius: 6px;
+
+		&--title {
+			width: 40%;
+		}
+
+		&--subtitle {
+			width: 25%;
+		}
+	}
+
+	&__avatar,
+	&__line {
+		background-color: var(--color-background-dark);
+		animation: share-skeleton-pulse 1.5s ease-in-out infinite;
+	}
+}
+
+@keyframes share-skeleton-pulse {
+	0%, 100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.share-skeleton__avatar,
+	.share-skeleton__line {
+		animation: none;
+	}
+}
+</style>

--- a/apps/files_sharing/src/lib/unifiedSharing.spec.ts
+++ b/apps/files_sharing/src/lib/unifiedSharing.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SharingPermission, SharingRecipient, SharingShare } from '../types/unifiedSharing.ts'
+
+import { describe, expect, test, vi } from 'vitest'
+import {
+	isNoUserRecipient,
+	permissionLabel,
+	recipientPermissionLabel,
+	recipientSummary,
+	reshareSubtitle,
+	sharePermissionRank,
+	sortSharesByPermission,
+} from './unifiedSharing.ts'
+import {
+	RECIPIENT_TYPE_GROUP,
+	RECIPIENT_TYPE_USER,
+} from './unifiedSharingConstants.ts'
+
+vi.mock('@nextcloud/l10n', () => ({
+	translate: (_app: string, text: string) => text,
+	translatePlural: (_app: string, singular: string, plural: string, count: number) => (count === 1 ? singular : plural).replace('%n', String(count)),
+}))
+
+vi.mock('@nextcloud/capabilities', () => ({
+	getCapabilities: () => ({
+		sharing: {
+			permission_presets: [
+				{ class: 'PresetView', display_name: 'Can view' },
+				{ class: 'PresetEdit', display_name: 'Can edit' },
+			],
+		},
+	}),
+}))
+
+function permission(cls: string, priority: number, enabled: boolean, presets: string[] = []): SharingPermission {
+	return {
+		class: cls,
+		source_class: null,
+		display_name: cls,
+		hint: null,
+		priority,
+		presets,
+		enabled,
+	}
+}
+
+function recipient(cls: string, value: string, initiator: SharingRecipient['initiator'] = null, permissions: SharingPermission[] = []): SharingRecipient {
+	return {
+		class: cls,
+		value,
+		instance: null,
+		display_name: value,
+		icon: null,
+		secret: { updatable: false },
+		initiator,
+		permissions,
+	}
+}
+
+function share(overrides: Partial<SharingShare> = {}): SharingShare {
+	return {
+		id: '1',
+		owner: { user_id: 'alice', instance: null, display_name: 'Alice', icon: { svg: '' } },
+		last_updated: 0,
+		state: 'active',
+		sources: [],
+		recipients: [],
+		permissions: [],
+		permission_preset: null,
+		...overrides,
+	}
+}
+
+describe('sharePermissionRank', () => {
+	test('sums priorities of enabled permissions only', () => {
+		const s = share({
+			permissions: [permission('read', 1, true), permission('write', 4, true), permission('share', 16, false)],
+		})
+		expect(sharePermissionRank(s)).toBe(5)
+	})
+})
+
+describe('sortSharesByPermission', () => {
+	test('orders by rank desc, then recipient count, then id', () => {
+		const low = share({ id: 'a', permissions: [permission('read', 1, true)] })
+		const high = share({ id: 'b', permissions: [permission('read', 1, true), permission('write', 4, true)] })
+		const highMoreRecipients = share({
+			id: 'c',
+			permissions: [permission('read', 1, true), permission('write', 4, true)],
+			recipients: [recipient(RECIPIENT_TYPE_USER, 'bob'), recipient(RECIPIENT_TYPE_USER, 'carol')],
+		})
+		const sorted = sortSharesByPermission([low, high, highMoreRecipients])
+		expect(sorted.map((s) => s.id)).toEqual(['c', 'b', 'a'])
+	})
+
+	test('does not mutate the input', () => {
+		const input = [share({ id: 'a' }), share({ id: 'b' })]
+		sortSharesByPermission(input)
+		expect(input.map((s) => s.id)).toEqual(['a', 'b'])
+	})
+})
+
+describe('isNoUserRecipient', () => {
+	test('true for non-user classes, false for users', () => {
+		expect(isNoUserRecipient(recipient(RECIPIENT_TYPE_GROUP, 'devs'))).toBe(true)
+		expect(isNoUserRecipient(recipient(RECIPIENT_TYPE_USER, 'bob'))).toBe(false)
+	})
+})
+
+describe('recipientSummary', () => {
+	test('counts and pluralizes by category', () => {
+		const recipients = [
+			recipient(RECIPIENT_TYPE_USER, 'bob'),
+			recipient(RECIPIENT_TYPE_GROUP, 'devs'),
+			recipient(RECIPIENT_TYPE_GROUP, 'ops'),
+		]
+		expect(recipientSummary(recipients)).toBe('1 person, 2 groups')
+	})
+})
+
+describe('permissionLabel', () => {
+	test('returns the preset display name', () => {
+		expect(permissionLabel(share({ permission_preset: 'PresetEdit' }))).toBe('Can edit')
+	})
+
+	test('returns Custom permissions when no preset matches', () => {
+		expect(permissionLabel(share({ permission_preset: null }))).toBe('Custom permissions')
+		expect(permissionLabel(share({ permission_preset: 'Unknown' }))).toBe('Custom permissions')
+	})
+})
+
+describe('reshareSubtitle', () => {
+	test('counts recipients added by someone other than the owner', () => {
+		const initiator = { user_id: 'bob', instance: null, display_name: 'Bob', icon: { svg: '' } }
+		const s = share({
+			recipients: [
+				recipient(RECIPIENT_TYPE_USER, 'carol', initiator),
+				recipient(RECIPIENT_TYPE_USER, 'dave'),
+			],
+		})
+		expect(reshareSubtitle(s)).toBe('Reshared with 1 person')
+	})
+
+	test('empty when no reshares', () => {
+		expect(reshareSubtitle(share({ recipients: [recipient(RECIPIENT_TYPE_USER, 'bob')] }))).toBe('')
+	})
+})
+
+describe('recipientPermissionLabel', () => {
+	const read = (enabled: boolean) => permission('read', 1, enabled, ['PresetView', 'PresetEdit'])
+	const write = (enabled: boolean) => permission('write', 4, enabled, ['PresetEdit'])
+	// Share grants both -> its own label would be "Can edit".
+	const base = share({ permissions: [read(true), write(true)] })
+
+	test('inherits the share permissions when the recipient has no overrides', () => {
+		expect(recipientPermissionLabel(base, recipient(RECIPIENT_TYPE_USER, 'bob'))).toBe('Can edit')
+	})
+
+	test('applies the recipient overrides on top of the share', () => {
+		const r = recipient(RECIPIENT_TYPE_USER, 'bob', null, [write(false)])
+		expect(recipientPermissionLabel(base, r)).toBe('Can view')
+	})
+
+	test('falls back to Custom permissions when nothing matches', () => {
+		const r = recipient(RECIPIENT_TYPE_USER, 'bob', null, [read(false)])
+		expect(recipientPermissionLabel(base, r)).toBe('Custom permissions')
+	})
+})

--- a/apps/files_sharing/src/lib/unifiedSharing.ts
+++ b/apps/files_sharing/src/lib/unifiedSharing.ts
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { SharingPermission, SharingRecipient, SharingShare } from '../types/unifiedSharing.ts'
+
+import { getCapabilities } from '@nextcloud/capabilities'
+import { translatePlural as n, translate as t } from '@nextcloud/l10n'
+import {
+	RECIPIENT_TYPE_EMAIL,
+	RECIPIENT_TYPE_GROUP,
+	RECIPIENT_TYPE_TEAM,
+	RECIPIENT_TYPE_TOKEN,
+	RECIPIENT_TYPE_USER,
+} from './unifiedSharingConstants.ts'
+
+/**
+ * Rank a share by its highest granted permissions: the sum of priorities of its
+ * enabled permissions. Used to order the flat share list (highest first).
+ *
+ * @param share The share to rank
+ */
+export function sharePermissionRank(share: SharingShare): number {
+	return share.permissions
+		.filter((permission) => permission.enabled)
+		.reduce((sum, permission) => sum + permission.priority, 0)
+}
+
+/**
+ * Sort shares by highest permissions first, then by recipient count, then by id
+ * for a stable order.
+ *
+ * @param shares The shares to sort (not mutated)
+ */
+export function sortSharesByPermission(shares: SharingShare[]): SharingShare[] {
+	return [...shares].sort((a, b) => {
+		const rank = sharePermissionRank(b) - sharePermissionRank(a)
+		if (rank !== 0) {
+			return rank
+		}
+		const count = b.recipients.length - a.recipients.length
+		if (count !== 0) {
+			return count
+		}
+		return a.id.localeCompare(b.id)
+	})
+}
+
+type CapabilitiesWithPresets = {
+	sharing?: {
+		permission_presets?: { class: string, display_name: string }[]
+	}
+}
+
+/**
+ * Human-readable label for a share's permission preset, e.g. "Can edit". Falls
+ * back to "Custom permissions" when the enabled permissions match no preset.
+ *
+ * @param share The share
+ */
+export function permissionLabel(share: SharingShare): string {
+	if (share.permission_preset === null) {
+		return t('files_sharing', 'Custom permissions')
+	}
+	const capabilities = getCapabilities() as CapabilitiesWithPresets
+	const preset = (capabilities.sharing?.permission_presets ?? []).find((p) => p.class === share.permission_preset)
+	return preset?.display_name ?? t('files_sharing', 'Custom permissions')
+}
+
+/**
+ * Human-readable label for a set of permissions: the preset whose member
+ * permissions are exactly the enabled ones, else "Custom permissions".
+ *
+ * @param permissions The permissions to label
+ */
+function labelForPermissions(permissions: SharingPermission[]): string {
+	const capabilities = getCapabilities() as CapabilitiesWithPresets
+	const enabled = new Set(permissions.filter((permission) => permission.enabled).map((permission) => permission.class))
+	for (const preset of capabilities.sharing?.permission_presets ?? []) {
+		const members = permissions.filter((permission) => permission.presets.includes(preset.class))
+		if (members.length > 0 && members.length === enabled.size && members.every((permission) => enabled.has(permission.class))) {
+			return preset.display_name
+		}
+	}
+	return t('files_sharing', 'Custom permissions')
+}
+
+/**
+ * Human-readable permission label for a single recipient.
+ *
+ * A recipient's permissions are sparse overrides on top of the share's, so the
+ * effective state is the share's permissions with the recipient's applied.
+ *
+ * @param share The share the recipient belongs to
+ * @param recipient The recipient
+ */
+export function recipientPermissionLabel(share: SharingShare, recipient: SharingRecipient): string {
+	const overrides = new Map((recipient.permissions ?? []).map((permission) => [permission.class, permission]))
+	return labelForPermissions(share.permissions.map((permission) => ({
+		...permission,
+		enabled: overrides.get(permission.class)?.enabled ?? permission.enabled,
+	})))
+}
+
+/**
+ * Whether a recipient should render a non-user (initials) avatar.
+ *
+ * @param recipient The recipient
+ */
+export function isNoUserRecipient(recipient: SharingRecipient): boolean {
+	return recipient.class !== RECIPIENT_TYPE_USER
+}
+
+/**
+ * Build a human-readable summary of a share's recipients, e.g.
+ * "1 person, 2 groups". Categories are listed in a stable order and only
+ * non-empty ones are included.
+ *
+ * @param recipients The share's recipients
+ */
+export function recipientSummary(recipients: SharingRecipient[]): string {
+	const counts: Record<string, number> = {}
+	for (const recipient of recipients) {
+		counts[recipient.class] = (counts[recipient.class] ?? 0) + 1
+	}
+
+	const parts: string[] = []
+	const push = (count: number, singular: string, plural: string) => {
+		if (count > 0) {
+			parts.push(n('files_sharing', singular, plural, count))
+		}
+	}
+
+	push(counts[RECIPIENT_TYPE_USER] ?? 0, '%n person', '%n people')
+	push(counts[RECIPIENT_TYPE_GROUP] ?? 0, '%n group', '%n groups')
+	push(counts[RECIPIENT_TYPE_TEAM] ?? 0, '%n team', '%n teams')
+	push(counts[RECIPIENT_TYPE_EMAIL] ?? 0, '%n email', '%n emails')
+	push(counts[RECIPIENT_TYPE_TOKEN] ?? 0, '%n link', '%n links')
+
+	// Fallback for any unknown recipient class not covered above.
+	const known = new Set([
+		RECIPIENT_TYPE_USER,
+		RECIPIENT_TYPE_GROUP,
+		RECIPIENT_TYPE_TEAM,
+		RECIPIENT_TYPE_EMAIL,
+		RECIPIENT_TYPE_TOKEN,
+	])
+	const otherCount = recipients.filter((r) => !known.has(r.class)).length
+	push(otherCount, '%n recipient', '%n recipients')
+
+	return parts.join(t('files_sharing', ', '))
+}
+
+/**
+ * Best-effort "Reshared with N people" subtitle: counts recipients that were
+ * added by someone other than the share owner (i.e. via a reshare). Returns an
+ * empty string when there are none.
+ *
+ * @param share The share
+ */
+export function reshareSubtitle(share: SharingShare): string {
+	const reshared = share.recipients.filter((recipient) => recipient.initiator !== null && recipient.initiator.user_id !== share.owner.user_id).length
+	if (reshared === 0) {
+		return ''
+	}
+	return n('files_sharing', 'Reshared with %n person', 'Reshared with %n people', reshared)
+}

--- a/apps/files_sharing/src/lib/unifiedSharingConstants.ts
+++ b/apps/files_sharing/src/lib/unifiedSharingConstants.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Hardcoded backend class strings from the unified sharing API, mirrored from
+ * the dialog library's constants. They are validated against the server
+ * capabilities at runtime before use (see `unifiedShares.ts`).
+ */
+
+/** Node (file/folder) source type. */
+export const SOURCE_TYPE_NODE = 'OCA\\Files\\Sharing\\Source\\NodeShareSourceType'
+
+/** Recipient type classes. */
+export const RECIPIENT_TYPE_USER = 'OC\\Core\\Sharing\\Recipient\\UserShareRecipientType'
+export const RECIPIENT_TYPE_EMAIL = 'OC\\Core\\Sharing\\Recipient\\EmailShareRecipientType'
+export const RECIPIENT_TYPE_GROUP = 'OC\\Core\\Sharing\\Recipient\\GroupShareRecipientType'
+export const RECIPIENT_TYPE_TEAM = 'OC\\Core\\Sharing\\Recipient\\TeamShareRecipientType'
+export const RECIPIENT_TYPE_TOKEN = 'OC\\Core\\Sharing\\Recipient\\TokenShareRecipientType'

--- a/apps/files_sharing/src/services/ConfigService.ts
+++ b/apps/files_sharing/src/services/ConfigService.ts
@@ -4,6 +4,7 @@
  */
 import { getCapabilities } from '@nextcloud/capabilities'
 import { loadState } from '@nextcloud/initial-state'
+import { isSharingDialogAvailable } from './SharingDialog.ts'
 
 type PasswordPolicySettings = {
 	enforceNonCommonPassword: boolean
@@ -353,5 +354,14 @@ export default class Config {
 	 */
 	get showExternalSharing(): boolean {
 		return loadState('files_sharing', 'showExternalSharing', true)
+	}
+
+	/**
+	 * Whether the new unified sharing dialog replaces the legacy inline sharing UI.
+	 * Derived from the server capabilities: when the unified sharing API is not
+	 * advertised (capability empty), the legacy inputs and menus are used instead.
+	 */
+	get sharingDialogEnabled(): boolean {
+		return isSharingDialogAvailable()
 	}
 }

--- a/apps/files_sharing/src/services/ConfigService.ts
+++ b/apps/files_sharing/src/services/ConfigService.ts
@@ -344,4 +344,13 @@ export default class Config {
 	get showExternalSharing(): boolean {
 		return loadState('files_sharing', 'showExternalSharing', true)
 	}
+
+	/**
+	 * Whether the new unified sharing dialog replaces the legacy inline sharing UI.
+	 * Hidden killswitch (appconfig files_sharing sharing_dialog_enabled); set to
+	 * false to temporarily restore the legacy inputs and menus.
+	 */
+	get sharingDialogEnabled(): boolean {
+		return loadState('files_sharing', 'sharingDialogEnabled', true)
+	}
 }

--- a/apps/files_sharing/src/services/SharingDialog.ts
+++ b/apps/files_sharing/src/services/SharingDialog.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@nextcloud/files'
+
+import { getShare, openSharingDialog } from '@nextcloud/sharing/dialog'
+
+/**
+ * Open the unified sharing dialog to create a new share for a node.
+ *
+ * @param node The file or folder to share
+ */
+export async function openShareCreateDialog(node: Node): Promise<unknown> {
+	return openSharingDialog(node)
+}
+
+/**
+ * Open the unified sharing dialog to edit an existing share.
+ *
+ * @param shareId The share id (mapped to the unified API by the legacy bridge)
+ * @param node The backing node, used for the dialog title
+ */
+export async function openShareEditDialog(shareId: string | number, node?: Node): Promise<unknown> {
+	const share = await getShare(String(shareId))
+	return share.showDialog(node)
+}

--- a/apps/files_sharing/src/services/SharingDialog.ts
+++ b/apps/files_sharing/src/services/SharingDialog.ts
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@nextcloud/files'
+
+import { getCapabilities } from '@nextcloud/capabilities'
+
+/**
+ * The unified sharing dialog is a Vue 3 component. It is registered on the
+ * global `OCA.Sharing` namespace by the Vue 3 bridge entry point
+ * (`sharing-dialog-bridge.ts`), so this Vue 2 frontend can trigger it without
+ * pulling Vue 3 into its bundle.
+ */
+type SharingDialogApi = {
+	openSharingDialog(node: Node): Promise<unknown>
+	openShareEditDialog(shareId: string | number, node?: Node): Promise<unknown>
+}
+
+/**
+ * Get the sharing dialog API registered by the Vue 3 bridge, if loaded.
+ */
+function sharingDialogApi(): SharingDialogApi | undefined {
+	return (window.OCA?.Sharing as Partial<SharingDialogApi> | undefined) as SharingDialogApi | undefined
+}
+
+/**
+ * Whether the server provides the unified sharing API this dialog talks to.
+ * Mirrors the library check so the sidebar can gate on it without importing
+ * the Vue 3 code.
+ */
+export function isSharingDialogAvailable(): boolean {
+	const capabilities = getCapabilities() as { sharing?: { api_versions?: unknown[] } }
+	return (capabilities.sharing?.api_versions?.length ?? 0) > 0
+}
+
+/**
+ * Open the unified sharing dialog to create a new share for a node.
+ *
+ * @param node The file or folder to share
+ */
+export function openShareCreateDialog(node: Node): Promise<unknown> {
+	const api = sharingDialogApi()
+	if (!api?.openSharingDialog) {
+		return Promise.reject(new Error('The unified sharing dialog is not available'))
+	}
+	return api.openSharingDialog(node)
+}
+
+/**
+ * Open the unified sharing dialog to edit an existing share.
+ *
+ * @param shareId The share id (mapped to the unified API by the legacy bridge)
+ * @param node The backing node, used for the dialog title
+ */
+export function openShareEditDialog(shareId: string | number, node?: Node): Promise<unknown> {
+	const api = sharingDialogApi()
+	if (!api?.openShareEditDialog) {
+		return Promise.reject(new Error('The unified sharing dialog is not available'))
+	}
+	return api.openShareEditDialog(shareId, node)
+}

--- a/apps/files_sharing/src/services/unifiedShares.spec.ts
+++ b/apps/files_sharing/src/services/unifiedShares.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { SOURCE_TYPE_NODE } from '../lib/unifiedSharingConstants.ts'
+import { deleteShare, getSharesForNode, removeRecipient } from './unifiedShares.ts'
+
+const axios = vi.hoisted(() => ({ get: vi.fn(), delete: vi.fn() }))
+vi.mock('@nextcloud/axios', () => ({ default: axios }))
+
+const capabilities = vi.hoisted(() => ({ value: {} as unknown }))
+vi.mock('@nextcloud/capabilities', () => ({ getCapabilities: () => capabilities.value }))
+
+vi.mock('@nextcloud/router', () => ({
+	generateOcsUrl: (path: string, params?: Record<string, string>) => 'ocs/' + path.replace(/\{(\w+)\}/g, (_, k) => params?.[k] ?? ''),
+}))
+
+vi.mock('./logger.ts', () => ({ default: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }))
+
+const ocs = (data: unknown[]) => ({ data: { ocs: { data } } })
+const node = { fileid: 42 } as never
+
+beforeEach(() => {
+	vi.resetAllMocks()
+	capabilities.value = { sharing: { source_types: [{ class: SOURCE_TYPE_NODE }] } }
+})
+
+describe('getSharesForNode', () => {
+	test('returns [] and does not call the API when the node source type is unavailable', async () => {
+		capabilities.value = { sharing: { source_types: [] } }
+		expect(await getSharesForNode(node)).toEqual([])
+		expect(axios.get).not.toHaveBeenCalled()
+	})
+
+	test('unwraps ocs.data and filters by node', async () => {
+		axios.get.mockResolvedValueOnce(ocs([{ id: '1' }, { id: '2' }]))
+		const shares = await getSharesForNode(node)
+		expect(shares).toEqual([{ id: '1' }, { id: '2' }])
+		expect(axios.get).toHaveBeenCalledTimes(1)
+		expect(axios.get.mock.calls[0][1].params).toMatchObject({
+			filterSourceTypeClass: SOURCE_TYPE_NODE,
+			filterSourceTypeValue: '42',
+			filterState: 'active',
+			limit: 100,
+		})
+	})
+
+	test('walks all pages until a short page', async () => {
+		const fullPage = Array.from({ length: 100 }, (_, i) => ({ id: String(i) }))
+		axios.get
+			.mockResolvedValueOnce(ocs(fullPage))
+			.mockResolvedValueOnce(ocs([{ id: '100' }, { id: '101' }]))
+		const shares = await getSharesForNode(node)
+		expect(shares).toHaveLength(102)
+		expect(axios.get).toHaveBeenCalledTimes(2)
+		// Second page requests the id after the last of the first page.
+		expect(axios.get.mock.calls[1][1].params.lastShareID).toBe('99')
+	})
+})
+
+describe('deleteShare', () => {
+	test('DELETEs the share by id', async () => {
+		await deleteShare('7')
+		expect(axios.delete).toHaveBeenCalledWith('ocs//apps/sharing/api/v1/share/7')
+	})
+})
+
+describe('removeRecipient', () => {
+	test('DELETEs the recipient with the class/value/instance body', async () => {
+		await removeRecipient('7', 'RecipClass', 'bob', null)
+		expect(axios.delete).toHaveBeenCalledWith('ocs//apps/sharing/api/v1/share/7/recipient', {
+			data: { class: 'RecipClass', value: 'bob', instance: null },
+		})
+	})
+})

--- a/apps/files_sharing/src/services/unifiedShares.ts
+++ b/apps/files_sharing/src/services/unifiedShares.ts
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@nextcloud/files'
+import type { SharingShare } from '../types/unifiedSharing.ts'
+
+import axios from '@nextcloud/axios'
+import { getCapabilities } from '@nextcloud/capabilities'
+import { generateOcsUrl } from '@nextcloud/router'
+import { SOURCE_TYPE_NODE } from '../lib/unifiedSharingConstants.ts'
+import logger from './logger.ts'
+
+const PAGE_SIZE = 100
+
+type Capabilities = {
+	sharing?: {
+		source_types?: { class: string }[]
+	}
+}
+
+/**
+ * Whether the node source type is registered on the server. The hardcoded class
+ * string must match a capability entry, otherwise listing would silently return
+ * nothing.
+ */
+function isNodeSourceTypeAvailable(): boolean {
+	const capabilities = getCapabilities() as Capabilities
+	return (capabilities.sharing?.source_types ?? []).some((type) => type.class === SOURCE_TYPE_NODE)
+}
+
+/**
+ * Fetch every active share whose source is the given node, from the unified
+ * sharing API. Results are paginated by the backend; this walks all pages.
+ *
+ * @param node The file or folder whose shares to list
+ */
+export async function getSharesForNode(node: Node): Promise<SharingShare[]> {
+	if (!isNodeSourceTypeAvailable()) {
+		logger.warn('Node source type is not advertised by the sharing capability; cannot list unified shares')
+		return []
+	}
+
+	const url = generateOcsUrl('/apps/sharing/api/v1/shares')
+	const shares: SharingShare[] = []
+	let lastShareID: string | undefined
+
+	// Walk pages until the backend returns a short (final) page.
+	for (;;) {
+		const response = await axios.get(url, {
+			params: {
+				filterSourceTypeClass: SOURCE_TYPE_NODE,
+				filterSourceTypeValue: String(node.fileid),
+				filterState: 'active',
+				limit: PAGE_SIZE,
+				...(lastShareID ? { lastShareID } : {}),
+			},
+		})
+		const page: SharingShare[] = response.data.ocs.data
+		shares.push(...page)
+		if (page.length < PAGE_SIZE) {
+			break
+		}
+		lastShareID = page[page.length - 1].id
+	}
+
+	return shares
+}
+
+/**
+ * Delete a share by id.
+ *
+ * @param id The share id
+ */
+export async function deleteShare(id: string): Promise<void> {
+	await axios.delete(generateOcsUrl('/apps/sharing/api/v1/share/{id}', { id }))
+}
+
+/**
+ * Remove a single recipient from a share.
+ *
+ * @param id The share id
+ * @param recipientClass The recipient type class
+ * @param recipientValue The recipient value
+ * @param instance The recipient's instance (federated recipients)
+ */
+export async function removeRecipient(id: string, recipientClass: string, recipientValue: string, instance?: string | null): Promise<void> {
+	await axios.delete(generateOcsUrl('/apps/sharing/api/v1/share/{id}/recipient', { id }), {
+		data: {
+			class: recipientClass,
+			value: recipientValue,
+			instance: instance ?? null,
+		},
+	})
+}

--- a/apps/files_sharing/src/sharing-dialog-bridge.ts
+++ b/apps/files_sharing/src/sharing-dialog-bridge.ts
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Node } from '@nextcloud/files'
+
+import { getShare, isSharingDialogAvailable, openSharingDialog } from '@nextcloud/sharing/dialog'
+
+/**
+ * Bridge the Vue 3 unified sharing dialog into the global `OCA.Sharing`
+ * namespace so the (still Vue 2) files_sharing sidebar can trigger it without
+ * importing Vue 3 code into its bundle. The dialog spawns its own Vue 3 app,
+ * so it must be registered from this Vue 3 entry point where `vue` and
+ * `@nextcloud/vue` resolve to their Vue 3 versions.
+ *
+ * Once files_sharing is migrated to Vue 3 this bridge can be dropped and the
+ * library imported directly.
+ */
+
+window.OCA ??= {}
+window.OCA.Sharing ??= {}
+
+Object.assign(window.OCA.Sharing, {
+	openSharingDialog,
+
+	/**
+	 * Open the unified sharing dialog to edit an existing share.
+	 *
+	 * @param shareId The share id (mapped to the unified API by the legacy bridge)
+	 * @param node The backing node, used for the dialog title
+	 */
+	async openShareEditDialog(shareId: string | number, node?: Node): Promise<unknown> {
+		const share = await getShare(String(shareId))
+		return share.showDialog(node)
+	},
+
+	isSharingDialogAvailable,
+})

--- a/apps/files_sharing/src/types/unifiedSharing.ts
+++ b/apps/files_sharing/src/types/unifiedSharing.ts
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Types mirroring the unified sharing API (`@nextcloud/sharing/dialog`).
+ *
+ * The dialog library is Vue 3 and cannot be imported into this Vue 2 frontend,
+ * so the subset of the schema needed to list shares in the sidebar is kept here.
+ * Keep in sync with the library's `lib/dialog/types/api.ts`.
+ */
+
+export interface SharingIconSVG {
+	svg: string
+}
+
+export interface SharingIconURL {
+	light: string
+	dark: string
+}
+
+export type SharingIcon = SharingIconSVG | SharingIconURL
+
+export interface SharingOwner {
+	user_id: string
+	instance: string | null
+	display_name: string
+	icon: SharingIcon
+}
+
+export interface SharingSource {
+	class: string
+	value: string
+	display_name: string
+	icon: SharingIcon | null
+}
+
+export interface SharingRecipientSecret {
+	updatable: boolean
+	value?: string
+	url?: string
+}
+
+export interface SharingRecipient {
+	class: string
+	value: string
+	instance: string | null
+	display_name: string
+	icon: SharingIcon | null
+	secret: SharingRecipientSecret
+	initiator: SharingOwner | null
+	/** Per-recipient permissions, capped at the share-level ones */
+	permissions: SharingPermission[]
+}
+
+export interface SharingPermission {
+	class: string
+	source_class: string | null
+	display_name: string
+	hint: string | null
+	priority: number
+	presets: string[]
+	enabled: boolean
+}
+
+export type SharingState = 'active' | 'draft' | 'deleted'
+
+export interface SharingShare {
+	id: string
+	owner: SharingOwner
+	last_updated: number
+	state: SharingState
+	sources: SharingSource[]
+	recipients: SharingRecipient[]
+	permissions: SharingPermission[]
+	permission_preset: string | null
+}

--- a/apps/files_sharing/src/views/SharingTab.spec.ts
+++ b/apps/files_sharing/src/views/SharingTab.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The component reads the theme at module scope, so it must exist before import.
+vi.hoisted(() => {
+	window.OC = { ...window.OC, theme: { productName: 'Nextcloud' } }
+})
+
+import SharingTab from './SharingTab.vue'
+import { openShareCreateDialog } from '../services/SharingDialog.ts'
+import { getSharesForNode } from '../services/unifiedShares.ts'
+
+vi.mock('../services/SharingDialog.ts', () => ({
+	openShareCreateDialog: vi.fn().mockResolvedValue(undefined),
+	isSharingDialogAvailable: vi.fn().mockReturnValue(true),
+}))
+
+vi.mock('../services/unifiedShares.ts', () => ({
+	getSharesForNode: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../services/logger.ts', () => ({
+	default: { error: vi.fn(), debug: vi.fn() },
+}))
+
+function buildContext(overrides: Record<string, unknown> = {}) {
+	return {
+		fileInfo: { node: { fileid: 1 } },
+		unifiedShares: [],
+		loading: false,
+		error: '',
+		getUnifiedShares: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	}
+}
+
+type Ctx = ReturnType<typeof buildContext>
+
+/**
+ * Call a component method with a fake `this`, as the other specs here do.
+ *
+ * @param method The method name
+ * @param ctx The fake component context
+ * @param args Arguments passed to the method
+ */
+function call(method: string, ctx: Ctx, ...args: unknown[]) {
+	return SharingTab.methods[method].call(ctx, ...args)
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('openShareDialog', () => {
+	it('refreshes the list once the dialog closes', async () => {
+		const ctx = buildContext()
+		await call('openShareDialog', ctx)
+		expect(openShareCreateDialog).toHaveBeenCalledWith(ctx.fileInfo.node)
+		// Without the loading state, so the rendered rows stay mounted.
+		expect(ctx.getUnifiedShares).toHaveBeenCalledWith(false)
+	})
+
+	it('still refreshes when the dialog fails', async () => {
+		vi.mocked(openShareCreateDialog).mockRejectedValueOnce(new Error('nope'))
+		const ctx = buildContext()
+		await call('openShareDialog', ctx)
+		expect(ctx.getUnifiedShares).toHaveBeenCalledWith(false)
+	})
+})
+
+describe('getUnifiedShares', () => {
+	it('loads the shares of the current node', async () => {
+		const shares = [{ id: '1' }]
+		vi.mocked(getSharesForNode).mockResolvedValueOnce(shares)
+		const ctx = buildContext({ getUnifiedShares: SharingTab.methods.getUnifiedShares })
+		await SharingTab.methods.getUnifiedShares.call(ctx)
+		expect(getSharesForNode).toHaveBeenCalledWith(ctx.fileInfo.node)
+		expect(ctx.unifiedShares).toEqual(shares)
+	})
+
+	it('keeps the rows mounted while refreshing in place', async () => {
+		const ctx = buildContext()
+		let loadingWhileFetching = false
+		vi.mocked(getSharesForNode).mockImplementationOnce(async () => {
+			loadingWhileFetching = ctx.loading
+			return []
+		})
+		await SharingTab.methods.getUnifiedShares.call(ctx, false)
+		expect(loadingWhileFetching).toBe(false)
+	})
+
+	it('surfaces the backend error message', async () => {
+		vi.mocked(getSharesForNode).mockRejectedValueOnce({
+			response: { data: { ocs: { meta: { message: 'Nope' } } } },
+		})
+		const ctx = buildContext()
+		await SharingTab.methods.getUnifiedShares.call(ctx)
+		expect(ctx.error).toBe('Nope')
+		expect(ctx.loading).toBe(false)
+	})
+})

--- a/apps/files_sharing/src/views/SharingTab.vue
+++ b/apps/files_sharing/src/views/SharingTab.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div class="sharingTab" :class="{ 'icon-loading': loading }">
+	<div class="sharingTab" :class="{ 'icon-loading': loading && !config.sharingDialogEnabled }">
 		<!-- error message -->
 		<div v-if="error" class="emptycontent" :class="{ emptyContentWithSections: hasExternalSections }">
 			<div class="icon icon-error" />
@@ -21,16 +21,41 @@
 					<template #avatar>
 						<NcAvatar
 							:user="sharedWithMe.user"
-							:display-name="sharedWithMe.displayName"
+							:displayName="sharedWithMe.displayName"
 							class="sharing-entry__avatar" />
 					</template>
 				</SharingEntrySimple>
 			</ul>
 
-			<section>
+			<!-- Unified sharing dialog entry point (replaces the inline inputs) -->
+			<NcButton
+				v-if="config.sharingDialogEnabled"
+				class="sharingTab__share-button"
+				variant="primary"
+				wide
+				@click="openShareDialog">
+				<template #icon>
+					<ShareVariantIcon :size="20" />
+				</template>
+				{{ t('files_sharing', 'Share') }}
+			</NcButton>
+
+			<!-- Unified flat share list: all shares, ordered by permission -->
+			<section v-if="config.sharingDialogEnabled">
+				<UnifiedShareListSkeleton v-if="loading" />
+				<UnifiedShareList
+					v-else
+					:shares="unifiedShares"
+					:fileInfo="fileInfo"
+					@refresh="getUnifiedShares(false)" />
+				<!-- internal link copy -->
+				<SharingEntryInternal :fileInfo="fileInfo" />
+			</section>
+
+			<section v-if="!config.sharingDialogEnabled">
 				<div class="section-header">
 					<h4>{{ t('files_sharing', 'Internal shares') }}</h4>
-					<NcPopover popup-role="dialog">
+					<NcPopover popupRole="dialog">
 						<template #trigger>
 							<NcButton
 								class="hint-icon"
@@ -48,10 +73,10 @@
 				</div>
 				<!-- add new share input -->
 				<SharingInput
-					v-if="!loading"
-					:can-reshare="canReshare"
-					:file-info="fileInfo"
-					:link-shares="linkShares"
+					v-if="!loading && !config.sharingDialogEnabled"
+					:canReshare="canReshare"
+					:fileInfo="fileInfo"
+					:linkShares="linkShares"
 					:reshare="reshare"
 					:shares="shares"
 					:placeholder="internalShareInputPlaceholder"
@@ -62,20 +87,20 @@
 					v-if="!loading"
 					ref="shareList"
 					:shares="shares"
-					:file-info="fileInfo"
+					:fileInfo="fileInfo"
 					@open-sharing-details="toggleShareDetailsView" />
 
 				<!-- inherited shares -->
-				<SharingInherited v-if="canReshare && !loading" :file-info="fileInfo" />
+				<SharingInherited v-if="canReshare && !loading" :fileInfo="fileInfo" />
 
 				<!-- internal link copy -->
-				<SharingEntryInternal :file-info="fileInfo" />
+				<SharingEntryInternal :fileInfo="fileInfo" />
 			</section>
 
-			<section v-if="config.showExternalSharing">
+			<section v-if="config.showExternalSharing && !config.sharingDialogEnabled">
 				<div class="section-header">
 					<h4>{{ t('files_sharing', 'External shares') }}</h4>
-					<NcPopover popup-role="dialog">
+					<NcPopover popupRole="dialog">
 						<template #trigger>
 							<NcButton
 								class="hint-icon"
@@ -92,11 +117,11 @@
 					</NcPopover>
 				</div>
 				<SharingInput
-					v-if="!loading"
-					:can-reshare="canReshare"
-					:file-info="fileInfo"
-					:link-shares="linkShares"
-					:is-external="true"
+					v-if="!loading && !config.sharingDialogEnabled"
+					:canReshare="canReshare"
+					:fileInfo="fileInfo"
+					:linkShares="linkShares"
+					:isExternal="true"
 					:placeholder="externalShareInputPlaceholder"
 					:reshare="reshare"
 					:shares="shares"
@@ -105,14 +130,14 @@
 				<SharingList
 					v-if="!loading"
 					:shares="externalShares"
-					:file-info="fileInfo"
+					:fileInfo="fileInfo"
 					@open-sharing-details="toggleShareDetailsView" />
 				<!-- link shares list -->
 				<SharingLinkList
 					v-if="!loading && isLinkSharingAllowed"
 					ref="linkShareList"
-					:can-reshare="canReshare"
-					:file-info="fileInfo"
+					:canReshare="canReshare"
+					:fileInfo="fileInfo"
 					:shares="linkShares"
 					@open-sharing-details="toggleShareDetailsView" />
 			</section>
@@ -120,7 +145,7 @@
 			<section v-if="hasExternalSections && !showSharingDetailsView">
 				<div class="section-header">
 					<h4>{{ t('files_sharing', 'Additional shares') }}</h4>
-					<NcPopover popup-role="dialog">
+					<NcPopover popupRole="dialog">
 						<template #trigger>
 							<NcButton
 								class="hint-icon"
@@ -148,8 +173,8 @@
 				<SidebarTabExternalSectionLegacy
 					v-for="(section, index) in legacySections"
 					:key="index"
-					:file-info="fileInfo"
-					:section-callback="section"
+					:fileInfo="fileInfo"
+					:sectionCallback="section"
 					class="sharingTab__additionalContent" />
 
 				<!-- projects (deprecated as of NC25 (replaced by related_resources) - see instance config "projects.enabled" ; ignore this / remove it / move into own section) -->
@@ -168,7 +193,7 @@
 		<!-- share details -->
 		<SharingDetailsTab
 			v-if="showSharingDetailsView"
-			:file-info="shareDetailsData.fileInfo"
+			:fileInfo="shareDetailsData.fileInfo"
 			:share="shareDetailsData.share"
 			@close-sharing-details="toggleShareDetailsView"
 			@add:share="addShare"
@@ -191,11 +216,14 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCollectionList from '@nextcloud/vue/components/NcCollectionList'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
 import InfoIcon from 'vue-material-design-icons/InformationOutline.vue'
+import ShareVariantIcon from 'vue-material-design-icons/ShareVariant.vue'
 import SharingEntryInternal from '../components/SharingEntryInternal.vue'
 import SharingEntrySimple from '../components/SharingEntrySimple.vue'
 import SharingInput from '../components/SharingInput.vue'
 import SidebarTabExternalSection from '../components/SidebarTabExternal/SidebarTabExternalSection.vue'
 import SidebarTabExternalSectionLegacy from '../components/SidebarTabExternal/SidebarTabExternalSectionLegacy.vue'
+import UnifiedShareList from '../components/UnifiedShareList.vue'
+import UnifiedShareListSkeleton from '../components/UnifiedShareListSkeleton.vue'
 import SharingDetailsTab from './SharingDetailsTab.vue'
 import SharingInherited from './SharingInherited.vue'
 import SharingLinkList from './SharingLinkList.vue'
@@ -204,6 +232,8 @@ import ShareDetails from '../mixins/ShareDetails.js'
 import Share from '../models/Share.ts'
 import Config from '../services/ConfigService.ts'
 import logger from '../services/logger.ts'
+import { openShareCreateDialog } from '../services/SharingDialog.ts'
+import { getSharesForNode } from '../services/unifiedShares.ts'
 import { shareWithTitle } from '../utils/SharedWithMe.js'
 
 const productName = window.OC.theme.productName
@@ -217,6 +247,7 @@ export default {
 		NcButton,
 		NcCollectionList,
 		NcPopover,
+		ShareVariantIcon,
 		SharingEntryInternal,
 		SharingEntrySimple,
 		SharingInherited,
@@ -226,6 +257,8 @@ export default {
 		SharingDetailsTab,
 		SidebarTabExternalSection,
 		SidebarTabExternalSectionLegacy,
+		UnifiedShareList,
+		UnifiedShareListSkeleton,
 	},
 
 	mixins: [ShareDetails],
@@ -251,6 +284,8 @@ export default {
 			shares: [],
 			linkShares: [],
 			externalShares: [],
+			// Flat list of unified-API shares (new sidebar), used when the dialog is enabled
+			unifiedShares: [],
 
 			legacySections: OCA.Sharing.ShareTabSections.getSections(),
 			sections: getSidebarSections(),
@@ -347,9 +382,28 @@ export default {
 
 	methods: {
 		/**
+		 * Open the unified sharing dialog to create a share for the current node.
+		 */
+		async openShareDialog() {
+			try {
+				await openShareCreateDialog(this.fileInfo.node)
+			} catch (error) {
+				logger.error('Failed to open the sharing dialog', { error })
+			} finally {
+				// The dialog writes straight to the backend, so pick up whatever it
+				// created (or changed) once it closes.
+				await this.getUnifiedShares(false)
+			}
+		},
+
+		/**
 		 * Get the existing shares infos
 		 */
 		async getShares() {
+			// New unified sidebar: a single flat list from the unified sharing API.
+			if (this.config.sharingDialogEnabled) {
+				return this.getUnifiedShares()
+			}
 			try {
 				this.loading = true
 
@@ -394,6 +448,31 @@ export default {
 		},
 
 		/**
+		 * Get the existing shares from the unified sharing API as one flat list.
+		 *
+		 * @param {boolean} showLoading Toggle the loading state (unmounts the
+		 *   list). Skipped on in-place refreshes so keyed rows keep their state
+		 *   (e.g. an expanded recipient group).
+		 */
+		async getUnifiedShares(showLoading = true) {
+			try {
+				if (showLoading) {
+					this.loading = true
+				}
+				this.unifiedShares = await getSharesForNode(this.fileInfo.node)
+			} catch (error) {
+				if (error?.response?.data?.ocs?.meta?.message) {
+					this.error = error.response.data.ocs.meta.message
+				} else {
+					this.error = t('files_sharing', 'Unable to load the shares list')
+				}
+				logger.error('Error loading the unified shares list', error)
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
 		 * Reset the current view to its default state
 		 */
 		resetState() {
@@ -404,6 +483,7 @@ export default {
 			this.shares = []
 			this.linkShares = []
 			this.externalShares = []
+			this.unifiedShares = []
 			this.showSharingDetailsView = false
 			this.shareDetailsData = {}
 		},
@@ -614,6 +694,11 @@ export default {
 
 	&__content {
 		padding: 0 6px;
+
+		// Space between the big Share button and the list of shares below.
+		.sharingTab__share-button {
+			margin-block-end: 12px;
+		}
 
 		section {
 			padding-bottom: 16px;

--- a/apps/files_sharing/src/views/SharingTab.vue
+++ b/apps/files_sharing/src/views/SharingTab.vue
@@ -27,6 +27,19 @@
 				</SharingEntrySimple>
 			</ul>
 
+			<!-- Unified sharing dialog entry point (replaces the inline inputs) -->
+			<NcButton
+				v-if="config.sharingDialogEnabled"
+				class="sharingTab__share-button"
+				variant="primary"
+				wide
+				@click="openShareDialog">
+				<template #icon>
+					<ShareVariantIcon :size="20" />
+				</template>
+				{{ t('files_sharing', 'Share') }}
+			</NcButton>
+
 			<section>
 				<div class="section-header">
 					<h4>{{ t('files_sharing', 'Internal shares') }}</h4>
@@ -48,7 +61,7 @@
 				</div>
 				<!-- add new share input -->
 				<SharingInput
-					v-if="!loading"
+					v-if="!loading && !config.sharingDialogEnabled"
 					:can-reshare="canReshare"
 					:file-info="fileInfo"
 					:link-shares="linkShares"
@@ -92,7 +105,7 @@
 					</NcPopover>
 				</div>
 				<SharingInput
-					v-if="!loading"
+					v-if="!loading && !config.sharingDialogEnabled"
 					:can-reshare="canReshare"
 					:file-info="fileInfo"
 					:link-shares="linkShares"
@@ -191,6 +204,7 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCollectionList from '@nextcloud/vue/components/NcCollectionList'
 import NcPopover from '@nextcloud/vue/components/NcPopover'
 import InfoIcon from 'vue-material-design-icons/InformationOutline.vue'
+import ShareVariantIcon from 'vue-material-design-icons/ShareVariant.vue'
 import SharingEntryInternal from '../components/SharingEntryInternal.vue'
 import SharingEntrySimple from '../components/SharingEntrySimple.vue'
 import SharingInput from '../components/SharingInput.vue'
@@ -203,6 +217,7 @@ import SharingList from './SharingList.vue'
 import ShareDetails from '../mixins/ShareDetails.js'
 import Share from '../models/Share.ts'
 import Config from '../services/ConfigService.ts'
+import { openShareCreateDialog } from '../services/SharingDialog.ts'
 import logger from '../services/logger.ts'
 import { shareWithTitle } from '../utils/SharedWithMe.js'
 
@@ -217,6 +232,7 @@ export default {
 		NcButton,
 		NcCollectionList,
 		NcPopover,
+		ShareVariantIcon,
 		SharingEntryInternal,
 		SharingEntrySimple,
 		SharingInherited,
@@ -346,6 +362,17 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Open the unified sharing dialog to create a share for the current node.
+		 */
+		async openShareDialog() {
+			try {
+				await openShareCreateDialog(this.fileInfo.node)
+			} catch (error) {
+				logger.error('Failed to open the sharing dialog', { error })
+			}
+		},
+
 		/**
 		 * Get the existing shares infos
 		 */

--- a/apps/sharing/lib/Controller/ApiV1Controller.php
+++ b/apps/sharing/lib/Controller/ApiV1Controller.php
@@ -92,7 +92,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'GET', url: '/api/v1/recipients')]
-	#[UserRateLimit(limit: 5, period: 1)]
+	#[UserRateLimit(limit: 60, period: 60)]
 	public function searchRecipients(?array $filterRecipientTypeClasses, string $query, int $limit = 10, int $offset = 0, ?string $id = null): DataResponse {
 		/** @psalm-suppress DocblockTypeContradiction */
 		if ($limit < 1) {
@@ -147,7 +147,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'POST', url: '/api/v1/share')]
-	#[UserRateLimit(limit: 1, period: 5)]
+	#[UserRateLimit(limit: 30, period: 60)]
 	public function createShare(): DataResponse {
 		try {
 			try {
@@ -180,7 +180,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1/share/{id}/state')]
-	#[UserRateLimit(limit: 1, period: 5)]
+	#[UserRateLimit(limit: 60, period: 60)]
 	public function updateShareState(string $id, string $state): DataResponse {
 		try {
 			$shareState = ShareState::from($state);
@@ -220,7 +220,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1/share/{id}/user-status')]
-	#[UserRateLimit(limit: 1, period: 5)]
+	#[UserRateLimit(limit: 60, period: 60)]
 	public function updateShareUserStatus(string $id, string $userStatus): DataResponse {
 		try {
 			$shareUserStatus = ShareUserStatus::from($userStatus);
@@ -260,7 +260,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'POST', url: '/api/v1/share/{id}/source')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 60, period: 60)]
 	public function addShareSource(string $id, string $class, string $value): DataResponse {
 		try {
 			try {
@@ -297,7 +297,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'DELETE', url: '/api/v1/share/{id}/source')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 60, period: 60)]
 	public function removeShareSource(string $id, string $class, string $value): DataResponse {
 		try {
 			try {
@@ -334,7 +334,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'POST', url: '/api/v1/share/{id}/recipient')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 120, period: 60)]
 	public function addShareRecipient(string $id, string $class, string $value, ?string $instance): DataResponse {
 		try {
 			try {
@@ -372,7 +372,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'DELETE', url: '/api/v1/share/{id}/recipient')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 120, period: 60)]
 	public function removeShareRecipient(string $id, string $class, string $value, ?string $instance): DataResponse {
 		try {
 			try {
@@ -410,7 +410,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1/share/{id}/recipient/secret')]
-	#[UserRateLimit(limit: 1, period: 5)]
+	#[UserRateLimit(limit: 20, period: 60)]
 	public function updateShareRecipientSecret(string $id, string $class, string $value, ?string $instance, string $secret): DataResponse {
 		try {
 			try {
@@ -448,7 +448,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1/share/{id}/property')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 120, period: 60)]
 	public function updateShareProperty(string $id, string $class, ?string $value): DataResponse {
 		try {
 			try {
@@ -486,7 +486,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1/share/{id}/permission')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 240, period: 60)]
 	public function updateSharePermission(string $id, string $class, bool $enabled): DataResponse {
 		try {
 			try {
@@ -526,6 +526,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1/share/{id}/recipient/permission')]
+	#[UserRateLimit(limit: 240, period: 60)]
 	public function updateShareRecipientPermission(string $id, string $recipientClass, string $recipientValue, ?string $recipientInstance, string $permissionClass, bool $enabled): DataResponse {
 		try {
 			try {
@@ -560,7 +561,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1/share/{id}/permission/preset')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 60, period: 60)]
 	public function selectSharePermissionPreset(string $id, string $permissionPresetClass): DataResponse {
 		try {
 			try {
@@ -593,7 +594,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'DELETE', url: '/api/v1/share/{id}')]
-	#[UserRateLimit(limit: 1, period: 5)]
+	#[UserRateLimit(limit: 60, period: 60)]
 	public function deleteShare(string $id): DataResponse {
 		try {
 			try {
@@ -628,7 +629,7 @@ final class ApiV1Controller extends OCSController {
 	#[PublicPage]
 	// This should be a GET, but GET doesn't allow a request body which is required for the $arguments.
 	#[ApiRoute(verb: 'POST', url: '/api/v1/share/{id}')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 120, period: 60)]
 	#[AnonRateLimit(limit: 1, period: 5)]
 	#[BruteForceProtection(action: 'getShare')]
 	public function getShare(string $id, ?string $secret = null, array $arguments = []): DataResponse {
@@ -667,7 +668,7 @@ final class ApiV1Controller extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[ApiRoute(verb: 'GET', url: '/api/v1/shares')]
-	#[UserRateLimit(limit: 1, period: 1)]
+	#[UserRateLimit(limit: 240, period: 60)]
 	public function getShares(?string $filterSourceTypeClass, ?string $filterSourceTypeValue, ?string $filterState, ?string $filterUserStatus, ?string $lastShareID, int $limit = 100): DataResponse {
 		/** @psalm-suppress DocblockTypeContradiction */
 		if ($limit < 1) {

--- a/apps/sharing/tests/CapabilitiesTest.php
+++ b/apps/sharing/tests/CapabilitiesTest.php
@@ -85,6 +85,15 @@ final class CapabilitiesTest extends TestCase {
 		$config->deleteSystemValue('sharing.unified_api_enable');
 	}
 
+	public function testGetCapabilitiesUnifiedSharingApiDisabledByDefault(): void {
+		$config = Server::get(IConfig::class);
+		$config->deleteSystemValue('sharing.unified_api_enable');
+
+		$this->registry->registerSourceType(new TestShareSourceType1([]));
+
+		$this->assertEquals([], $this->capabilities->getCapabilities());
+	}
+
 	public function testGetCapabilitiesDisableUnifiedSharingApi(): void {
 		$config = Server::get(IConfig::class);
 		$config->setSystemValue('sharing.unified_api_enable', false);

--- a/build/frontend/apps/files_sharing
+++ b/build/frontend/apps/files_sharing
@@ -1,0 +1,1 @@
+../../../apps/files_sharing

--- a/build/frontend/vite.config.ts
+++ b/build/frontend/vite.config.ts
@@ -46,6 +46,9 @@ const modules = {
 	files_reminders: {
 		init: resolve(import.meta.dirname, 'apps/files_reminders/src', 'files-init.ts'),
 	},
+	files_sharing: {
+		'sharing-dialog': resolve(import.meta.dirname, 'apps/files_sharing/src', 'sharing-dialog-bridge.ts'),
+	},
 	files_trashbin: {
 		init: resolve(import.meta.dirname, 'apps/files_trashbin/src', 'files-init.ts'),
 	},

--- a/build/frontend/vitest.config.ts
+++ b/build/frontend/vitest.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
 		exclude: [
 			...defaultExclude,
 			...gitIgnore,
+			// files_sharing is symlinked here only for its Vue 3 bridge entry point;
+			// the rest of the app is still Vue 2, so its tests belong to the legacy
+			// frontend project, which is where their dependencies resolve.
+			'apps/files_sharing/**',
 		],
 		globalSetup: resolve(import.meta.dirname, '__tests__/setup-global.js'),
 		server: {

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2195,6 +2195,14 @@ $CONFIG = [
 	'sharing.managerFactory' => '\OC\Share20\ProviderFactory',
 
 	/**
+	 * Enables the unified sharing API and the sharing dialog it powers. While it
+	 * is disabled, the files sidebar shows the previous share editor.
+	 *
+	 * Defaults to ``false``
+	 */
+	'sharing.unified_api_enable' => false,
+
+	/**
 	 * Enables expiration for link share passwords sent by email (sharebymail).
 	 * The passwords will expire after the configured interval; the users can
 	 * still request a new one on the public link page.

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2195,14 +2195,6 @@ $CONFIG = [
 	'sharing.managerFactory' => '\OC\Share20\ProviderFactory',
 
 	/**
-	 * Enables the unified sharing API and the sharing dialog it powers. While it
-	 * is disabled, the files sidebar shows the previous share editor.
-	 *
-	 * Defaults to ``false``
-	 */
-	'sharing.unified_api_enable' => false,
-
-	/**
 	 * Enables expiration for link share passwords sent by email (sharebymail).
 	 * The passwords will expire after the configured interval; the users can
 	 * still request a new one on the public link page.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -90,6 +90,10 @@ export default defineConfig([
 			'**/js/',
 			'**/l10n/', // all translations (config only ignored in root)
 			'**/vendor/', // different vendors
+			// files_sharing is symlinked into the Vue 3 frontend only for its bridge
+			// entry point; the app itself is still Vue 2 and is linted through the
+			// legacy frontend, whose config matches the code it actually is.
+			'build/frontend/apps/files_sharing/',
 		],
 	},
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nextcloud/password-confirmation": "^6.1.0",
         "@nextcloud/paths": "^3.1.0",
         "@nextcloud/router": "^3.1.0",
-        "@nextcloud/sharing": "^0.4.0",
+        "@nextcloud/sharing": "^1.0.0-beta.2",
         "@nextcloud/vue": "^9.10.0",
         "@vueuse/core": "^14.1.0",
         "@vueuse/integrations": "^14.1.0",
@@ -1848,6 +1848,22 @@
         "node": "^20 || ^22 || ^24"
       }
     },
+    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/sharing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
+      "integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/initial-state": "^3.0.0",
+        "is-svg": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      },
+      "optionalDependencies": {
+        "@nextcloud/files": "^3.12.2 || ^4.0.0"
+      }
+    },
     "node_modules/@nextcloud/dialogs/node_modules/@vueuse/core": {
       "version": "14.4.0",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
@@ -2081,19 +2097,43 @@
       }
     },
     "node_modules/@nextcloud/sharing": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
-      "integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-1.0.0-beta.2.tgz",
+      "integrity": "sha512-XMx32IkE0GoPxEY8lp/lnGIj5AGm2sj9vXUGD7TEw1r+qJfJkhKAwAFjQzEzVzMaa7V1J8KgrvcUVWe4w2e6cA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@mdi/svg": "^7.4.47",
+        "@nextcloud/axios": "^2.6.0",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/dialogs": "^7.5.0",
         "@nextcloud/initial-state": "^3.0.0",
-        "is-svg": "^6.1.0"
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/router": "^3.1.0",
+        "debounce": "^3.0.0",
+        "is-svg": "^6.1.0",
+        "qrcode.vue": "^3.10.0",
+        "uuid": "^14.0.2"
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       },
-      "optionalDependencies": {
-        "@nextcloud/files": "^3.12.2 || ^4.0.0"
+      "peerDependencies": {
+        "@nextcloud/vue": "^9.0.0",
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@nextcloud/sharing/node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@nextcloud/stylelint-config": {
@@ -2220,6 +2260,22 @@
       },
       "peerDependencies": {
         "vue": "^3"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
+      "integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/initial-state": "^3.0.0",
+        "is-svg": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      },
+      "optionalDependencies": {
+        "@nextcloud/files": "^3.12.2 || ^4.0.0"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@vueuse/core": {
@@ -11803,6 +11859,15 @@
       "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/qrcode.vue": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-3.10.0.tgz",
+      "integrity": "sha512-1bjeBds9hRKMszZuBuYQZor9HdJYWtb0S44HG1JofZ9uicpJpdF+TtDvqo3+2ZlH0k80WVIkmiKB4hq0/N6/rA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.16.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nextcloud/password-confirmation": "^6.1.0",
     "@nextcloud/paths": "^3.1.0",
     "@nextcloud/router": "^3.1.0",
-    "@nextcloud/sharing": "^0.4.0",
+    "@nextcloud/sharing": "^1.0.0-beta.2",
     "@nextcloud/vue": "^9.10.0",
     "@vueuse/core": "^14.1.0",
     "@vueuse/integrations": "^14.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,6 +44,22 @@ export default defineConfig({
 			fullyParallel: false,
 			workers: 1, // only one admin setting test can run at a time due to shared state
 			testMatch: '**/admin-settings*.spec.ts',
+			// The sharing ones belong to the serial `sharing` project below
+			testIgnore: '**/e2e/files_sharing/**',
+			use: {
+				...BROWSWER_CONFIG_CHROME,
+			},
+		},
+
+		{
+			// Sharing tests. Which sidebar the sharing tab renders is an
+			// instance-wide switch (`sharing.unified_api_enable`): the unified specs
+			// need it on, the share editor specs need it off, so none of them may
+			// run alongside another
+			name: 'sharing',
+			fullyParallel: false,
+			workers: 1,
+			testMatch: '**/e2e/files_sharing/**/*.spec.ts',
 			use: {
 				...BROWSWER_CONFIG_CHROME,
 			},
@@ -52,6 +68,7 @@ export default defineConfig({
 		{
 			name: 'default',
 			testMatch: /\/(?!admin-settings)[^/]*\.spec\.ts$/,
+			testIgnore: '**/e2e/files_sharing/**',
 			grepInvert: /@setup/,
 			use: {
 				...BROWSWER_CONFIG_CHROME,

--- a/tests/playwright/e2e/files_sharing/unified-killswitch.spec.ts
+++ b/tests/playwright/e2e/files_sharing/unified-killswitch.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '../../support/fixtures/sharing-page.ts'
+import { mkdir } from '../../support/utils/dav.ts'
+import { createShare, openSharingPanel } from '../../support/utils/sharing.ts'
+
+/**
+ * The unified sharing API is the killswitch for the new sidebar: with no API
+ * version advertised in the capabilities, the sidebar falls back to the legacy
+ * sections. That is the state the API ships in, which the share editor fixtures
+ * this spec builds on already set for their worker.
+ */
+test.describe('files_sharing: sidebar without the unified sharing API', () => {
+	test('falls back to the legacy share sections', async ({ page, user, recipient, filesListPage, sharingTab }) => {
+		await mkdir(page.request, user, '/legacy')
+		await createShare(page.request, '/legacy', recipient.userId)
+		await filesListPage.open()
+		await openSharingPanel(filesListPage, sharingTab, 'legacy')
+
+		const tab = page.locator('.sharingTab')
+		await expect(tab.getByText('Internal shares')).toBeVisible()
+		await expect(tab.locator('.unified-share-list')).toHaveCount(0)
+		// The legacy editor still lists the share it was given.
+		await expect(tab.getByText(recipient.userId).first()).toBeVisible()
+	})
+})

--- a/tests/playwright/e2e/files_sharing/unified-share-create.spec.ts
+++ b/tests/playwright/e2e/files_sharing/unified-share-create.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '../../support/fixtures/unified-sharing-page.ts'
+import { mkdir } from '../../support/utils/dav.ts'
+import {
+	expectUnifiedSharingRegistered,
+	getUnifiedShares,
+	RECIPIENT_TYPE_TOKEN,
+} from '../../support/utils/unifiedSharing.ts'
+
+test.describe('files_sharing: creating a share with the unified dialog', () => {
+	let fileId: string
+
+	test.beforeEach(async ({ page, user, filesListPage, unifiedShareList }) => {
+		await expectUnifiedSharingRegistered(page.request)
+		fileId = await mkdir(page.request, user, '/shared')
+		await unifiedShareList.open(filesListPage, 'shared')
+		await unifiedShareList.shareButton.click()
+	})
+
+	test('opens a draft for the current folder with both share types offered', async ({ sharingDialog }) => {
+		await expect(sharingDialog.title).toHaveText('Share "shared"')
+		await expect(sharingDialog.panel).toBeVisible()
+		// The share type is still open to change while the share is a draft.
+		await expect(sharingDialog.tabBar).toBeVisible()
+		await expect(sharingDialog.tab('Invited people')).toBeChecked()
+	})
+
+	test('adds a recipient carrying the share default permission', async ({ recipient, sharingDialog }) => {
+		await sharingDialog.addRecipient(recipient.userId)
+
+		await expect(sharingDialog.recipientRow(recipient.userId)).toBeVisible()
+		// A new share defaults to view-only, and the row says so.
+		await expect(sharingDialog.recipientPermission(recipient.userId)).toHaveText(/^Can view/)
+	})
+
+	test('adds several recipients to one share', async ({ recipient, secondRecipient, sharingDialog }) => {
+		await sharingDialog.addRecipient(recipient.userId)
+		await sharingDialog.addRecipient(secondRecipient.userId)
+
+		await expect(sharingDialog.recipientRows).toHaveCount(2)
+	})
+
+	test('sends the share and shows it in the sidebar', async ({ page, recipient, sharingDialog, unifiedShareList }) => {
+		await sharingDialog.addRecipient(recipient.userId)
+		await sharingDialog.send()
+		await sharingDialog.done()
+
+		// The sidebar picks up whatever the dialog created once it closes.
+		await expect(unifiedShareList.row(recipient.userId)).toBeVisible()
+		const shares = await getUnifiedShares(page.request, fileId)
+		expect(shares).toHaveLength(1)
+		expect(shares[0].state).toBe('active')
+	})
+
+	test('cannot be sent before it has a recipient', async ({ page, recipient, sharingDialog }) => {
+		await expect(sharingDialog.sendButton).toBeDisabled()
+		expect(await getUnifiedShares(page.request, fileId)).toHaveLength(0)
+
+		await sharingDialog.addRecipient(recipient.userId)
+		await expect(sharingDialog.sendButton).toBeEnabled()
+	})
+
+	test('keeps the invited people when the switch to a public link is declined', async ({ recipient, sharingDialog }) => {
+		await sharingDialog.addRecipient(recipient.userId)
+
+		await sharingDialog.selectTab('Anyone')
+		await sharingDialog.answerConfirmation('Share with anyone', 'Cancel')
+
+		// Neither the recipient nor the active tab may change.
+		await expect(sharingDialog.recipientRow(recipient.userId)).toBeVisible()
+		await expect(sharingDialog.tab('Invited people')).toBeChecked()
+	})
+
+	test('drops the invited people when the switch to a public link is confirmed', async ({ recipient, sharingDialog }) => {
+		await sharingDialog.addRecipient(recipient.userId)
+
+		await sharingDialog.selectTab('Anyone')
+		await sharingDialog.answerConfirmation('Share with anyone', 'Continue')
+
+		await expect(sharingDialog.tab('Anyone')).toBeChecked()
+		await expect(sharingDialog.recipientRows).toHaveCount(0)
+		await expect(sharingDialog.copyLinkButton).toBeVisible()
+	})
+
+	test('creates a public link share and hands out its link', async ({ page, sharingDialog }) => {
+		await sharingDialog.selectTab('Anyone')
+		// Switching to a link adds the token recipient that makes it public.
+		await expect(sharingDialog.copyLinkButton).toBeEnabled()
+
+		await sharingDialog.send()
+		await expect(sharingDialog.confirmationLink).toHaveValue(/\/s\/\w+/)
+		await sharingDialog.done()
+
+		const [share] = await getUnifiedShares(page.request, fileId)
+		expect(share.recipients.map((r) => r.class)).toContain(RECIPIENT_TYPE_TOKEN)
+	})
+
+	test('lists a newly shared recipient without collapsing the existing rows', async ({ page, recipient, secondRecipient, sharingDialog, unifiedShareList }) => {
+		// Two recipients so the sidebar renders an expandable group.
+		await sharingDialog.addRecipient(recipient.userId)
+		await sharingDialog.addRecipient(secondRecipient.userId)
+		await sharingDialog.send()
+		await sharingDialog.done()
+
+		const group = unifiedShareList.groups.first()
+		await expect(group).toBeVisible()
+		expect(await unifiedShareList.isExpanded('2 people')).toBe(true)
+
+		// Editing the same share again must refresh in place, not reset the rows.
+		await unifiedShareList.triggerAction('2 people', 'Edit share')
+		await expect(sharingDialog.recipientRows).toHaveCount(2)
+		await sharingDialog.close()
+		expect(await unifiedShareList.isExpanded('2 people')).toBe(true)
+		expect(await getUnifiedShares(page.request, fileId)).toHaveLength(1)
+	})
+})

--- a/tests/playwright/e2e/files_sharing/unified-share-edit.spec.ts
+++ b/tests/playwright/e2e/files_sharing/unified-share-edit.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '../../support/fixtures/unified-sharing-page.ts'
+import { mkdir } from '../../support/utils/dav.ts'
+import {
+	createUnifiedShare,
+	expectUnifiedSharingRegistered,
+	getUnifiedShares,
+	PERMISSION_UPDATE,
+	PRESET_EDIT,
+	PRESET_VIEW,
+	RECIPIENT_TYPE_TOKEN,
+	RECIPIENT_TYPE_USER,
+	setRecipientPermission,
+} from '../../support/utils/unifiedSharing.ts'
+
+/** A token recipient value has to be at least 32 characters. */
+const linkToken = () => crypto.randomUUID().replaceAll('-', '')
+
+test.describe('files_sharing: editing a share with the unified dialog', () => {
+	let fileId: string
+
+	test.beforeEach(async ({ page, user }) => {
+		await expectUnifiedSharingRegistered(page.request)
+		fileId = await mkdir(page.request, user, '/shared')
+	})
+
+	test('hides the share type of a share that has already been sent', async ({ page, recipient, filesListPage, unifiedShareList, sharingDialog }) => {
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_USER, recipient.userId]] })
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.triggerAction(recipient.userId, 'Edit share')
+
+		await expect(sharingDialog.panel).toBeVisible()
+		await expect(sharingDialog.tabBar).toHaveCount(0)
+	})
+
+	test('opens an existing link share on the link view and keeps its link', async ({ page, filesListPage, unifiedShareList, sharingDialog }) => {
+		const token = linkToken()
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_TOKEN, token]] })
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.rows.first().getByRole('button', { name: 'Actions' }).click()
+		await page.getByRole('menu').getByRole('menuitem', { name: 'Edit share' }).click()
+
+		await expect(sharingDialog.copyLinkButton).toBeVisible()
+		await sharingDialog.close()
+
+		// Opening the editor must not strip the token, which would destroy the link.
+		const [share] = await getUnifiedShares(page.request, fileId)
+		expect(share.recipients.map((r) => r.value)).toContain(token)
+	})
+
+	test('adds a recipient to an existing share and shows it in the sidebar', async ({ page, recipient, secondRecipient, filesListPage, unifiedShareList, sharingDialog }) => {
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_USER, recipient.userId]] })
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.triggerAction(recipient.userId, 'Edit share')
+		await sharingDialog.addRecipient(secondRecipient.userId)
+		await sharingDialog.close()
+
+		// The single row became a group of two once the dialog closed.
+		await expect(unifiedShareList.groups.first()).toBeVisible()
+		await expect(unifiedShareList.row(secondRecipient.userId)).toBeVisible()
+		const [share] = await getUnifiedShares(page.request, fileId)
+		expect(share.recipients).toHaveLength(2)
+	})
+
+	test('deletes the share from the settings view', async ({ page, recipient, filesListPage, unifiedShareList, sharingDialog }) => {
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_USER, recipient.userId]] })
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.triggerAction(recipient.userId, 'Edit share')
+		await sharingDialog.settingsButton.click()
+		await expect(sharingDialog.deleteButton).toBeVisible()
+
+		await sharingDialog.deleteButton.click()
+		await sharingDialog.answerConfirmation('Delete share', 'Delete share')
+		await sharingDialog.dialog.waitFor({ state: 'detached' })
+
+		await expect(unifiedShareList.rows).toHaveCount(0)
+		expect(await getUnifiedShares(page.request, fileId)).toHaveLength(0)
+	})
+
+	test('changes the permission of one recipient only', async ({ page, recipient, secondRecipient, filesListPage, unifiedShareList, sharingDialog }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId], [RECIPIENT_TYPE_USER, secondRecipient.userId]],
+			preset: PRESET_EDIT,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.triggerAction('2 people', 'Edit share')
+		// Both start on the share default, which the row marks as such.
+		await expect(sharingDialog.recipientPermission(recipient.userId)).toHaveText('Can edit (default)')
+		await sharingDialog.setRecipientPreset(recipient.userId, /^Can view/)
+
+		// Only the edited recipient moves off the default.
+		await expect(sharingDialog.recipientPermission(recipient.userId)).toHaveText('Can view')
+		await expect(sharingDialog.recipientPermission(secondRecipient.userId)).toHaveText('Can edit (default)')
+
+		await sharingDialog.close()
+		await expect(unifiedShareList.subtitle(recipient.userId)).toHaveText('Can view')
+		await expect(unifiedShareList.subtitle(secondRecipient.userId)).toHaveText('Can edit')
+	})
+
+	test('marks the share default in the per-recipient menu', async ({ page, recipient, filesListPage, unifiedShareList, sharingDialog }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId]],
+			preset: PRESET_VIEW,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.triggerAction(recipient.userId, 'Edit share')
+		const menu = await sharingDialog.openRecipientMenu(recipient.userId)
+
+		await expect(menu.getByRole('menuitem', { name: 'Can view (default)' })).toBeVisible()
+		await expect(menu.getByRole('menuitem', { name: 'Custom permissions' })).toBeVisible()
+		await expect(menu.getByRole('menuitem', { name: 'Remove participant' })).toBeVisible()
+	})
+
+	test('caps the recipient toggles at the permissions the share grants', async ({ page, recipient, filesListPage, unifiedShareList, sharingDialog }) => {
+		// A view-only share cannot grant editing to any of its recipients.
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId]],
+			preset: PRESET_VIEW,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.triggerAction(recipient.userId, 'Edit share')
+		const menu = await sharingDialog.openRecipientMenu(recipient.userId)
+		await menu.getByRole('menuitem', { name: 'Custom permissions' }).click()
+
+		const modal = sharingDialog.recipientPermissionsModal
+		await expect(modal).toBeVisible()
+		// The toggles are revealed straight away, and what the share withholds
+		// cannot be granted here.
+		await expect(modal.getByRole('switch', { name: 'Edit files' })).toBeDisabled()
+		await expect(modal.getByRole('switch', { name: 'View files' })).toBeChecked()
+		await expect(modal.getByText(/You can only grant the same or fewer permissions/)).toBeVisible()
+	})
+
+	test('shows a recipient permission that was set outside the dialog', async ({ page, recipient, filesListPage, unifiedShareList }) => {
+		const share = await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId]],
+			preset: PRESET_EDIT,
+		})
+		// Recipient permissions are overrides on the share's, so revoking one here
+		// must show up as a narrower permission on the row.
+		await setRecipientPermission(page.request, share.id, [RECIPIENT_TYPE_USER, recipient.userId], PERMISSION_UPDATE, false)
+
+		await unifiedShareList.open(filesListPage, 'shared')
+		await expect(unifiedShareList.subtitle(recipient.userId)).not.toHaveText('Can edit')
+	})
+})

--- a/tests/playwright/e2e/files_sharing/unified-share-journeys.spec.ts
+++ b/tests/playwright/e2e/files_sharing/unified-share-journeys.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '../../support/fixtures/unified-sharing-page.ts'
+import { mkdir } from '../../support/utils/dav.ts'
+import {
+	createUnifiedShare,
+	expectUnifiedSharingRegistered,
+	getUnifiedShares,
+	PRESET_EDIT,
+	PRESET_VIEW,
+	RECIPIENT_TYPE_GROUP,
+	RECIPIENT_TYPE_TOKEN,
+	RECIPIENT_TYPE_USER,
+	setSharePreset,
+} from '../../support/utils/unifiedSharing.ts'
+
+/**
+ * Whole journeys through the sharing UI, as a user would run them, rather than
+ * one interaction per test.
+ */
+test.describe('files_sharing: unified sharing journeys', () => {
+	let fileId: string
+
+	test.beforeEach(async ({ page, user }) => {
+		await expectUnifiedSharingRegistered(page.request)
+		fileId = await mkdir(page.request, user, '/shared')
+	})
+
+	test('shares with a group, then grants one person more than the group', async ({ page, recipientGroup, secondRecipient, unifiedShareList, sharingDialog, filesListPage }) => {
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		// Share the folder with a group, view only.
+		await unifiedShareList.shareButton.click()
+		await sharingDialog.addRecipient(recipientGroup)
+		await sharingDialog.send()
+		await sharingDialog.done()
+		await expect(unifiedShareList.subtitle(recipientGroup)).toHaveText('Can view')
+
+		// Someone needs to edit, so raise the share, which is the cap for everyone.
+		// Through the API: the share-level select rebuilds its options on every
+		// share sync, which makes picking from it unreliable (see the note in the
+		// PR), and this journey is about the per-recipient permissions.
+		const [draft] = await getUnifiedShares(page.request, fileId)
+		await setSharePreset(page.request, draft.id, PRESET_EDIT)
+
+		// Whoever is added now inherits the new default.
+		await unifiedShareList.triggerAction(recipientGroup, 'Edit share')
+		await sharingDialog.addRecipient(secondRecipient.userId)
+		await expect(sharingDialog.recipientPermission(secondRecipient.userId)).toHaveText('Can edit (default)')
+
+		// The group should stay on view only, so put it back.
+		await sharingDialog.setRecipientPreset(recipientGroup, /^Can view/)
+		await expect(sharingDialog.recipientPermission(recipientGroup)).toHaveText('Can view')
+		await sharingDialog.close()
+
+		// One share, two recipients, two different permissions.
+		await expect(unifiedShareList.subtitle(recipientGroup)).toHaveText('Can view')
+		await expect(unifiedShareList.subtitle(secondRecipient.userId)).toHaveText('Can edit')
+
+		const [share] = await getUnifiedShares(page.request, fileId)
+		expect(share.recipients).toHaveLength(2)
+	})
+
+	test('reaches both a named person and everyone with the link', async ({ page, recipient, unifiedShareList, sharingDialog, filesListPage }) => {
+		// An invited share first…
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId]],
+			preset: PRESET_EDIT,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		// …then a public link next to it, from the same sidebar.
+		await unifiedShareList.shareButton.click()
+		await sharingDialog.selectTab('Anyone')
+		await sharingDialog.send()
+		await expect(sharingDialog.confirmationLink).toHaveValue(/\/s\/\w+/)
+		await sharingDialog.done()
+
+		await expect(unifiedShareList.rows).toHaveCount(2)
+
+		// Dropping the link leaves the invited share untouched.
+		const shares = await getUnifiedShares(page.request, fileId)
+		const linkName = shares
+			.flatMap((s) => s.recipients)
+			.find((r) => r.class === RECIPIENT_TYPE_TOKEN)!.display_name
+		await unifiedShareList.triggerAction(linkName, 'Delete share')
+		await unifiedShareList.answerConfirmation(true)
+
+		await expect(unifiedShareList.row(recipient.userId)).toBeVisible()
+		// Only read the backend once the deletion has landed in the list.
+		await expect(unifiedShareList.rows).toHaveCount(1)
+		const remaining = await getUnifiedShares(page.request, fileId)
+		expect(remaining).toHaveLength(1)
+		expect(remaining[0].recipients.map((r) => r.class)).not.toContain(RECIPIENT_TYPE_TOKEN)
+	})
+
+	test('leaves nothing behind when the dialog is abandoned', async ({ page, recipient, unifiedShareList, sharingDialog, filesListPage }) => {
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.shareButton.click()
+		await sharingDialog.addRecipient(recipient.userId)
+		// Closing without sending leaves the share a draft.
+		await sharingDialog.close()
+
+		await expect(unifiedShareList.rows).toHaveCount(0)
+		expect(await getUnifiedShares(page.request, fileId)).toHaveLength(0)
+	})
+
+	test('narrows one recipient by hand and keeps it after reopening', async ({ page, recipient, secondRecipient, unifiedShareList, sharingDialog, filesListPage }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId], [RECIPIENT_TYPE_USER, secondRecipient.userId]],
+			preset: PRESET_EDIT,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		// Both start on the share default; take one of them down to view only.
+		await unifiedShareList.triggerAction('2 people', 'Edit share')
+		await expect(sharingDialog.recipientPermission(recipient.userId)).toHaveText('Can edit (default)')
+		await sharingDialog.setRecipientPreset(recipient.userId, /^Can view/)
+		await expect(sharingDialog.recipientPermission(recipient.userId)).toHaveText('Can view')
+		await sharingDialog.close()
+
+		// It survives closing the dialog, in the list and on reopening.
+		await expect(unifiedShareList.subtitle(recipient.userId)).toHaveText('Can view')
+		await expect(unifiedShareList.subtitle(secondRecipient.userId)).toHaveText('Can edit')
+
+		await unifiedShareList.triggerAction('2 people', 'Edit share')
+		await expect(sharingDialog.recipientPermission(recipient.userId)).toHaveText('Can view')
+		await expect(sharingDialog.recipientPermission(secondRecipient.userId)).toHaveText('Can edit (default)')
+
+		// The narrowing is an override on the recipient, the share is untouched.
+		const [share] = await getUnifiedShares(page.request, fileId)
+		expect(share.permission_preset).toBe(PRESET_EDIT)
+	})
+
+	test('adds a group to a share that already has a person', async ({ page, recipientGroup, secondRecipient, unifiedShareList, sharingDialog, filesListPage }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, secondRecipient.userId]],
+			preset: PRESET_VIEW,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+		// A single recipient renders as a plain row.
+		await expect(unifiedShareList.groups).toHaveCount(0)
+
+		await unifiedShareList.triggerAction(secondRecipient.userId, 'Edit share')
+		await sharingDialog.addRecipient(recipientGroup)
+		await sharingDialog.close()
+
+		// It becomes a group of two, and the new group members can see it.
+		await expect(unifiedShareList.groups.first()).toBeVisible()
+		await expect(unifiedShareList.row(recipientGroup)).toBeVisible()
+		const [share] = await getUnifiedShares(page.request, fileId)
+		expect(share.recipients.map((r) => r.class)).toContain(RECIPIENT_TYPE_GROUP)
+	})
+})

--- a/tests/playwright/e2e/files_sharing/unified-sidebar.spec.ts
+++ b/tests/playwright/e2e/files_sharing/unified-sidebar.spec.ts
@@ -1,0 +1,189 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '../../support/fixtures/unified-sharing-page.ts'
+import { mkdir } from '../../support/utils/dav.ts'
+import {
+	createUnifiedShare,
+	expectUnifiedSharingRegistered,
+	getUnifiedShares,
+	PRESET_EDIT,
+	PRESET_VIEW,
+	RECIPIENT_TYPE_GROUP,
+	RECIPIENT_TYPE_USER,
+} from '../../support/utils/unifiedSharing.ts'
+
+test.describe('files_sharing: unified share list in the sidebar', () => {
+	let fileId: string
+
+	test.beforeEach(async ({ page, user }) => {
+		await expectUnifiedSharingRegistered(page.request)
+		fileId = await mkdir(page.request, user, '/shared')
+	})
+
+	test('lists nothing but the share button for an unshared folder', async ({ filesListPage, unifiedShareList }) => {
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await expect(unifiedShareList.shareButton).toBeVisible()
+		await expect(unifiedShareList.rows).toHaveCount(0)
+		// The legacy internal/external sections are replaced, not merely hidden.
+		await expect(unifiedShareList.root.getByText('Internal shares')).toHaveCount(0)
+		await expect(unifiedShareList.root.getByText('External shares')).toHaveCount(0)
+	})
+
+	test('shows a placeholder while loading, then the share', async ({ page, recipient, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_USER, recipient.userId]] })
+
+		// Hold the list request so the placeholder is observable.
+		let release: () => void = () => {}
+		const held = new Promise<void>((resolve) => {
+			release = resolve
+		})
+		await page.route(/\/apps\/sharing\/api\/v1\/shares/, async (route) => {
+			await held
+			await route.continue()
+		})
+
+		await unifiedShareList.open(filesListPage, 'shared')
+		await expect(unifiedShareList.skeleton).toBeVisible()
+		release()
+		await expect(unifiedShareList.skeleton).toBeHidden()
+		await expect(unifiedShareList.row(recipient.userId)).toBeVisible()
+	})
+
+	test('renders a single-recipient share as one row with its permission', async ({ page, recipient, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId]],
+			preset: PRESET_VIEW,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await expect(unifiedShareList.rows).toHaveCount(1)
+		await expect(unifiedShareList.row(recipient.userId)).toBeVisible()
+		await expect(unifiedShareList.subtitle(recipient.userId)).toHaveText('Can view')
+		// A single recipient is a plain row, not a group.
+		await expect(unifiedShareList.groups).toHaveCount(0)
+	})
+
+	test('renders a multi-recipient share as a group, expanded by default', async ({ page, recipient, recipientGroup, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId], [RECIPIENT_TYPE_GROUP, recipientGroup]],
+			preset: PRESET_VIEW,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		const summary = unifiedShareList.groups.first()
+		await expect(summary).toBeVisible()
+		await expect(summary.locator('.sharing-entry__title')).toHaveText('1 person, 1 group')
+		// Expanded on open: both recipients are listed, each with its permission.
+		await expect(unifiedShareList.recipientRows).toHaveCount(2)
+		await expect(unifiedShareList.subtitle(recipient.userId)).toHaveText('Can view')
+		// The stack only stands in for the recipients while they are hidden.
+		await expect(unifiedShareList.avatarStack).toHaveCount(0)
+	})
+
+	test('collapses and expands a share group', async ({ page, recipient, recipientGroup, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId], [RECIPIENT_TYPE_GROUP, recipientGroup]],
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		const title = '1 person, 1 group'
+		expect(await unifiedShareList.isExpanded(title)).toBe(true)
+
+		await unifiedShareList.toggleRecipients(title)
+		expect(await unifiedShareList.isExpanded(title)).toBe(false)
+		await expect(unifiedShareList.recipientRows.first()).toBeHidden()
+		await expect(unifiedShareList.avatarStack).toBeVisible()
+
+		await unifiedShareList.toggleRecipients(title)
+		expect(await unifiedShareList.isExpanded(title)).toBe(true)
+		await expect(unifiedShareList.recipientRows.first()).toBeVisible()
+	})
+
+	test('orders the shares by their permissions, most permissive first', async ({ page, recipient, secondRecipient, filesListPage, unifiedShareList }) => {
+		const viewer = secondRecipient.userId
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, viewer]],
+			preset: PRESET_VIEW,
+		})
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId]],
+			preset: PRESET_EDIT,
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await expect(unifiedShareList.rows).toHaveCount(2)
+		await expect(unifiedShareList.rows.first().locator('.sharing-entry__title')).toHaveText(recipient.userId)
+		await expect(unifiedShareList.subtitle(recipient.userId)).toHaveText('Can edit')
+		await expect(unifiedShareList.subtitle(viewer)).toHaveText('Can view')
+	})
+
+	test('deletes a share once the confirmation is accepted', async ({ page, recipient, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_USER, recipient.userId]] })
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		const deleted = page.waitForResponse((response) => response.request().method() === 'DELETE'
+			&& response.url().includes('/apps/sharing/api/v1/share/'))
+		await unifiedShareList.triggerAction(recipient.userId, 'Delete share')
+		await unifiedShareList.answerConfirmation(true)
+		await deleted
+
+		await expect(unifiedShareList.rows).toHaveCount(0)
+		expect(await getUnifiedShares(page.request, fileId)).toHaveLength(0)
+	})
+
+	test('keeps the share when the delete confirmation is declined', async ({ page, recipient, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_USER, recipient.userId]] })
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await unifiedShareList.triggerAction(recipient.userId, 'Delete share')
+		await unifiedShareList.answerConfirmation(false)
+
+		await expect(unifiedShareList.row(recipient.userId)).toBeVisible()
+		expect(await getUnifiedShares(page.request, fileId)).toHaveLength(1)
+	})
+
+	test('removes a single participant from a share group', async ({ page, recipient, recipientGroup, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, {
+			fileId,
+			recipients: [[RECIPIENT_TYPE_USER, recipient.userId], [RECIPIENT_TYPE_GROUP, recipientGroup]],
+		})
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		const removed = page.waitForResponse((response) => response.request().method() === 'DELETE'
+			&& response.url().includes('/recipient'))
+		await unifiedShareList.triggerAction(recipient.userId, 'Remove participant')
+		await removed
+
+		// One recipient left, so the group collapses into a plain row.
+		await expect(unifiedShareList.rows).toHaveCount(1)
+		await expect(unifiedShareList.row(recipient.userId)).toHaveCount(0)
+		const [share] = await getUnifiedShares(page.request, fileId)
+		expect(share.recipients).toHaveLength(1)
+	})
+
+	test('offers destructive actions only inside the action menu', async ({ page, recipient, filesListPage, unifiedShareList }) => {
+		await createUnifiedShare(page.request, { fileId, recipients: [[RECIPIENT_TYPE_USER, recipient.userId]] })
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		// No bare delete control on the row itself.
+		await expect(unifiedShareList.row(recipient.userId).getByRole('button', { name: /Delete|Remove|Unshare/ })).toHaveCount(0)
+		const menu = await unifiedShareList.openMenu(recipient.userId)
+		await expect(menu.getByRole('menuitem', { name: 'Delete share' })).toBeVisible()
+	})
+
+	test('surfaces an error when the list cannot be loaded', async ({ page, filesListPage, unifiedShareList }) => {
+		await page.route(/\/apps\/sharing\/api\/v1\/shares/, (route) => route.fulfill({ status: 500 }))
+		await unifiedShareList.open(filesListPage, 'shared')
+
+		await expect(unifiedShareList.error).toBeVisible()
+	})
+})

--- a/tests/playwright/support/fixtures/sharing-page.ts
+++ b/tests/playwright/support/fixtures/sharing-page.ts
@@ -9,7 +9,21 @@ import type { APIRequestContext } from '@playwright/test'
 import { runOcc } from '@nextcloud/e2e-test-server/docker'
 import { createRandomUser } from '@nextcloud/e2e-test-server/playwright'
 import { SharingTab } from '../sections/SharingTab.ts'
+import { disableUnifiedSharing, enableUnifiedSharing } from '../utils/unifiedSharing.ts'
 import { test as filesTest } from './files-page.ts'
+
+type SharingWorkerFixtures = {
+	/**
+	 * Which sharing UI the sidebar renders. The unified sharing API ships disabled,
+	 * which is what these specs need to drive the share editor; the unified specs
+	 * override this to `'on'`.
+	 *
+	 * The switch is instance-wide, hence the serial `sharing` project.
+	 */
+	unifiedSharingMode: 'on' | 'off'
+	/** Applies {@link unifiedSharingMode} for the worker. */
+	unifiedSharingApi: void
+}
 
 type SharingFixtures = {
 	/**
@@ -36,7 +50,17 @@ type SharingFixtures = {
  * browser is the recipient of a share seeded by `owner`) — pick whichever side
  * the spec drives through the UI.
  */
-export const test = filesTest.extend<SharingFixtures>({
+export const test = filesTest.extend<SharingFixtures, SharingWorkerFixtures>({
+	unifiedSharingMode: ['off', { scope: 'worker' }],
+
+	unifiedSharingApi: [async ({ unifiedSharingMode }, use) => {
+		const restore = unifiedSharingMode === 'on'
+			? await enableUnifiedSharing()
+			: await disableUnifiedSharing()
+		await use()
+		await restore()
+	}, { scope: 'worker', auto: true }],
+
 	recipient: async ({}, use) => {
 		const recipient = await createRandomUser()
 		await use(recipient)

--- a/tests/playwright/support/fixtures/unified-sharing-page.ts
+++ b/tests/playwright/support/fixtures/unified-sharing-page.ts
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { User } from '@nextcloud/e2e-test-server'
+
+import { runOcc } from '@nextcloud/e2e-test-server/docker'
+import { createRandomUser } from '@nextcloud/e2e-test-server/playwright'
+import { SharingDialogPage } from '../sections/SharingDialogPage.ts'
+import { UnifiedShareListPage } from '../sections/UnifiedShareListPage.ts'
+import { test as sharingTest } from './sharing-page.ts'
+
+type UnifiedSharingFixtures = {
+	/** The unified share list in the files sidebar. */
+	unifiedShareList: UnifiedShareListPage
+	/** The unified sharing dialog. */
+	sharingDialog: SharingDialogPage
+	/** A second account to share with, for specs needing two recipients. */
+	secondRecipient: User
+	/** A group containing `recipient`, to share with a group recipient. */
+	recipientGroup: string
+}
+
+/**
+ * Fixtures for the unified sharing sidebar and dialog. On top of the share
+ * editor fixtures (`user` is the sharer, `recipient` a second account) it keeps
+ * the unified sharing API on and lifts its rate limits.
+ *
+ * The switch is instance-wide and hides the legacy sidebar sections, so these
+ * specs must not run beside specs driving the legacy share editor — hence the
+ * serial `sharing` project in `playwright.config.ts`.
+ */
+export const test = sharingTest.extend<UnifiedSharingFixtures>({
+	// The share editor fixtures turn the unified API off; these specs need it on.
+	unifiedSharingMode: ['on', { scope: 'worker' }],
+
+	secondRecipient: async ({}, use) => {
+		const user = await createRandomUser()
+		await use(user)
+		await runOcc(['user:delete', user.userId], { failOnError: false })
+	},
+
+	recipientGroup: async ({ recipient }, use) => {
+		const group = `unified-sharing-${crypto.randomUUID().slice(0, 8)}`
+		await runOcc(['group:add', group])
+		await runOcc(['group:adduser', group, recipient.userId])
+		await use(group)
+		await runOcc(['group:delete', group], { failOnError: false })
+	},
+
+	unifiedShareList: async ({ page }, use) => {
+		await use(new UnifiedShareListPage(page))
+	},
+
+	sharingDialog: async ({ page }, use) => {
+		await use(new SharingDialogPage(page))
+	},
+})
+
+export { expect } from '../matchers.ts'

--- a/tests/playwright/support/sections/SharingDialogPage.ts
+++ b/tests/playwright/support/sections/SharingDialogPage.ts
@@ -1,0 +1,227 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Locator, Page } from '@playwright/test'
+
+import { expect } from '@playwright/test'
+
+/**
+ * The unified sharing dialog (`@nextcloud/sharing/dialog`), opened from the
+ * files sidebar through the `OCA.Sharing` bridge.
+ */
+export class SharingDialogPage {
+	readonly #page: Page
+
+	constructor(page: Page) {
+		this.#page = page
+	}
+
+	/** The dialog itself. */
+	get dialog(): Locator {
+		return this.#page.locator('.sharing-dialog')
+	}
+
+	get title(): Locator {
+		return this.dialog.locator('.sharing-dialog__title')
+	}
+
+	/** The share form; absent while the draft is still being created. */
+	get panel(): Locator {
+		return this.dialog.locator('.share-panel')
+	}
+
+	// --- Share type ---
+
+	/** The invited/anyone tab bar. Only present while the share is a draft. */
+	get tabBar(): Locator {
+		return this.dialog.locator('.share-panel__tab-bar')
+	}
+
+	/**
+	 * Switch the share type.
+	 *
+	 * @param tab The tab to activate
+	 */
+	async selectTab(tab: 'Invited people' | 'Anyone'): Promise<void> {
+		// The radio itself is visually hidden, its label is what a user clicks.
+		await this.tabBar.getByText(tab, { exact: true }).click()
+	}
+
+	/**
+	 * The share type radio, to assert on with `toBeChecked()` — switching runs
+	 * through a confirmation and recipient removals, so it needs a retrying
+	 * assertion rather than a one-shot read.
+	 *
+	 * @param tab The tab to locate
+	 */
+	tab(tab: 'Invited people' | 'Anyone'): Locator {
+		return this.tabBar.getByRole('radio', { name: tab })
+	}
+
+	// --- Recipients ---
+
+	get recipientSearch(): Locator {
+		return this.dialog.getByRole('combobox', { name: 'Add people' })
+	}
+
+	get recipientList(): Locator {
+		return this.dialog.locator('.recipient-list')
+	}
+
+	get recipientRows(): Locator {
+		return this.dialog.locator('.recipient-row')
+	}
+
+	/**
+	 * A recipient row by display name.
+	 *
+	 * @param name The recipient's display name
+	 */
+	recipientRow(name: string): Locator {
+		return this.recipientRows.filter({ has: this.#page.locator('.recipient-row__name', { hasText: name }) })
+	}
+
+	/**
+	 * The permission label shown under a recipient's name.
+	 *
+	 * @param name The recipient's display name
+	 */
+	recipientPermission(name: string): Locator {
+		return this.recipientRow(name).locator('.recipient-row__subtitle')
+	}
+
+	/**
+	 * Search for a recipient and pick it from the results, which adds it to the
+	 * share right away.
+	 *
+	 * @param query What to type
+	 * @param name The result to pick; defaults to the query
+	 */
+	async addRecipient(query: string, name: string = query): Promise<void> {
+		// The search is debounced, the picker fires one of its own when it opens,
+		// and a late answer can replace the list with results for another query.
+		// Retype until the wanted result is actually on screen.
+		await expect(async () => {
+			const searched = this.#page.waitForResponse((response) => response.url().includes('/api/v1/recipients')
+				&& response.url().includes(query))
+			await this.recipientSearch.fill('')
+			await this.recipientSearch.fill(query)
+			await searched
+			await expect(this.option(name)).toBeVisible({ timeout: 5_000 })
+		}).toPass({ timeout: 30_000 })
+
+		// The recipient is added by the request the selection triggers.
+		const added = this.#page.waitForResponse((response) => response.url().includes('/recipient')
+			&& response.request().method() === 'POST')
+		await this.option(name).click()
+		await added
+	}
+
+	/**
+	 * A result of the recipient search.
+	 *
+	 * @param name The display name to match
+	 */
+	option(name: string): Locator {
+		return this.#page.getByRole('option', { name: new RegExp(name) })
+	}
+
+	/**
+	 * Open a recipient's action menu and return the menu.
+	 *
+	 * @param name The recipient's display name
+	 */
+	async openRecipientMenu(name: string): Promise<Locator> {
+		await this.recipientRow(name).getByRole('button', { name: 'Recipient actions' }).click()
+		return this.#page.getByRole('menu')
+	}
+
+	/**
+	 * Pick a preset for one recipient from its action menu.
+	 *
+	 * @param name The recipient's display name
+	 * @param preset The preset label as shown in the menu
+	 */
+	async setRecipientPreset(name: string, preset: string | RegExp): Promise<void> {
+		const menu = await this.openRecipientMenu(name)
+		const changed = this.#page.waitForResponse((response) => response.url().includes('/recipient/permission'))
+		await menu.getByRole('menuitem', { name: preset }).click()
+		await changed
+	}
+
+	/** The per-recipient custom permissions modal. */
+	get recipientPermissionsModal(): Locator {
+		return this.#page.getByRole('dialog', { name: /^Permissions for / })
+	}
+
+	// --- Share level permissions ---
+
+	/**
+	 * A share-level permission toggle, shown once "Custom permissions" is picked.
+	 *
+	 * @param name The permission's label
+	 */
+	permissionToggle(name: string): Locator {
+		return this.dialog.getByRole('checkbox', { name })
+	}
+
+	// --- Actions ---
+
+	get sendButton(): Locator {
+		return this.dialog.locator('.share-panel__link-send')
+	}
+
+	get copyLinkButton(): Locator {
+		return this.dialog.locator('.share-panel__link-copy')
+	}
+
+	get settingsButton(): Locator {
+		return this.dialog.getByRole('button', { name: 'Additional sharing settings' })
+	}
+
+	get deleteButton(): Locator {
+		return this.dialog.locator('.share-panel__delete')
+	}
+
+	/** Submit the share and wait for the confirmation view. */
+	async send(): Promise<void> {
+		// Switching to a public link creates its token recipient first, and the
+		// button stays disabled until that lands.
+		await expect(this.sendButton).toBeEnabled({ timeout: 10_000 })
+		await this.sendButton.click()
+		await this.confirmation.waitFor()
+	}
+
+	get confirmation(): Locator {
+		return this.dialog.locator('.share-confirmation')
+	}
+
+	get confirmationLink(): Locator {
+		return this.dialog.locator('.share-confirmation__link-input').getByRole('textbox')
+	}
+
+	/** Close the dialog from the confirmation view. */
+	async done(): Promise<void> {
+		await this.dialog.locator('.share-confirmation__done').click()
+		await this.dialog.waitFor({ state: 'detached' })
+	}
+
+	/** Close the dialog with its own close button. */
+	async close(): Promise<void> {
+		await this.#page.getByRole('button', { name: 'Close', exact: true }).click()
+		await this.dialog.waitFor({ state: 'detached' })
+	}
+
+	/**
+	 * Answer a confirmation dialog raised inside the sharing dialog, e.g. when
+	 * switching to a public link or deleting the share.
+	 *
+	 * @param name The confirmation dialog's name
+	 * @param button The button to press
+	 */
+	async answerConfirmation(name: string, button: string): Promise<void> {
+		await this.#page.getByRole('dialog', { name }).getByRole('button', { name: button, exact: true }).click()
+	}
+}

--- a/tests/playwright/support/sections/UnifiedShareListPage.ts
+++ b/tests/playwright/support/sections/UnifiedShareListPage.ts
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Locator, Page } from '@playwright/test'
+import type { FilesListPage } from './FilesListPage.ts'
+
+import { expect } from '@playwright/test'
+
+/**
+ * The unified share list in the files sidebar: one flat list of shares, where a
+ * share with several recipients renders as a collapsible group.
+ */
+export class UnifiedShareListPage {
+	readonly #page: Page
+
+	constructor(page: Page) {
+		this.#page = page
+	}
+
+	/**
+	 * Open a file's sidebar on the Sharing tab and wait for the unified list.
+	 *
+	 * The legacy `openSharingPanel` helper cannot be used here: it waits for the
+	 * recipient input of the old editor, which the unified sidebar replaces with
+	 * the share button.
+	 *
+	 * @param filesListPage The files list page object
+	 * @param fileName The row whose shares to open
+	 */
+	async open(filesListPage: FilesListPage, fileName: string): Promise<void> {
+		await filesListPage.open()
+		await filesListPage.triggerActionForFile(fileName, 'details')
+		const tab = this.#page.locator('#app-sidebar-vue').getByRole('tab', { name: 'Sharing' })
+		if (await tab.getAttribute('aria-selected') !== 'true') {
+			await tab.click()
+		}
+		await expect(this.#page.getByRole('tabpanel', { name: 'Sharing' })).toBeVisible()
+		// Readiness is the share button: it is rendered with the list itself.
+		await expect(this.shareButton).toBeVisible()
+	}
+
+	/** The sharing tab's own root, to scope away from other sidebar tabs. */
+	get root(): Locator {
+		return this.#page.locator('.sharingTab')
+	}
+
+	/** The flat list of shares. */
+	get list(): Locator {
+		return this.root.locator('.unified-share-list')
+	}
+
+	/** The loading placeholder shown while the list is fetched. */
+	get skeleton(): Locator {
+		return this.root.locator('.share-skeleton')
+	}
+
+	/** The button that opens the dialog to create a new share. */
+	get shareButton(): Locator {
+		return this.root.getByRole('button', { name: 'Share', exact: true })
+	}
+
+	/** Every row, share groups and their recipients alike, in visual order. */
+	get rows(): Locator {
+		return this.list.locator('.sharing-entry')
+	}
+
+	/** The rows nested under an expanded share group. */
+	get recipientRows(): Locator {
+		return this.list.locator('.sharing-entry.unified-share__recipient')
+	}
+
+	/** The error shown when the list cannot be loaded. */
+	get error(): Locator {
+		return this.root.getByText('Unable to load the shares list')
+	}
+
+	/**
+	 * A row by the title it renders: a recipient's display name for a
+	 * single-recipient share, or the summary for a group.
+	 *
+	 * @param title The row title
+	 */
+	row(title: string): Locator {
+		return this.rows.filter({ has: this.#page.locator('.sharing-entry__title', { hasText: title }) })
+	}
+
+	/** The share groups, i.e. the rows that own a recipients toggle. */
+	get groups(): Locator {
+		return this.rows.filter({ has: this.#page.getByRole('button', { name: 'Toggle recipients' }) })
+	}
+
+	/**
+	 * The permission label shown under a row's title.
+	 *
+	 * @param title The row title
+	 */
+	subtitle(title: string): Locator {
+		// The entry renders its subtitle as a bare paragraph.
+		return this.row(title).locator('.sharing-entry__desc p')
+	}
+
+	/**
+	 * Open a row's action menu and return the menu, so actions can be clicked.
+	 *
+	 * @param title The row title
+	 */
+	async openMenu(title: string): Promise<Locator> {
+		await this.row(title).getByRole('button', { name: 'Actions' }).click()
+		return this.#page.getByRole('menu')
+	}
+
+	/**
+	 * Trigger a row action by its label.
+	 *
+	 * @param title The row title
+	 * @param action The action label, e.g. 'Edit share'
+	 */
+	async triggerAction(title: string, action: string): Promise<void> {
+		const menu = await this.openMenu(title)
+		await menu.getByRole('menuitem', { name: action }).click()
+	}
+
+	/**
+	 * Collapse or expand a share group.
+	 *
+	 * @param title The group's summary title
+	 */
+	async toggleRecipients(title: string): Promise<void> {
+		await this.row(title).getByRole('button', { name: 'Toggle recipients' }).click()
+	}
+
+	/**
+	 * Whether a share group is expanded.
+	 *
+	 * @param title The group's summary title
+	 */
+	async isExpanded(title: string): Promise<boolean> {
+		const toggle = this.row(title).getByRole('button', { name: 'Toggle recipients' })
+		return await toggle.getAttribute('aria-expanded') === 'true'
+	}
+
+	/** The avatar stack a collapsed group shows in place of its avatar. */
+	get avatarStack(): Locator {
+		return this.list.locator('.avatar-stack')
+	}
+
+	/**
+	 * Answer the confirmation dialog raised by a destructive action.
+	 *
+	 * @param confirm Whether to go through with it
+	 */
+	async answerConfirmation(confirm: boolean): Promise<void> {
+		const dialog = this.#page.getByRole('dialog', { name: 'Delete share' })
+		await dialog.getByRole('button', { name: confirm ? 'Delete' : 'Cancel', exact: true }).click()
+	}
+}

--- a/tests/playwright/support/utils/unifiedSharing.ts
+++ b/tests/playwright/support/utils/unifiedSharing.ts
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { APIRequestContext } from '@playwright/test'
+
+import { runOcc } from '@nextcloud/e2e-test-server/docker'
+
+/**
+ * Backend class strings of the unified sharing API. They are hardcoded here the
+ * same way the frontend hardcodes them, and are asserted against the
+ * capabilities by {@link expectUnifiedSharingRegistered} so a rename on the
+ * backend fails loudly instead of silently seeding nothing.
+ */
+export const SOURCE_TYPE_NODE = 'OCA\\Files\\Sharing\\Source\\NodeShareSourceType'
+
+export const RECIPIENT_TYPE_USER = 'OC\\Core\\Sharing\\Recipient\\UserShareRecipientType'
+export const RECIPIENT_TYPE_GROUP = 'OC\\Core\\Sharing\\Recipient\\GroupShareRecipientType'
+export const RECIPIENT_TYPE_TOKEN = 'OC\\Core\\Sharing\\Recipient\\TokenShareRecipientType'
+
+export const PRESET_VIEW = 'OC\\Core\\Sharing\\Permission\\ViewSharePermissionPreset'
+export const PRESET_EDIT = 'OC\\Core\\Sharing\\Permission\\EditSharePermissionPreset'
+
+export const PERMISSION_UPDATE = 'OCA\\Files\\Sharing\\Permission\\NodeUpdateSharePermissionType'
+
+const API_BASE = '/ocs/v2.php/apps/sharing/api/v1'
+
+/** A share as returned by the unified sharing API. */
+export interface UnifiedShare {
+	id: string
+	state: 'active' | 'draft' | 'deleted'
+	recipients: { class: string, value: string, display_name: string }[]
+	permissions: { class: string, enabled: boolean }[]
+	permission_preset: string | null
+}
+
+/**
+ * Call the unified sharing API and unwrap the OCS envelope. OCS answers HTTP 200
+ * for failures too, so the real status comes from `ocs.meta`.
+ *
+ * @param request A request context authenticated as the acting user
+ * @param method The HTTP verb
+ * @param path The path below the API base, e.g. `/share`
+ * @param form Form parameters to send
+ */
+async function ocs<T>(
+	request: APIRequestContext,
+	method: 'get' | 'post' | 'put' | 'delete',
+	path: string,
+	form: Record<string, string | boolean> = {},
+): Promise<T> {
+	const response = await request[method](`${API_BASE}${path}?format=json`, {
+		headers: { 'OCS-APIRequest': 'true' },
+		...(method === 'get' ? {} : { form }),
+	})
+	const { ocs: envelope } = await response.json()
+	const status = envelope?.meta?.statuscode
+	// Creating a share answers 201, everything else 200.
+	if (status !== 200 && status !== 201) {
+		throw new Error(`${method.toUpperCase()} ${path} failed: ${status} ${envelope?.meta?.message}`)
+	}
+	return envelope.data as T
+}
+
+/**
+ * Turn the unified sharing API on for the whole instance and return a restore
+ * function. It ships disabled, so every unified spec needs this.
+ *
+ * The rate limiter is deliberately left on: these specs drive the dialog the
+ * way a person does, so they are also the check that the API's limits are
+ * livable.
+ *
+ * The switch is instance-wide, so specs using this must not run next to specs
+ * that expect the legacy sidebar. See the serial `sharing` Playwright project.
+ */
+export async function enableUnifiedSharing(): Promise<() => Promise<void>> {
+	await runOcc(['config:system:set', 'sharing.unified_api_enable', '--value', 'true', '--type', 'boolean'])
+	return async () => {
+		await runOcc(['config:system:delete', 'sharing.unified_api_enable'], { failOnError: false })
+	}
+}
+
+/**
+ * Turn the unified sharing API off for the whole instance, so the sidebar falls
+ * back to the previous share editor, and return a restore function.
+ */
+export async function disableUnifiedSharing(): Promise<() => Promise<void>> {
+	await runOcc(['config:system:set', 'sharing.unified_api_enable', '--value', 'false', '--type', 'boolean'])
+	return async () => {
+		await runOcc(['config:system:delete', 'sharing.unified_api_enable'], { failOnError: false })
+	}
+}
+
+/**
+ * Assert the class strings this file hardcodes are actually registered on the
+ * server, so a backend rename surfaces as a clear failure.
+ *
+ * @param request A request context authenticated as any user
+ */
+export async function expectUnifiedSharingRegistered(request: APIRequestContext): Promise<void> {
+	const response = await request.get('/ocs/v2.php/cloud/capabilities?format=json', {
+		headers: { 'OCS-APIRequest': 'true' },
+	})
+	const { sharing } = (await response.json()).ocs.data.capabilities
+	const missing: string[] = []
+	if (!sharing?.api_versions?.length) {
+		missing.push('sharing.api_versions (is sharing.unified_api_enable set?)')
+	}
+	if (!sharing?.source_types?.some((type: { class: string }) => type.class === SOURCE_TYPE_NODE)) {
+		missing.push(SOURCE_TYPE_NODE)
+	}
+	// Recipient types are not advertised, but the presets are, and the specs
+	// assert their labels.
+	for (const preset of [PRESET_VIEW, PRESET_EDIT]) {
+		if (!sharing?.permission_presets?.some((type: { class: string }) => type.class === preset)) {
+			missing.push(preset)
+		}
+	}
+	if (missing.length > 0) {
+		throw new Error(`Unified sharing is not usable, missing: ${missing.join(', ')}`)
+	}
+}
+
+/** Options for {@link createUnifiedShare}. */
+export interface CreateUnifiedShareOptions {
+	/** The file id of the node to share (returned by `mkdir`/`uploadContent`). */
+	fileId: string
+	/** Recipients to add, as `[class, value]` pairs. */
+	recipients?: [string, string][]
+	/** The permission preset to apply, e.g. {@link PRESET_EDIT}. */
+	preset?: string
+	/** Whether to activate the share; a draft is not listed in the sidebar. */
+	activate?: boolean
+}
+
+/**
+ * Seed a share through the unified sharing API: create the draft, attach the
+ * node, add the recipients, apply a preset and activate it.
+ *
+ * Legacy shares (the `files_sharing` OCS API) are invisible to this API until a
+ * legacy backend is registered, so unified specs have to seed through here.
+ *
+ * @param request A request context authenticated as the share owner
+ * @param options The node, recipients, preset and state to seed
+ */
+export async function createUnifiedShare(
+	request: APIRequestContext,
+	options: CreateUnifiedShareOptions,
+): Promise<UnifiedShare> {
+	const { fileId, recipients = [], preset, activate = true } = options
+
+	let share = await ocs<UnifiedShare>(request, 'post', '/share')
+	await ocs(request, 'post', `/share/${share.id}/source`, { class: SOURCE_TYPE_NODE, value: fileId })
+	for (const [recipientClass, value] of recipients) {
+		await ocs(request, 'post', `/share/${share.id}/recipient`, { class: recipientClass, value })
+	}
+	if (preset !== undefined) {
+		await ocs(request, 'put', `/share/${share.id}/permission/preset`, { permissionPresetClass: preset })
+	}
+	if (activate) {
+		share = await ocs<UnifiedShare>(request, 'put', `/share/${share.id}/state`, { state: 'active' })
+	}
+	return share
+}
+
+/**
+ * List the unified shares of a node, as the sidebar does.
+ *
+ * @param request A request context authenticated as the share owner
+ * @param fileId The file id of the shared node
+ */
+export async function getUnifiedShares(request: APIRequestContext, fileId: string): Promise<UnifiedShare[]> {
+	const response = await request.get(
+		`${API_BASE}/shares?format=json&filterSourceTypeClass=${encodeURIComponent(SOURCE_TYPE_NODE)}`
+		+ `&filterSourceTypeValue=${fileId}&filterState=active`,
+		{ headers: { 'OCS-APIRequest': 'true' } },
+	)
+	return (await response.json()).ocs.data as UnifiedShare[]
+}
+
+/**
+ * Set the share's permission preset, which is the default and the cap for its
+ * recipients.
+ *
+ * @param request A request context authenticated as the share owner
+ * @param shareId The share id
+ * @param preset The preset class to apply
+ */
+export async function setSharePreset(request: APIRequestContext, shareId: string, preset: string): Promise<void> {
+	await ocs(request, 'put', `/share/${shareId}/permission/preset`, { permissionPresetClass: preset })
+}
+
+/**
+ * Set a single permission of one recipient, the way the per-recipient menu does.
+ *
+ * @param request A request context authenticated as the share owner
+ * @param shareId The share id
+ * @param recipient The recipient as a `[class, value]` pair
+ * @param permissionClass The permission to change
+ * @param enabled The new state
+ */
+export async function setRecipientPermission(
+	request: APIRequestContext,
+	shareId: string,
+	recipient: [string, string],
+	permissionClass: string,
+	enabled: boolean,
+): Promise<void> {
+	await ocs(request, 'put', `/share/${shareId}/recipient/permission`, {
+		recipientClass: recipient[0],
+		recipientValue: recipient[1],
+		permissionClass,
+		enabled,
+	})
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
 			if (error.message.includes('`fallbackFocus` was specified but was not a node, or did not return a node')) {
 				return false
 			}
+			// A worker that still has console output in flight when it shuts down
+			// fails the run even though every test passed. The specs that log
+			// heavily (the focus trap above prints per interaction) hit this
+			// depending on how the files are spread over the workers.
+			if (error.name === 'EnvironmentTeardownError' && error.message.includes('Closing rpc while')) {
+				return false
+			}
 		},
 	},
 	server: {


### PR DESCRIPTION
Replaces the share editor in the files sidebar with the unified sharing UI: a single flat list of shares, and the Vue 3 sharing dialog from `@nextcloud/sharing` for creating and editing them.

## What changed

- **Sidebar**: one flat list ordered by permission, instead of the Internal/External sections. A share with several recipients renders as an expandable group with stacked avatars; every row shows its permission, and each recipient shows its own. Destructive actions live in the overflow menu.
- **Dialog**: reached through an `OCA.Sharing` bridge — the Vue 3 entry point registers it, the (still Vue 2) sidebar calls it. Once `files_sharing` is Vue 3 the bridge can go and the library be imported directly.
- **Off by default**: the whole thing stays behind `sharing.unified_api_enable`, which is off and now documented in the config sample. Turning it on is left to a follow-up.
- Bumps `@nextcloud/sharing` to `1.0.0-beta.2`.
- Raises the unified sharing API's rate limits, which were set low enough that the dialog tripped them on its own.

## Known gap

Legacy shares (`oc_share`) do not appear in the new list until a `ISharingLegacyBackend` is registered, which is backend work outside this PR. That is one of the reasons the feature stays off by default here; the frontend needs no change when the backend lands.

## Testing

- `npx vitest run apps/files_sharing` — 104 unit tests, including the sidebar refresh and the delete/remove guards.
- `NOCOVERAGE=0 ./autotest.sh sqlite apps/sharing/tests/CapabilitiesTest.php` — pins the API to off by default.
- `npx playwright test --project=sharing` — 34 new end-to-end tests: opening the sidebar, listing and grouping, the row actions, creating and editing shares (including declined confirmations and editing a link share), plus whole journeys such as sharing with a group and then granting one person more than the group. Which sidebar the tab renders is instance-wide state, so all sharing specs now run in one serial project; the share editor specs turn the API off for their worker.

These caught a regression in this branch: the share detail listeners had been camel-cased, which Vue 2 does not match against the hyphenated events the entries emit, so the previous share editor stopped opening.

## Notes for the reviewer

- Recipients cannot list the shares addressed to them through the unified API yet, so the tests assert what the share owner sees.
- The share-level permission select rebuilds its options whenever the share re-syncs, which detaches its open dropdown. A click that lands while that happens hits whatever is underneath — in one test run it silently toggled "Note to recipients". Worth a look, separately from this PR.
- The API's write endpoints allowed one call per one to five seconds, which the dialog exceeds by itself, so they are now sized per minute from the flows that use them. The per-recipient permission endpoint had no limit at all and got one. The end-to-end tests run against the real limiter rather than switching it off.

<!-- TODO(human): before/after screenshots of the sidebar and the dialog, and the linked issue -->

## AI disclosure

This pull request was written with AI assistance (Claude Code); every commit carries an `Assisted-by` trailer. The code was reviewed by me before submission.
