### PR TITLE
test(sharing): sort recipients before asserting in testGetShareWithPublicSecret

### DIFF
--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -3019,6 +3019,8 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		unset($share['last_updated']);
 		$this->assertIsList($share['recipients']);
 		$this->assertCount(2, $share['recipients']);
+		// Sort because database order is not guaranteed
+		usort($share['recipients'], fn (array $a, array $b): int => $a['value'] <=> $b['value']);
 		$this->assertEquals([
 			'class' => TestShareRecipientType1::class,
 			'value' => 'recipient1',
@@ -3159,6 +3161,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->dbConnection->commit();
 
 		$share = $this->getShare($accessContext, $id);
+
+		// Sort because database order is not guaranteed
+		usort($share['sources'], fn (array $a, array $b): int => $a['value'] <=> $b['value']);
 		usort($share['recipients'], fn (array $a, array $b): int => $a['value'] <=> $b['value']);
 		$this->assertEquals([
 			[


### PR DESCRIPTION
The error in question

```
ApiV1ControllerTest::testGetShareWithPublicSecret with data set #0 (true)
  Failed asserting that two arrays are equal.
  --- Expected
  +++ Actual
  @@ @@
   Array (
  -    'class' => 'Test\Sharing\TestShareRecipientType1'
  -    'value' => 'recipient1'
  +    'class' => 'Test\Sharing\TestShareRecipientTypePublicSecret'
  +    'value' => 'recipient2'
       'instance' => null
  -    'display_name' => 'Recipient 1'
  +    'display_name' => 'Recipient 2'
       'icon' => [...]
       'secret' => Array (
           'updatable' => false
  +        'value' => '47BN3fes63WP0usnjUyF3pUYJh36RHMl'
  +        'url' => 'http://localhost/index.php/s/...36RHMl'
       )
       'initiator' => [...]
   )
```

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
