### PR TITLE
fix(files_trashbin): misleading trashbin:expire output when expiration is disabled

### DIFF
--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -49,9 +49,14 @@ class ExpireTrash extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$minAge = $this->expiration->getMinAgeAsTimestamp();
 		$maxAge = $this->expiration->getMaxAgeAsTimestamp();
+		// Both minAge and maxAge resolve to `false` only when
+		// Expiration::isEnabled() is false, i.e. the retention policy is "disabled".
 		if ($minAge === false && $maxAge === false) {
-			$output->writeln('Auto expiration is configured - keeps files and folders in the trash bin for 30 days and automatically deletes anytime after that if space is needed (note: files may not be deleted if space is not needed)');
-			return 1;
+			$output->writeln(
+				'Trash bin expiration is disabled (trashbin_retention_obligation is set to "disabled"). '
+				. 'No files or folders will be automatically expired by this command.'
+			);
+			return 0;
 		}
 
 		$userIds = $input->getArgument('user_id');


### PR DESCRIPTION
When trashbin_retention_obligation is set to disabled, trashbin:expire incorrectly reports the auto-expiration policy and exits with a failure status.

Report that automatic expiration is disabled and exit successfully instead.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #n/a <!-- related github issue -->

## Summary

Discovered while working on nextcloud/documentation#15421

Fixes the output and exit status of `occ trashbin:expire` when automatic trash-bin expiration is disabled with:

```php
'trashbin_retention_obligation' => 'disabled',
```

When expiration is disabled, `trashbin:expire` currently prints a message describing the default auto policy:

> Auto expiration is configured - keeps files and folders in the trash bin for 30 days ...

It also exits with status `1`, even though the configured state is valid and no operation has failed.

This is misleading.

Changes:

- Report that trash-bin expiration is disabled.
- Clarify that no files or folders will be automatically expired by the command.
- Return exit status `0` for this valid no-op condition.


Only updates `occ trashbin:expire` output/return value behavior for the disabled retention policy. It does not change retention-policy semantics or the behavior of `trashbin:cleanup` or any other aspect of the implementation.

## TODO

- n/a

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
