### PR TITLE
fix(NavigationManager): properly register closures

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -34,7 +34,7 @@ class NavigationManager implements INavigationManager {
 	 * negative to keep this group in front of everything else.
 	 * Apps that are not listed keep their own order.
 	 */
-	private const DEFAULT_APP_ORDER = [
+	private const array DEFAULT_APP_ORDER = [
 		// Basics
 		'dashboard' => -100,
 		'files' => -99,
@@ -54,15 +54,20 @@ class NavigationManager implements INavigationManager {
 		'activity' => -88,
 	];
 
+	protected ?string $activeEntry = null;
 	/** @var array<string, NavigationEntryOutput> */
 	protected array $entries = [];
 	/** @var list<callable(): NavigationEntry> */
 	protected array $closureEntries = [];
-	protected ?string $activeEntry = null;
-	protected array $unreadCounters = [];
-	protected bool $init = false;
 	/** User defined app order (cached for the `add` function) */
-	private ?array $customAppOrder = null;
+	protected ?array $customAppOrder = null;
+	/** @var array<string, int> */
+	protected array $unreadCounters = [];
+
+	/** true if the internal state has been initialized */
+	protected bool $initAppOrderDone = false;
+	/** true if all apps have been loaded by the App Manager */
+	protected bool $initSetupDone = false;
 	/** List of loaded app info */
 	private array $loadedAppInfo = [];
 
@@ -80,11 +85,12 @@ class NavigationManager implements INavigationManager {
 
 	#[Override]
 	public function add(array|callable $entry): void {
-		if ($entry instanceof \Closure) {
+		if (is_callable($entry)) {
 			$this->closureEntries[] = $entry;
 			return;
 		}
-		$this->init();
+		// if needed initialize the internal state to allow setting app order and default app
+		$this->initCustomAppOrder();
 
 		$id = $entry['id'];
 
@@ -201,7 +207,7 @@ class NavigationManager implements INavigationManager {
 
 		if ($resetInit) {
 			$this->loadedAppInfo = [];
-			$this->init = false;
+			$this->initAppOrderDone = false;
 		}
 	}
 
@@ -219,11 +225,11 @@ class NavigationManager implements INavigationManager {
 	 * Initialize the internal state.
 	 * This loads the default app mapping and user mapping for app ordering.
 	 */
-	private function init(): void {
-		if ($this->init) {
+	private function initCustomAppOrder(): void {
+		if ($this->initAppOrderDone) {
 			return;
 		}
-		$this->init = true;
+		$this->initAppOrderDone = true;
 
 		if ($this->customAppOrder === null) {
 			if ($this->userSession->isLoggedIn()) {
@@ -237,20 +243,22 @@ class NavigationManager implements INavigationManager {
 
 	/**
 	 * Setup the navigation manager.
+	 *
 	 * @internal - This is only used by Nextcloud core to setup the navigation manager. It is not intended for use by apps.
 	 */
 	public function setup(): void {
-		// Resolve app navigation closures
-		while ($c = array_pop($this->closureEntries)) {
-			$this->add($c());
-		}
-
 		// Resolve dynamically added navigation entries via event listeners
 		$this->eventDispatcher->dispatchTyped(new LoadAdditionalEntriesEvent());
+
+		// mark setup as done to allow performance optimizations
+		$this->initSetupDone = true;
 	}
 
 	/**
-	 * Resolve classic info.xml based navigation entires.
+	 * Resolve app navigation entries.
+	 *
+	 * This is called every time by any getter as some code for legacy reasons relies
+	 * on the navigation entries being available before the app loading is finished.
 	 * Some code relies on this to be available earlier then the app loading finished.
 	 * So we need to resolve the navigation entries here, even if not all apps are loaded yet.
 	 */
@@ -340,6 +348,19 @@ class NavigationManager implements INavigationManager {
 					'app' => $app,
 				] : []
 				));
+			}
+		}
+
+		// once all apps are loaded we can resolve the app navigation closures
+		if ($this->initSetupDone) {
+			// This has to be done on every call,
+			// as apps might add new navigation entries via closures at any time
+			while ($c = array_pop($this->closureEntries)) {
+				try {
+					$this->add($c());
+				} catch (\Throwable $e) {
+					$this->logger->error('Failed to add navigation entry from closure', ['exception' => $e]);
+				}
 			}
 		}
 	}

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -28,15 +28,20 @@ use Psr\Log\LoggerInterface;
  * @psalm-import-type NavigationEntryOutput from INavigationManager
  */
 class NavigationManager implements INavigationManager {
+	protected ?string $activeEntry = null;
 	/** @var array<string, NavigationEntryOutput> */
 	protected array $entries = [];
 	/** @var list<callable(): NavigationEntry> */
 	protected array $closureEntries = [];
-	protected ?string $activeEntry = null;
-	protected array $unreadCounters = [];
-	protected bool $init = false;
 	/** User defined app order (cached for the `add` function) */
-	private ?array $customAppOrder = null;
+	protected ?array $customAppOrder = null;
+	/** @var array<string, int> */
+	protected array $unreadCounters = [];
+
+	/** true if the internal state has been initialized */
+	protected bool $initAppOrderDone = false;
+	/** true if all apps have been loaded by the App Manager */
+	protected bool $initSetupDone = false;
 	/** List of loaded app info */
 	private array $loadedAppInfo = [];
 
@@ -58,7 +63,8 @@ class NavigationManager implements INavigationManager {
 			$this->closureEntries[] = $entry;
 			return;
 		}
-		$this->init();
+		// if needed initialize the internal state to allow setting app order and default app
+		$this->initCustomAppOrder();
 
 		$id = $entry['id'];
 
@@ -172,7 +178,7 @@ class NavigationManager implements INavigationManager {
 
 		if ($resetInit) {
 			$this->loadedAppInfo = [];
-			$this->init = false;
+			$this->initAppOrderDone = false;
 		}
 	}
 
@@ -190,11 +196,11 @@ class NavigationManager implements INavigationManager {
 	 * Initialize the internal state.
 	 * This loads the default app mapping and user mapping for app ordering.
 	 */
-	private function init(): void {
-		if ($this->init) {
+	private function initCustomAppOrder(): void {
+		if ($this->initAppOrderDone) {
 			return;
 		}
-		$this->init = true;
+		$this->initAppOrderDone = true;
 
 		if ($this->customAppOrder === null) {
 			if ($this->userSession->isLoggedIn()) {
@@ -208,20 +214,23 @@ class NavigationManager implements INavigationManager {
 
 	/**
 	 * Setup the navigation manager.
+	 *
 	 * @internal - This is only used by Nextcloud core to setup the navigation manager. It is not intended for use by apps.
 	 */
 	public function setup(): void {
-		// Resolve app navigation closures
-		while ($c = array_pop($this->closureEntries)) {
-			$this->add($c());
-		}
-
 		// Resolve dynamically added navigation entries via event listeners
 		$this->eventDispatcher->dispatchTyped(new LoadAdditionalEntriesEvent());
+
+		// mark setup as done to allow performance optimizations
+		$this->initSetupDone = true;
 	}
 
 	/**
-	 * Resolve classic info.xml based navigation entires.
+	 * Resolve app navigation entries.
+	 *
+	 * This is called every time by any getter as some code for legacy reasons relies
+	 * on the navigation entries being available before the app loading is finished.
+	 * So once all apps are loaded we 
 	 * Some code relies on this to be available earlier then the app loading finished.
 	 * So we need to resolve the navigation entries here, even if not all apps are loaded yet.
 	 */
@@ -311,6 +320,19 @@ class NavigationManager implements INavigationManager {
 					'app' => $app,
 				] : []
 				));
+			}
+		}
+
+		// once all apps are loaded we can resolve the app navigation closures
+		if ($this->initSetupDone) {
+			// This has to be done on every call,
+			// as apps might add new navigation entries via closures at any time
+			while ($c = array_pop($this->closureEntries)) {
+				try {
+					$this->add($c());
+				} catch (\Throwable $e) {
+					$this->logger->error('Failed to add navigation entry from closure', ['exception' => $e]);
+				}
 			}
 		}
 	}

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -172,6 +172,35 @@ class NavigationManagerTest extends TestCase {
 		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists after clear()');
 	}
 
+	public function testAddClosureAfterSetup(): void {
+		$this->navigationManager->setup();
+		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists');
+
+		$numberOfCalls = 0;
+		$this->navigationManager->add(function () use (&$numberOfCalls) {
+			$numberOfCalls++;
+
+			return [
+				'id' => 'late entry',
+				'name' => 'link text',
+				'order' => 1,
+				'href' => 'url',
+			];
+		});
+
+		$this->assertEquals(0, $numberOfCalls, 'Expected that the closure is not called by add()');
+
+		$navigationEntries = $this->navigationManager->getAll('all');
+		$this->assertEquals(1, $numberOfCalls, 'Expected that the closure added after setup() is called by getAll()');
+		$this->assertCount(1, $navigationEntries, 'Expected that 1 navigation entry exists');
+		$this->assertArrayHasKey('late entry', $navigationEntries);
+
+		$navigationEntries = $this->navigationManager->getAll('all');
+		$this->assertEquals(1, $numberOfCalls, 'Expected that the closure is only called once');
+		$this->assertCount(1, $navigationEntries, 'Expected that 1 navigation entry exists');
+		$this->assertArrayHasKey('late entry', $navigationEntries);
+	}
+
 	public function testAddArrayClearGetAll(): void {
 		$entry = [
 			'id' => 'entry id',


### PR DESCRIPTION
## Summary
Lately there were quite some issues with the NavigationManager, so this tries to clarifies the implementation a bit. But more important this fixes an issue when closures are registered after the setup was already done (see added unit test).

This fixes the issue reported by @blizzz in tables - though table should instead move to the proper event.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
