### PR TITLE
feat(trash): Add getTrashRootItem to ITrashBackend

### DIFF
--- a/apps/files_trashbin/lib/Trash/ITrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/ITrashBackend.php
@@ -36,6 +36,15 @@ interface ITrashBackend {
 	public function listTrashFolder(ITrashItem $folder): array;
 
 	/**
+	 * Get a specific item in the root of the trashbin
+	 *
+	 * @param IUser $user
+	 * @return ?ITrashItem
+	 * @since 35.0.0
+	 */
+	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem;
+
+	/**
 	 * Restore a trashbin item
 	 *
 	 * @param ITrashItem $item

--- a/apps/files_trashbin/lib/Trash/ITrashManager.php
+++ b/apps/files_trashbin/lib/Trash/ITrashManager.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Files_Trashbin\Trash;
 
-use OCP\IUser;
-
 interface ITrashManager extends ITrashBackend {
 	/**
 	 * Add a backend for the trashbin
@@ -20,25 +18,6 @@ interface ITrashManager extends ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function registerBackend(string $storageType, ITrashBackend $backend);
-
-	/**
-	 * List all trash items in the root of the trashbin
-	 *
-	 * @param IUser $user
-	 * @return ITrashItem[]
-	 * @since 15.0.0
-	 */
-	#[\Override]
-	public function listTrashRoot(IUser $user): array;
-
-	/**
-	 * Get a specific item in the root of the trashbin
-	 *
-	 * @param IUser $user
-	 * @return ?ITrashItem
-	 * @since 35.0.0
-	 */
-	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem;
 
 	/**
 	 * Temporally prevent files from being moved to the trash

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -61,6 +61,7 @@ class LegacyTrashBackend implements ITrashBackend {
 		return array_map(fn (FileInfo $fileInfo): ITrashItem => $this->mapTrashItem($fileInfo, $user), $entries);
 	}
 
+	#[\Override]
 	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem {
 		$entry = Helper::getTrashFile('/', $user->getUID(), $name);
 		if ($entry === null) {

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -59,6 +59,7 @@ class LegacyTrashBackend implements ITrashBackend {
 		return array_map(fn (FileInfo $fileInfo): ITrashItem => $this->mapTrashItem($fileInfo, $user), $entries);
 	}
 
+	#[\Override]
 	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem {
 		$entry = Helper::getTrashFile('/', $user->getUID(), $name);
 		if ($entry === null) {

--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -42,18 +42,9 @@ class TrashManager implements ITrashManager {
 	#[\Override]
 	public function getTrashRootItem(IUser $user, string $name): ?ITrashItem {
 		foreach ($this->getBackends() as $backend) {
-			if (method_exists($backend, 'getTrashRootItem')) {
-				$item = $backend->getTrashRootItem($user, $name);
-				if ($item !== null) {
-					return $item;
-				}
-			} else {
-				$items = $backend->listTrashRoot($user);
-				foreach ($items as $item) {
-					if ($item->getName() === $name) {
-						return $item;
-					}
-				}
+			$item = $backend->getTrashRootItem($user, $name);
+			if ($item !== null) {
+				return $item;
 			}
 		}
 		return null;


### PR DESCRIPTION
## Summary

Now all backends implement it and we don't need the legacy fallback anymore.

## TODO

- [x] https://github.com/nextcloud/collectives/pull/2664

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
