### PR TITLE
Fix cancelling the customization of a share

### DIFF
--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -128,15 +128,6 @@ export default {
 			return (typeof this.share.status === 'object' && !Array.isArray(this.share.status))
 		},
 	},
-
-	methods: {
-		/**
-		 * Save potential changed data on menu close
-		 */
-		onMenuClose() {
-			this.onNoteSubmit()
-		},
-	},
 }
 </script>
 

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -900,7 +900,6 @@ export default {
 		 */
 		onMenuClose() {
 			this.onPasswordSubmit()
-			this.onNoteSubmit()
 		},
 
 		/**

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -452,30 +452,6 @@ export default {
 		},
 
 		/**
-		 * Is it possible to protect the password by Talk?
-		 *
-		 * @return {boolean}
-		 */
-		isPasswordProtectedByTalkAvailable() {
-			return this.isPasswordProtected && this.isTalkEnabled
-		},
-
-		/**
-		 * Is the current share password protected by Talk?
-		 *
-		 * @return {boolean}
-		 */
-		isPasswordProtectedByTalk: {
-			get() {
-				return this.share.sendPasswordByTalk
-			},
-
-			async set(enabled) {
-				this.share.sendPasswordByTalk = enabled
-			},
-		},
-
-		/**
 		 * Is the current share an email share ?
 		 *
 		 * @return {boolean}
@@ -484,20 +460,6 @@ export default {
 			return this.share
 				? this.share.type === ShareType.Email
 				: false
-		},
-
-		canTogglePasswordProtectedByTalkAvailable() {
-			if (!this.isPasswordProtected) {
-				// Makes no sense
-				return false
-			} else if (this.isEmailShareType && !this.hasUnsavedPassword) {
-				// For email shares we need a new password in order to enable or
-				// disable
-				return false
-			}
-
-			// Anything else should be fine
-			return true
 		},
 
 		/**
@@ -860,22 +822,6 @@ export default {
 			if (this.share.id) {
 				this.queueUpdate('password')
 			}
-		},
-
-		/**
-		 * Update the password along with "sendPasswordByTalk".
-		 *
-		 * If the password was modified the new password is sent; otherwise
-		 * updating a mail share would fail, as in that case it is required that
-		 * a new password is set when enabling or disabling
-		 * "sendPasswordByTalk".
-		 */
-		onPasswordProtectedByTalkChange() {
-			if (this.hasUnsavedPassword) {
-				this.share.newPassword = this.share.newPassword.trim()
-			}
-
-			this.queueUpdate('sendPasswordByTalk', 'password')
 		},
 
 		/**

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -147,8 +147,7 @@
 			class="sharing-entry__actions"
 			:aria-label="actionsTooltip"
 			menu-align="right"
-			:open.sync="open"
-			@close="onMenuClose">
+			:open.sync="open">
 			<template v-if="share">
 				<template v-if="share.canEdit && canReshare">
 					<NcActionButton
@@ -864,22 +863,6 @@ export default {
 		},
 
 		/**
-		 * Menu have been closed or password has been submitted.
-		 * The only property that does not get
-		 * synced automatically is the password
-		 * So let's check if we have an unsaved
-		 * password.
-		 * expireDate is saved on datepicker pick
-		 * or close.
-		 */
-		onPasswordSubmit() {
-			if (this.hasUnsavedPassword) {
-				this.share.newPassword = this.share.newPassword.trim()
-				this.queueUpdate('password')
-			}
-		},
-
-		/**
 		 * Update the password along with "sendPasswordByTalk".
 		 *
 		 * If the password was modified the new password is sent; otherwise
@@ -893,13 +876,6 @@ export default {
 			}
 
 			this.queueUpdate('sendPasswordByTalk', 'password')
-		},
-
-		/**
-		 * Save potential changed data on menu close
-		 */
-		onMenuClose() {
-			this.onPasswordSubmit()
 		},
 
 		/**

--- a/apps/files_sharing/src/mixins/SharesMixin.js
+++ b/apps/files_sharing/src/mixins/SharesMixin.js
@@ -262,27 +262,6 @@ export default {
 		},
 
 		/**
-		 * Note changed, let's save it to a different key
-		 *
-		 * @param {string} note the share note
-		 */
-		onNoteChange(note) {
-			this.$set(this.share, 'newNote', note.trim())
-		},
-
-		/**
-		 * When the note change, we trim, save and dispatch
-		 *
-		 */
-		onNoteSubmit() {
-			if (this.share.newNote) {
-				this.share.note = this.share.newNote
-				this.$delete(this.share, 'newNote')
-				this.queueUpdate('note')
-			}
-		},
-
-		/**
 		 * Delete share button handler
 		 */
 		async onDelete() {

--- a/apps/files_sharing/src/mixins/SharesMixin.js
+++ b/apps/files_sharing/src/mixins/SharesMixin.js
@@ -327,7 +327,7 @@ export default {
 						if (propertyNames.includes('password')) {
 							// reset password state after sync
 							this.share.password = this.share.newPassword || undefined
-							this.$delete(this.share, 'newPassword')
+							this.$set(this.share, 'newPassword', undefined)
 
 							// updates password expiration time after sync
 							this.share.passwordExpirationTime = updatedShare.password_expiration_time
@@ -398,7 +398,7 @@ export default {
 				if (this.share.newPassword === this.share.password) {
 					this.share.password = ''
 				}
-				this.$delete(this.share, 'newPassword')
+				this.$set(this.share, 'newPassword', undefined)
 			}
 
 			// re-open menu if closed

--- a/apps/files_sharing/src/models/Share.ts
+++ b/apps/files_sharing/src/models/Share.ts
@@ -422,7 +422,7 @@ export default class Share {
 		const hasDisabledDownload = (attribute) => {
 			return attribute.scope === 'permissions' && attribute.key === 'download' && attribute.value === false
 		}
-		return this.attributes.some(hasDisabledDownload)
+		return !this.attributes.some(hasDisabledDownload)
 	}
 
 	/**

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -398,6 +398,13 @@ export default {
 			creating: false,
 			initialToken: this.share.token,
 			loadingToken: false,
+			initialPermissions: undefined,
+			initialExpireDate: undefined,
+			initialNote: undefined,
+			initialLabel: undefined,
+			initialHideDownload: undefined,
+			initialSendPasswordByTalk: undefined,
+			initialHasDownloadPermission: undefined,
 
 			externalShareActions: getSidebarActions(),
 			// legacy
@@ -865,6 +872,14 @@ export default {
 	},
 
 	beforeMount() {
+		this.initialPermissions = this.share.permissions
+		this.initialExpireDate = this.share.expireDate
+		this.initialNote = this.share.note
+		this.initialLabel = this.share.label
+		this.initialHideDownload = this.share.hideDownload
+		this.initialSendPasswordByTalk = this.share.sendPasswordByTalk
+		this.initialHasDownloadPermission = this.share.hasDownloadPermission
+
 		this.initializePermissions()
 		this.initializeAttributes()
 		logger.debug('Share object received', { share: this.share })
@@ -929,6 +944,16 @@ export default {
 
 		cancel() {
 			this.share.token = this.initialToken
+			this.share.permissions = this.initialPermissions
+			this.share.expireDate = this.initialExpireDate
+			this.share.note = this.initialNote
+			this.share.label = this.initialLabel
+			this.share.hideDownload = this.initialHideDownload
+			this.share.sendPasswordByTalk = this.initialSendPasswordByTalk
+			this.share.hasDownloadPermission = this.initialHasDownloadPermission
+
+			this.$set(this.share, 'newPassword', undefined)
+
 			this.$emit('close-sharing-details')
 		},
 

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -155,8 +155,7 @@
 					</template>
 					<NcCheckboxRadioSwitch
 						v-if="canTogglePasswordProtectedByTalkAvailable"
-						v-model="isPasswordProtectedByTalk"
-						@update:modelValue="onPasswordProtectedByTalkChange">
+						v-model="isPasswordProtectedByTalk">
 						{{ t('files_sharing', 'Video verification') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch v-model="hasExpirationDate" :disabled="isExpiryDateEnforced">
@@ -1240,22 +1239,6 @@ export default {
 			}
 			this.passwordError = !this.isValidShareAttribute(password)
 			this.$set(this.share, 'newPassword', password)
-		},
-
-		/**
-		 * Update the password along with "sendPasswordByTalk".
-		 *
-		 * If the password was modified the new password is sent; otherwise
-		 * updating a mail share would fail, as in that case it is required that
-		 * a new password is set when enabling or disabling
-		 * "sendPasswordByTalk".
-		 */
-		onPasswordProtectedByTalkChange() {
-			if (this.isEmailShareType || this.hasUnsavedPassword) {
-				this.queueUpdate('sendPasswordByTalk', 'password')
-			} else {
-				this.queueUpdate('sendPasswordByTalk')
-			}
 		},
 
 		isValidShareAttribute(value) {

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -178,8 +178,7 @@
 					<NcCheckboxRadioSwitch
 						v-if="isPublicShare"
 						v-model="share.hideDownload"
-						:disabled="canChangeHideDownload"
-						@update:modelValue="queueUpdate('hideDownload')">
+						:disabled="canChangeHideDownload">
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -1258,7 +1258,7 @@ export default {
 		 */
 		onPasswordChange(password) {
 			if (password === '') {
-				this.$delete(this.share, 'newPassword')
+				this.$set(this.share, 'newPassword', undefined)
 				this.passwordError = this.isNewShare && this.isPasswordEnforced
 				return
 			}

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -1064,7 +1064,7 @@ export default {
 
 		async saveShare() {
 			const permissionsAndAttributes = ['permissions', 'attributes', 'note', 'expireDate']
-			const publicShareAttributes = ['label', 'hideDownload']
+			const publicShareAttributes = ['label', 'hideDownload', 'sendPasswordByTalk']
 			// Only include password if it's being actively changed
 			if (this.hasUnsavedPassword) {
 				publicShareAttributes.push('password')
@@ -1096,6 +1096,13 @@ export default {
 				}
 			} else {
 				this.share.password = ''
+			}
+
+			// "Video verification" must be disabled if the password was
+			// disabled, as it does not make sense and would also prevent
+			// saving if it is still enabled.
+			if (this.isPasswordProtectedByTalk && !this.isPasswordProtected) {
+				this.isPasswordProtectedByTalk = false
 			}
 
 			if (!this.hasExpirationDate) {

--- a/build/eslint-baseline-legacy.json
+++ b/build/eslint-baseline-legacy.json
@@ -16,7 +16,7 @@
   },
   "apps/files_sharing/src/views/SharingDetailsTab.vue": {
     "vue/no-mutating-props": {
-      "count": 24
+      "count": 31
     }
   },
   "apps/files_sharing/src/views/SharingLinkList.vue": {

--- a/tests/playwright/e2e/files_sharing/public-share/share-editor.spec.ts
+++ b/tests/playwright/e2e/files_sharing/public-share/share-editor.spec.ts
@@ -41,8 +41,8 @@ test.describe('files_sharing: Link share editor', () => {
 		await sharingTab.openLinkShareDetails()
 		await sharingTab.openAdvancedSettings()
 		await expect(sharingTab.checkbox('Hide download')).not.toBeChecked()
-		await sharingTab.setCheckbox('Hide download', true, { persists: true })
-		await sharingTab.closeDetails()
+		await sharingTab.setCheckbox('Hide download', true)
+		await sharingTab.save()
 
 		// Still set when the editor is opened again …
 		await sharingTab.openLinkShareDetails()

--- a/tests/playwright/e2e/files_sharing/public-share/share-editor.spec.ts
+++ b/tests/playwright/e2e/files_sharing/public-share/share-editor.spec.ts
@@ -56,6 +56,53 @@ test.describe('files_sharing: Link share editor', () => {
 		await sharingTab.openAdvancedSettings()
 		await expect(sharingTab.checkbox('Hide download')).toBeChecked()
 	})
+
+	test('cancelling the edition resets to the previous state', async ({ page, filesListPage, sharingTab }) => {
+		await openSharingPanel(filesListPage, sharingTab, 'test')
+
+		await sharingTab.openLinkShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.labelInput()).toHaveValue('')
+		await sharingTab.labelInput().fill('The label')
+		await expect(sharingTab.checkbox('Set password')).not.toBeChecked()
+		await sharingTab.setCheckbox('Set password', true)
+		// A password is automatically generated and added to the input
+		await expect(sharingTab.checkbox('Set expiration date')).not.toBeChecked()
+		await sharingTab.setCheckbox('Set expiration date', true)
+		// A default expiration date is automatically added to the input
+		await expect(sharingTab.checkbox('Hide download')).not.toBeChecked()
+		await sharingTab.setCheckbox('Hide download', true)
+		await expect(sharingTab.checkbox('Note to recipient')).not.toBeChecked()
+		await sharingTab.setCheckbox('Note to recipient', true)
+		await sharingTab.noteInput().fill('The note')
+		await expect(sharingTab.checkbox('Custom permissions')).not.toBeChecked()
+		await sharingTab.setCheckbox('Custom permissions', true)
+		await expect(sharingTab.checkbox('Edit')).not.toBeChecked()
+		await sharingTab.setCheckbox('Edit', true)
+		await sharingTab.cancel()
+
+		// Back to the original state when the editor is opened again …
+		await sharingTab.openLinkShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.labelInput()).toHaveValue('')
+		await expect(sharingTab.checkbox('Set password')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Set expiration date')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Hide download')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Note to recipient')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Custom permissions')).not.toBeChecked()
+
+		// … and after a reload, i.e. it was not stored
+		await page.reload()
+		await openSharingPanel(filesListPage, sharingTab, 'test')
+		await sharingTab.openLinkShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.labelInput()).toHaveValue('')
+		await expect(sharingTab.checkbox('Set password')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Set expiration date')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Hide download')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Note to recipient')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Custom permissions')).not.toBeChecked()
+	})
 })
 
 test.describe('files_sharing: Email share editor', () => {

--- a/tests/playwright/e2e/files_sharing/public-share/share-editor.spec.ts
+++ b/tests/playwright/e2e/files_sharing/public-share/share-editor.spec.ts
@@ -103,6 +103,27 @@ test.describe('files_sharing: Link share editor', () => {
 		await expect(sharingTab.checkbox('Note to recipient')).not.toBeChecked()
 		await expect(sharingTab.checkbox('Custom permissions')).not.toBeChecked()
 	})
+
+	test('the password is unchecked after clearing and saving it', async ({ filesListPage, sharingTab }) => {
+		await openSharingPanel(filesListPage, sharingTab, 'test')
+
+		await sharingTab.openLinkShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.checkbox('Set password')).not.toBeChecked()
+		await sharingTab.setCheckbox('Set password', true)
+		// A password is automatically generated and added to the input
+		await sharingTab.save()
+
+		await sharingTab.openLinkShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.checkbox('Set password')).toBeChecked()
+		await sharingTab.setCheckbox('Set password', false)
+		await sharingTab.save()
+
+		await sharingTab.openLinkShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.checkbox('Set password')).not.toBeChecked()
+	})
 })
 
 test.describe('files_sharing: Email share editor', () => {

--- a/tests/playwright/e2e/files_sharing/share-editor.spec.ts
+++ b/tests/playwright/e2e/files_sharing/share-editor.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '../../support/fixtures/sharing-page.ts'
+import { mkdir } from '../../support/utils/dav.ts'
+import { createShare, openSharingPanel } from '../../support/utils/sharing.ts'
+
+test.describe('files_sharing: User share editor', () => {
+	test.beforeEach(async ({ page, user, recipient, filesListPage }) => {
+		await mkdir(page.request, user, '/test')
+		await createShare(page.request, '/test', recipient.userId)
+		await filesListPage.open()
+	})
+
+	test('cancelling the edition resets to the previous state', async ({ page, filesListPage, sharingTab }) => {
+		await openSharingPanel(filesListPage, sharingTab, 'test')
+
+		await sharingTab.openShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.checkbox('Set expiration date')).not.toBeChecked()
+		await sharingTab.setCheckbox('Set expiration date', true)
+		// A default expiration date is automatically added to the input
+		await expect(sharingTab.checkbox('Allow download and sync')).toBeChecked()
+		await sharingTab.setCheckbox('Allow download and sync', false)
+		await expect(sharingTab.checkbox('Note to recipient')).not.toBeChecked()
+		await sharingTab.setCheckbox('Note to recipient', true)
+		await sharingTab.noteInput().fill('The note')
+		await expect(sharingTab.checkbox('Custom permissions')).not.toBeChecked()
+		await sharingTab.setCheckbox('Custom permissions', true)
+		await expect(sharingTab.checkbox('Edit')).toBeChecked()
+		await sharingTab.setCheckbox('Edit', false)
+		await sharingTab.cancel()
+
+		// Back to the original state when the editor is opened again …
+		await sharingTab.openShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.checkbox('Set expiration date')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Allow download and sync')).toBeChecked()
+		await expect(sharingTab.checkbox('Note to recipient')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Custom permissions')).not.toBeChecked()
+
+		// … and after a reload, i.e. it was not stored
+		await page.reload()
+		await openSharingPanel(filesListPage, sharingTab, 'test')
+		await sharingTab.openShareDetails()
+		await sharingTab.openAdvancedSettings()
+		await expect(sharingTab.checkbox('Set expiration date')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Allow download and sync')).toBeChecked()
+		await expect(sharingTab.checkbox('Note to recipient')).not.toBeChecked()
+		await expect(sharingTab.checkbox('Custom permissions')).not.toBeChecked()
+	})
+})

--- a/tests/playwright/support/sections/SharingTab.ts
+++ b/tests/playwright/support/sections/SharingTab.ts
@@ -216,24 +216,14 @@ export class SharingTab {
 	 * whose real input is visually hidden, hence the forced check plus an explicit
 	 * state assertion.
 	 *
-	 * Some public-share options ("Hide download") are queued for saving the moment
-	 * they change rather than when the editor is saved — pass `persists` for those
-	 * so the update is awaited here, and close the editor with
-	 * {@link closeDetails} instead of {@link save} afterwards.
-	 *
 	 * @param name - The checkbox label
 	 * @param checked - The state to set
-	 * @param options - `persists` awaits the share update the toggle triggers
 	 */
-	async setCheckbox(name: string | RegExp, checked: boolean, { persists = false }: { persists?: boolean } = {}): Promise<void> {
-		const updated = persists
-			? this.page.waitForResponse((r) => r.request().method() === 'PUT' && r.url().includes(SHARES_API))
-			: undefined
+	async setCheckbox(name: string | RegExp, checked: boolean): Promise<void> {
 		const box = this.checkbox(name)
 		await box.scrollIntoViewIfNeeded()
 		await box.setChecked(checked, { force: true })
 		await expect(box).toBeChecked({ checked })
-		await updated
 	}
 
 	/** The note-to-recipient text area (only rendered once its checkbox is on). */
@@ -268,16 +258,6 @@ export class SharingTab {
 	 */
 	private saveButton(): Locator {
 		return this.panel().getByRole('button', { name: /^(Save|Update|Create) share$/ })
-	}
-
-	/**
-	 * Leave the open editor through its save button without expecting a request —
-	 * for edits that were already persisted when they were made (see
-	 * {@link setCheckbox}). Returns once the share list is back.
-	 */
-	async closeDetails(): Promise<void> {
-		await this.saveButton().click()
-		await expect(this.saveButton()).toBeHidden()
 	}
 
 	/**

--- a/tests/playwright/support/sections/SharingTab.ts
+++ b/tests/playwright/support/sections/SharingTab.ts
@@ -272,4 +272,21 @@ export class SharingTab {
 		const body = await (await saved).json() as { ocs: { data: { id: number, permissions: number, url?: string } } }
 		return body.ocs.data
 	}
+
+	/**
+	 * The editor's cancel button.
+	 */
+	private cancelButton(): Locator {
+		return this.panel().getByRole('button', { name: 'Cancel' })
+	}
+
+	/**
+	 * Leave the open editor without saving the changes.
+	 * Returns once the button is no longer visible and therefore the share list
+	 * is back.
+	 */
+	async cancel(): Promise<void> {
+		await this.cancelButton().click()
+		await expect(this.cancelButton()).toBeHidden()
+	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

In the past shares were edited through a dropdown menu, and changed settings were immediately applied. Since #39472 a panel with the different settings and buttons to save and cancel the changes is used instead. However, some specific settings were still saved as soon as they were modified, even if the changes were later cancelled.

Besides that, the panel modifies the received share object whenever a setting is changed (even if they are not applied on the server), but the changes were not reverted when the edition was cancelled. Due to that, if the share was customized again after cancelling the previous changes were still there.

This pull request fixes all that by removing the immediate saving on those settings that still had it, and reverting the changes to the share object when the edition is cancelled.

Additionally it also fixes a problem when the password is removed and _Video verification_ was checked (scenario 4 below) and a problem with how the new password was cleared (scenario 7 below). They were not really issues when cancelling the edition but when saving the share, but in the first case the code was quite related and in the second the effect was similar (inconsistent UI if the share was edited again), so they were included here.



## How to test (scenario 1)

- Open the Files app
- Open the Sharing tab for a file
- Create a public link share
- Customize the share
- Hide download

### Result with this pull request

The share is not saved

### Result without this pull request

The share is saved



## How to test (scenario 2)

- Open the Files app
- Open the Sharing tab for a file
- Create a public link share
- Customize the share
- Set a password
- Cancel
- Open the menu for the share
- Close the menu by clicking outside it

### Result with this pull request

The share is not saved

### Result without this pull request

The share is saved



## How to test (scenario 3)

- Enable Talk
- Open the Files app
- Open the Sharing tab for a file
- Create a public link share
- Customize the share
- Set a password
- Enable video verification (only available after setting the password)

### Result with this pull request

The share is not saved

### Result without this pull request

The share is saved



## How to test (scenario 4)

- Enable Talk
- Open the Files app
- Open the Sharing tab for a file
- Create a public link share
- Customize the share
- Set a password
- Enable video verification (only available after setting the password)
- Save the share
- Reload the page
- Customize the share
- Remove the password
- Save the share

### Result with this pull request

Saving the share succeeds

### Result without this pull request

Saving the share fails



## How to test (scenario 5)

- Enable Talk
- Open the Files app
- Open the Sharing tab for a file
- Create a public link share
- Customize the share
- Set a label
- Set a password
- Enable video verification (only available after setting the password)
- Set an expiration date
- Hide download
- Add a note to recipient
- Customize permissions and add edit permission
- Cancel
- Customize the share again

### Result with this pull request

Everything is back to the original state. If the page is reloaded and the share customized again everything is in the original state.

### Result without this pull request

Everything is still set despite being cancelled. If the page is reloaded and the share customized again then the password, video verification and hide download are checked, but the rest is back to the original state.



## How to test (scenario 6)

- Open the Files app
- Open the Sharing tab for a file
- Add and save a share with a user
- Customize the share
- Set an expiration date
- Disallow download and sync
- Add a note to recipient
- Customize permissions and remove edit permission
- Cancel
- Customize the share again

### Result with this pull request

Everything is back to the original state. If the page is reloaded and the share customized again everything is in the original state.

### Result without this pull request

Everything* is still set (or disallowed) despite being cancelled. If the page is reloaded and the share customized again everything is in the original state.

* "Custom permissions" checkbox is not checked in the advanced permissions, but "Read, share" can be nevertheless seen in the quick permissions list



## How to test (scenario 7)

- Open the Files app
- Open the Sharing tab for a file
- Create a public link share
- Customize the share
- Set a password
- Save the share
- Customize the share
- Remove the password
- Save the share
- Customize the share

### Result with this pull request

The password is unchecked

### Result without this pull request

The password is checked. If the page is reloaded and the share customized again the password is unchecked
