### PR TITLE
feat(setup): allow to pass SSL/TLS config for database connection

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4101,12 +4101,6 @@
     <TypeDoesNotContainType>
       <code><![CDATA[ctype_digit($this->dbPort)]]></code>
     </TypeDoesNotContainType>
-    <UndefinedThisPropertyFetch>
-      <code><![CDATA[$this->dbprettyname]]></code>
-      <code><![CDATA[$this->dbprettyname]]></code>
-      <code><![CDATA[$this->dbprettyname]]></code>
-      <code><![CDATA[$this->dbprettyname]]></code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/private/Share20/DefaultShareProvider.php">
     <FalsableReturnStatement>

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -19,6 +19,12 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 abstract class AbstractDatabase {
+	/**
+	 * Installer options configuring an encrypted database connection.
+	 * @var string[]
+	 */
+	protected const array CONNECTION_ENCRYPTION_OPTIONS = ['dbdriveroptions'];
+
 	protected string $dbUser;
 	protected string $dbPassword;
 	protected string $dbName;
@@ -47,6 +53,13 @@ abstract class AbstractDatabase {
 		if (substr_count($config['dbname'], '.') >= 1) {
 			$errors[] = $this->trans->t('You cannot use dots in the database name %s', [$this->dbprettyname]);
 		}
+		foreach (static::CONNECTION_ENCRYPTION_OPTIONS as $option) {
+			if (isset($config[$option]) && !is_array($config[$option])) {
+				// Fail instead of ignoring the option, otherwise the instance would be
+				// installed with an unencrypted connection without the admin noticing.
+				$errors[] = $this->trans->t('The database option "%1$s" for %2$s has to be a list of values', [$option, $this->dbprettyname]);
+			}
+		}
 		return $errors;
 	}
 
@@ -62,11 +75,27 @@ abstract class AbstractDatabase {
 		// accept `false` both as bool and string, since setting config values from env will result in a string
 		$this->tryCreateDbUser = $createUserConfig !== false && $createUserConfig !== 'false';
 
-		$this->config->setValues([
+		$configValues = [
 			'dbname' => $dbName,
 			'dbhost' => $dbHost,
 			'dbtableprefix' => $dbTablePrefix,
-		]);
+		];
+
+		// An encrypted connection can only be configured through the system config, so the
+		// options have to be persisted before the first connection is opened.
+		foreach (static::CONNECTION_ENCRYPTION_OPTIONS as $option) {
+			if (empty($config[$option])) {
+				continue;
+			}
+			if (!is_array($config[$option])) {
+				// Rejected by validate() already, but subclasses may not use that check
+				$this->logger->error('Ignoring database option "{option}" passed to the installer because it is not a list of values', ['option' => $option]);
+				continue;
+			}
+			$configValues[$option] = $config[$option];
+		}
+
+		$this->config->setValues($configValues);
 
 		$this->dbUser = $dbUser;
 		$this->dbPassword = $dbPass;

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -25,6 +25,8 @@ abstract class AbstractDatabase {
 	 */
 	protected const array CONNECTION_ENCRYPTION_OPTIONS = ['dbdriveroptions'];
 
+	protected string $dbprettyname = 'abstract';
+
 	protected string $dbUser;
 	protected string $dbPassword;
 	protected string $dbName;

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -11,7 +11,7 @@ namespace OC\Setup;
 use OC\DatabaseSetupException;
 
 class OCI extends AbstractDatabase {
-	public $dbprettyname = 'Oracle';
+	public string $dbprettyname = 'Oracle';
 
 	protected $dbtablespace;
 

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -16,6 +16,9 @@ use OC\DB\QueryBuilder\Literal;
 class PostgreSQL extends AbstractDatabase {
 	public $dbprettyname = 'PostgreSQL';
 
+	// #[\Override] TODO: Uncomment this when we only support PHP 8.5+ support
+	protected const array CONNECTION_ENCRYPTION_OPTIONS = [...parent::CONNECTION_ENCRYPTION_OPTIONS, 'pgsql_ssl'];
+
 	/**
 	 * @throws DatabaseSetupException
 	 */

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -14,7 +14,7 @@ use OC\DB\Connection;
 use OC\DB\QueryBuilder\Literal;
 
 class PostgreSQL extends AbstractDatabase {
-	public $dbprettyname = 'PostgreSQL';
+	public string $dbprettyname = 'PostgreSQL';
 
 	// #[\Override] TODO: Uncomment this when we only support PHP 8.5+ support
 	protected const array CONNECTION_ENCRYPTION_OPTIONS = [...parent::CONNECTION_ENCRYPTION_OPTIONS, 'pgsql_ssl'];

--- a/tests/lib/Setup/AbstractDatabaseTest.php
+++ b/tests/lib/Setup/AbstractDatabaseTest.php
@@ -18,9 +18,16 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class AbstractDatabaseTest extends TestCase {
+	/**
+	 * Numeric literal instead of PDO::MYSQL_ATTR_SSL_CA: the constant is deprecated
+	 * since PHP 8.5 and only defined when the MySQL driver is available.
+	 */
+	private const MYSQL_ATTR_SSL_CA = 1008;
+
 	private SystemConfig&MockObject $config;
 	private ConnectionFactory&MockObject $connectionFactory;
 	private Connection&MockObject $connection;
+	private LoggerInterface&MockObject $logger;
 	private TestDatabase $database;
 
 	#[\Override]
@@ -30,11 +37,16 @@ class AbstractDatabaseTest extends TestCase {
 		$this->config = $this->createMock(SystemConfig::class);
 		$this->connectionFactory = $this->createMock(ConnectionFactory::class);
 		$this->connection = $this->createMock(Connection::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')
+			->willReturnCallback(fn (string $text, array $parameters = []) => vsprintf($text, $parameters));
 
 		$this->database = new TestDatabase(
-			$this->createMock(IL10N::class),
+			$l10n,
 			$this->config,
-			$this->createMock(LoggerInterface::class),
+			$this->logger,
 			$this->createMock(ISecureRandom::class),
 		);
 		$this->database->connectionFactory = $this->connectionFactory;
@@ -73,6 +85,100 @@ class AbstractDatabaseTest extends TestCase {
 			'dbname' => 'nextcloud',
 			'dbhost' => '',
 		]);
+	}
+
+	/**
+	 * The connection encryption options are only read from the system config, so they have
+	 * to be persisted by initialize() - before any connection is opened by setupDatabase().
+	 */
+	public function testInitializePersistsDriverOptions(): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org',
+				'dbtableprefix' => 'oc_',
+				'dbdriveroptions' => [self::MYSQL_ATTR_SSL_CA => '/ca.pem'],
+			]);
+
+		$this->database->initialize($this->options([
+			'dbdriveroptions' => [self::MYSQL_ATTR_SSL_CA => '/ca.pem'],
+		]));
+	}
+
+	/**
+	 * Only the options of the database being set up may be persisted, every database
+	 * configures an encrypted connection differently.
+	 */
+	public function testInitializeSkipsOptionsOfOtherDatabases(): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org',
+				'dbtableprefix' => 'oc_',
+			]);
+
+		$this->database->initialize($this->options([
+			'pgsql_ssl' => ['mode' => 'verify-full'],
+		]));
+	}
+
+	public static function emptyEncryptionOptions(): array {
+		return [
+			'not provided' => [[]],
+			'empty array' => [['dbdriveroptions' => []]],
+			'null' => [['dbdriveroptions' => null]],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('emptyEncryptionOptions')]
+	public function testInitializeSkipsEmptyEncryptionOptions(array $additional): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org',
+				'dbtableprefix' => 'oc_',
+			]);
+
+		$this->database->initialize($this->options($additional));
+	}
+
+	/**
+	 * A malformed option must never be persisted, as that would end up configuring an
+	 * unencrypted connection while the admin expects an encrypted one.
+	 */
+	public function testInitializeRejectsMalformedEncryptionOptions(): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org',
+				'dbtableprefix' => 'oc_',
+			]);
+		$this->logger->expects($this->once())
+			->method('error');
+
+		$this->database->initialize($this->options(['dbdriveroptions' => '/ca.pem']));
+	}
+
+	public function testValidateRejectsMalformedEncryptionOptions(): void {
+		$errors = $this->database->validate($this->options(['dbdriveroptions' => '/ca.pem']));
+
+		$this->assertEquals([
+			'The database option "dbdriveroptions" for Test has to be a list of values',
+		], $errors);
+	}
+
+	public function testValidateAcceptsEncryptionOptions(): void {
+		$errors = $this->database->validate($this->options([
+			'dbdriveroptions' => [self::MYSQL_ATTR_SSL_CA => '/ca.pem'],
+			// not an option of this database, so it is not validated either
+			'pgsql_ssl' => 'verify-full',
+		]));
+
+		$this->assertEquals([], $errors);
 	}
 
 	/**

--- a/tests/lib/Setup/PostgreSQLTest.php
+++ b/tests/lib/Setup/PostgreSQLTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Setup;
+
+use OC\Setup\PostgreSQL;
+use OC\SystemConfig;
+use OCP\IL10N;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class PostgreSQLTest extends TestCase {
+	private const PGSQL_SSL = [
+		'mode' => 'verify-full',
+		'rootcert' => '/rootCA.crt',
+		'cert' => '/client.crt',
+		'key' => '/client.key',
+	];
+
+	private SystemConfig&MockObject $config;
+	private LoggerInterface&MockObject $logger;
+	private PostgreSQL $database;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(SystemConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')
+			->willReturnCallback(fn (string $text, array $parameters = []) => vsprintf($text, $parameters));
+
+		$this->database = new PostgreSQL(
+			$l10n,
+			$this->config,
+			$this->logger,
+			$this->createMock(ISecureRandom::class),
+		);
+	}
+
+	/**
+	 * PostgreSQL is configured through its own set of connection parameters instead of PDO
+	 * driver options. They are only read from the system config, so they have to be
+	 * persisted by initialize() - before any connection is opened by setupDatabase().
+	 */
+	public function testInitializePersistsPgsqlSsl(): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org',
+				'dbtableprefix' => 'oc_',
+				'pgsql_ssl' => self::PGSQL_SSL,
+			]);
+
+		$this->database->initialize($this->options(['pgsql_ssl' => self::PGSQL_SSL]));
+	}
+
+	public static function emptyPgsqlSsl(): array {
+		return [
+			'not provided' => [[]],
+			'empty array' => [['pgsql_ssl' => []]],
+			'null' => [['pgsql_ssl' => null]],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('emptyPgsqlSsl')]
+	public function testInitializeSkipsEmptyPgsqlSsl(array $additional): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org',
+				'dbtableprefix' => 'oc_',
+			]);
+
+		$this->database->initialize($this->options($additional));
+	}
+
+	/**
+	 * A malformed option must never be persisted, as that would end up configuring an
+	 * unencrypted connection while the admin expects an encrypted one.
+	 */
+	public function testInitializeRejectsMalformedPgsqlSsl(): void {
+		$this->config->expects($this->once())
+			->method('setValues')
+			->with([
+				'dbname' => 'nextcloud',
+				'dbhost' => 'db.example.org',
+				'dbtableprefix' => 'oc_',
+			]);
+		$this->logger->expects($this->once())
+			->method('error');
+
+		$this->database->initialize($this->options(['pgsql_ssl' => 'verify-full']));
+	}
+
+	public function testValidateRejectsMalformedPgsqlSsl(): void {
+		$errors = $this->database->validate($this->options(['pgsql_ssl' => 'verify-full']));
+
+		$this->assertEquals([
+			'The database option "pgsql_ssl" for PostgreSQL has to be a list of values',
+		], $errors);
+	}
+
+	public function testValidateAcceptsPgsqlSsl(): void {
+		$errors = $this->database->validate($this->options(['pgsql_ssl' => self::PGSQL_SSL]));
+
+		$this->assertEquals([], $errors);
+	}
+
+	private function options(array $additional = []): array {
+		return array_merge([
+			'dbuser' => 'admin',
+			'dbpass' => 'admin-password',
+			'dbname' => 'nextcloud',
+			'dbhost' => 'db.example.org',
+		], $additional);
+	}
+}

--- a/tests/lib/Setup/TestDatabase.php
+++ b/tests/lib/Setup/TestDatabase.php
@@ -1,11 +1,10 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-declare(strict_types=1);
 
 namespace Test\Setup;
 


### PR DESCRIPTION
- chained on #62932 

## Summary
Allow to set the database configuration for SSL/TLS connection also during the setup. This is needed to allow installation with proper SSL configuration when using the AUTOCONFIG approach.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
**Unit tests are generated with Claude Code**