### PR TITLE
fix(encryption): handle decryption exception with outdated passwords

### DIFF
--- a/apps/encryption/lib/Controller/SettingsController.php
+++ b/apps/encryption/lib/Controller/SettingsController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\ISession;
@@ -76,7 +77,13 @@ class SettingsController extends Controller {
 
 		if ($passwordCorrect !== false) {
 			$encryptedKey = $this->keyManager->getPrivateKey($uid);
-			$decryptedKey = $this->crypt->decryptPrivateKey($encryptedKey, $oldPassword, $uid);
+			try {
+				$decryptedKey = $this->crypt->decryptPrivateKey($encryptedKey, $oldPassword, $uid);
+			} catch (GenericEncryptionException) {
+				// A wrong passphrase does not only make decrypting return false, it can
+				// also fail the signature check or the decryption itself
+				$decryptedKey = false;
+			}
 
 			if ($decryptedKey) {
 				$encryptedKey = $this->crypt->encryptPrivateKey($decryptedKey, $newPassword, $uid);

--- a/apps/encryption/tests/Controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/Controller/SettingsControllerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace OCA\Encryption\Tests\Controller;
 
+use OC\Encryption\Exceptions\DecryptionFailedException;
 use OCA\Encryption\Controller\SettingsController;
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\KeyManager;
@@ -145,6 +146,28 @@ class SettingsControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $result->getStatus());
 		$this->assertSame('The old password was not correct, please try again.',
 			$data['message']);
+	}
+
+	/**
+	 * test updatePrivateKeyPassword() if decrypting the private key with the given
+	 * old password fails with an exception instead of returning false
+	 */
+	public function testUpdatePrivateKeyPasswordUndecryptableKey(): void {
+		$this->userManagerMock
+			->expects($this->once())
+			->method('checkPassword')
+			->willReturn(true);
+
+		$this->cryptMock
+			->expects($this->once())
+			->method('decryptPrivateKey')
+			->willThrowException(new DecryptionFailedException('Decryption failed'));
+
+		$result = $this->controller->updatePrivateKeyPassword('old', 'new');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $result->getStatus());
+		$this->assertSame('The old password was not correct, please try again.',
+			$result->getData()['message']);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Properly handle exception during decryption as an outdated password will cause a signature exception.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
