### PR TITLE
allow specifying output format in unified sharing cli 

### DIFF
--- a/apps/sharing/lib/Command/GetShares.php
+++ b/apps/sharing/lib/Command/GetShares.php
@@ -55,7 +55,9 @@ final class GetShares extends SharingBase {
 
 			$shares = $this->manager->getShares($this->accessContext, $filterSourceTypeClass, $filterSourceTypeValue, $lastShareID, $limit);
 			$this->dbConnection->commit();
-			$output->writeln(json_encode(Share::formatMultiple($this->registry, $this->l10nFactory, $this->urlGenerator, $this->userManager, $shares), JSON_THROW_ON_ERROR));
+
+			$data = Share::formatMultiple($this->registry, $this->l10nFactory, $this->urlGenerator, $this->userManager, $shares);
+			$this->writeArrayInOutputFormat($input, $output, $data);
 			return Base::SUCCESS;
 		} catch (Exception $exception) {
 			$this->dbConnection->rollBack();

--- a/apps/sharing/lib/Command/SharingBase.php
+++ b/apps/sharing/lib/Command/SharingBase.php
@@ -21,13 +21,12 @@ use OCP\IDBConnection;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-abstract class SharingBase extends Command {
+abstract class SharingBase extends Base {
 	public ShareAccessContext $accessContext;
 
 	public function __construct(
@@ -71,7 +70,10 @@ abstract class SharingBase extends Command {
 
 				$share = $closure();
 				$this->dbConnection->commit();
-				$output->writeln(json_encode($share->format($this->registry, $this->l10nFactory, $this->urlGenerator, $this->userManager), JSON_THROW_ON_ERROR));
+
+				$data = $share->format($this->registry, $this->l10nFactory, $this->urlGenerator, $this->userManager);
+				$this->writeArrayInOutputFormat($input, $output, $data);
+
 				return Base::SUCCESS;
 			} catch (Exception $exception) {
 				$this->dbConnection->rollBack();

--- a/apps/sharing/tests/Command/CommandTest.php
+++ b/apps/sharing/tests/Command/CommandTest.php
@@ -98,13 +98,13 @@ final class CommandTest extends AbstractSharingManagerTests {
 		}
 
 		$options[] = ['actor', null];
+		$options[] = ['output', Base::OUTPUT_FORMAT_JSON];
 		$input = $this->createMock(Input::class);
 		$input
 			->expects($this->exactly(count($arguments)))
 			->method('getArgument')
 			->willReturnMap($arguments);
 		$input
-			->expects($this->exactly(count($options)))
 			->method('getOption')
 			->willReturnMap($options);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Gives the cli the usual output options

## Depends on

- [x] https://github.com/nextcloud/server/pull/63190

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
