### PR TITLE
feat: customizable Quota handler

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -545,7 +545,7 @@ class DirectoryTest extends \Test\TestCase {
 			->method('free_space')
 			->willReturn(800);
 
-		$this->info->expects($this->once())
+		$storage->expects($this->once())
 			->method('getSize')
 			->willReturn(200);
 

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -209,20 +209,6 @@ class SetupManager implements ISetupManager {
 			return $storage;
 		}, 50, $existingMounts);
 
-		$quotaIncludeExternal = $this->config->getSystemValue('quota_include_external_storage', false);
-		$this->storageFactory->addStorageWrapper(Quota::class, function ($mountPoint, $storage, IMountPoint $mount) use ($quotaIncludeExternal) {
-			// set up quota for home storages, even for other users
-			// which can happen when using sharing
-			if ($mount instanceof HomeMountPoint) {
-				$user = $mount->getUser();
-				return new Quota(['storage' => $storage, 'quotaCallback' => function () use ($user) {
-					return $user->getQuotaBytes();
-				}, 'root' => 'files', 'include_external_storage' => $quotaIncludeExternal]);
-			}
-
-			return $storage;
-		}, 50, $existingMounts);
-
 		$this->storageFactory->addStorageWrapper('readonly', function (string $mountPoint, IStorage $storage, IMountPoint $mount) {
 			/*
 			 * Do not allow any operations that modify the storage
@@ -237,6 +223,28 @@ class SetupManager implements ISetupManager {
 					),
 				]);
 			}
+			return $storage;
+		}, 50, $existingMounts);
+	}
+
+	/**
+	 * Some wrapper are inited after BeforeFileSystemSetupEvent, to permit
+	 * custom apps to preventively register their own handler
+	 *
+	 * @param IMountPoint[] $existingMounts
+	 */
+	private function setupCustomizableWrappers(array $existingMounts): void {
+		$quotaIncludeExternal = $this->config->getSystemValue('quota_include_external_storage', false);
+		$this->storageFactory->addStorageWrapper(Quota::class, function ($mountPoint, $storage, IMountPoint $mount) use ($quotaIncludeExternal) {
+			// set up quota for home storages, even for other users
+			// which can happen when using sharing
+			if ($mount instanceof HomeMountPoint) {
+				$user = $mount->getUser();
+				return new Quota(['storage' => $storage, 'quotaCallback' => function () use ($user) {
+					return $user->getQuotaBytes();
+				}, 'root' => 'files', 'include_external_storage' => $quotaIncludeExternal]);
+			}
+
 			return $storage;
 		}, 50, $existingMounts);
 	}
@@ -327,6 +335,8 @@ class SetupManager implements ISetupManager {
 				$this->storageFactory->addStorageWrapper($wrapperName, $wrapper['callable'], $wrapper['priority'], $mounts);
 			}
 		}
+
+		$this->setupCustomizableWrappers($mounts);
 
 		$userDir = '/' . $user->getUID() . '/files';
 

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -56,7 +56,7 @@ class Quota extends Wrapper {
 		return $this->getQuota() !== FileInfo::SPACE_UNLIMITED;
 	}
 
-	protected function getSize(string $path, ?IStorage $storage = null): int|float {
+	public function getSize(string $path, ?IStorage $storage = null): int|float {
 		if ($this->quotaIncludeExternalStorage) {
 			$rootInfo = Filesystem::getFileInfo('', 'ext');
 			if ($rootInfo) {

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -187,10 +187,7 @@ class OC_Helper {
 		if (!$rootInfo instanceof FileInfo) {
 			throw new NotFoundException('The root directory of the user\'s files is missing');
 		}
-		$used = $rootInfo->getSize($includeMountPoints);
-		if ($used < 0) {
-			$used = 0.0;
-		}
+
 		/** @var int|float $quota */
 		$quota = FileInfo::SPACE_UNLIMITED;
 		$mount = $rootInfo->getMountPoint();
@@ -226,7 +223,13 @@ class OC_Helper {
 		if ($sourceStorage->instanceOfStorage('\OC\Files\Storage\Wrapper\Quota')) {
 			/** @var Quota $sourceStorage */
 			$quota = $sourceStorage->getQuota();
+			$used = $sourceStorage->getSize($path, $storage);
+		} else {
+			$used = $rootInfo->getSize($includeMountPoints);
 		}
+
+		$used = max($used, 0.0);
+
 		try {
 			$free = $sourceStorage->free_space($rootInfo->getInternalPath());
 			if (is_bool($free)) {


### PR DESCRIPTION
Registration of the `Quota` wrapper for `Storage` is postponed after handling the `BeforeFileSystemSetupEvent` event with the aim to permit third party apps to register their own version of the handler (as `StorageFactory::addStorageWrapper()` will no register twice the same wrapper name).
At the same time, statistics about used storage are fetched from that same `Quota` wrapper when available.

Exposing `Quota` to user-provided alternative implementation, with custom logics, unlocks a quantity of use cases, to be delegated to third party apps instead of being hard coded in the core.

Those include:
- global quota to be shared among users #2016 
- directory based quota #1763 
- merging files and mail quotas https://github.com/nextcloud/mail/issues/10152