### PR TITLE
[stable34] fix: bump dav version for to trigger migration

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>WebDAV</name>
 	<summary>WebDAV endpoint</summary>
 	<description>WebDAV endpoint</description>
-	<version>1.39.0</version>
+	<version>1.40.0</version>
 	<licence>agpl</licence>
 	<author>owncloud.org</author>
 	<namespace>DAV</namespace>


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/63113 got a new migration step, but not the required version bump

fixed an `Column not found: 1054 Unknown column 'state' in 'WHERE'`  when upgrading to 34.0.3 RC1.