### PR TITLE
feat(console): Expose raw Symfony OutputInterface and InputInterface

### DIFF
--- a/lib/private/Console/CommandAdapter.php
+++ b/lib/private/Console/CommandAdapter.php
@@ -256,6 +256,18 @@ class CommandAdapter extends Base {
 				continue;
 			}
 
+			if ($type instanceof \ReflectionNamedType && $type->getName() === InputInterface::class) {
+				// Not documented for some advanced usage
+				$parameters[] = $input;
+				continue;
+			}
+
+			if ($type instanceof \ReflectionNamedType && $type->getName() === OutputInterface::class) {
+				// Not documented for some advanced usage
+				$parameters[] = $output;
+				continue;
+			}
+
 			throw new \LogicException(\sprintf('Unable to resolve parameter "$%s" of "%s": it is neither an #[Argument], an #[Option], nor an %s, %s, %s or %s.', $name, $this->reflectionMethod->getName(), IOutput::class, IInput::class, ISignalHandler::class, OutputFormat::class));
 		}
 


### PR DESCRIPTION
## Summary

This is not documented but helps with porting help in e.g. the fulltextsearch app which does quite complex stuff with multiple progress bar.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
