### PR TITLE
fix(provisioning_api): read newUser.sendEmail as a boolean

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -597,7 +597,7 @@ class UsersController extends AUserDataOCSController {
 			// Send new user mail only if a mail is set
 			if ($email !== '') {
 				$newUser->setSystemEMailAddress($email);
-				if ($this->config->getAppValue('core', 'newUser.sendEmail', 'yes') === 'yes') {
+				if ($this->appConfig->getValueBool('core', 'newUser.sendEmail', true)) {
 					try {
 						$emailTemplate = $this->newUserMailHelper->generateTemplate($newUser, $generatePasswordResetToken);
 						$this->newUserMailHelper->sendMail($newUser, $emailTemplate);

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -734,6 +734,67 @@ class UsersControllerTest extends TestCase {
 		));
 	}
 
+	/**
+	 * `newUser.sendEmail` has to be read as a boolean. It is stored as an untyped
+	 * 'yes'/'no' string on instances created before Nextcloud 33 and as a typed
+	 * boolean once the account settings toggle has been used, so comparing it to
+	 * the string 'yes' silently skipped the mail on upgraded instances.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAddUserWelcomeMail')]
+	public function testAddUserSendsWelcomeMailWhenEnabled(bool $enabled): void {
+		$this->appConfig
+			->expects($this->atLeastOnce())
+			->method('getValueBool')
+			->with('core', 'newUser.sendEmail', true)
+			->willReturn($enabled);
+
+		$newUser = $this->createMock(IUser::class);
+		$newUser->expects($this->once())
+			->method('setSystemEMailAddress')
+			->with('foo@bar.com');
+		$this->userManager
+			->expects($this->once())
+			->method('userExists')
+			->with('NewUser')
+			->willReturn(false);
+		$this->userManager
+			->expects($this->once())
+			->method('createUser')
+			->willReturn($newUser);
+		$loggedInUser = $this->createMock(IUser::class);
+		$loggedInUser
+			->method('getUID')
+			->willReturn('adminUser');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($loggedInUser);
+		$this->groupManager
+			->expects($this->once())
+			->method('isAdmin')
+			->with('adminUser')
+			->willReturn(true);
+
+		$emailTemplate = $this->createMock(IEMailTemplate::class);
+		$this->newUserMailHelper
+			->expects($enabled ? $this->once() : $this->never())
+			->method('generateTemplate')
+			->willReturn($emailTemplate);
+		$this->newUserMailHelper
+			->expects($enabled ? $this->once() : $this->never())
+			->method('sendMail')
+			->with($newUser, $emailTemplate);
+
+		$this->api->addUser('NewUser', 'PasswordOfTheNewUser', '', 'foo@bar.com');
+	}
+
+	public static function dataAddUserWelcomeMail(): array {
+		return [
+			'enabled' => [true],
+			'disabled' => [false],
+		];
+	}
+
 	public function testAddUserSuccessfulLowercaseEmail(): void {
 		$this->userManager
 			->expects($this->once())

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2271,7 +2271,6 @@
       <code><![CDATA[generate]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[implementsActions]]></code>
       <code><![CDATA[implementsActions]]></code>

--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -183,7 +183,7 @@ class Add extends Command {
 
 			$user->setSystemEMailAddress($email);
 
-			if ($this->appConfig->getValueString('core', 'newUser.sendEmail', 'yes') === 'yes') {
+			if ($this->appConfig->getValueBool('core', 'newUser.sendEmail', true)) {
 				try {
 					$this->mailHelper->sendMail($user, $this->mailHelper->generateTemplate($user, true));
 					$output->writeln('Welcome email sent to ' . $email);

--- a/tests/Core/Command/User/AddTest.php
+++ b/tests/Core/Command/User/AddTest.php
@@ -100,8 +100,8 @@ class AddTest extends TestCase {
 		$this->userManager->method('createUser')
 			->willReturn($this->user);
 
-		$this->appConfig->method('getValueString')
-			->willReturn($shouldSendEmail ? 'yes' : 'no');
+		$this->appConfig->method('getValueBool')
+			->willReturn($shouldSendEmail);
 
 		$this->mailHelper->method('generateTemplate')
 			->willReturn(static::createMock(IEMailTemplate::class));

--- a/tests/lib/AppConfigIntegrationTest.php
+++ b/tests/lib/AppConfigIntegrationTest.php
@@ -494,6 +494,34 @@ class AppConfigIntegrationTest extends TestCase {
 		$this->assertSame(true, $config->getValueBool('typed', 'bool'));
 	}
 
+	/**
+	 * Untyped values predate the typed config API and are still in the database of
+	 * every upgraded instance, so they have to keep resolving to a boolean. The
+	 * deprecated setter is used on purpose, as it is the only way to write a value
+	 * without a type.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUntypedBool')]
+	public function testGetValueBoolOnUntypedValue(string $stored, bool $expected): void {
+		/** @var AppConfig $config */
+		$config = $this->generateAppConfig();
+		$config->setValue('feed', 'untyped-bool', $stored);
+
+		$this->assertSame($expected, $config->getValueBool('feed', 'untyped-bool'));
+	}
+
+	public static function dataUntypedBool(): array {
+		return [
+			'yes' => ['yes', true],
+			'no' => ['no', false],
+			'true' => ['true', true],
+			'false' => ['false', false],
+			'on' => ['on', true],
+			'1' => ['1', true],
+			'0' => ['0', false],
+			'empty' => ['', false],
+		];
+	}
+
 	public function testGetValueBoolOnUnknownAppReturnsDefault(): void {
 		$config = $this->generateAppConfig();
 		$this->assertSame(false, $config->getValueBool('typed-1', 'bool', false));


### PR DESCRIPTION
* Resolves: #59329

## Summary

`newUser.sendEmail` is written as a typed boolean since #57079, but both user creation paths still compared it to the string `yes`

## TODO

- [ ] Backport to `stable34` and `stable33`

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (tests)
