### PR TITLE
fix(console): write app command loading errors to stderr

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -96,7 +96,7 @@ class Application {
 							try {
 								$this->loadCommandsFromInfoXml($info['commands']);
 							} catch (\Throwable $e) {
-								$output->writeln('<error>' . $e->getMessage() . '</error>');
+								$output->getErrorOutput()->writeln('<error>' . $e->getMessage() . '</error>');
 								$this->logger->error($e->getMessage(), [
 									'exception' => $e,
 								]);
@@ -118,7 +118,7 @@ class Application {
 							try {
 								$this->loadCommandsFromInfoXml($info['commands']);
 							} catch (\Throwable $e) {
-								$output->writeln('<error>' . $e->getMessage() . '</error>');
+								$output->getErrorOutput()->writeln('<error>' . $e->getMessage() . '</error>');
 								$this->logger->error($e->getMessage(), [
 									'exception' => $e,
 								]);


### PR DESCRIPTION
### Summary

When an app fails to load its console commands from `info.xml`, `OC\Console\Application::loadCommands()` reports the failure with `$output->writeln()` — i.e. **stdout** — while every other diagnostic in the same method already uses `$output->getErrorOutput()` (insufficient memory limit, "Nextcloud is not installed", "requires upgrade", maintenance-mode notices).

The command then runs normally and exits `0`, so the message silently corrupts machine-readable output:

```console
$ ./occ app:list --output=json
Connection refused
{"enabled":{"cloud_federation_api":"1.17.0", ...},"disabled":{...}}
$ echo $?
0
```

Anything piping `occ <cmd> --output=json` into a JSON parser breaks, and there is no non-zero exit code to detect it by. `--no-warnings` is not a workaround, since it sets `VERBOSITY_QUIET` and suppresses the payload too.

`$output` is typed `ConsoleOutputInterface`, so `getErrorOutput()` is guaranteed by the signature. Two call sites are affected: the `app_api` maintenance-mode block and the regular installed-apps loop. The `logger->error()` calls are unchanged, so the failure is still logged with its stack trace.

### How this was hit

An app with the phpredis extension loaded but **no** Redis configured. `RedisFactory::isAvailable()` only checks `extension_loaded('redis')`, not whether a `redis` config block exists, so the app's queue factory took the Redis branch, fell back to `127.0.0.1:6379` and threw `RedisException: Connection refused` while its console commands were being constructed. Because `enable_lazy_objects` defaults to `true`, the constructor runs inside `$this->application->add($c)` → `Command::setApplication()`, so the throw surfaces outside `loadCommandsFromInfoXml()`'s inner `catch (ContainerExceptionInterface)` and lands in the outer `catch (\Throwable)`.

The app-side behaviour is arguably its own issue; the console bootstrap should not corrupt stdout regardless of which app fails to load.

### Verification

Reproduced deterministically with a throwaway app whose `info.xml` names a nonexistent command class:

| | stdout | `jq` | stderr | exit |
|---|---|---|---|---|
| before | `Console command '...' is un…` | parse error (5) | *empty* | 0 |
| after | `{"enabled":{...}` | ok, 21 keys | the error message | 0 |

The error remains in `nextcloud.log`.

### On tests

No test is included. There is currently no test for `lib/private/Console/*`, and `grep -rn getErrorOutput tests/` returns nothing, so there is no existing harness or stdout-vs-stderr assertion precedent to extend. `loadCommands()` also does an unstubbable `require_once core/register_command.php` (~138 `Server::get()` calls, re-fetching the real `IConfig` rather than an injected mock), which makes a genuine unit test a DB-group test whose result is order-dependent because `require_once` runs once per process.

This change adds no logic — it only redirects an existing message from one stream to the other. Happy to add a `build/integration` scenario (`CommandLine.php` already captures stdout and stderr separately) or to extract that `require_once` behind an injected collaborator to make the class unit-testable, if a maintainer would prefer either.

### Checklist

- [x] Code is properly formatted
- [x] `Signed-off-by` is present (added by the contributor)
- [ ] Tests — see "On tests" above
- [x] Documentation has been updated or is not required

### AI disclosure

This change and this description were drafted with AI assistance (Claude Code, claude-opus-5), then reviewed by the submitting contributor. Disclosed per the Nextcloud AI Contribution Policy.


