### PR TITLE
feat(caldav): allow attendees to add guests to an event

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -250,6 +250,7 @@ class Application extends App implements IBootstrap {
 	#[\Override]
 	public function boot(IBootContext $context): void {
 		VObject\Component\VCalendar::$propertyMap[TipBroker::INVITATION_FORWARDING_PROPERTY] = VObject\Property\Boolean::class;
+		VObject\Component\VCalendar::$propertyMap[TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY] = VObject\Property\Boolean::class;
 
 		// Load all dav apps
 		$context->getServerContainer()->get(IAppManager::class)->loadApps(['dav']);

--- a/apps/dav/lib/CalDAV/TipBroker.php
+++ b/apps/dav/lib/CalDAV/TipBroker.php
@@ -23,6 +23,8 @@ use Sabre\VObject\Recur\EventIterator;
 
 class TipBroker extends Broker {
 	public const INVITATION_FORWARDING_PROPERTY = 'X-NC-INVITATION-FORWARDING';
+	public const ALLOW_ATTENDEE_GUESTS_PROPERTY = 'X-NC-ALLOW-ATTENDEE-GUESTS';
+	public const ADD_GUEST_PROPERTY = 'X-NC-ADD-GUEST';
 
 	public $significantChangeProperties = [
 		'DTSTART',
@@ -95,6 +97,7 @@ class TipBroker extends Broker {
 			return null;
 		}
 		$instances = [];
+		$guests = [];
 		$requestStatus = '2.0';
 
 		/** @var list<VEvent> $vevents */
@@ -115,6 +118,7 @@ class TipBroker extends Broker {
 				continue;
 			}
 			$instances[$recurId] = $partstat->getValue();
+			$guests[$recurId] = $this->getGuestsFromReply($vevent);
 			if (isset($vevent->{'REQUEST-STATUS'})) {
 				$requestStatus = $vevent->{'REQUEST-STATUS'}->getValue();
 				[$requestStatus] = explode(';', $requestStatus);
@@ -142,9 +146,12 @@ class TipBroker extends Broker {
 							$attendeeFound = true;
 							$attendee['PARTSTAT'] = $instances[$recurId];
 							$attendee['SCHEDULE-STATUS'] = $requestStatus;
-							// Un-setting the RSVP status, because we now know
-							// that the attendee already replied.
-							unset($attendee['RSVP']);
+							if ($instances[$recurId] !== 'NEEDS-ACTION') {
+								// A reply leaving the attendee at NEEDS-ACTION, for
+								// example one only forwarding the invitation, is not
+								// an answer, so keep asking for one.
+								unset($attendee['RSVP']);
+							}
 							break;
 						}
 					}
@@ -159,6 +166,10 @@ class TipBroker extends Broker {
 						$parameters['CN'] = $itipMessage->senderName;
 					}
 					$vevent->add('ATTENDEE', $itipMessage->sender, $parameters);
+				} elseif ($attendeeFound && $this->allowAttendeeGuests($vevent)) {
+					// Only guests of a known attendee are invited, otherwise a
+					// party crasher could bring others along.
+					$this->addGuests($vevent, $guests[$recurId] ?? []);
 				}
 				unset($instances[$recurId]);
 			}
@@ -203,7 +214,10 @@ class TipBroker extends Broker {
 						$attendeeFound = true;
 						$attendee['PARTSTAT'] = $partstat;
 						$attendee['SCHEDULE-STATUS'] = $requestStatus;
-						unset($attendee['RSVP']);
+						if ($partstat !== 'NEEDS-ACTION') {
+							// Not an answer yet, so keep asking for one.
+							unset($attendee['RSVP']);
+						}
 						break;
 					}
 				}
@@ -252,6 +266,86 @@ class TipBroker extends Broker {
 		return null;
 	}
 
+	/**
+	 * Collects the guests a replying attendee added to the event.
+	 *
+	 * @return array<string, string|null> Calendar user address => common name
+	 */
+	protected function getGuestsFromReply(VEvent $vevent): array {
+		$guests = [];
+		/** @var list<Property> $properties */
+		$properties = $vevent->select(self::ADD_GUEST_PROPERTY);
+		foreach ($properties as $property) {
+			$href = $property->getValue();
+			if ($href === null || $href === '') {
+				continue;
+			}
+			$commonName = $property->offsetGet('CN');
+			$guests[$href] = $commonName instanceof Parameter ? $commonName->getValue() : null;
+		}
+
+		return $guests;
+	}
+
+	/**
+	 * Adds guests that are not part of the event yet as attendees.
+	 *
+	 * @param array<string, string|null> $guests Calendar user address => common name
+	 */
+	protected function addGuests(VEvent $vevent, array $guests): void {
+		$known = [];
+		/** @var list<Property> $properties */
+		$properties = $vevent->select('ATTENDEE');
+		foreach ($properties as $property) {
+			if ($property instanceof CalAddress) {
+				$known[strtolower($property->getNormalizedValue())] = true;
+			}
+		}
+		$organizer = $this->getOrganizerHref($vevent);
+		if ($organizer !== null) {
+			$known[strtolower($organizer)] = true;
+		}
+
+		foreach ($guests as $href => $commonName) {
+			if (isset($known[strtolower($href)])) {
+				continue;
+			}
+			$parameters = [
+				'PARTSTAT' => 'NEEDS-ACTION',
+				'RSVP' => 'TRUE',
+			];
+			if ($commonName !== null) {
+				$parameters['CN'] = $commonName;
+			}
+			$vevent->add('ATTENDEE', $href, $parameters);
+		}
+	}
+
+	protected function getOrganizerHref(VEvent $vevent): ?string {
+		/** @var list<Property> $properties */
+		$properties = $vevent->select('ORGANIZER');
+		foreach ($properties as $property) {
+			if ($property instanceof CalAddress) {
+				return $property->getNormalizedValue();
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Unlike forwarding, this has to be turned on by the organizer, so it is
+	 * also absent on invitations we could not report guests back to.
+	 */
+	protected function allowAttendeeGuests(VEvent $vevent): bool {
+		$properties = $vevent->select(self::ALLOW_ATTENDEE_GUESTS_PROPERTY);
+		foreach ($properties as $property) {
+			if ($property instanceof Boolean) {
+				return $property->getValue() === true;
+			}
+		}
+		return false;
+	}
+
 	protected function allowInvitationForwarding(VEvent $vevent): bool {
 		$properties = $vevent->select(self::INVITATION_FORWARDING_PROPERTY);
 		foreach ($properties as $property) {
@@ -260,6 +354,117 @@ class TipBroker extends Broker {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * On top of the participation status handled by the parent, an attendee may
+	 * add guests to an event they were invited to. Those go out as a separate
+	 * reply, from which the organizer invites them.
+	 *
+	 * @param string $attendee
+	 *
+	 * @return array<int,Message>
+	 */
+	#[\Override]
+	protected function parseEventForAttendee(VCalendar $calendar, array $eventInfo, array $oldEventInfo, $attendee) {
+		$messages = parent::parseEventForAttendee($calendar, $eventInfo, $oldEventInfo, $attendee);
+
+		$guests = $this->extractAddedGuests($eventInfo, $oldEventInfo, $attendee);
+		if ($guests !== []) {
+			$messages[] = $this->generateGuestReply($eventInfo, $attendee, $guests);
+		}
+
+		return $messages;
+	}
+
+	/**
+	 * Collects the guests an attendee added to their own copy of an event.
+	 *
+	 * Only guests of the base instance are picked up, guests on a recurrence
+	 * exception are ignored. The calendar app therefore does not offer this
+	 * for recurring events.
+	 *
+	 * @return array<string, string|null> Calendar user address => common name
+	 */
+	protected function extractAddedGuests(array $eventInfo, array $oldEventInfo, string $attendee): array {
+		$master = $eventInfo['instances']['master'] ?? null;
+		if (!$master instanceof VEvent || !$this->allowAttendeeGuests($master)) {
+			return [];
+		}
+
+		$guests = [];
+		foreach ($eventInfo['attendees'] as $href => $info) {
+			if ($href === $attendee || $href === $eventInfo['organizer']) {
+				continue;
+			}
+			// Already invited, so not a guest of this attendee
+			if (isset($oldEventInfo['attendees'][$href])) {
+				continue;
+			}
+			// Added to a recurrence exception instead of the whole event
+			if (!isset($info['instances']['master'])) {
+				continue;
+			}
+			$guests[$href] = $info['name'];
+		}
+
+		return $guests;
+	}
+
+	/**
+	 * Generates a reply carrying the guests an attendee added to the event.
+	 *
+	 * The organizer invites them from there.
+	 *
+	 * @param array<string, string|null> $guests Calendar user address => common name
+	 */
+	protected function generateGuestReply(array $eventInfo, string $attendee, array $guests): Message {
+		// A reply only carries scheduling information, the organizer already
+		// knows the event itself.
+		$calendar = new VCalendar();
+		$calendar->add('METHOD', 'REPLY');
+		/** @var VEvent $vevent */
+		$vevent = $calendar->add('VEVENT', [
+			'UID' => $eventInfo['uid'],
+			'SEQUENCE' => $eventInfo['sequence'],
+		]);
+		$organizerParameters = [];
+		if ($eventInfo['organizerName']) {
+			$organizerParameters['CN'] = $eventInfo['organizerName'];
+		}
+		$vevent->add('ORGANIZER', $eventInfo['organizer'], $organizerParameters);
+
+		$attendeeParameters = [
+			'PARTSTAT' => $eventInfo['attendees'][$attendee]['instances']['master']['partstat'] ?? 'NEEDS-ACTION',
+		];
+		if ($eventInfo['attendees'][$attendee]['name']) {
+			$attendeeParameters['CN'] = $eventInfo['attendees'][$attendee]['name'];
+		}
+		$vevent->add('ATTENDEE', $attendee, $attendeeParameters);
+
+		foreach ($guests as $href => $commonName) {
+			$guestParameters = [];
+			if ($commonName) {
+				$guestParameters['CN'] = $commonName;
+			}
+			$vevent->add(self::ADD_GUEST_PROPERTY, $href, $guestParameters);
+		}
+
+		$message = new Message();
+		$message->uid = $eventInfo['uid'];
+		$message->method = 'REPLY';
+		$message->component = 'VEVENT';
+		$message->sequence = $eventInfo['sequence'];
+		$message->sender = $attendee;
+		$message->senderName = $eventInfo['attendees'][$attendee]['name'];
+		$message->recipient = $eventInfo['organizer'];
+		$message->recipientName = $eventInfo['organizerName'];
+		// The participation status did not necessarily change, so an email about
+		// this reply would be misleading.
+		$message->significantChange = false;
+		$message->message = $calendar;
+
+		return $message;
 	}
 
 	/**

--- a/apps/dav/lib/CalDAV/TipBroker.php
+++ b/apps/dav/lib/CalDAV/TipBroker.php
@@ -256,7 +256,7 @@ class TipBroker extends Broker {
 		$properties = $vevent->select(self::INVITATION_FORWARDING_PROPERTY);
 		foreach ($properties as $property) {
 			if ($property instanceof Boolean) {
-				return $property->getValue() === 'TRUE';
+				return $property->getValue() === true;
 			}
 		}
 		return true;

--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -21,7 +21,7 @@ class Capabilities implements ICapability {
 	}
 
 	/**
-	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, search_supports_creation_time: bool, search_supports_upload_time: bool, search_supports_last_activity: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
+	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, search_supports_creation_time: bool, search_supports_upload_time: bool, search_supports_last_activity: bool, attendee_guests: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
 	 */
 	#[\Override]
 	public function getCapabilities() {
@@ -32,6 +32,8 @@ class Capabilities implements ICapability {
 				'search_supports_creation_time' => true,
 				'search_supports_upload_time' => true,
 				'search_supports_last_activity' => true,
+				// An attendee can add guests, which the server reports to the organizer
+				'attendee_guests' => true,
 			]
 		];
 		if ($this->config->getSystemValueBool('bulkupload.enabled', true)) {

--- a/apps/dav/openapi.json
+++ b/apps/dav/openapi.json
@@ -33,7 +33,8 @@
                             "public_shares_chunking",
                             "search_supports_creation_time",
                             "search_supports_upload_time",
-                            "search_supports_last_activity"
+                            "search_supports_last_activity",
+                            "attendee_guests"
                         ],
                         "properties": {
                             "chunking": {
@@ -49,6 +50,9 @@
                                 "type": "boolean"
                             },
                             "search_supports_last_activity": {
+                                "type": "boolean"
+                            },
+                            "attendee_guests": {
                                 "type": "boolean"
                             },
                             "bulkupload": {

--- a/apps/dav/tests/unit/CalDAV/TipBrokerTest.php
+++ b/apps/dav/tests/unit/CalDAV/TipBrokerTest.php
@@ -591,7 +591,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyDisallowsInvitationForwarding(): void {
 		$existingCalendar = clone $this->vCalendar1a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'FALSE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, false);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		$reply = new Message();
 		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
@@ -616,7 +616,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyUpdatesExistingAttendeeWhenInvitationForwardingDisabled(): void {
 		$existingCalendar = clone $this->vCalendar1a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'FALSE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, false);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		$reply = new Message();
 		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
@@ -645,7 +645,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyAllowsInvitationForwarding(): void {
 		$existingCalendar = clone $this->vCalendar1a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'TRUE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, true);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		$reply = new Message();
 		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
@@ -668,6 +668,32 @@ class TipBrokerTest extends TestCase {
 		$this->assertEquals('mailto:attendee2@example.org', $result->VEVENT->ATTENDEE[1]->getValue());
 		$this->assertEquals('ACCEPTED', $result->VEVENT->ATTENDEE[1]['PARTSTAT']->getValue());
 		$this->assertEquals('Attendee Two', $result->VEVENT->ATTENDEE[1]['CN']->getValue());
+	}
+
+	public function testProcessMessageReplyAllowsInvitationForwardingWithParsedProperty(): void {
+		$existingCalendar = clone $this->vCalendar1a;
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, true);
+		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
+		// Parsing turns the property into a bool, unlike adding it in memory
+		$existingCalendar = VObject\Reader::read($existingCalendar->serialize());
+		$reply = new Message();
+		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
+		$reply->component = 'VEVENT';
+		$reply->sender = 'mailto:attendee2@example.org';
+		$reply->senderName = 'Attendee Two';
+		$reply->sequence = 1;
+		$reply->message = new VCalendar();
+		/** @var \Sabre\VObject\Component\VEvent $replyEvent */
+		$replyEvent = $reply->message->add('VEVENT', []);
+		$replyEvent->add('UID', $reply->uid);
+		$replyEvent->add('ATTENDEE', $reply->sender, [
+			'PARTSTAT' => 'ACCEPTED',
+		]);
+
+		$result = $this->invokePrivate($this->broker, 'processMessageReply', [$reply, $existingCalendar]);
+
+		$this->assertCount(2, $result->VEVENT->ATTENDEE);
+		$this->assertEquals('mailto:attendee2@example.org', $result->VEVENT->ATTENDEE[1]->getValue());
 	}
 
 	public function testProcessMessageReplyAllowsInvitationForwardingByDefault(): void {
@@ -741,7 +767,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyDisallowsInvitationForwardingForGeneratedRecurringInstance(): void {
 		$existingCalendar = clone $this->vCalendar2a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'FALSE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, false);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		$reply = new Message();
 		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
@@ -768,7 +794,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyUpdatesExistingAttendeeForGeneratedRecurringInstanceWhenInvitationForwardingDisabled(): void {
 		$existingCalendar = clone $this->vCalendar2a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'FALSE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, false);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		$reply = new Message();
 		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
@@ -800,7 +826,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyAllowsInvitationForwardingForDetachedRecurringExceptionWhenMasterDisallows(): void {
 		$existingCalendar = clone $this->vCalendar2a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'FALSE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, false);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		/** @var \Sabre\VObject\Component\VEvent $detachedInstance */
 		$detachedInstance = $existingCalendar->add('VEVENT', []);
@@ -811,7 +837,7 @@ class TipBrokerTest extends TestCase {
 		$detachedInstance->add('DTEND', '20240715T090000', ['TZID' => 'America/Toronto']);
 		$detachedInstance->add('SUMMARY', 'Detached Test Event');
 		$detachedInstance->add('ORGANIZER', 'mailto:organizer@example.org', ['CN' => 'Organizer']);
-		$detachedInstance->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'TRUE');
+		$detachedInstance->add(TipBroker::INVITATION_FORWARDING_PROPERTY, true);
 		$detachedInstance->add('ATTENDEE', 'mailto:attendee1@example.org', [
 			'CN' => 'Attendee One',
 			'CUTYPE' => 'INDIVIDUAL',
@@ -845,7 +871,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyDisallowsInvitationForwardingForDetachedRecurringExceptionWhenMasterAllows(): void {
 		$existingCalendar = clone $this->vCalendar2a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'TRUE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, true);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		/** @var \Sabre\VObject\Component\VEvent $detachedInstance */
 		$detachedInstance = $existingCalendar->add('VEVENT', []);
@@ -856,7 +882,7 @@ class TipBrokerTest extends TestCase {
 		$detachedInstance->add('DTEND', '20240715T090000', ['TZID' => 'America/Toronto']);
 		$detachedInstance->add('SUMMARY', 'Detached Test Event');
 		$detachedInstance->add('ORGANIZER', 'mailto:organizer@example.org', ['CN' => 'Organizer']);
-		$detachedInstance->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'FALSE');
+		$detachedInstance->add(TipBroker::INVITATION_FORWARDING_PROPERTY, false);
 		$detachedInstance->add('ATTENDEE', 'mailto:attendee1@example.org', [
 			'CN' => 'Attendee One',
 			'CUTYPE' => 'INDIVIDUAL',
@@ -890,7 +916,7 @@ class TipBrokerTest extends TestCase {
 
 	public function testProcessMessageReplyAllowsInvitationForwardingForGeneratedRecurringInstance(): void {
 		$existingCalendar = clone $this->vCalendar2a;
-		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, 'TRUE');
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, true);
 		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
 		$reply = new Message();
 		$reply->uid = $existingCalendar->VEVENT->UID->getValue();

--- a/apps/dav/tests/unit/CalDAV/TipBrokerTest.php
+++ b/apps/dav/tests/unit/CalDAV/TipBrokerTest.php
@@ -25,6 +25,7 @@ class TipBrokerTest extends TestCase {
 		parent::setUp();
 
 		VCalendar::$propertyMap[TipBroker::INVITATION_FORWARDING_PROPERTY] = VObject\Property\Boolean::class;
+		VCalendar::$propertyMap[TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY] = VObject\Property\Boolean::class;
 
 		$this->broker = new TipBroker();
 
@@ -81,7 +82,10 @@ class TipBrokerTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		unset(VCalendar::$propertyMap[TipBroker::INVITATION_FORWARDING_PROPERTY]);
+		unset(
+			VCalendar::$propertyMap[TipBroker::INVITATION_FORWARDING_PROPERTY],
+			VCalendar::$propertyMap[TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY],
+		);
 
 		parent::tearDown();
 	}
@@ -824,6 +828,33 @@ class TipBrokerTest extends TestCase {
 		$this->assertFalse(isset($result->VEVENT[1]->ATTENDEE[0]['RSVP']));
 	}
 
+	public function testProcessMessageReplyKeepsRsvpForGeneratedRecurringInstanceWithoutAnswer(): void {
+		$existingCalendar = clone $this->vCalendar2a;
+		$existingCalendar->VEVENT->ATTENDEE[0]->setValue('mailto:attendee1@example.org');
+		$reply = new Message();
+		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
+		$reply->component = 'VEVENT';
+		$reply->sender = 'mailto:attendee1@example.org';
+		$reply->senderName = 'Attendee One';
+		$reply->sequence = 1;
+		$reply->message = new VCalendar();
+		/** @var \Sabre\VObject\Component\VEvent $replyEvent */
+		$replyEvent = $reply->message->add('VEVENT', []);
+		$replyEvent->add('UID', $reply->uid);
+		$replyEvent->add('RECURRENCE-ID', '20240715T080000', ['TZID' => 'America/Toronto']);
+		$replyEvent->add('ATTENDEE', $reply->sender, [
+			'PARTSTAT' => 'NEEDS-ACTION',
+		]);
+		$replyEvent->add('REQUEST-STATUS', '2.0;Success');
+
+		$result = $this->invokePrivate($this->broker, 'processMessageReply', [$reply, $existingCalendar]);
+
+		$this->assertCount(2, $result->VEVENT);
+		$this->assertEquals('20240715T080000', $result->VEVENT[1]->{'RECURRENCE-ID'}->getValue());
+		$this->assertEquals('NEEDS-ACTION', $result->VEVENT[1]->ATTENDEE[0]['PARTSTAT']->getValue());
+		$this->assertTrue(isset($result->VEVENT[1]->ATTENDEE[0]['RSVP']));
+	}
+
 	public function testProcessMessageReplyAllowsInvitationForwardingForDetachedRecurringExceptionWhenMasterDisallows(): void {
 		$existingCalendar = clone $this->vCalendar2a;
 		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, false);
@@ -973,6 +1004,199 @@ class TipBrokerTest extends TestCase {
 		$this->assertEquals('mailto:attendee2@example.org', $result->VEVENT[1]->ATTENDEE[1]->getValue());
 		$this->assertEquals('ACCEPTED', $result->VEVENT[1]->ATTENDEE[1]['PARTSTAT']->getValue());
 		$this->assertEquals('Attendee Two', $result->VEVENT[1]->ATTENDEE[1]['CN']->getValue());
+	}
+
+	/**
+	 * Builds a reply from an attendee that also carries a guest they added
+	 */
+	private function buildReplyWithGuest(VCalendar $existingCalendar, string $sender): Message {
+		$reply = new Message();
+		$reply->uid = $existingCalendar->VEVENT->UID->getValue();
+		$reply->component = 'VEVENT';
+		$reply->sender = $sender;
+		$reply->senderName = 'Attendee One';
+		$reply->sequence = 1;
+		$reply->message = new VCalendar();
+		/** @var \Sabre\VObject\Component\VEvent $replyEvent */
+		$replyEvent = $reply->message->add('VEVENT', []);
+		$replyEvent->add('UID', $reply->uid);
+		$replyEvent->add('ORGANIZER', 'mailto:organizer@example.org');
+		$replyEvent->add('ATTENDEE', $sender, [
+			'PARTSTAT' => 'ACCEPTED',
+		]);
+		$replyEvent->add(TipBroker::ADD_GUEST_PROPERTY, 'mailto:guest@example.org', [
+			'CN' => 'Guest',
+		]);
+
+		return $reply;
+	}
+
+	public function testParseEventForAttendeeReportsAddedGuest(): void {
+		$originalCalendar = clone $this->vCalendar1a;
+		$originalCalendar->VEVENT->add(TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY, true);
+		$mutatedCalendar = clone $originalCalendar;
+		$mutatedCalendar->VEVENT->add('ATTENDEE', 'mailto:guest@example.org', [
+			'CN' => 'Guest',
+			'PARTSTAT' => 'NEEDS-ACTION',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForAttendee', [
+			$mutatedCalendar, $mutatedEventInfo, $originalEventInfo, 'mailto:attendee1@example.org',
+		]);
+
+		$this->assertCount(1, $messages);
+		$this->assertEquals('REPLY', $messages[0]->method);
+		$this->assertEquals('mailto:attendee1@example.org', $messages[0]->sender);
+		$this->assertEquals('mailto:organizer@example.org', $messages[0]->recipient);
+		// The participation status did not change, so no email should be sent
+		$this->assertFalse($messages[0]->significantChange);
+		// RFC 5546 allows exactly one attendee in a reply, so the guest travels
+		// as an extension property
+		$this->assertCount(1, $messages[0]->message->VEVENT->ATTENDEE);
+		$this->assertEquals('mailto:attendee1@example.org', $messages[0]->message->VEVENT->ATTENDEE[0]->getValue());
+		$this->assertEquals('NEEDS-ACTION', $messages[0]->message->VEVENT->ATTENDEE[0]['PARTSTAT']->getValue());
+		$guests = $messages[0]->message->VEVENT->{TipBroker::ADD_GUEST_PROPERTY};
+		$this->assertCount(1, $guests);
+		$this->assertEquals('mailto:guest@example.org', $guests[0]->getValue());
+		$this->assertEquals('Guest', $guests[0]['CN']->getValue());
+	}
+
+	public function testParseEventForAttendeeReportsAddedGuestAlongsideParticipationStatus(): void {
+		$originalCalendar = clone $this->vCalendar1a;
+		$originalCalendar->VEVENT->add(TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY, true);
+		$mutatedCalendar = clone $originalCalendar;
+		$mutatedCalendar->VEVENT->ATTENDEE[0]['PARTSTAT'] = 'ACCEPTED';
+		$mutatedCalendar->VEVENT->add('ATTENDEE', 'mailto:guest@example.org', [
+			'CN' => 'Guest',
+			'PARTSTAT' => 'NEEDS-ACTION',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForAttendee', [
+			$mutatedCalendar, $mutatedEventInfo, $originalEventInfo, 'mailto:attendee1@example.org',
+		]);
+
+		// One reply for the participation status, one carrying the guest
+		$this->assertCount(2, $messages);
+		$this->assertTrue($messages[0]->significantChange);
+		$this->assertCount(1, $messages[0]->message->VEVENT->ATTENDEE);
+		$this->assertEquals('ACCEPTED', $messages[0]->message->VEVENT->ATTENDEE[0]['PARTSTAT']->getValue());
+		$this->assertFalse($messages[1]->significantChange);
+		$this->assertCount(1, $messages[1]->message->VEVENT->ATTENDEE);
+		$this->assertEquals('ACCEPTED', $messages[1]->message->VEVENT->ATTENDEE[0]['PARTSTAT']->getValue());
+		$this->assertEquals('mailto:guest@example.org', $messages[1]->message->VEVENT->{TipBroker::ADD_GUEST_PROPERTY}[0]->getValue());
+	}
+
+	public function testParseEventForAttendeeIgnoresAddedGuestWhenNotAllowed(): void {
+		// The organizer has to opt in, so an event without the property is enough
+		$originalCalendar = clone $this->vCalendar1a;
+		$mutatedCalendar = clone $originalCalendar;
+		$mutatedCalendar->VEVENT->add('ATTENDEE', 'mailto:guest@example.org', [
+			'CN' => 'Guest',
+			'PARTSTAT' => 'NEEDS-ACTION',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForAttendee', [
+			$mutatedCalendar, $mutatedEventInfo, $originalEventInfo, 'mailto:attendee1@example.org',
+		]);
+
+		$this->assertCount(0, $messages);
+	}
+
+	public function testParseEventForAttendeeDoesNotReportTheOrganizer(): void {
+		$originalCalendar = clone $this->vCalendar1a;
+		$originalCalendar->VEVENT->add(TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY, true);
+		$mutatedCalendar = clone $originalCalendar;
+		// The organizer joining as an attendee is not a guest of anyone
+		$mutatedCalendar->VEVENT->add('ATTENDEE', 'mailto:organizer@example.org', [
+			'CN' => 'Organizer',
+			'PARTSTAT' => 'ACCEPTED',
+		]);
+		$originalEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$originalCalendar]);
+		$mutatedEventInfo = $this->invokePrivate($this->broker, 'parseEventInfo', [$mutatedCalendar]);
+
+		$messages = $this->invokePrivate($this->broker, 'parseEventForAttendee', [
+			$mutatedCalendar, $mutatedEventInfo, $originalEventInfo, 'mailto:attendee1@example.org',
+		]);
+
+		$this->assertCount(0, $messages);
+	}
+
+	public function testProcessMessageReplyAddsGuest(): void {
+		$existingCalendar = clone $this->vCalendar1a;
+		$existingCalendar->VEVENT->add(TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY, true);
+		$reply = $this->buildReplyWithGuest($existingCalendar, 'mailto:attendee1@example.org');
+
+		$result = $this->invokePrivate($this->broker, 'processMessageReply', [$reply, $existingCalendar]);
+
+		$this->assertSame($existingCalendar, $result);
+		$this->assertCount(2, $result->VEVENT->ATTENDEE);
+		$this->assertEquals('mailto:attendee1@example.org', $result->VEVENT->ATTENDEE[0]->getValue());
+		$this->assertEquals('ACCEPTED', $result->VEVENT->ATTENDEE[0]['PARTSTAT']->getValue());
+		$this->assertEquals('mailto:guest@example.org', $result->VEVENT->ATTENDEE[1]->getValue());
+		$this->assertEquals('NEEDS-ACTION', $result->VEVENT->ATTENDEE[1]['PARTSTAT']->getValue());
+		$this->assertEquals('Guest', $result->VEVENT->ATTENDEE[1]['CN']->getValue());
+	}
+
+	public function testProcessMessageReplyAddsGuestWithParsedProperty(): void {
+		$existingCalendar = clone $this->vCalendar1a;
+		$existingCalendar->VEVENT->add(TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY, true);
+		// Parsing turns the property into a bool, unlike adding it in memory
+		$existingCalendar = VObject\Reader::read($existingCalendar->serialize());
+		$reply = $this->buildReplyWithGuest($existingCalendar, 'mailto:attendee1@example.org');
+
+		$result = $this->invokePrivate($this->broker, 'processMessageReply', [$reply, $existingCalendar]);
+
+		$this->assertCount(2, $result->VEVENT->ATTENDEE);
+		$this->assertEquals('mailto:guest@example.org', $result->VEVENT->ATTENDEE[1]->getValue());
+	}
+
+	public function testProcessMessageReplyIgnoresGuestWhenNotAllowed(): void {
+		// Forwarding stays allowed, only adding guests was never turned on
+		$existingCalendar = clone $this->vCalendar1a;
+		$existingCalendar->VEVENT->add(TipBroker::INVITATION_FORWARDING_PROPERTY, true);
+		$reply = $this->buildReplyWithGuest($existingCalendar, 'mailto:attendee1@example.org');
+
+		$result = $this->invokePrivate($this->broker, 'processMessageReply', [$reply, $existingCalendar]);
+
+		$this->assertCount(1, $result->VEVENT->ATTENDEE);
+		$this->assertEquals('mailto:attendee1@example.org', $result->VEVENT->ATTENDEE[0]->getValue());
+		$this->assertEquals('ACCEPTED', $result->VEVENT->ATTENDEE[0]['PARTSTAT']->getValue());
+	}
+
+	public function testProcessMessageReplyIgnoresGuestOfUnknownSender(): void {
+		$existingCalendar = clone $this->vCalendar1a;
+		$existingCalendar->VEVENT->add(TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY, true);
+		// A party crasher must not be able to invite further guests
+		$reply = $this->buildReplyWithGuest($existingCalendar, 'mailto:crasher@example.org');
+
+		$result = $this->invokePrivate($this->broker, 'processMessageReply', [$reply, $existingCalendar]);
+
+		$this->assertCount(2, $result->VEVENT->ATTENDEE);
+		$this->assertEquals('mailto:attendee1@example.org', $result->VEVENT->ATTENDEE[0]->getValue());
+		$this->assertEquals('mailto:crasher@example.org', $result->VEVENT->ATTENDEE[1]->getValue());
+	}
+
+	public function testProcessMessageReplyDoesNotDuplicateAKnownGuest(): void {
+		$existingCalendar = clone $this->vCalendar1a;
+		$existingCalendar->VEVENT->add(TipBroker::ALLOW_ATTENDEE_GUESTS_PROPERTY, true);
+		$existingCalendar->VEVENT->add('ATTENDEE', 'mailto:guest@example.org', [
+			'CN' => 'Guest',
+			'PARTSTAT' => 'DECLINED',
+		]);
+		$reply = $this->buildReplyWithGuest($existingCalendar, 'mailto:attendee1@example.org');
+
+		$result = $this->invokePrivate($this->broker, 'processMessageReply', [$reply, $existingCalendar]);
+
+		$this->assertCount(2, $result->VEVENT->ATTENDEE);
+		$this->assertEquals('mailto:guest@example.org', $result->VEVENT->ATTENDEE[1]->getValue());
+		// A reply must not overwrite the participation status of anyone but the sender
+		$this->assertEquals('DECLINED', $result->VEVENT->ATTENDEE[1]['PARTSTAT']->getValue());
 	}
 
 }

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -35,6 +35,7 @@ class CapabilitiesTest extends TestCase {
 				'search_supports_creation_time' => true,
 				'search_supports_upload_time' => true,
 				'search_supports_last_activity' => true,
+				'attendee_guests' => true,
 			],
 		];
 		$this->assertSame($expected, $capabilities->getCapabilities());
@@ -58,6 +59,7 @@ class CapabilitiesTest extends TestCase {
 				'search_supports_creation_time' => true,
 				'search_supports_upload_time' => true,
 				'search_supports_last_activity' => true,
+				'attendee_guests' => true,
 				'bulkupload' => '1.0',
 			],
 		];
@@ -82,6 +84,7 @@ class CapabilitiesTest extends TestCase {
 				'search_supports_creation_time' => true,
 				'search_supports_upload_time' => true,
 				'search_supports_last_activity' => true,
+				'attendee_guests' => true,
 				'absence-supported' => true,
 				'absence-replacement' => true,
 			],

--- a/openapi.json
+++ b/openapi.json
@@ -1506,7 +1506,8 @@
                             "public_shares_chunking",
                             "search_supports_creation_time",
                             "search_supports_upload_time",
-                            "search_supports_last_activity"
+                            "search_supports_last_activity",
+                            "attendee_guests"
                         ],
                         "properties": {
                             "chunking": {
@@ -1522,6 +1523,9 @@
                                 "type": "boolean"
                             },
                             "search_supports_last_activity": {
+                                "type": "boolean"
+                            },
+                            "attendee_guests": {
                                 "type": "boolean"
                             },
                             "bulkupload": {


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/issues/34230

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

UI https://github.com/nextcloud/calendar/pull/8719

Organizers can set X-NC-ALLOW-ATTENDEE-GUESTS to let attendees invite further people. Their reply reports the guests back as X-NC-ADD-GUEST, and the organizer's copy picks them up as regular attendees.

## Notes

- Recurring events are skipped / excluded
- iMIP wording attributes the change to the organizer

## Test cases

- [ ] Organizer (own instance) creates a non-recurring event, sets "Attendees can invite guests", invites A. A opens it, adds G, saves. --> Organizer's copy gains G as attendee; G receives an invitation from the organizer; A's reply carried X-NC-ADD-GUEST.
- [ ] Same event, organizer never touches the toggle. --> A sees no add-guest option. Check the stored object has X-NC-ALLOW-ATTENDEE-GUESTS:FALSE (or absent).
- [ ] Organizer sets "Only you can invite attendees". --> A sees no option.
- [ ] Invite from Google/Outlook/Thunderbird, accept on the test instance. --> No add-guest option (this is the case that motivated the decoupling). Also confirm the organizer-side forwarding select isn't shown on someone else's event.
- [ ] Organizer turns the toggle on for a weekly event, invites A. --> A sees no add-guest option, on the master and on a single occurrence. (Server only reads guests off the master; series-only, so it's hidden.)
- [ ] Toggle guests on, forwarding off — and the reverse. --> Both selects move independently; the years-old party-crasher path still behaves as before when forwarding is on and guests are off.
- [ ] A adds G without answering (stays "Needs action"), saves. --> Organizer still sees A as awaiting a response, and still gets a reminder-worthy RSVP state.



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
