### PR TITLE
fix(files_external): propagate child copy failures in AmazonS3::copy()

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -558,7 +558,12 @@ class AmazonS3 extends Common {
 			foreach ($this->getDirectoryContent($source) as $item) {
 				$childSource = $source . '/' . $item['name'];
 				$childTarget = $target . '/' . $item['name'];
-				$this->copy($childSource, $childTarget, $item['mimetype'] !== FileInfo::MIMETYPE_FOLDER);
+				// Propagate copy failure
+				if ($this->copy($childSource, $childTarget, $item['mimetype'] !== FileInfo::MIMETYPE_FOLDER) === false) {
+					// Cache is stale because the target was already partially written
+					$this->invalidateCache($target);
+					return false;
+				}
 			}
 		}
 

--- a/apps/files_external/tests/Storage/Amazons3CopyTest.php
+++ b/apps/files_external/tests/Storage/Amazons3CopyTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Files_External\Tests\Storage;
+
+use Aws\Command;
+use Aws\S3\Exception\S3Exception;
+use OCA\Files_External\Lib\Storage\AmazonS3;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
+
+class Amazons3CopyTest extends \Test\TestCase {
+	/**
+	 * @param string[] $methods
+	 * @return AmazonS3|MockObject
+	 */
+	private function getStorageMock(array $methods) {
+		$storage = $this->getMockBuilder(AmazonS3::class)
+			->disableOriginalConstructor()
+			->onlyMethods($methods)
+			->getMock();
+
+		// The constructor is disabled, so the properties copy() relies on are uninitialised
+		$this->invokePrivate($storage, 'initCaches');
+		$this->invokePrivate($storage, 'storageClass', ['STANDARD']);
+		// invokePrivate() cannot reach these two: $logger is private, so it is invisible on
+		// the mock subclass, and 'test' resolves to the test() method before the property
+		(new \ReflectionProperty(AmazonS3::class, 'logger'))->setValue($storage, new NullLogger());
+		(new \ReflectionProperty(AmazonS3::class, 'test'))->setValue($storage, false);
+
+		return $storage;
+	}
+
+	private function failingCopyException(): S3Exception {
+		return new S3Exception('NotImplemented', new Command('CopyObject'));
+	}
+
+	/**
+	 * A directory copy must report failure when copying one of its children fails.
+	 */
+	public function testCopyDirectoryReportsFailureWhenChildCopyFails(): void {
+		$storage = $this->getStorageMock(['is_file', 'remove', 'mkdir', 'getDirectoryContent', 'copyObject']);
+
+		$storage->method('is_file')->willReturn(false);
+		$storage->method('remove')->willReturn(true);
+		$storage->method('mkdir')->willReturn(true);
+		$storage->method('getDirectoryContent')->willReturn(new \ArrayIterator([
+			['name' => 'child.txt', 'mimetype' => 'text/plain'],
+		]));
+		$storage->method('copyObject')->willThrowException($this->failingCopyException());
+
+		$this->assertFalse(
+			$storage->copy('source', 'target'),
+			'copy() must report failure when copying a child object fails'
+		);
+	}
+
+	/**
+	 * Renaming a directory must not remove the source when the copy failed.
+	 */
+	public function testRenameDirectoryKeepsSourceWhenCopyFails(): void {
+		$storage = $this->getStorageMock(['is_file', 'remove', 'mkdir', 'getDirectoryContent', 'copyObject', 'rmdir', 'unlink']);
+
+		$storage->method('is_file')->willReturn(false);
+		$storage->method('remove')->willReturn(true);
+		$storage->method('mkdir')->willReturn(true);
+		$storage->method('getDirectoryContent')->willReturn(new \ArrayIterator([
+			['name' => 'child.txt', 'mimetype' => 'text/plain'],
+		]));
+		$storage->method('copyObject')->willThrowException($this->failingCopyException());
+
+		$storage->expects($this->never())->method('rmdir');
+		$storage->expects($this->never())->method('unlink');
+
+		$this->assertFalse(
+			$storage->rename('source', 'target'),
+			'rename() must report failure when the underlying copy failed'
+		);
+	}
+
+	/**
+	 * A failing grandchild must propagate through nested directories as well.
+	 */
+	public function testCopyDirectoryReportsFailureFromNestedDirectory(): void {
+		$storage = $this->getStorageMock(['is_file', 'remove', 'mkdir', 'getDirectoryContent', 'copyObject']);
+
+		$storage->method('is_file')->willReturn(false);
+		$storage->method('remove')->willReturn(true);
+		$storage->method('mkdir')->willReturn(true);
+		$storage->method('getDirectoryContent')->willReturnCallback(
+			function (string $directory): \Traversable {
+				if ($directory === 'source') {
+					return new \ArrayIterator([
+						['name' => 'nested', 'mimetype' => \OC\Files\FileInfo::MIMETYPE_FOLDER],
+					]);
+				}
+				return new \ArrayIterator([
+					['name' => 'child.txt', 'mimetype' => 'text/plain'],
+				]);
+			}
+		);
+		$storage->method('copyObject')->willThrowException($this->failingCopyException());
+
+		$this->assertFalse(
+			$storage->copy('source', 'target'),
+			'copy() must propagate a failure from a nested directory'
+		);
+	}
+
+	/**
+	 * The success path must keep working: a directory whose children all copy fine
+	 * still reports true.
+	 */
+	public function testCopyDirectoryReportsSuccessWhenAllChildrenSucceed(): void {
+		$storage = $this->getStorageMock(['is_file', 'remove', 'mkdir', 'getDirectoryContent', 'copyObject']);
+
+		$storage->method('is_file')->willReturn(false);
+		$storage->method('remove')->willReturn(true);
+		$storage->method('mkdir')->willReturn(true);
+		$storage->method('getDirectoryContent')->willReturn(new \ArrayIterator([
+			['name' => 'child.txt', 'mimetype' => 'text/plain'],
+		]));
+		$storage->method('copyObject')->willReturn(null);
+
+		$this->assertTrue(
+			$storage->copy('source', 'target'),
+			'copy() must still report success when every child copies fine'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

When copying a directory, copy() discarded the return values of its recursive calls and always returned true. rename() relies on that value, so a failed copy still led to rmdir() on the source: every file in the directory was deleted, the destination stayed empty, and the UI reported success.

This is reachable whenever a provider rejects CopyObject for objects it otherwise serves — Hetzner Object Storage answers 501 NotImplemented for SSE-C encrypted objects, which makes every single child copy fail.

### Behaviour with the fix (measured on 34.0.1, Hetzner Object Storage + SSE-C)

  Renaming a folder now fails visibly instead of destroying its contents:

  - **Web UI**: the server answers `500`, the files stay where they are. The
    destination directory created by `mkdir()` before the failure remains as an
    empty folder and can be deleted normally.
  - **Desktop client**: the `MOVE` fails with `500`, and the client rolls the
    local rename back and re-fetches the files. It does *not* fall back to
    upload+delete, so nothing is duplicated and nothing is lost.
  - Upload, download and delete are unaffected.

  Renaming remains impossible on such providers — that part is outside
  Nextcloud's control. What changes is that the failure is now visible instead
  of silently deleting the data.

### Related

Previously reported without an issue:

https://help.nextcloud.com/t/nc-copy-move-not-working-and-destroying-files-in-s3-external-storage-with-sse-c-key/231896

(NC 31.0.8, same provider, same 501 NotImplemented, same silent data loss)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
