### PR TITLE
check free space in the proper folder when restoring from trash

### DIFF
--- a/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
@@ -13,6 +13,8 @@ use OC\Files\FileInfo;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCA\Files_Trashbin\Trash\ITrashItem;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountManager;
 use OCP\IPreview;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\INode;
@@ -43,7 +45,8 @@ class TrashbinPlugin extends ServerPlugin {
 
 	public function __construct(
 		private readonly IPreview $previewManager,
-		private readonly View $view,
+		private readonly IRootFolder $rootFolder,
+		private readonly IMountManager $mountManager,
 	) {
 	}
 
@@ -175,7 +178,16 @@ class TrashbinPlugin extends ServerPlugin {
 			return true;
 		}
 
-		$freeSpace = $this->view->free_space($destinationParentPath);
+		$userFolder = $this->rootFolder->getUserFolder($fileInfo->getUser()->getUID());
+		$originalPath = $userFolder->getFullPath(dirname($fileInfo->getOriginalLocation()));
+
+		// Since the parent folder might no longer exist, we don't try to get the parent node to check the free space
+		// instead we resolve the mount where the restore would go to, and check that for the free space
+		$originalMount = $this->mountManager->find($originalPath);
+		if (!$originalMount) {
+			throw new \Exception('no mount found when looking for restore path');
+		}
+		$freeSpace = $originalMount->getStorage()->free_space($originalMount->getInternalPath($originalPath));
 
 		if (
 			$freeSpace === FileInfo::SPACE_NOT_COMPUTED

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -37,6 +37,7 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\ILockingStorage;
@@ -566,6 +567,14 @@ class Trashbin implements IEventListener {
 
 		$sourceNode = self::getNodeForPath($user, $sourcePath);
 		$targetNode = self::getNodeForPath($user, $targetPath, 'files');
+
+		$targetParent = $targetNode->getParent();
+
+		$free = $targetParent->getFreeSpace();
+		if ($free >= 0 && $free < $sourceNode->getSize(false)) {
+			throw new NotEnoughSpaceException('Not enough free space in ' . $targetParent->getPath() . ' to restore ' . $sourceNode->getPath());
+		}
+
 		$run = true;
 		$event = new BeforeNodeRestoredEvent($sourceNode, $targetNode, $run);
 		$dispatcher = Server::get(IEventDispatcher::class);

--- a/apps/files_trashbin/tests/Sabre/TrashbinPluginTest.php
+++ b/apps/files_trashbin/tests/Sabre/TrashbinPluginTest.php
@@ -9,12 +9,17 @@ declare(strict_types=1);
 namespace OCA\Files_Trashbin\Tests\Sabre;
 
 use OC\Files\FileInfo;
-use OC\Files\View;
 use OCA\Files_Trashbin\Sabre\ITrash;
 use OCA\Files_Trashbin\Sabre\RestoreFolder;
 use OCA\Files_Trashbin\Sabre\TrashbinPlugin;
 use OCA\Files_Trashbin\Trash\ITrashItem;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Storage\IStorage;
 use OCP\IPreview;
+use OCP\IUser;
 use Sabre\DAV\Server;
 use Sabre\DAV\Tree;
 use Test\TestCase;
@@ -34,6 +39,13 @@ class TrashbinPluginTest extends TestCase {
 		$fileInfo = $this->createMock(ITrashItem::class);
 		$fileInfo->method('getSize')
 			->willReturn($fileSize);
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')
+			->willReturn('test');
+		$fileInfo->method('getUser')
+			->willReturn($user);
+		$fileInfo->method('getOriginalLocation')
+			->willReturn('relative/original/location');
 
 		$trashNode = $this->createMock(ITrash::class);
 		$trashNode->method('getFileInfo')
@@ -46,11 +58,30 @@ class TrashbinPluginTest extends TestCase {
 
 		$previewManager = $this->createMock(IPreview::class);
 
-		$view = $this->createMock(View::class);
-		$view->method('free_space')
-			->willReturn($quota);
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getFullPath')
+			->with('relative/original') // the parent path
+			->willReturn('/full/path/to/original');
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->method('getUserFolder')
+			->willReturn($userFolder);
 
-		$plugin = new TrashbinPlugin($previewManager, $view);
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('free_space')
+			->with('path/to/original')
+			->willReturn($quota);
+		$mount = $this->createMock(IMountPoint::class);
+		$mount->method('getStorage')
+			->willReturn($storage);
+		$mount->method('getInternalPath')
+			->with('/full/path/to/original')
+			->willReturn('path/to/original');
+		$mountManager = $this->createMock(IMountManager::class);
+		$mountManager->method('find')
+			->with('/full/path/to/original')
+			->willReturn($mount);
+
+		$plugin = new TrashbinPlugin($previewManager, $rootFolder, $mountManager);
 		$plugin->initialize($this->server);
 
 		$sourcePath = 'trashbin/test/trash/file1';
@@ -60,11 +91,11 @@ class TrashbinPluginTest extends TestCase {
 
 	public static function quotaProvider(): array {
 		return [
-			[ 1024 * 1024, 512 * 1024, true ],
-			[ 512 * 1024, 513 * 1024, false ],
-			[ FileInfo::SPACE_NOT_COMPUTED, 1024 * 1024, true ],
-			[ FileInfo::SPACE_UNKNOWN, 1024 * 1024, true ],
-			[ FileInfo::SPACE_UNLIMITED, 1024 * 1024, true ]
+			[1024 * 1024, 512 * 1024, true],
+			[512 * 1024, 513 * 1024, false],
+			[FileInfo::SPACE_NOT_COMPUTED, 1024 * 1024, true],
+			[FileInfo::SPACE_UNKNOWN, 1024 * 1024, true],
+			[FileInfo::SPACE_UNLIMITED, 1024 * 1024, true]
 		];
 	}
 }

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1892,11 +1892,6 @@
       <code><![CDATA[INode]]></code>
     </MismatchingDocblockReturnType>
   </file>
-  <file src="apps/files_trashbin/lib/Sabre/TrashbinPlugin.php">
-    <InternalMethod>
-      <code><![CDATA[free_space]]></code>
-    </InternalMethod>
-  </file>
   <file src="apps/files_trashbin/lib/Storage.php">
     <DeprecatedMethod>
       <code><![CDATA[dispatch]]></code>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Ensure that restoring trashed files can't lead to going over quota

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
