### PR TITLE
fix: Remove discovery fallback in external storage

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -35,8 +35,6 @@ use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IUserSession;
-use OCP\OCM\Exceptions\OCMArgumentException;
-use OCP\OCM\Exceptions\OCMProviderException;
 use OCP\OCM\IOCMDiscoveryService;
 use OCP\Server;
 use OCP\Share\IManager as IShareManager;
@@ -78,18 +76,10 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		$this->appConfig = Server::get(IAppConfig::class);
 		$this->shareManager = Server::get(IShareManager::class);
 
-		// use default path to webdav if not found on discovery
-		try {
-			$ocmProvider = $discoveryService->discover($this->cloudId->getRemote());
-			$webDavEndpoint = $ocmProvider->extractProtocolEntry('file', 'webdav');
-			$remote = $ocmProvider->getEndPoint();
-			$authType = \Sabre\DAV\Client::AUTH_BASIC;
-		} catch (OCMProviderException|OCMArgumentException $e) {
-			$this->logger->notice('exception while retrieving webdav endpoint', ['exception' => $e]);
-			$webDavEndpoint = '/public.php/webdav';
-			$remote = $this->cloudId->getRemote();
-			$authType = \Sabre\DAV\Client::AUTH_BASIC;
-		}
+		$ocmProvider = $discoveryService->discover($this->cloudId->getRemote());
+		$webDavEndpoint = $ocmProvider->extractProtocolEntry('file', 'webdav');
+		$remote = $ocmProvider->getEndPoint();
+		$authType = \Sabre\DAV\Client::AUTH_BASIC;
 
 		// Only use Bearer auth when an access token is already stored.
 		// Shares created before the exchange-token capability was introduced have no


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Follow-up of #63200

## Summary

If the OCM discovery throws an exception, let that bubble up into a FailedStorage instead of trying to be smart. 
This avoids unnecessary requests to badly configured or offline servers.

Locally I tested this together with #63200 and it helps a lot for browsing files unrelated to a federated share if the federated server is offline.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
