### PR TITLE
fix(previews): reject empty folder-share path in PublicPreviewController

### DIFF
--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -126,6 +126,9 @@ class PublicPreviewController extends PublicShareController {
 		try {
 			$node = $share->getNode();
 			if ($node instanceof Folder) {
+				if ($file === '') {
+					return new DataResponse([], Http::STATUS_BAD_REQUEST);
+				}
 				$file = $node->get($file);
 			} else {
 				$file = $node;

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -253,6 +253,32 @@ class PublicPreviewControllerTest extends TestCase {
 		$this->assertEquals($expected, $res);
 	}
 
+	public function testPreviewFolderEmptyFile(): void {
+		$share = $this->createMock(IShare::class);
+		$this->shareManager->method('getShareByToken')
+			->with($this->equalTo('token'))
+			->willReturn($share);
+
+		$share->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
+
+		$folder = $this->createMock(Folder::class);
+		$share->method('getNode')
+			->willReturn($folder);
+
+		$share->method('canSeeContent')
+			->willReturn(true);
+
+		$folder->expects($this->never())
+			->method('get');
+		$this->previewManager->expects($this->never())
+			->method('getPreview');
+
+		$res = $this->controller->getPreview('token', '', 10, 10, true);
+		$expected = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$this->assertEquals($expected, $res);
+	}
+
 	public function testPreviewFolderValidFile(): void {
 		$share = $this->createMock(IShare::class);
 		$this->shareManager->method('getShareByToken')


### PR DESCRIPTION
## Summary
- Return `400 Bad Request` when a folder-share public preview request has an empty file path, before preview generation.
- Adds a regression unit test so empty folder-share paths no longer reach folder lookup / preview code.

Fixes #59229

## Test plan
- [ ] Request a public preview for a folder share with an empty path → expect 400
- [ ] Valid file preview under a folder share still works
- [ ] Run the new PublicPreviewController unit test


Made with [Cursor](https://cursor.com)