### PR TITLE
fix(group): Set the display name on every backends that supports it

### DIFF
--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -79,6 +79,7 @@ class Group implements IGroup {
 	#[\Override]
 	public function setDisplayName(string $displayName): bool {
 		$displayName = trim($displayName);
+		$changed = false;
 		if ($displayName !== '') {
 			$this->dispatcher->dispatchTyped(new BeforeGroupChangedEvent($this, 'displayName', $displayName, $this->displayName));
 			$oldDisplayName = $this->displayName;
@@ -86,10 +87,13 @@ class Group implements IGroup {
 				if (($backend instanceof ISetDisplayNameBackend)
 					&& $backend->setDisplayName($this->gid, $displayName)) {
 					$this->displayName = $displayName;
-					$this->dispatcher->dispatchTyped(new GroupChangedEvent($this, 'displayName', $displayName, $oldDisplayName));
-					return true;
+					$changed = true;
 				}
 			}
+		}
+		if ($changed) {
+			$this->dispatcher->dispatchTyped(new GroupChangedEvent($this, 'displayName', $displayName, $oldDisplayName));
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/user_saml/issues/1208

## Summary

Otherwise it apply the change only to the group backend with ISetDisplaynameBackend

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
