### PR TITLE
fix(LocalStorage): Clear realpath cache on fopen failure and re-try access

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -24,6 +24,7 @@ use OCP\IConfig;
 use OCP\Server;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
+use function fopen;
 
 /**
  * for local filestore, we only have to map the paths
@@ -439,6 +440,20 @@ class Local extends Common {
 		}
 	}
 
+	/** The scope this has to keep is pinned by the stale realpath cache tests in LocalTest. */
+	private function clearRealpathCache(string $sourcePath): void {
+		$root = rtrim($this->datadir, '/');
+		$path = $sourcePath;
+		while (str_starts_with($path, $root . '/')) {
+			clearstatcache(true, $path);
+			$parent = dirname($path);
+			if ($parent === $path) {
+				return;
+			}
+			$path = $parent;
+		}
+	}
+
 	#[\Override]
 	public function fopen(string $path, string $mode) {
 		$sourcePath = $this->getSourcePath($path);
@@ -446,11 +461,21 @@ class Local extends Common {
 			return false;
 		}
 		$oldMask = umask($this->defUMask);
-		if (($mode === 'w' || $mode === 'w+') && $this->unlinkOnTruncate) {
-			$this->unlink($path);
+		try {
+			if (($mode === 'w' || $mode === 'w+') && $this->unlinkOnTruncate) {
+				$this->unlink($path);
+			}
+			$result = @fopen($sourcePath, $mode);
+			if ($result === false) {
+				// fopen() resolves through the realpath cache, so a false can just mean
+				// this process still has the path cached as a file after another one
+				// turned it into a directory, for up to realpath_cache_ttl.
+				$this->clearRealpathCache($sourcePath);
+				$result = @fopen($sourcePath, $mode);
+			}
+		} finally {
+			umask($oldMask);
 		}
-		$result = @fopen($sourcePath, $mode);
-		umask($oldMask);
 		return $result;
 	}
 

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -164,4 +164,120 @@ class LocalTest extends Storage {
 		$jail3->moveFromStorage($jail2, 'file.txt', 'file.txt');
 		$this->assertTrue($this->instance->file_exists('target/file.txt'));
 	}
+
+	public function testFopenRestoresUmaskWhenTheWritePathThrows(): void {
+		$storage = new class(['datadir' => $this->tmpDir]) extends Local {
+			#[\Override]
+			public function __construct(array $parameters) {
+				parent::__construct($parameters);
+				$this->unlinkOnTruncate = true;
+			}
+
+			#[\Override]
+			public function unlink(string $path): bool {
+				throw new \RuntimeException('unlink failed');
+			}
+		};
+
+		$ambient = umask(0077);
+		$thrown = false;
+		try {
+			$storage->fopen('target.txt', 'w');
+		} catch (\RuntimeException) {
+			$thrown = true;
+		}
+		$leaked = umask($ambient);
+
+		$this->assertTrue($thrown, 'the exception has to propagate');
+		$this->assertSame(0077, $leaked, 'umask has to be restored when the write path throws');
+	}
+
+	public function testFopenRecoveryLeavesEntriesOutsideTheDataDirectoryAlone(): void {
+		if (!function_exists('exec')) {
+			$this->markTestSkipped('exec() is required to change the path type out of process');
+		}
+
+		$dataDir = rtrim($this->tmpDir, '/');
+		$stalePath = $this->tmpDir . 'folder';
+		$file = $stalePath . '/a.txt';
+
+		// opened only to get the "not a directory" entry into the realpath cache
+		$this->instance->file_put_contents('folder', 'its a file');
+		$handle = $this->instance->fopen('folder', 'r');
+		$this->assertIsResource($handle);
+		fclose($handle);
+
+		if ((realpath_cache_get()[$stalePath]['is_dir'] ?? null) !== false) {
+			$this->markTestSkipped('the realpath cache of this setup does not hold the directory flag');
+		}
+
+		realpath(__DIR__);
+		realpath($dataDir);
+		$this->assertArrayHasKey(__DIR__, realpath_cache_get());
+		$this->assertArrayHasKey($dataDir, realpath_cache_get());
+
+		exec(
+			'rm -f ' . escapeshellarg($stalePath)
+			. ' && mkdir -p ' . escapeshellarg($stalePath)
+			. ' && printf abc > ' . escapeshellarg($file),
+			$output,
+			$status
+		);
+		$this->assertSame(0, $status, 'failed to replace the file with a directory');
+
+		$handle = $this->instance->fopen('folder/a.txt', 'r');
+		$this->assertIsResource($handle);
+		fclose($handle);
+
+		$cache = realpath_cache_get();
+		$this->assertArrayHasKey(__DIR__, $cache, 'entries outside the data directory have to survive');
+		$this->assertArrayHasKey($dataDir, $cache, 'the walk has to stop at the data directory');
+	}
+
+	public static function dataStaleRealpathCache(): array {
+		return [
+			// invalidating only the direct parent passes the first and fails the second
+			'stale direct parent' => ['staleName' => 'folder', 'filePath' => 'folder/a.txt'],
+			'stale grandparent' => ['staleName' => 'nickname', 'filePath' => 'nickname/folder/a.txt'],
+		];
+	}
+
+	/**
+	 * The type change has to happen out of process: PHP drops its own realpath cache
+	 * entry when it is the one calling unlink() and mkdir(), so doing it here would
+	 * leave nothing stale and the test would pass either way.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataStaleRealpathCache')]
+	public function testFopenRecoversFromStaleRealpathCache(string $staleName, string $filePath): void {
+		if (!function_exists('exec')) {
+			$this->markTestSkipped('exec() is required to change the path type out of process');
+		}
+
+		$stalePath = $this->tmpDir . $staleName;
+		$file = $this->tmpDir . $filePath;
+
+		// opened only to get the "not a directory" entry into the realpath cache
+		$this->instance->file_put_contents($staleName, 'its a file');
+		$handle = $this->instance->fopen($staleName, 'r');
+		$this->assertIsResource($handle);
+		fclose($handle);
+
+		if ((realpath_cache_get()[$stalePath]['is_dir'] ?? null) !== false) {
+			$this->markTestSkipped('the realpath cache of this setup does not hold the directory flag');
+		}
+
+		exec(
+			'rm -f ' . escapeshellarg($stalePath)
+			. ' && mkdir -p ' . escapeshellarg(dirname($file))
+			. ' && printf abc > ' . escapeshellarg($file),
+			$output,
+			$status
+		);
+		$this->assertSame(0, $status, 'failed to replace the file with a directory');
+
+		$handle = $this->instance->fopen($filePath, 'r');
+		$this->assertIsResource($handle, 'fopen() has to recover from the stale realpath cache entry');
+		$this->assertSame('abc', stream_get_contents($handle));
+		fclose($handle);
+	}
 }


### PR DESCRIPTION
## Summary

PHP resolves the path of every `fopen()` through its realpath cache, which stores per path component whether that component is a directory. That cache is per process, and entries live for `realpath_cache_ttl` (120s by default). If one process has a path cached as a file and another process replaces it with a directory, the first process keeps refusing to descend into it and `fopen()` fails as if the file were missing - while `stat()`/`file_exists()` bypass that cache and keep reporting the file. The file looks perfectly present and is still unreadable, for up to two minutes.

That is why the `filesdrop` integration tests fail intermittently: the suite recycles the same user and paths, one scenario stores `drop/Alice/folder` as a file, the next needs it as a directory, and the dev server runs several worker processes (`PHP_CLI_SERVER_WORKERS=2`), so the worker serving the download is usually not the one that created the directory (example run: …). It is not CI-specific: php-fpm workers keep the same cache, so a user who deletes a file `X`, creates a folder `X`, and downloads `X/y.txt` via another worker gets a 503 for up to `realpath_cache_ttl`.

This is being fixed by this PR, which in this case walks up the parents, clears their cache entry and re-tries to access the path.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
