### PR TITLE
fix(ObjectStore): reset multipart upload byte counter on retry

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -145,10 +145,10 @@ trait S3ObjectTrait {
 		$exception = null;
 		$state = null;
 		$size = $stream->getSize();
-		$totalWritten = 0;
 
 		// retry multipart upload once with concurrency at half on failure
 		while (!$uploaded && $attempts <= 1) {
+			$totalWritten = 0;
 			$uploader = new MultipartUploader($this->getConnection(), $stream, [
 				'bucket' => $this->bucket,
 				'concurrency' => $concurrency,


### PR DESCRIPTION
* Resolves: #59505

## Summary

writeMultiPart() initializes $totalWritten once outside the retry loop, so bytes from a failed first attempt accumulate into the second attempt. Since $state is never resumed, each retry rewinds the stream and re-uploads the whole object from scratch, making before_complete compare roughly twice the object size against the expected size. The retry then always fails with "Incomplete multi part upload, expected X bytes, wrote 2X" and the upload is aborted.

Reset the counter per attempt so the size check validates only the bytes written by the current attempt.

## TODO

N/A

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
