### PR TITLE
fix(TempManager): handle cleanup failures and close directory handles

### DIFF
--- a/lib/private/TempManager.php
+++ b/lib/private/TempManager.php
@@ -105,27 +105,30 @@ class TempManager implements ITempManager {
 
 	#[\Override]
 	public function clean(): void {
-		$this->cleanFiles($this->current);
+		$this->current = $this->cleanFiles($this->current);
 	}
 
 	/**
 	 * Remove the specified local temporary files and directories.
 	 *
 	 * Missing paths are ignored. Failures raised while traversing a directory
-	 * are logged and processing continues with the remaining paths. The method
-	 * does not report whether each path was removed successfully.
+	 * are logged and processing continues with the remaining paths.
 	 *
 	 * @param list<string> $files Local filesystem paths
-	 * @return void
+	 * @return list<string> Paths that still need cleanup
 	 */
-	protected function cleanFiles(array $files): void {
+	protected function cleanFiles(array $files): array {
+		$remaining = [];
+
 		foreach ($files as $file) {
 			if (!file_exists($file)) {
 				continue;
 			}
 			
 			try {
-				Files::rmdirr($file);
+				if (!Files::rmdirr($file)) {
+					$remaining[] = $file;
+				}
 			} catch (\UnexpectedValueException $ex) {
 				$this->log->warning(
 					'Error deleting temporary file/folder: {file} - Reason: {error}',
@@ -134,8 +137,11 @@ class TempManager implements ITempManager {
 						'error' => $ex->getMessage(),
 					]
 				);
+				$remaining[] = $file;
 			}
 		}
+
+		return $remaining;
 	}
 
 	#[\Override]
@@ -166,11 +172,12 @@ class TempManager implements ITempManager {
 			if (substr($file, 0, 7) === self::TMP_PREFIX) {
 				$path = $this->tmpBaseDir . '/' . $file;
 				$mtime = filemtime($path);
-				if ($mtime < $cutOfTime) {
+				if ($mtime !== false && $mtime < $cutOfTime) {
 					$files[] = $path;
 				}
 			}
 		}
+		closedir($dh);
 
 		return $files;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fix several small cleanup issues in `TempManager`. 

- Ignore entries where `filemtime()` returns `false` (instead of treating them as stale candidates for deletion).
- Remove successfully cleaned paths from the request-scoped tracking list (instead of remaining queued for repeated cleanup attempts).
- Close the directory handle opened while scanning for stale temporary files.

Paths that cannot be removed remain tracked so a later cleanup attempt can retry them.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
