### PR TITLE
Remove most usage of query exception

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1812,23 +1812,6 @@ class ShareAPIController extends OCSController {
 	}
 
 	/**
-	 * Returns the helper of ShareAPIHelper for sciencemesh shares.
-	 *
-	 * If the sciencemesh application is not enabled or the helper is not available
-	 * a ContainerExceptionInterface is thrown instead.
-	 *
-	 * @return ShareAPIHelper
-	 * @throws ContainerExceptionInterface
-	 */
-	private function getSciencemeshShareHelper() {
-		if (!$this->appManager->isEnabledForUser('sciencemesh')) {
-			throw new QueryException();
-		}
-
-		return $this->serverContainer->get('\OCA\ScienceMesh\Sharing\ShareAPIHelper');
-	}
-
-	/**
 	 * @param string $viewer
 	 * @param Node $node
 	 * @param bool $reShares

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -12,7 +12,6 @@ use OCA\WorkflowEngine\Entity\File;
 use OCA\WorkflowEngine\Helper\ScopeContext;
 use OCA\WorkflowEngine\Manager;
 use OCP\App\IAppManager;
-use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -37,6 +36,7 @@ use OCP\WorkflowEngine\IOperation;
 use OCP\WorkflowEngine\IRuleMatcher;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -327,7 +327,7 @@ class ManagerTest extends TestCase {
 					case 'OCA\WFE\TestOp':
 						return $operation;
 					case 'OCA\WFE\OtherTestOp':
-						throw new QueryException();
+						throw $this->createMock(ContainerExceptionInterface::class);
 				}
 			});
 

--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -15,7 +15,6 @@ use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootstrap;
-use OCP\AppFramework\QueryException;
 use OCP\Dashboard\IManager;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -166,7 +165,7 @@ class Coordinator {
 				$context = new BootContext($application->getContainer());
 				$application->boot($context);
 			}
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface $e) {
 			$this->logger->error("Could not boot $appId: " . $e->getMessage(), [
 				'exception' => $e,
 			]);

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -66,6 +66,7 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Security\Ip\IRemoteAddress;
 use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -342,12 +343,12 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		try {
 			return $this->queryNoFallback($name, $chain);
-		} catch (QueryException $firstException) {
+		} catch (ContainerExceptionInterface $firstException) {
 			try {
 				/** @var ServerContainer $server */
 				$server = $this->getServer();
 				return $server->query($name, $autoload, $chain);
-			} catch (QueryException $secondException) {
+			} catch (ContainerExceptionInterface $secondException) {
 				if ($firstException->getCode() === 1) {
 					throw $secondException;
 				}
@@ -360,7 +361,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 * @param string $name
 	 * @param list<class-string> $chain
 	 * @return mixed
-	 * @throws QueryException if the query could not be resolved
+	 * @throws ContainerExceptionInterface if the query could not be resolved
 	 */
 	public function queryNoFallback($name, array $chain) {
 		$name = $this->sanitizeName($name);

--- a/lib/private/Authentication/TwoFactorAuth/ProviderLoader.php
+++ b/lib/private/Authentication/TwoFactorAuth/ProviderLoader.php
@@ -12,10 +12,10 @@ namespace OC\Authentication\TwoFactorAuth;
 use Exception;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OCP\App\IAppManager;
-use OCP\AppFramework\QueryException;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\IUser;
 use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
 
 class ProviderLoader {
 	public const BACKUP_CODES_APP_ID = 'twofactor_backupcodes';
@@ -50,7 +50,7 @@ class ProviderLoader {
 						$this->loadTwoFactorApp($appId);
 						$provider = Server::get($class);
 						$providers[$provider->getId()] = $provider;
-					} catch (QueryException $exc) {
+					} catch (ContainerExceptionInterface $exc) {
 						// Provider class can not be resolved
 						throw new Exception("Could not load two-factor auth provider $class");
 					}
@@ -64,7 +64,7 @@ class ProviderLoader {
 				$this->loadTwoFactorApp($provider->getAppId());
 				$providerInstance = Server::get($provider->getService());
 				$providers[$providerInstance->getId()] = $providerInstance;
-			} catch (QueryException $exc) {
+			} catch (ContainerExceptionInterface $exc) {
 				// Provider class can not be resolved
 				throw new Exception('Could not load two-factor auth provider ' . $provider->getService());
 			}

--- a/lib/private/Calendar/Resource/Manager.php
+++ b/lib/private/Calendar/Resource/Manager.php
@@ -11,9 +11,9 @@ namespace OC\Calendar\Resource;
 
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Calendar\ResourcesRoomsUpdater;
-use OCP\AppFramework\QueryException;
 use OCP\Calendar\Resource\IBackend;
 use OCP\Calendar\Resource\IManager;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 
 class Manager implements IManager {
@@ -73,7 +73,7 @@ class Manager implements IManager {
 
 	/**
 	 * @return IBackend[]
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 * @since 14.0.0
 	 */
 	#[\Override]
@@ -93,7 +93,7 @@ class Manager implements IManager {
 
 	/**
 	 * @param string $backendId
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	#[\Override]
 	public function getBackend($backendId): ?IBackend {

--- a/lib/private/Calendar/Room/Manager.php
+++ b/lib/private/Calendar/Room/Manager.php
@@ -11,9 +11,9 @@ namespace OC\Calendar\Room;
 
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Calendar\ResourcesRoomsUpdater;
-use OCP\AppFramework\QueryException;
 use OCP\Calendar\Room\IBackend;
 use OCP\Calendar\Room\IManager;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 
 class Manager implements IManager {
@@ -74,7 +74,7 @@ class Manager implements IManager {
 
 	/**
 	 * @return IBackend[]
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 * @since 14.0.0
 	 */
 	#[\Override]
@@ -100,7 +100,7 @@ class Manager implements IManager {
 
 	/**
 	 * @param string $backendId
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	#[\Override]
 	public function getBackend($backendId): ?IBackend {

--- a/lib/private/CapabilitiesManager.php
+++ b/lib/private/CapabilitiesManager.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace OC;
 
-use OCP\AppFramework\QueryException;
 use OCP\Capabilities\ICapability;
 use OCP\Capabilities\IInitialStateExcludedCapability;
 use OCP\Capabilities\IPublicCapability;
 use OCP\ILogger;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 
 class CapabilitiesManager {
@@ -44,7 +44,7 @@ class CapabilitiesManager {
 		foreach ($this->capabilities as $capability) {
 			try {
 				$c = $capability();
-			} catch (QueryException $e) {
+			} catch (ContainerExceptionInterface $e) {
 				$this->logger->error('CapabilitiesManager', [
 					'exception' => $e,
 				]);

--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -7,13 +7,13 @@
 
 namespace OC\Collaboration\Collaborators;
 
-use OCP\AppFramework\QueryException;
 use OCP\Collaboration\Collaborators\ISearch;
 use OCP\Collaboration\Collaborators\ISearchPlugin;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
 use OCP\IContainer;
 use OCP\Share\IShare;
+use Psr\Container\ContainerExceptionInterface;
 
 class Search implements ISearch {
 	protected array $pluginList = [];
@@ -28,7 +28,7 @@ class Search implements ISearch {
 	 * @param bool $lookup
 	 * @param int|null $limit
 	 * @param int|null $offset
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	#[\Override]
 	public function search($search, array $shareTypes, $lookup, $limit, $offset): array {

--- a/lib/private/Collaboration/Resources/ProviderManager.php
+++ b/lib/private/Collaboration/Resources/ProviderManager.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 
 namespace OC\Collaboration\Resources;
 
-use OCP\AppFramework\QueryException;
 use OCP\Collaboration\Resources\IProvider;
 use OCP\Collaboration\Resources\IProviderManager;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -34,7 +34,7 @@ class ProviderManager implements IProviderManager {
 			foreach ($this->providers as $provider) {
 				try {
 					$this->providerInstances[] = $this->serverContainer->get($provider);
-				} catch (QueryException $e) {
+				} catch (ContainerExceptionInterface $e) {
 					$this->logger->error("Could not query resource provider $provider: " . $e->getMessage(), [
 						'exception' => $e,
 					]);

--- a/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
+++ b/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
@@ -14,10 +14,10 @@ use OC\App\AppManager;
 use OC\Contacts\ContactsMenu\Providers\EMailProvider;
 use OC\Contacts\ContactsMenu\Providers\LocalTimeProvider;
 use OC\Contacts\ContactsMenu\Providers\ProfileProvider;
-use OCP\AppFramework\QueryException;
 use OCP\Contacts\ContactsMenu\IBulkProvider;
 use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IUser;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -50,7 +50,7 @@ class ActionProviderStore {
 						'class' => $class,
 					]);
 				}
-			} catch (QueryException $ex) {
+			} catch (ContainerExceptionInterface $ex) {
 				$this->logger->error(
 					'Could not load contacts menu action provider ' . $class,
 					[

--- a/lib/private/EventDispatcher/ServiceEventListener.php
+++ b/lib/private/EventDispatcher/ServiceEventListener.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 
 namespace OC\EventDispatcher;
 
-use OCP\AppFramework\QueryException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use function sprintf;
@@ -39,7 +39,7 @@ final class ServiceEventListener {
 				//       parameters and aliases won't be resolved.
 				//       See https://github.com/nextcloud/server/issues/27793 for details.
 				$this->service = $this->container->get($this->class);
-			} catch (QueryException $e) {
+			} catch (ContainerExceptionInterface $e) {
 				$this->logger->error(
 					sprintf(
 						'Could not load event listener service %s: %s. Make sure the class is auto-loadable by the Nextcloud server container',

--- a/lib/private/Http/WellKnown/RequestManager.php
+++ b/lib/private/Http/WellKnown/RequestManager.php
@@ -11,12 +11,12 @@ namespace OC\Http\WellKnown;
 
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\AppFramework\Bootstrap\ServiceRegistration;
-use OCP\AppFramework\QueryException;
 use OCP\Http\WellKnown\IHandler;
 use OCP\Http\WellKnown\IRequestContext;
 use OCP\Http\WellKnown\IResponse;
 use OCP\Http\WellKnown\JrdResponse;
 use OCP\IRequest;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -85,7 +85,7 @@ class RequestManager {
 					}
 
 					return $handler;
-				} catch (QueryException $e) {
+				} catch (ContainerExceptionInterface $e) {
 					$this->logger->error("Could not load well known handler $class", [
 						'exception' => $e,
 						'app' => $registration->getAppId(),

--- a/lib/private/InitialStateService.php
+++ b/lib/private/InitialStateService.php
@@ -11,9 +11,9 @@ namespace OC;
 
 use Closure;
 use OC\AppFramework\Bootstrap\Coordinator;
-use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Services\InitialStateProvider;
 use OCP\IInitialStateService;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -94,8 +94,8 @@ class InitialStateService implements IInitialStateService {
 		$initialStates = $context->getInitialStates();
 		foreach ($initialStates as $initialState) {
 			try {
-				$provider = $this->container->query($initialState->getService());
-			} catch (QueryException $e) {
+				$provider = $this->container->get($initialState->getService());
+			} catch (ContainerExceptionInterface $e) {
 				// Log an continue. We can be fault tolerant here.
 				$this->logger->error('Could not load initial state provider dynamically: ' . $e->getMessage(), [
 					'exception' => $e,

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -13,6 +13,7 @@ use OC\AppFramework\App;
 use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\Utility\SimpleContainer;
 use OCP\AppFramework\QueryException;
+use Psr\Container\ContainerExceptionInterface;
 use function explode;
 use function strtolower;
 
@@ -60,7 +61,7 @@ class ServerContainer extends SimpleContainer {
 	/**
 	 * @param string $appName
 	 * @return DIContainer
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	public function getRegisteredAppContainer(string $appName): DIContainer {
 		if (isset($this->appContainers[strtolower(App::buildAppNamespace($appName))])) {
@@ -74,7 +75,7 @@ class ServerContainer extends SimpleContainer {
 	 * @param string $namespace
 	 * @param string $sensitiveNamespace
 	 * @return DIContainer
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	protected function getAppContainer(string $sensitiveNamespace): DIContainer {
 		$namespace = strtolower($sensitiveNamespace);
@@ -119,7 +120,7 @@ class ServerContainer extends SimpleContainer {
 	 * @psalm-template S as class-string<T>|string
 	 * @psalm-param S $name
 	 * @psalm-return (S is class-string<T> ? T : mixed)
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 */
 	#[\Override]
@@ -130,7 +131,7 @@ class ServerContainer extends SimpleContainer {
 			// Skip server container query for app namespace classes
 			try {
 				return parent::query($name, false, $chain);
-			} catch (QueryException $e) {
+			} catch (ContainerExceptionInterface $e) {
 				// Continue with general autoloading then
 			}
 			// In case the service starts with OCA\ we try to find the service in
@@ -138,7 +139,7 @@ class ServerContainer extends SimpleContainer {
 			if (($appContainer = $this->getAppContainerForService($name)) !== null) {
 				try {
 					return $appContainer->queryNoFallback($name, $chain);
-				} catch (QueryException $e) {
+				} catch (ContainerExceptionInterface $e) {
 					// Didn't find the service or the respective app container
 					// In this case the service won't be part of the core container,
 					// so we can throw directly
@@ -163,7 +164,7 @@ class ServerContainer extends SimpleContainer {
 		try {
 			[,$namespace,] = explode('\\', $id, 3);
 			return $this->getAppContainer('OCA\\' . $namespace);
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface $e) {
 			return null;
 		}
 	}

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -9,7 +9,6 @@ namespace OC\Settings;
 
 use Closure;
 use OCP\App\IAppManager;
-use OCP\AppFramework\QueryException;
 use OCP\Group\ISubAdmin;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -21,6 +20,7 @@ use OCP\Settings\IIconSection;
 use OCP\Settings\IManager;
 use OCP\Settings\ISettings;
 use OCP\Settings\ISubAdminSettings;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -92,7 +92,7 @@ class Manager implements IManager {
 			try {
 				/** @var IIconSection $section */
 				$section = $this->container->get($class);
-			} catch (QueryException $e) {
+			} catch (ContainerExceptionInterface $e) {
 				$this->log->info($e->getMessage(), ['exception' => $e]);
 				continue;
 			}
@@ -186,7 +186,7 @@ class Manager implements IManager {
 				try {
 					/** @var ISettings $setting */
 					$setting = $this->container->get($class);
-				} catch (QueryException $e) {
+				} catch (ContainerExceptionInterface $e) {
 					$this->log->info($e->getMessage(), ['exception' => $e]);
 					continue;
 				}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -31,7 +31,6 @@ use OC\TextProcessing\RemoveOldTasksBackgroundJob;
 use OC\User\BackgroundJobs\CleanupDeletedUsers;
 use OC\User\BackgroundJobs\CleanupLoginTokens;
 use OC\User\Session;
-use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\Defaults;
@@ -54,6 +53,7 @@ use OCP\Security\ISecureRandom;
 use OCP\Server;
 use OCP\ServerVersion;
 use OCP\Util;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 
 class Setup {
@@ -571,7 +571,7 @@ class Setup {
 	/**
 	 * Append the correct ErrorDocument path for Apache hosts
 	 *
-	 * @throws QueryException
+	 * @throws ContainerExceptionInterface
 	 */
 	public static function updateHtaccess(): bool {
 		$config = Server::get(SystemConfig::class);

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace OC\Support\CrashReport;
 
 use Exception;
-use OCP\AppFramework\QueryException;
 use OCP\Server;
 use OCP\Support\CrashReport\ICollectBreadcrumbs;
 use OCP\Support\CrashReport\IMessageReporter;
 use OCP\Support\CrashReport\IRegistry;
 use OCP\Support\CrashReport\IReporter;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use function array_shift;
@@ -90,7 +90,7 @@ class Registry implements IRegistry {
 			try {
 				/** @var IReporter $reporter */
 				$reporter = Server::get($class);
-			} catch (QueryException $e) {
+			} catch (ContainerExceptionInterface $e) {
 				/*
 				 * There is a circular dependency between the logger and the registry, so
 				 * we can not inject it. Thus the static call.

--- a/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
+++ b/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
@@ -17,11 +17,11 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\QueryException;
 use OCP\Dashboard\IManager;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -69,7 +69,7 @@ class CoordinatorTest extends TestCase {
 		$this->serverContainer->expects($this->once())
 			->method('get')
 			->with(Application::class)
-			->willThrowException(new QueryException(''));
+			->willThrowException($this->createMock(ContainerExceptionInterface::class));
 		$this->logger->expects($this->once())
 			->method('error');
 

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -17,10 +17,10 @@ use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OCP\AppFramework\Middleware;
-use OCP\AppFramework\QueryException;
 use OCP\IConfig;
 use OCP\IRequestId;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerExceptionInterface;
 
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class DIContainerTest extends \Test\TestCase {
@@ -137,7 +137,7 @@ class DIContainerTest extends \Test\TestCase {
 	}
 
 	public function testInvalidAppClass(): void {
-		$this->expectException(QueryException::class);
-		$this->container->query('\OCA\Name\Foo');
+		$this->expectException(ContainerExceptionInterface::class);
+		$this->container->get('\OCA\Name\Foo');
 	}
 }

--- a/tests/lib/AppFramework/Utility/SimpleContainerTest.php
+++ b/tests/lib/AppFramework/Utility/SimpleContainerTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace Test\AppFramework\Utility;
 
 use OC\AppFramework\Utility\SimpleContainer;
-use OCP\AppFramework\QueryException;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
 interface TestInterface {
@@ -70,55 +70,55 @@ class SimpleContainerTest extends \Test\TestCase {
 
 	public function testRegister(): void {
 		$this->container->registerParameter('test', 'abc');
-		$this->assertEquals('abc', $this->container->query('test'));
+		$this->assertEquals('abc', $this->container->get('test'));
 	}
 
 	/**
-	 * Test querying a class that is not registered without autoload enabled
+	 * Test geting a class that is not registered without autoload enabled
 	 */
 	public function testNothingRegistered(): void {
 		try {
-			$this->container->query('something really hard', false);
+			$this->container->get('something really hard', false);
 			$this->fail('Expected `QueryException` exception was not thrown');
 		} catch (\Throwable $exception) {
-			$this->assertInstanceOf(QueryException::class, $exception);
+			$this->assertInstanceOf(ContainerExceptionInterface::class, $exception);
 			$this->assertInstanceOf(NotFoundExceptionInterface::class, $exception);
 		}
 	}
 
 	/**
-	 * Test querying a class that is not registered with autoload enabled
+	 * Test geting a class that is not registered with autoload enabled
 	 */
 	public function testNothingRegistered_autoload(): void {
 		try {
-			$this->container->query('something really hard');
+			$this->container->get('something really hard');
 			$this->fail('Expected `QueryException` exception was not thrown');
 		} catch (\Throwable $exception) {
-			$this->assertInstanceOf(QueryException::class, $exception);
+			$this->assertInstanceOf(ContainerExceptionInterface::class, $exception);
 			$this->assertInstanceOf(NotFoundExceptionInterface::class, $exception);
 		}
 	}
 
 	public function testNotAClass(): void {
-		$this->expectException(QueryException::class);
+		$this->expectException(ContainerExceptionInterface::class);
 
-		$this->container->query('Test\AppFramework\Utility\TestInterface');
+		$this->container->get('Test\AppFramework\Utility\TestInterface');
 	}
 
 	public function testNoConstructorClass(): void {
-		$object = $this->container->query('Test\AppFramework\Utility\ClassEmptyConstructor');
+		$object = $this->container->get('Test\AppFramework\Utility\ClassEmptyConstructor');
 		$this->assertTrue($object instanceof ClassEmptyConstructor);
 	}
 
 	public function testInstancesOnlyOnce(): void {
-		$object = $this->container->query('Test\AppFramework\Utility\ClassEmptyConstructor');
-		$object2 = $this->container->query('Test\AppFramework\Utility\ClassEmptyConstructor');
+		$object = $this->container->get('Test\AppFramework\Utility\ClassEmptyConstructor');
+		$object2 = $this->container->get('Test\AppFramework\Utility\ClassEmptyConstructor');
 		$this->assertSame($object, $object2);
 	}
 
 	public function testConstructorSimple(): void {
 		$this->container->registerParameter('test', 'abc');
-		$object = $this->container->query(
+		$object = $this->container->get(
 			'Test\AppFramework\Utility\ClassSimpleConstructor'
 		);
 		$this->assertTrue($object instanceof ClassSimpleConstructor);
@@ -127,7 +127,7 @@ class SimpleContainerTest extends \Test\TestCase {
 
 	public function testConstructorComplex(): void {
 		$this->container->registerParameter('test', 'abc');
-		$object = $this->container->query(
+		$object = $this->container->get(
 			'Test\AppFramework\Utility\ClassComplexConstructor'
 		);
 		$this->assertTrue($object instanceof ClassComplexConstructor);
@@ -139,9 +139,9 @@ class SimpleContainerTest extends \Test\TestCase {
 		$this->container->registerParameter('test', 'abc');
 		$this->container->registerService(
 			'Test\AppFramework\Utility\IInterfaceConstructor', function ($c) {
-				return $c->query('Test\AppFramework\Utility\ClassSimpleConstructor');
+				return $c->get('Test\AppFramework\Utility\ClassSimpleConstructor');
 			});
-		$object = $this->container->query(
+		$object = $this->container->get(
 			'Test\AppFramework\Utility\ClassInterfaceConstructor'
 		);
 		$this->assertTrue($object instanceof ClassInterfaceConstructor);
@@ -152,13 +152,13 @@ class SimpleContainerTest extends \Test\TestCase {
 	public function testOverrideService(): void {
 		$this->container->registerService(
 			'Test\AppFramework\Utility\IInterfaceConstructor', function ($c) {
-				return $c->query('Test\AppFramework\Utility\ClassSimpleConstructor');
+				return $c->get('Test\AppFramework\Utility\ClassSimpleConstructor');
 			});
 		$this->container->registerService(
 			'Test\AppFramework\Utility\IInterfaceConstructor', function ($c) {
-				return $c->query('Test\AppFramework\Utility\ClassEmptyConstructor');
+				return $c->get('Test\AppFramework\Utility\ClassEmptyConstructor');
 			});
-		$object = $this->container->query(
+		$object = $this->container->get(
 			'Test\AppFramework\Utility\IInterfaceConstructor'
 		);
 		$this->assertTrue($object instanceof ClassEmptyConstructor);
@@ -167,7 +167,7 @@ class SimpleContainerTest extends \Test\TestCase {
 	public function testRegisterAliasParamter(): void {
 		$this->container->registerParameter('test', 'abc');
 		$this->container->registerAlias('test1', 'test');
-		$this->assertEquals('abc', $this->container->query('test1'));
+		$this->assertEquals('abc', $this->container->get('test1'));
 	}
 
 	public function testRegisterAliasService(): void {
@@ -176,11 +176,11 @@ class SimpleContainerTest extends \Test\TestCase {
 		}, true);
 		$this->container->registerAlias('test1', 'test');
 		$this->assertSame(
-			$this->container->query('test'), $this->container->query('test'));
+			$this->container->get('test'), $this->container->get('test'));
 		$this->assertSame(
-			$this->container->query('test1'), $this->container->query('test1'));
+			$this->container->get('test1'), $this->container->get('test1'));
 		$this->assertSame(
-			$this->container->query('test'), $this->container->query('test1'));
+			$this->container->get('test'), $this->container->get('test1'));
 	}
 
 	public static function sanitizeNameProvider(): array {
@@ -193,17 +193,17 @@ class SimpleContainerTest extends \Test\TestCase {
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('sanitizeNameProvider')]
-	public function testSanitizeName($register, $query): void {
+	public function testSanitizeName($register, $get): void {
 		$this->container->registerService($register, function () {
 			return 'abc';
 		});
-		$this->assertEquals('abc', $this->container->query($query));
+		$this->assertEquals('abc', $this->container->get($get));
 	}
 
 	public function testConstructorComplexNoTestParameterFound(): void {
-		$this->expectException(QueryException::class);
+		$this->expectException(ContainerExceptionInterface::class);
 
-		$object = $this->container->query(
+		$object = $this->container->get(
 			'Test\AppFramework\Utility\ClassComplexConstructor'
 		);
 		/* Use the object to trigger DI on PHP >= 8.4 */
@@ -215,7 +215,7 @@ class SimpleContainerTest extends \Test\TestCase {
 			return new \StdClass();
 		}, false);
 		$this->assertNotSame(
-			$this->container->query('test'), $this->container->query('test'));
+			$this->container->get('test'), $this->container->get('test'));
 	}
 
 	public function testRegisterAliasFactory(): void {
@@ -224,17 +224,17 @@ class SimpleContainerTest extends \Test\TestCase {
 		}, false);
 		$this->container->registerAlias('test1', 'test');
 		$this->assertNotSame(
-			$this->container->query('test'), $this->container->query('test'));
+			$this->container->get('test'), $this->container->get('test'));
 		$this->assertNotSame(
-			$this->container->query('test1'), $this->container->query('test1'));
+			$this->container->get('test1'), $this->container->get('test1'));
 		$this->assertNotSame(
-			$this->container->query('test'), $this->container->query('test1'));
+			$this->container->get('test'), $this->container->get('test1'));
 	}
 
 	public function testQueryUntypedNullable(): void {
-		$this->expectException(QueryException::class);
+		$this->expectException(ContainerExceptionInterface::class);
 
-		$object = $this->container->query(
+		$object = $this->container->get(
 			ClassNullableUntypedConstructorArg::class
 		);
 		/* Use the object to trigger DI on PHP >= 8.4 */
@@ -243,7 +243,7 @@ class SimpleContainerTest extends \Test\TestCase {
 
 	public function testQueryTypedNullable(): void {
 		/** @var ClassNullableTypedConstructorArg $service */
-		$service = $this->container->query(ClassNullableTypedConstructorArg::class);
+		$service = $this->container->get(ClassNullableTypedConstructorArg::class);
 
 		self::assertNull($service->class);
 	}

--- a/tests/lib/CapabilitiesManagerTest.php
+++ b/tests/lib/CapabilitiesManagerTest.php
@@ -9,9 +9,9 @@
 namespace Test;
 
 use OC\CapabilitiesManager;
-use OCP\AppFramework\QueryException;
 use OCP\Capabilities\ICapability;
 use OCP\Capabilities\IPublicCapability;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 
 class CapabilitiesManagerTest extends TestCase {
@@ -132,7 +132,7 @@ class CapabilitiesManagerTest extends TestCase {
 
 	public function testInvalidCapability(): void {
 		$this->manager->registerCapability(function (): void {
-			throw new QueryException();
+			throw $this->createMock(ContainerExceptionInterface::class);
 		});
 
 		$this->logger->expects($this->once())

--- a/tests/lib/Collaboration/Resources/ProviderManagerTest.php
+++ b/tests/lib/Collaboration/Resources/ProviderManagerTest.php
@@ -10,8 +10,8 @@ namespace Test\Collaboration\Resources;
 
 use OC\Collaboration\Resources\ProviderManager;
 use OCA\Files\Collaboration\Resources\ResourceProvider;
-use OCP\AppFramework\QueryException;
 use OCP\Collaboration\Resources\IProviderManager;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -64,7 +64,7 @@ class ProviderManagerTest extends TestCase {
 		$this->serverContainer->expects($this->once())
 			->method('get')
 			->with($this->equalTo('InvalidResourceProvider'))
-			->willThrowException(new QueryException('A meaningful error message'));
+			->willThrowException($this->createMock(ContainerExceptionInterface::class));
 
 		$this->logger->expects($this->once())
 			->method('error');
@@ -80,7 +80,7 @@ class ProviderManagerTest extends TestCase {
 			->method('get')
 			->willReturnCallback(function (string $service) {
 				if ($service === 'InvalidResourceProvider') {
-					throw new QueryException('A meaningful error message');
+					throw $this->createMock(ContainerExceptionInterface::class);
 				}
 				if ($service === ResourceProvider::class) {
 					return $this->createMock(ResourceProvider::class);

--- a/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
@@ -13,10 +13,10 @@ use OC\Contacts\ContactsMenu\Providers\EMailProvider;
 use OC\Contacts\ContactsMenu\Providers\LocalTimeProvider;
 use OC\Contacts\ContactsMenu\Providers\ProfileProvider;
 use OCP\App\IAppManager;
-use OCP\AppFramework\QueryException;
 use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -113,7 +113,7 @@ class ActionProviderStoreTest extends TestCase {
 			->willReturn([]);
 		$this->serverContainer->expects($this->once())
 			->method('get')
-			->willThrowException(new QueryException());
+			->willThrowException($this->createMock(ContainerExceptionInterface::class));
 
 		$this->actionProviderStore->getProviders($user);
 	}

--- a/tests/lib/Http/WellKnown/RequestManagerTest.php
+++ b/tests/lib/Http/WellKnown/RequestManagerTest.php
@@ -13,13 +13,13 @@ use OC\AppFramework\Bootstrap\Coordinator;
 use OC\AppFramework\Bootstrap\RegistrationContext;
 use OC\AppFramework\Bootstrap\ServiceRegistration;
 use OC\Http\WellKnown\RequestManager;
-use OCP\AppFramework\QueryException;
 use OCP\Http\WellKnown\IHandler;
 use OCP\Http\WellKnown\IRequestContext;
 use OCP\Http\WellKnown\IResponse;
 use OCP\Http\WellKnown\JrdResponse;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -85,7 +85,7 @@ class RequestManagerTest extends TestCase {
 		$this->container->expects(self::once())
 			->method('get')
 			->with(get_class($handler))
-			->willThrowException(new QueryException(''));
+			->willThrowException($this->createMock(ContainerExceptionInterface::class));
 		$this->logger->expects(self::once())
 			->method('error');
 

--- a/tests/lib/Talk/BrokerTest.php
+++ b/tests/lib/Talk/BrokerTest.php
@@ -13,10 +13,10 @@ use OC\AppFramework\Bootstrap\Coordinator;
 use OC\AppFramework\Bootstrap\RegistrationContext;
 use OC\AppFramework\Bootstrap\ServiceRegistration;
 use OC\Talk\Broker;
-use OCP\AppFramework\QueryException;
 use OCP\Talk\IConversationOptions;
 use OCP\Talk\ITalkBackend;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -73,7 +73,7 @@ class BrokerTest extends TestCase {
 			->willReturn(new ServiceRegistration('spreed', $fakeTalkServiceClass));
 		$this->container->expects($this->once())
 			->method('get')
-			->willThrowException(new QueryException());
+			->willThrowException($this->createMock(ContainerExceptionInterface::class));
 		$this->logger->expects($this->once())
 			->method('error');
 


### PR DESCRIPTION
## Summary

Only remaining are the actual throws

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
