### PR TITLE
fix(dav): scope CalDAV UID lookups to calendar objects

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2676,7 +2676,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$query->andWhere($query->expr()->eq('c.uri', $query->createNamedParameter($calendarUri)));
 		}
 
-		$query->->setMaxResults(1);
+		$query->setMaxResults(1);
 
 		$stmt = $query->executeQuery();
 		$row = $stmt->fetchAssociative();

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2670,12 +2670,13 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->andWhere($query->expr()->eq('co.uid', $query->createNamedParameter($uid)))
 			->andWhere($query->expr()->eq('co.calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_CALENDAR)))
 			->andWhere($query->expr()->isNull('co.deleted_at'))
-			->andWhere($query->expr()->isNull('c.deleted_at'))
-			->setMaxResults(1);
+			->andWhere($query->expr()->isNull('c.deleted_at'));
 
 		if ($calendarUri !== null) {
 			$query->andWhere($query->expr()->eq('c.uri', $query->createNamedParameter($calendarUri)));
 		}
+
+		$query->->setMaxResults(1);
 
 		$stmt = $query->executeQuery();
 		$row = $stmt->fetchAssociative();

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2636,33 +2636,42 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	/**
-	 * Searches through all of a users calendars and calendar objects to find
-	 * an object with a specific UID.
+	 * Find the path of the calendar object with a given UID in calendars owned by
+	 * a particular principal (user).
 	 *
-	 * This method should return the path to this object, relative to the
-	 * calendar home, so this path usually only contains two parts:
+	 * When $calendarUri is provided, the lookup is restricted to that calendar.
+	 * When it is null, all of the principal's calendars are searched. In that
+	 * case, callers must use both path components returned by this method: the
+	 * matching object may belong to a different calendar than one the caller
+	 * currently has selected.
 	 *
-	 * calendarpath/objectpath.ics
+	 * Subscription and federated cached objects, deleted objects, and objects in
+	 * deleted calendars are not considered.
 	 *
-	 * If the uid is not found, return null.
-	 *
-	 * This method should only consider * objects that the principal owns, so
-	 * any calendars owned by other principals that also appear in this
-	 * collection should be ignored.
+	 * The returned value is a path relative to the calendar home:
+	 * "<calendar-uri>/<object-uri>". It is null when no matching object exists.
+	 * UID uniqueness is guaranteed only within a calendar collection. Therefore,
+	 * an unrestricted lookup can be ambiguous if multiple owned calendars contain
+	 * the same UID.
 	 *
 	 * @param string $principalUri
 	 * @param string $uid
+	 * @param string|null $calendarUri Calendar URI to restrict the lookup to.
 	 * @return string|null
 	 */
 	#[\Override]
 	public function getCalendarObjectByUID($principalUri, $uid, $calendarUri = null) {
 		$query = $this->db->getQueryBuilder();
-		$query->selectAlias('c.uri', 'calendaruri')->selectAlias('co.uri', 'objecturi')
+		$query->selectAlias('c.uri', 'calendaruri')
+			->selectAlias('co.uri', 'objecturi')
 			->from('calendarobjects', 'co')
-			->leftJoin('co', 'calendars', 'c', $query->expr()->eq('co.calendarid', 'c.id'))
+			->join('co', 'calendars', 'c', $query->expr()->eq('co.calendarid', 'c.id'))
 			->where($query->expr()->eq('c.principaluri', $query->createNamedParameter($principalUri)))
 			->andWhere($query->expr()->eq('co.uid', $query->createNamedParameter($uid)))
-			->andWhere($query->expr()->isNull('co.deleted_at'));
+			->andWhere($query->expr()->eq('co.calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_CALENDAR)))
+			->andWhere($query->expr()->isNull('co.deleted_at'))
+			->andWhere($query->expr()->isNull('c.deleted_at'))
+			->setMaxResults(1);
 
 		if ($calendarUri !== null) {
 			$query->andWhere($query->expr()->eq('c.uri', $query->createNamedParameter($calendarUri)));
@@ -2671,6 +2680,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt = $query->executeQuery();
 		$row = $stmt->fetchAssociative();
 		$stmt->closeCursor();
+
 		if ($row) {
 			return $row['calendaruri'] . '/' . $row['objecturi'];
 		}

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2636,14 +2636,17 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	/**
-	 * Find the path of the calendar object with a given UID in calendars owned by
-	 * a particular principal (user).
+	 * Finds the path to the calendar object matching a given UID, restricted to
+	 * calendars owned by the specified principal. Calendars owned by other
+	 * principals, even if visible in the principal's calendar home (e.g. via
+	 * sharing), are ignored.
 	 *
-	 * When $calendarUri is provided, the lookup is restricted to that calendar.
-	 * When it is null, all of the principal's calendars are searched. In that
-	 * case, callers must use both path components returned by this method: the
-	 * matching object may belong to a different calendar than one the caller
-	 * currently has selected.
+	 * When $calendarUri is provided, the lookup is further restricted to that
+	 * calendar. It must be owned by $principalUri, otherwise no match is returned.
+	 * When $calendarUri is null, all calendars owned by the principal are searched.
+	 * In that case, callers must use both path components returned by this method:
+	 * the matching object may belong to a different calendar than the one the
+	 * caller currently has selected.
 	 *
 	 * Subscription and federated cached objects, deleted objects, and objects in
 	 * deleted calendars are not considered.
@@ -2652,11 +2655,12 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * "<calendar-uri>/<object-uri>". It is null when no matching object exists.
 	 * UID uniqueness is guaranteed only within a calendar collection. Therefore,
 	 * an unrestricted lookup can be ambiguous if multiple owned calendars contain
-	 * the same UID.
+	 * the same UID; in that case, one database-dependent matching result is
+	 * returned and no calendar is preferred.
 	 *
 	 * @param string $principalUri
 	 * @param string $uid
-	 * @param string|null $calendarUri Calendar URI to restrict the lookup to.
+	 * @param string|null $calendarUri Calendar URI to restrict the lookup to; must be owned by $principalUri.
 	 * @return string|null
 	 */
 	#[\Override]


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue --> (hard to say without digging thru many Issues; possibly many, perhaps only a few/none)

## Summary

This is equally a correctness, performance, bug elimination, and robustness PR. But it's still tiny[^docs] and I think straightforward.

It tightens `CalDavBackend::getCalendarObjectByUID()`, mostly so that it only resolves objects from regular calendars, rather than subscription or federated-calendar objects. The method’s documentation is also updated, particularly surrounding the the ambiguity of unrestricted lookups when the same UID exists in multiple owned calendars. It's possible the `JOIN` change will be performance bump, but that depends on the sophistication of the in-use database query optimizers.

Specifics:

* Switch from `LEFT JOIN` to `INNER JOIN` because the `WHERE` is right-focused and the query filters on `c.principaluri` (so rows without a matching `calendars` (`c`) record are excluded anyway), so it makes no sense to `LEFT JOIN` unless I'm somehow mistaken? (Also looks like this is already done presumably safely elsewhere, such as in the function immediately after, `getCalendarObjectById()`).
* Only resolve calendar objects that are - well - actually calendar objects.
* Exclude objects in deleted calendars not just already deleted objects.
* Add a one-row limit because this method only returns a singular result and, technically, there is no uniqueness rule that guarantees UID uniqueness across all calendars - only within a collection. This still doesn't make it entirely deterministic: whichever matching row the database happens to yield first is returned but it's more correct (well, or throwing an exception if we get >1 result)... [^dob] 
* Document the relevance of the presence - or lack thereof - of the `$calendarUri` parameter as an optional collection-scope filter and it's impact on caller responsibility.
* Formatting (minor).

Notes:

- UID uniqueness is collection-scoped. Therefore, callers using an unrestricted lookup must treat the calendar portion of the returned path as authoritative; a matching object may belong to a different owned calendar than the one currently being processed.

Possible follow-up:

- I think `getCalendarObjectById()` might have at least one of the above Issues too; worth a follow-up look.
- `BirthdayService` and any other consumers of `getCalendarObjectByUID()` that use  mode 2.
- Audit other `CalDavBackend` functions for similar issues.

[^docs]: Well, excluding the docs I suppose!
[^dob]: `setMaxResults(1)` only avoids retrieving unnecessary rows; it does not choose the correct calendar. The UID lookup itself has two valid modes: 1. Collection-scoped (caller supplies `$calendarUri`; deterministic); 2. Cross-calendar (this function supplies the `CalendarUri`, but the caller has to pay attention to it or else they'll perform the follow-up operation on the wrong calendar). Looks like consumers such as `ImportService` already use mode 1, but `BirthdayService` uses mode 2 so it may need to look to make sure it's not problematic (existing behavior; not created by this PR).

## TODO

- [ ] Check/improve/add test coverage
- [x] Double-check function docblock accuracy and clarity

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
