### PR TITLE
fix(setup): de-duplicate host parsing allowing IPv6 connections

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -98,39 +98,45 @@ abstract class AbstractDatabase {
 	}
 
 	/**
-	 * @param array $configOverwrite
-	 * @return \OC\DB\Connection
+	 * Create a new connection factory for the database.
+	 */
+	protected function createConnectionFactory(): ConnectionFactory {
+		// needed mostly because the factory caches `mysql.utf8mb4` within the constructor
+		// and we need to allow re-connect with new value (see MySQL::setupDatabase)
+		return new ConnectionFactory($this->config);
+	}
+
+	/**
+	 * Connect to the database that is currently being set up.
+	 *
+	 * Host, database name and table prefix are resolved from the system config by the connection factory,
+	 * so this only needs to additionally pass the credentials entered during setup.
+	 *
+	 * @param array $configOverwrite Connection parameters taking precedence over the resolved ones
 	 */
 	protected function connect(array $configOverwrite = []): Connection {
+		// The credentials entered during setup are only written to the config once the
+		// database user has been set up, so they have to be passed explicitly.
 		$connectionParams = [
-			'host' => $this->dbHost,
 			'user' => $this->dbUser,
 			'password' => $this->dbPassword,
-			'tablePrefix' => $this->tablePrefix,
-			'dbname' => $this->dbName
 		];
 
-		// adding port support through installer
+		// There is no `dbport` config value in the config - the port is part of `dbhost` - so a port
+		// provided by the installer can only be passed here. If set it takes precedence
+		// over a port or socket carried by the host.
 		if (!empty($this->dbPort)) {
 			if (ctype_digit($this->dbPort)) {
-				$connectionParams['port'] = $this->dbPort;
+				$connectionParams['port'] = (int)$this->dbPort;
 			} else {
 				$connectionParams['unix_socket'] = $this->dbPort;
 			}
-		} elseif (strpos($this->dbHost, ':')) {
-			// Host variable may carry a port or socket.
-			[$host, $portOrSocket] = explode(':', $this->dbHost, 2);
-			if (ctype_digit($portOrSocket)) {
-				$connectionParams['port'] = $portOrSocket;
-			} else {
-				$connectionParams['unix_socket'] = $portOrSocket;
-			}
-			$connectionParams['host'] = $host;
 		}
+
 		$connectionParams = array_merge($connectionParams, $configOverwrite);
-		$connectionParams = array_merge($connectionParams, ['primary' => $connectionParams, 'replica' => [$connectionParams]]);
-		$cf = new ConnectionFactory($this->config);
-		$connection = $cf->getConnection($this->config->getValue('dbtype', 'sqlite'), $connectionParams);
+
+		$connection = $this->createConnectionFactory()
+			->getConnection($this->config->getValue('dbtype', 'sqlite'), $connectionParams);
 		$connection->ensureConnectedToPrimary();
 		return $connection;
 	}

--- a/tests/lib/Setup/AbstractDatabaseTest.php
+++ b/tests/lib/Setup/AbstractDatabaseTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Setup;
+
+use OC\DB\Connection;
+use OC\DB\ConnectionFactory;
+use OC\SystemConfig;
+use OCP\IL10N;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class AbstractDatabaseTest extends TestCase {
+	private SystemConfig&MockObject $config;
+	private ConnectionFactory&MockObject $connectionFactory;
+	private Connection&MockObject $connection;
+	private TestDatabase $database;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(SystemConfig::class);
+		$this->connectionFactory = $this->createMock(ConnectionFactory::class);
+		$this->connection = $this->createMock(Connection::class);
+
+		$this->database = new TestDatabase(
+			$this->createMock(IL10N::class),
+			$this->config,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(ISecureRandom::class),
+		);
+		$this->database->connectionFactory = $this->connectionFactory;
+	}
+
+	public function testInitializeWritesConnectionConfig(): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org:5432',
+				'dbtableprefix' => 'nc_',
+			]);
+
+		$this->database->initialize([
+			'dbuser' => 'admin',
+			'dbpass' => 'admin-password',
+			'dbname' => 'nextcloud',
+			'dbhost' => 'db.example.org:5432',
+			'dbtableprefix' => 'nc_',
+		]);
+	}
+
+	public function testInitializeFallsBackToLocalhost(): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'localhost',
+				'dbtableprefix' => 'oc_',
+			]);
+
+		$this->database->initialize([
+			'dbuser' => 'admin',
+			'dbpass' => 'admin-password',
+			'dbname' => 'nextcloud',
+			'dbhost' => '',
+		]);
+	}
+
+	/**
+	 * Host, database name and table prefix must not be passed as additional parameters:
+	 * they are resolved from the system config by the connection factory, so that setup
+	 * connects exactly like the installed instance will.
+	 */
+	public function testConnectOnlyPassesCredentials(): void {
+		$this->expectConnection('mysql', [
+			'user' => 'admin',
+			'password' => 'admin-password',
+		]);
+
+		$this->database->initialize($this->options());
+
+		$this->assertSame($this->connection, $this->database->connectForTest());
+	}
+
+	public function testConnectPassesPort(): void {
+		$this->expectConnection('pgsql', [
+			'user' => 'admin',
+			'password' => 'admin-password',
+			'port' => 5432,
+		]);
+
+		$this->database->initialize($this->options(['dbport' => '5432']));
+		$this->database->connectForTest();
+	}
+
+	public function testConnectPassesSocket(): void {
+		$this->expectConnection('mysql', [
+			'user' => 'admin',
+			'password' => 'admin-password',
+			'unix_socket' => '/var/run/mysqld/mysqld.sock',
+		]);
+
+		$this->database->initialize($this->options(['dbport' => '/var/run/mysqld/mysqld.sock']));
+		$this->database->connectForTest();
+	}
+
+	public function testConnectAppliesConfigOverwrite(): void {
+		$this->expectConnection('pgsql', [
+			'user' => 'admin',
+			'password' => 'admin-password',
+			'dbname' => 'postgres',
+		]);
+
+		$this->database->initialize($this->options());
+		$this->database->connectForTest(['dbname' => 'postgres']);
+	}
+
+	private function options(array $additional = []): array {
+		return array_merge([
+			'dbuser' => 'admin',
+			'dbpass' => 'admin-password',
+			'dbname' => 'nextcloud',
+			'dbhost' => 'db.example.org',
+		], $additional);
+	}
+
+	private function expectConnection(string $dbType, array $expectedParams): void {
+		$this->config->method('getValue')
+			->willReturnCallback(fn ($key, $default = '') => $key === 'dbtype' ? $dbType : $default);
+
+		$this->connectionFactory->expects($this->once())
+			->method('getConnection')
+			->with($dbType, $expectedParams)
+			->willReturn($this->connection);
+
+		$this->connection->expects($this->once())
+			->method('ensureConnectedToPrimary');
+	}
+}

--- a/tests/lib/Setup/TestDatabase.php
+++ b/tests/lib/Setup/TestDatabase.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Test\Setup;
+
+use OC\DB\Connection;
+use OC\DB\ConnectionFactory;
+use OC\Setup\AbstractDatabase;
+
+/**
+ * Minimal concrete implementation to test the shared setup logic of
+ * {@see AbstractDatabase}, with the connection factory made injectable.
+ */
+class TestDatabase extends AbstractDatabase {
+	public string $dbprettyname = 'Test';
+
+	public ConnectionFactory $connectionFactory;
+
+	#[\Override]
+	protected function createConnectionFactory(): ConnectionFactory {
+		return $this->connectionFactory;
+	}
+
+	#[\Override]
+	public function setupDatabase(): void {
+	}
+
+	public function connectForTest(array $configOverwrite = []): Connection {
+		return $this->connect($configOverwrite);
+	}
+}


### PR DESCRIPTION
## Summary
The de-duplicates the connection params parsing,
previously it used `explode` to get host + port but this fails for IPv6 like `[::1]:80`. But a proper parsing is already available in the `ConnectionFactory`, so adjusted the code to reuse that.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
