### PR TITLE
fix: require admin permissions for all systemtag updates

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagNode.php
+++ b/apps/dav/lib/SystemTag/SystemTagNode.php
@@ -101,18 +101,10 @@ class SystemTagNode implements \Sabre\DAV\ICollection {
 			if (!$this->tagManager->canUserSeeTag($this->tag, $this->user)) {
 				throw new NotFound('Tag with id ' . $this->tag->getId() . ' does not exist');
 			}
-			if (!$this->tagManager->canUserAssignTag($this->tag, $this->user)) {
-				throw new Forbidden('No permission to update tag ' . $this->tag->getId());
-			}
 
-			// only admin is able to change permissions, regular users can only rename
+			// only admin is able to update system tags
 			if (!$this->isAdmin) {
-				// only renaming is allowed for regular users
-				if ($userVisible !== $this->tag->isUserVisible()
-					|| $userAssignable !== $this->tag->isUserAssignable()
-				) {
-					throw new Forbidden('No permission to update permissions for tag ' . $this->tag->getId());
-				}
+				throw new Forbidden('No permission to update tag ' . $this->tag->getId());
 			}
 
 			// Make sure color is a proper hex

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -70,36 +70,43 @@ class SystemTagNodeTest extends \Test\TestCase {
 			[
 				true,
 				new SystemTag('1', 'Original', true, true),
-				['Renamed', true, true, null]
+				['Renamed', true, true, null],
+				true,
 			],
 			[
 				true,
 				new SystemTag('1', 'Original', true, true),
-				['Original', false, false, null]
+				['Original', false, false, null],
+				true,
 			],
 			// non-admin
 			[
-				// renaming allowed
+				// renaming not allowed
 				false,
 				new SystemTag('1', 'Original', true, true),
-				['Rename', true, true, '0082c9']
+				['Renamed', true, true, null],
+				false,
 			],
 		];
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'tagNodeProvider')]
-	public function testUpdateTag(bool $isAdmin, ISystemTag $originalTag, array $changedArgs): void {
-		$this->tagManager->expects($this->once())
-			->method('canUserSeeTag')
+	public function testUpdateTag(bool $isAdmin, ISystemTag $originalTag, $changedArgs, $allowed): void {
+		$this->tagManager->method('canUserSeeTag')
 			->with($originalTag)
 			->willReturn($originalTag->isUserVisible() || $isAdmin);
-		$this->tagManager->expects($this->once())
-			->method('canUserAssignTag')
+		$this->tagManager->method('canUserAssignTag')
 			->with($originalTag)
 			->willReturn($originalTag->isUserAssignable() || $isAdmin);
-		$this->tagManager->expects($this->once())
-			->method('updateTag')
-			->with(1, $changedArgs[0], $changedArgs[1], $changedArgs[2], $changedArgs[3]);
+		if ($allowed) {
+			$this->tagManager->expects($this->once())
+				->method('updateTag')
+				->with(1, $changedArgs[0], $changedArgs[1], $changedArgs[2], $changedArgs[3]);
+		} else {
+			$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
+			$this->tagManager->expects($this->never())
+				->method('updateTag');
+		}
 		$this->getTagNode($isAdmin, $originalTag)
 			->update($changedArgs[0], $changedArgs[1], $changedArgs[2], $changedArgs[3]);
 	}
@@ -186,7 +193,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('updateTag')
 			->with(1, 'Renamed', true, true)
 			->willThrowException(new TagAlreadyExistsException());
-		$this->getTagNode(false, $tag)->update('Renamed', true, true, null);
+		$this->getTagNode(true, $tag)->update('Renamed', true, true, null);
 	}
 
 	public function testUpdateTagNotFound(): void {
@@ -205,7 +212,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('updateTag')
 			->with(1, 'Renamed', true, true)
 			->willThrowException(new TagNotFoundException());
-		$this->getTagNode(false, $tag)->update('Renamed', true, true, null);
+		$this->getTagNode(true, $tag)->update('Renamed', true, true, null);
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'adminFlagProvider')]

--- a/build/integration/files_features/tags.feature
+++ b/build/integration/files_features/tags.feature
@@ -36,13 +36,13 @@ Feature: tags
     Then The response should have a status code "400"
     And "0" tags should exist for "user0"
 
-  Scenario: Renaming a normal tag as regular user should work
+  Scenario: Renaming a normal tag as regular user should fail
     Given user "user0" exists
     Given "admin" creates a "normal" tag with name "MySuperAwesomeTagName"
     When "user0" edits the tag with name "MySuperAwesomeTagName" and sets its name to "AnotherTagName"
-    Then The response should have a status code "207"
+    Then The response should have a status code "403"
     And The following tags should exist for "admin"
-      |AnotherTagName|true|true|
+      |MySuperAwesomeTagName|true|true|
 
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given user "user0" exists


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Previously, there was an exception that non-admins could rename tags they had access to, this removes that exception.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
