### PR TITLE
fix(MemcachedFactory): Enable TCP_NODELAY and adjust default timeouts to be reasonable

### DIFF
--- a/lib/private/Memcache/MemcachedFactory.php
+++ b/lib/private/Memcache/MemcachedFactory.php
@@ -33,11 +33,13 @@ class MemcachedFactory {
 		$this->instance = new \Memcached();
 
 		$defaultOptions = [
-			\Memcached::OPT_CONNECT_TIMEOUT => 50,
-			\Memcached::OPT_RETRY_TIMEOUT => 50,
-			\Memcached::OPT_SEND_TIMEOUT => 50,
-			\Memcached::OPT_RECV_TIMEOUT => 50,
-			\Memcached::OPT_POLL_TIMEOUT => 50,
+			// Set connect and polling timeouts to 500 milliseconds
+			\Memcached::OPT_CONNECT_TIMEOUT => 500,
+			\Memcached::OPT_POLL_TIMEOUT => 500,
+
+			// Set send and receive timeouts to 500000 microseconds
+			\Memcached::OPT_SEND_TIMEOUT => 500000,
+			\Memcached::OPT_RECV_TIMEOUT => 500000,
 
 			// Enable compression
 			\Memcached::OPT_COMPRESSION => true,
@@ -47,6 +49,9 @@ class MemcachedFactory {
 
 			// Enable Binary Protocol
 			\Memcached::OPT_BINARY_PROTOCOL => true,
+
+			// Disable Nagle algorithm to speed up connection
+			\Memcached::OPT_TCP_NODELAY => true,
 		];
 		/**
 		 * By default enable igbinary serializer if available


### PR DESCRIPTION
* Resolves: #14995

## Summary

The CI tests against `memcached` fail [sporadically](https://github.com/nextcloud/server/actions/runs/30366916355/job/90300642158?pr=62580). After some research, it's because the default timeouts are way to low for high load scenarios. The ones being used at the moment have no reasoning behind them at all (we use [these ones](https://web.archive.org/web/20160506033018/http://apprize.info/php/scaling/15.html) according to the [commit message here](https://github.com/nextcloud/server/commit/e03f9e8103d7b9a8336c551d0f8ecee029f29723)). This is being mentioned in #14995 and can be observed when comparing our values with those of other PHP applications as well:

- MediaWiki: Uses 500ms for everything by default (see [those config](https://doc.wikimedia.org/mediawiki-core/REL1_41/php/MemcachedPeclBagOStuff_8php_source.html) on line 55 onward together with the option setters on line 100 onward)
- [Symfony](https://github.com/symfony/symfony/blob/8.2/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php#L172) and [Laravel](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Cache/MemcachedConnector.php#L54): None specific timeouts being set by default, which means the [library defaults](https://github.com/awesomized/libmemcached/blob/v1.x/include/libmemcached-1.0/defaults.h#L26) from 5 seconds for `POLL_TIMEOUT` and 4 seconds for `CONNECT_TIMEOUT` apply

For our CI tests, the `POLL_TIMEOUT` is the one that makes the tests fail. As we're not enabling `TCP_NODELAY` at the moment, the bare minimum ACK time for small packages (like a `HIT MISS` with binary protocol) is [40ms](https://github.com/torvalds/linux/blob/master/include/net/tcp.h#L157) with the default Linux kernel settings. Dangerously close to the 50ms timeout we currently use. Under high load scenarios, the kernel can increase the ACK time to up to [200ms](https://github.com/torvalds/linux/blob/master/include/net/tcp.h#L150) and the RFC even allows up to [500ms](https://www.rfc-editor.org/info/rfc1122/#section-4.2.3.2).

That's why this PR enabled `TCP_NODELAY` to speed up `HIT MISS` scenarios (same as Symfony does, which seem [reasonable as well](https://brooker.co.za/blog/2024/05/09/nagle.html)) and adjusts the default timeouts to those being used by MediaWiki as they seem pretty reasonable.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
