### PR TITLE
feat: Add setting to bypass password confirmation on a selected ip ranges

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2703,6 +2703,19 @@ $CONFIG = [
 	'allowed_admin_ranges' => ['192.0.2.42/32', '233.252.0.0/24', '2001:db8::13:37/64'],
 
 	/**
+	 * List of trusted IP ranges that can bypass password confirmation.
+	 * If non-empty, all endpoints marked with the PasswordConfirmationRequired attribute
+	 * won't need a password confirmation when originating from IPs within these ranges.
+	 *
+	 * Supported formats:
+	 * - IPv4 addresses or ranges, e.g., ``192.0.2.42/32``, ``233.252.0.0/24``
+	 * - IPv6 addresses or ranges, e.g., ``2001:db8::13:37/64``
+	 *
+	 * Defaults to ``[]`` (empty array)
+	 */
+	'allowed_no_password_confirmation_ranges' => ['192.0.2.42/32', '233.252.0.0/24', '2001:db8::13:37/64'],
+
+	/**
 	 * Maximum file size (in megabytes) for animating GIFs on public sharing pages.
 	 * If a GIF exceeds this size, a static preview is shown.
 	 *

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -22,6 +22,7 @@ use OCP\Authentication\Token\IToken;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
+use OCP\Security\Ip\IRemoteAddress;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\User\Backend\IPasswordConfirmationBackend;
 use ReflectionAttribute;
@@ -38,6 +39,7 @@ class PasswordConfirmationMiddleware extends Middleware {
 		private IProvider $tokenProvider,
 		private readonly IRequest $request,
 		private readonly Manager $userManager,
+		private readonly IRemoteAddress $remoteAddress,
 	) {
 	}
 
@@ -72,6 +74,10 @@ class PasswordConfirmationMiddleware extends Middleware {
 				return;
 			}
 		} catch (SessionNotAvailableException|InvalidTokenException|WipeTokenException|ExpiredTokenException) {
+			if ($this->remoteAddress->allowsBypassPasswordConfirmation()) {
+				return;
+			}
+
 			// No scope to test
 		}
 

--- a/lib/private/Security/Ip/RemoteAddress.php
+++ b/lib/private/Security/Ip/RemoteAddress.php
@@ -17,6 +17,7 @@ use OCP\Security\Ip\IRemoteAddress;
 
 class RemoteAddress implements IRemoteAddress, IAddress {
 	public const SETTING_NAME = 'allowed_admin_ranges';
+	public const SETTING_PASSWORD_CONFIRMATION_NAME = 'allowed_no_password_confirmation_ranges';
 
 	private readonly ?IAddress $ip;
 
@@ -57,6 +58,32 @@ class RemoteAddress implements IRemoteAddress, IAddress {
 			|| empty($allowedAdminRanges)
 		) {
 			return true;
+		}
+
+		foreach ($allowedAdminRanges as $allowedAdminRange) {
+			if ((new Range($allowedAdminRange))->contains($this->ip)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	#[\Override]
+	public function allowsBypassPasswordConfirmation(): bool {
+		if ($this->ip === null) {
+			return false;
+		}
+
+		$allowedAdminRanges = $this->config->getSystemValue(self::SETTING_PASSWORD_CONFIRMATION_NAME, false);
+
+		// Apply restrictions on empty or invalid configuration
+		if (
+			$allowedAdminRanges === false
+			|| !is_array($allowedAdminRanges)
+			|| empty($allowedAdminRanges)
+		) {
+			return false;
 		}
 
 		foreach ($allowedAdminRanges as $allowedAdminRange) {

--- a/lib/public/Security/Ip/IRemoteAddress.php
+++ b/lib/public/Security/Ip/IRemoteAddress.php
@@ -19,4 +19,10 @@ interface IRemoteAddress {
 	 * @since 30.0.0
 	 */
 	public function allowsAdminActions(): bool;
+
+	/**
+	 * Check if the current remote address is allowed to bypass the password confirmation.
+	 * @since 35.0.0
+	 */
+	public function allowsBypassPasswordConfirmation(): bool;
 }

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -18,7 +18,9 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Security\Ip\IRemoteAddress;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\AppFramework\Middleware\Security\Mock\PasswordConfirmationMiddlewareController;
 use Test\TestCase;
@@ -43,6 +45,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 	private IRequest $request;
 	/** @var Manager&\PHPUnit\Framework\MockObject\MockObject */
 	private Manager $userManager;
+	private IRemoteAddress&MockObject $remoteAddress;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -60,6 +63,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 			'test',
 			$this->createMock(IRequest::class)
 		);
+		$this->remoteAddress = $this->createMock(IRemoteAddress::class);
 
 		$this->middleware = new PasswordConfirmationMiddleware(
 			$this->reflector,
@@ -69,6 +73,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 			$this->tokenProvider,
 			$this->request,
 			$this->userManager,
+			$this->remoteAddress,
 		);
 	}
 


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
