### PR TITLE
feat: add option to send legacy style x-amx-user-agent header to s3 server

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -8,12 +8,15 @@
 namespace OC\Files\ObjectStore;
 
 use Aws\ClientResolver;
+use Aws\Command;
+use Aws\CommandInterface;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\Exception\CredentialsException;
 use Aws\Middleware;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
+use Aws\UserAgentMiddleware;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Utils;
@@ -69,6 +72,7 @@ trait S3ConnectionTrait {
 			$params['port'] = (isset($params['use_ssl']) && $params['use_ssl'] === false) ? 80 : 443;
 		}
 		$params['verify_bucket_exists'] = $params['verify_bucket_exists'] ?? true;
+		$params['legacyAmzUserAgent'] = $params['legacyAmzUserAgent'] ?? false;
 
 		if ($params['s3-accelerate']) {
 			$params['verify_bucket_exists'] = false;
@@ -164,6 +168,10 @@ trait S3ConnectionTrait {
 
 		$this->addDeleteObjectsContentMd5Middleware();
 
+		if ($this->params['legacyAmzUserAgent']) {
+			$this->addLegacyAmzUserAgentMiddleware();
+		}
+
 		try {
 			$logger = Server::get(LoggerInterface::class);
 			if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
@@ -257,6 +265,36 @@ trait S3ConnectionTrait {
 
 				return $request;
 			})
+		);
+	}
+
+	/**
+	 * Starting with aws-sdk 3.336.0, the user agent headers sent by the sdk have changed.
+	 *
+	 * Previously, the `X-Amz-User-Agent` and `User-Agent` header would both contain the same
+	 * user agent.
+	 * Since 3.336.0, the `X-Amz-User-Agent` no longer contains the user agent but is sent empty instead.
+	 *
+	 * This seems to break some s3 implementations, so we can add a middleware to re-add the value
+	 */
+	private function addLegacyAmzUserAgentMiddleware(): void {
+		if ($this->connection === null) {
+			return;
+		}
+
+		$handlerList = $this->connection->getHandlerList();
+		$handlerList->appendBuild(
+			Middleware::mapRequest(static function (
+				RequestInterface $request,
+			): RequestInterface {
+				// Get the upstream `UserAgentMiddleware` to generate a user id in the same format as the old `X-Amz-User-Agent`
+				// This won't be exactly what the final `User-Agent` will be, but it should be close enough for our goals.
+				$upstreamUAMiddleware = new UserAgentMiddleware(function (CommandInterface $_command, RequestInterface $request) {
+					return $request->getHeader('User-Agent');
+				});
+				$generatedUA = $upstreamUAMiddleware->__invoke(new Command('dummy'), $request);
+				return $request->withHeader('X-Amz-User-Agent', $generatedUA);
+			}),
 		);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Starting with aws-sdk 3.336.0, the user agent headers sent by the sdk have changed.

Previously, the `X-Amz-User-Agent` and `User-Agent` header would both contain the same user agent.

Since 3.336.0, the `X-Amz-User-Agent` no longer contains the user agent but is sent empty instead.

This seems to break some s3 implementations, so we can add a middleware to re-add the value

## TODO:

- [ ] Verify that this fixes the issue with the problematic s3 implementation
- [ ] Document the config flag

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
