### PR TITLE
fix(appstore): use URL-safe base64 encoding for user content proxy URLs

### DIFF
--- a/apps/appstore/lib/Controller/ApiController.php
+++ b/apps/appstore/lib/Controller/ApiController.php
@@ -306,7 +306,7 @@ class ApiController extends OCSController {
 			return '';
 		}
 
-		return 'https://usercontent.apps.nextcloud.com/' . base64_encode($url);
+		return 'https://usercontent.apps.nextcloud.com/' . strtr(base64_encode($url), '+/', '-_');
 	}
 
 	private function fetchApps(): void {
@@ -478,7 +478,7 @@ class ApiController extends OCSController {
 					$phpDependencies
 				),
 				'level' => ($app['isFeatured'] === true) ? 200 : 100,
-				'screenshot' => isset($app['screenshots'][0]['url']) ? 'https://usercontent.apps.nextcloud.com/' . base64_encode($app['screenshots'][0]['url']) : '',
+				'screenshot' => isset($app['screenshots'][0]['url']) ? 'https://usercontent.apps.nextcloud.com/' . strtr(base64_encode($app['screenshots'][0]['url']), '+/', '-_') : '',
 				'ratingOverall' => $app['ratingOverall'],
 				'ratingNumOverall' => $app['ratingNumOverall'],
 				'removable' => $existsLocally,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Some app screenshot URLs in the proxy server may include the '/' character in their base64 encoding, but since '/' is a prohibited character for file names, the computed proxy server URL was invalid and such screenshots would fail to be retrieved (or rather, the screenshots weren't saved to begin with because of this). This is addressed by making the encoding URL-safe (e.g. replacing `/` and `+` with `_` and `-`, respectively).

Accompanies https://github.com/nextcloud/usercontent.apps.nextcloud.com/pull/25.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
