### PR TITLE
fix(core): improve `app:update` feedback and error handling

### DIFF
--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -36,35 +36,35 @@ class Update extends Command {
 	protected function configure(): void {
 		$this
 			->setName('app:update')
-			->setDescription('update an app or all apps')
+			->setDescription('Update an app, or all apps, from the app store')
 			->addArgument(
 				'app-id',
 				InputArgument::OPTIONAL,
-				'update the specified app'
+				'the ID of the app to update'
 			)
 			->addOption(
 				'all',
 				null,
 				InputOption::VALUE_NONE,
-				'update all updatable apps'
+				'update all apps that have an available update'
 			)
 			->addOption(
 				'showonly',
 				null,
 				InputOption::VALUE_NONE,
-				'show update(s) without updating'
+				'only list available updates, without installing them'
 			)
 			->addOption(
 				'showcurrent',
 				null,
 				InputOption::VALUE_NONE,
-				'show currently installed version'
+				'also show the currently installed version alongside the available update (implies --showonly)'
 			)
 			->addOption(
 				'allow-unstable',
 				null,
 				InputOption::VALUE_NONE,
-				'allow updating to unstable releases'
+				'allow updating to unstable (e.g. beta) releases'
 			)
 		;
 	}
@@ -73,75 +73,100 @@ class Update extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appStoreEnabled = $this->config->getSystemValueBool('appstoreenabled', true);
 		if ($appStoreEnabled === false) {
-			$output->writeln('App store access is disabled');
+			$output->writeln('App store access is disabled by the administrator; cannot check for updates');
 			return 1;
 		}
 
 		$internetAvailable = $this->config->getSystemValueBool('has_internet_connection', true);
 		$isDefaultAppStore = $this->config->getSystemValueString('appstoreurl', self::APP_STORE_URL) === self::APP_STORE_URL;
 		if ($internetAvailable === false && $isDefaultAppStore === true) {
-			$output->writeln('Internet connection is disabled, and therefore the default public App store is not reachable');
+			$output->writeln('The default app store is configured, but Internet access is disabled, so the app store cannot be reached');
 			return 1;
 		}
 
 		$singleAppId = $input->getArgument('app-id');
 		$updateFound = false;
+		$checkFailed = false;
 		$showOnly = $input->getOption('showonly') || $input->getOption('showcurrent');
 
 		if ($singleAppId) {
 			$apps = [$singleAppId];
 			try {
 				$this->manager->getAppPath($singleAppId);
-			} catch (AppPathNotFoundException $e) {
-				$output->writeln($singleAppId . ' not installed');
+			} catch (AppPathNotFoundException) {
+				$output->writeln('App "' . $singleAppId . '" is not installed');
 				return 1;
 			}
 		} elseif ($input->getOption('all') || $showOnly) {
 			$apps = $this->manager->getAllAppsInAppsFolders();
 		} else {
-			$output->writeln('<error>Please specify an app to update or "--all" to update all updatable apps"</error>');
+			$output->writeln('<error>Please specify an app ID to update, or use "--all" to update all apps</error>');
 			return 1;
 		}
 
 		$return = 0;
 		foreach ($apps as $appId) {
-			$newVersion = $this->installer->isUpdateAvailable($appId, $input->getOption('allow-unstable'));
-			if ($newVersion) {
+			try {
+				$newVersion = $this->installer->isUpdateAvailable(
+					$appId,
+					$input->getOption('allow-unstable'),
+				);
+			} catch (\Exception $e) {
+				// Handles installer/app-manager failures that escape the app-store fetcher.
+				$this->logger->error('Failure while checking for an update of app "' . $appId . '"', [
+					'app' => 'app:update',
+					'exception' => $e,
+				]);
+				$output->writeln('App "' . $appId . '" could not be checked for updates: ' . $e->getMessage());
+				$checkFailed = true;
+				$return = 1;
+				continue;
+			}
+
+			if ($newVersion !== false) {
 				$updateFound = true;
-				$message = $appId . ' new version available: ' . $newVersion;
 				if ($input->getOption('showcurrent')) {
-					$message .= ' (current version: ' . $this->manager->getAppVersion($appId) . ')';
+					$message = 'App "' . $appId . '": ' . $this->manager->getAppVersion($appId) . ' → ' . $newVersion . ' available';
+				} else {
+					$message = 'App "' . $appId . '": update available (' . $newVersion . ')';
 				}
 				$output->writeln($message);
 
 				if (!$showOnly) {
 					try {
-						$result = $this->installer->updateAppstoreApp($appId, $input->getOption('allow-unstable'));
+						$result = $this->installer->updateAppstoreApp(
+							$appId,
+							$input->getOption('allow-unstable'),
+						);
 					} catch (\Exception $e) {
 						$this->logger->error('Failure during update of app "' . $appId . '"', [
 							'app' => 'app:update',
 							'exception' => $e,
 						]);
-						$output->writeln('Error: ' . $e->getMessage());
-						$result = false;
+						$output->writeln('App "' . $appId . '" could not be updated: ' . $e->getMessage());
 						$return = 1;
+						continue;
 					}
 
 					if ($result === false) {
-						$output->writeln($appId . ' couldn\'t be updated');
+						$output->writeln('App "' . $appId . '" could not be updated');
 						$return = 1;
 					} else {
-						$output->writeln($appId . ' updated');
+						$output->writeln('App "' . $appId . '" updated successfully');
 					}
 				}
 			}
 		}
 
 		if (!$updateFound) {
-			if ($singleAppId) {
-				$output->writeln($singleAppId . ' is up-to-date or no updates could be found');
+			if ($checkFailed) {
+				if (!$singleAppId) {
+					$output->writeln('Some apps could not be checked for updates; the rest are up to date');
+				}
+			} elseif ($singleAppId) {
+				$output->writeln('App "' . $singleAppId . '" is already up to date');
 			} else {
-				$output->writeln('All apps are up-to-date or no updates could be found');
+				$output->writeln('All apps are up to date');
 			}
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Improve `occ app:update`'s user-facing messages and per-app error handling, without changing its existing option contract.

## Changes

- Clarify command and option descriptions and improve messages for:
  - disabled app-store access;
  - an unavailable default app store;
  - missing apps or command targets;
  - available updates;
  - successful and failed updates;
  - apps that are already up to date.
- Preserve explicit app-ID precedence over `--all`, as well as the legacy behavior where `--showonly` or `--showcurrent` without an app ID inspect all apps.
- Catch exceptions escaping `Installer::isUpdateAvailable()` so one failed check no longer aborts an all-app run; remaining apps continue processing.
- Return a nonzero exit code when an update check or update operation fails.
- Avoid duplicate failure messages when an update throws an exception.

**Known limitation:** ordinary app-store fetch failures are still collapsed upstream into an empty result by `AppFetcher` and/or `false` by `Installer`. Consequently, this command still cannot distinguish those cases from a genuinely up-to-date app or another valid empty result, such as an administrator-configured app allowlist filtering out all apps. Improving that distinction is out of scope here and can be addressed later as part of an `AppFetcher`/result-model refactor.

## Output examples

| Scenario | Before | After |
|---|---|---|
| Already up to date | `calendar is up-to-date or no updates could be found` | `App "calendar" is already up to date` |
| Update available, `--showcurrent` | `calendar new version available: 5.3.0 (current version: 5.2.1)` | `App "calendar": 5.2.1 → 5.3.0 available` |
| Successful update | `calendar new version available: 5.3.0`<br>`calendar updated` | `App "calendar": update available (5.3.0)`<br>`App "calendar" updated successfully` |
| Update failure | `calendar new version available: 5.3.0`<br>`Error: Download failed`<br>`calendar couldn't be updated` | `App "calendar": update available (5.3.0)`<br>`App "calendar" could not be updated: Download failed` |
| Failed check during all-app run | *(uncaught exception; remaining apps not processed)* | `App "calendar" could not be checked for updates: App store unavailable`<br>`App "contacts": update available (2.0.0)`<br>`App "contacts" updated successfully` |

The command returns exit code `1` when an update check or update operation fails, even if other apps succeed.

Compatibility: existing options remain unchanged.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
