### PR TITLE
refactor: use DateTimeImmutable in unified sharing api instead of timestamp

### DIFF
--- a/apps/files/tests/Sharing/Source/NodeShareSourceTypeTest.php
+++ b/apps/files/tests/Sharing/Source/NodeShareSourceTypeTest.php
@@ -13,6 +13,7 @@ use NCU\Sharing\ISharingRegistry;
 use NCU\Sharing\ShareAccessContext;
 use NCU\Sharing\Source\ShareSource;
 use OC\Files\Filesystem;
+use OC\Sharing\SharingManager;
 use OCA\Files\Sharing\Source\NodeShareSourceType;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\IFileAccess;
@@ -111,14 +112,14 @@ final class NodeShareSourceTypeTest extends TestCase {
 		$this->manager->addShareSource($accessContext, $id, new ShareSource($this->sourceType::class, (string)$this->node->getId()));
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->node->delete();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$this->dbConnection->beginTransaction();
 		$share = $this->manager->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share->lastUpdated);
-		$this->assertLessThanOrEqual($after, $share->lastUpdated);
+		$this->assertGreaterThanOrEqual(SharingManager::timeToMs($before), SharingManager::timeToMs($share->lastUpdated));
+		$this->assertLessThanOrEqual(SharingManager::timeToMs($after), SharingManager::timeToMs($share->lastUpdated));
 		$this->assertEquals([], $share->sources);
 
 		$this->manager->deleteShare($accessContext, $id);

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -59,7 +59,7 @@ final readonly class SharingBackend implements ISharingBackend {
 	}
 
 	#[\Override]
-	public function createShare(string $id, ShareUser $owner, int $lastUpdated): void {
+	public function createShare(string $id, ShareUser $owner, \DateTimeImmutable $lastUpdated): void {
 		$qb = $this->connection->getQueryBuilder();
 		$qb
 			->insert('sharing_share')
@@ -67,7 +67,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				'id' => $qb->createNamedParameter($id),
 				'owner_user_id' => $qb->createNamedParameter($owner->userId),
 				'owner_instance' => $qb->createNamedParameter($owner->instance),
-				'last_updated' => $qb->createNamedParameter($lastUpdated),
+				'last_updated' => $qb->createNamedParameter(SharingManager::timeToMs($lastUpdated)),
 				'state' => $qb->createNamedParameter(ShareState::Draft->value),
 			])
 			->executeStatement();
@@ -534,13 +534,13 @@ final readonly class SharingBackend implements ISharingBackend {
 	 * @param non-empty-list<string> $ids
 	 */
 	#[\Override]
-	public function setLastUpdated(array $ids, int $lastUpdated): void {
+	public function setLastUpdated(array $ids, \DateTimeImmutable $lastUpdated): void {
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$qb = $this->connection->getQueryBuilder();
 
 			$rowCount = $qb
 				->update('sharing_share')
-				->set('last_updated', $qb->createNamedParameter($lastUpdated, IQueryBuilder::PARAM_INT))
+				->set('last_updated', $qb->createNamedParameter(SharingManager::timeToMs($lastUpdated), IQueryBuilder::PARAM_INT))
 				->where($qb->expr()->in('id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)))
 				->executeStatement();
 			if ($rowCount !== count($chunk)) {
@@ -979,7 +979,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		$shares = array_map(static fn (array $share): Share => new Share(
 			$share['id'],
 			$share['owner'],
-			$share['last_updated'],
+			self::parseTimestamp($share['last_updated']),
 			$share['state'],
 			$share['sources'],
 			$share['recipients'],
@@ -1030,5 +1030,20 @@ final readonly class SharingBackend implements ISharingBackend {
 		}
 
 		return array_values($shares);
+	}
+
+	private static function parseTimestamp(int $timestampMs): \DateTimeImmutable {
+		if (method_exists(\DateTimeImmutable::class, 'createFromTimestamp')) {
+			// with php 8.3 the method doesn't exist and psalm doesn't know the return type
+			/** @psalm-suppress MixedReturnStatement */
+			return \DateTimeImmutable::createFromTimestamp((float)$timestampMs / 1000.0);
+		}
+
+		$time = \DateTimeImmutable::createFromFormat('U.u', number_format((float)$timestampMs / 1000.0, 3, '.', ''));
+		if ($time === false) {
+			throw new \RuntimeException('Invalid timestamp for share: ' . $timestampMs);
+		}
+
+		return $time;
 	}
 }

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -42,6 +42,7 @@ use OCP\L10N\IFactory;
 use OCP\Security\ISecureRandom;
 use OCP\Snowflake\ISnowflakeGenerator;
 use OCP\User\Events\BeforeUserDeletedEvent;
+use Psr\Clock\ClockInterface;
 use Random\Randomizer;
 use RuntimeException;
 
@@ -70,6 +71,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		private IDBConnection $dbConnection,
 		private ISharingRegistry $registry,
 		IAppConfig $appConfig,
+		private ClockInterface $clock,
 	) {
 		$this->randomizer = new Randomizer();
 		$this->l10n = $l10nFactory->get('sharing');
@@ -140,13 +142,8 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	}
 
 	#[\Override]
-	public function generateTimestamp(): int {
-		$time = (int)(microtime(true) * 1000.0);
-		if ($time < 0) {
-			throw new RuntimeException('Have you invented time travel?');
-		}
-
-		return $time;
+	public function getTime(): \DateTimeImmutable {
+		return $this->clock->now();
 	}
 
 	#[\Override]
@@ -158,7 +155,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$this->assertInTransaction();
 
 		$id = $this->snowflakeGenerator->nextId();
-		$lastUpdated = $this->generateTimestamp();
+		$lastUpdated = $this->getTime();
 		$this->backend->createShare($id, new ShareUser($currentUser->getUID(), null), $lastUpdated);
 
 		$this->processShareUpdates([$id]);
@@ -190,7 +187,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function updateShareState(ShareAccessContext $accessContext, string $id, ShareState $state): void {
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 		$this->validateShareOwnerOperation($accessContext, $owner);
@@ -209,7 +206,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function addShareSource(ShareAccessContext $accessContext, string $id, ShareSource $source): void {
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 		$this->validateShareOwnerOperation($accessContext, $owner);
@@ -250,7 +247,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function removeShareSource(ShareAccessContext $accessContext, string $id, ShareSource $source): void {
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 		$this->validateShareOwnerOperation($accessContext, $owner);
@@ -268,7 +265,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->assertInTransaction();
 
-		$timestamp = $this->generateTimestamp();
+		$timestamp = $this->getTime();
 
 		$updatedIds = $this->backend->onSourceDeleted($source);
 		if ($updatedIds === []) {
@@ -288,7 +285,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 
@@ -351,7 +348,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 
@@ -376,7 +373,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->assertInTransaction();
 
-		$timestamp = $this->generateTimestamp();
+		$timestamp = $this->getTime();
 
 		$updatedIds = $this->backend->onRecipientDeleted($recipient);
 		if ($updatedIds === []) {
@@ -396,7 +393,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->assertInTransaction();
 
-		$timestamp = $this->generateTimestamp();
+		$timestamp = $this->getTime();
 
 		$updatedIds = $this->backend->onInitiatorDeleted($initiator);
 		if ($updatedIds === []) {
@@ -412,7 +409,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function updateShareRecipientSecret(ShareAccessContext $accessContext, string $id, ShareRecipient $recipient, string $secret): void {
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 
@@ -444,7 +441,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function createSharePropertyDefaultValue(Share $share, string $propertyTypeClass): Share {
 		$this->assertInTransaction();
 
-		$timestamp = $this->generateTimestamp();
+		$timestamp = $this->getTime();
 		$this->backend->setLastUpdated([$share->id], $timestamp);
 
 		if (($propertyType = $this->registry->getPropertyTypes()[$propertyTypeClass] ?? null) === null) {
@@ -478,7 +475,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function updateShareProperty(ShareAccessContext $accessContext, string $id, ShareProperty $property): void {
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 		$this->validateShareOwnerOperation($accessContext, $owner);
@@ -503,7 +500,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function createSharePermissionDefaultValue(Share $share, string $permissionTypeClass): Share {
 		$this->assertInTransaction();
 
-		$timestamp = $this->generateTimestamp();
+		$timestamp = $this->getTime();
 		$this->backend->setLastUpdated([$share->id], $timestamp);
 
 		if (($permissionType = $this->registry->getPermissionTypes()[$permissionTypeClass] ?? null) === null) {
@@ -537,7 +534,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function updateSharePermission(ShareAccessContext $accessContext, string $id, SharePermission $permission): void {
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 		$this->validateShareOwnerOperation($accessContext, $owner);
@@ -574,7 +571,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function selectSharePermissionPreset(ShareAccessContext $accessContext, string $id, string $permissionPresetClass): void {
 		$this->assertInTransaction();
 
-		$this->backend->setLastUpdated([$id], $this->generateTimestamp());
+		$this->backend->setLastUpdated([$id], $this->getTime());
 
 		$owner = $this->backend->getShareOwner($id);
 		$this->validateShareOwnerOperation($accessContext, $owner);
@@ -825,5 +822,24 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		}
 
 		return $shares;
+	}
+
+	/**
+	 * @return non-negative-int
+	 */
+	public static function timeToMs(\DateTimeImmutable $time): int {
+		if (method_exists($time, 'getMicrosecond')) {
+			/** @var int $micros */
+			$micros = $time->getMicrosecond();
+		} else {
+			$micros = (int)$time->format('u');
+		}
+
+		$time = $time->getTimestamp() * 1000 + (int)floor($micros / 1000);
+		if ($time > 0) {
+			return $time;
+		}
+
+		throw new \RuntimeException('invalid date-time');
 	}
 }

--- a/lib/unstable/Sharing/ISharingBackend.php
+++ b/lib/unstable/Sharing/ISharingBackend.php
@@ -29,7 +29,7 @@ interface ISharingBackend {
 	 *
 	 * @experimental 35.0.0
 	 */
-	public function createShare(string $id, ShareUser $owner, int $lastUpdated): void;
+	public function createShare(string $id, ShareUser $owner, \DateTimeImmutable $lastUpdated): void;
 
 	/**
 	 * Perform all updates when the owner was deleted.
@@ -200,9 +200,8 @@ interface ISharingBackend {
 	 * Set the last updated timestamp for multiple shares.
 	 *
 	 * @param non-empty-list<string> $ids
-	 * @param non-negative-int $lastUpdated
 	 * @throws ShareNotFoundException
 	 * @experimental 35.0.0
 	 */
-	public function setLastUpdated(array $ids, int $lastUpdated): void;
+	public function setLastUpdated(array $ids, \DateTimeImmutable $lastUpdated): void;
 }

--- a/lib/unstable/Sharing/ISharingManager.php
+++ b/lib/unstable/Sharing/ISharingManager.php
@@ -50,12 +50,11 @@ interface ISharingManager {
 	public function generateSecret(): string;
 
 	/**
-	 * Generate a new timestamp in milliseconds since the UNIX epoch.
+	 * Get the current time
 	 *
-	 * @return non-negative-int
 	 * @experimental 35.0.0
 	 */
-	public function generateTimestamp(): int;
+	public function getTime(): \DateTimeImmutable;
 
 	/**
 	 * Create a new share.

--- a/lib/unstable/Sharing/Share.php
+++ b/lib/unstable/Sharing/Share.php
@@ -18,6 +18,7 @@ use NCU\Sharing\Recipient\IShareRecipientType;
 use NCU\Sharing\Recipient\ShareRecipient;
 use NCU\Sharing\Source\IShareSourceType;
 use NCU\Sharing\Source\ShareSource;
+use OC\Sharing\SharingManager;
 use OCP\AppFramework\Attribute\Consumable;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -154,8 +155,7 @@ final class Share {
 		/** @var non-empty-string $id */
 		public readonly string $id,
 		public readonly ShareUser $owner,
-		/** @var non-negative-int $lastUpdated Unix time in milliseconds */
-		public readonly int $lastUpdated,
+		public readonly \DateTimeImmutable $lastUpdated,
 		public readonly ShareState $state,
 		/** @var list<ShareSource> $sources */
 		public readonly array $sources,
@@ -240,7 +240,7 @@ final class Share {
 		return [
 			'id' => $this->id,
 			'owner' => $this->owner->format($userManager),
-			'last_updated' => $this->lastUpdated,
+			'last_updated' => SharingManager::timeToMs($this->lastUpdated),
 			'state' => $this->state->value,
 			'sources' => ShareSource::formatMultiple($registry, $l10nFactory, $this->sources),
 			'recipients' => ShareRecipient::formatMultiple($registry, $l10nFactory, $urlGenerator, $userManager, $this->recipients),

--- a/tests/Core/Sharing/Property/ExpirationDateSharePropertyTypeTest.php
+++ b/tests/Core/Sharing/Property/ExpirationDateSharePropertyTypeTest.php
@@ -72,7 +72,7 @@ final class ExpirationDateSharePropertyTypeTest extends TestCase {
 		return new Share(
 			'123',
 			new ShareUser($this->user->getUID(), null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],
@@ -98,7 +98,7 @@ final class ExpirationDateSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[
@@ -133,7 +133,7 @@ final class ExpirationDateSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[
@@ -167,7 +167,7 @@ final class ExpirationDateSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[

--- a/tests/Core/Sharing/Property/PasswordSharePropertyTypeTest.php
+++ b/tests/Core/Sharing/Property/PasswordSharePropertyTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\Sharing\Property;
 
+use DateTimeImmutable;
 use NCU\Sharing\Property\ShareProperty;
 use NCU\Sharing\Share;
 use NCU\Sharing\ShareAccessContext;
@@ -59,7 +60,7 @@ final class PasswordSharePropertyTypeTest extends TestCase {
 		return new Share(
 			'123',
 			new ShareUser($this->user->getUID(), null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],
@@ -72,7 +73,7 @@ final class PasswordSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],

--- a/tests/Core/Sharing/Recipient/GroupShareRecipientTypeTest.php
+++ b/tests/Core/Sharing/Recipient/GroupShareRecipientTypeTest.php
@@ -15,6 +15,7 @@ use NCU\Sharing\Recipient\ShareRecipient;
 use NCU\Sharing\ShareAccessContext;
 use OC\Core\Sharing\Recipient\GroupShareRecipientType;
 use OC\Group\Database;
+use OC\Sharing\SharingManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
 use OCP\IGroup;
@@ -140,14 +141,14 @@ final class GroupShareRecipientTypeTest extends TestCase {
 		$this->manager->addShareRecipient($accessContext, $id, new ShareRecipient($this->recipientType::class, $this->group1->getGID(), null));
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->group1->delete();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$this->dbConnection->beginTransaction();
 		$share = $this->manager->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share->lastUpdated);
-		$this->assertLessThanOrEqual($after, $share->lastUpdated);
+		$this->assertGreaterThanOrEqual(SharingManager::timeToMs($before), SharingManager::timeToMs($share->lastUpdated));
+		$this->assertLessThanOrEqual(SharingManager::timeToMs($after), SharingManager::timeToMs($share->lastUpdated));
 		$this->assertEquals([], $share->recipients);
 
 		$this->manager->deleteShare($accessContext, $id);

--- a/tests/Core/Sharing/Recipient/TeamShareRecipientTypeTest.php
+++ b/tests/Core/Sharing/Recipient/TeamShareRecipientTypeTest.php
@@ -171,14 +171,14 @@ final class TeamShareRecipientTypeTest extends TestCase {
 		$circlesManager = Server::get(CirclesManager::class);
 		$circlesManager->startSession($circlesManager->getLocalFederatedUser($this->user1->getUID()));
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$circlesManager->destroyCircle($this->team1->getId());
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$this->dbConnection->beginTransaction();
 		$share = $this->manager->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share->lastUpdated);
-		$this->assertLessThanOrEqual($after, $share->lastUpdated);
+		$this->assertGreaterThanOrEqual($before, $share->lastUpdated->getTimestamp());
+		$this->assertLessThanOrEqual($after, $share->lastUpdated->getTimestamp());
 		$this->assertEquals([], $share->recipients);
 
 		$this->manager->deleteShare($accessContext, $id);

--- a/tests/Core/Sharing/Recipient/UserShareRecipientTypeTest.php
+++ b/tests/Core/Sharing/Recipient/UserShareRecipientTypeTest.php
@@ -14,6 +14,7 @@ use NCU\Sharing\ISharingRegistry;
 use NCU\Sharing\Recipient\ShareRecipient;
 use NCU\Sharing\ShareAccessContext;
 use OC\Core\Sharing\Recipient\UserShareRecipientType;
+use OC\Sharing\SharingManager;
 use OC\User\Database;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
@@ -144,14 +145,14 @@ final class UserShareRecipientTypeTest extends TestCase {
 		$this->manager->addShareRecipient($accessContext, $id, new ShareRecipient($this->recipientType::class, $this->user2->getUID(), null));
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->user2->delete();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$this->dbConnection->beginTransaction();
 		$share = $this->manager->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share->lastUpdated);
-		$this->assertLessThanOrEqual($after, $share->lastUpdated);
+		$this->assertGreaterThanOrEqual(SharingManager::timeToMs($before), SharingManager::timeToMs($share->lastUpdated));
+		$this->assertLessThanOrEqual(SharingManager::timeToMs($after), SharingManager::timeToMs($share->lastUpdated));
 		$this->assertEquals([], $share->recipients);
 
 		$this->manager->deleteShare($accessContext, $id);

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -19,6 +19,7 @@ use NCU\Sharing\ShareAccessContext;
 use NCU\Sharing\ShareState;
 use NCU\Sharing\Source\ShareSource;
 use OC\Core\Sharing\Permission\ReshareSharePermissionType;
+use OC\Sharing\SharingManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
 use OCP\IDBConnection;
@@ -84,6 +85,21 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	protected IUser $user1;
 
 	protected IUser $user2;
+
+	private function parseTime(mixed $timestampMs): \DateTimeImmutable {
+		$timestampMs = (int)$timestampMs;
+		$time = \DateTimeImmutable::createFromFormat('U.u', number_format((float)$timestampMs / 1000.0, 3, '.', ''));
+		if ($time === false) {
+			throw new \RuntimeException('invalid timestamp: ' . $timestampMs);
+		}
+
+		return $time;
+	}
+
+	private function assertDateBetween(\DateTimeImmutable $before, \DateTimeImmutable $after, \DateTimeImmutable $time): void {
+		$this->assertGreaterThanOrEqual(SharingManager::timeToMs($before), SharingManager::timeToMs($time));
+		$this->assertLessThanOrEqual(SharingManager::timeToMs($after), SharingManager::timeToMs($time));
+	}
 
 	#[\Override]
 	public function setUp(): void {
@@ -567,12 +583,11 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	public function testCreateShare(): void {
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->createShare($accessContext);
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 		unset($share['id']);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'owner' => [
@@ -690,11 +705,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 				$this->assertEquals($errorMessage, $exception->getHint());
 			}
 		} else {
-			$before = $this->manager->generateTimestamp();
+			$before = $this->manager->getTime();
 			$share = $this->updateShareState($accessContext, $id, ShareState::Active);
-			$after = $this->manager->generateTimestamp();
-			$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-			$this->assertLessThanOrEqual($after, $share['last_updated']);
+			$after = $this->manager->getTime();
+			$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 			$this->assertEquals(ShareState::Active->value, $share['state']);
 		}
 	}
@@ -706,11 +720,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$id = $this->manager->createShare($accessContext);
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestShareSourceType1::class,
@@ -765,11 +778,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->removeShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Active->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -782,11 +794,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['sources']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->removeShareSource($accessContext, $id, new ShareSource(TestShareSourceType2::class, 'source2'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Draft->value, $share['state']);
 		$this->assertEquals([], $share['sources']);
 	}
@@ -798,11 +809,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$id = $this->manager->createShare($accessContext);
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->addShareRecipient($accessContext, $id, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestShareRecipientType1::class,
@@ -890,11 +900,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->addShareRecipient(new ShareAccessContext($this->user1), $id, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestShareRecipientType1::class,
@@ -955,11 +964,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->removeShareRecipient($accessContext, $id, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Active->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -985,11 +993,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['recipients']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->removeShareRecipient($accessContext, $id, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Draft->value, $share['state']);
 		$this->assertEquals([], $share['recipients']);
 	}
@@ -1074,11 +1081,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->removeShareRecipient(new ShareAccessContext($this->user1), $id, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestShareRecipientType1::class,
@@ -1232,11 +1238,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 				$this->assertEquals('You are not allowed to edit this share.', $exception->getHint());
 			}
 		} else {
-			$before = $this->manager->generateTimestamp();
+			$before = $this->manager->getTime();
 			$share = $this->updateShareRecipientSecret($accessContext, $id, $recipient, 'mysecret');
-			$after = $this->manager->generateTimestamp();
-			$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-			$this->assertLessThanOrEqual($after, $share['last_updated']);
+			$after = $this->manager->getTime();
+			$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 			unset($share['last_updated']);
 			$this->assertEquals([
 				[
@@ -1292,11 +1297,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->dbConnection->commit();
 
 		foreach ($values as $value) {
-			$before = $this->manager->generateTimestamp();
+			$before = $this->manager->getTime();
 			$share = $this->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyType1::class, $value));
-			$after = $this->manager->generateTimestamp();
-			$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-			$this->assertLessThanOrEqual($after, $share['last_updated']);
+			$after = $this->manager->getTime();
+			$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 			$this->assertEquals([
 				[
 					'class' => TestSharePropertyType1::class,
@@ -1329,11 +1333,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeRequired::class, 'valid1'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Draft->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -1364,11 +1367,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeRequired::class, 'valid2'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Active->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -1395,11 +1397,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['properties']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeRequired::class, null));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Draft->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -1497,11 +1498,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'old-value'));
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'modify-on-save-old-value'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestSharePropertyType1::class,
@@ -1527,11 +1527,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['properties']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'modify-on-save'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestSharePropertyType1::class,
@@ -1557,11 +1556,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['properties']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'modify-on-load'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestSharePropertyType1::class,
@@ -1599,12 +1597,11 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->updateSharePermission($accessContext, $id, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->updateSharePermission($accessContext, $id, new SharePermission(TestSharePermissionType1::class, true));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Draft->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -1631,11 +1628,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 		$this->dbConnection->commit();
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateSharePermission($accessContext, $id, new SharePermission(ReshareSharePermissionType::class, false));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Active->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -1658,11 +1654,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateSharePermission($accessContext, $id, new SharePermission(TestSharePermissionType1::class, false));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(ShareState::Draft->value, $share['state']);
 		$this->assertEquals([
 			[
@@ -1727,16 +1722,15 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->getShare($accessContext, $id);
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertNull($share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1768,11 +1762,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->selectSharePermissionPreset($accessContext, $id, TestSharePermissionPreset2::class);
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(TestSharePermissionPreset2::class, $share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1804,11 +1797,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateSharePermission($accessContext, $id, new SharePermission(TestSharePermissionType3::class, true));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertNull($share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1840,11 +1832,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->selectSharePermissionPreset($accessContext, $id, TestSharePermissionPreset1::class);
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(TestSharePermissionPreset1::class, $share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1876,11 +1867,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->updateSharePermission($accessContext, $id, new SharePermission(TestSharePermissionType1::class, false));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertNull($share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1926,16 +1916,15 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->getShare($accessContext, $id);
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertNull($share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1949,11 +1938,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->selectSharePermissionPreset($accessContext, $id, TestSharePermissionPreset2::class);
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(TestSharePermissionPreset2::class, $share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1967,11 +1955,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertNull($share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -1994,11 +1981,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			],
 		], $share['permissions']);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$share = $this->selectSharePermissionPreset($accessContext, $id, TestSharePermissionPreset2::class);
-		$after = $this->manager->generateTimestamp();
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$after = $this->manager->getTime();
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals(TestSharePermissionPreset2::class, $share['permission_preset']);
 		$this->assertEquals([
 			[
@@ -2043,7 +2029,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	public function testGetShare(): void {
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -2051,11 +2037,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->getShare($accessContext, $id);
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -2160,7 +2145,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	public function testGetShareAsRecipientActive(): void {
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -2171,11 +2156,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare(new ShareAccessContext(currentUser: $this->user1), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -2285,7 +2269,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -2295,11 +2279,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare(new ShareAccessContext(currentUser: $this->user1, arguments: [TestShareRecipientTypeArguments::class => 'secret']), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -2409,7 +2392,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -2418,7 +2401,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateSharePermission($accessContext, $id, new SharePermission(TestSharePermissionType1::class, true));
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->manager->getShare($accessContext, $id);
 		$this->dbConnection->commit();
@@ -2426,8 +2409,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->assertNotNull($secret);
 
 		$share = $this->getShare(new ShareAccessContext(secret: $secret), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -2535,7 +2517,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -2546,11 +2528,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeFilter::class, 'visible'));
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare(new ShareAccessContext(currentUser: $this->user1), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -2644,15 +2625,14 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			'permission_preset' => TestSharePermissionPreset1::class,
 		], $share);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$this->manager->updateShareProperty($accessContext, $id, new ShareProperty(TestSharePropertyTypeFilter::class, 'filtered'));
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare(new ShareAccessContext(currentUser: $this->owner), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -2761,7 +2741,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -2771,11 +2751,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare(new ShareAccessContext(currentUser: $this->user1), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -2870,8 +2849,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		], $share);
 
 		$share = $this->getShare(new ShareAccessContext(currentUser: $this->owner, arguments: [TestSharePropertyTypeFilter::class => 'filtered']), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertEquals([
 			'id' => $id,
@@ -3004,18 +2982,17 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareRecipient($accessContext, $id, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
 		$this->manager->addShareRecipient($accessContext, $id, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient2', null));
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		unset($share['last_updated']);
 		$this->assertIsList($share['recipients']);
 		$this->assertCount(2, $share['recipients']);
@@ -3081,7 +3058,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -3094,11 +3071,10 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->addShareRecipient(new ShareAccessContext($this->user2), $id, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient4', null));
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$share = $this->getShare(new ShareAccessContext($this->user2), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 
 		usort($share['recipients'], fn (array $a, array $b): int => $a['value'] <=> $b['value']);
 		$this->assertArrayHasKey('recipients', $share);
@@ -3256,7 +3232,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	public function testGetShareDisabledOwner(): void {
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -3267,7 +3243,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$this->owner->setEnabled(false);
 
@@ -3279,8 +3255,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		}
 
 		$share = $this->getShare(new ShareAccessContext(overrideChecks: true), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			'user_id' => 'owner',
 			'instance' => null,
@@ -3295,7 +3270,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	public function testGetShareDisabledInitiator(): void {
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -3305,7 +3280,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->addShareRecipient(new ShareAccessContext(currentUser: $this->user1), $id, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
 
 		$this->dbConnection->commit();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 
 		$this->user1->setEnabled(false);
 
@@ -3317,8 +3292,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		}
 
 		$share = $this->getShare($accessContext, $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestShareRecipientType1::class,
@@ -3368,7 +3342,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	public function testGetShares(): void {
 		$accessContext = new ShareAccessContext($this->owner);
 
-		$before1 = $this->manager->generateTimestamp();
+		$before1 = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id1 = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id1, new ShareSource(TestShareSourceType1::class, 'source1'));
@@ -3376,9 +3350,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->getShare($accessContext, $id1);
 
 		$this->dbConnection->commit();
-		$after1 = $this->manager->generateTimestamp();
+		$after1 = $this->manager->getTime();
 
-		$before2 = $this->manager->generateTimestamp();
+		$before2 = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
 		$id2 = $this->manager->createShare($accessContext);
 		$this->manager->addShareSource($accessContext, $id2, new ShareSource(TestShareSourceType2::class, 'source2'));
@@ -3386,16 +3360,14 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->getShare($accessContext, $id2);
 
 		$this->dbConnection->commit();
-		$after2 = $this->manager->generateTimestamp();
+		$after2 = $this->manager->getTime();
 
 		$shares = $this->getShares($accessContext, null, null, null, null);
 		$this->assertCount(2, $shares);
 		$this->assertIsArray($shares[0]);
-		$this->assertGreaterThanOrEqual($before1, $shares[0]['last_updated']);
-		$this->assertLessThanOrEqual($after1, $shares[0]['last_updated']);
+		$this->assertDateBetween($before1, $after1, $this->parseTime($shares[0]['last_updated']));
 		$this->assertIsArray($shares[1]);
-		$this->assertGreaterThanOrEqual($before2, $shares[1]['last_updated']);
-		$this->assertLessThanOrEqual($after2, $shares[1]['last_updated']);
+		$this->assertDateBetween($before2, $after2, $this->parseTime($shares[1]['last_updated']));
 		unset($shares[0]['last_updated'], $shares[1]['last_updated']);
 		$this->assertEquals([
 			[
@@ -3563,8 +3535,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$shares = $this->getShares($accessContext, TestShareSourceType1::class, null, null, null);
 		$this->assertCount(1, $shares);
 		$this->assertIsArray($shares[0]);
-		$this->assertGreaterThanOrEqual($before1, $shares[0]['last_updated']);
-		$this->assertLessThanOrEqual($after1, $shares[0]['last_updated']);
+		$this->assertDateBetween($before1, $after1, $this->parseTime($shares[0]['last_updated']));
 		unset($shares[0]['last_updated']);
 		$this->assertEquals([
 			[
@@ -3652,8 +3623,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$shares = $this->getShares($accessContext, TestShareSourceType1::class, 'source1', null, null);
 		$this->assertCount(1, $shares);
 		$this->assertIsArray($shares[0]);
-		$this->assertGreaterThanOrEqual($before1, $shares[0]['last_updated']);
-		$this->assertLessThanOrEqual($after1, $shares[0]['last_updated']);
+		$this->assertDateBetween($before1, $after1, $this->parseTime($shares[0]['last_updated']));
 		unset($shares[0]['last_updated']);
 		$this->assertEquals([
 			[
@@ -3744,8 +3714,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$shares = $this->getShares($accessContext, null, null, $id1, null);
 		$this->assertCount(1, $shares);
 		$this->assertIsArray($shares[0]);
-		$this->assertGreaterThanOrEqual($before2, $shares[0]['last_updated']);
-		$this->assertLessThanOrEqual($after2, $shares[0]['last_updated']);
+		$this->assertDateBetween($before2, $after2, $this->parseTime($shares[0]['last_updated']));
 		unset($shares[0]['last_updated']);
 		$this->assertEquals([
 			[
@@ -3833,8 +3802,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$shares = $this->getShares($accessContext, null, null, null, 1);
 		$this->assertCount(1, $shares);
 		$this->assertIsArray($shares[0]);
-		$this->assertGreaterThanOrEqual($before1, $shares[0]['last_updated']);
-		$this->assertLessThanOrEqual($after1, $shares[0]['last_updated']);
+		$this->assertDateBetween($before1, $after1, $this->parseTime($shares[0]['last_updated']));
 		unset($shares[0]['last_updated']);
 		$this->assertEquals([
 			[
@@ -3979,14 +3947,13 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->manager->updateShareState($accessContext, $id, ShareState::Active);
 		$this->manager->addShareRecipient(new ShareAccessContext(currentUser: $this->user1), $id, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
 
-		$before = $this->manager->generateTimestamp();
+		$before = $this->manager->getTime();
 		$this->user1->delete();
-		$after = $this->manager->generateTimestamp();
+		$after = $this->manager->getTime();
 		$this->dbConnection->commit();
 
 		$share = $this->getShare(new ShareAccessContext(overrideChecks: true), $id);
-		$this->assertGreaterThanOrEqual($before, $share['last_updated']);
-		$this->assertLessThanOrEqual($after, $share['last_updated']);
+		$this->assertDateBetween($before, $after, $this->parseTime($share['last_updated']));
 		$this->assertEquals([
 			[
 				'class' => TestShareRecipientType1::class,

--- a/tests/lib/Sharing/Property/ABooleanSharePropertyTypeTest.php
+++ b/tests/lib/Sharing/Property/ABooleanSharePropertyTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Test\Sharing\Property;
 
+use DateTimeImmutable;
 use NCU\Sharing\Property\ABooleanSharePropertyType;
 use NCU\Sharing\Share;
 use NCU\Sharing\ShareState;
@@ -64,7 +65,7 @@ final class ABooleanSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],

--- a/tests/lib/Sharing/Property/ADateSharePropertyTypeTest.php
+++ b/tests/lib/Sharing/Property/ADateSharePropertyTypeTest.php
@@ -89,7 +89,7 @@ final class ADateSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],

--- a/tests/lib/Sharing/Property/AEnumSharePropertyTypeTest.php
+++ b/tests/lib/Sharing/Property/AEnumSharePropertyTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Test\Sharing\Property;
 
+use DateTimeImmutable;
 use NCU\Sharing\Property\AEnumSharePropertyType;
 use NCU\Sharing\Share;
 use NCU\Sharing\ShareState;
@@ -78,7 +79,7 @@ final class AEnumSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],

--- a/tests/lib/Sharing/Property/APasswordSharePropertyTypeTest.php
+++ b/tests/lib/Sharing/Property/APasswordSharePropertyTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Test\Sharing\Property;
 
+use DateTimeImmutable;
 use NCU\Sharing\Property\APasswordSharePropertyType;
 use NCU\Sharing\Share;
 use NCU\Sharing\ShareState;
@@ -92,7 +93,7 @@ final class APasswordSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],

--- a/tests/lib/Sharing/Property/AStringSharePropertyTypeTest.php
+++ b/tests/lib/Sharing/Property/AStringSharePropertyTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Test\Sharing\Property;
 
+use DateTimeImmutable;
 use NCU\Sharing\Property\AStringSharePropertyType;
 use NCU\Sharing\Share;
 use NCU\Sharing\ShareState;
@@ -85,7 +86,7 @@ final class AStringSharePropertyTypeTest extends TestCase {
 		$share = new Share(
 			'123',
 			new ShareUser('user', null),
-			0,
+			new DateTimeImmutable(),
 			ShareState::Active,
 			[],
 			[],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Extracted from https://github.com/nextcloud/server/pull/62708

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
