### PR TITLE
fix(sharing): Fix migration

### DIFF
--- a/apps/sharing/lib/Migration/Version1000Date20260731171922.php
+++ b/apps/sharing/lib/Migration/Version1000Date20260731171922.php
@@ -59,6 +59,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$table->setPrimaryKey(['class_id']);
 			$table->addUniqueIndex(['class_name']);
 		}
+		$classmapTable = $schema->getTable('sharing_classmap');
 
 		$sourcesTable = $schema->getTable('sharing_share_sources');
 		if ($sourcesTable->hasColumn('source_class')) {
@@ -66,7 +67,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$sourcesTable->addColumn('source_class_id', Types::INTEGER);
 			$sourcesTable->dropPrimaryKey();
 			$sourcesTable->setPrimaryKey(['share_id', 'source_class_id', 'source_value']);
-			$sourcesTable->addForeignKeyConstraint('sharing_classmap', ['source_class_id'], ['class_id']);
+			$sourcesTable->addForeignKeyConstraint($classmapTable->getName(), ['source_class_id'], ['class_id']);
 		}
 
 		$recipientsTable = $schema->getTable('sharing_share_recipients');
@@ -75,7 +76,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$recipientsTable->addColumn('recipient_class_id', Types::INTEGER);
 			$recipientsTable->dropPrimaryKey();
 			$recipientsTable->setPrimaryKey(['share_id', 'recipient_class_id', 'recipient_value']);
-			$recipientsTable->addForeignKeyConstraint('sharing_classmap', ['recipient_class_id'], ['class_id']);
+			$recipientsTable->addForeignKeyConstraint($classmapTable->getName(), ['recipient_class_id'], ['class_id']);
 		}
 
 		$propertiesTable = $schema->getTable('sharing_share_properties');
@@ -84,7 +85,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$propertiesTable->addColumn('property_class_id', Types::INTEGER);
 			$propertiesTable->dropPrimaryKey();
 			$propertiesTable->setPrimaryKey(['share_id', 'property_class_id']);
-			$propertiesTable->addForeignKeyConstraint('sharing_classmap', ['property_class_id'], ['class_id']);
+			$propertiesTable->addForeignKeyConstraint($classmapTable->getName(), ['property_class_id'], ['class_id']);
 		}
 
 		$permissionsTable = $schema->getTable('sharing_share_permissions');
@@ -93,7 +94,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$permissionsTable->addColumn('permission_class_id', Types::INTEGER);
 			$permissionsTable->dropPrimaryKey();
 			$permissionsTable->setPrimaryKey(['share_id', 'permission_class_id']);
-			$permissionsTable->addForeignKeyConstraint('sharing_classmap', ['permission_class_id'], ['class_id']);
+			$permissionsTable->addForeignKeyConstraint($classmapTable->getName(), ['permission_class_id'], ['class_id']);
 		}
 
 		return $schema;

--- a/lib/private/DB/Schema/Table.php
+++ b/lib/private/DB/Schema/Table.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Index as DBALIndex;
 use Doctrine\DBAL\Schema\SchemaException as DBALSchemaException;
 use Doctrine\DBAL\Schema\Table as DBALTable;
 use Doctrine\DBAL\Types\Type as DBALType;
+use OC\DB\Connection;
 use OCP\DB\Schema\ColumnType;
 use OCP\DB\Schema\IColumn;
 use OCP\DB\Schema\IForeignKeyConstraint;
@@ -27,7 +28,8 @@ use OCP\DB\Schema\SchemaException;
  */
 class Table implements ITable {
 	public function __construct(
-		private DBALTable $table,
+		private readonly DBALTable $table,
+		private readonly Connection $connection,
 	) {
 	}
 
@@ -117,7 +119,7 @@ class Table implements ITable {
 
 	#[\Override]
 	public function hasPrimaryKey(): bool {
-		return $this->table->hasPrimaryKey();
+		return $this->table->getPrimaryKey() !== null;
 	}
 
 	#[\Override]
@@ -206,7 +208,7 @@ class Table implements ITable {
 	): self {
 		try {
 			$this->table->addForeignKeyConstraint(
-				$foreignTable instanceof self ? $foreignTable->getWrappedTable() : $foreignTable,
+				$foreignTable instanceof self ? $foreignTable->getWrappedTable() : $this->connection->getPrefix() . $foreignTable,
 				$localColumnNames,
 				$foreignColumnNames,
 				$options,

--- a/lib/private/DB/SchemaWrapper.php
+++ b/lib/private/DB/SchemaWrapper.php
@@ -75,7 +75,7 @@ class SchemaWrapper implements ISchemaWrapper {
 	#[\Override]
 	public function getTable(string $tableName): ITable {
 		try {
-			return new Table($this->schema->getTable($this->connection->getPrefix() . $tableName));
+			return new Table($this->schema->getTable($this->connection->getPrefix() . $tableName), $this->connection);
 		} catch (DBALSchemaException $e) {
 			throw new SchemaException($e->getMessage(), $e->getCode(), $e);
 		}
@@ -93,7 +93,7 @@ class SchemaWrapper implements ISchemaWrapper {
 	public function createTable(string $tableName): ITable {
 		unset($this->tablesToDelete[$tableName]);
 		try {
-			return new Table($this->schema->createTable($this->connection->getPrefix() . $tableName));
+			return new Table($this->schema->createTable($this->connection->getPrefix() . $tableName), $this->connection);
 		} catch (DBALSchemaException $e) {
 			throw new SchemaException($e->getMessage(), $e->getCode(), $e);
 		}


### PR DESCRIPTION
The addForeignKeyConstraint call doesn't add the prefix so use getName to get it

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
