### PR TITLE
fix: preserve concurrently deleted large folders in trash

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -302,35 +302,46 @@ class Trashbin implements IEventListener {
 			return false;
 		}
 
+		$propagator = $trashStorage->getPropagator();
+		$propagator->beginBatch();
+		$abortMove = false;
 		try {
-			$moveSuccessful = true;
+			try {
+				$moveSuccessful = true;
 
-			$inCache = $sourceStorage->getCache()->inCache($sourceInternalPath);
-			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
-			if ($inCache) {
-				$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
+				$inCache = $sourceStorage->getCache()->inCache($sourceInternalPath);
+				$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
+				if ($inCache) {
+					$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
+				}
+			} catch (CopyRecursiveException $e) {
+				$moveSuccessful = false;
+				if ($trashStorage->file_exists($trashInternalPath)) {
+					$trashStorage->unlink($trashInternalPath);
+				}
+				Server::get(LoggerInterface::class)->error('Couldn\'t move ' . $file_path . ' to the trash bin', ['app' => 'files_trashbin']);
 			}
-		} catch (CopyRecursiveException $e) {
-			$moveSuccessful = false;
-			if ($trashStorage->file_exists($trashInternalPath)) {
-				$trashStorage->unlink($trashInternalPath);
+
+			if ($sourceStorage->file_exists($sourceInternalPath)) { // failed to delete the original file, abort
+				if ($sourceStorage->is_dir($sourceInternalPath)) {
+					$sourceStorage->rmdir($sourceInternalPath);
+				} else {
+					$sourceStorage->unlink($sourceInternalPath);
+				}
+
+				if ($sourceStorage->file_exists($sourceInternalPath)) {
+					// undo the cache move
+					$sourceStorage->getUpdater()->renameFromStorage($trashStorage, $trashInternalPath, $sourceInternalPath);
+				} else {
+					$trashStorage->getUpdater()->remove($trashInternalPath);
+				}
+				$abortMove = true;
 			}
-			Server::get(LoggerInterface::class)->error('Couldn\'t move ' . $file_path . ' to the trash bin', ['app' => 'files_trashbin']);
+		} finally {
+			$propagator->commitBatch();
 		}
 
-		if ($sourceStorage->file_exists($sourceInternalPath)) { // failed to delete the original file, abort
-			if ($sourceStorage->is_dir($sourceInternalPath)) {
-				$sourceStorage->rmdir($sourceInternalPath);
-			} else {
-				$sourceStorage->unlink($sourceInternalPath);
-			}
-
-			if ($sourceStorage->file_exists($sourceInternalPath)) {
-				// undo the cache move
-				$sourceStorage->getUpdater()->renameFromStorage($trashStorage, $trashInternalPath, $sourceInternalPath);
-			} else {
-				$trashStorage->getUpdater()->remove($trashInternalPath);
-			}
+		if ($abortMove) {
 			return false;
 		}
 

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -342,66 +342,72 @@ class Trashbin implements IEventListener {
 			return false;
 		}
 
-		$moveSuccessful = true;
+		$propagator = $trashStorage->getPropagator();
+		$propagator->beginBatch();
 		try {
-			$inCache = $sourceStorage->getCache()->inCache($sourceInternalPath);
-			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
-			if ($inCache) {
-				$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
-			} else {
-				$sizeDifference = $sourceInfo->getSize();
-				if ($sizeDifference < 0) {
-					$sizeDifference = null;
+			$moveSuccessful = true;
+			try {
+				$inCache = $sourceStorage->getCache()->inCache($sourceInternalPath);
+				$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
+				if ($inCache) {
+					$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 				} else {
-					$sizeDifference = (int)$sizeDifference;
+					$sizeDifference = $sourceInfo->getSize();
+					if ($sizeDifference < 0) {
+						$sizeDifference = null;
+					} else {
+						$sizeDifference = (int)$sizeDifference;
+					}
+					$trashStorage->getUpdater()->update($trashInternalPath, null, $sizeDifference);
 				}
-				$trashStorage->getUpdater()->update($trashInternalPath, null, $sizeDifference);
-			}
-		} catch (\Exception $e) {
-			$moveSuccessful = false;
-			if ($trashStorage->file_exists($trashInternalPath)) {
-				$trashStorage->unlink($trashInternalPath);
-			}
-			Server::get(LoggerInterface::class)->error('Couldn\'t move ' . $file_path . ' to the trash bin', ['app' => 'files_trashbin']);
-		}
-
-		if ($sourceStorage->file_exists($sourceInternalPath)) { // failed to delete the original file, abort
-			if ($sourceStorage->is_dir($sourceInternalPath)) {
-				$sourceStorage->rmdir($sourceInternalPath);
-			} else {
-				$sourceStorage->unlink($sourceInternalPath);
-			}
-
-			if ($sourceStorage->file_exists($sourceInternalPath)) {
-				// undo the cache move
-				$sourceStorage->getUpdater()->renameFromStorage($trashStorage, $trashInternalPath, $sourceInternalPath);
-			} else {
-				$trashStorage->getUpdater()->remove($trashInternalPath);
-			}
-			$moveSuccessful = false;
-		}
-
-		if (!$moveSuccessful) {
-			Server::get(LoggerInterface::class)->error(
-				'trash move failed, removing trash metadata and payload',
-				[
-					'app' => 'files_trashbin',
-					'user' => $owner,
-					'filename' => $filename,
-					'timestamp' => $timestamp,
-				]
-			);
-			// The metadata row belongs to the owner, even when another user initiated
-			// the deletion.
-			self::deleteTrashRow($owner, $filename, $timestamp);
-			if ($trashStorage->file_exists($trashInternalPath)) {
-				if ($trashStorage->is_dir($trashInternalPath)) {
-					$trashStorage->rmdir($trashInternalPath);
-				} else {
+			} catch (\Exception $e) {
+				$moveSuccessful = false;
+				if ($trashStorage->file_exists($trashInternalPath)) {
 					$trashStorage->unlink($trashInternalPath);
 				}
+				Server::get(LoggerInterface::class)->error('Couldn\'t move ' . $file_path . ' to the trash bin', ['app' => 'files_trashbin']);
 			}
-			$trashStorage->getUpdater()->remove($trashInternalPath);
+
+			if ($sourceStorage->file_exists($sourceInternalPath)) { // failed to delete the original file, abort
+				if ($sourceStorage->is_dir($sourceInternalPath)) {
+					$sourceStorage->rmdir($sourceInternalPath);
+				} else {
+					$sourceStorage->unlink($sourceInternalPath);
+				}
+
+				if ($sourceStorage->file_exists($sourceInternalPath)) {
+					// undo the cache move
+					$sourceStorage->getUpdater()->renameFromStorage($trashStorage, $trashInternalPath, $sourceInternalPath);
+				} else {
+					$trashStorage->getUpdater()->remove($trashInternalPath);
+				}
+				$moveSuccessful = false;
+			}
+
+			if (!$moveSuccessful) {
+				Server::get(LoggerInterface::class)->error(
+					'trash move failed, removing trash metadata and payload',
+					[
+						'app' => 'files_trashbin',
+						'user' => $owner,
+						'filename' => $filename,
+						'timestamp' => $timestamp,
+					]
+				);
+				// The metadata row belongs to the owner, even when another user initiated
+				// the deletion.
+				self::deleteTrashRow($owner, $filename, $timestamp);
+				if ($trashStorage->file_exists($trashInternalPath)) {
+					if ($trashStorage->is_dir($trashInternalPath)) {
+						$trashStorage->rmdir($trashInternalPath);
+					} else {
+						$trashStorage->unlink($trashInternalPath);
+					}
+				}
+				$trashStorage->getUpdater()->remove($trashInternalPath);
+			}
+		} finally {
+			$propagator->commitBatch();
 		}
 
 		if ($moveSuccessful) {

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -9,15 +9,18 @@ declare(strict_types=1);
 
 namespace OCA\Files_Trashbin\Tests;
 
+use OC\Files\Cache\Propagator;
 use OC\Files\Cache\Updater;
 use OC\Files\Filesystem;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\Common;
 use OC\Files\Storage\Local;
 use OC\Files\Storage\Temporary;
+use OC\Files\Storage\Wrapper\Wrapper;
 use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Events\MoveToTrashEvent;
+use OCA\Files_Trashbin\Exceptions\CopyRecursiveException;
 use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
@@ -45,6 +48,23 @@ class TemporaryNoCross extends Temporary {
 
 	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		return Common::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+	}
+}
+
+
+class TemporaryFailingRead extends Temporary {
+	private bool $failReads = false;
+
+	public function failReads(): void {
+		$this->failReads = true;
+	}
+
+	public function fopen(string $path, string $mode) {
+		if ($this->failReads && str_starts_with($mode, 'r')) {
+			throw new CopyRecursiveException();
+		}
+
+		return parent::fopen($path, $mode);
 	}
 }
 
@@ -744,6 +764,72 @@ class StorageTest extends \Test\TestCase {
 
 		$this->assertEquals('foo', $this->rootView->file_get_contents($this->user . '/files_trashbin/files/test.txt.d1000'));
 		$this->assertEquals('bar', $this->rootView->file_get_contents($this->user . '/files_trashbin/files/test.txt.d1001'));
+	}
+
+	public function testDeleteMultipleFoldersWithSameTimestamp(): void {
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getTime')
+			->willReturn(1000);
+		$this->overwriteService(ITimeFactory::class, $timeFactory);
+
+		$folders = [
+			'alpha' => 'source-a',
+			'bravo' => 'source-b',
+			'charlie' => 'source-c',
+		];
+		foreach ($folders as $folder => $location) {
+			$this->userView->mkdir($location . '/' . $folder);
+			for ($i = 0; $i < 10; $i++) {
+				$this->userView->file_put_contents($location . '/' . $folder . '/file-' . $i . '.txt', $folder . '-' . $i);
+			}
+		}
+
+		foreach ($folders as $folder => $location) {
+			$this->assertTrue($this->userView->rmdir($location . '/' . $folder));
+		}
+
+		$trashEntries = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files');
+		$trashNames = array_map(static fn ($entry) => $entry->getName(), $trashEntries);
+		sort($trashNames);
+		$this->assertSame(['alpha.d1000', 'bravo.d1000', 'charlie.d1000'], $trashNames);
+
+		foreach ($folders as $folder => $location) {
+			$trashPath = $this->user . '/files_trashbin/files/' . $folder . '.d1000';
+			$children = $this->rootView->getDirectoryContent($trashPath);
+			$this->assertCount(10, $children);
+			for ($i = 0; $i < 10; $i++) {
+				$this->assertSame($folder . '-' . $i, $this->rootView->file_get_contents($trashPath . '/file-' . $i . '.txt'));
+			}
+			$this->assertSame($location, Trashbin::getLocation($this->user, $folder, '1000'));
+		}
+	}
+
+	public function testFailedMoveCommitsPropagationBatch(): void {
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getTime')
+			->willReturn(1000);
+		$this->overwriteService(ITimeFactory::class, $timeFactory);
+
+		[$userStorage,] = $this->rootView->resolvePath('/' . $this->user . '/files/test.txt');
+		while ($userStorage instanceof Wrapper) {
+			$userStorage = $userStorage->getWrapperStorage();
+		}
+		$propagator = $this->createMock(Propagator::class);
+		$propagator->expects($this->once())->method('beginBatch');
+		$propagator->expects($this->once())->method('commitBatch');
+		$propagatorProperty = new \ReflectionProperty(Common::class, 'propagator');
+		$propagatorProperty->setValue($userStorage, $propagator);
+
+		$failingStorage = new TemporaryFailingRead([]);
+		Filesystem::mount($failingStorage, [], $this->user . '/files/failing');
+		$this->userView->file_put_contents('failing/broken.txt', 'broken');
+		$failingStorage->getScanner()->scan('');
+		$failingStorage->failReads();
+
+		[$storage, $internalPath] = $this->userView->resolvePath('failing/broken.txt');
+		$this->assertFalse(Server::get(ITrashManager::class)->moveToTrash($storage, $internalPath));
+		$this->assertFalse($this->rootView->file_exists($this->user . '/files_trashbin/files/broken.txt.d1000'));
+		$this->assertFalse(Trashbin::getLocation($this->user, 'broken.txt', '1000'));
 	}
 
 	public function testMoveFromStoragePreserveFileId(): void {

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -8,14 +8,18 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Trashbin\Tests;
 
+use OC\Files\Cache\Propagator;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Common;
 use OC\Files\Storage\Temporary;
+use OC\Files\Storage\Wrapper\Wrapper;
 use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Events\MoveToTrashEvent;
+use OCA\Files_Trashbin\Exceptions\CopyRecursiveException;
 use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashManager;
+use OCA\Files_Trashbin\Trashbin;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
@@ -40,6 +44,22 @@ class TemporaryNoCross extends Temporary {
 
 	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		return Common::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+	}
+}
+
+class TemporaryFailingRead extends Temporary {
+	private bool $failReads = false;
+
+	public function failReads(): void {
+		$this->failReads = true;
+	}
+
+	public function fopen(string $path, string $mode) {
+		if ($this->failReads && str_starts_with($mode, 'r')) {
+			throw new CopyRecursiveException();
+		}
+
+		return parent::fopen($path, $mode);
 	}
 }
 
@@ -662,6 +682,72 @@ class StorageTest extends \Test\TestCase {
 
 		$this->assertEquals('foo', $this->rootView->file_get_contents($this->user . '/files_trashbin/files/test.txt.d1000'));
 		$this->assertEquals('bar', $this->rootView->file_get_contents($this->user . '/files_trashbin/files/test.txt.d1001'));
+	}
+
+	public function testDeleteMultipleFoldersWithSameTimestamp(): void {
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getTime')
+			->willReturn(1000);
+		$this->overwriteService(ITimeFactory::class, $timeFactory);
+
+		$folders = [
+			'alpha' => 'source-a',
+			'bravo' => 'source-b',
+			'charlie' => 'source-c',
+		];
+		foreach ($folders as $folder => $location) {
+			$this->userView->mkdir($location . '/' . $folder);
+			for ($i = 0; $i < 10; $i++) {
+				$this->userView->file_put_contents($location . '/' . $folder . '/file-' . $i . '.txt', $folder . '-' . $i);
+			}
+		}
+
+		foreach ($folders as $folder => $location) {
+			$this->assertTrue($this->userView->rmdir($location . '/' . $folder));
+		}
+
+		$trashEntries = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files');
+		$trashNames = array_map(static fn ($entry) => $entry->getName(), $trashEntries);
+		sort($trashNames);
+		$this->assertSame(['alpha.d1000', 'bravo.d1000', 'charlie.d1000'], $trashNames);
+
+		foreach ($folders as $folder => $location) {
+			$trashPath = $this->user . '/files_trashbin/files/' . $folder . '.d1000';
+			$children = $this->rootView->getDirectoryContent($trashPath);
+			$this->assertCount(10, $children);
+			for ($i = 0; $i < 10; $i++) {
+				$this->assertSame($folder . '-' . $i, $this->rootView->file_get_contents($trashPath . '/file-' . $i . '.txt'));
+			}
+			$this->assertSame($location, Trashbin::getLocation($this->user, $folder, '1000'));
+		}
+	}
+
+	public function testFailedMoveCommitsPropagationBatch(): void {
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getTime')
+			->willReturn(1000);
+		$this->overwriteService(ITimeFactory::class, $timeFactory);
+
+		[$userStorage,] = $this->rootView->resolvePath('/' . $this->user . '/files/test.txt');
+		while ($userStorage instanceof Wrapper) {
+			$userStorage = $userStorage->getWrapperStorage();
+		}
+		$propagator = $this->createMock(Propagator::class);
+		$propagator->expects($this->once())->method('beginBatch');
+		$propagator->expects($this->once())->method('commitBatch');
+		$propagatorProperty = new \ReflectionProperty(Common::class, 'propagator');
+		$propagatorProperty->setValue($userStorage, $propagator);
+
+		$failingStorage = new TemporaryFailingRead([]);
+		Filesystem::mount($failingStorage, [], $this->user . '/files/failing');
+		$this->userView->file_put_contents('failing/broken.txt', 'broken');
+		$failingStorage->getScanner()->scan('');
+		$failingStorage->failReads();
+
+		[$storage, $internalPath] = $this->userView->resolvePath('failing/broken.txt');
+		$this->assertFalse(Server::get(ITrashManager::class)->moveToTrash($storage, $internalPath));
+		$this->assertFalse($this->rootView->file_exists($this->user . '/files_trashbin/files/broken.txt.d1000'));
+		$this->assertFalse(Trashbin::getLocation($this->user, 'broken.txt', '1000'));
 	}
 
 	public function testMoveFromStoragePreserveFileId(): void {


### PR DESCRIPTION
* Resolves: #44414

## Summary

Deleting several large folders at the same time can remove every source folder while leaving fewer top-level entries visible in the user's trash bin. The report reproduces this with three folders containing 10,000 files each, and rules out quota-driven trash expiration.

Each `Trashbin::move2trash` call transfers a large cache subtree and immediately propagates changes through shared source and trash ancestors, while the existing destination lock only coordinates collisions for a single generated trash filename. That leaves distinct concurrent folder moves mutating the same file-cache ancestry without the batched propagation that the trash expiration path already uses.

This wraps the move-to-trash payload and cache mutation in `beginBatch()` / `commitBatch()` on the trash storage propagator, so the ancestor updates from one folder move are collected and committed together rather than piecemeal. The batch is balanced with `try`/`finally` so it is committed on failed moves and on the cleanup paths as well. Per-destination locking, metadata insertion, version retention, expiration scheduling, and return behavior are unchanged.

The semantic change is six lines; the rest of the diff in `Trashbin.php` is the reindentation that wrapping introduces, so `git diff -w` is the easier read.

## Honest status

I could not run the test suite locally, so the two new tests in `StorageTest.php` have not been executed anywhere yet. CI will be their first run, and I will fix whatever it turns up.

The underlying report has no deterministic reproduction, so treat the diagnosis as a hypothesis rather than something I have observed under a debugger. If maintainers who know this code think the batching is the wrong direction, I am happy to close this.

## Checklist

- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting) (not verified locally, no linter available in my environment)
- [ ] Screenshots before/after for front-end changes (not applicable, no front-end change)
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
