### PR TITLE
fix(files_trashbin): cleanup trash metadata after failed cross-user moves

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -391,7 +391,9 @@ class Trashbin implements IEventListener {
 					'timestamp' => $timestamp,
 				]
 			);
-			self::deleteTrashRow($user, $filename, $timestamp);
+			// The metadata row belongs to the owner, even when another user initiated
+			// the deletion.
+			self::deleteTrashRow($owner, $filename, $timestamp);
 			if ($trashStorage->file_exists($trashInternalPath)) {
 				if ($trashStorage->is_dir($trashInternalPath)) {
 					$trashStorage->rmdir($trashInternalPath);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Discovered this while working on #63069.

When moving a shared file to the trash fails (after its metadata row has been inserted), the failure-cleanup path calls `deleteTrashRow()` with the deleting user.

The row was inserted for the file owner (not deleting user), so this leaves orphaned `files_trash` metadata whenever the owner and deleting user differ.

Doesn't impact success path; just the rollback path.

This change uses `$owner` for the cleanup call, ensuring the inserted metadata row is removed. Other call sites for deleteTrashRow() in the class are correct in their context.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
