### PR TITLE
Update CODEOWNERS to modify maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@ package-lock.json                             @nextcloud/server-dependabot
 
 # App maintainers
 /apps/admin_audit/appinfo/info.xml            @luka-nextcloud @samin-z
-/apps/cloud_federation_api/appinfo/info.xml   @nfebe @mejo-
+/apps/cloud_federation_api/appinfo/info.xml   @mejo-
 /apps/comments/appinfo/info.xml               @edward-ly @sorbaugh
 /apps/contactsinteraction/appinfo/info.xml    @kesselb @SebastianKrupinski
 /apps/contactsinteraction/lib                 @kesselb @SebastianKrupinski
@@ -37,11 +37,11 @@ package-lock.json                             @nextcloud/server-dependabot
 /apps/dav/tests/unit/CardDAV                  @hamza221 @SebastianKrupinski
 /apps/encryption/appinfo/info.xml             @come-nc @icewind1991
 /apps/federatedfilesharing/appinfo/info.xml   @icewind1991 @danxuliu
-/apps/federation/appinfo/info.xml             @nfebe @sorbaugh
-/apps/files/appinfo/info.xml                  @skjnldsv @icewind1991 @szaimen @susnux @nfebe
+/apps/federation/appinfo/info.xml             @sorbaugh
+/apps/files/appinfo/info.xml                  @skjnldsv @icewind1991 @szaimen @susnux
 /apps/files_external/appinfo/info.xml         @icewind1991 @artonge
 /apps/files_reminders/appinfo/info.xml        @skjnldsv @sorbaugh
-/apps/files_sharing/appinfo/info.xml          @skjnldsv @provokateurin @nfebe
+/apps/files_sharing/appinfo/info.xml          @skjnldsv @provokateurin
 /apps/files_trashbin/appinfo/info.xml         @icewind1991 @sorbaugh
 /apps/files_versions/appinfo/info.xml         @artonge @icewind1991
 /apps/oauth2/appinfo/info.xml                 @julien-nc @ChristophWurst


### PR DESCRIPTION
Removed nfebe from CODEOWNERS for cloud_federation_api and federation, and adjusted entries for files.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
