### PR TITLE
fix(setup): improve recovery when recommended apps fail to load

### DIFF
--- a/core/src/components/setup/RecommendedApps.vue
+++ b/core/src/components/setup/RecommendedApps.vue
@@ -42,7 +42,7 @@
 
 		<div class="dialog-row">
 			<NcButton
-				v-if="!loadingApps && !installingApps && (showInstallButton || loadingAppsError)"
+				v-if="showSkipButton"
 				data-cy-setup-recommended-apps-skip
 				:href="defaultPageUrl"
 				variant="tertiary">
@@ -50,14 +50,14 @@
 			</NcButton>
 
 			<NcButton
-				v-if="loadingAppsError"
+				v-if="loadingAppsError && !loadingApps"
 				variant="primary"
 				@click="loadApps">
 				{{ t('core', 'Retry') }}
 			</NcButton>
 
 			<NcButton
-				v-if="showInstallButton"
+				v-if="appsLoaded"
 				data-cy-setup-recommended-apps-install
 				:disabled="installingApps || !isAnyAppSelected"
 				variant="primary"
@@ -127,7 +127,7 @@ export default {
 
 	data() {
 		return {
-			showInstallButton: false,
+			appsLoaded: false,
 			installingApps: false,
 			loadingApps: true,
 			loadingAppsError: false,
@@ -144,6 +144,10 @@ export default {
 		isAnyAppSelected() {
 			return this.recommendedApps.some((app) => app.isSelected && !app.active)
 		},
+
+		showSkipButton() {
+			return !this.loadingApps && !this.installingApps && (this.appsLoaded || this.loadingAppsError)
+		},
 	},
 
 	async mounted() {
@@ -154,19 +158,21 @@ export default {
 		async loadApps() {
 			this.loadingApps = true
 			this.loadingAppsError = false
+			this.appsLoaded = false
+			this.apps = []
 
 			try {
 				const apps = await appstoreApi.getApps()
 				logger.info(`${apps.length} apps fetched`)
 
-				this.apps = apps.map((app) => Object.assign(app, {
+				this.apps = apps.map((app) => ({
+					...app,
 					loading: false,
-					installationError: false,
 					isSelected: app.isCompatible && !this.isHidden(app.id),
 				}))
 				this.$nextTick(() => logger.debug(`${this.recommendedApps.length} recommended apps found`, { apps: this.recommendedApps }))
 
-				this.showInstallButton = true
+				this.appsLoaded = true
 			} catch (error) {
 				logger.error('could not fetch app list', { error })
 
@@ -247,8 +253,8 @@ export default {
 		},
 
 		toggleSelect(appId) {
-			// disable toggle when installButton is disabled
-			if (!(appId in recommended) || !this.showInstallButton) {
+			// Disable toggles until the app list has loaded successfully.
+			if (!(appId in recommended) || !this.appsLoaded) {
 				return
 			}
 			const index = this.apps.findIndex((app) => app.id === appId)

--- a/core/src/components/setup/RecommendedApps.vue
+++ b/core/src/components/setup/RecommendedApps.vue
@@ -42,11 +42,18 @@
 
 		<div class="dialog-row">
 			<NcButton
-				v-if="showInstallButton && !installingApps"
+				v-if="!loadingApps && !installingApps && (showInstallButton || loadingAppsError)"
 				data-cy-setup-recommended-apps-skip
 				:href="defaultPageUrl"
 				variant="tertiary">
 				{{ t('core', 'Skip') }}
+			</NcButton>
+
+			<NcButton
+				v-if="loadingAppsError"
+				variant="primary"
+				@click="loadApps">
+				{{ t('core', 'Retry') }}
 			</NcButton>
 
 			<NcButton
@@ -140,28 +147,35 @@ export default {
 	},
 
 	async mounted() {
-		try {
-			const apps = await appstoreApi.getApps()
-			logger.info(`${apps.length} apps fetched`)
-
-			this.apps = apps.map((app) => Object.assign(app, {
-				loading: false,
-				installationError: false,
-				isSelected: app.isCompatible && !this.isHidden(app.id),
-			}))
-			this.$nextTick(() => logger.debug(`${this.recommendedApps.length} recommended apps found`, { apps: this.recommendedApps }))
-
-			this.showInstallButton = true
-		} catch (error) {
-			logger.error('could not fetch app list', { error })
-
-			this.loadingAppsError = true
-		} finally {
-			this.loadingApps = false
-		}
+		await this.loadApps()
 	},
 
 	methods: {
+		async loadApps() {
+			this.loadingApps = true
+			this.loadingAppsError = false
+
+			try {
+				const apps = await appstoreApi.getApps()
+				logger.info(`${apps.length} apps fetched`)
+
+				this.apps = apps.map((app) => Object.assign(app, {
+					loading: false,
+					installationError: false,
+					isSelected: app.isCompatible && !this.isHidden(app.id),
+				}))
+				this.$nextTick(() => logger.debug(`${this.recommendedApps.length} recommended apps found`, { apps: this.recommendedApps }))
+
+				this.showInstallButton = true
+			} catch (error) {
+				logger.error('could not fetch app list', { error })
+
+				this.loadingAppsError = true
+			} finally {
+				this.loadingApps = false
+			}
+		},
+
 		async installApps() {
 			const availableApps = this.recommendedApps.filter((app) => app.active || (app.isSelected && canInstall(app)))
 			const appsToInstall = [

--- a/core/src/tests/components/setup/RecommendedApps.spec.ts
+++ b/core/src/tests/components/setup/RecommendedApps.spec.ts
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import RecommendedApps from '../../../components/setup/RecommendedApps.vue'
+
+const getApps = vi.hoisted(() => vi.fn())
+
+vi.mock('~/apps/appstore/src/service/api.ts', () => ({
+	getApps,
+	enableApp: vi.fn(),
+}))
+
+describe('RecommendedApps', () => {
+	afterEach(() => {
+		vi.resetAllMocks()
+	})
+
+	it('clears stale apps and hides Install when loading fails', async () => {
+		getApps
+			.mockResolvedValueOnce([
+				{
+					id: 'calendar',
+					name: 'Calendar',
+					isCompatible: true,
+					active: false,
+				},
+			])
+			.mockRejectedValueOnce(new Error('App Store unavailable'))
+
+		const wrapper = mount(RecommendedApps, {
+			global: {
+				mocks: {
+					t: (_app: string, text: string) => text,
+				},
+				stubs: {
+					NcButton: {
+						template: '<button><slot /></button>',
+					},
+					NcCheckboxRadioSwitch: true,
+				},
+			},
+		})
+
+		await vi.waitFor(() => {
+			expect(wrapper.vm.appsLoaded).toBe(true)
+		})
+
+		expect(wrapper.text()).toContain('Calendar')
+		expect(wrapper.vm.apps).toHaveLength(1)
+
+		await wrapper.vm.loadApps()
+
+		expect(wrapper.vm.apps).toEqual([])
+		expect(wrapper.vm.appsLoaded).toBe(false)
+		expect(wrapper.vm.loadingAppsError).toBe(true)
+		expect(wrapper.text()).not.toContain('Calendar')
+		expect(wrapper.text()).toContain('Could not fetch list of apps from the App Store.')
+	})
+})

--- a/tests/playwright/e2e/core/setup.spec.ts
+++ b/tests/playwright/e2e/core/setup.spec.ts
@@ -169,6 +169,62 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 			await setupPage.skipRecommendedApps()
 			await expect(page.locator('[data-cy-files-content]')).toBeVisible()
 		})
+
+		test('clears loaded apps and Install when retrying the app list fails', async ({ page, setupPage }) => {
+			let appListRequests = 0
+			let retryStarted!: () => void
+			let releaseRetry!: () => void
+			const retryRequestStarted = new Promise<void>((resolve) => {
+				retryStarted = resolve
+			})
+			const continueRetryRequest = new Promise<void>((resolve) => {
+				releaseRetry = resolve
+			})
+
+			await page.route(/\/apps\/appstore\/api\/v1\/apps(\?.*)?$/, async (route) => {
+				appListRequests++
+
+				if (appListRequests === 1) {
+					await route.fulfill({ json: APPSTORE_APPS })
+					return
+				}
+
+				retryStarted()
+				await continueRetryRequest
+				await route.fulfill({ status: 503 })
+			})
+			await setupPage.open()
+
+			await setupPage.selectDatabase('SQLite')
+			const admin = randomAdmin()
+			await setupPage.install(admin, admin)
+
+			// Confirm that the initial request loaded the app list normally.
+			await expect(setupPage.recommendedApp('Calendar')).toBeVisible()
+			await expect(setupPage.installRecommendedButton()).toBeVisible()
+			await expect.poll(() => appListRequests).toBe(1)
+
+			// The retry must clear stale state immediately, before the request
+			// completes.
+			await setupPage.retryRecommendedAppsButton().click()
+			await retryRequestStarted
+
+			await expect(page.getByText('Loading apps …')).toBeVisible()
+			await expect(setupPage.recommendedAppsLoadError()).toBeHidden()
+			await expect(setupPage.recommendedApp('Calendar')).toBeHidden()
+			await expect(setupPage.recommendedApp('Contacts')).toBeHidden()
+			await expect(setupPage.installRecommendedButton()).toBeHidden()
+			await expect(setupPage.retryRecommendedAppsButton()).toBeHidden()
+
+			// Complete the pending request with an error and verify the final
+			// recovery state.
+			releaseRetry()
+
+			await expect(setupPage.recommendedAppsLoadError()).toBeVisible()
+			await expect(setupPage.installRecommendedButton()).toBeHidden()
+			await expect(setupPage.retryRecommendedAppsButton()).toBeVisible()
+			await expect.poll(() => appListRequests).toBe(2)
+		})	
 	})
 
 	test('installs with MySQL', { tag: '@db_mysql' }, async ({ page, setupPage }) => {

--- a/tests/playwright/e2e/core/setup.spec.ts
+++ b/tests/playwright/e2e/core/setup.spec.ts
@@ -82,8 +82,7 @@ async function completeSetup(page: Page, setupPage: SetupPage, mode: Recommended
 	await expect(setupPage.installRecommendedButton()).toBeVisible()
 
 	if (mode === 'skip') {
-		await setupPage.skipButton().click()
-		await page.goto('apps/files/')
+		await setupPage.skipRecommendedApps()
 		await expect(page.locator('[data-cy-files-content]')).toBeVisible()
 		return
 	}
@@ -131,6 +130,44 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 
 			await setupPage.selectDatabase('SQLite')
 			await completeSetup(page, setupPage, 'install-failure')
+		})
+
+		test('can retry or skip when loading recommended apps fails', async ({ page, setupPage }) => {
+			let appListRequests = 0
+			await page.route(/\/apps\/appstore\/api\/v1\/apps(\?.*)?$/, async (route) => {
+				appListRequests++
+
+				if (appListRequests === 1) {
+					await route.fulfill({ status: 503 })
+					return
+				}
+
+				await route.fulfill({ json: APPSTORE_APPS })
+			})
+			await setupPage.open()
+
+			await setupPage.selectDatabase('SQLite')
+			const admin = randomAdmin()
+			await setupPage.install(admin, admin)
+
+			// A failed initial listing must leave a usable escape hatch, without
+			// exposing the install action for an unavailable app list.
+			await expect(setupPage.recommendedAppsLoadError()).toBeVisible()
+			await expect(setupPage.retryRecommendedAppsButton()).toBeVisible()
+			await expect(setupPage.skipButton()).toBeVisible()
+			await expect(setupPage.installRecommendedButton()).toBeHidden()
+
+			// Retry requests the listing again and restores the normal install UI.
+			await setupPage.retryRecommendedAppsButton().click()
+			await expect(setupPage.recommendedAppsLoadError()).toBeHidden()
+			await expect(setupPage.retryRecommendedAppsButton()).toBeHidden()
+			await expect(setupPage.installRecommendedButton()).toBeVisible()
+			await expect.poll(() => appListRequests).toBe(2)
+
+			// Skip must navigate to the default page rather than leave the user
+			// stranded on the setup screen.
+			await setupPage.skipRecommendedApps()
+			await expect(page.locator('[data-cy-files-content]')).toBeVisible()
 		})
 	})
 

--- a/tests/playwright/e2e/core/setup.spec.ts
+++ b/tests/playwright/e2e/core/setup.spec.ts
@@ -169,62 +169,6 @@ test.describe('Nextcloud installation wizard', { tag: '@setup' }, () => {
 			await setupPage.skipRecommendedApps()
 			await expect(page.locator('[data-cy-files-content]')).toBeVisible()
 		})
-
-		test('clears loaded apps and Install when retrying the app list fails', async ({ page, setupPage }) => {
-			let appListRequests = 0
-			let retryStarted!: () => void
-			let releaseRetry!: () => void
-			const retryRequestStarted = new Promise<void>((resolve) => {
-				retryStarted = resolve
-			})
-			const continueRetryRequest = new Promise<void>((resolve) => {
-				releaseRetry = resolve
-			})
-
-			await page.route(/\/apps\/appstore\/api\/v1\/apps(\?.*)?$/, async (route) => {
-				appListRequests++
-
-				if (appListRequests === 1) {
-					await route.fulfill({ json: APPSTORE_APPS })
-					return
-				}
-
-				retryStarted()
-				await continueRetryRequest
-				await route.fulfill({ status: 503 })
-			})
-			await setupPage.open()
-
-			await setupPage.selectDatabase('SQLite')
-			const admin = randomAdmin()
-			await setupPage.install(admin, admin)
-
-			// Confirm that the initial request loaded the app list normally.
-			await expect(setupPage.recommendedApp('Calendar')).toBeVisible()
-			await expect(setupPage.installRecommendedButton()).toBeVisible()
-			await expect.poll(() => appListRequests).toBe(1)
-
-			// The retry must clear stale state immediately, before the request
-			// completes.
-			await setupPage.retryRecommendedAppsButton().click()
-			await retryRequestStarted
-
-			await expect(page.getByText('Loading apps …')).toBeVisible()
-			await expect(setupPage.recommendedAppsLoadError()).toBeHidden()
-			await expect(setupPage.recommendedApp('Calendar')).toBeHidden()
-			await expect(setupPage.recommendedApp('Contacts')).toBeHidden()
-			await expect(setupPage.installRecommendedButton()).toBeHidden()
-			await expect(setupPage.retryRecommendedAppsButton()).toBeHidden()
-
-			// Complete the pending request with an error and verify the final
-			// recovery state.
-			releaseRetry()
-
-			await expect(setupPage.recommendedAppsLoadError()).toBeVisible()
-			await expect(setupPage.installRecommendedButton()).toBeHidden()
-			await expect(setupPage.retryRecommendedAppsButton()).toBeVisible()
-			await expect.poll(() => appListRequests).toBe(2)
-		})	
 	})
 
 	test('installs with MySQL', { tag: '@db_mysql' }, async ({ page, setupPage }) => {

--- a/tests/playwright/support/sections/SetupPage.ts
+++ b/tests/playwright/support/sections/SetupPage.ts
@@ -103,6 +103,10 @@ export class SetupPage {
 		return this.page.getByRole('heading', { name: 'Recommended apps' })
 	}
 
+	recommendedApp(name: string): Locator {
+		return this.recommendedApps().getByRole('heading', { name })
+	}
+
 	skipButton(): Locator {
 		return this.page.getByRole('button', { name: 'Skip' })
 	}

--- a/tests/playwright/support/sections/SetupPage.ts
+++ b/tests/playwright/support/sections/SetupPage.ts
@@ -107,8 +107,31 @@ export class SetupPage {
 		return this.page.getByRole('button', { name: 'Skip' })
 	}
 
+	recommendedAppsLoadError(): Locator {
+		return this.page.getByText('Could not fetch list of apps from the App Store.')
+	}
+
+	retryRecommendedAppsButton(): Locator {
+		return this.page.getByRole('button', { name: 'Retry' })
+	}
+
 	installRecommendedButton(): Locator {
 		return this.page.getByRole('button', { name: 'Install recommended apps' })
+	}
+
+	/**
+	 * Follow the server-provided default-page URL exposed by the Skip button.
+	 */
+	async skipRecommendedApps(): Promise<void> {
+		const href = await this.skipButton().getAttribute('href')
+		if (!href) {
+			throw new Error('Recommended-apps Skip button has no href')
+		}
+
+		await Promise.all([
+			this.page.waitForURL(new URL(href, this.page.url()).toString()),
+			this.skipButton().click(),
+		])
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fix the Recommended Apps setup screen so that when fetching the app list from the App Store fails, the user isn't stranded (currently the only way forward is to manually change the URL in the browser).

An example of a screen where people can get stuck that this PR addresses can be seen in #61313. The underlying bug is different there, but the resulting scenario is the same: the user sees only an error and has no clear way to navigate or continue.

Changes:

- add a Retry action to reload the recommended app list without refreshing the page
- keep the Skip action available so users can continue setup without installing recommended apps
- clear stale app data and hide Install while reloading or after a failed app-list request
- keep the setup screen actionable when the App Store is unavailable
- add Playwright coverage for failed-load, retry, and skip flows
- add component coverage for clearing stale app data and resetting the install state after a reload failure

Related: #61575

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
