### PR TITLE
fix: Respect cached false for OCM discovery

### DIFF
--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -100,19 +100,19 @@ final class OCMDiscoveryService implements IOCMDiscoveryService {
 		$provider = new OCMProvider();
 
 		if (!$skipCache) {
-			try {
-				$cached = $this->cache->get($remote);
-				if ($cached === false) {
-					throw new OCMProviderException('Previous discovery failed.');
-				}
+			$cached = $this->cache->get($remote);
+			if ($cached === false) {
+				throw new OCMProviderException('Previous discovery failed.');
+			}
 
-				if ($cached !== null) {
+			if ($cached !== null) {
+				try {
 					$provider->import(json_decode($cached, true, 8, JSON_THROW_ON_ERROR) ?? []);
 					$this->remoteProviders[$remote] = $provider;
 					return $provider;
+				} catch (JsonException|OCMProviderException $e) {
+					$this->logger->warning('cache issue on ocm discovery', ['exception' => $e]);
 				}
-			} catch (JsonException|OCMProviderException $e) {
-				$this->logger->warning('cache issue on ocm discovery', ['exception' => $e]);
 			}
 		}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

The throw was caught so it was continuing to retry the discovery on each request. The intent of the code was clearly to cache the false result.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
