### PR TITLE
test(files): expand and improve quota wrapper coverage

### DIFF
--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -300,6 +300,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertSame(3, $instance->file_put_contents('uploads/foo', 'foo'));
 		$this->assertSame('foo', $instance->file_get_contents('uploads/foo'));
 
+		$this->assertTrue($instance->mkdir('cache'));
 		$this->assertSame(3, $instance->file_put_contents('cache/foo', 'foo'));
 		$this->assertSame('foo', $instance->file_get_contents('cache/foo'));
 	}
@@ -332,7 +333,6 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		fwrite($stream, 'foo');
 		rewind($stream);
 		$this->assertSame(3, $instance->writeStream('files/test.txt', $stream));
-		fclose($stream);
 
 		$this->assertSame('foo', $instance->file_get_contents('files/test.txt'));
 
@@ -354,7 +354,6 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 			3,
 			$instance->writeStream('files/test.txt', $stream, 3)
 		);
-		fclose($stream);
 
 		$this->assertSame('foo', $instance->file_get_contents('files/test.txt'));
 	}

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -60,6 +60,28 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertFalse($instance->file_put_contents('files/foo', 'foobar'));
 	}
 
+	public function testFilePutContentsRejectsExactQuotaLimit(): void {
+		$instance = $this->getLimitedStorage(3);
+
+		// Quota currently uses a strict "<" comparison, so an exact fit is
+		// rejected rather than accepted.
+		$this->assertFalse($instance->file_put_contents('files/foo', 'foo'));
+	}
+
+	public function testSizedWriteStreamRejectsExactQuotaLimit(): void {
+		$instance = $this->getLimitedStorage(3);
+		$stream = fopen('php://temp', 'w+');
+		fwrite($stream, 'foo');
+		rewind($stream);
+
+		$this->expectException(NotEnoughSpaceException::class);
+		try {
+			$instance->writeStream('files/test.txt', $stream, 3);
+		} finally {
+			fclose($stream);
+		}
+	}
+
 	public function testCopyNotEnoughSpace(): void {
 		$instance = $this->getLimitedStorage(9);
 		$this->assertEquals(6, $instance->file_put_contents('files/foo', 'foobar'));
@@ -214,7 +236,6 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 
 	public function testNoMkdirQuotaZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
-		$this->assertFalse($instance->mkdir('files'));
 		$this->assertFalse($instance->mkdir('files/foobar'));
 	}
 
@@ -242,13 +263,17 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$stream = fopen('php://temp', 'w+');
 		fwrite($stream, 'foo');
 		rewind($stream);
-		$instance->writeStream('files/test.txt', $stream);
+		$this->assertSame(3, $instance->writeStream('files/test.txt', $stream));
+		fclose($stream);
+
+		$this->assertSame('foo', $instance->file_get_contents('files/test.txt'));
 
 		$stream = fopen('php://temp', 'w+');
 		fwrite($stream, 'foobar');
 		rewind($stream);
 		$this->expectException(NotEnoughSpaceException::class);
 		$instance->writeStream('files/test.txt', $stream);
+		fclose($stream);
 	}
 
 	public function testNoWriteStreamQuotaZero(): void {

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -13,6 +13,7 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\Local;
 use OC\Files\Storage\Wrapper\Quota;
 use OCP\Files;
+use OCP\Files\FileInfo;
 use OCP\Files\NotEnoughSpaceException;
 use OCP\ITempManager;
 use OCP\Server;
@@ -117,6 +118,51 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 			'', ['size' => 3]
 		);
 		$this->assertEquals(6, $instance->free_space(''));
+	}
+
+	public function testQuotaCallbackIsUsedAndCached(): void {
+		$storage = new Local(['datadir' => $this->tmpDir]);
+		$storage->mkdir('files');
+		$storage->getScanner()->scan('');
+
+		$callbackCalls = 0;
+		$instance = new Quota([
+			'storage' => $storage,
+			'quotaCallback' => static function () use (&$callbackCalls): int {
+				$callbackCalls++;
+				return 9;
+			},
+		]);
+
+		$this->assertSame(9, $instance->getQuota());
+		$this->assertSame(9, $instance->getQuota());
+		$this->assertSame(1, $callbackCalls);
+	}
+
+	public function testUnlimitedQuotaDelegatesToWrappedStorage(): void {
+		$instance = $this->getLimitedStorage(FileInfo::SPACE_UNLIMITED);
+
+		$this->assertSame(
+			100,
+			$instance->file_put_contents('files/foo', str_repeat('x', 100))
+		);
+	}
+
+	public function testNegativeQuotaDelegatesToWrappedStorage(): void {
+		$instance = $this->getLimitedStorage(-1);
+
+		$this->assertSame(
+			100,
+			$instance->file_put_contents('files/foo', str_repeat('x', 100))
+		);
+	}
+
+	public function testQuotaCanBeDisabled(): void {
+		$instance = $this->getLimitedStorage(0);
+		$instance->enableQuota(false);
+
+		$this->assertSame(3, $instance->file_put_contents('files/foo', 'foo'));
+		$this->assertSame('foo', $instance->file_get_contents('files/foo'));
 	}
 
 	public function testFreeSpaceWithUsedSpaceAndEncryption(): void {
@@ -247,6 +293,28 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($instance->mkdir('cache'));
 	}
 
+	public function testCacheAndUploadsBypassQuota(): void {
+		$instance = $this->getLimitedStorage(0.0);
+
+		$this->assertTrue($instance->mkdir('uploads'));
+		$this->assertSame(3, $instance->file_put_contents('uploads/foo', 'foo'));
+		$this->assertSame('foo', $instance->file_get_contents('uploads/foo'));
+
+		$this->assertSame(3, $instance->file_put_contents('cache/foo', 'foo'));
+		$this->assertSame('foo', $instance->file_get_contents('cache/foo'));
+	}
+
+	public function testPartFilesBypassQuotaWhenOpenedForWriting(): void {
+		$instance = $this->getLimitedStorage(0.0);
+		$stream = $instance->fopen('files/foo.part', 'w');
+
+		$this->assertIsResource($stream);
+		$this->assertSame(3, fwrite($stream, 'foo'));
+		fclose($stream);
+
+		$this->assertSame('foo', $instance->file_get_contents('files/foo.part'));
+	}
+
 	public function testNoTouchQuotaZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
 		$this->assertFalse($instance->touch('foobar'));
@@ -274,6 +342,80 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->expectException(NotEnoughSpaceException::class);
 		$instance->writeStream('files/test.txt', $stream);
 		fclose($stream);
+	}
+
+	public function testSizedWriteStreamWithEnoughSpace(): void {
+		$instance = $this->getLimitedStorage(5);
+		$stream = fopen('php://temp', 'w+');
+		fwrite($stream, 'foo');
+		rewind($stream);
+
+		$this->assertSame(
+			3,
+			$instance->writeStream('files/test.txt', $stream, 3)
+		);
+		fclose($stream);
+
+		$this->assertSame('foo', $instance->file_get_contents('files/test.txt'));
+	}
+
+	public function testSizedWriteStreamRejectsWhenSizeReachesFreeSpace(): void {
+		$instance = $this->getLimitedStorage(3);
+		$stream = fopen('php://temp', 'w+');
+		fwrite($stream, 'foo');
+		rewind($stream);
+
+		try {
+			$this->expectException(NotEnoughSpaceException::class);
+			$instance->writeStream('files/test.txt', $stream, 3);
+		} finally {
+			fclose($stream);
+		}
+	}
+
+	public function testCopyFromStorageHonorsQuota(): void {
+		$instance = $this->getLimitedStorage(3);
+		$sourceDir = Server::get(ITempManager::class)->getTemporaryFolder();
+
+		try {
+			$sourceStorage = new Local(['datadir' => $sourceDir]);
+			$sourceStorage->file_put_contents('source.txt', 'foo');
+			$sourceStorage->getScanner()->scan('');
+
+			$this->assertFalse(
+				$instance->copyFromStorage(
+					$sourceStorage,
+					'source.txt',
+					'files/target.txt'
+				)
+			);
+			$this->assertFalse($instance->file_exists('files/target.txt'));
+		} finally {
+			Files::rmdirr($sourceDir);
+		}
+	}
+
+	public function testMoveFromStorageHonorsQuota(): void {
+		$instance = $this->getLimitedStorage(3);
+		$sourceDir = Server::get(ITempManager::class)->getTemporaryFolder();
+
+		try {
+			$sourceStorage = new Local(['datadir' => $sourceDir]);
+			$sourceStorage->file_put_contents('source.txt', 'foo');
+			$sourceStorage->getScanner()->scan('');
+
+			$this->assertFalse(
+				$instance->moveFromStorage(
+					$sourceStorage,
+					'source.txt',
+					'files/target.txt'
+				)
+			);
+			$this->assertTrue($sourceStorage->file_exists('source.txt'));
+			$this->assertFalse($instance->file_exists('files/target.txt'));
+		} finally {
+			Files::rmdirr($sourceDir);
+		}
 	}
 
 	public function testNoWriteStreamQuotaZero(): void {

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -163,6 +163,29 @@ class HelperStorageTest extends \Test\TestCase {
 	}
 
 	/**
+	 * Test that the quota wrapper includes mounted storage when configured.
+	 */
+	public function testQuotaIncludesExternalStorage(): void {
+		$homeStorage = new Temporary([]);
+		$homeStorage->file_put_contents('test.txt', '01234');
+		$homeStorage->getScanner()->scan('');
+
+		$quotaStorage = new Quota([
+			'storage' => $homeStorage,
+			'quota' => 25,
+			'include_external_storage' => true,
+		]);
+		Filesystem::mount($quotaStorage, [], '/' . $this->user . '/files');
+
+		$externalStorage = new Temporary([]);
+		$externalStorage->file_put_contents('extfile.txt', 'abcdefghijklmnopq');
+		$externalStorage->getScanner()->scan('');
+		Filesystem::mount($externalStorage, [], '/' . $this->user . '/files/ext');
+
+		$this->assertSame(3, $quotaStorage->free_space(''));
+	}
+
+	/**
 	 * Test getting the storage info excluding extra mount points
 	 * when user has no quota set, even when quota ext storage option
 	 * was set


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #n/a <!-- related github issue -->

## Summary

Fixes some existing test bugs for `OC\Files\Storage\Wrapper\Quota` and expands targeted PHPUnit coverage focusing on previously-untested branches and quota- boundary behavior.

**Notes**
- The changes are test-only and motivated by some documentation work + possible production code changes (and just generally good test hygiene!); no production code is modified in this PR.
- Fixes are in the first commit; bulk of new tests are in second commit; third commit adds a new test specifically for external storage quota inclusion handling.

**New coverage:**
- Exact quota boundary behavior (`file_put_contents`/`writeStream` reject exact-fit writes due to current strict `<` comparison)
- `quotaCallback` invocation and caching (`getQuota()` only calls the callback once)
- Unlimited (`FileInfo::SPACE_UNLIMITED`) and negative quota values delegate to wrapped storage
- `enableQuota(false)` disables enforcement
- `cache/` and `uploads/` path prefixes bypass quota
- `.part` files bypass quota when opened for writing
- `copyFromStorage`/`moveFromStorage` correctly reject and leave source/target untouched when quota is exceeded
- Sized `writeStream()` return values and exact-limit rejection (previously the return value wasn't asserted)
- `include_external_storage` quota accounting correctly reflects mounted external storage in `free_space()`

**Fix:**
- Removed an invalid assertion in `testNoMkdirQuotaZero()` (`assertFalse($instance->mkdir('files'))`). This was passing for the wrong reason: `getLimitedStorage()` already creates `files/` on the underlying storage before the test runs. In addition, `shouldApplyQuota()` only applies quota to paths matching `files/` (with trailing slash), so bare `files` was never quota-scoped to begin with.

## TODO

- [ ] Make sure all tests, particularly the integration ones pass reliably enough in CI run(s)
- [ ] Backport? (I vote at least to v34 to have some better coverage at least thru it's lifecycle)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
