### PR TITLE
fix(appstore): honor subclass cache invalidation duration in fetchers

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -151,8 +151,8 @@ abstract class Fetcher {
 			if (is_array($jsonBlob)) {
 				// No caching when the version has been updated
 				if (isset($jsonBlob['ncversion']) && $jsonBlob['ncversion'] === $this->getVersion()) {
-					// If the timestamp is older than 3600 seconds request the files new
-					$invalidateAfterSeconds = self::INVALIDATE_AFTER_SECONDS;
+					// If the timestamp is old, request the files new
+					$invalidateAfterSeconds = static::INVALIDATE_AFTER_SECONDS;
 
 					if ($allowUnstable) {
 						$invalidateAfterSeconds = self::INVALIDATE_AFTER_SECONDS_UNSTABLE;

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -211,8 +211,8 @@ abstract class FetcherBase extends TestCase {
 			->expects($this->exactly(2))
 			->method('getTime')
 			->willReturnOnConsecutiveCalls(
-				4801,
-				1502
+				90001,
+				90002,
 			);
 		$client = $this->createMock(IClient::class);
 		$this->clientService
@@ -474,8 +474,8 @@ abstract class FetcherBase extends TestCase {
 			->expects($this->exactly(2))
 			->method('getTime')
 			->willReturnOnConsecutiveCalls(
-				4801,
-				4802
+				90001,
+				90002,
 			);
 		$client = $this->createMock(IClient::class);
 		$this->clientService
@@ -557,8 +557,8 @@ abstract class FetcherBase extends TestCase {
 			->expects($this->exactly(2))
 			->method('getTime')
 			->willReturnOnConsecutiveCalls(
-				4801,
-				4802,
+				90001,
+				90002,
 			);
 		$client = $this->createMock(IClient::class);
 		$this->clientService


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

`AppDiscoverFetcher` declares:

```php
public const INVALIDATE_AFTER_SECONDS = 86400;
```

However, the base class (`Fetcher`) uses `self::INVALIDATE_AFTER_SECONDS`, causing `AppDiscoverFetcher`'s override value to be ignored.

Therefore the discover fetcher does not actually use 24 hours through this mechanism; it still uses the base class’s one-hour/15-minute thresholds.

Changes:

- Use late static binding when resolving `INVALIDATE_AFTER_SECONDS`.

Allows `AppDiscoverFetcher` to use [its existing 24-hour cache duration override](https://github.com/nextcloud/server/blob/0ab88812d64913aeade61de5e0d03c4948d2c5eb/lib/private/App/AppStore/Fetcher/AppDiscoverFetcher.php#L25-L27) as (presumably) intended. Preserves the existing default duration for fetchers that do not override the constant.

## TODO

- [x] Backport

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
