### PR TITLE
feat(dav): add IRoomMetadata::BUILDING_NAME

### DIFF
--- a/lib/public/Calendar/Room/IRoomMetadata.php
+++ b/lib/public/Calendar/Room/IRoomMetadata.php
@@ -38,6 +38,17 @@ interface IRoomMetadata {
 	public const CAPACITY = '{http://nextcloud.com/ns}room-seating-capacity';
 
 	/**
+	 * The name of the building this room is located in
+	 *
+	 * Clients group rooms by building. Without this key they have to guess a
+	 * building from BUILDING_ADDRESS, which only works for backends that
+	 * happen to put the building name first.
+	 *
+	 * @since 35.0.0
+	 */
+	public const BUILDING_NAME = '{http://nextcloud.com/ns}room-building-name';
+
+	/**
 	 * The physical address of the building this room is located in
 	 *
 	 * @since 17.0.0


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- no issue filed; happy to open one if preferred -->

## Summary

Adds `IRoomMetadata::BUILDING_NAME` — a metadata key for the name of the building a room is in.

`OCP\Calendar\Room\IRoomMetadata` has keys for where a room is, but not for which building it belongs to:

```php
BUILDING_ADDRESS     = '{http://nextcloud.com/ns}room-building-address'
BUILDING_STORY       = '{http://nextcloud.com/ns}room-building-story'
BUILDING_ROOM_NUMBER = '{http://nextcloud.com/ns}room-building-room-number'
```

Any client that wants to group rooms per building therefore has to derive a building name from the free-form address, in practice by taking everything before the first comma.

That guess fails on real data. On our test instance 51 of 113 rooms have an address whose first segment is empty, so the guess lands on the postal code instead: 32 rooms group under a building called "3511 EP" and 19 under "1098 XG". Neither is a building.

This is not hypothetical. [nextcloud/calendar#8264](https://github.com/nextcloud/calendar/pull/8264) adds a browsable room finder to the Calendar room picker that groups rooms per building, and it has to carry exactly that heuristic — including a special case to skip postal-code segments — purely because there is no field to read. Every other client that wants to group rooms will reinvent the same guess.

Room backends often do know the building name as a separate value. Exchange and Microsoft 365 room mailboxes expose `Building` as its own property on `Get-Place`, and other room backends store it separately from the address. The information exists; there is just no agreed key to publish it under.

**The change** is one constant, placed alongside the existing building keys:

```php
/**
 * The name of the building this room is located in
 *
 * @since 35.0.0
 */
public const BUILDING_NAME = '{http://nextcloud.com/ns}room-building-name';
```

Interface-only. No behaviour change and nothing to migrate: `IRoomMetadata` documents keys that backends *may* provide, and its docblock already states that backends are not limited to this list. Backends that have a building name publish it; clients that do not know the key ignore it.

**Alternatives considered**

- *Keep deriving it from the address.* The status quo, and what produces "3511 EP" as a building name. It also pushes the same heuristic into every client independently.
- *Let each backend invent its own key.* Backends can already do this, but without a shared key no two backends agree on a name and clients cannot rely on any of them.
- *Parse the building out of `BUILDING_ADDRESS` server-side.* That centralises the guess instead of removing it, and still cannot recover a name that was never in the address.

## TODO

- [x] Add the constant with a `@since` matching current master (35.0.0)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included <!-- interface-only: a public constant has no behaviour to test -->
- [ ] Screenshots before/after for front-end changes <!-- no front-end change -->
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required <!-- the constant is self-documenting via its docblock -->
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) <!-- new API, not a bugfix -->
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
