### PR TITLE
fix(preview): order previews by ID during pagination

### DIFF
--- a/lib/private/Preview/Db/PreviewMapper.php
+++ b/lib/private/Preview/Db/PreviewMapper.php
@@ -213,10 +213,17 @@ class PreviewMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$this->joinLocation($qb)
 			->where($qb->expr()->gt('p.id', $qb->createNamedParameter($lastId)))
+			->orderBy('p.id', 'ASC')
 			->setMaxResults($limit);
 
 		if ($maxAgeDays !== null) {
-			$qb->andWhere($qb->expr()->lt('mtime', $qb->createNamedParameter((new DateTimeImmutable())->sub(new DateInterval('P' . $maxAgeDays . 'D'))->getTimestamp(), IQueryBuilder::PARAM_INT)));
+			$qb->andWhere($qb->expr()->lt(
+				'p.mtime',
+				$qb->createNamedParameter(
+					(new DateTimeImmutable())->sub(new DateInterval('P' . $maxAgeDays . 'D'))->getTimestamp(),
+					IQueryBuilder::PARAM_INT,
+				),
+			));
 		}
 
 		return $this->yieldEntities($qb);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Ensure preview pagination is deterministic by ordering results by preview ID.

`PreviewMapper::getPreviews()` uses `p.id > $lastId` as a cursor and limits each query to a fixed number of rows. Without an explicit `ORDER BY`, SQL does not guarantee the order of returned rows. 

This can cause cursor-based cleanup to skip previews or process batches inconsistently.

Changes:

- Order `getPreviews()` results by `p.id ASC`.
- Qualify the `mtime` predicate with the `p` table alias (not currently a problem since there's no overlapping joined column name, but makes the query clearer).
- Tidy formatting.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
