### PR TITLE
test: reduce flakyness of files version tests

### DIFF
--- a/tests/playwright/e2e/files_versions/version-cross-share-move-and-copy.spec.ts
+++ b/tests/playwright/e2e/files_versions/version-cross-share-move-and-copy.spec.ts
@@ -121,6 +121,10 @@ async function copyToRoot(filesListPage: FilesListPage, copyMoveDialog: CopyMove
 }
 
 test.describe('files_versions: versions across a share move/copy', () => {
+	// Every test here seeds a share, boots the files app twice,
+	// and walks the sidebar, the versions list and the move/copy picker.
+	test.slow()
+
 	test('moves the versions when the file is moved out of a received share', async ({ page, user, owner, ownerRequest, filesListPage, versionsTab, filesSidebar, copyMoveDialog }) => {
 		await seedSharedVersionedFile(owner, ownerRequest, user, page.request, FILE_NAME)
 		await nameInitialVersion(filesListPage, versionsTab, SHARED_FOLDER, FILE_NAME)
@@ -150,8 +154,7 @@ test.describe('files_versions: versions across a share move/copy', () => {
 		await nameInitialVersion(filesListPage, versionsTab, `${SHARED_FOLDER}/${subFolder}/${subSubFolder}`, FILE_NAME)
 		await filesSidebar.close()
 
-		await filesListPage.open()
-		await filesListPage.navigateToFolder(SHARED_FOLDER)
+		await filesListPage.navigateToBreadcrumb(SHARED_FOLDER)
 		await moveToRoot(filesListPage, copyMoveDialog, subFolder)
 
 		await assertVersionsContent(filesListPage, versionsTab, relPath, { expectLabel: true })
@@ -165,8 +168,7 @@ test.describe('files_versions: versions across a share move/copy', () => {
 		await nameInitialVersion(filesListPage, versionsTab, `${SHARED_FOLDER}/${subFolder}/${subSubFolder}`, FILE_NAME)
 		await filesSidebar.close()
 
-		await filesListPage.open()
-		await filesListPage.navigateToFolder(SHARED_FOLDER)
+		await filesListPage.navigateToBreadcrumb(SHARED_FOLDER)
 		await copyToRoot(filesListPage, copyMoveDialog, subFolder)
 
 		await assertVersionsContent(filesListPage, versionsTab, relPath, { expectLabel: false })

--- a/tests/playwright/support/sections/FilesListPage.ts
+++ b/tests/playwright/support/sections/FilesListPage.ts
@@ -74,6 +74,16 @@ export class FilesListPage {
 		return this.page.getByRole('navigation', { name: 'Current directory path' })
 	}
 
+	/**
+	 * Navigate to an ancestor of the current folder through the breadcrumb
+	 *
+	 * @param name - The label of the crumb to navigate to
+	 */
+	async navigateToBreadcrumb(name: string): Promise<void> {
+		await this.getBreadcrumbs().getByRole('button', { name, exact: true }).click()
+		await this.waitForListLoaded()
+	}
+
 	getRowForFile(filename: string): Locator {
 		return this.page.locator(`[data-cy-files-list-row-name="${escapeAttributeValue(filename)}"]`)
 	}


### PR DESCRIPTION
## Summary
Those tests are pretty slow, even locally they took 11s for one test. Timeout is 30s, so on crowded CI this often failed.

Fixed with:
1. Reduce number of page loads by simply navigating back to parent folder using breadcrumbs (reduces run time by 4s per test locally)
2. Mark as slow as setup still takes some time.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
