### PR TITLE
fix(preview): delete version metadata by preview ID

### DIFF
--- a/lib/private/Preview/Db/Preview.php
+++ b/lib/private/Preview/Db/Preview.php
@@ -46,7 +46,8 @@ use OCP\Files\IMimeTypeDetector;
  * @method string getEtag() Get the etag of the preview.
  * @method void setEtag(string $etag)
  * @method string|null getVersion() Get the version for files_versions_s3
- * @method void setVersionId(string $versionId)
+ * @method string|null getVersionId() Get the ID of the version metadata row.
+ * @method void setVersionId(string $versionId) Set the ID of the version metadata row.
  * @method bool|null getIs() Get the version for files_versions_s3
  * @method bool isEncrypted() Get whether the preview is encrypted. At the moment every preview is unencrypted.
  * @method void setEncrypted(bool $encrypted)

--- a/lib/private/Preview/Db/PreviewMapper.php
+++ b/lib/private/Preview/Db/PreviewMapper.php
@@ -84,11 +84,15 @@ class PreviewMapper extends QBMapper {
 	public function delete(Entity $entity): Entity {
 		/** @var Preview $preview */
 		$preview = $entity;
-		if ($preview->getVersion() !== null && $preview->getVersion() !== '') {
+
+		$versionId = $preview->getVersionId();
+		if ($versionId !== null && $versionId !== '' && $versionId !== '-1') {
 			$qb = $this->db->getQueryBuilder();
 			$qb->delete(self::VERSION_TABLE_NAME)
-				->where($qb->expr()->eq('file_id', $qb->createNamedParameter($preview->getFileId())))
-				->andWhere($qb->expr()->eq('version', $qb->createNamedParameter($preview->getVersion())))
+				->where($qb->expr()->eq(
+					'id',
+					$qb->createNamedParameter($versionId),
+				))
 				->executeStatement();
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Delete version metadata using the specific `preview_versions` row referenced by the preview.

`insert()` creates one `preview_versions` row whose ID is the preview ID, and stores that ID in `previews.version_id`. The `delete()` query should therefore use `version_id` rather than `(file_id, version)`, which can match multiple previews (i.e. different dimensions) for the same file version.

Previously, deleting one preview could remove the `preview_versions` rows belonging to other previews of the same file version.

Changes:

- Read the preview's `version_id`.
- Delete the corresponding row from `preview_versions` by its `id`.
- Preserve the existing handling for non-versioned previews, whose persisted `version_id` is `-1`

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
