### PR TITLE
Expend a bit OCP\GlobalScale\IConfig

### DIFF
--- a/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
+++ b/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
@@ -14,6 +14,7 @@ use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\Job;
+use OCP\GlobalScale\IConfig as GlobalScaleConfig;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IUser;
@@ -39,6 +40,7 @@ class RetryJob extends Job {
 		private IUserManager $userManager,
 		private IAccountManager $accountManager,
 		private Signer $signer,
+		private GlobalScaleConfig $globalScaleConfig,
 	) {
 		parent::__construct($time);
 
@@ -86,7 +88,7 @@ class RetryJob extends Job {
 	protected function shouldRemoveBackgroundJob(): bool {
 		// TODO: Remove global scale condition once lookup server is used for non-global scale federation
 		// return $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'no') !== 'yes'
-		return !$this->config->getSystemValueBool('gs.enabled', false)
+		return !$this->globalScaleConfig->isGlobalScaleEnabled()
 			|| $this->config->getSystemValueBool('has_internet_connection', true) === false
 			|| $this->config->getSystemValueString('lookup_server', 'https://lookup.nextcloud.com') === ''
 			|| $this->retries >= 5;

--- a/apps/lookup_server_connector/lib/UpdateLookupServer.php
+++ b/apps/lookup_server_connector/lib/UpdateLookupServer.php
@@ -11,6 +11,8 @@ namespace OCA\LookupServerConnector;
 
 use OCA\LookupServerConnector\BackgroundJobs\RetryJob;
 use OCP\BackgroundJob\IJobList;
+use OCP\Config\IUserConfig;
+use OCP\GlobalScale\IConfig as GlobalScaleConfig;
 use OCP\IConfig;
 use OCP\IUser;
 
@@ -20,26 +22,21 @@ use OCP\IUser;
  * @package OCA\LookupServerConnector
  */
 class UpdateLookupServer {
-	/**
-	 * @param IJobList $jobList
-	 * @param IConfig $config
-	 */
 	public function __construct(
-		private IJobList $jobList,
-		private IConfig $config,
+		private readonly IJobList $jobList,
+		private readonly IConfig $config,
+		private readonly IUserConfig $userConfig,
+		private readonly GlobalScaleConfig $globalScaleConfig,
 	) {
 	}
 
-	/**
-	 * @param IUser $user
-	 */
 	public function userUpdated(IUser $user): void {
 		if (!$this->shouldUpdateLookupServer()) {
 			return;
 		}
 
 		// Reset retry counter
-		$this->config->deleteUserValue(
+		$this->userConfig->deleteUserConfig(
 			$user->getUID(),
 			'lookup_server_connector',
 			'update_retries'
@@ -48,17 +45,15 @@ class UpdateLookupServer {
 	}
 
 	/**
-	 * check if we should update the lookup server, we only do it if
+	 * Check if we should update the lookup server, we only do it if
 	 *
 	 * + we have an internet connection
 	 * + the lookup server update was not disabled by the admin
 	 * + we have a valid lookup server URL
-	 *
-	 * @return bool
 	 */
 	private function shouldUpdateLookupServer(): bool {
 		// TODO: Consider reenable for non-global-scale setups by checking "'files_sharing', 'lookupServerUploadEnabled'" instead of "gs.enabled"
-		return $this->config->getSystemValueBool('gs.enabled', false)
+		return $this->globalScaleConfig->isGlobalScaleEnabled()
 			&& $this->config->getSystemValueBool('has_internet_connection', true)
 			&& $this->config->getSystemValueString('lookup_server', 'https://lookup.nextcloud.com') !== '';
 	}

--- a/apps/settings/lib/BackgroundJobs/VerifyUserData.php
+++ b/apps/settings/lib/BackgroundJobs/VerifyUserData.php
@@ -15,6 +15,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\Job;
+use OCP\GlobalScale\IConfig as GlobalScaleConfig;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IUserManager;
@@ -38,6 +39,7 @@ class VerifyUserData extends Job {
 		private LoggerInterface $logger,
 		ITimeFactory $timeFactory,
 		private IConfig $config,
+		private GlobalScaleConfig $globalScaleConfig,
 	) {
 		parent::__construct($timeFactory);
 
@@ -124,7 +126,7 @@ class VerifyUserData extends Job {
 
 	protected function verifyViaLookupServer(array $argument, string $dataType): bool {
 		// TODO: Consider to enable for non-global-scale setups by checking 'files_sharing', 'lookupServerUploadEnabled'
-		if (!$this->config->getSystemValueBool('gs.enabled', false)
+		if (!$this->globalScaleConfig->isGlobalScaleEnabled()
 			|| empty($this->lookupServerUrl)
 			|| $this->config->getSystemValue('has_internet_connection', true) === false
 		) {

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2209,11 +2209,6 @@
       <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/lookup_server_connector/lib/UpdateLookupServer.php">
-    <DeprecatedMethod>
-      <code><![CDATA[deleteUserValue]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/oauth2/lib/Controller/LoginRedirectorController.php">
     <DeprecatedMethod>
       <code><![CDATA[generate]]></code>

--- a/lib/private/Collaboration/Collaborators/LookupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/LookupPlugin.php
@@ -12,6 +12,7 @@ use OCP\Collaboration\Collaborators\ISearchPlugin;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
 use OCP\Federation\ICloudIdManager;
+use OCP\GlobalScale\IConfig as GlobalScaleConfig;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IUserSession;
@@ -23,12 +24,13 @@ class LookupPlugin implements ISearchPlugin {
 	private string $currentUserRemote;
 
 	public function __construct(
-		private IConfig $config,
-		private IClientService $clientService,
+		private readonly IConfig $config,
+		private readonly IClientService $clientService,
 		IUserSession $userSession,
-		private ICloudIdManager $cloudIdManager,
-		private LoggerInterface $logger,
-		private ?TrustedServers $trustedServers,
+		private readonly ICloudIdManager $cloudIdManager,
+		private readonly LoggerInterface $logger,
+		private readonly ?TrustedServers $trustedServers,
+		private readonly GlobalScaleConfig $globalScaleConfig,
 	) {
 		$currentUserCloudId = $userSession->getUser()->getCloudId();
 		$this->currentUserRemote = $cloudIdManager->resolveCloudId($currentUserCloudId)->getRemote();
@@ -36,7 +38,7 @@ class LookupPlugin implements ISearchPlugin {
 
 	#[\Override]
 	public function search($search, $limit, $offset, ISearchResult $searchResult): bool {
-		$isGlobalScaleEnabled = $this->config->getSystemValueBool('gs.enabled', false);
+		$isGlobalScaleEnabled = $this->globalScaleConfig->isGlobalScaleEnabled();
 		$isLookupServerEnabled = $this->config->getAppValue('files_sharing', 'lookupServerEnabled', 'no') === 'yes';
 		$hasInternetConnection = $this->config->getSystemValueBool('has_internet_connection', true);
 

--- a/lib/private/GlobalScale/Config.php
+++ b/lib/private/GlobalScale/Config.php
@@ -35,4 +35,24 @@ class Config implements \OCP\GlobalScale\IConfig {
 
 		return $enabled === 'internal';
 	}
+
+	#[Override]
+	public function isPrimary(): bool {
+		return $this->isGlobalScaleEnabled()
+			&& ($this->config->getSystemValueString('gss.mode', 'slave') === 'master'
+				|| $this->config->getSystemValueString('gss.mode', 'slave') === 'primary');
+	}
+
+	#[Override]
+	public function isSecondary(): bool {
+		return $this->isGlobalScaleEnabled()
+			&& ($this->config->getSystemValueString('gss.mode', 'slave') === 'slave'
+				|| $this->config->getSystemValueString('gss.mode', 'slave') === 'secondary');
+	}
+
+	#[Override]
+	public function isPrimaryAdmin(string $userId): bool {
+		return in_array($userId, $this->config->getSystemValue('gss.master.admin', []))
+			|| in_array($userId, $this->config->getSystemValue('gss.primary.admin', []));
+	}
 }

--- a/lib/public/GlobalScale/IConfig.php
+++ b/lib/public/GlobalScale/IConfig.php
@@ -31,4 +31,33 @@ interface IConfig {
 	 * @since 12.0.1
 	 */
 	public function onlyInternalFederation(): bool;
+
+	/**
+	 * Check if the current instance is the primary instance.
+	 *
+	 * This instance is then only used to log in the users and then redirect them
+	 * to their associated secondary instance.
+	 *
+	 * @since 34.0.3
+	 */
+	public function isPrimary(): bool;
+
+	/**
+	 * Check if the current instance is one of the secondary instance.
+	 *
+	 * These instances are the actual instance of a user and hold all their data.
+	 *
+	 * @since 34.0.3
+	 */
+	public function isSecondary(): bool;
+
+	/**
+	 * Check if the given user is one of the admin on the primary instance.
+	 *
+	 * These users won't be redirected to a secondary instance and instead will
+	 * stay on the primary instance to manage the configuration of the instance.
+	 *
+	 * @since 34.0.3
+	 */
+	public function isPrimaryAdmin(string $userId): bool;
 }

--- a/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -13,6 +15,7 @@ use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
+use OCP\GlobalScale\IConfig as GlobalScaleConfig;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
@@ -25,18 +28,13 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class LookupPluginTest extends TestCase {
-	/** @var IConfig|MockObject */
-	protected $config;
-	/** @var IClientService|MockObject */
-	protected $clientService;
-	/** @var IUserSession|MockObject */
-	protected $userSession;
-	/** @var ICloudIdManager|MockObject */
-	protected $cloudIdManager;
-	/** @var LookupPlugin */
-	protected $plugin;
-	/** @var LoggerInterface|MockObject */
-	protected $logger;
+	protected IConfig&MockObject $config;
+	protected GlobalScaleConfig&MockObject $globalScaleConfig;
+	protected IClientService&MockObject $clientService;
+	protected IUserSession&MockObject $userSession;
+	protected ICloudIdManager&MockObject $cloudIdManager;
+	protected LookupPlugin $plugin;
+	protected LoggerInterface&MockObject $logger;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -45,6 +43,7 @@ class LookupPluginTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->globalScaleConfig = $this->createMock(GlobalScaleConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->clientService = $this->createMock(IClientService::class);
 		$cloudId = $this->createMock(ICloudId::class);
@@ -71,7 +70,8 @@ class LookupPluginTest extends TestCase {
 			$this->userSession,
 			$this->cloudIdManager,
 			$this->logger,
-			null
+			null,
+			$this->globalScaleConfig,
 		);
 	}
 
@@ -80,12 +80,15 @@ class LookupPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('files_sharing', 'lookupServerEnabled', 'no')
 			->willReturn('yes');
-		$this->config->expects($this->exactly(2))
+		$this->config->expects($this->once())
 			->method('getSystemValueBool')
 			->willReturnMap([
-				['gs.enabled', false, true],
 				['has_internet_connection', true, true],
 			]);
+
+		$this->globalScaleConfig->expects($this->once())
+			->method('isGlobalScaleEnabled')
+			->willReturn(true);
 
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
@@ -106,12 +109,15 @@ class LookupPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('files_sharing', 'lookupServerEnabled', 'no')
 			->willReturn('yes');
-		$this->config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(1))
 			->method('getSystemValueBool')
 			->willReturnMap([
-				['gs.enabled', false, false],
 				['has_internet_connection', true, false],
 			]);
+
+		$this->globalScaleConfig->expects($this->exactly(1))
+			->method('isGlobalScaleEnabled')
+			->willReturn(false);
 
 		$this->clientService->expects($this->never())
 			->method('newClient');
@@ -139,12 +145,15 @@ class LookupPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('files_sharing', 'lookupServerEnabled', 'no')
 			->willReturn('yes');
-		$this->config->expects($this->exactly(2))
+		$this->config->expects($this->once())
 			->method('getSystemValueBool')
 			->willReturnMap([
-				['gs.enabled', false, true],
 				['has_internet_connection', true, true],
 			]);
+
+		$this->globalScaleConfig->expects($this->once())
+			->method('isGlobalScaleEnabled')
+			->willReturn(true);
 
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
@@ -200,12 +209,15 @@ class LookupPluginTest extends TestCase {
 				->method('addResultSet')
 				->with($type, $searchParams['expectedResult'], []);
 
-			$this->config->expects($this->exactly(2))
+			$this->config->expects($this->once())
 				->method('getSystemValueBool')
 				->willReturnMap([
-					['gs.enabled', false, $GSEnabled],
 					['has_internet_connection', true, true],
 				]);
+
+			$this->globalScaleConfig->expects($this->once())
+				->method('isGlobalScaleEnabled')
+				->willReturn($GSEnabled);
 			$this->config->expects($this->once())
 				->method('getSystemValueString')
 				->with('lookup_server', 'https://lookup.nextcloud.com')
@@ -230,12 +242,15 @@ class LookupPluginTest extends TestCase {
 				->willReturn($client);
 		} else {
 			$searchResult->expects($this->never())->method('addResultSet');
-			$this->config->expects($this->exactly(2))
+			$this->config->expects($this->once())
 				->method('getSystemValueBool')
 				->willReturnMap([
-					['gs.enabled', false, $GSEnabled],
 					['has_internet_connection', true, true],
 				]);
+
+			$this->globalScaleConfig->expects($this->once())
+				->method('isGlobalScaleEnabled')
+				->willReturn($GSEnabled);
 		}
 		$moreResults = $this->plugin->search(
 			$searchParams['search'],
@@ -248,12 +263,15 @@ class LookupPluginTest extends TestCase {
 	}
 
 	public function testSearchGSDisabled(): void {
-		$this->config->expects($this->atLeastOnce())
+		$this->config->expects($this->once())
 			->method('getSystemValueBool')
 			->willReturnMap([
 				['has_internet_connection', true, true],
-				['gs.enabled', false, false],
 			]);
+
+		$this->globalScaleConfig->expects($this->once())
+			->method('isGlobalScaleEnabled')
+			->willReturn(false);
 
 		/** @var ISearchResult|MockObject $searchResult */
 		$searchResult = $this->createMock(ISearchResult::class);


### PR DESCRIPTION
## Summary

These settings are hardcoded in a few places and we want to use them in even more places.

Additionally support the new agreed configuration keys from https://github.com/nextcloud/globalsiteselector/issues/19

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
