### PR TITLE
feat: allow specifying the actor in unified sharing cli

### DIFF
--- a/apps/sharing/lib/Command/AddShareRecipient.php
+++ b/apps/sharing/lib/Command/AddShareRecipient.php
@@ -27,6 +27,7 @@ final class AddShareRecipient extends SharingBase {
 			->addArgument('class', InputArgument::REQUIRED, 'Recipient class')
 			->addArgument('value', InputArgument::REQUIRED, 'Recipient value')
 			->addArgument('instance', InputArgument::OPTIONAL, 'Recipient instance');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -40,7 +41,7 @@ final class AddShareRecipient extends SharingBase {
 		/** @var ?non-empty-string $instance */
 		$instance = $input->getArgument('instance');
 
-		return $this->wrapExecution($output, function () use ($id, $class, $value, $instance): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $class, $value, $instance): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->addShareRecipient($this->accessContext, $share, new ShareRecipient($class, $value, $instance));
 		});

--- a/apps/sharing/lib/Command/AddShareSource.php
+++ b/apps/sharing/lib/Command/AddShareSource.php
@@ -25,6 +25,7 @@ final class AddShareSource extends SharingBase {
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID')
 			->addArgument('class', InputArgument::REQUIRED, 'Source class')
 			->addArgument('value', InputArgument::REQUIRED, 'Source value');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -36,7 +37,7 @@ final class AddShareSource extends SharingBase {
 		/** @var non-empty-string $value */
 		$value = $input->getArgument('value');
 
-		return $this->wrapExecution($output, function () use ($id, $class, $value): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $class, $value): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->addShareSource($this->accessContext, $share, new ShareSource($class, $value));
 		});

--- a/apps/sharing/lib/Command/CreateShare.php
+++ b/apps/sharing/lib/Command/CreateShare.php
@@ -26,6 +26,7 @@ final class CreateShare extends SharingBase {
 			->setName('sharing:create-share')
 			->setDescription('Create a new share.')
 			->addArgument('owner', InputArgument::REQUIRED, 'User ID of the owner');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -37,6 +38,6 @@ final class CreateShare extends SharingBase {
 			throw new ShareInvalidException('The owner does not exist: ' . $ownerUid, Server::get(IFactory::class)->get('sharing')->t('The owner does not exist: %s', [$ownerUid]));
 		}
 
-		return $this->wrapExecution($output, fn (): Share => $this->manager->createShare(new ShareAccessContext($owner)));
+		return $this->wrapExecution($input, $output, fn (): Share => $this->manager->createShare(new ShareAccessContext($owner)));
 	}
 }

--- a/apps/sharing/lib/Command/DeleteShare.php
+++ b/apps/sharing/lib/Command/DeleteShare.php
@@ -24,12 +24,14 @@ final class DeleteShare extends SharingBase {
 			->setName('sharing:delete-share')
 			->setDescription('Delete a share.')
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID');
+		parent::configure();
 	}
 
 	#[\Override]
 	public function execute(InputInterface $input, OutputInterface $output): int {
 		/** @var string $id */
 		$id = $input->getArgument('id');
+		$this->applyActor($input);
 
 		try {
 			try {

--- a/apps/sharing/lib/Command/GetShare.php
+++ b/apps/sharing/lib/Command/GetShare.php
@@ -21,6 +21,7 @@ final class GetShare extends SharingBase {
 			->setName('sharing:get-share')
 			->setDescription('Get a share.')
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -28,6 +29,6 @@ final class GetShare extends SharingBase {
 		/** @var string $id */
 		$id = $input->getArgument('id');
 
-		return $this->wrapExecution($output, fn (): Share => $this->manager->getShare($this->accessContext, $id));
+		return $this->wrapExecution($input, $output, fn (): Share => $this->manager->getShare($this->accessContext, $id));
 	}
 }

--- a/apps/sharing/lib/Command/GetShares.php
+++ b/apps/sharing/lib/Command/GetShares.php
@@ -27,10 +27,13 @@ final class GetShares extends SharingBase {
 			->addOption('filter-source-type-value', '', InputOption::VALUE_REQUIRED, 'Source type value to filter by')
 			->addOption('last-share-id', '', InputOption::VALUE_REQUIRED, 'Share ID to use as an offset')
 			->addOption('limit', '', InputOption::VALUE_REQUIRED, 'Maximum number of shares to return');
+		parent::configure();
 	}
 
 	#[\Override]
 	public function execute(InputInterface $input, OutputInterface $output): int {
+		$this->applyActor($input);
+
 		/** @var ?class-string<IShareSourceType> $filterSourceTypeClass */
 		$filterSourceTypeClass = $input->getOption('filter-source-type-class');
 		/** @var ?class-string<IShareSourceType> $filterSourceTypeValue */

--- a/apps/sharing/lib/Command/RemoveShareRecipient.php
+++ b/apps/sharing/lib/Command/RemoveShareRecipient.php
@@ -26,6 +26,7 @@ final class RemoveShareRecipient extends SharingBase {
 			->addArgument('class', InputArgument::REQUIRED, 'Recipient class')
 			->addArgument('value', InputArgument::REQUIRED, 'Recipient value')
 			->addArgument('instance', InputArgument::OPTIONAL, 'Recipient instance');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -39,7 +40,7 @@ final class RemoveShareRecipient extends SharingBase {
 		/** @var ?non-empty-string $instance */
 		$instance = $input->getArgument('instance');
 
-		return $this->wrapExecution($output, function () use ($id, $class, $value, $instance): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $class, $value, $instance): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->removeShareRecipient($this->accessContext, $share, new ShareRecipient($class, $value, $instance));
 		});

--- a/apps/sharing/lib/Command/RemoveShareSource.php
+++ b/apps/sharing/lib/Command/RemoveShareSource.php
@@ -25,6 +25,7 @@ final class RemoveShareSource extends SharingBase {
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID')
 			->addArgument('class', InputArgument::REQUIRED, 'Source class')
 			->addArgument('value', InputArgument::REQUIRED, 'Source value');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -36,7 +37,7 @@ final class RemoveShareSource extends SharingBase {
 		/** @var non-empty-string $value */
 		$value = $input->getArgument('value');
 
-		return $this->wrapExecution($output, function () use ($id, $class, $value): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $class, $value): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->removeShareSource($this->accessContext, $share, new ShareSource($class, $value));
 		});

--- a/apps/sharing/lib/Command/SelectSharePermissionPreset.php
+++ b/apps/sharing/lib/Command/SelectSharePermissionPreset.php
@@ -23,6 +23,7 @@ final class SelectSharePermissionPreset extends SharingBase {
 			->setDescription('Select a permission preset for a share.')
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID')
 			->addArgument('permission-preset', InputArgument::REQUIRED, 'Permission preset');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -32,7 +33,7 @@ final class SelectSharePermissionPreset extends SharingBase {
 		/** @var class-string<ISharePermissionPreset> $permissionPresetClass */
 		$permissionPresetClass = $input->getArgument('permission-preset');
 
-		return $this->wrapExecution($output, function () use ($id, $permissionPresetClass): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $permissionPresetClass): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->selectSharePermissionPreset($this->accessContext, $share, $permissionPresetClass);
 		});

--- a/apps/sharing/lib/Command/SharingBase.php
+++ b/apps/sharing/lib/Command/SharingBase.php
@@ -22,6 +22,8 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,10 +42,28 @@ abstract class SharingBase extends Command {
 		$this->accessContext = new ShareAccessContext(overrideChecks: true);
 	}
 
+	#[\Override]
+	public function configure(): void {
+		$this
+			->addOption('actor', null, InputOption::VALUE_REQUIRED, 'User ID to use as the actor for any share modification');
+		parent::configure();
+	}
+
+	protected function applyActor(InputInterface $input): void {
+		/** @var ?string $actorId */
+		$actorId = $input->getOption('actor');
+
+		if ($actorId !== null) {
+			$actor = $this->userManager->get($actorId);
+			$this->accessContext = new ShareAccessContext(currentUser: $actor, overrideChecks: true);
+		}
+	}
+
 	/**
 	 * @param Closure():Share $closure
 	 */
-	protected function wrapExecution(OutputInterface $output, Closure $closure): int {
+	protected function wrapExecution(InputInterface $input, OutputInterface $output, Closure $closure): int {
+		$this->applyActor($input);
 
 		try {
 			try {

--- a/apps/sharing/lib/Command/UpdateSharePermission.php
+++ b/apps/sharing/lib/Command/UpdateSharePermission.php
@@ -25,6 +25,7 @@ final class UpdateSharePermission extends SharingBase {
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID')
 			->addArgument('class', InputArgument::REQUIRED, 'Permission class')
 			->addArgument('enabled', InputArgument::REQUIRED, 'Permission enabled. Only takes "true" or "false".');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -37,7 +38,7 @@ final class UpdateSharePermission extends SharingBase {
 		$enabled = $input->getArgument('enabled');
 		$enabled = $enabled === 'true';
 
-		return $this->wrapExecution($output, function () use ($id, $class, $enabled): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $class, $enabled): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->updateSharePermission($this->accessContext, $share, new SharePermission($class, $enabled));
 		});

--- a/apps/sharing/lib/Command/UpdateShareProperty.php
+++ b/apps/sharing/lib/Command/UpdateShareProperty.php
@@ -25,6 +25,7 @@ final class UpdateShareProperty extends SharingBase {
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID')
 			->addArgument('class', InputArgument::REQUIRED, 'Property class')
 			->addArgument('value', InputArgument::OPTIONAL, 'Property value. Omitting it will remove the value.');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -36,7 +37,7 @@ final class UpdateShareProperty extends SharingBase {
 		/** @var ?string $value */
 		$value = $input->getArgument('value');
 
-		return $this->wrapExecution($output, function () use ($id, $class, $value): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $class, $value): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->updateShareProperty($this->accessContext, $share, new ShareProperty($class, $value));
 		});

--- a/apps/sharing/lib/Command/UpdateShareRecipientSecret.php
+++ b/apps/sharing/lib/Command/UpdateShareRecipientSecret.php
@@ -27,6 +27,7 @@ final class UpdateShareRecipientSecret extends SharingBase {
 			->addArgument('class', InputArgument::REQUIRED, 'Recipient class')
 			->addArgument('value', InputArgument::REQUIRED, 'Recipient value')
 			->addArgument('instance', InputArgument::OPTIONAL, 'Recipient instance');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -42,7 +43,7 @@ final class UpdateShareRecipientSecret extends SharingBase {
 		/** @var non-empty-string $secret */
 		$secret = $input->getArgument('secret');
 
-		return $this->wrapExecution($output, function () use ($id, $class, $value, $instance, $secret): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $class, $value, $instance, $secret): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->updateShareRecipientSecret($this->accessContext, $share, new ShareRecipient($class, $value, $instance), $secret);
 		});

--- a/apps/sharing/lib/Command/UpdateShareState.php
+++ b/apps/sharing/lib/Command/UpdateShareState.php
@@ -23,6 +23,7 @@ final class UpdateShareState extends SharingBase {
 			->setDescription('Update the state of a share.')
 			->addArgument('id', InputArgument::REQUIRED, 'Share ID')
 			->addArgument('state', InputArgument::REQUIRED, 'State');
+		parent::configure();
 	}
 
 	#[\Override]
@@ -33,7 +34,7 @@ final class UpdateShareState extends SharingBase {
 		$state = $input->getArgument('state');
 		$state = ShareState::from($state);
 
-		return $this->wrapExecution($output, function () use ($id, $state): Share {
+		return $this->wrapExecution($input, $output, function () use ($id, $state): Share {
 			$share = $this->manager->getShare($this->accessContext, $id);
 			return $this->manager->updateShareState($this->accessContext, $share, $state);
 		});

--- a/apps/sharing/tests/Command/CommandTest.php
+++ b/apps/sharing/tests/Command/CommandTest.php
@@ -97,6 +97,7 @@ final class CommandTest extends AbstractSharingManagerTests {
 			throw new RuntimeException('Command class ' . $class . ' is not allowed to be used unless added to the array.');
 		}
 
+		$options[] = ['actor', null];
 		$input = $this->createMock(Input::class);
 		$input
 			->expects($this->exactly(count($arguments)))


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Otherwise adding a recipient is impossible because it can't determine the initiator

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
