### PR TITLE
test(version-check): Fix flaky test

### DIFF
--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -66,6 +66,7 @@ class VersionCheckTest extends \Test\TestCase {
 	}
 
 	public function testCheckInCache(): void {
+		$time = time();
 		$expectedResult = [
 			'version' => '8.0.4.2',
 			'versionstring' => 'ownCloud 8.0.4',
@@ -83,7 +84,7 @@ class VersionCheckTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('getValueInt')
 			->with('core', 'lastupdatedat')
-			->willReturn(time());
+			->willReturn($time);
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')
@@ -284,7 +285,7 @@ class VersionCheckTest extends \Test\TestCase {
 			->with('core', 'lastupdatedat')
 			->willReturnOnConsecutiveCalls(
 				0,
-				time(),
+				$lastUpdateDate,
 			);
 		$this->config
 			->expects($this->exactly(2))
@@ -299,7 +300,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->appConfig
 			->expects($this->once())
 			->method('setValueInt')
-			->with('core', 'lastupdatedat', time());
+			->with('core', 'lastupdatedat', $lastUpdateDate);
 		$this->config
 			->expects($this->once())
 			->method('setAppValue')


### PR DESCRIPTION
Fix flaky tests like https://github.com/nextcloud/server/actions/runs/30356507708/job/90266119531?pr=62441
```
Parameter 2 for invocation OCP\IAppConfig::setValueInt('core', 'lastupdatedat', 1785239917, false, false): bool does not match expected value.
Failed asserting that 1785239917 matches expected 1785239918.
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
