### PR TITLE
test(core): restore CLI state and correct assertion in SetupTest

### DIFF
--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -149,10 +149,11 @@ class SetupTest extends \Test\TestCase {
 			$webRoot = self::invokePrivate($this->setupClass, 'findWebRoot', [$this->config]);
 		} catch (\InvalidArgumentException $e) {
 			$webRoot = false;
+		} finally {
+			\OC::$CLI = $cliState;
 		}
 
-		\OC::$CLI = $cliState;
-		$this->assertSame($webRoot, $expected);
+		$this->assertSame($expected, $webRoot);
 	}
 
 	public static function findWebRootProvider(): array {


### PR DESCRIPTION
**🔀 Review triage:** ⚠️ Risk: Low · ⏱️ Effort: Quick

## Summary

Ensure `testFindWebRootCli()` restores `\OC::$CLI` even when an unexpected exception occurs, and correct the PHPUnit assertion argument order.

No production code changes.

Related production code: [`Setup::findWebRoot()`](https://github.com/nextcloud/server/blob/2878e339366db50c06574ec8e6e76c58a9459405/lib/private/Setup.php#L519-L540)

## Testing

Existing `testFindWebRootCli()` data-provider coverage is unchanged.

## Checklist

- [x] Code is properly formatted
- [x] Sign-off message is included
- [x] Tests are included
- [ ] Documentation is not required
- [ ] Backport is not required
- [x] Labels added
- [x] Milestone added

## AI disclosure

- [ ] The content of this PR was partly or fully generated using AI