### PR TITLE
fix(preview): execute PreviewMapper::deleteAll()

### DIFF
--- a/lib/private/Preview/Db/PreviewMapper.php
+++ b/lib/private/Preview/Db/PreviewMapper.php
@@ -203,7 +203,8 @@ class PreviewMapper extends QBMapper {
 
 	public function deleteAll(): void {
 		$delete = $this->db->getQueryBuilder();
-		$delete->delete($this->getTableName());
+		$delete->delete($this->getTableName())
+			->executeStatement();
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Fix `PreviewMapper::deleteAll()` so that it actually executes the generated `DELETE` statement. ;-)

Production code, such as preview cleanup currently removes previews individually through `PreviewService::deleteAll()` (which uses `PreviewMapper::delete()` for each one), but this mapper method is used by tests (in `tearDown()`) and is a no-op for any future callers.

## TODO

- [ ] Backport to >=v33

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
