### PR TITLE
Rescan external storage shares on missing metadata

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -455,20 +455,34 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 			return $this->watcher;
 		}
 
+		$isHomeStorage = null;
 		// Get node information
 		$node = $this->getShare()->getNodeCacheEntry();
 		if ($node instanceof CacheEntry) {
 			$storageId = $node->getData()['storage_string_id'] ?? null;
-			// for shares from the home storage we can rely on the home storage to keep itself up to date
-			// for other storages we need use the proper watcher
-			if ($storageId !== null && !(str_starts_with($storageId, 'home::') || str_starts_with($storageId, 'object::user'))) {
-				$cache = $this->getCache();
-				$this->watcher = parent::getWatcher($path, $storage);
-				if ($cache instanceof Cache) {
-					$this->watcher->onUpdate($cache->markRootChanged(...));
-				}
-				return $this->watcher;
+			if ($storageId !== null) {
+				// for shares from the home storage we can rely on the home storage to keep itself up to date
+				// for other storages we need use the proper watcher
+				$isHomeStorage = str_starts_with($storageId, 'home::') || str_starts_with($storageId, 'object::user');
 			}
+		}
+
+		if ($isHomeStorage === null) {
+			// the share metadata doesn't tell us what kind of storage this is (e.g. not
+			// scanned yet, or the share was fetched through a code path that doesn't join
+			// the storages table) - fall back to checking the real underlying storage
+			$this->init();
+			$isHomeStorage = $this->storage instanceof FailedStorage
+				|| $this->nonMaskedStorage->instanceOfStorage(IHomeStorage::class);
+		}
+
+		if (!$isHomeStorage) {
+			$cache = $this->getCache();
+			$this->watcher = parent::getWatcher($path, $storage);
+			if ($cache instanceof Cache) {
+				$this->watcher->onUpdate($cache->markRootChanged(...));
+			}
+			return $this->watcher;
 		}
 
 		// cache updating is handled by the share source

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -8,7 +8,9 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Cache\CacheEntry;
 use OC\Files\Cache\FailedCache;
+use OC\Files\Cache\NullWatcher;
 use OC\Files\Filesystem;
 use OC\Files\Storage\FailedStorage;
 use OC\Files\Storage\Temporary;
@@ -18,10 +20,24 @@ use OCA\Files_Trashbin\AppInfo\Application;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\Constants;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\Folder;
+use OCP\Files\IHomeStorage;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
 use OCP\Share\IShare;
+
+/**
+ * Storage fixture that mimics a home storage without needing a real user backend.
+ */
+class FakeHomeStorage extends Temporary implements IHomeStorage {
+	public function getUser(): IUser {
+		return Server::get(IUserManager::class)->get(SharedStorageTest::TEST_FILES_SHARING_API_USER1);
+	}
+}
 
 /**
  * Class SharedStorageTest
@@ -457,6 +473,8 @@ class SharedStorageTest extends TestCase {
 		// trigger init
 		$this->assertInstanceOf(FailedStorage::class, $storage->getSourceStorage());
 		$this->assertInstanceOf(FailedCache::class, $storage->getCache());
+		// a failed storage should never be treated as needing a live rescan
+		$this->assertInstanceOf(NullWatcher::class, $storage->getWatcher());
 	}
 
 	public function testInitWithNotFoundSource(): void {
@@ -475,6 +493,68 @@ class SharedStorageTest extends TestCase {
 		// trigger init
 		$this->assertInstanceOf(FailedStorage::class, $storage->getSourceStorage());
 		$this->assertInstanceOf(FailedCache::class, $storage->getCache());
+	}
+
+	/**
+	 * A share whose node cache entry is missing (e.g. fetched through a share
+	 * provider method that doesn't join the storages table) must still get a real
+	 * watcher when the underlying storage isn't a home storage, so re-shares of
+	 * external storage get rescanned. See: #63253
+	 */
+	public function testGetWatcherFallsBackToRealWatcherWhenCacheEntryMissing(): void {
+		$storage = $this->createShareWithMissingCacheEntry(new Temporary([]));
+
+		$this->assertNotInstanceOf(NullWatcher::class, $storage->getWatcher());
+	}
+
+	/**
+	 * Same as above, but the node cache entry is present and simply lacks the
+	 * `storage_string_id` key, matching the crash reported in #50235.
+	 */
+	public function testGetWatcherFallsBackToRealWatcherWhenStorageStringIdMissing(): void {
+		$cacheEntry = new CacheEntry(['fileid' => 1, 'storage' => 1, 'path' => '', 'name' => '', 'mimetype' => 'httpd/unix-directory']);
+		$storage = $this->createShareWithMissingCacheEntry(new Temporary([]), $cacheEntry);
+
+		$this->assertNotInstanceOf(NullWatcher::class, $storage->getWatcher());
+	}
+
+	/**
+	 * When the node cache entry is missing but the underlying storage genuinely is
+	 * a home storage, we must keep relying on NullWatcher (no behaviour change).
+	 */
+	public function testGetWatcherStaysNullWatcherForHomeStorageWhenCacheEntryMissing(): void {
+		$storage = $this->createShareWithMissingCacheEntry(new FakeHomeStorage([]));
+
+		$this->assertInstanceOf(NullWatcher::class, $storage->getWatcher());
+	}
+
+	private function createShareWithMissingCacheEntry($sourceStorage, ?CacheEntry $cacheEntry = null): SharedStorage {
+		$sourceStorage->getScanner()->scan('');
+
+		$ownerNode = $this->createMock(Node::class);
+		$ownerNode->method('getStorage')->willReturn($sourceStorage);
+		$ownerNode->method('getPath')->willReturn('/' . self::TEST_FILES_SHARING_API_USER1 . '/files/foo');
+		$ownerNode->method('getInternalPath')->willReturn('');
+
+		$ownerFolder = $this->createMock(Folder::class);
+		$ownerFolder->method('getById')->with(1)->willReturn([$ownerNode]);
+
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$rootFolder->method('getUserFolder')->with(self::TEST_FILES_SHARING_API_USER1)->willReturn($ownerFolder);
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareOwner')->willReturn(self::TEST_FILES_SHARING_API_USER1);
+		$share->method('getNodeId')->willReturn(1);
+		$share->method('getPermissions')->willReturn(Constants::PERMISSION_ALL);
+		$share->method('getNodeCacheEntry')->willReturn($cacheEntry);
+
+		return new SharedStorage([
+			'ownerView' => $this->createMock(View::class),
+			'superShare' => $share,
+			'groupedShares' => [$share],
+			'user' => self::TEST_FILES_SHARING_API_USER2,
+			'rootFolder' => $rootFolder,
+		]);
 	}
 
 	public function testCopyPermissions(): void {


### PR DESCRIPTION
* Resolves: #63253

## Summary

`SharedStorage::getWatcher()` decided between a real `Watcher` and a `NullWatcher` purely from the share's node cache entry `storage_string_id`. When that metadata was `null` or missing the key (e.g. shares fetched via `DefaultShareProvider::getSharesBy()`/`getShareById()`/`getSharesByPath()`, or not yet scanned at share-fetch time), it silently assumed home storage and installed a `NullWatcher`, so re-shares of external storage (SMB, S3, etc.) never got rescanned for the recipient.

This falls back to a live check of the real underlying storage (`instanceOfStorage(IHomeStorage::class)`) when the metadata is missing or incomplete, mirroring the existing fallback in `getSourceRootInfo()`. A `FailedStorage` guard keeps a deleted owner/offline storage safely on `NullWatcher`.

Manually verified against a real Samba server on a fresh Debian VM: mounted a real SMB share as external storage for one user, shared the folder with a second user, then modified files directly on the SMB backend (bypassing Nextcloud). The recipient's WebDAV listing picked up the changes immediately, no regression from `master`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI