### PR TITLE
refactor: use IUser for IShareSourceType::getSourceInteractionResource instead of user id string

### DIFF
--- a/apps/files/lib/Sharing/Source/NodeShareSourceType.php
+++ b/apps/files/lib/Sharing/Source/NodeShareSourceType.php
@@ -27,6 +27,7 @@ use OCP\IDBConnection;
 use OCP\Interaction\InteractionResource;
 use OCP\Interaction\Resources\NodeResource;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\L10N\IFactory;
 
 /**
@@ -72,8 +73,8 @@ final readonly class NodeShareSourceType implements IShareSourceType, IEventList
 	}
 
 	#[\Override]
-	public function getSourceInteractionResource(string $userId, string $source): InteractionResource {
-		return new NodeResource((int)$source, $userId);
+	public function getSourceInteractionResource(IUser $user, string $source): InteractionResource {
+		return new NodeResource((int)$source, $user->getUID());
 	}
 
 	#[\Override]

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -698,7 +698,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$action = new ShareAction(null, array_values(array_map(static fn (SharePermission $permission): string => $permission->class, $share->getEnabledPermissions())));
 
 		$usersToCheck = [];
-		if ($share->owner->instance === null && ($ownerUser = $this->userManager->get($share->owner->userId)) !== null) {
+		if ($share->owner->instance === null && ($ownerUser = $this->userManager->get($share->owner->userId)) instanceof IUser) {
 			$usersToCheck[] = $ownerUser;
 		}
 
@@ -733,7 +733,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 					continue;
 				}
 
-				$resources[] = $sourceType->getSourceInteractionResource($userToCheck->getUID(), $source->value);
+				$resources[] = $sourceType->getSourceInteractionResource($userToCheck, $source->value);
 			}
 
 			$event = new RestrictInteractionEvent($userToCheck->getUID(), $userToCheck, $resources, $action, $receivers);

--- a/lib/unstable/Sharing/Source/IShareSourceType.php
+++ b/lib/unstable/Sharing/Source/IShareSourceType.php
@@ -13,6 +13,7 @@ use NCU\Sharing\Icon\ShareIconSVG;
 use NCU\Sharing\Icon\ShareIconURL;
 use OCP\AppFramework\Attribute\Implementable;
 use OCP\Interaction\InteractionResource;
+use OCP\IUser;
 use OCP\L10N\IFactory;
 
 /**
@@ -52,9 +53,8 @@ interface IShareSourceType {
 	public function getSourceIcon(string $source): null|ShareIconSVG|ShareIconURL;
 
 	/**
-	 * @param non-empty-string $userId
 	 * @param non-empty-string $source
 	 * @experimental 35.0.0
 	 */
-	public function getSourceInteractionResource(string $userId, string $source): InteractionResource;
+	public function getSourceInteractionResource(IUser $user, string $source): InteractionResource;
 }

--- a/tests/lib/Sharing/TestShareSourceType1.php
+++ b/tests/lib/Sharing/TestShareSourceType1.php
@@ -13,6 +13,7 @@ use NCU\Sharing\Icon\ShareIconSVG;
 use NCU\Sharing\Icon\ShareIconURL;
 use NCU\Sharing\Source\IShareSourceType;
 use OCP\Interaction\InteractionResource;
+use OCP\IUser;
 use OCP\L10N\IFactory;
 
 class TestShareSourceType1 implements IShareSourceType {
@@ -45,7 +46,7 @@ class TestShareSourceType1 implements IShareSourceType {
 	}
 
 	#[\Override]
-	public function getSourceInteractionResource(string $userId, string $source): InteractionResource {
+	public function getSourceInteractionResource(IUser $user, string $source): InteractionResource {
 		return new TestInteractionResource($source);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

More types, less strings

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
