### PR TITLE
fix(taskprocessing): AppAPI webhook error handling

### DIFF
--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -1923,9 +1923,11 @@ class Manager implements IManager {
 	private function runWebhook(Task $task): void {
 		$uri = $task->getWebhookUri();
 		$method = $task->getWebhookMethod();
+
 		if (!$uri || !$method) {
 			return;
 		}
+
 		if (in_array($method, ['HTTP:GET', 'HTTP:POST', 'HTTP:PUT', 'HTTP:DELETE'], true)) {
 			$client = $this->clientService->newClient();
 			$httpMethod = preg_replace('/^HTTP:/', '', $method);
@@ -1936,56 +1938,120 @@ class Manager implements IManager {
 				]),
 				'headers' => ['Content-Type' => 'application/json'],
 			];
+
 			try {
 				$client->request($httpMethod, $uri, $options);
 			} catch (ClientException|ServerException $e) {
-				$this->logger->warning('Task processing HTTP webhook failed for task ' . $task->getId() . '. Request failed', ['exception' => $e]);
+				$this->logger->warning(
+					'Task processing HTTP webhook failed for task ' . $task->getId() . '. Request failed',
+					['exception' => $e],
+				);
 			} catch (\Exception|\Throwable $e) {
-				$this->logger->warning('Task processing HTTP webhook failed for task ' . $task->getId() . '. Unknown error', ['exception' => $e]);
+				$this->logger->warning(
+					'Task processing HTTP webhook failed for task ' . $task->getId() . '. Unknown error',
+					['exception' => $e],
+				);
 			}
-		} elseif (str_starts_with($method, 'AppAPI:') && str_starts_with($uri, '/')) {
-			$parsedMethod = explode(':', $method, 4);
-			if (
-				count($parsedMethod) !== 3
-				|| $parsedMethod[1] === ''
-				|| !in_array($parsedMethod[2], ['GET', 'POST', 'PUT', 'DELETE'], true)
-			) {
-				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Invalid method: ' . $method);
-				return;
+
+			return;
+		}
+
+		if (!str_starts_with($method, 'AppAPI:') || !str_starts_with($uri, '/')) {
+			return;
+		}
+
+		$parsedMethod = explode(':', $method, 4);
+		if (
+			count($parsedMethod) !== 3
+			|| $parsedMethod[1] === ''
+			|| !in_array($parsedMethod[2], ['GET', 'POST', 'PUT', 'DELETE'], true)
+		) {
+			$this->logger->warning(
+				'Task processing AppAPI webhook failed for task '
+					. $task->getId()
+					. '. Invalid method: '
+					. $method,
+			);
+			return;
+		}
+
+		[, $exAppId, $httpMethod] = $parsedMethod;
+
+		if (!$this->appManager->isEnabledForAnyone('app_api')) {
+			$this->logger->warning(
+				'Task processing AppAPI webhook failed for task '
+					. $task->getId()
+					. '. AppAPI is disabled or not installed.',
+			);
+			return;
+		}
+
+		try {
+			$appApiFunctions = Server::get(PublicFunctions::class);
+		} catch (ContainerExceptionInterface|NotFoundExceptionInterface) {
+			$this->logger->warning(
+				'Task processing AppAPI webhook failed for task '
+					. $task->getId()
+					. '. Could not get AppAPI public functions.',
+			);
+			return;
+		}
+
+		$exApp = $appApiFunctions->getExApp($exAppId);
+		if ($exApp === null) {
+			$this->logger->warning(
+				'Task processing AppAPI webhook failed for task '
+					. $task->getId()
+					. '. ExApp '
+					. $exAppId
+					. ' is missing.',
+			);
+			return;
+		}
+
+		if (!$exApp['enabled']) {
+			$this->logger->warning(
+				'Task processing AppAPI webhook failed for task '
+					. $task->getId()
+					. '. ExApp '
+					. $exAppId
+					. ' is disabled.',
+			);
+			return;
+		}
+
+		$requestParams = [
+			'task' => $task->jsonSerialize(),
+		];
+		$requestOptions = [
+			'timeout' => 30,
+		];
+
+		try {
+			$response = $appApiFunctions->exAppRequest(
+				$exAppId,
+				$uri,
+				$task->getUserId(),
+				$httpMethod,
+				$requestParams,
+				$requestOptions,
+			);
+
+			if (is_array($response) && isset($response['error'])) {
+				$this->logger->warning(
+					'Task processing AppAPI webhook failed for task '
+						. $task->getId()
+						. '. Error during request to ExApp('
+						. $exAppId
+						. ').',
+					['error' => $response['error']],
+				);
 			}
-			[, $exAppId, $httpMethod] = $parsedMethod;
-			if (!$this->appManager->isEnabledForAnyone('app_api')) {
-				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. AppAPI is disabled or not installed.');
-				return;
-			}
-			try {
-				$appApiFunctions = Server::get(PublicFunctions::class);
-			} catch (ContainerExceptionInterface|NotFoundExceptionInterface) {
-				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Could not get AppAPI public functions.');
-				return;
-			}
-			$exApp = $appApiFunctions->getExApp($exAppId);
-			if ($exApp === null) {
-				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. ExApp ' . $exAppId . ' is missing.');
-				return;
-			} elseif (!$exApp['enabled']) {
-				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. ExApp ' . $exAppId . ' is disabled.');
-				return;
-			}
-			$requestParams = [
-				'task' => $task->jsonSerialize(),
-			];
-			$requestOptions = [
-				'timeout' => 30,
-			];
-			try {
-				$response = $appApiFunctions->exAppRequest($exAppId, $uri, $task->getUserId(), $httpMethod, $requestParams, $requestOptions);
-				if (is_array($response) && isset($response['error'])) {
-					$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Error during request to ExApp(' . $exAppId . ').', ['error' => $response['error']]);
-				}
-			} catch (\Throwable $e) {
-				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Request failed.', ['exception' => $e]);
- 			}
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'Task processing AppAPI webhook failed for task ' . $task->getId() . '. Request failed.',
+				['exception' => $e],
+			);
 		}
 	}
 }

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -1923,11 +1923,9 @@ class Manager implements IManager {
 	private function runWebhook(Task $task): void {
 		$uri = $task->getWebhookUri();
 		$method = $task->getWebhookMethod();
-
 		if (!$uri || !$method) {
 			return;
 		}
-
 		if (in_array($method, ['HTTP:GET', 'HTTP:POST', 'HTTP:PUT', 'HTTP:DELETE'], true)) {
 			$client = $this->clientService->newClient();
 			$httpMethod = preg_replace('/^HTTP:/', '', $method);
@@ -1947,8 +1945,13 @@ class Manager implements IManager {
 			}
 		} elseif (str_starts_with($method, 'AppAPI:') && str_starts_with($uri, '/')) {
 			$parsedMethod = explode(':', $method, 4);
-			if (count($parsedMethod) < 3) {
+			if (
+				count($parsedMethod) !== 3
+				|| $parsedMethod[1] === ''
+				|| !in_array($parsedMethod[2], ['GET', 'POST', 'PUT', 'DELETE'], true)
+			) {
 				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Invalid method: ' . $method);
+				return;
 			}
 			[, $exAppId, $httpMethod] = $parsedMethod;
 			if (!$this->appManager->isEnabledForAnyone('app_api')) {

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -1978,10 +1978,14 @@ class Manager implements IManager {
 			$requestOptions = [
 				'timeout' => 30,
 			];
-			$response = $appApiFunctions->exAppRequest($exAppId, $uri, $task->getUserId(), $httpMethod, $requestParams, $requestOptions);
-			if (is_array($response) && isset($response['error'])) {
-				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Error during request to ExApp(' . $exAppId . '): ', $response['error']);
-			}
+			try {
+				$response = $appApiFunctions->exAppRequest($exAppId, $uri, $task->getUserId(), $httpMethod, $requestParams, $requestOptions);
+				if (is_array($response) && isset($response['error'])) {
+					$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Error during request to ExApp(' . $exAppId . ').', ['error' => $response['error']]);
+				}
+			} catch (\Throwable $e) {
+				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Request failed.', ['exception' => $e]);
+ 			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Harden TaskProcessing AppAPI webhook handling.

* (Commit 1) Validate `AppAPI:<exAppId>:<method>` webhook methods before parsing and return safely when malformed.
  - Previously, malformed `AppAPI:` methods were logged but execution continued.
* (Commit 2) Harden error handling for ExApp webhook requests.
  - Pass ExApp request errors as PSR-3 logger context instead of as a scalar value.
  - Previously, logging an array response error could itself throw a `TypeError`, masking the webhook failure.
  - Catch exceptions thrown by `exAppRequest()` so failed AppAPI webhook calls do not interrupt task completion.
* (Commit 3) Reformat `runWebhook()` for readability.
  - Add whitespace and line wrapping, standardize logger formatting, and use early returns to reduce nesting without changing behavior.

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
