### PR TITLE
feat: show recent people on contact icon

### DIFF
--- a/core/Controller/ContactsMenuController.php
+++ b/core/Controller/ContactsMenuController.php
@@ -13,18 +13,24 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Contacts\ContactsMenu\IEntry;
+use OCP\ICacheFactory;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Teams\ITeamManager;
 
 class ContactsMenuController extends Controller {
+	private const PREVIEW_AVATARS_LIMIT = 3;
+	private const PREVIEW_AVATARS_CACHE_TTL = 300;
+
 	public function __construct(
 		IRequest $request,
 		private IUserSession $userSession,
 		private Manager $manager,
 		private ITeamManager $teamManager,
+		private ICacheFactory $cacheFactory,
 	) {
 		parent::__construct('core', $request);
 	}
@@ -69,5 +75,45 @@ class ContactsMenuController extends Controller {
 	#[FrontpageRoute(verb: 'GET', url: '/contactsmenu/teams')]
 	public function getTeams(): array {
 		return $this->teamManager->getTeamsForUser($this->userSession->getUser()->getUID());
+	}
+
+	/**
+	 * Top contacts for the People menu header avatar stack (max 3).
+	 * Uses a lightweight query (limited results, no action providers) and
+	 * caches per user for a few minutes.
+	 *
+	 * @return list<array>
+	 * @throws Exception
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 30, period: 300)]
+	#[FrontpageRoute(verb: 'GET', url: '/contactsmenu/preview-avatars')]
+	public function previewAvatars(?string $teamId = null): array {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return [];
+		}
+
+		$cache = $this->cacheFactory->createDistributed('contactsmenu-preview');
+		$cacheKey = $user->getUID();
+		$cached = $cache->get($cacheKey);
+		if (!is_array($cached)) {
+			$entries = $this->manager->getPreviewEntries($user, self::PREVIEW_AVATARS_LIMIT);
+			$cached = array_map(
+				static fn (IEntry $entry): array => $entry->jsonSerialize(),
+				$entries,
+			);
+			$cache->set($cacheKey, $cached, self::PREVIEW_AVATARS_CACHE_TTL);
+		}
+
+		if ($teamId !== null && $teamId !== '') {
+			$memberIds = $this->teamManager->getMembersOfTeam($teamId, $user->getUID());
+			$cached = array_filter(
+				$cached,
+				static fn (array $entry): bool => array_key_exists($entry['uid'] ?? '', $memberIds)
+			);
+		}
+
+		return array_values(array_slice($cached, 0, self::PREVIEW_AVATARS_LIMIT));
 	}
 }

--- a/core/src/tests/views/ContactsMenu.spec.ts
+++ b/core/src/tests/views/ContactsMenu.spec.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { IPreviewUser } from '../../types/contactsMenu.ts'
+
 import { cleanup, findAllByRole, render } from '@testing-library/vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import ContactsMenu from '../../views/ContactsMenu.vue'
@@ -18,6 +20,15 @@ vi.mock('@nextcloud/auth', () => ({
 }))
 
 afterEach(cleanup)
+
+function mockDefaultGets(previewUsers: IPreviewUser[] = []) {
+	axios.get.mockImplementation(async (url: string) => {
+		if (String(url).includes('/contactsmenu/preview-avatars')) {
+			return { data: previewUsers }
+		}
+		return { data: [] }
+	})
+}
 
 describe('ContactsMenu', function() {
 	it('shows a loading text', async () => {
@@ -123,5 +134,42 @@ describe('ContactsMenu', function() {
 		const items = await findAllByRole(list, 'listitem')
 		expect(items[0]!.textContent).toContain('Acosta Lancaster')
 		expect(items[1]!.textContent).toContain('Adeline Snider')
+	})
+
+	it('shows the contacts icon when fewer than two preview users are available', async () => {
+		mockDefaultGets([{ uid: 'alice', fullName: 'Alice', isUser: true }])
+		axios.post.mockResolvedValue({
+			data: { contacts: [], contactsAppEnabled: false },
+		})
+
+		const view = render(ContactsMenu)
+		await view.findByRole('button')
+
+		await vi.waitFor(() => {
+			expect(axios.get.mock.calls.some(([url]) => String(url).includes('/contactsmenu/preview-avatars'))).toBe(true)
+			expect(view.container.querySelector('.contactsmenu__trigger-avatars')).toBeNull()
+			expect(view.container.querySelector('.contactsmenu__trigger-icon')).toBeTruthy()
+		})
+	})
+
+	it('shows an avatar stack when at least two preview users are available', async () => {
+		mockDefaultGets([
+			{ uid: 'alice', fullName: 'Alice', isUser: true },
+			{ uid: 'contact-1', fullName: 'External Contact', isUser: false },
+			{ uid: 'bob', fullName: 'Bob', isUser: true },
+		])
+		axios.post.mockResolvedValue({
+			data: { contacts: [], contactsAppEnabled: false },
+		})
+
+		const view = render(ContactsMenu)
+		await view.findByRole('button')
+
+		// wait for onMounted preview load
+		await vi.waitFor(() => {
+			expect(view.container.querySelector('.contactsmenu__trigger-avatars')).toBeTruthy()
+		})
+		expect(view.container.querySelectorAll('.contactsmenu__trigger-avatars__avatar')).toHaveLength(3)
+		expect(view.container.querySelector('.contactsmenu__trigger-icon')).toBeNull()
 	})
 })

--- a/core/src/types/contactsMenu.ts
+++ b/core/src/types/contactsMenu.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export interface IPreviewUser {
+	uid: string
+	fullName: string
+	isUser: boolean
+}
+
+export interface ITeam {
+	teamId: string
+	displayName: string
+	link: string
+}

--- a/core/src/views/ContactsMenu.vue
+++ b/core/src/views/ContactsMenu.vue
@@ -4,6 +4,8 @@
 -->
 
 <script setup lang="ts">
+import type { IPreviewUser, ITeam } from '../types/contactsMenu.ts'
+
 import { mdiAccountGroupOutline, mdiContacts, mdiMagnify } from '@mdi/js'
 import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
@@ -14,6 +16,7 @@ import debounce from 'debounce'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcHeaderMenu from '@nextcloud/vue/components/NcHeaderMenu'
@@ -42,15 +45,13 @@ const hasError = ref(false)
 const searchTerm = ref('')
 
 const teams = ref<ITeam[]>([])
-const selectedTeam = ref<string>('$_all_$')
+const storedTeam = storage.getItem('core:contacts:team')
+const selectedTeam = ref<string>(storedTeam ? JSON.parse(storedTeam) : '$_all_$')
 const selectedTeamName = computed(() => teams.value.find((t) => t.teamId === selectedTeam.value)?.displayName)
+const previewUsers = ref<IPreviewUser[]>([])
+const showAvatarStack = computed(() => previewUsers.value.length >= 2)
 
 onMounted(async () => {
-	const team = storage.getItem('core:contacts:team')
-	if (team) {
-		selectedTeam.value = JSON.parse(team)
-	}
-
 	if (userTeams.length === 0) {
 		try {
 			const { data } = await axios.get<ITeam[]>(generateUrl('/contactsmenu/teams'))
@@ -65,7 +66,28 @@ onMounted(async () => {
 watch(selectedTeam, () => {
 	storage.setItem('core:contacts:team', JSON.stringify(selectedTeam.value))
 	getContacts(searchTerm.value)
+	loadPreviewAvatars()
 })
+
+/**
+ * Load avatars for the People menu header trigger
+ */
+async function loadPreviewAvatars() {
+	try {
+		const { data } = await axios.get<IPreviewUser[]>(generateUrl('/contactsmenu/preview-avatars'), {
+			params: {
+				teamId: selectedTeam.value !== '$_all_$' ? selectedTeam.value : undefined,
+			},
+		})
+		previewUsers.value = data
+	} catch (error) {
+		logger.error('could not load preview avatars', { error })
+		previewUsers.value = []
+	}
+}
+
+// Seeded selectedTeam above so this runs once on mount with the correct team
+loadPreviewAvatars()
 
 /**
  * Load contacts when opening the menu
@@ -132,11 +154,7 @@ function focusInput() {
 </script>
 
 <script lang="ts">
-interface ITeam {
-	teamId: string
-	displayName: string
-	link: string
-}
+import type { ITeam } from '../types/contactsMenu.ts'
 
 const userTeams: ITeam[] = []
 </script>
@@ -145,11 +163,32 @@ const userTeams: ITeam[] = []
 	<NcHeaderMenu
 		id="contactsmenu"
 		class="contactsmenu"
+		:class="{ 'contactsmenu--avatar-stack': showAvatarStack }"
 		:aria-label="t('core', 'Search contacts')"
 		exclude-click-outside-selectors=".v-popper__popper"
 		@open="onOpened">
 		<template #trigger>
-			<NcIconSvgWrapper class="contactsmenu__trigger-icon" :path="mdiContacts" />
+			<span
+				v-if="showAvatarStack"
+				class="contactsmenu__trigger-avatars"
+				aria-hidden="true">
+				<NcAvatar
+					v-for="(previewUser, index) in previewUsers"
+					:key="previewUser.isUser ? previewUser.uid : `${previewUser.fullName}-${index}`"
+					class="contactsmenu__trigger-avatars__avatar"
+					:style="{ zIndex: previewUsers.length - index }"
+					:user="previewUser.isUser ? previewUser.uid : undefined"
+					:is-no-user="!previewUser.isUser"
+					:display-name="previewUser.fullName"
+					:size="32"
+					disable-menu
+					disable-tooltip
+					hide-status />
+			</span>
+			<NcIconSvgWrapper
+				v-else
+				class="contactsmenu__trigger-icon"
+				:path="mdiContacts" />
 		</template>
 		<div class="contactsmenu__menu">
 			<div class="contactsmenu__menu__search-container">
@@ -242,10 +281,65 @@ const userTeams: ITeam[] = []
 
 <style lang="scss" scoped>
 .contactsmenu {
-	overflow-y: hidden;
+	margin-inline-end: calc(2 * var(--default-grid-baseline));
+
+	:deep(.header-menu__trigger) {
+		// NcHeaderMenu applies --header-menu-icon-mask (vertical alpha fade) to
+		// .button-vue__icon:not(:has(svg)). Avatars need the full face visible.
+		.button-vue__icon:has(.contactsmenu__trigger-avatars) {
+			mask: none !important;
+		}
+	}
+
+	&--avatar-stack {
+		width: fit-content !important;
+		min-width: var(--header-height);
+		overflow: visible;
+		flex-shrink: 0;
+
+		:deep(.header-menu__trigger) {
+			width: fit-content !important;
+			min-width: var(--header-height);
+			max-width: none;
+			overflow: visible !important;
+			padding-inline: var(--default-grid-baseline);
+
+			.button-vue__wrapper {
+				width: auto;
+				justify-content: center;
+			}
+
+			.button-vue__icon {
+				width: auto !important;
+				min-width: 0;
+				max-width: none;
+				height: auto;
+				min-height: 0;
+				overflow: visible;
+			}
+		}
+	}
 
 	&__trigger-icon {
 		color: var(--color-background-plain-text) !important;
+	}
+
+	&__trigger-avatars {
+		display: flex;
+		align-items: center;
+		pointer-events: none;
+
+		&__avatar {
+			box-sizing: content-box;
+			flex-shrink: 0;
+			--contactsmenu-avatar-outline: var(--border-width-input) solid color-mix(in srgb, var(--color-background-plain-text), transparent 75%);
+			outline: var(--contactsmenu-avatar-outline);
+			margin-inline-start: -12px;
+
+			&:first-child {
+				margin-inline-start: 0;
+			}
+		}
 	}
 
 	&__menu {

--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -48,6 +48,23 @@ class Manager {
 	}
 
 	/**
+	 * Lightweight recent contacts for the People menu header avatar stack.
+	 * Limits the store query and skips action providers.
+	 *
+	 * @return IEntry[]
+	 * @throws Exception
+	 */
+	public function getPreviewEntries(IUser $user, int $limit = 3): array {
+		$limit = max(0, $limit);
+		if ($limit === 0) {
+			return [];
+		}
+
+		$entries = $this->store->getContacts($user, '', $limit);
+		return array_slice($this->sortEntries($entries), 0, $limit);
+	}
+
+	/**
 	 * @throws Exception
 	 */
 	public function findOne(IUser $user, int $shareType, string $shareWith): ?IEntry {

--- a/tests/Core/Controller/ContactsMenuControllerTest.php
+++ b/tests/Core/Controller/ContactsMenuControllerTest.php
@@ -10,6 +10,8 @@ namespace Tests\Controller;
 use OC\Contacts\ContactsMenu\Manager;
 use OC\Core\Controller\ContactsMenuController;
 use OCP\Contacts\ContactsMenu\IEntry;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -21,6 +23,8 @@ class ContactsMenuControllerTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private Manager&MockObject $contactsManager;
 	private ITeamManager&MockObject $teamManager;
+	private ICacheFactory&MockObject $cacheFactory;
+	private ICache&MockObject $cache;
 
 	private ContactsMenuController $controller;
 
@@ -32,12 +36,19 @@ class ContactsMenuControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->contactsManager = $this->createMock(Manager::class);
 		$this->teamManager = $this->createMock(ITeamManager::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cache = $this->createMock(ICache::class);
+
+		$this->cacheFactory->method('createDistributed')
+			->with('contactsmenu-preview')
+			->willReturn($this->cache);
 
 		$this->controller = new ContactsMenuController(
 			$request,
 			$this->userSession,
 			$this->contactsManager,
 			$this->teamManager,
+			$this->cacheFactory,
 		);
 	}
 
@@ -124,5 +135,120 @@ class ContactsMenuControllerTest extends TestCase {
 
 		$this->assertEquals([], $response->getData());
 		$this->assertEquals(404, $response->getStatus());
+	}
+
+	public function testPreviewAvatarsWithoutTeam(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('current-user');
+
+		$contacts = [
+			$this->createPreviewEntry('alice', 'Alice'),
+			$this->createPreviewEntry('bob', 'Bob'),
+			$this->createPreviewEntry('carol', 'Carol'),
+			$this->createPreviewEntry('dave', 'Dave'),
+		];
+		$expected = [
+			$contacts[0]->jsonSerialize(),
+			$contacts[1]->jsonSerialize(),
+			$contacts[2]->jsonSerialize(),
+		];
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->cache->expects($this->once())
+			->method('get')
+			->with('current-user')
+			->willReturn(null);
+		$this->contactsManager->expects($this->once())
+			->method('getPreviewEntries')
+			->with($user, 3)
+			->willReturn([$contacts[0], $contacts[1], $contacts[2]]);
+		$this->cache->expects($this->once())
+			->method('set')
+			->with('current-user', $expected, 300);
+		$this->teamManager->expects($this->never())
+			->method('getMembersOfTeam');
+
+		$this->assertEquals($expected, $this->controller->previewAvatars());
+	}
+
+	public function testPreviewAvatarsUsesCache(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('current-user');
+		$cached = [
+			['uid' => 'alice', 'fullName' => 'Alice', 'isUser' => true],
+			['uid' => 'bob', 'fullName' => 'Bob', 'isUser' => true],
+		];
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->cache->expects($this->once())
+			->method('get')
+			->with('current-user')
+			->willReturn($cached);
+		$this->contactsManager->expects($this->never())
+			->method('getPreviewEntries');
+		$this->cache->expects($this->never())
+			->method('set');
+
+		$this->assertEquals($cached, $this->controller->previewAvatars());
+	}
+
+	public function testPreviewAvatarsWithTeam(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('current-user');
+
+		$cached = [
+			['uid' => 'alice', 'fullName' => 'Alice', 'isUser' => true],
+			['uid' => 'contact-1', 'fullName' => 'External', 'isUser' => false],
+			['uid' => 'bob', 'fullName' => 'Bob', 'isUser' => true],
+		];
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->cache->expects($this->once())
+			->method('get')
+			->with('current-user')
+			->willReturn($cached);
+		$this->contactsManager->expects($this->never())
+			->method('getPreviewEntries');
+		$this->teamManager->expects($this->once())
+			->method('getMembersOfTeam')
+			->with('team-id', 'current-user')
+			->willReturn([
+				'alice' => 'Alice',
+				'bob' => 'Bob',
+				'carol' => 'Carol',
+			]);
+
+		$this->assertEquals([
+			$cached[0],
+			$cached[2],
+		], $this->controller->previewAvatars('team-id'));
+	}
+
+	public function testPreviewAvatarsWithoutUser(): void {
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn(null);
+		$this->contactsManager->expects($this->never())
+			->method('getPreviewEntries');
+		$this->cache->expects($this->never())
+			->method('get');
+
+		$this->assertEquals([], $this->controller->previewAvatars());
+	}
+
+	private function createPreviewEntry(string $uid, string $fullName): IEntry&MockObject {
+		$entry = $this->createMock(IEntry::class);
+		$entry->method('jsonSerialize')->willReturn([
+			'uid' => $uid,
+			'fullName' => $fullName,
+			'isUser' => true,
+		]);
+		return $entry;
 	}
 }

--- a/tests/lib/Contacts/ContactsMenu/ManagerTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ManagerTest.php
@@ -155,6 +155,27 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($expected, $data);
 	}
 
+	public function testGetPreviewEntries(): void {
+		$user = $this->createMock(IUser::class);
+		$entries = $this->generateTestEntries();
+
+		$this->contactsStore->expects($this->once())
+			->method('getContacts')
+			->with($user, '', 3)
+			->willReturn($entries);
+		$this->actionProviderStore->expects($this->never())
+			->method('getProviders');
+		$this->config->expects($this->never())
+			->method('getSystemValueInt');
+
+		$data = $this->manager->getPreviewEntries($user, 3);
+
+		$this->assertCount(3, $data);
+		$this->assertSame('Contact A', $data[0]->getFullName());
+		$this->assertSame('Contact B', $data[1]->getFullName());
+		$this->assertSame('Contact C', $data[2]->getFullName());
+	}
+
 	public function testFindOne(): void {
 		$shareTypeFilter = 42;
 		$shareWithFilter = 'foobar';


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #60304 

## Summary
Makes the People (contacts) header menu more inviting by showing a stack of up to 3 overlapping avatars of recent contacts on the menu trigger, instead of only the contacts icon.
- Adds `GET /contactsmenu/preview-avatars` which returns the first 3 entries from the same unfiltered contacts list as the menu (`Manager::getEntries` with an empty filter), with optional team filtering matching the existing index endpoint.
- Frontend loads those contacts on mount and shows an `NcAvatar` stack when at least 2 are available; otherwise keeps the existing contacts icon.
- Widens the header trigger (`width: fit-content`) so the stack does not overlap notifications/profile and remains fully clickable.
- Adds PHP and Vue unit tests for the new endpoint and trigger behavior.

## Screenshot
### 🏚️ Before
<img width="1904" height="46" alt="image" src="https://github.com/user-attachments/assets/35338596-65a8-495d-a1c1-c54139799bb4" />

### 🏡 After
<img width="1913" height="46" alt="image" src="https://github.com/user-attachments/assets/5d05c091-4a10-426d-8a37-cdbd4143f506" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
