### PR TITLE
feat: profile hovercard

### DIFF
--- a/core/src/components/ContactsMenu/ContactMenuEntry.vue
+++ b/core/src/components/ContactsMenu/ContactMenuEntry.vue
@@ -5,21 +5,26 @@
 
 <template>
 	<li class="contact">
-		<NcAvatar
-			class="contact__avatar"
-			:user="contact.isUser ? contact.uid : undefined"
-			:is-no-user="!contact.isUser"
-			:disable-menu="true"
-			:display-name="contact.avatarLabel"
-			:preloaded-user-status="preloadedUserStatus" />
-		<a
-			class="contact__body"
-			:href="contact.profileUrl || contact.topAction?.hyperlink">
-			<div class="contact__body__full-name">{{ contact.fullName }}</div>
-			<div v-if="contact.lastMessage" class="contact__body__last-message">{{ contact.lastMessage }}</div>
-			<div v-if="contact.statusMessage" class="contact__body__status-message">{{ contact.statusMessage }}</div>
-			<div v-else class="contact__body__email-address">{{ contact.emailAddresses[0] }}</div>
-		</a>
+		<NcProfileHoverCard
+			:user="contact.isUser ? contact.uid : null">
+			<div class="contact__main">
+				<NcAvatar
+					class="contact__avatar"
+					:user="contact.isUser ? contact.uid : undefined"
+					:is-no-user="!contact.isUser"
+					:disable-menu="true"
+					:display-name="contact.avatarLabel"
+					:preloaded-user-status="preloadedUserStatus" />
+				<a
+					class="contact__body"
+					:href="contact.profileUrl || contact.topAction?.hyperlink">
+					<div class="contact__body__full-name">{{ contact.fullName }}</div>
+					<div v-if="contact.lastMessage" class="contact__body__last-message">{{ contact.lastMessage }}</div>
+					<div v-if="contact.statusMessage" class="contact__body__status-message">{{ contact.statusMessage }}</div>
+					<div v-else class="contact__body__email-address">{{ contact.emailAddresses[0] }}</div>
+				</a>
+			</div>
+		</NcProfileHoverCard>
 		<NcActions
 			v-if="actions.length"
 			:inline="contact.topAction ? 1 : 0">
@@ -64,6 +69,7 @@ import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionText from '@nextcloud/vue/components/NcActionText'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import NcProfileHoverCard from '@nextcloud/vue/components/NcProfileHoverCard'
 
 export default {
 	name: 'ContactMenuEntry',
@@ -74,6 +80,7 @@ export default {
 		NcActions,
 		NcAvatar,
 		NcIconSvgWrapper,
+		NcProfileHoverCard,
 	},
 
 	props: {
@@ -124,6 +131,11 @@ export default {
 			padding: calc((var(--default-clickable-area) - 20px) / 2);
 			filter: var(--background-invert-if-dark);
 		}
+	}
+
+	&__main {
+		display: flex;
+		align-items: center;
 	}
 
 	&__avatar {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #30868 
* Related PR: https://github.com/nextcloud-libraries/nextcloud-vue/pull/8845

## Summary
- Wrap contacts menu entries with `NcProfileHoverCard` so hovering a user in the contacts menu shows their profile hovercard

## Screenshots
### Desktop
<img width="568" height="331" alt="image" src="https://github.com/user-attachments/assets/0df7ac07-2694-4a26-ae22-2bf2f23c5b7c" />
<img width="568" height="301" alt="image" src="https://github.com/user-attachments/assets/d35d33e4-8043-4611-b4ed-c9c959b03836" />

### Mobile
<img width="491" height="397" alt="image" src="https://github.com/user-attachments/assets/4e323bae-24dd-40b3-b130-db3f34833f9c" />
<img width="492" height="371" alt="image" src="https://github.com/user-attachments/assets/0a346200-0baf-43f3-b97c-087225390f07" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
