### PR TITLE
allow every with direct access to a shared file to modify all shares for the file

### DIFF
--- a/apps/files/lib/Sharing/Source/NodeShareSourceType.php
+++ b/apps/files/lib/Sharing/Source/NodeShareSourceType.php
@@ -24,7 +24,9 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Cache\IFileAccess;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IShareOwnerlessMount;
 use OCP\Files\Node;
+use OCP\Files\Storage\ISharedStorage;
 use OCP\IDBConnection;
 use OCP\Interaction\InteractionResource;
 use OCP\Interaction\Resources\NodeResource;
@@ -94,5 +96,19 @@ final readonly class NodeShareSourceType implements IShareSourceType, IEventList
 			$this->dbConnection->rollBack();
 			throw $exception;
 		}
+	}
+
+	#[\Override]
+	public function userHasDirectSharingAccessToSource(IUser $user, string $source): bool {
+		// TODO: cache nodes by id?
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$nodes = $userFolder->getById((int)$source);
+		foreach ($nodes as $node) {
+			if (!$node->getStorage() instanceof ISharedStorage && $node->isShareable() && $node->getMountPoint() instanceof IShareOwnerlessMount) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -358,7 +358,7 @@ final readonly class SharingBackend implements ISharingBackend {
 	}
 
 	#[\Override]
-	public function createShareProperty(string $id, ShareProperty $property): void {
+	public function createShareProperty(string $id, ShareProperty $property): ?string {
 		$value = $property->value;
 
 		$propertyType = $this->registry->getPropertyTypes()[$property->class];
@@ -377,6 +377,8 @@ final readonly class SharingBackend implements ISharingBackend {
 					'property_value' => $qb->createNamedParameter($value),
 				])
 				->executeStatement();
+
+			return $value;
 		} catch (\OCP\DB\Exception $exception) {
 			if ($exception->getReason() === \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 				throw new RuntimeException('The property already exists: ' . $property->class, $exception->getCode(), $exception);
@@ -387,7 +389,7 @@ final readonly class SharingBackend implements ISharingBackend {
 	}
 
 	#[\Override]
-	public function updateShareProperty(string $id, ShareProperty $property): void {
+	public function updateShareProperty(string $id, ShareProperty $property): ?string {
 		$value = $property->value;
 
 		$propertyType = $this->registry->getPropertyTypes()[$property->class];
@@ -425,6 +427,8 @@ final readonly class SharingBackend implements ISharingBackend {
 		if ($rowCount === 0) {
 			throw new ShareNotFoundException();
 		}
+
+		return $value;
 	}
 
 	#[\Override]
@@ -1155,7 +1159,15 @@ final readonly class SharingBackend implements ISharingBackend {
 
 		$property = new ShareProperty($propertyTypeClass, $propertyType->getDefaultValue($share));
 
-		$this->createShareProperty($share->id, $property);
+		$value = $this->createShareProperty($share->id, $property);
+		if ($propertyType instanceof ISharePropertyTypeModifyValue) {
+			$value = $propertyType->modifyValueOnLoad($value);
+		}
+
+		$property = new ShareProperty(
+			$property->class,
+			$value,
+		);
 
 		$properties = $share->properties;
 		$properties[$propertyTypeClass] = $property;

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -610,18 +610,11 @@ final readonly class SharingBackend implements ISharingBackend {
 		$queries = [];
 		if ($accessContext->overrideChecks) {
 			$queries[] = $this->connection->getQueryBuilder();
-			$userHasDirectAccess = false;
 		} else {
-			if ($filterSourceType && $filterSourceTypeValue !== null && $accessContext->currentUser instanceof IUser) {
-				$userHasDirectAccess = $filterSourceType->userHasDirectSharingAccessToSource($accessContext->currentUser, $filterSourceTypeValue);
-			} else {
-				$userHasDirectAccess = false;
-			}
-
 			if ($accessContext->currentUser instanceof IUser) {
 				$qb = $this->connection->getQueryBuilder();
-				// if the access user has "direct share access" we don't filter by owner, but instead validate that all share sources are accessible
-				if (!$userHasDirectAccess) {
+				// if we're filtering by source or id, we need to also check for non-owned shares
+				if ($filterSourceTypeValue === null && $filterShareID === null) {
 					$qb->where($qb->expr()->eq('s.owner_user_id', $qb->createNamedParameter($accessContext->currentUser->getUID())));
 				}
 
@@ -637,7 +630,7 @@ final readonly class SharingBackend implements ISharingBackend {
 
 			// Do not add a query if no recipients matched, otherwise all shares will be returned.
 			// If the user has "direct" access, we already get all the shares, so no need to run an extra query for recipients
-			if ($recipientTypeValues !== [] && !$userHasDirectAccess) {
+			if ($recipientTypeValues !== []) {
 				$qb = $this->connection->getQueryBuilder();
 				$qb->innerJoin(
 					's', 'sharing_share_recipients', 'sr', $qb->expr()->andX(
@@ -891,8 +884,10 @@ final readonly class SharingBackend implements ISharingBackend {
 
 		// Some recipients might have been removed if the initiator was disabled, so check again if this share can be accessed by the current user as a recipient.
 		// This logic is a bit duplicated with the SQL logic that selects shares based on the secret and the recipient type values, but neither can be removed.
+		/** @var array<string, bool> $hasRecipientAccess */
+		$hasRecipientAccess = [];
 		if (!$accessContext->overrideChecks) {
-			foreach ($shares as $id => &$share) {
+			foreach ($shares as &$share) {
 				if ($share['owner']->isCurrentUser($accessContext)) {
 					continue;
 				}
@@ -928,9 +923,7 @@ final readonly class SharingBackend implements ISharingBackend {
 
 				unset($recipient);
 
-				if (!$isAnyMatchingRecipient) {
-					unset($shares[$id]);
-				}
+				$hasRecipientAccess[$share['id']] = $isAnyMatchingRecipient && $share['state'] === ShareState::Active;
 			}
 
 			unset($share);
@@ -1042,19 +1035,37 @@ final readonly class SharingBackend implements ISharingBackend {
 
 		// when listing shares for a source, we also return any non-owned share if the user has "direct" access to the source
 		// but we do need to validate that the user has "direct" access to *all* of the sources in the share, not just one
-		if (!$accessContext->overrideChecks && $filterSourceType && $filterSourceTypeValue !== null && $accessContext->currentUser instanceof IUser) {
-			$shares = array_filter($shares, function (Share $share) use ($accessContext): bool {
-				if (!$share->owner->isCurrentUser($accessContext) && count($share->sources) > 1) {
-					foreach ($share->sources as $source) {
-						$sourceType = $this->registry->getSourceTypes()[$source->class];
-						if (!$sourceType->userHasDirectSharingAccessToSource($accessContext->currentUser, $source->value)) {
-							return false;
-						}
-					}
+		$hasSourceAccess = [];
+		if (!$accessContext->overrideChecks && $accessContext->currentUser instanceof IUser) {
+			foreach ($shares as $share) {
+				if ($share->owner->isCurrentUser($accessContext)) {
+					continue;
 				}
 
-				return true;
-			});
+				if ($hasRecipientAccess[$share->id]) {
+					continue;
+				}
+
+				if ($share->sources === []) {
+					$hasSourceAccess[$share->id] = false;
+					continue;
+				}
+
+				$hasSourceAccess[$share->id] = true;
+				foreach ($share->sources as $source) {
+					$sourceType = $this->registry->getSourceTypes()[$source->class];
+					if (!$sourceType->userHasDirectSharingAccessToSource($accessContext->currentUser, $source->value)) {
+						$hasSourceAccess[$share->id] = false;
+					}
+				}
+			}
+		}
+
+		if (!$accessContext->overrideChecks) {
+			$shares = array_filter(
+				$shares,
+				fn (Share $share): bool => $share->owner->isCurrentUser($accessContext) || $hasRecipientAccess[$share->id] || $hasSourceAccess[$share->id]
+			);
 		}
 
 		if (!$accessContext->overrideChecks) {

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -588,9 +588,21 @@ final readonly class SharingBackend implements ISharingBackend {
 	 * @return list<Share>
 	 */
 	private function list(
-		ShareAccessContext $accessContext, ?string $filterShareID, ?string $filterSourceTypeClass, ?string $filterSourceTypeValue, ?string $lastShareID,
+		ShareAccessContext $accessContext,
+		?string $filterShareID,
+		?string $filterSourceTypeClass,
+		?string $filterSourceTypeValue,
+		?string $lastShareID,
 		?int $limit,
 	): array {
+		if ($filterSourceTypeClass) {
+			$filterSourceType = $this->registry->getSourceTypes()[$filterSourceTypeClass] ?? null;
+			if ($filterSourceType === null) {
+				throw new RuntimeException('The source type is not registered: ' . $filterSourceTypeClass);
+			}
+		} else {
+			$filterSourceType = null;
+		}
 		/** @var array<class-string<IShareRecipientType>, list<string>> $recipientTypeValues */
 		$recipientTypeValues = [];
 
@@ -598,10 +610,21 @@ final readonly class SharingBackend implements ISharingBackend {
 		$queries = [];
 		if ($accessContext->overrideChecks) {
 			$queries[] = $this->connection->getQueryBuilder();
+			$userHasDirectAccess = false;
 		} else {
+			if ($filterSourceType && $filterSourceTypeValue !== null && $accessContext->currentUser instanceof IUser) {
+				$userHasDirectAccess = $filterSourceType->userHasDirectSharingAccessToSource($accessContext->currentUser, $filterSourceTypeValue);
+			} else {
+				$userHasDirectAccess = false;
+			}
+
 			if ($accessContext->currentUser instanceof IUser) {
 				$qb = $this->connection->getQueryBuilder();
-				$qb->where($qb->expr()->eq('s.owner_user_id', $qb->createNamedParameter($accessContext->currentUser->getUID())));
+				// if the access user has "direct share access" we don't filter by owner, but instead validate that all share sources are accessible
+				if (!$userHasDirectAccess) {
+					$qb->where($qb->expr()->eq('s.owner_user_id', $qb->createNamedParameter($accessContext->currentUser->getUID())));
+				}
+
 				$queries[] = $qb;
 			}
 
@@ -613,7 +636,8 @@ final readonly class SharingBackend implements ISharingBackend {
 			}
 
 			// Do not add a query if no recipients matched, otherwise all shares will be returned.
-			if ($recipientTypeValues !== []) {
+			// If the user has "direct" access, we already get all the shares, so no need to run an extra query for recipients
+			if ($recipientTypeValues !== [] && !$userHasDirectAccess) {
 				$qb = $this->connection->getQueryBuilder();
 				$qb->innerJoin(
 					's', 'sharing_share_recipients', 'sr', $qb->expr()->andX(
@@ -672,7 +696,7 @@ final readonly class SharingBackend implements ISharingBackend {
 				$qb->andWhere($qb->expr()->eq('s.id', $qb->createNamedParameter($filterShareID)));
 			}
 
-			if ($filterSourceTypeClass !== null) {
+			if ($filterSourceType !== null && $filterSourceTypeClass !== null) {
 				$sourceTypeFilters = [
 					$qb->expr()->eq('s.id', 'ss.share_id'),
 					$qb->expr()->eq(
@@ -1015,6 +1039,23 @@ final readonly class SharingBackend implements ISharingBackend {
 			$share['properties'],
 			$share['permissions'],
 		), $shares);
+
+		// when listing shares for a source, we also return any non-owned share if the user has "direct" access to the source
+		// but we do need to validate that the user has "direct" access to *all* of the sources in the share, not just one
+		if (!$accessContext->overrideChecks && $filterSourceType && $filterSourceTypeValue !== null && $accessContext->currentUser instanceof IUser) {
+			$shares = array_filter($shares, function (Share $share) use ($accessContext): bool {
+				if (!$share->owner->isCurrentUser($accessContext) && count($share->sources) > 1) {
+					foreach ($share->sources as $source) {
+						$sourceType = $this->registry->getSourceTypes()[$source->class];
+						if (!$sourceType->userHasDirectSharingAccessToSource($accessContext->currentUser, $source->value)) {
+							return false;
+						}
+					}
+				}
+
+				return true;
+			});
+		}
 
 		if (!$accessContext->overrideChecks) {
 			$filterPropertyTypes = array_filter(

--- a/lib/private/Sharing/SharingBackend.php
+++ b/lib/private/Sharing/SharingBackend.php
@@ -603,6 +603,7 @@ final readonly class SharingBackend implements ISharingBackend {
 		} else {
 			$filterSourceType = null;
 		}
+
 		/** @var array<class-string<IShareRecipientType>, list<string>> $recipientTypeValues */
 		$recipientTypeValues = [];
 

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -158,7 +158,8 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$lastUpdated = $this->getTime();
 		$this->backend->createShare($id, new ShareUser($currentUser->getUID(), null), $lastUpdated);
 
-		[$share] = $this->processShareUpdates([$id]);
+		$share = $this->backend->getShare($accessContext, $id);
+		[$share] = $this->processShareUpdates([$share]);
 
 		return $share;
 	}
@@ -311,7 +312,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->backend->setLastUpdated($updatedIds, $timestamp);
 
-		$this->processShareUpdates($updatedIds);
+		$this->processShareUpdates(array_map(fn (string $id): Share => $this->backend->getShare($accessContext, $id), $updatedIds));
 	}
 
 	#[\Override]
@@ -451,7 +452,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->backend->setLastUpdated($updatedIds, $timestamp);
 
-		$this->processShareUpdates($updatedIds);
+		$this->processShareUpdates(array_map(fn (string $id): Share => $this->backend->getShare($accessContext, $id), $updatedIds));
 	}
 
 	#[\Override]
@@ -471,7 +472,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		$this->backend->setLastUpdated($updatedIds, $timestamp);
 
-		$this->processShareUpdates($updatedIds);
+		$this->processShareUpdates(array_map(fn (string $id): Share => $this->backend->getShare($accessContext, $id), $updatedIds));
 	}
 
 	/**
@@ -571,7 +572,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 			$share->permissions,
 		);
 
-		[$share] = $this->processShareUpdates([$share->id]);
+		[$share] = $this->processShareUpdates([$share]);
 		return $share;
 	}
 
@@ -861,19 +862,11 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	}
 
 	/**
-	 * @param non-empty-list<Share|string> $sharesOrIds
+	 * @param non-empty-list<Share> $shares
 	 * @return non-empty-list<Share>
 	 */
-	private function processShareUpdates(array $sharesOrIds): array {
-		$shares = [];
-
-		foreach ($sharesOrIds as $shareOrId) {
-			if ($shareOrId instanceof Share) {
-				$share = $shareOrId;
-			} else {
-				$share = $this->backend->getShare(new ShareAccessContext(overrideChecks: true), $shareOrId);
-			}
-
+	private function processShareUpdates(array $shares): array {
+		foreach ($shares as &$share) {
 			if ($share->state === ShareState::Active) {
 				try {
 					$this->assertShareCanBeActive($share);
@@ -913,8 +906,6 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 				$legacyBackend->updateShare($share);
 			}
-
-			$shares[] = $share;
 		}
 
 		return $shares;

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -190,7 +190,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$time = $this->getTime();
 		$this->backend->setLastUpdated([$share->id], $time);
 
-		$this->validateShareOwnerOperation($accessContext, $share->owner);
+		$this->validateShareEditPermissions($accessContext, $share);
 
 		if ($state === ShareState::Active) {
 			$this->assertShareCanBeActive($share);
@@ -217,7 +217,8 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function addShareSource(ShareAccessContext $accessContext, Share $share, ShareSource $source): Share {
 		$this->assertInTransaction();
 
-		$this->validateShareOwnerOperation($accessContext, $share->owner);
+		// only the owner can add sources, otherwise a user could add sources others don't have access to, which would remove their access
+		$this->validateShareEditPermissions($accessContext, $share, true);
 
 		if (($sourceType = $this->registry->getSourceTypes()[$source->class] ?? null) === null) {
 			throw new RuntimeException('The source type is not registered: ' . $source->class);
@@ -260,7 +261,8 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function removeShareSource(ShareAccessContext $accessContext, Share $share, ShareSource $source): Share {
 		$this->assertInTransaction();
 
-		$this->validateShareOwnerOperation($accessContext, $share->owner);
+		// only the owner can remove sources, to mirror the "add source" permissions
+		$this->validateShareEditPermissions($accessContext, $share, true);
 
 		$time = $this->getTime();
 		$this->backend->setLastUpdated([$share->id], $time);
@@ -321,7 +323,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$this->assertInTransaction();
 
 		try {
-			$this->validateShareOwnerOperation($accessContext, $share->owner);
+			$this->validateShareEditPermissions($accessContext, $share);
 		} catch (ShareOperationForbiddenException) {
 			$this->validatePermission($share, ReshareSharePermissionType::class);
 		}
@@ -398,7 +400,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$this->assertInTransaction();
 
 		try {
-			$this->validateShareOwnerOperation($accessContext, $share->owner);
+			$this->validateShareEditPermissions($accessContext, $share);
 		} catch (ShareOperationForbiddenException) {
 			// This does not allow removing own recipients. A user can only reject a share, but not remove it for the recipient.
 			$this->validateReshareOperation($accessContext, $share, $recipient);
@@ -484,7 +486,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$this->assertInTransaction();
 
 		try {
-			$this->validateShareOwnerOperation($accessContext, $share->owner);
+			$this->validateShareEditPermissions($accessContext, $share);
 		} catch (ShareOperationForbiddenException) {
 			$this->validateReshareOperation($accessContext, $share, $recipient);
 		}
@@ -540,7 +542,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function updateShareProperty(ShareAccessContext $accessContext, Share $share, ShareProperty $property): Share {
 		$this->assertInTransaction();
 
-		$this->validateShareOwnerOperation($accessContext, $share->owner);
+		$this->validateShareEditPermissions($accessContext, $share);
 
 		if (($propertyType = $this->registry->getPropertyTypes()[$property->class] ?? null) === null) {
 			throw new RuntimeException('The property is not registered: ' . $property->class);
@@ -577,7 +579,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function updateSharePermission(ShareAccessContext $accessContext, Share $share, SharePermission $permission): Share {
 		$this->assertInTransaction();
 
-		$this->validateShareOwnerOperation($accessContext, $share->owner);
+		$this->validateShareEditPermissions($accessContext, $share);
 
 		if (!isset($this->registry->getPermissionTypes()[$permission->class])) {
 			throw new RuntimeException('The permission type is not registered: ' . $permission->class);
@@ -614,7 +616,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	public function selectSharePermissionPreset(ShareAccessContext $accessContext, Share $share, string $permissionPresetClass): Share {
 		$this->assertInTransaction();
 
-		$this->validateShareOwnerOperation($accessContext, $share->owner);
+		$this->validateShareEditPermissions($accessContext, $share);
 
 		if (($this->registry->getPermissionPresetCompatiblePermissionTypeClasses()[$permissionPresetClass] ?? null) === null) {
 			throw new RuntimeException('The permission preset is not registered: ' . $permissionPresetClass);
@@ -654,7 +656,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 
 		// No need to update the last updated timestamp, because the share will be deleted anyway.
 
-		$this->validateShareOwnerOperation($accessContext, $share->owner);
+		$this->validateShareEditPermissions($accessContext, $share);
 
 		$this->backend->deleteShare($share->id);
 
@@ -710,18 +712,35 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		}
 	}
 
-	// TODO: Support IShareOwnerlessMount
-
 	/**
 	 * @throws ShareOperationForbiddenException
 	 */
-	private function validateShareOwnerOperation(ShareAccessContext $accessContext, ShareUser $owner): void {
+	private function validateShareEditPermissions(ShareAccessContext $accessContext, Share $share, bool $onlyOwner = false): void {
 		if ($accessContext->overrideChecks) {
 			return;
 		}
 
-		if ($owner->instance !== null || !$accessContext->currentUser instanceof IUser || $owner->userId !== $accessContext->currentUser->getUID()) {
+		if ($share->owner->instance !== null || !$accessContext->currentUser instanceof IUser) {
 			throw new ShareOperationForbiddenException();
+		}
+
+		if ($share->owner->userId === $accessContext->currentUser->getUID()) {
+			return;
+		}
+
+		if ($onlyOwner) {
+			throw new ShareOperationForbiddenException();
+		}
+
+		foreach ($share->sources as $source) {
+			$sourceType = $this->registry->getSourceTypes()[$source->class] ?? null;
+			if (!$sourceType) {
+				throw new ShareOperationForbiddenException();
+			}
+
+			if (!$sourceType->userHasDirectSharingAccessToSource($accessContext->currentUser, $source->value)) {
+				throw new ShareOperationForbiddenException();
+			}
 		}
 	}
 

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -749,7 +749,6 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	 * @throws ShareOperationForbiddenException
 	 */
 	private function validatePermission(Share $share, string $permissionTypeClass): void {
-		// TODO: Only fetch permisions
 		if ((($permission = $share->permissions[$permissionTypeClass] ?? null) !== null) && $permission->enabled) {
 			return;
 		}
@@ -763,7 +762,6 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 	private function validateReshareOperation(ShareAccessContext $accessContext, Share $share, ShareRecipient $recipient): void {
 		$this->validatePermission($share, ReshareSharePermissionType::class);
 
-		// TODO: Only fetch recipients
 		foreach ($share->recipients as $shareRecipient) {
 			if (
 				$recipient->class === $shareRecipient->class

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -18,6 +18,7 @@ use NCU\Sharing\ISharingManager;
 use NCU\Sharing\ISharingRegistry;
 use NCU\Sharing\Permission\ISharePermissionType;
 use NCU\Sharing\Permission\SharePermission;
+use NCU\Sharing\Property\ISharePropertyTypeModifyValue;
 use NCU\Sharing\Property\ShareProperty;
 use NCU\Sharing\Recipient\IShareRecipientType;
 use NCU\Sharing\Recipient\IShareRecipientTypePublicSecret;
@@ -556,7 +557,15 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$time = $this->getTime();
 		$this->backend->setLastUpdated([$share->id], $time);
 
-		$this->backend->updateShareProperty($share->id, $property);
+		$value = $this->backend->updateShareProperty($share->id, $property);
+		if ($propertyType instanceof ISharePropertyTypeModifyValue) {
+			$value = $propertyType->modifyValueOnLoad($value);
+		}
+
+		$property = new ShareProperty(
+			$property->class,
+			$value,
+		);
 
 		$properties = $share->properties;
 		$properties[$property->class] = $property;

--- a/lib/unstable/Sharing/ISharingBackend.php
+++ b/lib/unstable/Sharing/ISharingBackend.php
@@ -119,7 +119,7 @@ interface ISharingBackend {
 	 * @throws ShareNotFoundException
 	 * @experimental 35.0.0
 	 */
-	public function createShareProperty(string $id, ShareProperty $property): void;
+	public function createShareProperty(string $id, ShareProperty $property): ?string;
 
 	/**
 	 * Update a property of a share.
@@ -127,7 +127,7 @@ interface ISharingBackend {
 	 * @throws ShareNotFoundException
 	 * @experimental 35.0.0
 	 */
-	public function updateShareProperty(string $id, ShareProperty $property): void;
+	public function updateShareProperty(string $id, ShareProperty $property): ?string;
 
 	/**
 	 * Insert a permission for a share.

--- a/lib/unstable/Sharing/Source/IShareSourceType.php
+++ b/lib/unstable/Sharing/Source/IShareSourceType.php
@@ -55,4 +55,14 @@ interface IShareSourceType {
 	 * @experimental 35.0.0
 	 */
 	public function getSourceInteractionResource(IUser $user, string $source): InteractionResource;
+
+	/**
+	 * Check if a user has access to the specified source without taking sharing into account, and has sufficient permissions to create shares.
+	 *
+	 * All users with "direct" access to the source will be able to see and manage shares made by other users for the source.
+	 *
+	 * @experimental 35.0.0
+	 * @param non-empty-string $source
+	 */
+	public function userHasDirectSharingAccessToSource(IUser $user, string $source): bool;
 }

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -4075,6 +4075,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 	public function testGetWithDirectAccess(): void {
 		$accessContext = new ShareAccessContext($this->owner);
+		$accessContext2 = new ShareAccessContext(currentUser: $this->user2);
 
 		$before = $this->manager->getTime();
 		$this->dbConnection->beginTransaction();
@@ -4090,12 +4091,19 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$after = $this->manager->getTime();
 
 		// user2 has no direct access, no shares
-		$formattedShares = $this->getShares(new ShareAccessContext(currentUser: $this->user2), TestShareSourceType1::class, 'source1', null, null);
+		$formattedShares = $this->getShares($accessContext2, TestShareSourceType1::class, 'source1', null, null);
 		$this->assertCount(0, $formattedShares);
+
+		try {
+			$this->getShare($accessContext2, $share->id);
+			$this->fail('user has invalid share access');
+		} catch(ShareNotFoundException) {
+
+		}
 
 		// give user2 direct access, can see shares
 		$this->shareSourceType1->userAccess[$this->user2->getUID()] = ['source1'];
-		$formattedShares = $this->getShares(new ShareAccessContext(currentUser: $this->user2), TestShareSourceType1::class, 'source1', null, null);
+		$formattedShares = $this->getShares($accessContext2, TestShareSourceType1::class, 'source1', null, null);
 
 		$this->assertCount(1, $formattedShares);
 		$formatted = $formattedShares[0];
@@ -4110,6 +4118,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 				'dark' => 'http://localhost/index.php/avatar/owner/64/dark',
 			],
 		], $formatted['owner']);
+
+		$singleFormatted = $this->getShare($accessContext2, $share->id);
+		$this->assertEquals($singleFormatted, $formatted);
 
 		// add a source that user2 doesn't have access to, can't see share anymore
 		$this->dbConnection->beginTransaction();

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -117,9 +117,14 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 	protected IUser $user2;
 
+	protected TestShareSourceType1 $shareSourceType1;
+
+	protected TestShareSourceType2 $shareSourceType2;
+
 	protected IFactory $l10nFactory;
 
-	private function parseTime(string $timestampMs): \DateTimeImmutable {
+	private function parseTime(mixed $timestampMs): \DateTimeImmutable {
+		$timestampMs = (int)$timestampMs;
 		$time = \DateTimeImmutable::createFromFormat('U.u', number_format((float)$timestampMs / 1000.0, 3, '.', ''));
 		if ($time === false) {
 			throw new \RuntimeException('invalid timestamp: ' . $timestampMs);
@@ -162,8 +167,11 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->registry = Server::get(ISharingRegistry::class);
 		$this->registry->clear();
-		$this->registry->registerSourceType(new TestShareSourceType1(['source1' => 'Source 1']));
-		$this->registry->registerSourceType(new TestShareSourceType2(['source2' => 'Source 2']));
+
+		$this->shareSourceType1 = new TestShareSourceType1(['source1' => 'Source 1']);
+		$this->registry->registerSourceType($this->shareSourceType1);
+		$this->shareSourceType2 = new TestShareSourceType2(['source2' => 'Source 2']);
+		$this->registry->registerSourceType($this->shareSourceType2);
 		$this->registry->registerRecipientType(new TestShareRecipientType1(
 			[
 				'recipient1' => 'Recipient 1',
@@ -4063,5 +4071,51 @@ abstract class AbstractSharingManagerTests extends TestCase {
 				],
 			],
 		], $formatted['recipients']);
+	}
+
+	public function testGetWithDirectAccess(): void {
+		$accessContext = new ShareAccessContext($this->owner);
+
+		$before = $this->manager->getTime();
+		$this->dbConnection->beginTransaction();
+		$share = $this->manager->createShare($accessContext);
+		$share = $this->manager->addShareSource($accessContext, $share, new ShareSource(TestShareSourceType1::class, 'source1'));
+		$share = $this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
+
+		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(TestSharePermissionType1::class, true));
+		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
+
+		$this->dbConnection->commit();
+
+		$after = $this->manager->getTime();
+
+		// user2 has no direct access, no shares
+		$formattedShares = $this->getShares(new ShareAccessContext(currentUser: $this->user2), TestShareSourceType1::class, 'source1', null, null);
+		$this->assertCount(0, $formattedShares);
+
+		// give user2 direct access, can see shares
+		$this->shareSourceType1->userAccess[$this->user2->getUID()] = ['source1'];
+		$formattedShares = $this->getShares(new ShareAccessContext(currentUser: $this->user2), TestShareSourceType1::class, 'source1', null, null);
+
+		$this->assertCount(1, $formattedShares);
+		$formatted = $formattedShares[0];
+
+		$this->assertDateBetween($before, $after, $this->parseTime($formatted['last_updated']));
+		$this->assertEquals([
+			'user_id' => 'owner',
+			'instance' => null,
+			'display_name' => 'Owner',
+			'icon' => [
+				'light' => 'http://localhost/index.php/avatar/owner/64',
+				'dark' => 'http://localhost/index.php/avatar/owner/64/dark',
+			],
+		], $formatted['owner']);
+
+		// add a source that user2 doesn't have access to, can't see share anymore
+		$this->dbConnection->beginTransaction();
+		$this->manager->addShareSource($accessContext, $share, new ShareSource(TestShareSourceType2::class, 'source2'));
+		$this->dbConnection->commit();
+		$formattedShares = $this->getShares(new ShareAccessContext(currentUser: $this->user2), TestShareSourceType1::class, 'source1', null, null);
+		$this->assertCount(0, $formattedShares);
 	}
 }

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -1416,11 +1416,11 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->beginTransaction();
 		$share = $this->manager->createShare($accessContext);
-		$this->manager->addShareSource($accessContext, $share, new ShareSource(TestShareSourceType1::class, 'source1'));
-		$this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
+		$share = $this->manager->addShareSource($accessContext, $share, new ShareSource(TestShareSourceType1::class, 'source1'));
+		$share = $this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
 
-		$this->manager->getShare($accessContext, $share->id);
-		$this->manager->updateSharePermission($accessContext, $share, new SharePermission(TestSharePermissionType1::class, true));
+		$share = $this->manager->getShare($accessContext, $share->id);
+		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(TestSharePermissionType1::class, true));
 
 		$this->dbConnection->commit();
 
@@ -1456,7 +1456,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		], $formatted['properties']);
 
 		$this->dbConnection->beginTransaction();
-		$this->manager->updateShareState($accessContext, $share, ShareState::Active);
+		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
 		$this->dbConnection->commit();
 
 		$before = $this->manager->getTime();
@@ -1532,36 +1532,12 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$this->dbConnection->beginTransaction();
 		$share = $this->manager->createShare($accessContext);
-		$this->manager->addShareSource($accessContext, $share, new ShareSource(TestShareSourceType1::class, 'source1'));
-		$this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
+		$share = $this->manager->addShareSource($accessContext, $share, new ShareSource(TestShareSourceType1::class, 'source1'));
+		$share = $this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
 
 		$this->dbConnection->commit();
 
-		$formatted = $this->getShare($accessContext, $share->id);
-		$this->assertEquals([
-			[
-				'class' => TestSharePropertyType1::class,
-				'display_name' => 'TestSharePropertyType1',
-				'hint' => 'hint TestSharePropertyType1',
-				'priority' => 1,
-				'advanced' => false,
-				'required' => false,
-				'value' => null,
-				'type' => 'enum',
-				'valid_values' => ['valid1'],
-			],
-			[
-				'class' => TestSharePropertyTypeModifyValue::class,
-				'display_name' => 'TestSharePropertyTypeModifyValue',
-				'hint' => 'hint TestSharePropertyTypeModifyValue',
-				'priority' => 1,
-				'advanced' => false,
-				'required' => false,
-				'value' => 'modify-on-save',
-				'type' => 'enum',
-				'valid_values' => ['old-value', 'modify-on-save-old-value', 'modify-on-save', 'modify-on-load'],
-			],
-		], $formatted['properties']);
+		// We cannot test for modify-on-save, because we will always see modified-on-save as the returned value.
 
 		$formatted = $this->getShare($accessContext, $share->id);
 		$this->assertEquals([
@@ -1590,7 +1566,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		], $formatted['properties']);
 
 		$this->dbConnection->beginTransaction();
-		$this->manager->updateShareProperty($accessContext, $share, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'old-value'));
+		$share = $this->manager->updateShareProperty($accessContext, $share, new ShareProperty(TestSharePropertyTypeModifyValue::class, 'old-value'));
 		$this->dbConnection->commit();
 
 		$before = $this->manager->getTime();

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -41,7 +41,9 @@ use Test\TestCase;
  * @psalm-suppress PossiblyUndefinedArrayOffset
  */
 abstract class AbstractSharingManagerTests extends TestCase {
-	abstract protected function searchRecipients(ShareAccessContext $accessContext, ?array $filterRecipientTypeClasses, string $query, int $limit, int $offset, ?Share $forShare = null): array;
+	abstract protected function searchRecipients(
+		ShareAccessContext $accessContext, ?array $filterRecipientTypeClasses, string $query, int $limit, int $offset, ?Share $forShare = null,
+	): array;
 
 	/**
 	 * @return SharingShare
@@ -103,7 +105,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	/**
 	 * @return SharingShare[]
 	 */
-	abstract protected function getShares(ShareAccessContext $accessContext, ?string $filterSourceTypeClass, ?string $filterSourceTypeValue, ?string $lastShareID, ?int $limit): array;
+	abstract protected function getShares(
+		ShareAccessContext $accessContext, ?string $filterSourceTypeClass, ?string $filterSourceTypeValue, ?string $lastShareID, ?int $limit,
+	): array;
 
 	protected IDBConnection $dbConnection;
 
@@ -172,28 +176,32 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->registry->registerSourceType($this->shareSourceType1);
 		$this->shareSourceType2 = new TestShareSourceType2(['source2' => 'Source 2']);
 		$this->registry->registerSourceType($this->shareSourceType2);
-		$this->registry->registerRecipientType(new TestShareRecipientType1(
-			[
-				'recipient1' => 'Recipient 1',
-			],
-			[
-				$this->user1->getUID() => ['recipient1'],
-			],
-			[
-				new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null),
-			],
-		));
-		$this->registry->registerRecipientType(new TestShareRecipientType2(
-			[
-				'recipient2' => 'Recipient 2',
-			],
-			[
-				$this->user2->getUID() => ['recipient2'],
-			],
-			[
-				new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null),
-			],
-		));
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType1(
+				[
+					'recipient1' => 'Recipient 1',
+				],
+				[
+					$this->user1->getUID() => ['recipient1'],
+				],
+				[
+					new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null),
+				],
+			)
+		);
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType2(
+				[
+					'recipient2' => 'Recipient 2',
+				],
+				[
+					$this->user2->getUID() => ['recipient2'],
+				],
+				[
+					new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null),
+				],
+			)
+		);
 		$this->registry->registerPropertyType(new TestSharePropertyType1(['valid1']));
 		$this->registry->markPropertyTypeCompatibleWithSourceType(TestSharePropertyType1::class, TestShareSourceType1::class);
 		$this->registry->markPropertyTypeCompatibleWithRecipientType(TestSharePropertyType1::class, TestShareRecipientType1::class);
@@ -259,32 +267,36 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 	public function testSearchRecipients(): void {
 		$this->registry->clear();
-		$this->registry->registerRecipientType(new TestShareRecipientType1(
-			[
-				'recipient1a' => 'Recipient 1A',
-				'recipient1b' => 'Recipient 1B',
-				'recipient1c' => 'Recipient 1C',
-			],
-			[],
-			[
-				new ShareRecipient(TestShareRecipientType1::class, 'recipient1a', null),
-				new ShareRecipient(TestShareRecipientType1::class, 'recipient1b', null),
-				new ShareRecipient(TestShareRecipientType1::class, 'recipient1c', null),
-			],
-		));
-		$this->registry->registerRecipientType(new TestShareRecipientType2(
-			[
-				'recipient2a' => 'Recipient 2A',
-				'recipient2b' => 'Recipient 2B',
-				'recipient2c' => 'Recipient 2C',
-			],
-			[],
-			[
-				new ShareRecipient(TestShareRecipientType2::class, 'recipient2a', null),
-				new ShareRecipient(TestShareRecipientType2::class, 'recipient2b', null),
-				new ShareRecipient(TestShareRecipientType2::class, 'recipient2c', null),
-			],
-		));
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType1(
+				[
+					'recipient1a' => 'Recipient 1A',
+					'recipient1b' => 'Recipient 1B',
+					'recipient1c' => 'Recipient 1C',
+				],
+				[],
+				[
+					new ShareRecipient(TestShareRecipientType1::class, 'recipient1a', null),
+					new ShareRecipient(TestShareRecipientType1::class, 'recipient1b', null),
+					new ShareRecipient(TestShareRecipientType1::class, 'recipient1c', null),
+				],
+			)
+		);
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType2(
+				[
+					'recipient2a' => 'Recipient 2A',
+					'recipient2b' => 'Recipient 2B',
+					'recipient2c' => 'Recipient 2C',
+				],
+				[],
+				[
+					new ShareRecipient(TestShareRecipientType2::class, 'recipient2a', null),
+					new ShareRecipient(TestShareRecipientType2::class, 'recipient2b', null),
+					new ShareRecipient(TestShareRecipientType2::class, 'recipient2c', null),
+				],
+			)
+		);
 
 		$accessContext = new ShareAccessContext($this->owner);
 
@@ -459,26 +471,30 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 	public function testSearchRecipientsUniqueDisplayNames(): void {
 		$this->registry->clear();
-		$this->registry->registerRecipientType(new TestShareRecipientType1(
-			[
-				'recipient1' => 'Recipient',
-			],
-			[],
-			[
-				new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null),
-			],
-		));
-		$this->registry->registerRecipientType(new TestShareRecipientType2(
-			[
-				'recipient2' => 'Recipient',
-				'recipient3' => 'Other',
-			],
-			[],
-			[
-				new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null),
-				new ShareRecipient(TestShareRecipientType2::class, 'recipient3', null),
-			],
-		));
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType1(
+				[
+					'recipient1' => 'Recipient',
+				],
+				[],
+				[
+					new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null),
+				],
+			)
+		);
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType2(
+				[
+					'recipient2' => 'Recipient',
+					'recipient3' => 'Other',
+				],
+				[],
+				[
+					new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null),
+					new ShareRecipient(TestShareRecipientType2::class, 'recipient3', null),
+				],
+			)
+		);
 
 		$accessContext = new ShareAccessContext($this->owner);
 
@@ -527,17 +543,19 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 	public function testSearchRecipientsIcons(): void {
 		$this->registry->clear();
-		$this->registry->registerRecipientType(new TestShareRecipientType1(
-			[
-				'svg' => 'SVG',
-				'url' => 'URL',
-			],
-			[],
-			[
-				new ShareRecipient(TestShareRecipientType1::class, 'svg', null),
-				new ShareRecipient(TestShareRecipientType1::class, 'url', null),
-			],
-		));
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType1(
+				[
+					'svg' => 'SVG',
+					'url' => 'URL',
+				],
+				[],
+				[
+					new ShareRecipient(TestShareRecipientType1::class, 'svg', null),
+					new ShareRecipient(TestShareRecipientType1::class, 'url', null),
+				],
+			)
+		);
 
 		$accessContext = new ShareAccessContext($this->owner);
 
@@ -953,7 +971,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->dbConnection->commit();
 
 		$before = $this->manager->getTime();
-		$formatted = $this->addShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$formatted = $this->addShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 		$after = $this->manager->getTime();
 		$this->assertDateBetween($before, $after, $this->parseTime($formatted['last_updated']));
 		$this->assertEquals([
@@ -1111,7 +1131,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(TestSharePermissionType1::class, true));
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
-		$share = $this->manager->addShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, false));
 
 		$this->dbConnection->commit();
@@ -1135,12 +1157,16 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$share = $this->manager->getShare($accessContext, $share->id);
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
-		$share = $this->manager->addShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 
 		$this->dbConnection->commit();
 
 		$before = $this->manager->getTime();
-		$formatted = $this->removeShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$formatted = $this->removeShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 		$after = $this->manager->getTime();
 		$this->assertDateBetween($before, $after, $this->parseTime($formatted['last_updated']));
 		$this->assertEquals([
@@ -1224,7 +1250,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(TestSharePermissionType1::class, true));
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
-		$share = $this->manager->addShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, false));
 
 		$this->dbConnection->commit();
@@ -1247,7 +1275,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$share = $this->manager->getShare($accessContext, $share->id);
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
-		$share = $this->manager->addShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 
 		$this->dbConnection->commit();
 
@@ -1271,14 +1301,16 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 	#[DataProvider('dataUpdateShareRecipientSecret')]
 	public function testUpdateShareRecipientSecret(bool $isSecretUpdatable): void {
-		$this->registry->registerRecipientType(new TestShareRecipientTypePublicSecret(
-			[
-				'recipient1' => 'Recipient 1',
-			],
-			[],
-			true,
-			$isSecretUpdatable,
-		));
+		$this->registry->registerRecipientType(
+			new TestShareRecipientTypePublicSecret(
+				[
+					'recipient1' => 'Recipient 1',
+				],
+				[],
+				true,
+				$isSecretUpdatable,
+			)
+		);
 
 		$accessContext = new ShareAccessContext($this->owner);
 
@@ -1490,7 +1522,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	}
 
 	public function testUpdateSharePropertyModifyProperties(): void {
-		$this->registry->registerPropertyType(new TestSharePropertyTypeModifyValue(['old-value', 'modify-on-save-old-value', 'modify-on-save', 'modify-on-load']));
+		$this->registry->registerPropertyType(
+			new TestSharePropertyTypeModifyValue(['old-value', 'modify-on-save-old-value', 'modify-on-save', 'modify-on-load'])
+		);
 		$this->registry->markPropertyTypeCompatibleWithSourceType(TestSharePropertyTypeModifyValue::class, TestShareSourceType1::class);
 		$this->registry->markPropertyTypeCompatibleWithRecipientType(TestSharePropertyTypeModifyValue::class, TestShareRecipientType1::class);
 
@@ -1749,7 +1783,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 	public function testUpdateSharePermissionInteractionRestricted(): void {
 		$listener = function (RestrictInteractionEvent $event): void {
-			if ($event->action instanceof ShareAction && $event->action->unifiedSharingPermissions !== null && in_array(TestSharePermissionType1::class, $event->action->unifiedSharingPermissions, true)) {
+			if ($event->action instanceof ShareAction && $event->action->unifiedSharingPermissions !== null && in_array(
+				TestSharePermissionType1::class, $event->action->unifiedSharingPermissions, true
+			)) {
 				throw new InteractionRestrictedException('Permission not allowed.', 'You are not allowed to enable this permission.');
 			}
 		};
@@ -2352,7 +2388,8 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->dbConnection->commit();
 		$after = $this->manager->getTime();
 
-		$formatted = $this->getShare(new ShareAccessContext(currentUser: $this->user1, arguments: [TestShareRecipientTypeArguments::class => 'secret']), $share->id);
+		$formatted = $this->getShare(new ShareAccessContext(currentUser: $this->user1, arguments: [TestShareRecipientTypeArguments::class => 'secret']),
+			$share->id);
 		$this->assertDateBetween($before, $after, $this->parseTime($formatted['last_updated']));
 		unset($formatted['last_updated']);
 		$this->assertEquals([
@@ -2918,7 +2955,8 @@ abstract class AbstractSharingManagerTests extends TestCase {
 			'permission_preset' => TestSharePermissionPreset1::class,
 		], $formatted);
 
-		$formatted = $this->getShare(new ShareAccessContext(currentUser: $this->owner, arguments: [TestSharePropertyTypeFilter::class => 'filtered']), $share->id);
+		$formatted = $this->getShare(new ShareAccessContext(currentUser: $this->owner, arguments: [TestSharePropertyTypeFilter::class => 'filtered']),
+			$share->id);
 		$this->assertDateBetween($before, $after, $this->parseTime($formatted['last_updated']));
 		unset($formatted['last_updated']);
 		$this->assertEquals([
@@ -3034,21 +3072,25 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	#[DataProvider('dataGetShareWithPublicSecret')]
 	public function testGetShareWithPublicSecret(bool $isSecretPublic): void {
 		$this->registry->clear();
-		$this->registry->registerRecipientType(new TestShareRecipientType1(
-			[
-				'recipient1' => 'Recipient 1',
-			],
-			[],
-			[],
-		));
-		$this->registry->registerRecipientType(new TestShareRecipientTypePublicSecret(
-			[
-				'recipient2' => 'Recipient 2',
-			],
-			[],
-			$isSecretPublic,
-			false,
-		));
+		$this->registry->registerRecipientType(
+			new TestShareRecipientType1(
+				[
+					'recipient1' => 'Recipient 1',
+				],
+				[],
+				[],
+			)
+		);
+		$this->registry->registerRecipientType(
+			new TestShareRecipientTypePublicSecret(
+				[
+					'recipient2' => 'Recipient 2',
+				],
+				[],
+				$isSecretPublic,
+				false,
+			)
+		);
 
 		$accessContext = new ShareAccessContext($this->owner);
 
@@ -3112,20 +3154,22 @@ abstract class AbstractSharingManagerTests extends TestCase {
 	public function testGetShareWithSecret(): void {
 		$this->registry->clear();
 		$this->registry->registerSourceType(new TestShareSourceType1(['source1' => 'Source']));
-		$this->registry->registerRecipientType(new TestShareRecipientTypePublicSecret(
-			[
-				'recipient1' => 'Recipient 1',
-				'recipient2' => 'Recipient 2',
-				'recipient3' => 'Recipient 3',
-				'recipient4' => 'Recipient 4',
-			],
-			[
-				$this->user1->getUID() => ['recipient1'],
-				$this->user2->getUID() => ['recipient2'],
-			],
-			true,
-			false,
-		));
+		$this->registry->registerRecipientType(
+			new TestShareRecipientTypePublicSecret(
+				[
+					'recipient1' => 'Recipient 1',
+					'recipient2' => 'Recipient 2',
+					'recipient3' => 'Recipient 3',
+					'recipient4' => 'Recipient 4',
+				],
+				[
+					$this->user1->getUID() => ['recipient1'],
+					$this->user2->getUID() => ['recipient2'],
+				],
+				true,
+				false,
+			)
+		);
 		$this->registry->registerPermissionType(null, Server::get(ReshareSharePermissionType::class));
 
 		$accessContext = new ShareAccessContext($this->owner);
@@ -3138,9 +3182,15 @@ abstract class AbstractSharingManagerTests extends TestCase {
 
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
-		$share = $this->manager->addShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient2', null));
-		$share = $this->manager->addShareRecipient(new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient3', null));
-		$share = $this->manager->addShareRecipient(new ShareAccessContext($this->user2), $share, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient4', null));
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient2', null)
+		);
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext($this->user1), $share, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient3', null)
+		);
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext($this->user2), $share, new ShareRecipient(TestShareRecipientTypePublicSecret::class, 'recipient4', null)
+		);
 
 		$this->dbConnection->commit();
 		$after = $this->manager->getTime();
@@ -3352,7 +3402,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$share = $this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
-		$share = $this->manager->addShareRecipient(new ShareAccessContext(currentUser: $this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext(currentUser: $this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 
 		$this->dbConnection->commit();
 		$after = $this->manager->getTime();
@@ -4018,7 +4070,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$share = $this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
 		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(ReshareSharePermissionType::class, true));
 		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
-		$share = $this->manager->addShareRecipient(new ShareAccessContext(currentUser: $this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null));
+		$share = $this->manager->addShareRecipient(
+			new ShareAccessContext(currentUser: $this->user1), $share, new ShareRecipient(TestShareRecipientType2::class, 'recipient2', null)
+		);
 
 		$before = $this->manager->getTime();
 		$this->user1->delete();
@@ -4097,7 +4151,7 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		try {
 			$this->getShare($accessContext2, $share->id);
 			$this->fail('user has invalid share access');
-		} catch(ShareNotFoundException) {
+		} catch (HintException) {
 
 		}
 
@@ -4128,5 +4182,47 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$this->dbConnection->commit();
 		$formattedShares = $this->getShares(new ShareAccessContext(currentUser: $this->user2), TestShareSourceType1::class, 'source1', null, null);
 		$this->assertCount(0, $formattedShares);
+	}
+
+	public function testEditWithDirectAccess(): void {
+		$accessContext = new ShareAccessContext($this->owner);
+		$accessContext2 = new ShareAccessContext(currentUser: $this->user2);
+
+		$this->dbConnection->beginTransaction();
+		$share = $this->manager->createShare($accessContext);
+		$share = $this->manager->addShareSource($accessContext, $share, new ShareSource(TestShareSourceType1::class, 'source1'));
+		$share = $this->manager->addShareRecipient($accessContext, $share, new ShareRecipient(TestShareRecipientType1::class, 'recipient1', null));
+
+		$share = $this->manager->updateSharePermission($accessContext, $share, new SharePermission(TestSharePermissionType1::class, true));
+		$share = $this->manager->updateShareState($accessContext, $share, ShareState::Active);
+
+		$this->dbConnection->commit();
+
+		try {
+			$this->updateShareProperty($accessContext2, $share, new ShareProperty(TestSharePropertyType1::class, 'valid1'));
+			$this->fail('update allowed');
+		} catch (HintException) {
+
+		}
+
+		// give user2 direct access
+		$this->shareSourceType1->userAccess[$this->user2->getUID()] = ['source1'];
+		$user2Share = $this->reloadShare($accessContext2, $share);
+		$this->assertNull($user2Share->recipients[0]->secret);
+		$formatted = $this->updateShareProperty($accessContext2, $user2Share, new ShareProperty(TestSharePropertyType1::class, 'valid1'));
+
+		$this->assertEquals([
+			[
+				'display_name' => 'TestSharePropertyType1',
+				'hint' => 'hint TestSharePropertyType1',
+				'priority' => 1,
+				'required' => false,
+				'advanced' => false,
+				'value' => 'valid1',
+				'class' => \Test\Sharing\TestSharePropertyType1::class,
+				'type' => 'enum',
+				'valid_values' => ['valid1'],
+			]
+		], $formatted['properties']);
 	}
 }

--- a/tests/lib/Sharing/TestShareSourceType1.php
+++ b/tests/lib/Sharing/TestShareSourceType1.php
@@ -21,6 +21,8 @@ class TestShareSourceType1 implements IShareSourceType {
 	public function __construct(
 		/** @var array<string, non-empty-string> $validSources */
 		private readonly array $validSources,
+		/** @var array<non-empty-string, non-empty-string[]> $validSources */
+		public array $userAccess = [],
 	) {
 	}
 
@@ -58,5 +60,11 @@ class TestShareSourceType1 implements IShareSourceType {
 	#[\Override]
 	public function getSourceInteractionResource(IUser $user, string $source): InteractionResource {
 		return new TestInteractionResource($source);
+	}
+
+	#[\Override]
+	public function userHasDirectSharingAccessToSource(IUser $user, string $source): bool {
+		$userSources = $this->userAccess[$user->getUID()] ?? [];
+		return in_array($source, $userSources);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Allow all users that have direct (not through a share) access, and share permissions to a file access to see and modify all shares for that file, even ones created by other users.

Non-owner are still unable to change the share sources, as modifying the share sources can impact who has "direct" access to the share. Which adds a whole list of potential issues.

This mirrors the existing logic around `IShareOwnerlessMount`, ~~but makes the behavior work automatically instead of mounts having to opt-in. Afaik this is equivilent since all mounts I'm aware of that this behavior would trigger for (external storage, groupfolders) opt-in to `IShareOwnerlessMount`.~~

Edit: switched to to still require the explicit mount opt-in

- [x] Return shares owned by others when listing shares for a specific file
- [x] Allow modifications to the returned shares

## Requires

- [x] https://github.com/nextcloud/server/pull/63140

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
