### PR TITLE
fix: Handle 2fa enforcement earlier

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -418,10 +418,8 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		if (!$isTokenPassword && $this->isTokenAuthEnforced()) {
-			throw new PasswordLoginForbiddenException();
-		}
-		if (!$isTokenPassword && $this->isTwoFactorEnforced($user)) {
+		if (!$isTokenPassword && ($this->isTokenAuthEnforced() || $this->isTwoFactorEnforced($user))) {
+			$this->handleLoginFailed($throttler, $currentDelay, $remoteAddress, $user, $password);
 			throw new PasswordLoginForbiddenException();
 		}
 
@@ -576,7 +574,8 @@ class Session implements IUserSession, Emitter {
 				// If credentials were provided, they need to be valid, otherwise we do boom
 				throw new LoginException();
 			} catch (PasswordLoginForbiddenException $ex) {
-				// Nothing to do
+				// If credentials were provided, they need to be valid, otherwise we do boom
+				throw new LoginException(previous: $ex);
 			}
 		}
 		return false;

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -451,7 +451,7 @@ class SessionTest extends \Test\TestCase {
 			->method('getRemoteAddress')
 			->willReturn('192.168.0.1');
 		$this->throttler
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('sleepDelayOrThrowOnMax')
 			->with('192.168.0.1');
 		$this->throttler
@@ -459,6 +459,15 @@ class SessionTest extends \Test\TestCase {
 			->method('getDelay')
 			->with('192.168.0.1')
 			->willReturn(0);
+
+		$this->throttler
+			->expects($this->once())
+			->method('registerAttempt')
+			->with('login', '192.168.0.1', ['user' => 'john']);
+		$this->dispatcher
+			->expects($this->once())
+			->method('dispatchTyped')
+			->with(new LoginFailed('john', 'doe'));
 
 		$userSession->logClientIn('john', 'doe', $request, $this->throttler);
 	}
@@ -561,7 +570,7 @@ class SessionTest extends \Test\TestCase {
 			->method('getRemoteAddress')
 			->willReturn('192.168.0.1');
 		$this->throttler
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('sleepDelayOrThrowOnMax')
 			->with('192.168.0.1');
 		$this->throttler
@@ -569,6 +578,15 @@ class SessionTest extends \Test\TestCase {
 			->method('getDelay')
 			->with('192.168.0.1')
 			->willReturn(0);
+
+		$this->throttler
+			->expects($this->once())
+			->method('registerAttempt')
+			->with('login', '192.168.0.1', ['user' => 'john']);
+		$this->dispatcher
+			->expects($this->once())
+			->method('dispatchTyped')
+			->with(new LoginFailed('john', 'doe'));
 
 		$userSession->logClientIn('john', 'doe', $request, $this->throttler);
 	}


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
