### PR TITLE
[stable30] chore(psalm): use full qualified class name for Circles

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1523,7 +1523,8 @@ class ShareAPIController extends OCSController {
 					$sharedWith = substr($share->getSharedWith(), $shareWithStart, $shareWithLength);
 				}
 				try {
-					$member = Circles::getMember($sharedWith, $this->userId, 1);
+
+					$member = \OCA\Circles\Api\v1\Circles::getMember($sharedWith, $this->userId, 1);
 					if ($member->getLevel() >= 1) {
 						return true;
 					}


### PR DESCRIPTION
The entire file is written in a way to ensure it also works
if the circles app is not installed.

So there is no `Circles` alias as it cannot be added with `use`.

This is only relevant for stable30 and before due as https://github.com/nextcloud/server/pull/48371 landed in stable31.