### PR TITLE
feat(dav): serialize concurrent MOVE/COPY

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -251,6 +251,7 @@ return array(
     'OCA\\DAV\\Connector\\Sabre\\PublicAuth' => $baseDir . '/../lib/Connector/Sabre/PublicAuth.php',
     'OCA\\DAV\\Connector\\Sabre\\QuotaPlugin' => $baseDir . '/../lib/Connector/Sabre/QuotaPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\RequestIdHeaderPlugin' => $baseDir . '/../lib/Connector/Sabre/RequestIdHeaderPlugin.php',
+    'OCA\\DAV\\Connector\\Sabre\\SerializeMoveCopyPlugin' => $baseDir . '/../lib/Connector/Sabre/SerializeMoveCopyPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\Server' => $baseDir . '/../lib/Connector/Sabre/Server.php',
     'OCA\\DAV\\Connector\\Sabre\\ServerFactory' => $baseDir . '/../lib/Connector/Sabre/ServerFactory.php',
     'OCA\\DAV\\Connector\\Sabre\\ShareTypeList' => $baseDir . '/../lib/Connector/Sabre/ShareTypeList.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -266,6 +266,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Connector\\Sabre\\PublicAuth' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PublicAuth.php',
         'OCA\\DAV\\Connector\\Sabre\\QuotaPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/QuotaPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\RequestIdHeaderPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/RequestIdHeaderPlugin.php',
+        'OCA\\DAV\\Connector\\Sabre\\SerializeMoveCopyPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/SerializeMoveCopyPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\Server' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Server.php',
         'OCA\\DAV\\Connector\\Sabre\\ServerFactory' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ServerFactory.php',
         'OCA\\DAV\\Connector\\Sabre\\ShareTypeList' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ShareTypeList.php',

--- a/apps/dav/lib/Connector/Sabre/SerializeMoveCopyPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SerializeMoveCopyPlugin.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\DAV\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\Exception\FileLocked;
+use OCP\IConfig;
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+/**
+ * Serialize concurrent WebDAV MOVE and COPY on the same source or destination path.
+ * Enable via 'dav.serialize_move_copy'.
+ */
+class SerializeMoveCopyPlugin extends ServerPlugin {
+	/** Distinct namespace from the storage-layer View locks on the same path. */
+	private const LOCK_KEY_PREFIX = 'webdav-serialize:';
+
+	private const CONFIG_KEY = 'dav.serialize_move_copy';
+
+	/** @var list<array{key: string, type: int}> */
+	private array $heldLocks = [];
+
+	public function __construct(
+		private ILockingProvider $lockingProvider,
+		private IConfig $config,
+	) {
+	}
+
+	#[\Override]
+	public function initialize(Server $server): void {
+		$server->on('beforeMove', [$this, 'beforeMove']);
+		$server->on('beforeCopy', [$this, 'beforeCopy']);
+		$server->on('afterMethod:MOVE', [$this, 'afterMethod']);
+		$server->on('afterMethod:COPY', [$this, 'afterMethod']);
+		$server->on('exception', [$this, 'onException']);
+	}
+
+	/** @throws FileLocked when the source or destination is contended. */
+	public function beforeMove(string $source, string $destination): bool {
+		return $this->guard($source, $destination, ILockingProvider::LOCK_EXCLUSIVE);
+	}
+
+	/** @throws FileLocked when the source or destination is contended. */
+	public function beforeCopy(string $source, string $destination): bool {
+		return $this->guard($source, $destination, ILockingProvider::LOCK_SHARED);
+	}
+
+	private function guard(string $source, string $destination, int $sourceLockType): bool {
+		if (!$this->config->getSystemValueBool(self::CONFIG_KEY, false)) {
+			return true;
+		}
+		$srcKey = self::LOCK_KEY_PREFIX . $source;
+		$dstKey = self::LOCK_KEY_PREFIX . $destination;
+		if ($srcKey === $dstKey) {
+			return true;
+		}
+		// Path sort ensures two concurrent operations with swapped source and destination acquire in the same order.
+		$order = strcmp($srcKey, $dstKey) < 0
+			? [[$srcKey, $sourceLockType, $source], [$dstKey, ILockingProvider::LOCK_EXCLUSIVE, $destination]]
+			: [[$dstKey, ILockingProvider::LOCK_EXCLUSIVE, $destination], [$srcKey, $sourceLockType, $source]];
+		try {
+			foreach ($order as [$key, $type, $readablePath]) {
+				$this->lockingProvider->acquireLock($key, $type, $readablePath);
+				$this->heldLocks[] = ['key' => $key, 'type' => $type];
+			}
+		} catch (LockedException $e) {
+			$this->release();
+			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
+		}
+		return true;
+	}
+
+	public function afterMethod(RequestInterface $request, ResponseInterface $response): void {
+		$this->release();
+	}
+
+	public function onException(\Throwable $exception): void {
+		// afterMethod does not fire on exception. Release here so locks do not leak.
+		$this->release();
+	}
+
+	public function __destruct() {
+		$this->release();
+	}
+
+	private function release(): void {
+		while ($lock = array_pop($this->heldLocks)) {
+			try {
+				$this->lockingProvider->releaseLock($lock['key'], $lock['type']);
+			} catch (\Throwable) {
+				// Multiple release() calls are expected across the hooks and destructor. Suppress to stay idempotent.
+			}
+		}
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -107,6 +107,10 @@ class ServerFactory {
 		$server->addPlugin(new DummyGetResponsePlugin());
 		$server->addPlugin(new ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new LockPlugin());
+		$server->addPlugin(new SerializeMoveCopyPlugin(
+			\OCP\Server::get(\OCP\Lock\ILockingProvider::class),
+			$this->config,
+		));
 
 		$server->addPlugin(new RequestIdHeaderPlugin($this->request));
 		$server->addPlugin(new UserIdHeaderPlugin($this->userSession));

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -191,6 +191,10 @@ class Server {
 
 		$this->server->addPlugin(new ExceptionLoggerPlugin('webdav', $logger));
 		$this->server->addPlugin(new LockPlugin());
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\SerializeMoveCopyPlugin(
+			\OCP\Server::get(\OCP\Lock\ILockingProvider::class),
+			\OCP\Server::get(\OCP\IConfig::class),
+		));
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 
 		// acl

--- a/apps/dav/tests/unit/Connector/Sabre/SerializeMoveCopyPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SerializeMoveCopyPluginTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\Exception\FileLocked;
+use OCA\DAV\Connector\Sabre\SerializeMoveCopyPlugin;
+use OCP\IConfig;
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Server;
+use Sabre\HTTP\Request;
+use Sabre\HTTP\Response;
+use Test\TestCase;
+
+class SerializeMoveCopyPluginTest extends TestCase {
+	private const LOCK_KEY_PREFIX = 'webdav-serialize:';
+	private const CONFIG_KEY = 'dav.serialize_move_copy';
+
+	private ILockingProvider&MockObject $lockingProvider;
+	private IConfig&MockObject $config;
+	private SerializeMoveCopyPlugin $plugin;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->lockingProvider = $this->createMock(ILockingProvider::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->plugin = new SerializeMoveCopyPlugin($this->lockingProvider, $this->config);
+	}
+
+	private function toggle(bool $enabled): void {
+		$this->config->method('getSystemValueBool')->with(self::CONFIG_KEY, false)->willReturn($enabled);
+	}
+
+	/** @param list<array{key: string, type: int}> $calls appended by the mock callback in call order */
+	private function captureAcquireCalls(array &$calls): void {
+		$this->lockingProvider
+			->method('acquireLock')
+			->willReturnCallback(function (string $key, int $type) use (&$calls): void {
+				$calls[] = ['key' => $key, 'type' => $type];
+			});
+	}
+
+	public function testInitializeSubscribesToExpectedEvents(): void {
+		$server = new Server();
+		$this->plugin->initialize($server);
+		foreach (['beforeMove', 'beforeCopy', 'afterMethod:MOVE', 'afterMethod:COPY', 'exception'] as $event) {
+			$this->assertNotEmpty($server->listeners($event), "no listener registered for $event");
+		}
+	}
+
+	public function testToggleOffIsNoop(): void {
+		$this->toggle(false);
+		$this->lockingProvider->expects($this->never())->method('acquireLock');
+		$this->assertTrue($this->plugin->beforeMove('files/a/src.txt', 'files/a/dst.txt'));
+		$this->assertTrue($this->plugin->beforeCopy('files/a/src.txt', 'files/a/dst.txt'));
+	}
+
+	public function testMoveAcquiresExclusiveOnBothInSortedOrder(): void {
+		$this->toggle(true);
+		$calls = [];
+		$this->captureAcquireCalls($calls);
+		$this->plugin->beforeMove('files/a/1-src.txt', 'files/a/2-dst.txt');
+		$this->assertSame([
+			['key' => self::LOCK_KEY_PREFIX . 'files/a/1-src.txt', 'type' => ILockingProvider::LOCK_EXCLUSIVE],
+			['key' => self::LOCK_KEY_PREFIX . 'files/a/2-dst.txt', 'type' => ILockingProvider::LOCK_EXCLUSIVE],
+		], $calls);
+	}
+
+	public function testCopyAcquiresSharedSourceAndExclusiveDestination(): void {
+		$this->toggle(true);
+		$calls = [];
+		$this->captureAcquireCalls($calls);
+		$this->plugin->beforeCopy('files/a/1-src.txt', 'files/a/2-dst.txt');
+		$this->assertSame([
+			['key' => self::LOCK_KEY_PREFIX . 'files/a/1-src.txt', 'type' => ILockingProvider::LOCK_SHARED],
+			['key' => self::LOCK_KEY_PREFIX . 'files/a/2-dst.txt', 'type' => ILockingProvider::LOCK_EXCLUSIVE],
+		], $calls);
+	}
+
+	public function testAcquisitionOrderFollowsPathSortNotArgumentOrder(): void {
+		// destination sorts before source alphabetically. The plugin MUST still lock destination first.
+		$this->toggle(true);
+		$calls = [];
+		$this->captureAcquireCalls($calls);
+		$this->plugin->beforeMove('files/a/z-src.txt', 'files/a/a-dst.txt');
+		$this->assertSame([
+			self::LOCK_KEY_PREFIX . 'files/a/a-dst.txt',
+			self::LOCK_KEY_PREFIX . 'files/a/z-src.txt',
+		], array_column($calls, 'key'));
+	}
+
+	public function testSourceEqualsDestinationShortCircuits(): void {
+		$this->toggle(true);
+		$this->lockingProvider->expects($this->never())->method('acquireLock');
+		$this->assertTrue($this->plugin->beforeMove('files/a/src.txt', 'files/a/src.txt'));
+		$this->assertTrue($this->plugin->beforeCopy('files/a/src.txt', 'files/a/src.txt'));
+	}
+
+	public function testLockedExceptionOnFirstLockMapsTo423(): void {
+		$this->toggle(true);
+		$this->lockingProvider->method('acquireLock')
+			->willThrowException(new LockedException('files/a/src.txt'));
+		$this->lockingProvider->expects($this->never())->method('releaseLock');
+
+		$this->expectException(FileLocked::class);
+		try {
+			$this->plugin->beforeMove('files/a/src.txt', 'files/a/dst.txt');
+		} catch (FileLocked $e) {
+			$this->assertSame(423, $e->getHTTPCode());
+			throw $e;
+		}
+	}
+
+	public function testLockedExceptionOnSecondLockRollsBackFirst(): void {
+		$this->toggle(true);
+		$callCount = 0;
+		$this->lockingProvider->expects($this->exactly(2))
+			->method('acquireLock')
+			->willReturnCallback(function () use (&$callCount): void {
+				$callCount++;
+				if ($callCount === 2) {
+					throw new LockedException('files/a/2-dst.txt');
+				}
+			});
+		$this->lockingProvider->expects($this->once())
+			->method('releaseLock')
+			->with(self::LOCK_KEY_PREFIX . 'files/a/1-src.txt', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->expectException(FileLocked::class);
+		$this->plugin->beforeMove('files/a/1-src.txt', 'files/a/2-dst.txt');
+	}
+
+	public function testAfterMethodReleasesAllHeldLocks(): void {
+		$this->toggle(true);
+		$this->lockingProvider->expects($this->exactly(2))->method('releaseLock');
+		$this->plugin->beforeMove('files/a/1-src.txt', 'files/a/2-dst.txt');
+		$this->plugin->afterMethod(new Request('MOVE', 'files/a/1-src.txt'), new Response());
+	}
+
+	public function testOnExceptionReleasesAllHeldLocks(): void {
+		$this->toggle(true);
+		$this->lockingProvider->expects($this->exactly(2))->method('releaseLock');
+		$this->plugin->beforeCopy('files/a/1-src.txt', 'files/a/2-dst.txt');
+		$this->plugin->onException(new \RuntimeException('boom'));
+	}
+
+	public function testReleaseIsIdempotent(): void {
+		$this->toggle(true);
+		$this->lockingProvider->expects($this->exactly(2))->method('releaseLock');
+		$this->plugin->beforeMove('files/a/1-src.txt', 'files/a/2-dst.txt');
+		$this->plugin->afterMethod(new Request('MOVE', 'files/a/1-src.txt'), new Response());
+		$this->plugin->onException(new \RuntimeException('later'));
+	}
+}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2741,6 +2741,16 @@ $CONFIG = [
 	'filelocking.debug' => false,
 
 	/**
+	 * Serialize concurrent WebDAV MOVE and COPY on the same source or destination
+	 * path. When ``true``, the server MUST reject a conflicting concurrent
+	 * operation with HTTP 423 Locked. Concurrent COPY from one source to
+	 * different destinations remains allowed.
+	 *
+	 * Defaults to ``false``
+	 */
+	'dav.serialize_move_copy' => false,
+
+	/**
 	 * Disable the web-based updater.
 	 *
 	 * Defaults to ``false``


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #62648

## Summary

Serialize concurrent WebDAV MOVE and COPY on the same source or destination path via a new `SerializeMoveCopyPlugin` registered at the DAV entry. When enabled, a conflicting concurrent operation MUST receive HTTP 423 Locked. Concurrent COPY from one source to different destinations remains allowed.

### Lock scheme

| Method | Source lock       | Destination lock  |
| ------ | ----------------- | ----------------- |
| MOVE   | `LOCK_EXCLUSIVE`  | `LOCK_EXCLUSIVE`  |
| COPY   | `LOCK_SHARED`     | `LOCK_EXCLUSIVE`  |

Locks share the namespace `webdav-serialize:<davPath>`. Path-sorted acquisition prevents deadlock between two concurrent operations with swapped source and destination. Source == destination short-circuits with no lock (defensive).

### Config

Set `dav.serialize_move_copy` to `true` in `config/config.sample.php`. Defaults to `false`.

### Behaviour matrix (op B arrives while A in flight)

| A    | B    | Same source | Same destination | B outcome |
| ---- | ---- | ----------- | ---------------- | --------- |
| MOVE | MOVE | yes         | either           | 423       |
| MOVE | COPY | yes         | either           | 423       |
| COPY | MOVE | yes         | either           | 423       |
| COPY | COPY | yes         | different        | 201       |
| COPY | COPY | yes         | same             | 423       |
| MOVE | MOVE | different   | same             | 423       |
| COPY | COPY | different   | same             | 423       |
| MOVE | COPY | different   | same             | 423       |
| COPY | MOVE | different   | same             | 423       |
| any  | any  | different   | different        | 201       |

Cross-user contention on the same shared file is serialized one layer down. The md5 lock key at `Common.php:696` collapses both users onto one key (owner-storage id plus owner-internal path). `ObjectTree::copy` wraps the storage-layer `\OCP\Lock\LockedException` to HTTP 423 for COPY. `Node::setName` does not wrap for MOVE and surfaces HTTP 500..

### Known limitations

- SHARED starvation of EXCLUSIVE. A continuous stream of concurrent COPYs on a source blocks a MOVE on that source indefinitely. `ILockingProvider` provides no fair-lock primitive.
- Backend TTL vs long request. `filelocking.ttl` default 3600 s exceeds typical `max_execution_time`. The lock outlives the request only on runaway workloads. Same posture as inner-lock behaviour.

## TODO

- [x] Implementation
- [x] Unit tests
- [x] E2E matrix on the `.devcontainer` stack

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests (unit) are included at `apps/dav/tests/unit/Connector/Sabre/SerializeMoveCopyPluginTest.php`. Unit suite: 11 tests, 48 assertions, all passing on PHP 8.4.23 + PHPUnit 11.5.50. E2E matrix (10 rows, `.devcontainer` stack, 5 MB source, 100 ms stagger): all rows PASS. Contended rows produce one 20x and one 423. Allowed rows (fan-out COPY) produce two 20x.
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation (manuals or wiki) has been updated or is not required
- [ ] Backports requested where applicable (ex: critical bugfixes)
- [ ] Labels added where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] Milestone added for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
