### PR TITLE
fix: allow file request upload when `part_file_in_storage=false`

### DIFF
--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -71,7 +71,9 @@ class PermissionsMask extends Wrapper {
 	#[\Override]
 	public function rename(string $source, string $target): bool {
 		//This is a rename of the transfer file to the original file
-		if (dirname($source) === dirname($target) && strpos($source, '.ocTransferId') > 0) {
+		$sourceDir = dirname($source);
+		$targetDir = dirname($target);
+		if (($sourceDir === $targetDir || $sourceDir === dirname($targetDir)) && strpos($source, '.ocTransferId') > 0) {
 			return $this->checkMask(Constants::PERMISSION_CREATE) && parent::rename($source, $target);
 		}
 		return $this->checkMask(Constants::PERMISSION_UPDATE) && parent::rename($source, $target);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Setting the config value `part_file_in_storage=false` and trying to upload files in a file request, using local storage and providing a nickname always fail. The reason is that the storage wrapper fails to detect the case when the file gets uploaded in the root due to the configuration, failing the parent directory check and checking for the UPDATE permission instead of the CREATE one.

**Note: the fix aims at restoring working upload requests. The already-existing problem that despite the configuration, uploads may not happen in the user's root is a separate issue.**

## Reproducing the issue

- Set the config value `part_file_in_storage=false`
- With a user create a folder in the root and create an upload request inside it
- Open the link in an anonymous browser tab
- Enter a nickname
- Upload a file

### Expected result

The file is uploaded

### Actual result

The upload fails

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
