### PR TITLE
feat: FullTextSearch request includes portion of data to be retrieved from indexer

### DIFF
--- a/lib/public/FullTextSearch/Model/BodyPortion.php
+++ b/lib/public/FullTextSearch/Model/BodyPortion.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\FullTextSearch\Model;
+
+/**
+ * Body portion to be retrieved from the index.
+ *
+ * @since 35.0.0
+ */
+enum BodyPortion: string {
+	/**
+	 * @since 35.0.0
+	 */
+	case TITLE = 'title';
+
+	/**
+	 * @since 35.0.0
+	 */
+	case LINKS = 'links';
+
+	/**
+	 * @since 35.0.0
+	 */
+	case TAGS = 'tags';
+
+	/**
+	 * @since 35.0.0
+	 */
+	case SUBTAGS = 'subtags';
+
+	/**
+	 * @since 35.0.0
+	 */
+	case METATAGS = 'metatags';
+
+	/**
+	 * @since 35.0.0
+	 */
+	case PARTS = 'parts';
+
+	/**
+	 * @since 35.0.0
+	 */
+	case MORE = 'more';
+}

--- a/lib/public/FullTextSearch/Model/ISearchRequest.php
+++ b/lib/public/FullTextSearch/Model/ISearchRequest.php
@@ -206,6 +206,22 @@ interface ISearchRequest {
 	public function setSubTags(array $tags): ISearchRequest;
 
 	/**
+	 * Add a portion of data to be retrieved from the index.
+	 *
+	 * @since 35.0.0
+	 */
+	public function addPortion(BodyPortion $portion): ISearchRequest;
+
+	/**
+	 * Get the portions of data to be retrieved from the index.
+	 *
+	 * @since 35.0.0
+	 *
+	 * @return list<string>
+	 */
+	public function getPortions(): array;
+
+	/**
 	 * Limit the search to a specific field of the mapping, using a full string.
 	 *
 	 * @since 15.0.0


### PR DESCRIPTION
Follow-up https://github.com/nextcloud/fulltextsearch/pull/960

---

Right now, FTS platform `fulltextsearch_elasticsearch` [returns](https://github.com/nextcloud/fulltextsearch_elasticsearch/blob/master/lib/Service/SearchService.php#L196) an arbitrary set of data among those stored in the index, ignoring tags, subtags, metatags and more (pun intended).

It is fine to no fetch and pass everything all the time, but sometime a provider may find convenient to just reuse data already attached to a document instead of retrieve all of them from scratch.

Use case: I'm hacking a FTS provider for mail, and I have lots of structured data to index, to filter in search requests (e.g. `from:` filters), and to use while displaying the response (e.g. `from` can be used to retrieve the avatar of the message sender). Retrieve all of them again from the database (or, even worse: from the IMAP server) for each search result may become a bit inefficient.

Rationale of this proposal is to provide a method for the provider to specify (eventually in own implementation of `IFullTextSearchProvider::improveSearchRequest()`) the list of parts required back from the platform. A mere list of strings in `SearchRequest`, meant to be read and handled from the platform.



Sample implied implementation of changes in `SearchMappingService::generateSearchQueryParams()` ([here](https://github.com/nextcloud/fulltextsearch_elasticsearch/blob/master/lib/Service/SearchMappingService.php#L65)):

```
$params = [
	'index' => $this->configService->getElasticIndex(),
	'size' => $request->getSize(),
	'from' => (($request->getPage() - 1) * $request->getSize()),
	'_source_excludes' => 'content',
	'_source_includes' => join(',', $request->getPortions()),   // <----- this line!
];
```

and `SearchService::parseSearchEntry()` also would require some adjustment (which I can provide myself if this is approved!).