### PR TITLE
fix(CalDAV): Check for user status before serving public calendars

### DIFF
--- a/apps/dav/lib/CalDAV/PublicCalendarRoot.php
+++ b/apps/dav/lib/CalDAV/PublicCalendarRoot.php
@@ -8,10 +8,14 @@
 
 namespace OCA\DAV\CalDAV;
 
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Collection;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\Uri;
 
 class PublicCalendarRoot extends Collection {
 
@@ -21,12 +25,15 @@ class PublicCalendarRoot extends Collection {
 	 * @param CalDavBackend $caldavBackend
 	 * @param IL10N $l10n
 	 * @param IConfig $config
+	 * @param IAppConfig $appConfig
 	 */
 	public function __construct(
 		protected CalDavBackend $caldavBackend,
 		protected IL10N $l10n,
 		protected IConfig $config,
+		protected IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private IUserManager $userManager,
 	) {
 	}
 
@@ -44,6 +51,9 @@ class PublicCalendarRoot extends Collection {
 	#[\Override]
 	public function getChild($name) {
 		$calendar = $this->caldavBackend->getPublicCalendar($name);
+		if (!$this->validateVisibility((string)$calendar['principaluri'])) {
+			throw new NotFound('Node with name \'' . $name . '\' could not be found');
+		}
 		return new PublicCalendar($this->caldavBackend, $calendar, $this->l10n, $this->config, $this->logger);
 	}
 
@@ -53,5 +63,27 @@ class PublicCalendarRoot extends Collection {
 	#[\Override]
 	public function getChildren() {
 		return [];
+	}
+
+	/**
+	 * Checks if the public calendar should be visible or not, based on
+	 * the configuration of the `hide_disabled_user_shares` setting within
+	 * `files_sharing` and the status of the owning user (disabled or not).
+	 */
+	private function validateVisibility(string $principalUri): bool {
+		$hideCalendarsOfDisabledUsers = $this->appConfig->getValueBool(
+			'files_sharing', 'hide_disabled_user_shares', true
+		);
+
+		if (!$hideCalendarsOfDisabledUsers) {
+			return true;
+		}
+
+		[$prefix, $name] = Uri\split($principalUri);
+		if ($prefix !== 'principals/users') {
+			return true;
+		}
+
+		return $this->userManager->get((string)$name)?->isEnabled() !== false;
 	}
 }

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -63,6 +64,7 @@ class RootCollection extends SimpleCollection {
 		$db = Server::get(IDBConnection::class);
 		$dispatcher = Server::get(IEventDispatcher::class);
 		$config = Server::get(IConfig::class);
+		$appConfig = Server::get(IAppConfig::class);
 		$proxyMapper = Server::get(ProxyMapper::class);
 		$rootFolder = Server::get(IRootFolder::class);
 		$federatedCalendarFactory = Server::get(FederatedCalendarFactory::class);
@@ -125,7 +127,7 @@ class RootCollection extends SimpleCollection {
 		$roomCalendarRoot = new CalendarRoot($calendarRoomPrincipalBackend, $caldavBackend, 'principals/calendar-rooms', $logger, $l10n, $config, $federatedCalendarFactory);
 		$roomCalendarRoot->disableListing = $disableListing;
 
-		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend, $l10n, $config, $logger);
+		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend, $l10n, $config, $appConfig, $logger, $userManager);
 
 		$systemTagCollection = Server::get(SystemTagsByIdCollection::class);
 		$systemTagRelationsCollection = new SystemTagsRelationsCollection(

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -15,16 +15,19 @@ use OCA\DAV\CalDAV\PublicCalendar;
 use OCA\DAV\CalDAV\PublicCalendarRoot;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IL10N;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
+use Sabre\DAV\Exception\NotFound;
 use Test\TestCase;
 
 /**
@@ -36,6 +39,7 @@ use Test\TestCase;
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 class PublicCalendarRootTest extends TestCase {
 	public const UNIT_TEST_USER = '';
+	private const DISABLED_USER_PRINCIPAL = 'principals/users/disabled-caldav-unit-test';
 	private CalDavBackend $backend;
 	private PublicCalendarRoot $publicCalendarRoot;
 	private IL10N&MockObject $l10n;
@@ -43,6 +47,7 @@ class PublicCalendarRootTest extends TestCase {
 	protected IUserManager&MockObject $userManager;
 	protected IGroupManager&MockObject $groupManager;
 	protected IConfig&MockObject $config;
+	protected IAppConfig&MockObject $appConfig;
 	private ISecureRandom $random;
 	private LoggerInterface&MockObject $logger;
 	protected ICacheFactory&MockObject $cacheFactory;
@@ -87,9 +92,10 @@ class PublicCalendarRootTest extends TestCase {
 		);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 
 		$this->publicCalendarRoot = new PublicCalendarRoot($this->backend,
-			$this->l10n, $this->config, $this->logger);
+			$this->l10n, $this->config, $this->appConfig, $this->logger, $this->userManager);
 	}
 
 	protected function tearDown(): void {
@@ -106,7 +112,10 @@ class PublicCalendarRootTest extends TestCase {
 			->withAnyParameters()
 			->willReturn([]);
 
-		$books = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER);
+		$books = array_merge(
+			$this->backend->getCalendarsForUser(self::UNIT_TEST_USER),
+			$this->backend->getCalendarsForUser(self::DISABLED_USER_PRINCIPAL),
+		);
 		foreach ($books as $book) {
 			$this->backend->deleteCalendar($book['id'], true);
 		}
@@ -136,10 +145,32 @@ class PublicCalendarRootTest extends TestCase {
 		$this->assertSame([], $calendarResults);
 	}
 
-	protected function createPublicCalendar(): Calendar {
-		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Example', []);
+	public function testGetChildHidesCalendarOfDisabledUser(): void {
+		$calendar = $this->createPublicCalendar(self::DISABLED_USER_PRINCIPAL);
+		$publicUri = $calendar->getPublishStatus();
 
-		$calendarInfo = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER)[0];
+		$this->mockDisabledOwner();
+		$this->setHideDisabledUserShares(true);
+
+		$this->expectException(NotFound::class);
+		$this->publicCalendarRoot->getChild($publicUri);
+	}
+
+	public function testGetChildServesCalendarOfDisabledUserWhenHidingIsDisabled(): void {
+		$calendar = $this->createPublicCalendar(self::DISABLED_USER_PRINCIPAL);
+		$publicUri = $calendar->getPublishStatus();
+
+		$this->mockDisabledOwner();
+		$this->setHideDisabledUserShares(false);
+
+		$calendarResult = $this->publicCalendarRoot->getChild($publicUri);
+		$this->assertEquals($calendar, $calendarResult);
+	}
+
+	protected function createPublicCalendar(string $principal = self::UNIT_TEST_USER): Calendar {
+		$this->backend->createCalendar($principal, 'Example', []);
+
+		$calendarInfo = $this->backend->getCalendarsForUser($principal)[0];
 		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$publicUri = $calendar->setPublishStatus(true);
 
@@ -147,5 +178,19 @@ class PublicCalendarRootTest extends TestCase {
 		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 
 		return $calendar;
+	}
+
+	private function mockDisabledOwner(): void {
+		$disabledUser = $this->createMock(IUser::class);
+		$disabledUser->method('isEnabled')
+			->willReturn(false);
+		$this->userManager->method('get')
+			->willReturn($disabledUser);
+	}
+
+	private function setHideDisabledUserShares(bool $hide): void {
+		$this->appConfig->method('getValueBool')
+			->with('files_sharing', 'hide_disabled_user_shares', 'yes')
+			->willReturn($hide);
 	}
 }

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -698,7 +698,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$action = new ShareAction(null, array_values(array_map(static fn (SharePermission $permission): string => $permission->class, $share->getEnabledPermissions())));
 
 		$usersToCheck = [];
-		if ($share->owner->instance === null && ($ownerUser = $this->userManager->get($share->owner->userId)) !== null) {
+		if ($share->owner->instance === null && ($ownerUser = $this->userManager->get($share->owner->userId)) instanceof IUser) {
 			$usersToCheck[] = $ownerUser;
 		}
 


### PR DESCRIPTION
## Summary

This PR adds support for the `hide_disabled_user_shares` setting on calendars. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
