### PR TITLE
fix: Public link with multiple mounts

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -129,6 +129,17 @@ $server = $serverFactory->createServer(
 		if (!$node) {
 			throw new \Sabre\DAV\Exception\NotFound();
 		}
+
+		// getFirstNodeById might return a node without share permission -> try to find a node which is shareable
+		if (!$node->isShareable()) {
+			foreach ($userFolder->getById($fileId) as $candidate) {
+				if ($candidate->isShareable()) {
+					$node = $candidate;
+					break;
+				}
+			}
+		}
+
 		$linkCheckPlugin->setFileInfo($node);
 
 		// If not readable (files_drop) enable the filesdrop plugin

--- a/apps/dav/appinfo/v2/publicremote.php
+++ b/apps/dav/appinfo/v2/publicremote.php
@@ -162,6 +162,17 @@ $server = $serverFactory->createServer(true, $baseuri, $requestUri, $authPlugin,
 	if (!$node) {
 		throw new NotFound();
 	}
+
+	// getFirstNodeById might return a node without share permission -> try to find a node which is shareable
+	if (!$node->isShareable()) {
+		foreach ($userFolder->getById($fileId) as $candidate) {
+			if ($candidate->isShareable()) {
+				$node = $candidate;
+				break;
+			}
+		}
+	}
+
 	$linkCheckPlugin->setFileInfo($node);
 
 	// If not readable (files_drop) enable the filesdrop plugin

--- a/build/integration/dav_features/dav-v2-public.feature
+++ b/build/integration/dav_features/dav-v2-public.feature
@@ -110,3 +110,33 @@ Feature: dav-v2-public
 		Then the downloaded zip file contains a folder named "testFolder/"
 		And the downloaded zip file contains a file named "testFolder/text.txt" with the contents of "/testshare/testFolder/text.txt" from "user0" data
 		And the downloaded zip file contains a file named "testFolder/image.png" with the contents of "/testshare/testFolder/image.png" from "user0" data
+
+	# After the link share was created the initiator gets a second, read-only path to the
+	# shared folder. Nodes are ordered by path descending, so "/z-child" is found before
+	# "/parent/z-child" and the shareable path has to be picked explicitly.
+	Scenario: Downloading a file from a public share of a folder the initiator can also reach without share permission
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And As an "user0"
+		And user "user0" created a folder "/parent"
+		And user "user0" created a folder "/parent/z-child"
+		And User "user0" uploads file with content "shared content" to "/parent/z-child/text.txt"
+		And folder "/parent" of user "user0" is shared with user "user1" with permissions 31
+		And user "user1" accepts last share
+		And as "user1" creating a share with
+		  | path | parent/z-child |
+		  | shareType | 3 |
+		  | permissions | 1 |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And save the last share data as "publicLink"
+		And folder "/parent/z-child" of user "user0" is shared with user "user1" with permissions 1
+		And user "user1" accepts last share
+		And restore the last share data from "publicLink"
+		And As an "user0"
+		Given using new public dav path
+		When Downloading public file "/text.txt"
+		Then the HTTP status code should be "200"
+		And Downloaded content should be "shared content"


### PR DESCRIPTION
## Summary

When multiple mounts with different permissions are available to access a file, a public link for such a file might access the wrong (non-shareable) node and show a 404 instead of the file.
Question generally would be if it makes sense to extract that code (e.g. `getFirstShareableNodeById` or a separate class to resolve these types of nodes).

The test was created with help of AI, which pointed out that a similar exists at https://github.com/nextcloud/server/blob/4fcbb98af8413a55b35f3067841a0fd2617b47b3/apps/files_sharing/lib/Listener/RestrictInteractionListener.php#L54-L56 and the check should probably use `getNodePermissions` there. This seems 34+ only, the fix here is also < 34.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
