### PR TITLE
Hide personal settings of apps not enabled for the user

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -523,32 +523,32 @@ class AppManager implements IAppManager {
 			$settingsManager = Server::get(ISettingsManager::class);
 			if (!empty($info['settings']['admin'])) {
 				foreach ($info['settings']['admin'] as $setting) {
-					$settingsManager->registerSetting('admin', $setting);
+					$settingsManager->registerSetting('admin', $setting, $app);
 				}
 			}
 			if (!empty($info['settings']['admin-section'])) {
 				foreach ($info['settings']['admin-section'] as $section) {
-					$settingsManager->registerSection('admin', $section);
+					$settingsManager->registerSection('admin', $section, $app);
 				}
 			}
 			if (!empty($info['settings']['personal'])) {
 				foreach ($info['settings']['personal'] as $setting) {
-					$settingsManager->registerSetting('personal', $setting);
+					$settingsManager->registerSetting('personal', $setting, $app);
 				}
 			}
 			if (!empty($info['settings']['personal-section'])) {
 				foreach ($info['settings']['personal-section'] as $section) {
-					$settingsManager->registerSection('personal', $section);
+					$settingsManager->registerSection('personal', $section, $app);
 				}
 			}
 			if (!empty($info['settings']['admin-delegation'])) {
 				foreach ($info['settings']['admin-delegation'] as $setting) {
-					$settingsManager->registerSetting(ISettingsManager::SETTINGS_DELEGATION, $setting);
+					$settingsManager->registerSetting(ISettingsManager::SETTINGS_DELEGATION, $setting, $app);
 				}
 			}
 			if (!empty($info['settings']['admin-delegation-section'])) {
 				foreach ($info['settings']['admin-delegation-section'] as $section) {
-					$settingsManager->registerSection(ISettingsManager::SETTINGS_DELEGATION, $section);
+					$settingsManager->registerSection(ISettingsManager::SETTINGS_DELEGATION, $section, $app);
 				}
 			}
 		}

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -8,6 +8,7 @@
 namespace OC\Settings;
 
 use Closure;
+use OCP\App\IAppManager;
 use OCP\AppFramework\QueryException;
 use OCP\Group\ISubAdmin;
 use OCP\IGroupManager;
@@ -38,6 +39,9 @@ class Manager implements IManager {
 	/** @var array<self::SETTINGS_*, array<string, list<ISettings>>> */
 	protected array $settings = [];
 
+	/** @var array<class-string<ISettings|IIconSection>, string> App each class was registered by */
+	protected array $appIds = [];
+
 	public function __construct(
 		private LoggerInterface $log,
 		private IFactory $l10nFactory,
@@ -46,6 +50,7 @@ class Manager implements IManager {
 		private AuthorizedGroupMapper $mapper,
 		private IGroupManager $groupManager,
 		private ISubAdmin $subAdmin,
+		private IAppManager $appManager,
 	) {
 	}
 
@@ -53,12 +58,15 @@ class Manager implements IManager {
 	 * @inheritdoc
 	 */
 	#[\Override]
-	public function registerSection(string $type, string $section) {
+	public function registerSection(string $type, string $section, ?string $appId = null) {
 		if (!isset($this->sectionClasses[$type])) {
 			$this->sectionClasses[$type] = [];
 		}
 
 		$this->sectionClasses[$type][] = $section;
+		if ($appId !== null) {
+			$this->appIds[$section] = $appId;
+		}
 	}
 
 	/**
@@ -76,6 +84,11 @@ class Manager implements IManager {
 		}
 
 		foreach (array_unique($this->sectionClasses[$type]) as $index => $class) {
+			if ($type === self::SETTINGS_PERSONAL && !$this->isAvailableToCurrentUser($class)) {
+				unset($this->sectionClasses[$type][$index]);
+				continue;
+			}
+
 			try {
 				/** @var IIconSection $section */
 				$section = $this->container->get($class);
@@ -122,8 +135,28 @@ class Manager implements IManager {
 	 * @inheritdoc
 	 */
 	#[\Override]
-	public function registerSetting(string $type, string $setting) {
+	public function registerSetting(string $type, string $setting, ?string $appId = null) {
 		$this->settingClasses[$setting] = $type;
+		if ($appId !== null) {
+			$this->appIds[$setting] = $appId;
+		}
+	}
+
+	/**
+	 * Apps can be limited to some groups, but their settings are registered for
+	 * every user. So check the app of a setting or section is available to the
+	 * current user before showing it.
+	 *
+	 * @param class-string<ISettings|IIconSection> $class
+	 */
+	protected function isAvailableToCurrentUser(string $class): bool {
+		$appId = $this->appIds[$class] ?? null;
+		if ($appId === null) {
+			// Not registered by an app, e.g. a built-in setting.
+			return true;
+		}
+
+		return $this->appManager->isEnabledForUser($appId);
 	}
 
 	/**
@@ -142,6 +175,11 @@ class Manager implements IManager {
 
 			foreach ($this->settingClasses as $class => $settingsType) {
 				if ($type !== $settingsType) {
+					continue;
+				}
+
+				if ($type === self::SETTINGS_PERSONAL && !$this->isAvailableToCurrentUser($class)) {
+					unset($this->settingClasses[$class]);
 					continue;
 				}
 

--- a/lib/public/Settings/IManager.php
+++ b/lib/public/Settings/IManager.php
@@ -56,16 +56,20 @@ interface IManager {
 	/**
 	 * @psalm-param self::SETTINGS_* $type
 	 * @param class-string<IIconSection> $section
+	 * @param ?string $appId app the section belongs to, so personal sections of
+	 *                       apps not enabled for the user can be hidden (since 35.0.0)
 	 * @since 14.0.0
 	 */
-	public function registerSection(string $type, string $section);
+	public function registerSection(string $type, string $section, ?string $appId = null);
 
 	/**
 	 * @psalm-param self::SETTINGS_* $type
 	 * @param class-string<ISettings> $setting
+	 * @param ?string $appId app the setting belongs to, so personal settings of
+	 *                       apps not enabled for the user can be hidden (since 35.0.0)
 	 * @since 14.0.0
 	 */
-	public function registerSetting(string $type, string $setting);
+	public function registerSetting(string $type, string $setting, ?string $appId = null);
 
 	/**
 	 * returns a list of the admin sections

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -10,6 +10,7 @@ namespace OC\Settings\Tests\AppInfo;
 use OC\Settings\AuthorizedGroupMapper;
 use OC\Settings\Manager;
 use OCA\WorkflowEngine\Settings\Section;
+use OCP\App\IAppManager;
 use OCP\Group\ISubAdmin;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -32,6 +33,7 @@ class ManagerTest extends TestCase {
 	private AuthorizedGroupMapper&MockObject $mapper;
 	private IGroupManager&MockObject $groupManager;
 	private ISubAdmin&MockObject $subAdmin;
+	private IAppManager&MockObject $appManager;
 
 	private Manager $manager;
 
@@ -47,6 +49,7 @@ class ManagerTest extends TestCase {
 		$this->mapper = $this->createMock(AuthorizedGroupMapper::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->subAdmin = $this->createMock(ISubAdmin::class);
+		$this->appManager = $this->createMock(IAppManager::class);
 
 		$this->manager = new Manager(
 			$this->logger,
@@ -56,6 +59,7 @@ class ManagerTest extends TestCase {
 			$this->mapper,
 			$this->groupManager,
 			$this->subAdmin,
+			$this->appManager,
 		);
 	}
 
@@ -184,6 +188,70 @@ class ManagerTest extends TestCase {
 			16 => [$section],
 			100 => [$section2],
 		], $settings);
+	}
+
+	public function testGetPersonalSettingsHidesSettingsOfAppsNotEnabledForUser(): void {
+		$visible = $this->createMock(ISettings::class);
+		$visible->method('getPriority')
+			->willReturn(16);
+		$visible->method('getSection')
+			->willReturn('security');
+
+		$this->manager->registerSetting('personal', 'visibleClass', 'enabled_app');
+		$this->manager->registerSetting('personal', 'hiddenClass', 'restricted_app');
+
+		$this->appManager->method('isEnabledForUser')
+			->willReturnCallback(static fn (string $appId): bool => $appId === 'enabled_app');
+
+		// The settings of the app the user has no access to are never instantiated.
+		$this->container->expects($this->once())
+			->method('get')
+			->with('visibleClass')
+			->willReturn($visible);
+
+		$this->assertEquals([
+			16 => [$visible],
+		], $this->manager->getPersonalSettings('security'));
+	}
+
+	public function testGetPersonalSectionsHidesSectionsOfAppsNotEnabledForUser(): void {
+		$this->l10nFactory->method('get')
+			->with('lib')
+			->willReturn($this->l10n);
+		$this->l10n->method('t')
+			->willReturnArgument(0);
+
+		$this->manager->registerSection('personal', Section::class, 'restricted_app');
+
+		$this->appManager->method('isEnabledForUser')
+			->with('restricted_app')
+			->willReturn(false);
+
+		$this->container->expects($this->never())
+			->method('get');
+
+		$this->assertEquals([], $this->manager->getPersonalSections());
+	}
+
+	public function testGetAdminSettingsAreNotHiddenForAppsNotEnabledForUser(): void {
+		// Admins configure apps they are not a member of themselves.
+		$setting = $this->createMock(ISettings::class);
+		$setting->method('getPriority')
+			->willReturn(13);
+		$setting->method('getSection')
+			->willReturn('sharing');
+
+		$this->manager->registerSetting('admin', 'myAdminClass', 'restricted_app');
+
+		$this->appManager->expects($this->never())
+			->method('isEnabledForUser');
+		$this->container->method('get')
+			->with('myAdminClass')
+			->willReturn($setting);
+
+		$this->assertEquals([
+			13 => [$setting],
+		], $this->manager->getAdminSettings('sharing'));
 	}
 
 	public function testSameSectionAsPersonalAndAdmin(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/absence/issues/18

## Summary

This fixes the Absence app showing even when not enabled for user. Fix https://github.com/nextcloud/absence/issues/18

Initial PR at https://github.com/nextcloud/absence/pull/24 but it’s not a fix only for that specific app. Also as requested by @CarlSchwan 

Seems it needs backporting too as it would fix it on 34.


## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
