### PR TITLE
feat: keep a classname mapping instead of always storing the full name for shares

### DIFF
--- a/apps/sharing/composer/composer/autoload_classmap.php
+++ b/apps/sharing/composer/composer/autoload_classmap.php
@@ -26,5 +26,6 @@ return array(
     'OCA\\Sharing\\Controller\\ApiV1Controller' => $baseDir . '/../lib/Controller/ApiV1Controller.php',
     'OCA\\Sharing\\Middleware\\ShareApiEnabledMiddleware' => $baseDir . '/../lib/Middleware/ShareApiEnabledMiddleware.php',
     'OCA\\Sharing\\Migration\\Version1000Date20250929161325' => $baseDir . '/../lib/Migration/Version1000Date20250929161325.php',
+    'OCA\\Sharing\\Migration\\Version1000Date20260731171922' => $baseDir . '/../lib/Migration/Version1000Date20260731171922.php',
     'OCA\\Sharing\\ResponseDefinitions' => $baseDir . '/../lib/ResponseDefinitions.php',
 );

--- a/apps/sharing/composer/composer/autoload_static.php
+++ b/apps/sharing/composer/composer/autoload_static.php
@@ -41,6 +41,7 @@ class ComposerStaticInitSharing
         'OCA\\Sharing\\Controller\\ApiV1Controller' => __DIR__ . '/..' . '/../lib/Controller/ApiV1Controller.php',
         'OCA\\Sharing\\Middleware\\ShareApiEnabledMiddleware' => __DIR__ . '/..' . '/../lib/Middleware/ShareApiEnabledMiddleware.php',
         'OCA\\Sharing\\Migration\\Version1000Date20250929161325' => __DIR__ . '/..' . '/../lib/Migration/Version1000Date20250929161325.php',
+        'OCA\\Sharing\\Migration\\Version1000Date20260731171922' => __DIR__ . '/..' . '/../lib/Migration/Version1000Date20260731171922.php',
         'OCA\\Sharing\\ResponseDefinitions' => __DIR__ . '/..' . '/../lib/ResponseDefinitions.php',
     );
 

--- a/apps/sharing/lib/Migration/Version1000Date20250929161325.php
+++ b/apps/sharing/lib/Migration/Version1000Date20250929161325.php
@@ -26,8 +26,16 @@ final class Version1000Date20250929161325 extends SimpleMigrationStep {
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		$schema = $schemaClosure();
 
-		// TODO: Add mapping table for class names
 		// TODO: Check indexes
+
+		$mappingTable = $schema->createTable('sharing_classmap');
+		$mappingTable->addColumn('class_id', Types::INTEGER, [
+			'autoincrement' => true,
+			'notnull' => true,
+		]);
+		$mappingTable->addColumn('class_name', Types::STRING, ['length' => 64]);
+		$mappingTable->setPrimaryKey(['class_id']);
+		$mappingTable->addUniqueIndex(['class_name']);
 
 		$shareTable = $schema->createTable('sharing_share');
 		$shareTable->addColumn('id', Types::BIGINT);
@@ -39,38 +47,42 @@ final class Version1000Date20250929161325 extends SimpleMigrationStep {
 
 		$sourcesTable = $schema->createTable('sharing_share_sources');
 		$sourcesTable->addColumn('share_id', Types::BIGINT);
-		$sourcesTable->addColumn('source_class', Types::STRING, ['length' => 64]);
+		$sourcesTable->addColumn('source_class_id', Types::INTEGER);
 		$sourcesTable->addColumn('source_value', Types::STRING, ['length' => 255]);
-		$sourcesTable->setPrimaryKey(['share_id', 'source_class', 'source_value']);
+		$sourcesTable->setPrimaryKey(['share_id', 'source_class_id', 'source_value']);
 		$sourcesTable->addForeignKeyConstraint($shareTable->getName(), ['share_id'], ['id'], ['onDelete' => 'CASCADE']);
+		$sourcesTable->addForeignKeyConstraint($mappingTable->getName(), ['source_class_id'], ['class_id']);
 
 		// TODO: Add possibility to mask permissions for recipients. For reshares the user may only mask permissions for their child recipients, not their self recipients
 		$recipientsTable = $schema->createTable('sharing_share_recipients');
 		$recipientsTable->addColumn('share_id', Types::BIGINT);
-		$recipientsTable->addColumn('recipient_class', Types::STRING, ['length' => 64]);
+		$recipientsTable->addColumn('recipient_class_id', Types::INTEGER);
 		$recipientsTable->addColumn('recipient_value', Types::STRING, ['length' => 255]);
 		$recipientsTable->addColumn('recipient_instance', Types::STRING, ['length' => 128, 'notnull' => false]);
 		$recipientsTable->addColumn('recipient_secret', Types::STRING, ['length' => 32]);
 		$recipientsTable->addColumn('initiator_user_id', Types::STRING, ['length' => 64]);
 		$recipientsTable->addColumn('initiator_instance', Types::STRING, ['length' => 128, 'notnull' => false]);
-		$recipientsTable->setPrimaryKey(['share_id', 'recipient_class', 'recipient_value']);
+		$recipientsTable->setPrimaryKey(['share_id', 'recipient_class_id', 'recipient_value']);
 		$recipientsTable->addForeignKeyConstraint($shareTable->getName(), ['share_id'], ['id'], ['onDelete' => 'CASCADE']);
 		// TODO: Maybe needs composite index with share_id
 		$recipientsTable->addUniqueIndex(['recipient_secret']);
+		$recipientsTable->addForeignKeyConstraint($mappingTable->getName(), ['recipient_class_id'], ['class_id']);
 
 		$propertiesTable = $schema->createTable('sharing_share_properties');
 		$propertiesTable->addColumn('share_id', Types::BIGINT);
-		$propertiesTable->addColumn('property_class', Types::STRING, ['length' => 64]);
+		$propertiesTable->addColumn('property_class_id', Types::INTEGER);
 		$propertiesTable->addColumn('property_value', Types::STRING, ['length' => 1000, 'notnull' => false]);
-		$propertiesTable->setPrimaryKey(['share_id', 'property_class']);
+		$propertiesTable->setPrimaryKey(['share_id', 'property_class_id']);
 		$propertiesTable->addForeignKeyConstraint($shareTable->getName(), ['share_id'], ['id'], ['onDelete' => 'CASCADE']);
+		$propertiesTable->addForeignKeyConstraint($mappingTable->getName(), ['property_class_id'], ['class_id']);
 
 		$permissionsTable = $schema->createTable('sharing_share_permissions');
 		$permissionsTable->addColumn('share_id', Types::BIGINT);
-		$permissionsTable->addColumn('permission_class', Types::STRING, ['length' => 64]);
+		$permissionsTable->addColumn('permission_class_id', Types::INTEGER);
 		$permissionsTable->addColumn('permission_enabled', Types::BOOLEAN);
-		$permissionsTable->setPrimaryKey(['share_id', 'permission_class']);
+		$permissionsTable->setPrimaryKey(['share_id', 'permission_class_id']);
 		$permissionsTable->addForeignKeyConstraint($shareTable->getName(), ['share_id'], ['id'], ['onDelete' => 'CASCADE']);
+		$permissionsTable->addForeignKeyConstraint($mappingTable->getName(), ['permission_class_id'], ['class_id']);
 
 		return $schema;
 	}

--- a/apps/sharing/lib/Migration/Version1000Date20260731171922.php
+++ b/apps/sharing/lib/Migration/Version1000Date20260731171922.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Sharing\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\Attributes\AddColumn;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\CreateTable;
+use OCP\Migration\Attributes\DropColumn;
+use OCP\Migration\Attributes\DropIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+#[CreateTable(table: 'sharing_classmap')]
+#[DropColumn(table: 'sharing_share_sources', name: 'source_class')]
+#[DropColumn(table: 'sharing_share_recipients', name: 'recipient_class')]
+#[DropColumn(table: 'sharing_share_properties', name: 'property_class')]
+#[DropColumn(table: 'sharing_share_permissions', name: 'permission_class')]
+#[AddColumn(table: 'sharing_share_sources', name: 'source_class_id')]
+#[AddColumn(table: 'sharing_share_recipients', name: 'recipient_class_id')]
+#[AddColumn(table: 'sharing_share_properties', name: 'property_class_id')]
+#[AddColumn(table: 'sharing_share_permissions', name: 'permission_class_id')]
+#[DropIndex(table: 'sharing_share_sources', type: IndexType::PRIMARY)]
+#[DropIndex(table: 'sharing_share_recipients', type: IndexType::PRIMARY)]
+#[DropIndex(table: 'sharing_share_properties', type: IndexType::PRIMARY)]
+#[DropIndex(table: 'sharing_share_permissions', type: IndexType::PRIMARY)]
+#[AddIndex(table: 'sharing_share_sources', type: IndexType::PRIMARY)]
+#[AddIndex(table: 'sharing_share_recipients', type: IndexType::PRIMARY)]
+#[AddIndex(table: 'sharing_share_properties', type: IndexType::PRIMARY)]
+#[AddIndex(table: 'sharing_share_permissions', type: IndexType::PRIMARY)]
+final class Version1000Date20260731171922 extends SimpleMigrationStep {
+	/**
+	 * @param Closure():ISchemaWrapper $schemaClosure
+	 * @throws SchemaException
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('sharing_classmap')) {
+			$table = $schema->createTable('sharing_classmap');
+			$table->addColumn('class_id', Types::INTEGER, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('class_name', Types::STRING, ['length' => 64]);
+			$table->setPrimaryKey(['class_id']);
+			$table->addUniqueIndex(['class_name']);
+		}
+
+		$sourcesTable = $schema->getTable('sharing_share_sources');
+		if ($sourcesTable->hasColumn('source_class')) {
+			$sourcesTable->dropColumn('source_class');
+			$sourcesTable->addColumn('source_class_id', Types::INTEGER);
+			$sourcesTable->dropPrimaryKey();
+			$sourcesTable->setPrimaryKey(['share_id', 'source_class_id', 'source_value']);
+			$sourcesTable->addForeignKeyConstraint('sharing_classmap', ['source_class_id'], ['class_id']);
+		}
+
+		$recipientsTable = $schema->getTable('sharing_share_recipients');
+		if ($recipientsTable->hasColumn('recipient_class')) {
+			$recipientsTable->dropColumn('recipient_class');
+			$recipientsTable->addColumn('recipient_class_id', Types::INTEGER);
+			$recipientsTable->dropPrimaryKey();
+			$recipientsTable->setPrimaryKey(['share_id', 'recipient_class_id', 'recipient_value']);
+			$recipientsTable->addForeignKeyConstraint('sharing_classmap', ['recipient_class_id'], ['class_id']);
+		}
+
+		$propertiesTable = $schema->getTable('sharing_share_properties');
+		if ($propertiesTable->hasColumn('property_class')) {
+			$propertiesTable->dropColumn('property_class');
+			$propertiesTable->addColumn('property_class_id', Types::INTEGER);
+			$propertiesTable->dropPrimaryKey();
+			$propertiesTable->setPrimaryKey(['share_id', 'property_class_id']);
+			$propertiesTable->addForeignKeyConstraint('sharing_classmap', ['property_class_id'], ['class_id']);
+		}
+
+		$permissionsTable = $schema->getTable('sharing_share_permissions');
+		if ($permissionsTable->hasColumn('permission_class')) {
+			$permissionsTable->dropColumn('permission_class');
+			$permissionsTable->addColumn('permission_class_id', Types::INTEGER);
+			$permissionsTable->dropPrimaryKey();
+			$permissionsTable->setPrimaryKey(['share_id', 'permission_class_id']);
+			$permissionsTable->addForeignKeyConstraint('sharing_classmap', ['permission_class_id'], ['class_id']);
+		}
+
+		return $schema;
+	}
+
+	#[Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -37,6 +37,7 @@ return array(
     'NCU\\Security\\Signature\\ISignatureManager' => $baseDir . '/lib/unstable/Security/Signature/ISignatureManager.php',
     'NCU\\Security\\Signature\\ISignedRequest' => $baseDir . '/lib/unstable/Security/Signature/ISignedRequest.php',
     'NCU\\Security\\Signature\\Model\\Signatory' => $baseDir . '/lib/unstable/Security/Signature/Model/Signatory.php',
+    'NCU\\Sharing\\Event\\SharesDefaultSetEvent' => $baseDir . '/lib/unstable/Sharing/Event/SharesDefaultSetEvent.php',
     'NCU\\Sharing\\Exception\\AShareException' => $baseDir . '/lib/unstable/Sharing/Exception/AShareException.php',
     'NCU\\Sharing\\Exception\\ShareInvalidException' => $baseDir . '/lib/unstable/Sharing/Exception/ShareInvalidException.php',
     'NCU\\Sharing\\Exception\\ShareNotFoundException' => $baseDir . '/lib/unstable/Sharing/Exception/ShareNotFoundException.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -2308,6 +2308,7 @@ return array(
     'OC\\Share20\\UserDeletedListener' => $baseDir . '/lib/private/Share20/UserDeletedListener.php',
     'OC\\Share20\\UserRemovedListener' => $baseDir . '/lib/private/Share20/UserRemovedListener.php',
     'OC\\Share\\Constants' => $baseDir . '/lib/private/Share/Constants.php',
+    'OC\\Sharing\\ClassMapper' => $baseDir . '/lib/private/Sharing/ClassMapper.php',
     'OC\\Sharing\\ISharingLegacyBackend' => $baseDir . '/lib/private/Sharing/ISharingLegacyBackend.php',
     'OC\\Sharing\\SharingBackend' => $baseDir . '/lib/private/Sharing/SharingBackend.php',
     'OC\\Sharing\\SharingManager' => $baseDir . '/lib/private/Sharing/SharingManager.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -78,6 +78,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'NCU\\Security\\Signature\\ISignatureManager' => __DIR__ . '/../../..' . '/lib/unstable/Security/Signature/ISignatureManager.php',
         'NCU\\Security\\Signature\\ISignedRequest' => __DIR__ . '/../../..' . '/lib/unstable/Security/Signature/ISignedRequest.php',
         'NCU\\Security\\Signature\\Model\\Signatory' => __DIR__ . '/../../..' . '/lib/unstable/Security/Signature/Model/Signatory.php',
+        'NCU\\Sharing\\Event\\SharesDefaultSetEvent' => __DIR__ . '/../../..' . '/lib/unstable/Sharing/Event/SharesDefaultSetEvent.php',
         'NCU\\Sharing\\Exception\\AShareException' => __DIR__ . '/../../..' . '/lib/unstable/Sharing/Exception/AShareException.php',
         'NCU\\Sharing\\Exception\\ShareInvalidException' => __DIR__ . '/../../..' . '/lib/unstable/Sharing/Exception/ShareInvalidException.php',
         'NCU\\Sharing\\Exception\\ShareNotFoundException' => __DIR__ . '/../../..' . '/lib/unstable/Sharing/Exception/ShareNotFoundException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -2349,6 +2349,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Share20\\UserDeletedListener' => __DIR__ . '/../../..' . '/lib/private/Share20/UserDeletedListener.php',
         'OC\\Share20\\UserRemovedListener' => __DIR__ . '/../../..' . '/lib/private/Share20/UserRemovedListener.php',
         'OC\\Share\\Constants' => __DIR__ . '/../../..' . '/lib/private/Share/Constants.php',
+        'OC\\Sharing\\ClassMapper' => __DIR__ . '/../../..' . '/lib/private/Sharing/ClassMapper.php',
         'OC\\Sharing\\ISharingLegacyBackend' => __DIR__ . '/../../..' . '/lib/private/Sharing/ISharingLegacyBackend.php',
         'OC\\Sharing\\SharingBackend' => __DIR__ . '/../../..' . '/lib/private/Sharing/SharingBackend.php',
         'OC\\Sharing\\SharingManager' => __DIR__ . '/../../..' . '/lib/private/Sharing/SharingManager.php',

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1156,6 +1156,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerAlias(\NCU\Sharing\ISharingRegistry::class, SharingRegistry::class);
 		$this->registerAlias(\NCU\Sharing\ISharingManager::class, SharingManager::class);
+		$this->registerAlias(\NCU\Sharing\ISharingBackend::class, \OC\Sharing\SharingBackend::class);
 
 		$this->connectDispatcher();
 	}

--- a/lib/private/Sharing/ClassMapper.php
+++ b/lib/private/Sharing/ClassMapper.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Sharing;
+
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+final class ClassMapper {
+	/** @var array<int, class-string> $map */
+	private array $map = [];
+
+	/** @var array<class-string, int> */
+	private array $reverseMap = [];
+
+	private bool $loaded = false;
+
+	public function __construct(
+		private readonly IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * @param array{class_id: int|string, class_name: class-string} $row
+	 */
+	private function insertRow(array $row): void {
+		$id = (int)$row['class_id'];
+		$class = $row['class_name'];
+		$this->map[$id] = $class;
+		$this->reverseMap[$class] = $id;
+	}
+
+	private function loadFromDb(): void {
+		if ($this->loaded) {
+			return;
+		}
+
+		$query = $this->connection->getTypedQueryBuilder();
+		$query->selectColumns('class_id', 'class_name')
+			->from('sharing_classmap');
+		$rows = $query->executeQuery()->fetchAll();
+
+		foreach ($rows as $row) {
+			/** @var array{class_id: int|string, class_name: class-string} $row */
+			$this->insertRow($row);
+		}
+
+		$this->loaded = true;
+	}
+
+	/**
+	 * @param class-string $className
+	 */
+	private function loadFromDbByName(string $className): ?int {
+		$query = $this->connection->getTypedQueryBuilder();
+		$query->selectColumns('class_id', 'class_name')
+			->from('sharing_classmap')
+			->where($query->expr()->eq('class_name', $query->createNamedParameter($className)));
+		$row = $query->executeQuery()->fetchAssociative();
+
+		if ($row !== false) {
+			/** @var array{class_id: int|string, class_name: class-string} $row */
+			$this->insertRow($row);
+			return (int)$row['class_id'];
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return class-string|null
+	 */
+	private function loadFromDbById(int $id): ?string {
+		$query = $this->connection->getTypedQueryBuilder();
+		$query->selectColumns('class_id', 'class_name')
+			->from('sharing_classmap')
+			->where($query->expr()->eq('class_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$row = $query->executeQuery()->fetchAssociative();
+
+		if ($row !== false) {
+			/** @var array{class_id: int|string, class_name: class-string} $row */
+			$this->insertRow($row);
+			return $row['class_name'];
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param class-string $className
+	 */
+	private function insert(string $className): int {
+		$id = $this->loadFromDbByName($className);
+		if ($id !== null) {
+			return $id;
+		}
+
+		$query = $this->connection->getTypedQueryBuilder();
+		$query->insert('sharing_classmap')
+			->values([
+				'class_name' => $query->createNamedParameter($className)
+			]);
+		try {
+			$query->executeStatement();
+			$id = $query->getLastInsertId();
+			$this->map[$id] = $className;
+			$this->reverseMap[$className] = $id;
+			return $id;
+		} catch (Exception $exception) {
+			// handle concurrent inserts
+			if ($exception->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				$id = $this->loadFromDbByName($className);
+				if ($id === null) {
+					throw new \Exception(sprintf("Failed to insert '%s' into sharing_classmap, duplicate on insert but can't fetch it either", $className), $exception->getCode(), $exception);
+				}
+
+				return $id;
+			}
+
+			throw $exception;
+		}
+	}
+
+	/**
+	 * @param class-string $class
+	 */
+	public function getClassId(string $class): int {
+		$this->loadFromDb();
+
+		return $this->reverseMap[$class] ?? $this->insert($class);
+	}
+
+	/**
+	 * @return class-string
+	 */
+	public function getClassName(int $id): string {
+		$this->loadFromDb();
+		if (isset($this->map[$id])) {
+			return $this->map[$id];
+		}
+
+		$class = $this->loadFromDbById($id);
+		if ($class) {
+			return $class;
+		}
+
+		throw new \Exception(sprintf("Unknown mapped class '%d'", $id));
+	}
+
+	public function flush(): void {
+		$this->loaded = false;
+		$this->map = [];
+		$this->reverseMap = [];
+	}
+}

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -39,8 +39,6 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use RuntimeException;
 
-// TODO: Add mapping table for class names in sources, recipients, permissions and properties
-
 /**
  * @psalm-import-type SharingShare from Share
  */
@@ -54,6 +52,8 @@ final readonly class SharingBackend implements ISharingBackend {
 		private IAppConfig $appConfig,
 		private ISharingRegistry $registry,
 		private ISharingManager $manager,
+		private ClassMapper $classMapper,
+		private ClockInterface $clock,
 	) {
 		$this->l10n = $factory->get('sharing');
 	}
@@ -128,7 +128,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				->insert('sharing_share_sources')
 				->values([
 					'share_id' => $qb->createNamedParameter($id),
-					'source_class' => $qb->createNamedParameter($source->class),
+					'source_class_id' => $qb->createNamedParameter($this->classMapper->getClassId($source->class), IQueryBuilder::PARAM_INT),
 					'source_value' => $qb->createNamedParameter($source->value),
 				])
 				->executeStatement();
@@ -147,7 +147,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		$rowCount = $qb
 			->delete('sharing_share_sources')
 			->where($qb->expr()->eq('share_id', $qb->createNamedParameter($id)))
-			->andWhere($qb->expr()->eq('source_class', $qb->createNamedParameter($source->class)))
+			->andWhere($qb->expr()->eq('source_class_id', $qb->createNamedParameter($this->classMapper->getClassId($source->class), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('source_value', $qb->createNamedParameter($source->value)))
 			->executeStatement();
 		if ($rowCount === 0) {
@@ -161,7 +161,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		$result = $qb
 			->selectDistinct('share_id')
 			->from('sharing_share_sources')
-			->where($qb->expr()->eq('source_class', $qb->createNamedParameter($source->class)))
+			->where($qb->expr()->eq('source_class_id', $qb->createNamedParameter($this->classMapper->getClassId($source->class), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('source_value', $qb->createNamedParameter($source->value)))
 			->executeQuery();
 
@@ -176,7 +176,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		$qb = $this->connection->getQueryBuilder();
 		$qb
 			->delete('sharing_share_sources')
-			->where($qb->expr()->eq('source_class', $qb->createNamedParameter($source->class)))
+			->where($qb->expr()->eq('source_class_id', $qb->createNamedParameter($this->classMapper->getClassId($source->class), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('source_value', $qb->createNamedParameter($source->value)))
 			->executeStatement();
 
@@ -198,7 +198,7 @@ final readonly class SharingBackend implements ISharingBackend {
 
 			$values = [
 				'share_id' => $qb->createNamedParameter($id),
-				'recipient_class' => $qb->createNamedParameter($recipient->class),
+				'recipient_class_id' => $qb->createNamedParameter($this->classMapper->getClassId($recipient->class), IQueryBuilder::PARAM_INT),
 				'recipient_value' => $qb->createNamedParameter($recipient->value),
 				'recipient_instance' => $qb->createNamedParameter($recipient->instance),
 				'recipient_secret' => $qb->createNamedParameter($recipient->secret),
@@ -225,7 +225,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		$rowCount = $qb
 			->delete('sharing_share_recipients')
 			->where($qb->expr()->eq('share_id', $qb->createNamedParameter($id)))
-			->andWhere($qb->expr()->eq('recipient_class', $qb->createNamedParameter($recipient->class)))
+			->andWhere($qb->expr()->eq('recipient_class_id', $qb->createNamedParameter($this->classMapper->getClassId($recipient->class), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('recipient_value', $qb->createNamedParameter($recipient->value)))
 			->andWhere(
 				$recipient->instance === null
@@ -244,7 +244,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		$result = $qb
 			->selectDistinct('share_id')
 			->from('sharing_share_recipients')
-			->where($qb->expr()->eq('recipient_class', $qb->createNamedParameter($recipient->class)))
+			->where($qb->expr()->eq('recipient_class_id', $qb->createNamedParameter($this->classMapper->getClassId($recipient->class), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('recipient_value', $qb->createNamedParameter($recipient->value)))
 			->andWhere(
 				$recipient->instance === null
@@ -264,7 +264,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		$qb = $this->connection->getQueryBuilder();
 		$qb
 			->delete('sharing_share_recipients')
-			->where($qb->expr()->eq('recipient_class', $qb->createNamedParameter($recipient->class)))
+			->where($qb->expr()->eq('recipient_class_id', $qb->createNamedParameter($this->classMapper->getClassId($recipient->class), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('recipient_value', $qb->createNamedParameter($recipient->value)))
 			->andWhere(
 				$recipient->instance === null
@@ -328,7 +328,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			->update('sharing_share_recipients')
 			->set('recipient_secret', $qb->createNamedParameter($secret))
 			->where($qb->expr()->eq('share_id', $qb->createNamedParameter($id)))
-			->andWhere($qb->expr()->eq('recipient_class', $qb->createNamedParameter($recipient->class)))
+			->andWhere($qb->expr()->eq('recipient_class_id', $qb->createNamedParameter($this->classMapper->getClassId($recipient->class), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('recipient_value', $qb->createNamedParameter($recipient->value)))
 			->andWhere(
 				$recipient->instance === null
@@ -357,7 +357,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				->insert('sharing_share_properties')
 				->values([
 					'share_id' => $qb->createNamedParameter($id),
-					'property_class' => $qb->createNamedParameter($property->class),
+					'property_class_id' => $qb->createNamedParameter($this->classMapper->getClassId($property->class), IQueryBuilder::PARAM_INT),
 					'property_value' => $qb->createNamedParameter($value),
 				])
 				->executeStatement();
@@ -382,7 +382,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				->select('sp.property_value')
 				->from('sharing_share_properties', 'sp')
 				->where($qb->expr()->eq('sp.share_id', $qb->createNamedParameter($id)))
-				->andWhere($qb->expr()->eq('sp.property_class', $qb->createNamedParameter($property->class)));
+				->andWhere($qb->expr()->eq('sp.property_class_id', $qb->createNamedParameter($this->classMapper->getClassId($property->class), IQueryBuilder::PARAM_INT)));
 
 			/** @var string|false $oldValue */
 			$oldValue = $qb->executeQuery()->fetchOne();
@@ -398,7 +398,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			->update('sharing_share_properties')
 			->set('property_value', $qb->createNamedParameter($value))
 			->where($qb->expr()->eq('share_id', $qb->createNamedParameter($id)))
-			->andWhere($qb->expr()->eq('property_class', $qb->createNamedParameter($property->class)))
+			->andWhere($qb->expr()->eq('property_class_id', $qb->createNamedParameter($this->classMapper->getClassId($property->class), IQueryBuilder::PARAM_INT)))
 			->executeStatement();
 		if ($rowCount === 0) {
 			throw new ShareNotFoundException();
@@ -413,7 +413,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				->insert('sharing_share_permissions')
 				->values([
 					'share_id' => $qb->createNamedParameter($id),
-					'permission_class' => $qb->createNamedParameter($permission->class),
+					'permission_class_id' => $qb->createNamedParameter($this->classMapper->getClassId($permission->class), IQueryBuilder::PARAM_INT),
 					'permission_enabled' => $qb->createNamedParameter($permission->enabled, IQueryBuilder::PARAM_BOOL),
 				])
 				->executeStatement();
@@ -433,7 +433,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			->update('sharing_share_permissions')
 			->set('permission_enabled', $qb->createNamedParameter($permission->enabled, IQueryBuilder::PARAM_BOOL))
 			->where($qb->expr()->eq('share_id', $qb->createNamedParameter($id)))
-			->andWhere($qb->expr()->eq('permission_class', $qb->createNamedParameter($permission->class)))
+			->andWhere($qb->expr()->eq('permission_class_id', $qb->createNamedParameter($this->classMapper->getClassId($permission->class), IQueryBuilder::PARAM_INT)))
 			->executeStatement();
 		if ($rowCount === 0) {
 			throw new ShareNotFoundException();
@@ -451,13 +451,14 @@ final readonly class SharingBackend implements ISharingBackend {
 
 		$permissionPresetCompatiblePermissionTypeClasses = $this->registry->getPermissionPresetCompatiblePermissionTypeClasses()[$permissionPresetClass];
 		foreach (array_chunk($permissionPresetCompatiblePermissionTypeClasses, 1000) as $chunk) {
+			$chunkIds = array_map($this->classMapper->getClassId(...), $chunk);
 			// Some permissions might not be compatible with the share, just ignore it and update the ones that are present.
 			$qb = $this->connection->getQueryBuilder();
 			$qb
 				->update('sharing_share_permissions')
 				->set('permission_enabled', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
 				->where($qb->expr()->eq('share_id', $qb->createNamedParameter($id)))
-				->andWhere($qb->expr()->in('permission_class', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_STR_ARRAY)))
+				->andWhere($qb->expr()->in('permission_class_id', $qb->createNamedParameter($chunkIds, IQueryBuilder::PARAM_INT_ARRAY)))
 				->executeStatement();
 		}
 
@@ -592,7 +593,7 @@ final readonly class SharingBackend implements ISharingBackend {
 
 				foreach ($recipientTypeValues as $recipientTypeClass => $recipientValues) {
 					$qb->orWhere($qb->expr()->andX(
-						$qb->expr()->eq('sr.recipient_class', $qb->createNamedParameter($recipientTypeClass)),
+						$qb->expr()->eq('sr.recipient_class_id', $qb->createNamedParameter($this->classMapper->getClassId($recipientTypeClass), IQueryBuilder::PARAM_INT)),
 						// TODO: Add chunking
 						$qb->expr()->in('sr.recipient_value', $qb->createNamedParameter($recipientValues, IQueryBuilder::PARAM_STR_ARRAY)),
 						$qb->expr()->isNull('sr.recipient_instance'),
@@ -636,7 +637,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			if ($filterSourceTypeClass !== null) {
 				$sourceTypeFilters = [
 					$qb->expr()->eq('s.id', 'ss.share_id'),
-					$qb->expr()->eq('ss.source_class', $qb->createNamedParameter($filterSourceTypeClass)),
+					$qb->expr()->eq('ss.source_class_id', $qb->createNamedParameter($this->classMapper->getClassId($filterSourceTypeClass), IQueryBuilder::PARAM_INT)),
 				];
 
 				if ($filterSourceTypeValue !== null) {
@@ -711,18 +712,18 @@ final readonly class SharingBackend implements ISharingBackend {
 			$qb
 				->select(
 					'ss.share_id',
-					'ss.source_class',
+					'ss.source_class_id',
 					'ss.source_value',
 				)
 				->from('sharing_share_sources', 'ss')
 				->where($qb->expr()->in('ss.share_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
 
 			$result = $qb->executeQuery();
-			/** @var array{source_class: class-string<IShareSourceType>, source_value: non-empty-string, share_id: int}[] $rows */
+			/** @var array{source_class_id: mixed, source_value: non-empty-string, share_id: int}[] $rows */
 			$rows = $result->fetchAll();
 
 			foreach ($rows as $row) {
-				$typeClass = $row['source_class'];
+				$typeClass = $this->classMapper->getClassName((int)$row['source_class_id']);
 				$value = $row['source_value'];
 
 				$shareSourceValues[$typeClass] ??= [];
@@ -738,7 +739,8 @@ final readonly class SharingBackend implements ISharingBackend {
 			}
 
 			foreach ($rows as $row) {
-				$typeClass = $row['source_class'];
+				/** @var class-string<IShareSourceType> $typeClass */
+				$typeClass = $this->classMapper->getClassName((int)$row['source_class_id']);
 				if (!isset($registrySourceTypes[$typeClass])) {
 					// Skip sources that are currently not compatible, but don't remove them.
 					continue;
@@ -765,7 +767,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			$qb
 				->select(
 					'sr.share_id',
-					'sr.recipient_class',
+					'sr.recipient_class_id',
 					'sr.recipient_value',
 					'sr.recipient_instance',
 					'sr.recipient_secret',
@@ -777,7 +779,7 @@ final readonly class SharingBackend implements ISharingBackend {
 
 			foreach ($qb->executeQuery()->fetchAll() as $row) {
 				/** @var class-string<IShareRecipientType> $typeClass */
-				$typeClass = $row['recipient_class'];
+				$typeClass = $this->classMapper->getClassName((int)$row['recipient_class_id']);
 				if (!isset($registryRecipientTypes[$typeClass])) {
 					// Skip recipients that are currently not compatible, but don't remove them.
 					continue;
@@ -882,7 +884,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			$qb
 				->select(
 					'sp.share_id',
-					'sp.property_class',
+					'sp.property_class_id',
 					'sp.property_value',
 				)
 				->from('sharing_share_properties', 'sp')
@@ -897,7 +899,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				}
 
 				/** @var class-string<ISharePropertyType> $propertyTypeClass */
-				$propertyTypeClass = $row['property_class'];
+				$propertyTypeClass = $this->classMapper->getClassName((int)$row['property_class_id']);
 				if (!isset($registryPropertyTypeCompatibleSourceTypeClasses[$propertyTypeClass], $registryPropertyTypeCompatibleRecipientTypeClasses[$propertyTypeClass])) {
 					// Skip properties that are currently not compatible, but don't remove them.
 					continue;
@@ -953,7 +955,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			$qb
 				->select(
 					'sp.share_id',
-					'sp.permission_class',
+					'sp.permission_class_id',
 					'sp.permission_enabled',
 				)
 				->from('sharing_share_permissions', 'sp')
@@ -965,7 +967,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				$id = (string)$row['share_id'];
 
 				/** @var class-string<ISharePermissionType> $permissionTypeClass */
-				$permissionTypeClass = $row['permission_class'];
+				$permissionTypeClass = $this->classMapper->getClassName((int)$row['permission_class_id']);
 				if (!isset($shareCompatiblePermissionTypeClasses[$id][$permissionTypeClass])) {
 					// Skip permissions that are currently not compatible, but don't remove them.
 					continue;

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 namespace OC\Sharing;
 
 use Exception;
+use NCU\Sharing\Event\SharesDefaultSetEvent;
 use NCU\Sharing\Exception\ShareInvalidException;
 use NCU\Sharing\Exception\ShareNotFoundException;
 use NCU\Sharing\ISharingBackend;
-use NCU\Sharing\ISharingManager;
 use NCU\Sharing\ISharingRegistry;
 use NCU\Sharing\Permission\ISharePermissionType;
 use NCU\Sharing\Permission\SharePermission;
@@ -31,12 +31,14 @@ use NCU\Sharing\Source\IShareSourceMetadata;
 use NCU\Sharing\Source\IShareSourceType;
 use NCU\Sharing\Source\ShareSource;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use Psr\Clock\ClockInterface;
 use RuntimeException;
 
 /**
@@ -51,7 +53,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		private IUserManager $userManager,
 		private IAppConfig $appConfig,
 		private ISharingRegistry $registry,
-		private ISharingManager $manager,
+		private IEventDispatcher $eventDispatcher,
 		private ClassMapper $classMapper,
 		private ClockInterface $clock,
 	) {
@@ -1008,6 +1010,7 @@ final readonly class SharingBackend implements ISharingBackend {
 			}
 		}
 
+		$defaultSet = false;
 		foreach (array_keys($shares) as $id) {
 			$id = (string)$id;
 			foreach (array_keys($registryPropertyTypes) as $propertyTypeClass) {
@@ -1017,7 +1020,8 @@ final readonly class SharingBackend implements ISharingBackend {
 					&& isset($shareSourceTypeClasses[$id], $shareRecipientTypeClasses[$id])
 					&& array_intersect($registryPropertyTypeCompatibleSourceTypeClasses[$propertyTypeClass], array_keys($shareSourceTypeClasses[$id])) !== []
 					&& array_intersect($registryPropertyTypeCompatibleRecipientTypeClasses[$propertyTypeClass], array_keys($shareRecipientTypeClasses[$id])) !== []) {
-					$shares[$id] = $this->manager->createSharePropertyDefaultValue($shares[$id], $propertyTypeClass);
+					$shares[$id] = $this->createSharePropertyDefaultValue($shares[$id], $propertyTypeClass);
+					$defaultSet = true;
 				}
 			}
 		}
@@ -1026,12 +1030,84 @@ final readonly class SharingBackend implements ISharingBackend {
 			foreach (array_keys($shareCompatiblePermissionTypeClasses[$id]) as $permissionTypeClass) {
 				$share = $shares[$id];
 				if (!isset($share->permissions[$permissionTypeClass])) {
-					$shares[$id] = $this->manager->createSharePermissionDefaultValue($shares[$id], $permissionTypeClass);
+					$shares[$id] = $this->createSharePermissionDefaultValue($shares[$id], $permissionTypeClass);
+					$defaultSet = true;
 				}
 			}
 		}
 
-		return array_values($shares);
+		$shares = array_values($shares);
+		if ($defaultSet && $shares !== []) {
+			$event = new SharesDefaultSetEvent($shares);
+			$this->eventDispatcher->dispatchTyped($event);
+			$shares = $event->getShares();
+		}
+
+		return $shares;
+	}
+
+	/**
+	 * @param class-string<ISharePropertyType> $propertyTypeClass
+	 */
+	public function createSharePropertyDefaultValue(Share $share, string $propertyTypeClass): Share {
+		$timestamp = $this->clock->now();
+		$this->setLastUpdated([$share->id], $timestamp);
+
+		if (($propertyType = $this->registry->getPropertyTypes()[$propertyTypeClass] ?? null) === null) {
+			throw new RuntimeException('The property is not registered: ' . $propertyTypeClass);
+		}
+
+		$property = new ShareProperty($propertyTypeClass, $propertyType->getDefaultValue($share));
+
+		$this->createShareProperty($share->id, $property);
+
+		$properties = $share->properties;
+		$properties[$propertyTypeClass] = $property;
+
+		$share = new Share(
+			$share->id,
+			$share->owner,
+			$timestamp,
+			$share->state,
+			$share->sources,
+			$share->recipients,
+			$properties,
+			$share->permissions,
+		);
+
+		return $share;
+	}
+
+	/**
+	 * @param class-string<ISharePermissionType> $permissionTypeClass
+	 */
+	public function createSharePermissionDefaultValue(Share $share, string $permissionTypeClass): Share {
+		$timestamp = $this->clock->now();
+		$this->setLastUpdated([$share->id], $timestamp);
+
+		if (($permissionType = $this->registry->getPermissionTypes()[$permissionTypeClass] ?? null) === null) {
+			throw new RuntimeException('The permission is not registered: ' . $permissionTypeClass);
+		}
+
+		$permission = new SharePermission($permissionTypeClass, $permissionType->isEnabledByDefault());
+
+		$this->createSharePermission($share->id, $permission);
+
+		$permissions = $share->permissions;
+		$permissions[$permissionTypeClass] = $permission;
+
+		$share = new Share(
+			$share->id,
+			$share->owner,
+			$timestamp,
+			$share->state,
+			$share->sources,
+			$share->recipients,
+			$share->properties,
+			$permissions,
+		);
+
+		return $share;
 	}
 
 	private static function parseTimestamp(int $timestampMs): \DateTimeImmutable {

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -31,7 +31,6 @@ use OC\Core\Sharing\Permission\ReshareSharePermissionType;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\Interaction\Actions\ShareAction;
@@ -61,8 +60,6 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 	private IL10N $l10n;
 
-	private ISharingBackend $backend;
-
 	public function __construct(
 		IEventDispatcher $eventDispatcher,
 		private IUserManager $userManager,
@@ -70,19 +67,11 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		private ISnowflakeGenerator $snowflakeGenerator,
 		private IDBConnection $dbConnection,
 		private ISharingRegistry $registry,
-		IAppConfig $appConfig,
+		private ISharingBackend $backend,
 		private ClockInterface $clock,
 	) {
 		$this->randomizer = new Randomizer();
 		$this->l10n = $l10nFactory->get('sharing');
-		$this->backend = new SharingBackend(
-			$l10nFactory,
-			$dbConnection,
-			$userManager,
-			$appConfig,
-			$registry,
-			$this,
-		);
 
 		$eventDispatcher->addServiceListener(BeforeUserDeletedEvent::class, self::class);
 	}

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OC\Sharing;
 
 use Exception;
+use NCU\Sharing\Event\SharesDefaultSetEvent;
 use NCU\Sharing\Exception\ShareInvalidException;
 use NCU\Sharing\Exception\ShareOperationForbiddenException;
 use NCU\Sharing\ISharingBackend;
@@ -53,7 +54,7 @@ use RuntimeException;
 
 /**
  * @psalm-import-type SharingShare from Share
- * @template-implements IEventListener<BeforeUserDeletedEvent>
+ * @template-implements IEventListener<BeforeUserDeletedEvent|SharesDefaultSetEvent>
  */
 final readonly class SharingManager implements ISharingManager, IEventListener {
 	private Randomizer $randomizer;
@@ -427,40 +428,6 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	}
 
 	#[\Override]
-	public function createSharePropertyDefaultValue(Share $share, string $propertyTypeClass): Share {
-		$this->assertInTransaction();
-
-		$timestamp = $this->getTime();
-		$this->backend->setLastUpdated([$share->id], $timestamp);
-
-		if (($propertyType = $this->registry->getPropertyTypes()[$propertyTypeClass] ?? null) === null) {
-			throw new RuntimeException('The property is not registered: ' . $propertyTypeClass);
-		}
-
-		$property = new ShareProperty($propertyTypeClass, $propertyType->getDefaultValue($share));
-
-		$this->backend->createShareProperty($share->id, $property);
-
-		$properties = $share->properties;
-		$properties[$propertyTypeClass] = $property;
-
-		$share = new Share(
-			$share->id,
-			$share->owner,
-			$timestamp,
-			$share->state,
-			$share->sources,
-			$share->recipients,
-			$properties,
-			$share->permissions,
-		);
-
-		[$share] = $this->processShareUpdates([$share]);
-
-		return $share;
-	}
-
-	#[\Override]
 	public function updateShareProperty(ShareAccessContext $accessContext, string $id, ShareProperty $property): void {
 		$this->assertInTransaction();
 
@@ -483,40 +450,6 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$this->backend->updateShareProperty($id, $property);
 
 		$this->processShareUpdates([$id]);
-	}
-
-	#[\Override]
-	public function createSharePermissionDefaultValue(Share $share, string $permissionTypeClass): Share {
-		$this->assertInTransaction();
-
-		$timestamp = $this->getTime();
-		$this->backend->setLastUpdated([$share->id], $timestamp);
-
-		if (($permissionType = $this->registry->getPermissionTypes()[$permissionTypeClass] ?? null) === null) {
-			throw new RuntimeException('The permission is not registered: ' . $permissionTypeClass);
-		}
-
-		$permission = new SharePermission($permissionTypeClass, $permissionType->isEnabledByDefault());
-
-		$this->backend->createSharePermission($share->id, $permission);
-
-		$permissions = $share->permissions;
-		$permissions[$permissionTypeClass] = $permission;
-
-		$share = new Share(
-			$share->id,
-			$share->owner,
-			$timestamp,
-			$share->state,
-			$share->sources,
-			$share->recipients,
-			$share->properties,
-			$permissions,
-		);
-
-		[$share] = $this->processShareUpdates([$share]);
-
-		return $share;
 	}
 
 	#[\Override]
@@ -608,16 +541,22 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 	#[\Override]
 	public function handle(Event $event): void {
-		$shareUser = new ShareUser($event->getUser()->getUID(), null);
+		if ($event instanceof SharesDefaultSetEvent) {
+			$this->processShareUpdates($event->getShares());
+		}
 
-		try {
-			$this->dbConnection->beginTransaction();
-			$this->onOwnerDeleted(new ShareAccessContext(overrideChecks: true), $shareUser);
-			$this->onInitiatorDeleted(new ShareAccessContext(overrideChecks: true), $shareUser);
-			$this->dbConnection->commit();
-		} catch (Exception $exception) {
-			$this->dbConnection->rollBack();
-			throw $exception;
+		if ($event instanceof  BeforeUserDeletedEvent) {
+			$shareUser = new ShareUser($event->getUser()->getUID(), null);
+
+			try {
+				$this->dbConnection->beginTransaction();
+				$this->onOwnerDeleted(new ShareAccessContext(overrideChecks: true), $shareUser);
+				$this->onInitiatorDeleted(new ShareAccessContext(overrideChecks: true), $shareUser);
+				$this->dbConnection->commit();
+			} catch (Exception $exception) {
+				$this->dbConnection->rollBack();
+				throw $exception;
+			}
 		}
 	}
 

--- a/lib/unstable/Sharing/Event/SharesDefaultSetEvent.php
+++ b/lib/unstable/Sharing/Event/SharesDefaultSetEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Sharing\Event;
+
+use NCU\Sharing\Share;
+use OCP\EventDispatcher\Event;
+
+/**
+ * Emitted when a default value for a permission or property has been applied to an existing share
+ *
+ * @experimental 35.0.0
+ */
+final class SharesDefaultSetEvent extends Event {
+	/**
+	 * @param non-empty-list<Share> $shares
+	 * @experimental 35.0.0
+	 */
+	public function __construct(
+		private array $shares,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @return non-empty-list<Share>
+	 * @experimental 35.0.0
+	 */
+	public function getShares(): array {
+		return $this->shares;
+	}
+
+	/**
+	 * @param non-empty-list<Share> $shares
+	 * @experimental 35.0.0
+	 */
+	public function setShares(array $shares): void {
+		$this->shares = $shares;
+	}
+}

--- a/lib/unstable/Sharing/ISharingManager.php
+++ b/lib/unstable/Sharing/ISharingManager.php
@@ -13,9 +13,7 @@ use NCU\Sharing\Exception\ShareInvalidException;
 use NCU\Sharing\Exception\ShareNotFoundException;
 use NCU\Sharing\Exception\ShareOperationForbiddenException;
 use NCU\Sharing\Permission\ISharePermissionPreset;
-use NCU\Sharing\Permission\ISharePermissionType;
 use NCU\Sharing\Permission\SharePermission;
-use NCU\Sharing\Property\ISharePropertyType;
 use NCU\Sharing\Property\ShareProperty;
 use NCU\Sharing\Recipient\IShareRecipientType;
 use NCU\Sharing\Recipient\ShareRecipient;
@@ -150,13 +148,6 @@ interface ISharingManager {
 	public function updateShareRecipientSecret(ShareAccessContext $accessContext, string $id, ShareRecipient $recipient, string $secret): void;
 
 	/**
-	 * @param class-string<ISharePropertyType> $propertyTypeClass
-	 * @throws ShareNotFoundException
-	 * @experimental 35.0.0
-	 */
-	public function createSharePropertyDefaultValue(Share $share, string $propertyTypeClass): Share;
-
-	/**
 	 * Update a property of a share.
 	 *
 	 * @throws ShareInvalidException
@@ -165,13 +156,6 @@ interface ISharingManager {
 	 * @experimental 35.0.0
 	 */
 	public function updateShareProperty(ShareAccessContext $accessContext, string $id, ShareProperty $property): void;
-
-	/**
-	 * @param class-string<ISharePermissionType> $permissionTypeClass
-	 * @throws ShareNotFoundException
-	 * @experimental 35.0.0
-	 */
-	public function createSharePermissionDefaultValue(Share $share, string $permissionTypeClass): Share;
 
 	/**
 	 * Update a permission of a share.

--- a/tests/lib/Sharing/ClassMapperTest.php
+++ b/tests/lib/Sharing/ClassMapperTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Sharing;
+
+use OC\Sharing\ClassMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\Group;
+use Test\TestCase;
+
+#[Group(name: 'DB')]
+final class ClassMapperTest extends TestCase {
+	private IDBConnection $connection;
+
+	private ClassMapper $classMapper;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->connection = Server::get(IDBConnection::class);
+		$this->clearMappings();
+		$this->classMapper = $this->getMapper();
+	}
+
+	private function clearMappings(): void {
+		$query = $this->connection->getTypedQueryBuilder();
+		$cleanupClasses = [IDBConnection::class, ClassMapper::class];
+		$query->delete('sharing_classmap')
+			->where($query->expr()->in('class_name', $query->createNamedParameter($cleanupClasses, IQueryBuilder::PARAM_STR_ARRAY)));
+		$query->executeStatement();
+	}
+
+	private function getMapper(): ClassMapper {
+		return new ClassMapper($this->connection);
+	}
+
+	public function testGetInsert(): void {
+		$id = $this->classMapper->getClassId(IDBConnection::class);
+		$this->assertEquals($id, $this->classMapper->getClassId(IDBConnection::class));
+		$this->assertEquals(IDBConnection::class, $this->classMapper->getClassName($id));
+
+		$this->assertEquals($id, $this->getMapper()->getClassId(IDBConnection::class));
+	}
+
+	public function testInsertConcurrent(): void {
+		$concurrentMapper = $this->getMapper();
+
+		// trigger a load
+		$this->classMapper->getClassId(ClassMapper::class);
+
+		$id = $concurrentMapper->getClassId(IDBConnection::class);
+		$this->assertEquals($id, $this->classMapper->getClassId(IDBConnection::class));
+		$this->assertEquals(IDBConnection::class, $this->classMapper->getClassName($id));
+	}
+
+	public function testGetUnknownId(): void {
+		$this->expectException(\Exception::class);
+		$this->classMapper->getClassName(PHP_INT_MAX - 1);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Instead of storing the full class name every time, keep a table that maps them to integers, so we only need to store an int.

Saves 60 bytes for each sharing source, recipient, property and permission

Extracted from https://github.com/nextcloud/server/pull/62708

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
