### PR TITLE
fix(wordings): Shorter labels for the share action buttons (to avoid longer words being truncated in languages other than English)

### DIFF
--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -271,7 +271,6 @@
 				<div class="sharingTabDetailsView__delete">
 					<NcButton
 						v-if="!isNewShare"
-						:aria-label="t('files_sharing', 'Delete share')"
 						:disabled="false"
 						:readonly="false"
 						variant="tertiary"
@@ -279,7 +278,8 @@
 						<template #icon>
 							<CloseIcon :size="20" />
 						</template>
-						{{ t('files_sharing', 'Delete share') }}
+						<!-- TRANSLATORS: Button to delete the share -->
+						{{ t('files_sharing', 'Delete') }}
 					</NcButton>
 				</div>
 				<NcButton
@@ -434,9 +434,9 @@ export default {
 				default: {
 					if (this.share.id) {
 					// Share already exists
-						return t('files_sharing', 'Update share')
+						return t('files_sharing', 'Update') /** TRANSLATORS: Button to update share (apply changes) **/
 					} else {
-						return t('files_sharing', 'Create share')
+						return t('files_sharing', 'Create') /** TRANSLATORS: Button to create new share **/
 					}
 				}
 			}
@@ -627,9 +627,9 @@ export default {
 
 		shareButtonText() {
 			if (this.isNewShare) {
-				return t('files_sharing', 'Save share')
+				return t('files_sharing', 'Save') /** TRANSLATORS: Button to save new share **/
 			}
-			return t('files_sharing', 'Update share')
+			return t('files_sharing', 'Update') /** TRANSLATORS: Button to update share (apply changes) **/
 		},
 
 		resharingIsPossible() {


### PR DESCRIPTION
⚠️ Important : not tested (no test environment)

Current problem in French (many other languages may have the same issue) : 
- buttons are very large
- some texts are truncated (ellipsis)

<img width="508" height="61" alt="2026-08-04_13-52" src="https://github.com/user-attachments/assets/bea7d295-e372-4ee8-84e4-e0af5f66a145" />

I suggest using only action verbs (one word per button) so that the information is clear and easy to read, and so that the interface isn't cluttered with buttons that are too large.