### PR TITLE
App menu sorting improvement

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -28,6 +28,32 @@ use Psr\Log\LoggerInterface;
  * @psalm-import-type NavigationEntryOutput from INavigationManager
  */
 class NavigationManager implements INavigationManager {
+	/**
+	 * Default app menu order, grouped by topic with four apps per row.
+	 * Apps ship very different orders in their info.xml, so the values are
+	 * negative to keep this group in front of everything else.
+	 * Apps that are not listed keep their own order.
+	 */
+	private const DEFAULT_APP_ORDER = [
+		// Basics
+		'dashboard' => -100,
+		'files' => -99,
+		'office' => -98,
+		'photos' => -97,
+		// Collaboration
+		'spreed' => -96,
+		'mail' => -95,
+		'calendar' => -94,
+		'contacts' => -93,
+		// Productivity
+		'deck' => -92,
+		'collectives' => -91,
+		'tables' => -90,
+		'circles' => -89,
+		// All other apps follow, starting with Activity
+		'activity' => -88,
+	];
+
 	/** @var array<string, NavigationEntryOutput> */
 	protected array $entries = [];
 	/** @var list<callable(): NavigationEntry> */
@@ -80,8 +106,11 @@ class NavigationManager implements INavigationManager {
 				$entry['app'] = $id;
 			}
 
-			// Set order from user defined app order
-			$entry['order'] = (int)($this->customAppOrder[$id]['order'] ?? $entry['order'] ?? 100);
+			// Set order from user defined app order, then the default app order.
+			// The default order is skipped for users that sorted the apps themselves,
+			// so a newly installed app does not jump to the front of their order.
+			$defaultOrder = $this->customAppOrder === [] ? (self::DEFAULT_APP_ORDER[$id] ?? null) : null;
+			$entry['order'] = (int)($this->customAppOrder[$id]['order'] ?? $defaultOrder ?? $entry['order'] ?? 100);
 		}
 
 		$this->entries[$id] = $entry;

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -481,6 +481,53 @@ class NavigationManagerTest extends TestCase {
 	}
 
 	/**
+	 * Known apps get a default order, all other apps keep the order from their info.xml.
+	 */
+	public function testDefaultAppOrder(): void {
+		$this->userSession->method('isLoggedIn')->willReturn(false);
+		$this->appManager->method('getEnabledApps')->willReturn([]);
+		$this->appManager->method('isEnabledForUser')->willReturn(true);
+
+		// order as shipped by the apps themselves
+		$apps = ['circles' => 80, 'activity' => 1, 'other' => 2, 'spreed' => -5, 'files' => 0, 'dashboard' => -10];
+		foreach ($apps as $id => $order) {
+			$this->navigationManager->add(['id' => $id, 'name' => $id, 'href' => '/', 'order' => $order]);
+		}
+
+		$this->assertSame(
+			['dashboard', 'files', 'spreed', 'circles', 'activity', 'other'],
+			array_keys($this->navigationManager->getAll()),
+		);
+	}
+
+	/**
+	 * Users that sorted the apps themselves keep their order, also for apps they never sorted.
+	 */
+	public function testDefaultAppOrderIsSkippedForCustomOrder(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user001');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->userSession->method('isLoggedIn')->willReturn(true);
+		$this->appManager->method('getEnabledAppsForUser')->willReturn([]);
+		$this->appManager->method('isEnabledForUser')->willReturn(true);
+		$this->config->method('getUserValue')
+			->willReturnCallback(static function (string $userId, string $appName, string $key, mixed $default = '') {
+				return $key === 'apporder' ? json_encode(['other' => ['app' => 'other', 'order' => 0]]) : $default;
+			});
+
+		// `circles` is not part of the user order, so it keeps the order from its info.xml
+		// instead of moving to the front of the user order
+		foreach (['other' => 2, 'circles' => 80] as $id => $order) {
+			$this->navigationManager->add(['id' => $id, 'name' => $id, 'href' => '/', 'order' => $order]);
+		}
+
+		$this->assertSame(
+			['other', 'circles'],
+			array_keys($this->navigationManager->getAll()),
+		);
+	}
+
+	/**
 	 * Navigation entries of enabled apps that are not booted yet must not be resolved.
 	 */
 	public function testResolveOnlyLoadedApps(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Splitting this out of https://github.com/nextcloud/server/pull/62963 as per @susnux’s feedback at https://github.com/nextcloud/server/pull/62963#discussion_r3730253818

## Summary

The app-menu currently has apps very wildly and inconsistently sorted. Especially now that we have the rows of 4 apps each, like a home screen, it would be good to have the default Nextcloud Hub experience nice and organized.

The sorting is based on this logic, with one bullet point representing a row, and 4 app icons fitting in each row:
- **Basics:** Dashboard, Files, Office, Photos
- **Collaboration:** Talk, Mail, Calendar, Contacts
- **Productivity:** Deck, Collectives, Tables, Teams
- **Other:** Activity, all other apps
- "More apps" (for admins) or "App store" (for users) should always be the last entry, like it is now.

Some things don’t fit the imaginary categories completely, like "Teams" being with Productivity. But Groupware is together as it makes sense. And since the labels don’t show up anywhere I think it’s fine.


Before | After
-|-
<img width="548" height="802" alt="Screenshot From 2026-08-06 13-38-50" src="https://github.com/user-attachments/assets/7f362a15-ee97-455e-9e55-f264a8006d6e" />|<img width="548" height="802" alt="Screenshot From 2026-08-06 14-00-31" src="https://github.com/user-attachments/assets/9d8c906b-dc93-4ff1-af10-8bb094dba3a9" />


## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
