### PR TITLE
[stable31] test: remove bad backported tests for non-existing endpoint

### DIFF
--- a/build/integration/dav_features/dav-v2-public.feature
+++ b/build/integration/dav_features/dav-v2-public.feature
@@ -57,39 +57,9 @@ Feature: dav-v2-public
 		When Downloading public file "/image.png" without ajax header
 		Then the downloaded file has the content of "/testshare/image.png" from "user1" data
 
-	Scenario: Finalizing a public chunked upload with COPY is not allowed
-		Given using new dav path
-		And user "user0" exists
-		And As an "user0"
-		And user "user0" created a folder "/public-upload"
-		And User "user0" uploads file with content "original content" to "/public-upload/target.txt"
-		And as "user0" creating a share with
-			| path         | public-upload |
-			| shareType    | 3             |
-			| publicUpload | true          |
-		And creating a new public chunking upload with id "chunking-public-copy"
-		And uploading new public chunk file "1" with "AAAAA" to id "chunking-public-copy"
-		When copying new public chunk file with id "chunking-public-copy" to "/target.txt"
-		Then the HTTP status code should be "405"
-		And Downloading file "/public-upload/target.txt" as "user0"
-		Then Downloaded content should be "original content"
-
-	Scenario: Finalizing a public chunked upload with MOVE overwrites the target
-		Given using new dav path
-		And user "user0" exists
-		And As an "user0"
-		And user "user0" created a folder "/public-upload"
-		And User "user0" uploads file with content "original content" to "/public-upload/target.txt"
-		And as "user0" creating a share with
-			| path         | public-upload |
-			| shareType    | 3             |
-			| publicUpload | true          |
-		And creating a new public chunking upload with id "chunking-public-move"
-		And uploading new public chunk file "1" with "AAAAA" to id "chunking-public-move"
-		When moving new public chunk file with id "chunking-public-move" to "/target.txt"
-		Then the HTTP status code should be "204"
-		And Downloading file "/public-upload/target.txt" as "user0"
-		Then Downloaded content should be "AAAAA"
+	# The chunked upload scenarios of this feature are not backported:
+	# `/public.php/dav/uploads/<token>` does not exist on this branch, the public
+	# DAV endpoint only serves `/public.php/dav/files/<token>`.
 
 	Scenario: Download a folder
 		Given using new dav path


### PR DESCRIPTION

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
