### PR TITLE
test(setup): Improve db detection and web-root resolution coverage

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -101,7 +101,7 @@ class Setup {
 	 * Wrapper around \PDO::getAvailableDrivers
 	 */
 	protected function getAvailableDbDriversForPdo(): array {
-		if (class_exists(\PDO::class)) {
+		if ($this->class_exists(\PDO::class)) {
 			return \PDO::getAvailableDrivers();
 		}
 		return [];

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -186,6 +186,33 @@ class SetupTest extends \Test\TestCase {
 		$this->setupClass->getSupportedDatabases();
 	}
 
+	public function testGetAvailableDbDriversForPdoWhenPdoIsUnavailable(): void {
+		$setup = $this->getMockBuilder(Setup::class)
+			->onlyMethods(['class_exists'])
+			->setConstructorArgs([
+				$this->config,
+				$this->iniWrapper,
+				$this->l10nFactory,
+				$this->defaults,
+				$this->logger,
+				$this->random,
+				$this->installer,
+				$this->eventDispatcher,
+			])
+			->getMock();
+
+		$setup
+			->expects($this->once())
+			->method('class_exists')
+			->with(\PDO::class)
+			->willReturn(false);
+
+		$this->assertSame(
+			[],
+			self::invokePrivate($setup, 'getAvailableDbDriversForPdo'),
+		);
+	}
+
 	/**
 	 * @param $url
 	 * @param $expected

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -68,21 +68,19 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getValue')
-			->willReturn(
-				['sqlite', 'mysql', 'oci']
-			);
+			->willReturn(['sqlite', 'mysql', 'oci']);
 		$this->setupClass
 			->expects($this->once())
 			->method('is_callable')
+			->with('oci_connect')
 			->willReturn(false);
 		$this->setupClass
-			->expects($this->any())
+			->expects($this->exactly(2))
 			->method('getAvailableDbDriversForPdo')
 			->willReturn(['sqlite']);
+
 		$result = $this->setupClass->getSupportedDatabases();
-		$expectedResult = [
-			'sqlite' => 'SQLite'
-		];
+		$expectedResult = ['sqlite' => 'SQLite'];
 
 		$this->assertSame($expectedResult, $result);
 	}
@@ -91,17 +89,17 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getValue')
-			->willReturn(
-				['sqlite', 'mysql', 'oci', 'pgsql']
-			);
+			->willReturn(['sqlite', 'mysql', 'oci', 'pgsql']);
 		$this->setupClass
-			->expects($this->any())
+			->expects($this->once())
 			->method('is_callable')
+			->with('oci_connect')
 			->willReturn(false);
 		$this->setupClass
-			->expects($this->any())
+			->expects($this->exactly(3))
 			->method('getAvailableDbDriversForPdo')
 			->willReturn([]);
+
 		$result = $this->setupClass->getSupportedDatabases();
 
 		$this->assertSame([], $result);
@@ -111,17 +109,17 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getValue')
-			->willReturn(
-				['sqlite', 'mysql', 'pgsql', 'oci']
-			);
+			->willReturn(['sqlite', 'mysql', 'pgsql', 'oci']);
 		$this->setupClass
-			->expects($this->any())
+			->expects($this->once())
 			->method('is_callable')
+			->with('oci_connect')
 			->willReturn(true);
 		$this->setupClass
-			->expects($this->any())
+			->expects($this->exactly(3))
 			->method('getAvailableDbDriversForPdo')
 			->willReturn(['sqlite', 'mysql', 'pgsql']);
+
 		$result = $this->setupClass->getSupportedDatabases();
 		$expectedResult = [
 			'sqlite' => 'SQLite',
@@ -129,7 +127,51 @@ class SetupTest extends \Test\TestCase {
 			'pgsql' => 'PostgreSQL',
 			'oci' => 'Oracle'
 		];
+
 		$this->assertSame($expectedResult, $result);
+	}
+
+	public function testGetSupportedDatabasesAllowsAllKnownDatabasesWithoutConfiguration(): void {
+		$this->config
+			->expects($this->never())
+			->method('getValue');
+		$this->setupClass
+			->expects($this->once())
+			->method('is_callable')
+			->with('oci_connect')
+			->willReturn(true);
+		$this->setupClass
+			->expects($this->exactly(3))
+			->method('getAvailableDbDriversForPdo')
+			->willReturn(['sqlite', 'mysql', 'pgsql']);
+
+		$result = $this->setupClass->getSupportedDatabases(true);
+
+		$this->assertSame([
+			'sqlite' => 'SQLite',
+			'mysql' => 'MySQL/MariaDB',
+			'pgsql' => 'PostgreSQL',
+			'oci' => 'Oracle',
+		], $result);
+	}
+
+	public function testGetSupportedDatabasesIgnoresUnknownConfiguredDatabases(): void {
+		$this->config
+			->expects($this->once())
+			->method('getValue')
+			->with('supportedDatabases', ['sqlite', 'mysql', 'pgsql'])
+			->willReturn(['unknown', 'sqlite']);
+		$this->setupClass
+			->expects($this->never())
+			->method('is_callable');
+		$this->setupClass
+			->expects($this->once())
+			->method('getAvailableDbDriversForPdo')
+			->willReturn(['sqlite']);
+
+		$result = $this->setupClass->getSupportedDatabases();
+
+		$this->assertSame(['sqlite' => 'SQLite'], $result);
 	}
 
 	public function testGetSupportedDatabaseException(): void {
@@ -140,6 +182,7 @@ class SetupTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('getValue')
 			->willReturn('NotAnArray');
+
 		$this->setupClass->getSupportedDatabases();
 	}
 
@@ -183,6 +226,37 @@ class SetupTest extends \Test\TestCase {
 			'https://192.168.10.10' => ['https://192.168.10.10', ''],
 			'invalid' => ['invalid', false],
 			'empty' => ['', false],
+		];
+	}
+
+	/**
+	 * @param string $configuredWebRoot
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('findWebRootWebProvider')]
+	public function testFindWebRootWeb(string $configuredWebRoot, string $expected): void {
+		$cliState = \OC::$CLI;
+		$webRootState = \OC::$WEBROOT;
+		$this->config
+			->expects($this->never())
+			->method('getValue');
+
+		try {
+			\OC::$CLI = false;
+			\OC::$WEBROOT = $configuredWebRoot;
+
+			$webRoot = self::invokePrivate($this->setupClass, 'findWebRoot', [$this->config]);
+		} finally {
+			\OC::$CLI = $cliState;
+			\OC::$WEBROOT = $webRootState;
+		}
+
+		$this->assertSame($expected, $webRoot);
+	}
+
+	public static function findWebRootWebProvider(): array {
+		return [
+			'configured web root' => ['/nextcloud', '/nextcloud'],
+			'empty web root defaults to slash' => ['', '/'],
 		];
 	}
 }

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -37,18 +37,30 @@ class SetupTest extends \Test\TestCase {
 
 		$this->config = $this->createMock(SystemConfig::class);
 		$this->iniWrapper = $this->createMock(IniGetWrapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->random = $this->createMock(ISecureRandom::class);
+
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10nFactory = $this->createMock(IL10NFactory::class);
 		$this->l10nFactory->method('get')
 			->willReturn($this->l10n);
+
 		$this->defaults = $this->createMock(Defaults::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->random = $this->createMock(ISecureRandom::class);
 		$this->installer = $this->createMock(Installer::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+
 		$this->setupClass = $this->getMockBuilder(Setup::class)
 			->onlyMethods(['class_exists', 'is_callable', 'getAvailableDbDriversForPdo'])
-			->setConstructorArgs([$this->config, $this->iniWrapper, $this->l10nFactory, $this->defaults, $this->logger, $this->random, $this->installer, $this->eventDispatcher])
+			->setConstructorArgs([
+				$this->config,
+				$this->iniWrapper,
+				$this->l10nFactory,
+				$this->defaults,
+				$this->logger,
+				$this->random,
+				$this->installer,
+				$this->eventDispatcher,
+			])
 			->getMock();
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Improve `SetupTest` coverage for database detection and web-root resolution.

- Assert the expected PDO-driver lookups and `oci_connect` availability check.
- Cover `getSupportedDatabases(true)` (`allowAllDatabases`) without reading configuration.
- Cover ignoring unknown configured database names.
- Cover non-CLI `findWebRoot()` behavior, including the `/` fallback.
- Restore global `\OC::$CLI` and `\OC::$WEBROOT` state safely in the web-root tests.
- Route the PDO availability check through the existing mockable `class_exists()` wrapper, making the unavailable-PDO path unit-testable.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
