### PR TITLE
feat(api): Add getOrCreateFolder also for SimpleFS module

### DIFF
--- a/lib/private/Files/SimpleFS/SimpleFolder.php
+++ b/lib/private/Files/SimpleFS/SimpleFolder.php
@@ -89,4 +89,11 @@ class SimpleFolder implements ISimpleFolder {
 		$folder = $this->folder->newFolder($path);
 		return new SimpleFolder($folder);
 	}
+
+	#[\Override]
+	public function getOrCreateFolder(string $path, int $maxRetries = 5): ISimpleFolder {
+		$folder = $this->folder->getOrCreateFolder($path, $maxRetries);
+		return new SimpleFolder($folder);
+	}
+
 }

--- a/lib/public/Files/SimpleFS/ISimpleFolder.php
+++ b/lib/public/Files/SimpleFS/ISimpleFolder.php
@@ -81,4 +81,13 @@ interface ISimpleFolder {
 	 * @since 25.0.0
 	 */
 	public function newFolder(string $path): ISimpleFolder;
+
+	/**
+	 * Get or create new folder if the folder does not already exist.
+	 *
+	 * @param string $path relative path of the file or folder
+	 * @throw NotPermittedException
+	 * @since 35.0.0
+	 */
+	public function getOrCreateFolder(string $path, int $maxRetries = 5): ISimpleFolder;
 }


### PR DESCRIPTION
## Summary

Saw that this was missing when reviewing https://github.com/nextcloud/server/pull/62355

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
