### PR TITLE
fix(files_external): skip BSD ftpd total N listing headers

### DIFF
--- a/apps/files_external/lib/Lib/Storage/FtpConnection.php
+++ b/apps/files_external/lib/Lib/Storage/FtpConnection.php
@@ -121,9 +121,15 @@ class FtpConnection {
 
 	// rawlist parsing logic is based on the ftp implementation from https://github.com/thephpleague/flysystem
 	private function parseRawList(array $rawList, string $directory): array {
+		$filtered = array_values(array_filter($rawList, static function (string $item): bool {
+			$item = trim($item);
+			// BSD ftpd (and some Unix servers) prepend listings with a "total N" header
+			return $item !== '' && !preg_match('/^total\b/i', $item);
+		}));
+
 		return array_map(function ($item) use ($directory) {
 			return $this->parseRawListItem($item, $directory);
-		}, $rawList);
+		}, $filtered);
 	}
 
 	private function parseRawListItem(string $item, string $directory): array {


### PR DESCRIPTION
## Summary
- BSD ftpd prepends `LIST` output with a `total N` line. The raw-list fallback in `FtpConnection` tried to parse that as a file entry and threw `Metadata can't be parsed from item 'total 17'`.
- Skip empty lines and `total` headers the same way [flysystem does](https://github.com/thephpleague/flysystem/blob/235ae805a26f6fbd4d7a5f1c8e3bdf2c386adab3/src/Ftp/FtpAdapter.php#L365-L381). `.` / `..` are still parsed as `cdir` / `pdir`.

Fixes #37045

## Checklist
- [x] Code is from this PR's author
- [x] Signed-off-by is in the commit
- [ ] Tests added where possible (parser is private; existing FTP tests are integration-only against a live server)


Made with [Cursor](https://cursor.com)