### PR TITLE
fix: improve type hinting for unified share listing methods

### DIFF
--- a/apps/sharing/lib/Controller/ApiV1Controller.php
+++ b/apps/sharing/lib/Controller/ApiV1Controller.php
@@ -557,7 +557,7 @@ final class ApiV1Controller extends OCSController {
 	 * Get multiple shares.
 	 *
 	 * @param ?class-string<IShareSourceType> $filterSourceTypeClass Source type class to filter by.
-	 * @param ?string $filterSourceTypeValue Source type value to filter by.
+	 * @param ?non-empty-string $filterSourceTypeValue Source type value to filter by.
 	 * @param ?string $lastShareID The ID of the previous share. This is used as an offset and only shares with higher IDs are returned.
 	 * @param int<1, 100> $limit The number of shares to return.
 	 * @return DataResponse<Http::STATUS_OK, list<SharingShare>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, string, array{}>
@@ -576,6 +576,15 @@ final class ApiV1Controller extends OCSController {
 		/** @psalm-suppress DocblockTypeContradiction */
 		if ($limit > 100) {
 			return new DataResponse('The limit is too high.', Http::STATUS_BAD_REQUEST);
+		}
+
+		/** @psalm-suppress TypeDoesNotContainType */
+		if ($filterSourceTypeValue === '') {
+			return new DataResponse('Filter source value is empty.', Http::STATUS_BAD_REQUEST);
+		}
+
+		if ($filterSourceTypeClass && !isset($this->registry->getSourceTypes()[$filterSourceTypeClass])) {
+			return new DataResponse('The filter source type is not registered: ' . $filterSourceTypeClass, Http::STATUS_BAD_REQUEST);
 		}
 
 		try {

--- a/apps/sharing/openapi.json
+++ b/apps/sharing/openapi.json
@@ -3110,7 +3110,8 @@
                         "description": "Source type value to filter by.",
                         "schema": {
                             "type": "string",
-                            "nullable": true
+                            "nullable": true,
+                            "minLength": 1
                         }
                     },
                     {

--- a/apps/sharing/tests/Controller/ApiV1ControllerTest.php
+++ b/apps/sharing/tests/Controller/ApiV1ControllerTest.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use NCU\Sharing\ISharingManager;
-use NCU\Sharing\ISharingRegistry;
 use NCU\Sharing\Permission\SharePermission;
 use NCU\Sharing\Property\ShareProperty;
 use NCU\Sharing\Recipient\ShareRecipient;
@@ -47,7 +46,7 @@ final class ApiV1ControllerTest extends AbstractSharingManagerTests {
 			Server::get(IRequest::class),
 			Server::get(IUserSession::class),
 			Server::get(ISharingManager::class),
-			Server::get(ISharingRegistry::class),
+			$this->registry,
 			Server::get(IFactory::class),
 			Server::get(IURLGenerator::class),
 			Server::get(IUserManager::class),
@@ -68,7 +67,7 @@ final class ApiV1ControllerTest extends AbstractSharingManagerTests {
 			Server::get(IRequest::class),
 			Server::get(IUserSession::class),
 			Server::get(ISharingManager::class),
-			Server::get(ISharingRegistry::class),
+			$this->registry,
 			Server::get(IFactory::class),
 			Server::get(IURLGenerator::class),
 			Server::get(IUserManager::class),

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -556,6 +556,7 @@ final readonly class SharingBackend implements ISharingBackend {
 
 	/**
 	 * @param ?class-string<IShareSourceType> $filterSourceTypeClass
+	 * @param ?non-empty-string $filterSourceTypeValue
 	 * @return list<Share>
 	 */
 	private function list(ShareAccessContext $accessContext, ?string $filterShareID, ?string $filterSourceTypeClass, ?string $filterSourceTypeValue, ?string $lastShareID, ?int $limit): array {

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -698,7 +698,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$action = new ShareAction(null, array_values(array_map(static fn (SharePermission $permission): string => $permission->class, $share->getEnabledPermissions())));
 
 		$usersToCheck = [];
-		if ($share->owner->instance === null && ($ownerUser = $this->userManager->get($share->owner->userId)) !== null) {
+		if ($share->owner->instance === null && ($ownerUser = $this->userManager->get($share->owner->userId)) instanceof IUser) {
 			$usersToCheck[] = $ownerUser;
 		}
 

--- a/lib/unstable/Sharing/ISharingBackend.php
+++ b/lib/unstable/Sharing/ISharingBackend.php
@@ -174,6 +174,7 @@ interface ISharingBackend {
 	 * Get multiple shares.
 	 *
 	 * @param ?class-string<IShareSourceType> $filterSourceTypeClass
+	 * @param ?non-empty-string $filterSourceTypeValue
 	 * @param ?positive-int $limit
 	 * @return list<Share>
 	 * @experimental 35.0.0

--- a/lib/unstable/Sharing/ISharingManager.php
+++ b/lib/unstable/Sharing/ISharingManager.php
@@ -216,6 +216,7 @@ interface ISharingManager {
 	 * Get multiple shares.
 	 *
 	 * @param ?class-string<IShareSourceType> $filterSourceTypeClass
+	 * @param ?non-empty-string $filterSourceTypeValue
 	 * @param ?positive-int $limit
 	 * @return list<Share>
 	 * @experimental 35.0.0

--- a/openapi.json
+++ b/openapi.json
@@ -39006,7 +39006,8 @@
                         "description": "Source type value to filter by.",
                         "schema": {
                             "type": "string",
-                            "nullable": true
+                            "nullable": true,
+                            "minLength": 1
                         }
                     },
                     {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Minor improvements to type hints and improved parameter checking in controller.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
