### PR TITLE
fix(user_ldap): restore OCS API functionality for configID = ''

### DIFF
--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -72,7 +72,7 @@ class ConfigAPIController extends OCSController {
 	 * 200: Config deleted successfully
 	 */
 	#[AuthorizedAdminSetting(settings: Admin::class)]
-	#[ApiRoute(verb: 'DELETE', url: '/api/v1/config/{configID}')]
+	#[ApiRoute(verb: 'DELETE', url: '/api/v1/config/{configID}', requirements: ['configID' => '.*'], defaults: ['configID' => ''])]
 	public function delete($configID) {
 		try {
 			$this->ensureConfigIDExists($configID);
@@ -102,7 +102,7 @@ class ConfigAPIController extends OCSController {
 	 * 200: Config returned
 	 */
 	#[AuthorizedAdminSetting(settings: Admin::class)]
-	#[ApiRoute(verb: 'PUT', url: '/api/v1/config/{configID}')]
+	#[ApiRoute(verb: 'PUT', url: '/api/v1/config/{configID}', requirements: ['configID' => '.*'], defaults: ['configID' => ''])]
 	public function modify($configID, $configData) {
 		try {
 			$this->ensureConfigIDExists($configID);
@@ -207,7 +207,7 @@ class ConfigAPIController extends OCSController {
 	 * 200: Config returned
 	 */
 	#[AuthorizedAdminSetting(settings: Admin::class)]
-	#[ApiRoute(verb: 'GET', url: '/api/v1/config/{configID}')]
+	#[ApiRoute(verb: 'GET', url: '/api/v1/config/{configID}', requirements: ['configID' => '.*'], defaults: ['configID' => ''])]
 	public function show($configID, $showPassword = false) {
 		try {
 			$this->ensureConfigIDExists($configID);
@@ -244,7 +244,7 @@ class ConfigAPIController extends OCSController {
 	 * 200: Test was run and results are returned
 	 */
 	#[AuthorizedAdminSetting(settings: Admin::class)]
-	#[ApiRoute(verb: 'POST', url: '/api/v1/config/{configID}/test')]
+	#[ApiRoute(verb: 'POST', url: '/api/v1/config/{configID}/test', requirements: ['configID' => '.*'], defaults: ['configID' => ''])]
 	public function testConfiguration(string $configID) {
 		try {
 			$this->ensureConfigIDExists($configID);
@@ -312,7 +312,7 @@ class ConfigAPIController extends OCSController {
 	 * 200: Config was copied, new configID was returned
 	 */
 	#[AuthorizedAdminSetting(settings: Admin::class)]
-	#[ApiRoute(verb: 'POST', url: '/api/v1/config/{configID}/copy')]
+	#[ApiRoute(verb: 'POST', url: '/api/v1/config/{configID}/copy', requirements: ['configID' => '.*'], defaults: ['configID' => ''])]
 	public function copyConfiguration(string $configID) {
 		try {
 			$this->ensureConfigIDExists($configID);

--- a/apps/user_ldap/openapi.json
+++ b/apps/user_ldap/openapi.json
@@ -196,7 +196,9 @@
                         "description": "ID of the config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -369,7 +371,9 @@
                         "description": "ID of the config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -553,7 +557,9 @@
                         "description": "ID of the config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -720,7 +726,9 @@
                         "description": "ID of the LDAP config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -887,7 +895,9 @@
                         "description": "ID of the LDAP config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {

--- a/openapi.json
+++ b/openapi.json
@@ -40726,7 +40726,9 @@
                         "description": "ID of the config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -40899,7 +40901,9 @@
                         "description": "ID of the config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -41083,7 +41087,9 @@
                         "description": "ID of the config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -41250,7 +41256,9 @@
                         "description": "ID of the LDAP config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {
@@ -41417,7 +41425,9 @@
                         "description": "ID of the LDAP config",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^.*$",
+                            "default": ""
                         }
                     },
                     {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

LDAP configurations get a prefix in the form of `s01`, `s02`, etc. This default in the past was ``. A refactor of the routes led to dropping the possibility of passing an empty config ID, breaking the administration interface for all users affected.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
