### PR TITLE
fix(systemTags): setObjectIdsForTag() dispatches once

### DIFF
--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -358,16 +358,6 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		if (!empty($addedObjectIds)) {
 			$this->dispatcher->dispatchTyped(new TagAssignedEvent($objectType, array_map(fn ($objectId) => (string)$objectId, $addedObjectIds), [(int)$tagId]));
 		}
-
-		// Dispatch unassign events for removed object ids
-		foreach ($removedObjectIds as $objectId) {
-			$this->dispatcher->dispatch(MapperEvent::EVENT_UNASSIGN, new MapperEvent(
-				MapperEvent::EVENT_UNASSIGN,
-				$objectType,
-				(string)$objectId,
-				[(int)$tagId]
-			));
-		}
 	}
 
 	/**

--- a/tests/lib/SystemTag/SystemTagObjectMapperTest.php
+++ b/tests/lib/SystemTag/SystemTagObjectMapperTest.php
@@ -18,6 +18,7 @@ use OCP\Server;
 use OCP\SystemTag\ISystemTag;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
+use OCP\SystemTag\MapperEvent;
 use OCP\SystemTag\TagAssignedEvent;
 use OCP\SystemTag\TagNotFoundException;
 use OCP\SystemTag\TagUnassignedEvent;
@@ -256,6 +257,28 @@ class SystemTagObjectMapperTest extends TestCase {
 		$this->assertEquals([
 			'1' => [$this->tag1->getId(), $this->tag2->getId(), $this->tag3->getId()],
 		], $tagIdMapping);
+	}
+
+	public function testSetObjectIdsForTagDispatchesUnassignEventOncePerObject(): void {
+		$unassignedObjectIds = [];
+		$this->dispatcher->expects($this->any())->method('dispatch')->willReturnCallback(
+			function (string $eventName, Event $event) use (&$unassignedObjectIds): void {
+				if ($eventName === MapperEvent::EVENT_UNASSIGN) {
+					$unassignedObjectIds[] = $event->getObjectId();
+				}
+			}
+		);
+
+		// tag1 is assigned to objects '1' and '2', keep only '2'
+		$this->tagMapper->setObjectIdsForTag((string)$this->tag1->getId(), 'testtype', ['2']);
+
+		$this->assertEquals(['1'], $unassignedObjectIds);
+
+		// same expectation when the new object list is empty
+		$unassignedObjectIds = [];
+		$this->tagMapper->setObjectIdsForTag((string)$this->tag1->getId(), 'testtype', []);
+
+		$this->assertEquals(['2'], $unassignedObjectIds);
 	}
 
 	public function testReAssignUnassignTags(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/62631

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
