### PR TITLE
[stable33] fix: bump dav version for to trigger migration

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>WebDAV</name>
 	<summary>WebDAV endpoint</summary>
 	<description>WebDAV endpoint</description>
-	<version>1.36.0</version>
+	<version>1.36.1</version>
 	<licence>agpl</licence>
 	<author>owncloud.org</author>
 	<namespace>DAV</namespace>


### PR DESCRIPTION
sorta backport of https://github.com/nextcloud/server/pull/63135