### PR TITLE
fix(Sharing): Set explicit ordering to prevent flaky database tests

### DIFF
--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -708,7 +708,10 @@ final readonly class SharingBackend implements ISharingBackend {
 					'ss.source_value',
 				)
 				->from('sharing_share_sources', 'ss')
-				->where($qb->expr()->in('ss.share_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
+				->where($qb->expr()->in('ss.share_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)))
+				->orderBy('ss.share_id', 'ASC')
+				->addOrderBy('ss.source_class', 'ASC')
+				->addOrderBy('ss.source_value', 'ASC');
 
 			$result = $qb->executeQuery();
 			foreach ($result->fetchAll() as $row) {
@@ -749,7 +752,10 @@ final readonly class SharingBackend implements ISharingBackend {
 					'sr.initiator_instance',
 				)
 				->from('sharing_share_recipients', 'sr')
-				->where($qb->expr()->in('sr.share_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
+				->where($qb->expr()->in('sr.share_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)))
+				->orderBy('sr.share_id', 'ASC')
+				->addOrderBy('sr.recipient_class', 'ASC')
+				->addOrderBy('sr.recipient_value', 'ASC');
 
 			foreach ($qb->executeQuery()->fetchAll() as $row) {
 				/** @var class-string<IShareRecipientType> $typeClass */


### PR DESCRIPTION
## Summary

One of the database tests fail intermittently on PostgreSQL 18 with the following message:

```
There was 1 failure:

1) ApiV1ControllerTest::testGetShareWithPublicSecret with data set #0 (true)
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'class' => 'Test\Sharing\TestShareRecipientType1'
-    'value' => 'recipient1'
+    'class' => 'Test\Sharing\TestShareRecipientTypePublicSecret'
+    'value' => 'recipient2'
     'instance' => null
-    'display_name' => 'Recipient 1'
+    'display_name' => 'Recipient 2'
     'icon' => [...]
     'secret' => Array (
         'updatable' => false
+        'value' => 'fAnaqCfnxwP4UDG45aIT3R6AI3gSc8ZL'
+        'url' => 'http://localhost/index.php/s/...gSc8ZL'
     )
     'initiator' => [...]
 )

/home/runner/work/server/server/tests/lib/Sharing/AbstractSharingManagerTests.php:3022
```

Examples are the following runs:
- https://github.com/nextcloud/server/actions/runs/31165319602/job/92829302778?pr=63004#step:7:113
- https://github.com/nextcloud/server/actions/runs/31155327956/job/92793702302#step:7:114
- https://github.com/nextcloud/server/actions/runs/31144690040/job/92761736862#step:7:113

The reason for the flakiness is a missing explicit ordering within the same share, which is added by this PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
