### PR TITLE
Add activity focused selector api

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -32,6 +32,7 @@ return array(
     'OCA\\DAV\\BulkUpload\\BulkUploadPlugin' => $baseDir . '/../lib/BulkUpload/BulkUploadPlugin.php',
     'OCA\\DAV\\BulkUpload\\MultipartRequestParser' => $baseDir . '/../lib/BulkUpload/MultipartRequestParser.php',
     'OCA\\DAV\\CalDAV\\Activity\\Backend' => $baseDir . '/../lib/CalDAV/Activity/Backend.php',
+    'OCA\\DAV\\CalDAV\\Activity\\CalendarFocusedSelector' => $baseDir . '/../lib/CalDAV/Activity/CalendarFocusedSelector.php',
     'OCA\\DAV\\CalDAV\\Activity\\Filter\\Calendar' => $baseDir . '/../lib/CalDAV/Activity/Filter/Calendar.php',
     'OCA\\DAV\\CalDAV\\Activity\\Filter\\Todo' => $baseDir . '/../lib/CalDAV/Activity/Filter/Todo.php',
     'OCA\\DAV\\CalDAV\\Activity\\Provider\\Base' => $baseDir . '/../lib/CalDAV/Activity/Provider/Base.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -47,6 +47,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\BulkUpload\\BulkUploadPlugin' => __DIR__ . '/..' . '/../lib/BulkUpload/BulkUploadPlugin.php',
         'OCA\\DAV\\BulkUpload\\MultipartRequestParser' => __DIR__ . '/..' . '/../lib/BulkUpload/MultipartRequestParser.php',
         'OCA\\DAV\\CalDAV\\Activity\\Backend' => __DIR__ . '/..' . '/../lib/CalDAV/Activity/Backend.php',
+        'OCA\\DAV\\CalDAV\\Activity\\CalendarFocusedSelector' => __DIR__ . '/..' . '/../lib/CalDAV/Activity/CalendarFocusedSelector.php',
         'OCA\\DAV\\CalDAV\\Activity\\Filter\\Calendar' => __DIR__ . '/..' . '/../lib/CalDAV/Activity/Filter/Calendar.php',
         'OCA\\DAV\\CalDAV\\Activity\\Filter\\Todo' => __DIR__ . '/..' . '/../lib/CalDAV/Activity/Filter/Todo.php',
         'OCA\\DAV\\CalDAV\\Activity\\Provider\\Base' => __DIR__ . '/..' . '/../lib/CalDAV/Activity/Provider/Base.php',

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\AppInfo;
 
+use OCA\DAV\CalDAV\Activity\CalendarFocusedSelector;
 use OCA\DAV\CalDAV\AppCalendar\AppCalendarPlugin;
 use OCA\DAV\CalDAV\CachedSubscriptionProvider;
 use OCA\DAV\CalDAV\CalendarManager;
@@ -243,6 +244,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(DeclarativeSettingsSetValueEvent::class, DavAdminSettingsListener::class);
 
 		$context->registerConfigLexicon(ConfigLexicon::class);
+
+		$context->registerActivityFocusedSelector(CalendarFocusedSelector::class);
 	}
 
 	#[\Override]

--- a/apps/dav/lib/CalDAV/Activity/CalendarFocusedSelector.php
+++ b/apps/dav/lib/CalDAV/Activity/CalendarFocusedSelector.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\CalDAV\Activity;
+
+use OCP\Activity\IActivityFocusedSelector;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class CalendarFocusedSelector implements IActivityFocusedSelector {
+	#[\Override]
+	public function extendQuery(IQueryBuilder $query, string $userId): array {
+		// Activity related to calendars owned by the user
+		$query->leftJoin('a', 'calendars', 'calendars',
+			$query->expr()->andX(
+				$query->expr()->eq('a.object_type', $query->createNamedParameter('calendar')),
+				$query->expr()->eq('a.object_id', 'calendars.id'),
+			));
+		return [
+			$query->expr()->eq('calendars.principaluri', $query->createNamedParameter('principals/users/' . $userId)),
+		];
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -87,6 +87,7 @@ return array(
     'OCP\\Activity\\Exceptions\\InvalidValueException' => $baseDir . '/lib/public/Activity/Exceptions/InvalidValueException.php',
     'OCP\\Activity\\Exceptions\\SettingNotFoundException' => $baseDir . '/lib/public/Activity/Exceptions/SettingNotFoundException.php',
     'OCP\\Activity\\Exceptions\\UnknownActivityException' => $baseDir . '/lib/public/Activity/Exceptions/UnknownActivityException.php',
+    'OCP\\Activity\\IActivityFocusedSelector' => $baseDir . '/lib/public/Activity/IActivityFocusedSelector.php',
     'OCP\\Activity\\IBulkConsumer' => $baseDir . '/lib/public/Activity/IBulkConsumer.php',
     'OCP\\Activity\\IConsumer' => $baseDir . '/lib/public/Activity/IConsumer.php',
     'OCP\\Activity\\IEvent' => $baseDir . '/lib/public/Activity/IEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -128,6 +128,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Activity\\Exceptions\\InvalidValueException' => __DIR__ . '/../../..' . '/lib/public/Activity/Exceptions/InvalidValueException.php',
         'OCP\\Activity\\Exceptions\\SettingNotFoundException' => __DIR__ . '/../../..' . '/lib/public/Activity/Exceptions/SettingNotFoundException.php',
         'OCP\\Activity\\Exceptions\\UnknownActivityException' => __DIR__ . '/../../..' . '/lib/public/Activity/Exceptions/UnknownActivityException.php',
+        'OCP\\Activity\\IActivityFocusedSelector' => __DIR__ . '/../../..' . '/lib/public/Activity/IActivityFocusedSelector.php',
         'OCP\\Activity\\IBulkConsumer' => __DIR__ . '/../../..' . '/lib/public/Activity/IBulkConsumer.php',
         'OCP\\Activity\\IConsumer' => __DIR__ . '/../../..' . '/lib/public/Activity/IConsumer.php',
         'OCP\\Activity\\IEvent' => __DIR__ . '/../../..' . '/lib/public/Activity/IEvent.php',

--- a/lib/private/Activity/Manager.php
+++ b/lib/private/Activity/Manager.php
@@ -8,6 +8,7 @@
 
 namespace OC\Activity;
 
+use OC\AppFramework\Bootstrap\Coordinator;
 use OCP\Activity\ActivitySettings;
 use OCP\Activity\Exceptions\FilterNotFoundException;
 use OCP\Activity\Exceptions\IncompleteActivityException;
@@ -30,18 +31,10 @@ use OCP\RichObjectStrings\IValidator;
 use OCP\Server;
 
 class Manager implements IManager {
-
-	/** @var string */
-	protected $formattingObjectType;
-
-	/** @var int|string */
-	protected $formattingObjectId;
-
-	/** @var bool */
-	protected $requirePNG = false;
-
-	/** @var string */
-	protected $currentUserId;
+	protected ?string $formattingObjectType = null;
+	protected int|string|null $formattingObjectId = null;
+	protected bool $requirePNG = false;
+	protected ?string $currentUserId = null;
 
 	public function __construct(
 		protected IRequest $request,
@@ -51,6 +44,7 @@ class Manager implements IManager {
 		protected IRichTextFormatter $richTextFormatter,
 		protected IL10N $l10n,
 		protected ITimeFactory $timeFactory,
+		private Coordinator $coordinator,
 	) {
 	}
 
@@ -395,5 +389,15 @@ class Manager implements IManager {
 
 		// Token found login as that user
 		return array_shift($users);
+	}
+
+	#[\Override]
+	public function getActivityFocusedSelectors(): array {
+		$registeredSelectors = $this->coordinator->getRegistrationContext()?->getActivityFocusedSelectors() ?? [];
+		$selectors = [];
+		foreach ($registeredSelectors as $registration) {
+			$selectors[] = Server::get($registration->getService());
+		}
+		return $selectors;
 	}
 }

--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -12,6 +12,7 @@ namespace OC\AppFramework\Bootstrap;
 use Closure;
 use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\Support\CrashReport\Registry;
+use OCP\Activity\IActivityFocusedSelector;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Middleware;
@@ -166,6 +167,9 @@ class RegistrationContext {
 
 	/** @var ServiceRegistration<IMailProvider>[] */
 	private $mailProviders = [];
+
+	/** @var ServiceRegistration<IActivityFocusedSelector>[] */
+	private array $activityFocusedSelectors = [];
 
 	public function __construct(
 		private LoggerInterface $logger,
@@ -491,6 +495,14 @@ class RegistrationContext {
 					$configLexiconClass
 				);
 			}
+
+			#[\Override]
+			public function registerActivityFocusedSelector(string $activityFocusedSelectorClass): void {
+				$this->context->registerActivityFocusedSelector(
+					$this->appId,
+					$activityFocusedSelectorClass
+				);
+			}
 		};
 	}
 
@@ -707,6 +719,10 @@ class RegistrationContext {
 	 */
 	public function registerConfigLexicon(string $appId, string $configLexiconClass): void {
 		$this->configLexiconClasses[$appId] = $configLexiconClass;
+	}
+
+	public function registerActivityFocusedSelector(string $appId, string $activityFocusedSelectorClass): void {
+		$this->activityFocusedSelectors[] = new ServiceRegistration($appId, $activityFocusedSelectorClass);
 	}
 
 	/**
@@ -1093,5 +1109,12 @@ class RegistrationContext {
 		}
 
 		return Server::get($this->configLexiconClasses[$appId]);
+	}
+
+	/**
+	 * @return ServiceRegistration<IActivityFocusedSelector>[]
+	 */
+	public function getActivityFocusedSelectors(): array {
+		return $this->activityFocusedSelectors;
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -591,6 +591,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IRichTextFormatter::class),
 				$l10n,
 				$c->get(ITimeFactory::class),
+				$c->get(\OC\AppFramework\Bootstrap\Coordinator::class),
 			);
 		});
 

--- a/lib/public/Activity/IActivityFocusedSelector.php
+++ b/lib/public/Activity/IActivityFocusedSelector.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Activity;
+
+use OCP\AppFramework\Attribute\Implementable;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+/**
+ * @since 35.0.0
+ */
+#[Implementable(since: '35.0.0')]
+interface IActivityFocusedSelector {
+	/**
+	 * Extend query with joins if needed, and return an array of conditions to add
+	 * in the OR clause of the WHERE for filtering focused activity events
+	 *
+	 * @return list<string> conditions to add in the where clause
+	 * @since 35.0.0
+	 */
+	public function extendQuery(IQueryBuilder $query, string $userId): array;
+}

--- a/lib/public/Activity/IActivityFocusedSelector.php
+++ b/lib/public/Activity/IActivityFocusedSelector.php
@@ -10,7 +10,9 @@ declare(strict_types=1);
 namespace OCP\Activity;
 
 use OCP\AppFramework\Attribute\Implementable;
+use OCP\DB\QueryBuilder\ICompositeExpression;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
 
 /**
  * @since 35.0.0
@@ -21,7 +23,7 @@ interface IActivityFocusedSelector {
 	 * Extend query with joins if needed, and return an array of conditions to add
 	 * in the OR clause of the WHERE for filtering focused activity events
 	 *
-	 * @return list<string> conditions to add in the where clause
+	 * @return list<string|ICompositeExpression|IQueryFunction> conditions to add in the where clause
 	 * @since 35.0.0
 	 */
 	public function extendQuery(IQueryBuilder $query, string $userId): array;

--- a/lib/public/Activity/IManager.php
+++ b/lib/public/Activity/IManager.php
@@ -12,6 +12,7 @@ namespace OCP\Activity;
 use OCP\Activity\Exceptions\FilterNotFoundException;
 use OCP\Activity\Exceptions\IncompleteActivityException;
 use OCP\Activity\Exceptions\SettingNotFoundException;
+use OCP\AppFramework\QueryException;
 
 /**
  * Interface IManager
@@ -175,4 +176,13 @@ interface IManager {
 	 * @since 8.1.0
 	 */
 	public function getCurrentUserId(): string;
+
+	/**
+	 * Get "focused activity" selectors declared by booted applications
+	 *
+	 * @throws QueryException If an application registered a class that cannot be instanciated
+	 * @return list<IActivityFocusedSelector>
+	 * @since 35.0.0
+	 */
+	public function getActivityFocusedSelectors(): array;
 }

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -452,4 +452,13 @@ interface IRegistrationContext {
 	 * @since 31.0.0
 	 */
 	public function registerConfigLexicon(string $configLexiconClass): void;
+
+	/**
+	 * Register an implementation of \OCP\Activity\IActivityFocusedSelector that
+	 * will extend the DB query to find focused activity events
+	 *
+	 * @param class-string<\OCP\Activity\IActivityFocusedSelector> $configLexiconClass
+	 * @since 35.0.0
+	 */
+	public function registerActivityFocusedSelector(string $activityFocusedSelectorClass): void;
 }

--- a/tests/lib/Activity/ManagerTest.php
+++ b/tests/lib/Activity/ManagerTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Test\Activity;
 
 use OC\Activity\Manager;
+use OC\AppFramework\Bootstrap\Coordinator;
 use OCP\Activity\Exceptions\IncompleteActivityException;
 use OCP\Activity\IConsumer;
 use OCP\Activity\IEvent;
@@ -34,6 +35,7 @@ class ManagerTest extends TestCase {
 	protected IValidator&MockObject $validator;
 	protected IRichTextFormatter&MockObject $richTextFormatter;
 	private ITimeFactory&MockObject $time;
+	private Coordinator&MockObject $coordinator;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -45,6 +47,7 @@ class ManagerTest extends TestCase {
 		$this->validator = $this->createMock(IValidator::class);
 		$this->richTextFormatter = $this->createMock(IRichTextFormatter::class);
 		$this->time = $this->createMock(ITimeFactory::class);
+		$this->coordinator = $this->createMock(Coordinator::class);
 
 		$this->activityManager = new Manager(
 			$this->request,
@@ -54,6 +57,7 @@ class ManagerTest extends TestCase {
 			$this->richTextFormatter,
 			$this->createMock(IL10N::class),
 			$this->time,
+			$this->coordinator,
 		);
 
 		$this->assertSame([], self::invokePrivate($this->activityManager, 'getConsumers'));


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Adds an API for application to register an activity focused selector to extend the DB query for "focused" activity filter.
Implements the API in dav for calendar events as an example.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
