### PR TITLE
fix(trashbin): properly show deleted by for federated shares

### DIFF
--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -12,6 +12,7 @@ use OC\Files\View;
 use OCA\Files_Trashbin\Helper;
 use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trashbin;
+use OCP\Federation\ICloudIdManager;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -28,6 +29,7 @@ class LegacyTrashBackend implements ITrashBackend {
 	public function __construct(
 		private readonly IRootFolder $rootFolder,
 		private readonly IUserManager $userManager,
+		private readonly ICloudIdManager $cloudIdManager,
 	) {
 	}
 
@@ -40,7 +42,7 @@ class LegacyTrashBackend implements ITrashBackend {
 			$originalLocation = $file->getName();
 		}
 		/** @psalm-suppress UndefinedInterfaceMethod */
-		$deletedBy = $this->userManager->get($file['deletedBy']) ?? $parent?->getDeletedBy();
+		$deletedBy = $this->resolveDeletedBy($file['deletedBy']) ?? $parent?->getDeletedBy();
 		$trashFilename = Trashbin::getTrashFilename($file->getName(), $file->getMtime());
 		return new TrashItem(
 			$this,
@@ -126,5 +128,30 @@ class LegacyTrashBackend implements ITrashBackend {
 		} catch (NotFoundException $e) {
 			return null;
 		}
+	}
+
+	/**
+	 * Resolve the user that deleted a trash item. Files deleted by a federated share
+	 * recipient only carry the recipient's remote cloud ID, which no local IUserManager
+	 * backend can resolve, so fall back to a display-only user for the cloud ID in that
+	 * case instead of leaving the item without an "Unknown" deleted by user.
+	 */
+	private function resolveDeletedBy(?string $uid): ?IUser {
+		if (!$uid) {
+			return null;
+		}
+
+		$user = $this->userManager->get($uid);
+		if ($user !== null) {
+			return $user;
+		}
+
+		try {
+			$cloudId = $this->cloudIdManager->resolveCloudId($uid);
+		} catch (\InvalidArgumentException $e) {
+			return null;
+		}
+
+		return $this->userManager->getFederatedUser($cloudId);
 	}
 }

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -13,6 +13,7 @@ use OC\Memcache\WithLocalCache;
 use OCP\Config\IUserConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudId;
 use OCP\HintException;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -882,5 +883,10 @@ class Manager extends PublicEmitter implements IUserManager {
 	#[\Override]
 	public function getAvatarUrlDark(string $userId, int $size): string {
 		return ($this->urlGenerator ??= Server::get(IURLGenerator::class))->linkToRouteAbsolute('core.avatar.getAvatarDark', ['userId' => $userId, 'size' => $size]);
+	}
+
+	#[\Override]
+	public function getFederatedUser(ICloudId $cloudId): IUser {
+		return new LazyUser($cloudId->getDisplayId(), $this, $cloudId->getDisplayId());
 	}
 }

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -282,4 +282,15 @@ interface IUserManager {
 	 * @since 34.0.0
 	 */
 	public function getAvatarUrlDark(string $userId, int $size): string;
+
+	/**
+	 * Get a read-only user from a cloud ID for showing the display name of a remote
+	 * federation user (e.g. the "deleted by" user of a federated share) that has no
+	 * local account.
+	 *
+	 * @param \OCP\Federation\ICloudId $federatedUserId A cloud ID of the federated user
+	 * @return IUser
+	 * @since 35.0.0
+	 */
+	public function getFederatedUser(\OCP\Federation\ICloudId $cloudId): IUser;
 }

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -15,6 +15,7 @@ use OC\User\Manager;
 use OC\User\User;
 use OCP\Config\IUserConfig;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudId;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -735,5 +736,19 @@ class ManagerTest extends TestCase {
 
 	public function testGetAvatarUrlDark(): void {
 		$this->assertEquals('http://localhost/index.php/avatar/userid/64/dark', $this->manager->getAvatarUrlDark('userid', 64));
+	}
+
+	public function testGetFederatedUser(): void {
+		$userId = 'test@example.com';
+
+		$cloudId = $this->createMock(ICloudId::class);
+		$cloudId->expects($this->exactly(2))
+			->method('getDisplayId')
+			->willReturn($userId);
+
+		$user = $this->manager->getFederatedUser($cloudId);
+
+		$this->assertEquals($userId, $user->getUID());
+		$this->assertEquals($userId, $user->getDisplayName());
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
When a remote user deletes a file in a federated share, the deleted by column in trashbin shows "Unknown" instead of the remote user. This fixes it so that it properly shows the remote user under the deleted by column.

### Before
<img width="1603" height="185" alt="image" src="https://github.com/user-attachments/assets/46365c34-0e43-4e38-92ac-85192379b4d9" />

### After
<img width="1603" height="207" alt="image" src="https://github.com/user-attachments/assets/c80dbb71-0a53-4ea4-9e92-ee7a47cf027f" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
