### PR TITLE
fix(files): keep reactivity when destructuring the store in grid view

### DIFF
--- a/apps/files/src/components/FileEntryGrid.spec.ts
+++ b/apps/files/src/components/FileEntryGrid.spec.ts
@@ -1,0 +1,69 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { File, Folder, Permission } from '@nextcloud/files'
+import { createTestingPinia } from '@pinia/testing'
+import { shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { nextTick } from 'vue'
+import FileEntryGrid from './FileEntryGrid.vue'
+import router from '../router/router.ts'
+import { useActiveStore } from '../store/active.ts'
+
+// useFileListWidth builds its ResizeObserver while the module is evaluated, so
+// the stub has to exist before the import chain runs. jsdom-testing-mocks sets
+// its observer up from a hook, which is already too late here.
+vi.hoisted(() => {
+	globalThis.ResizeObserver = class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	}
+})
+
+vi.mock('@nextcloud/auth')
+
+const source = new File({
+	id: 42,
+	source: 'http://nextcloud.local/remote.php/dav/files/test/Deep/Nested/report.pdf',
+	root: '/files/test',
+	owner: 'test',
+	mime: 'application/pdf',
+	permissions: Permission.READ,
+})
+
+const nestedFolder = new Folder({
+	id: 41,
+	source: 'http://nextcloud.local/remote.php/dav/files/test/Deep/Nested',
+	root: '/files/test',
+	owner: 'test',
+	permissions: Permission.READ,
+})
+
+describe('FileEntryGrid.vue', () => {
+	beforeEach(async () => {
+		await router.replace({ name: 'filelist', params: { view: 'files' } })
+	})
+
+	// The grid entry hands its `activeFolder` to the file actions, so a stale copy
+	// makes opening a file navigate to whichever folder was active when the entry
+	// was first rendered rather than the one the file lives in.
+	test('follows the active folder after navigating', async () => {
+		const wrapper = shallowMount(FileEntryGrid, {
+			propsData: { source, nodes: [source] },
+			mocks: { t: (_: string, text: string) => text },
+			router,
+			pinia: createTestingPinia({ createSpy: vi.fn }),
+		})
+		const activeStore = useActiveStore()
+
+		expect(wrapper.vm.activeFolder).not.toBe(nestedFolder)
+
+		activeStore.activeFolder = nestedFolder
+		await nextTick()
+
+		expect(wrapper.vm.activeFolder).toBe(nestedFolder)
+	})
+})

--- a/apps/files/src/components/FileEntryGrid.vue
+++ b/apps/files/src/components/FileEntryGrid.vue
@@ -71,6 +71,7 @@
 </template>
 
 <script lang="ts">
+import { storeToRefs } from 'pinia'
 import { defineComponent } from 'vue'
 import NcDateTime from '@nextcloud/vue/components/NcDateTime'
 import FileEntryActions from './FileEntry/FileEntryActions.vue'
@@ -117,11 +118,12 @@ export default defineComponent({
 			fileId: currentRouteFileId,
 		} = useRouteParameters()
 
+		const activeStore = useActiveStore()
 		const {
 			activeFolder,
 			activeNode,
 			activeView,
-		} = useActiveStore()
+		} = storeToRefs(activeStore)
 
 		const actions = useFileActions()
 


### PR DESCRIPTION
* Follow-up to #59942, related to #59941

## Summary

#59942 fixed `FileEntry.vue` but left `FileEntryGrid.vue` behind, so the same bug is still there in grid view on 34.

The grid entry destructures the store directly:

```js
const {
	activeFolder,
	activeNode,
	activeView,
} = useActiveStore()
```

Those are plain values captured on the first render and never update again. `FileEntryMixin.execDefaultAction` hands `this.activeFolder` to the file action, the viewer builds its route from `folder.path`, and the list gets navigated to whichever folder was active back then.

Reproduced on 34.0.2 with the list in grid view, going into `/Level1/Level2/Level3/Level4` and clicking a PDF:

```
pushState    /apps/files/files/79?dir=/Level1/Level2/Level3/Level4
replaceState /apps/files/files/80?dir=/&editing=false&openfile=true
replaceState /apps/files/files/80?dir=/Level1/Level2/Level3/Level4&editing=false&openfile=true
```

The first replace goes to `dir=/`, so the root is fetched and the file opens over the wrong listing. It corrects itself a moment later, but the wrong navigation has already happened, and that is the "dropped back at the root" from #59941. The same steps in list view keep the right dir the whole way.

Same `storeToRefs` change as #59942. The setup block already carried a `// keep in sync with FileEntry.vue` comment, which is what got missed.

`FileEntryGrid.spec.ts` covers it: it fails on master and passes with the change.

Worth backporting to stable34 and stable33, both are affected. Happy to request that once this looks good.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
