### PR TITLE
fix: bump dav version for to trigger migration

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<name>WebDAV</name>
 	<summary>WebDAV endpoint</summary>
 	<description>WebDAV endpoint</description>
-	<version>2.0.0-dev.0</version>
+	<version>2.0.0-dev.1</version>
 	<licence>agpl</licence>
 	<author>owncloud.org</author>
 	<namespace>DAV</namespace>


### PR DESCRIPTION
Sorta forward port of https://github.com/nextcloud/server/pull/63135 (not sure it is exactly necessary as being in dev state, but won't hurt).