### PR TITLE
fix: disable direct link if link shares are disabled

### DIFF
--- a/apps/dav/lib/Controller/DirectController.php
+++ b/apps/dav/lib/Controller/DirectController.php
@@ -26,6 +26,7 @@ use OCP\Files\IRootFolder;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\Security\ISecureRandom;
+use OCP\Share\IManager;
 
 class DirectController extends OCSController {
 
@@ -39,6 +40,7 @@ class DirectController extends OCSController {
 		private ITimeFactory $timeFactory,
 		private IURLGenerator $urlGenerator,
 		private IEventDispatcher $eventDispatcher,
+		private IManager $shareManager,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -57,6 +59,10 @@ class DirectController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function getUrl(int $fileId, int $expirationTime = 60 * 60 * 8): DataResponse {
+		if (!$this->shareManager->shareApiAllowLinks()) {
+			throw new OCSForbiddenException('Creating direct links is disabled');
+		}
+
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
 
 		$file = $userFolder->getFirstNodeById($fileId);

--- a/apps/dav/tests/unit/Controller/DirectControllerTest.php
+++ b/apps/dav/tests/unit/Controller/DirectControllerTest.php
@@ -14,6 +14,7 @@ use OCA\DAV\Db\Direct;
 use OCA\DAV\Db\DirectMapper;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -23,6 +24,7 @@ use OCP\Files\IRootFolder;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\Security\ISecureRandom;
+use OCP\Share\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -33,6 +35,7 @@ class DirectControllerTest extends TestCase {
 	private ITimeFactory&MockObject $timeFactory;
 	private IURLGenerator&MockObject $urlGenerator;
 	private IEventDispatcher&MockObject $eventDispatcher;
+	private IManager&MockObject $shareManager;
 
 	private DirectController $controller;
 
@@ -45,6 +48,7 @@ class DirectControllerTest extends TestCase {
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->shareManager = $this->createMock(IManager::class);
 
 		$this->controller = new DirectController(
 			'dav',
@@ -55,11 +59,15 @@ class DirectControllerTest extends TestCase {
 			$this->random,
 			$this->timeFactory,
 			$this->urlGenerator,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->shareManager,
 		);
 	}
 
 	public function testGetUrlNonExistingFileId(): void {
+		$this->shareManager->method('shareApiAllowLinks')
+			->willReturn(true);
+
 		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with('awesomeUser')
@@ -74,6 +82,9 @@ class DirectControllerTest extends TestCase {
 	}
 
 	public function testGetUrlForFolder(): void {
+		$this->shareManager->method('shareApiAllowLinks')
+			->willReturn(true);
+
 		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with('awesomeUser')
@@ -90,6 +101,9 @@ class DirectControllerTest extends TestCase {
 	}
 
 	public function testGetUrlValid(): void {
+		$this->shareManager->method('shareApiAllowLinks')
+			->willReturn(true);
+
 		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with('awesomeUser')
@@ -135,5 +149,24 @@ class DirectControllerTest extends TestCase {
 		$this->assertSame([
 			'url' => 'https://my.nextcloud/remote.php/direct/superduperlongtoken',
 		], $result->getData());
+	}
+
+	public function testGetUrlNoLinkShares(): void {
+		$this->shareManager->method('shareApiAllowLinks')
+			->willReturn(false);
+
+		$userFolder = $this->createMock(Folder::class);
+		$this->rootFolder->method('getUserFolder')
+			->with('awesomeUser')
+			->willReturn($userFolder);
+
+		$file = $this->createMock(File::class);
+
+		$userFolder->method('getFirstNodeById')
+			->with(101)
+			->willReturn($file);
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->controller->getUrl(101);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Makes the hardening configuration more consistent

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
