### PR TITLE
fix(files_trashbin): normalize paths before restoring and deleting

### DIFF
--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -78,12 +78,14 @@ class LegacyTrashBackend implements ITrashBackend {
 
 	#[\Override]
 	public function restoreItem(ITrashItem $item) {
-		Trashbin::restore($item->getTrashPath(), $item->getName(), $item->isRootItem() ? $item->getDeletedTime() : null);
+		Trashbin::restore(ltrim($item->getTrashPath(), '/'), $item->getName(), $item->isRootItem() ? $item->getDeletedTime() : null);
 	}
 
 	#[\Override]
 	public function removeItem(ITrashItem $item) {
 		$user = $item->getUser();
+		$trashPath = ltrim($item->getTrashPath(), '/');
+
 		if ($item->isRootItem()) {
 			$path = substr($item->getTrashPath(), 0, -strlen('.d' . $item->getDeletedTime()));
 			Trashbin::delete($path, $user->getUID(), $item->getDeletedTime());

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -22,6 +22,17 @@ use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 use OCP\IUserManager;
 
+/**
+ * Default backend provided by files_trashbin.
+ *
+ * This backend is registered for the generic IStorage interface. Specialized
+ * backends can be registered for specific storage types and take precedence
+ * when handling those storages.
+ *
+ * The "legacy" designation refers to the files_trashbin storage layout and
+ * static Trashbin API that this class wraps and exposes through the
+ * ITrashBackend interface, not to this backend being unused or deprecated.
+ */
 class LegacyTrashBackend implements ITrashBackend {
 	/** @var array<string, string> */
 	private array $deletedFiles = [];

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -515,14 +515,17 @@ class Trashbin implements IEventListener {
 	}
 
 	/**
-	 * Restore a file or folder from trash bin
+	 * Restore a file or folder from the trash bin.
 	 *
-	 * @param string $file path to the deleted file/folder relative to "files_trashbin/files/",
-	 *                     including the timestamp suffix ".d12345678"
-	 * @param string $filename name of the file/folder
-	 * @param int $timestamp time when the file/folder was deleted
+	 * @param string $file Stored trash path relative to "files_trashbin/files/",
+	 *                     including the ".d<timestamp>" suffix for a root item.
+	 *                     The path must not start with "/".
+	 * @param string $filename Original filename or folder name, without the
+	 *                         ".d<timestamp>" suffix.
+	 * @param int|null $timestamp Deletion timestamp for a root trash item;
+	 *                            null when restoring an item below a root trash item.
 	 *
-	 * @return bool true on success, false otherwise
+	 * @return bool Whether the item was restored successfully.
 	 */
 	public static function restore($file, $filename, $timestamp) {
 		$user = OC_User::getUser();
@@ -732,13 +735,17 @@ class Trashbin implements IEventListener {
 	}
 
 	/**
-	 * delete file from trash bin permanently
+	 * Delete a file or folder permanently from the trash bin.
 	 *
-	 * @param string $filename path to the file
-	 * @param string $user
-	 * @param int $timestamp of deletion time
+	 * @param string $filename Path relative to "files_trashbin/files/".
+	 *                         The path must not start with "/".
+	 *                         If $timestamp is provided, this is the original
+	 *                         filename/path without the ".d<timestamp>" suffix.
+	 *                         If $timestamp is null, this is the stored trash path.
+	 * @param string $user User owning the trash bin.
+	 * @param int|null $timestamp Deletion timestamp for a root trash item.
 	 *
-	 * @return int|float size of deleted files
+	 * @return int|float Size of deleted files.
 	 */
 	public static function delete($filename, $user, $timestamp = null) {
 		$userRoot = \OC::$server->getUserFolder($user)->getParent();

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -20,6 +20,7 @@ use OCA\Files_Trashbin\AppInfo\Application as TrashbinApplication;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Helper;
 use OCA\Files_Trashbin\Storage;
+use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -47,6 +48,8 @@ class TrashbinTest extends \Test\TestCase {
 	private static $rememberRetentionObligation;
 	private static bool $trashBinStatus;
 	private View $rootView;
+	private array $trashDeleteHookParams = [];
+	private array $trashRestoreHookParams = [];
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -347,6 +350,183 @@ class TrashbinTest extends \Test\TestCase {
 		$this->assertSame(1, count($newTrashContent));
 		$element = reset($newTrashContent);
 		$this->assertSame('file1.txt', $element['name']);
+	}
+
+	private function getTrashRow(string $filename, int $timestamp): array|false {
+		$connection = Server::get(IDBConnection::class);
+		$query = $connection->getQueryBuilder();
+
+		return $query
+			->select('id', 'timestamp')
+			->from('files_trash')
+			->where(
+				$query->expr()->eq(
+					'user',
+					$query->createNamedParameter(self::TEST_TRASHBIN_USER1),
+				)
+			)
+			->andWhere(
+				$query->expr()->eq(
+					'id',
+					$query->createNamedParameter($filename),
+				)
+			)
+			->andWhere(
+				$query->expr()->eq(
+					'timestamp',
+					$query->createNamedParameter($timestamp),
+				)
+			)
+			->executeQuery()
+			->fetchAssociative();
+	}
+
+	public function captureTrashDeleteHook(array $params): void {
+		$this->trashDeleteHookParams[] = $params;
+	}
+
+	public function captureTrashRestoreHook(array $params): void {
+		$this->trashRestoreHookParams[] = $params;
+	}
+
+	/**
+	 * Permanent deletion through the trash manager removes the physical trash
+	 * item and its files_trash metadata row.
+	 */
+	public function testRemoveItemRemovesMetadataAndEmitsCanonicalPath(): void {
+		$userManager = Server::get(IUserManager::class);
+		$user = $userManager->get(self::TEST_TRASHBIN_USER1);
+		$this->assertNotNull($user);
+
+		$userFolder = Server::get(IRootFolder::class)
+			->getUserFolder(self::TEST_TRASHBIN_USER1);
+
+		$file = $userFolder->newFile('file1.txt');
+		$file->putContent('foo');
+		$file->delete();
+
+		$filesInTrash = Helper::getTrashFiles('/', self::TEST_TRASHBIN_USER1);
+		$this->assertCount(1, $filesInTrash);
+
+		/** @var FileInfo $trashedFile */
+		$trashedFile = $filesInTrash[0];
+		$timestamp = $trashedFile->getMtime();
+
+		$this->assertNotFalse(
+			$this->getTrashRow('file1.txt', $timestamp),
+		);
+
+		$trashManager = Server::get(ITrashManager::class);
+		$trashItem = $trashManager->getTrashRootItem($user, 'file1.txt');
+
+		$this->assertNotNull($trashItem);
+		$this->assertSame(
+			'/file1.txt.d' . $timestamp,
+			$trashItem->getTrashPath(),
+		);
+
+		$this->trashDeleteHookParams = [];
+		\OC_Hook::connect(
+			'\OCP\Trashbin',
+			'delete',
+			$this,
+			'captureTrashDeleteHook',
+		);
+
+		$trashManager->removeItem($trashItem);
+
+		$this->assertFalse(
+			$this->rootView->file_exists(
+				$this->trashRoot1 . '/files/file1.txt.d' . $timestamp,
+			),
+		);
+
+		$this->assertFalse(
+			$this->getTrashRow('file1.txt', $timestamp),
+		);
+
+		$this->assertCount(1, $this->trashDeleteHookParams);
+		$this->assertSame(
+			'/files_trashbin/files/file1.txt.d' . $timestamp,
+			$this->trashDeleteHookParams[0]['path'],
+		);
+		$this->assertStringNotContainsString(
+			'//',
+			$this->trashDeleteHookParams[0]['path'],
+		);
+	}
+
+	/**
+	 * Restore through the trash manager accepts the ITrashItem path representation
+	 * and emits a canonical trash path.
+	 */
+	public function testRestoreItemEmitsCanonicalPathAndRemovesMetadata(): void {
+		$userManager = Server::get(IUserManager::class);
+		$user = $userManager->get(self::TEST_TRASHBIN_USER1);
+		$this->assertNotNull($user);
+
+		$userFolder = Server::get(IRootFolder::class)
+			->getUserFolder(self::TEST_TRASHBIN_USER1);
+
+		$file = $userFolder->newFile('file1.txt');
+		$file->putContent('foo');
+		$file->delete();
+
+		$filesInTrash = Helper::getTrashFiles('/', self::TEST_TRASHBIN_USER1);
+		$this->assertCount(1, $filesInTrash);
+
+		/** @var FileInfo $trashedFile */
+		$trashedFile = $filesInTrash[0];
+		$timestamp = $trashedFile->getMtime();
+
+		$this->assertNotFalse(
+			$this->getTrashRow('file1.txt', $timestamp),
+		);
+
+		$trashManager = Server::get(ITrashManager::class);
+		$trashItem = $trashManager->getTrashRootItem($user, 'file1.txt');
+
+		$this->assertNotNull($trashItem);
+		$this->assertSame(
+			'/file1.txt.d' . $timestamp,
+			$trashItem->getTrashPath(),
+		);
+
+		$this->trashRestoreHookParams = [];
+		\OC_Hook::connect(
+			'\OCA\Files_Trashbin\Trashbin',
+			'post_restore',
+			$this,
+			'captureTrashRestoreHook',
+		);
+
+		$trashManager->restoreItem($trashItem);
+
+		$this->assertTrue($userFolder->nodeExists('file1.txt'));
+		$this->assertSame(
+			'foo',
+			$userFolder->get('file1.txt')->getContent(),
+		);
+
+		$this->assertFalse(
+			$this->rootView->file_exists(
+				$this->trashRoot1 . '/files/file1.txt.d' . $timestamp,
+			),
+		);
+
+		$this->assertFalse(
+			$this->getTrashRow('file1.txt', $timestamp),
+		);
+
+		$this->assertCount(1, $this->trashRestoreHookParams);
+		$this->assertSame(
+			'/file1.txt.d' . $timestamp,
+			$this->trashRestoreHookParams[0]['trashPath'],
+		);
+		$this->assertStringNotContainsString(
+			'//',
+			$this->trashRestoreHookParams[0]['trashPath'],
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #49430 <!-- related github issue -->

## Summary

Fix leading-slash handling when `LegacyTrashBackend` passes trash item paths to `Trashbin::restore()` and `Trashbin::delete()` APIs.

`ITrashItem::getTrashPath()` currently returns paths with a leading slash, for example:

```text
/file.txt.d1731917455
```

The `Trashbin` APIs expect paths relative to `files_trashbin/files/`. Passing the slash-prefixed value can produce paths such as:

```text
/files_trashbin/files//file.txt.d1731917455
```

Filesystem path normalization currently masks the extra slash, but for permanent deletion the leading slash also causes the `files_trash` database cleanup query to use `/file.txt` instead of the stored ID `file.txt`. As a result, the physical trash item is deleted but its metadata row remains.

This change normalizes the path at the `LegacyTrashBackend` boundary before calling `Trashbin::restore()` and `Trashbin::delete()`, keeping those callers consistent with the APIs' relative-path contract.

Changes:

- Clarify the relative-path contracts in the `Trashbin::restore()` and `Trashbin::delete()` docblocks.The `delete()` documentation was already relatively clear; `restore()` required the more substantial clarification.
- Normalize trash paths in:
  - `LegacyTrashBackend::restoreItem()`
  - `LegacyTrashBackend::removeItem()`
- Add regression coverage for:
  - permanent deletion through the trash manager;
  - removal of the corresponding `files_trash` row;
  - canonical delete hook paths;
  - restore behavior through the trash manager;
  - canonical restore hook paths.

The existing `ITrashItem` path representation is unchanged to avoid affecting other consumers that rely on its leading slash.

## Follow-up ideas

- Existing orphaned `files_trash` rows are not repaired by this change, but they are already orphaned today. This fix prevents new incorrect rows from being left behind. Historical metadata cleanup can be addressed separately in a follow-up repair PR.
- Audit `files_versions` for anything possibly similar (not necessary applicable - just came to mind)

## TODO

- [x] Audit the Team Folders `ITrashBackend` implementation for similar issues (though any changes will obviously be handled in a separate PR)
- [ ] Consider backporting

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
