### PR TITLE
Port oauth2 to new Entity system

### DIFF
--- a/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
+++ b/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
@@ -30,12 +30,11 @@ class CleanupExpiredAuthorizationCode extends TimedJob {
 
 	/**
 	 * @param mixed $argument
-	 * @inheritDoc
 	 */
 	#[\Override]
 	protected function run($argument): void {
 		try {
-			$this->accessTokenMapper->cleanupExpiredAuthorizationCode();
+			$this->accessTokenMapper->cleanupExpiredAuthorizationCode($this->time);
 		} catch (Exception $e) {
 			$this->logger->warning('Failed to cleanup tokens with expired authorization code', ['exception' => $e]);
 		}

--- a/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
+++ b/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
@@ -19,8 +19,8 @@ final class CleanupExpiredAuthorizationCode extends TimedJob {
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		private AccessTokenMapper $accessTokenMapper,
-		private LoggerInterface $logger,
+		private readonly AccessTokenMapper $accessTokenMapper,
+		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct($timeFactory);
 		// 30 days
@@ -35,8 +35,8 @@ final class CleanupExpiredAuthorizationCode extends TimedJob {
 	protected function run($argument): void {
 		try {
 			$this->accessTokenMapper->cleanupExpiredAuthorizationCode($this->time);
-		} catch (Exception $e) {
-			$this->logger->warning('Failed to cleanup tokens with expired authorization code', ['exception' => $e]);
+		} catch (Exception $exception) {
+			$this->logger->warning('Failed to cleanup tokens with expired authorization code', ['exception' => $exception]);
 		}
 	}
 }

--- a/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
+++ b/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
@@ -15,7 +15,7 @@ use OCP\BackgroundJob\TimedJob;
 use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
 
-class CleanupExpiredAuthorizationCode extends TimedJob {
+final class CleanupExpiredAuthorizationCode extends TimedJob {
 
 	public function __construct(
 		ITimeFactory $timeFactory,

--- a/apps/oauth2/lib/Command/AddClient.php
+++ b/apps/oauth2/lib/Command/AddClient.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class AddClient extends Base {
+final class AddClient extends Base {
 	private const string ARGUMENT_CLIENT_NAME = 'client-name';
 	private const string ARGUMENT_CLIENT_REDIRECT_URI = 'client-redirect-uri';
 

--- a/apps/oauth2/lib/Command/AddClient.php
+++ b/apps/oauth2/lib/Command/AddClient.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class AddClient extends Base {
 	private const string ARGUMENT_CLIENT_NAME = 'client-name';
+
 	private const string ARGUMENT_CLIENT_REDIRECT_URI = 'client-redirect-uri';
 
 	public function __construct(

--- a/apps/oauth2/lib/Command/DeleteClient.php
+++ b/apps/oauth2/lib/Command/DeleteClient.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DeleteClient extends Base {
+final class DeleteClient extends Base {
 	private const string ARGUMENT_CLIENT_ID = 'client-id';
 
 	public function __construct(

--- a/apps/oauth2/lib/Command/DeleteClient.php
+++ b/apps/oauth2/lib/Command/DeleteClient.php
@@ -53,6 +53,7 @@ final class DeleteClient extends Base {
 			$output->writeln('<error>' . $exception->getMessage() . '</error>');
 			return Command::FAILURE;
 		}
+
 		return Command::SUCCESS;
 	}
 }

--- a/apps/oauth2/lib/Command/ImportLegacyOcClient.php
+++ b/apps/oauth2/lib/Command/ImportLegacyOcClient.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ImportLegacyOcClient extends Command {
+final class ImportLegacyOcClient extends Command {
 	private const string ARGUMENT_CLIENT_ID = 'client-id';
 	private const string ARGUMENT_CLIENT_SECRET = 'client-secret';
 

--- a/apps/oauth2/lib/Command/ImportLegacyOcClient.php
+++ b/apps/oauth2/lib/Command/ImportLegacyOcClient.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class ImportLegacyOcClient extends Command {
 	private const string ARGUMENT_CLIENT_ID = 'client-id';
+
 	private const string ARGUMENT_CLIENT_SECRET = 'client-secret';
 
 	public function __construct(
@@ -71,6 +72,7 @@ final class ImportLegacyOcClient extends Command {
 		$client->redirectUri = 'http://localhost:*';
 		$client->clientIdentifier = $clientId;
 		$client->secret = $hashedClientSecret;
+
 		$this->clientMapper->insert($client);
 
 		$output->writeln('<info>Client imported successfully</info>');

--- a/apps/oauth2/lib/Command/ImportLegacyOcClient.php
+++ b/apps/oauth2/lib/Command/ImportLegacyOcClient.php
@@ -67,10 +67,10 @@ class ImportLegacyOcClient extends Command {
 		$hashedClientSecret = bin2hex($this->crypto->calculateHMAC($clientSecret));
 
 		$client = new Client();
-		$client->setName('ownCloud Desktop Client');
-		$client->setRedirectUri('http://localhost:*');
-		$client->setClientIdentifier($clientId);
-		$client->setSecret($hashedClientSecret);
+		$client->name = 'ownCloud Desktop Client';
+		$client->redirectUri = 'http://localhost:*';
+		$client->clientIdentifier = $clientId;
+		$client->secret = $hashedClientSecret;
 		$this->clientMapper->insert($client);
 
 		$output->writeln('<info>Client imported successfully</info>');

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -73,20 +73,20 @@ class LoginRedirectorController extends Controller {
 
 		if ($response_type !== 'code') {
 			//Fail
-			$url = $client->getRedirectUri() . '?error=unsupported_response_type&state=' . \urlencode($state);
+			$url = $client->redirectUri . '?error=unsupported_response_type&state=' . \urlencode($state);
 			return new RedirectResponse($url);
 		}
 
 		$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);
 
 		$providedRedirectUri = '';
-		if ($enableOcClients && $client->getRedirectUri() === 'http://localhost:*') {
+		if ($enableOcClients && $client->redirectUri === 'http://localhost:*') {
 			$providedRedirectUri = $redirect_uri;
 		}
 
 		$this->session->set('oauth.state', $state);
 
-		if (in_array($client->getName(), $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
+		if (in_array($client->name, $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/
 			$stateToken = $this->random->generate(
 				64,
@@ -97,7 +97,7 @@ class LoginRedirectorController extends Controller {
 				'core.ClientFlowLogin.grantPage',
 				[
 					'stateToken' => $stateToken,
-					'clientIdentifier' => $client->getClientIdentifier(),
+					'clientIdentifier' => $client->clientIdentifier,
 					'providedRedirectUri' => $providedRedirectUri,
 				]
 			);
@@ -105,7 +105,7 @@ class LoginRedirectorController extends Controller {
 			$targetUrl = $this->urlGenerator->linkToRouteAbsolute(
 				'core.ClientFlowLogin.showAuthPickerPage',
 				[
-					'clientIdentifier' => $client->getClientIdentifier(),
+					'clientIdentifier' => $client->clientIdentifier,
 					'providedRedirectUri' => $providedRedirectUri,
 				]
 			);

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -64,7 +64,7 @@ final class LoginRedirectorController extends Controller {
 	): TemplateResponse|RedirectResponse {
 		try {
 			$client = $this->clientMapper->getByIdentifier($client_id);
-		} catch (ClientNotFoundException $e) {
+		} catch (ClientNotFoundException) {
 			$params = [
 				'content' => $this->l->t('Your client is not authorized to connect. Please inform the administrator of your client.'),
 			];
@@ -111,6 +111,7 @@ final class LoginRedirectorController extends Controller {
 				]
 			);
 		}
+
 		return new RedirectResponse($targetUrl);
 	}
 }

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -29,7 +29,7 @@ use OCP\IURLGenerator;
 use OCP\Security\ISecureRandom;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
-class LoginRedirectorController extends Controller {
+final class LoginRedirectorController extends Controller {
 	public function __construct(
 		string $appName,
 		IRequest $request,
@@ -88,6 +88,7 @@ class LoginRedirectorController extends Controller {
 
 		if (in_array($client->name, $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/
+			/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 			$stateToken = $this->random->generate(
 				64,
 				ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -31,6 +31,7 @@ use OCP\GlobalScale\IGlobalScaleService;
 use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ICrypto;
@@ -112,7 +113,7 @@ final class OauthApiController extends Controller {
 
 		try {
 			$accessToken = $this->accessTokenMapper->getByCode($code);
-		} catch (AccessTokenNotFoundException $e) {
+		} catch (AccessTokenNotFoundException) {
 			$response = new JSONResponse([
 				'error' => 'invalid_request',
 			], Http::STATUS_BAD_REQUEST);
@@ -149,7 +150,7 @@ final class OauthApiController extends Controller {
 
 		try {
 			$client = $this->clientMapper->getByUid($accessToken->clientId);
-		} catch (ClientNotFoundException $e) {
+		} catch (ClientNotFoundException) {
 			$response = new JSONResponse([
 				'error' => 'invalid_request',
 			], Http::STATUS_BAD_REQUEST);
@@ -177,13 +178,14 @@ final class OauthApiController extends Controller {
 		try {
 			$storedClientSecretHash = $client->secret;
 			$clientSecretHash = bin2hex($this->crypto->calculateHMAC($client_secret));
-		} catch (\Exception $e) {
-			$this->logger->error('OAuth client secret decryption error', ['exception' => $e]);
+		} catch (\Exception $exception) {
+			$this->logger->error('OAuth client secret decryption error', ['exception' => $exception]);
 			// we don't throttle here because it might not be a bruteforce attack
 			return new JSONResponse([
 				'error' => 'invalid_client',
 			], Http::STATUS_BAD_REQUEST);
 		}
+
 		// The client id and secret must match. Else we don't provide an access token!
 		if ($client->clientIdentifier !== $client_id || $storedClientSecretHash !== $clientSecretHash) {
 			$response = new JSONResponse([
@@ -200,7 +202,7 @@ final class OauthApiController extends Controller {
 			$appToken = $this->tokenProvider->getTokenById($accessToken->tokenId);
 		} catch (ExpiredTokenException $e) {
 			$appToken = $e->getToken();
-		} catch (InvalidTokenException $e) {
+		} catch (InvalidTokenException) {
 			//We can't do anything...
 			$this->accessTokenMapper->delete($accessToken);
 			$response = new JSONResponse([
@@ -251,15 +253,16 @@ final class OauthApiController extends Controller {
 			$this->tokenProvider->updateToken($appToken);
 
 			$this->db->commit();
-		} catch (\Throwable $e) {
+		} catch (\Throwable $throwable) {
 			if ($this->db->inTransaction()) {
 				$this->db->rollBack();
 			}
+
 			// rotate() and updateToken() write the auth token to the cache,
 			// so if we are past rotate() we must invalidate the new token
 			$this->tokenProvider->invalidateToken($newToken);
 
-			throw $e;
+			throw $throwable;
 		}
 
 		$this->throttler->resetDelay($this->request->getRemoteAddress(), 'login', ['user' => $appToken->getUID()]);
@@ -286,7 +289,7 @@ final class OauthApiController extends Controller {
 	 */
 	private function pushTokenToSecondary(IToken $appToken, string $newToken, ?int $expires): ?string {
 		$user = $this->userManager->get($appToken->getUID());
-		if ($user === null) {
+		if (!$user instanceof IUser) {
 			$this->logger->warning('could not push oauth token to secondary: unknown user', ['uid' => $appToken->getUID()]);
 			return null;
 		}
@@ -294,8 +297,8 @@ final class OauthApiController extends Controller {
 		try {
 			/** @var IGlobalScaleService $globalScaleService */
 			$globalScaleService = $this->container->get(IGlobalScaleService::class);
-		} catch (ContainerExceptionInterface $e) {
-			$this->logger->warning('could not push oauth token to secondary: globalsiteselector is not available', ['exception' => $e]);
+		} catch (ContainerExceptionInterface $containerException) {
+			$this->logger->warning('could not push oauth token to secondary: globalsiteselector is not available', ['exception' => $containerException]);
 			return null;
 		}
 
@@ -312,9 +315,10 @@ final class OauthApiController extends Controller {
 				'expires' => $expires,
 				'token' => $newToken,
 			]);
-		} catch (\Exception $e) {
-			$this->logger->warning('could not push oauth token to secondary', ['exception' => $e]);
+		} catch (\Exception $exception) {
+			$this->logger->warning('could not push oauth token to secondary', ['exception' => $exception]);
 		}
+
 		return null;
 	}
 
@@ -336,8 +340,8 @@ final class OauthApiController extends Controller {
 		try {
 			/** @var IGlobalScaleService $globalScaleService */
 			$globalScaleService = $this->container->get(IGlobalScaleService::class);
-		} catch (ContainerExceptionInterface $e) {
-			$this->logger->warning('could not receive oauth token from primary: globalsiteselector is not available', ['exception' => $e]);
+		} catch (ContainerExceptionInterface $containerException) {
+			$this->logger->warning('could not receive oauth token from primary: globalsiteselector is not available', ['exception' => $containerException]);
 			$response = new JSONResponse([], Http::STATUS_BAD_REQUEST);
 			$response->throttle();
 			return $response;
@@ -362,8 +366,8 @@ final class OauthApiController extends Controller {
 				(array)$decoded['scope'],
 				$decoded['expires'] !== null ? (int)$decoded['expires'] : null,
 			);
-		} catch (\Exception $e) {
-			$this->logger->warning('could not create pushed oauth token', ['exception' => $e]);
+		} catch (\Exception $exception) {
+			$this->logger->warning('could not create pushed oauth token', ['exception' => $exception]);
 			$response = new JSONResponse([], Http::STATUS_BAD_REQUEST);
 			$response->throttle();
 			return $response;

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -70,7 +70,6 @@ final class OauthApiController extends Controller {
 	 * Get a token
 	 *
 	 * @param 'authorization_code'|'refresh_token' $grant_type Token type that should be granted
-	 * @psalm-param string $grant_type
 	 * @param ?string $code Code of the flow
 	 * @param ?string $refresh_token Refresh token
 	 * @param ?string $client_id Client ID
@@ -90,6 +89,7 @@ final class OauthApiController extends Controller {
 	): JSONResponse {
 
 		// We only handle two types
+		/** @psalm-suppress DocblockTypeContradiction We don't trust user input */
 		if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {
 			$response = new JSONResponse([
 				'error' => 'invalid_grant',

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -40,9 +40,9 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
-class OauthApiController extends Controller {
+final class OauthApiController extends Controller {
 	// the authorization code expires after 10 minutes
-	public const AUTHORIZATION_CODE_EXPIRES_AFTER = 10 * 60;
+	public const int AUTHORIZATION_CODE_EXPIRES_AFTER = 10 * 60;
 
 	public function __construct(
 		string $appName,
@@ -69,6 +69,7 @@ class OauthApiController extends Controller {
 	 * Get a token
 	 *
 	 * @param 'authorization_code'|'refresh_token' $grant_type Token type that should be granted
+	 * @psalm-param string $grant_type
 	 * @param ?string $code Code of the flow
 	 * @param ?string $refresh_token Refresh token
 	 * @param ?string $client_id Client ID
@@ -99,6 +100,14 @@ class OauthApiController extends Controller {
 		// We handle the initial and refresh tokens the same way
 		if ($grant_type === 'refresh_token') {
 			$code = $refresh_token;
+		}
+
+		if ($code === null) {
+			$response = new JSONResponse([
+				'error' => 'invalid_request',
+			], Http::STATUS_BAD_REQUEST);
+			$response->throttle(['invalid_request' => 'token not found']);
+			return $response;
 		}
 
 		try {
@@ -148,9 +157,21 @@ class OauthApiController extends Controller {
 			return $response;
 		}
 
+		/**
+		 * @psalm-suppress NoInterfaceProperties, MixedArrayAccess
+		 * IRequest exposes $server via a magic @property-read for the request's $_SERVER superglobal.
+		 */
 		if (isset($this->request->server['PHP_AUTH_USER'])) {
-			$client_id = $this->request->server['PHP_AUTH_USER'];
-			$client_secret = $this->request->server['PHP_AUTH_PW'];
+			$client_id = (string)$this->request->server['PHP_AUTH_USER'];
+			$client_secret = (string)$this->request->server['PHP_AUTH_PW'];
+		}
+
+		if ($client_secret === null) {
+			$response = new JSONResponse([
+				'error' => 'invalid_client',
+			], Http::STATUS_BAD_REQUEST);
+			$response->throttle(['invalid_client' => 'client ID or secret does not match']);
+			return $response;
 		}
 
 		try {
@@ -190,7 +211,9 @@ class OauthApiController extends Controller {
 		}
 
 		// Rotate the apptoken (so the old one becomes invalid basically)
+		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$newToken = $this->secureRandom->generate(72, ISecureRandom::CHAR_ALPHANUMERIC);
+		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$newCode = $this->secureRandom->generate(128, ISecureRandom::CHAR_ALPHANUMERIC);
 		$newEncryptedToken = $this->crypto->encrypt($newToken, $newCode);
 		$redeemedThrottleReason = $grant_type === 'authorization_code'
@@ -277,7 +300,9 @@ class OauthApiController extends Controller {
 		}
 
 		try {
-			return $globalScaleService->sendToSecondary($user, $this->urlGenerator->linkToRoute('oauth2.OauthApi.pushToken'), [
+			/** @var non-empty-string $pushRouteUrl */
+			$pushRouteUrl = $this->urlGenerator->linkToRoute('oauth2.OauthApi.pushToken');
+			return $globalScaleService->sendToSecondary($user, $pushRouteUrl, [
 				'uid' => $appToken->getUID(),
 				'loginName' => $appToken->getLoginName(),
 				'name' => $appToken->getName(),

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -113,7 +113,7 @@ class OauthApiController extends Controller {
 
 		if ($grant_type === 'authorization_code') {
 			// check this token is in authorization code state
-			$deliveredTokenCount = $accessToken->getTokenCount();
+			$deliveredTokenCount = $accessToken->tokenCount;
 			if ($deliveredTokenCount > 0) {
 				$response = new JSONResponse([
 					'error' => 'invalid_request',
@@ -124,7 +124,7 @@ class OauthApiController extends Controller {
 
 			// check authorization code expiration
 			$now = $this->timeFactory->now()->getTimestamp();
-			$codeCreatedAt = $accessToken->getCodeCreatedAt();
+			$codeCreatedAt = $accessToken->codeCreatedAt;
 			if ($codeCreatedAt < $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER) {
 				// we know this token is not useful anymore
 				$this->accessTokenMapper->delete($accessToken);
@@ -139,12 +139,12 @@ class OauthApiController extends Controller {
 		}
 
 		try {
-			$client = $this->clientMapper->getByUid($accessToken->getClientId());
+			$client = $this->clientMapper->getByUid($accessToken->clientId);
 		} catch (ClientNotFoundException $e) {
 			$response = new JSONResponse([
 				'error' => 'invalid_request',
 			], Http::STATUS_BAD_REQUEST);
-			$response->throttle(['invalid_request' => 'client not found', 'client_id' => $accessToken->getClientId()]);
+			$response->throttle(['invalid_request' => 'client not found', 'client_id' => $accessToken->clientId]);
 			return $response;
 		}
 
@@ -154,7 +154,7 @@ class OauthApiController extends Controller {
 		}
 
 		try {
-			$storedClientSecretHash = $client->getSecret();
+			$storedClientSecretHash = $client->secret;
 			$clientSecretHash = bin2hex($this->crypto->calculateHMAC($client_secret));
 		} catch (\Exception $e) {
 			$this->logger->error('OAuth client secret decryption error', ['exception' => $e]);
@@ -164,7 +164,7 @@ class OauthApiController extends Controller {
 			], Http::STATUS_BAD_REQUEST);
 		}
 		// The client id and secret must match. Else we don't provide an access token!
-		if ($client->getClientIdentifier() !== $client_id || $storedClientSecretHash !== $clientSecretHash) {
+		if ($client->clientIdentifier !== $client_id || $storedClientSecretHash !== $clientSecretHash) {
 			$response = new JSONResponse([
 				'error' => 'invalid_client',
 			], Http::STATUS_BAD_REQUEST);
@@ -172,11 +172,11 @@ class OauthApiController extends Controller {
 			return $response;
 		}
 
-		$decryptedToken = $this->crypto->decrypt($accessToken->getEncryptedToken(), $code);
+		$decryptedToken = $this->crypto->decrypt($accessToken->encryptedToken, $code);
 
 		// Obtain the appToken associated
 		try {
-			$appToken = $this->tokenProvider->getTokenById($accessToken->getTokenId());
+			$appToken = $this->tokenProvider->getTokenById($accessToken->tokenId);
 		} catch (ExpiredTokenException $e) {
 			$appToken = $e->getToken();
 		} catch (InvalidTokenException $e) {
@@ -200,7 +200,7 @@ class OauthApiController extends Controller {
 		$this->db->beginTransaction();
 		try {
 			$updatedRows = $this->accessTokenMapper->rotateToken(
-				$accessToken->getId(),
+				$accessToken->id,
 				$code,
 				$newCode,
 				$newEncryptedToken,

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -187,7 +187,7 @@ final class OauthApiController extends Controller {
 		}
 
 		// The client id and secret must match. Else we don't provide an access token!
-		if ($client->clientIdentifier !== $client_id || $storedClientSecretHash !== $clientSecretHash) {
+		if ($client->clientIdentifier !== $client_id || !hash_equals($storedClientSecretHash, $clientSecretHash)) {
 			$response = new JSONResponse([
 				'error' => 'invalid_client',
 			], Http::STATUS_BAD_REQUEST);

--- a/apps/oauth2/lib/Controller/SettingsController.php
+++ b/apps/oauth2/lib/Controller/SettingsController.php
@@ -17,7 +17,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
 use OCP\IRequest;
 
-class SettingsController extends Controller {
+final class SettingsController extends Controller {
 	public function __construct(
 		string $appName,
 		IRequest $request,
@@ -30,7 +30,11 @@ class SettingsController extends Controller {
 	#[PasswordConfirmationRequired(strict: true)]
 	public function addClient(string $name,
 		string $redirectUri): JSONResponse {
-		if (filter_var($redirectUri, FILTER_VALIDATE_URL) === false) {
+		if ($name === '') {
+			return new JSONResponse(['message' => $this->l->t('Client name cannot be empty.')], Http::STATUS_BAD_REQUEST);
+		}
+
+		if ($redirectUri === '' || filter_var($redirectUri, FILTER_VALIDATE_URL) === false) {
 			return new JSONResponse(['message' => $this->l->t('Your redirect URL needs to be a full URL for example: https://yourdomain.com/path')], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/apps/oauth2/lib/Controller/SettingsController.php
+++ b/apps/oauth2/lib/Controller/SettingsController.php
@@ -21,7 +21,7 @@ final class SettingsController extends Controller {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		private IL10N $l,
+		private readonly IL10N $l,
 		private readonly ClientService $clientService,
 	) {
 		parent::__construct($appName, $request);

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -9,44 +9,31 @@ declare(strict_types=1);
 
 namespace OCA\OAuth2\Db;
 
-use OCP\AppFramework\Db\Entity;
-use OCP\DB\Types;
+use OCP\AppFramework\ORM\Attribute\Column;
+use OCP\AppFramework\ORM\Attribute\Entity;
+use OCP\AppFramework\ORM\Attribute\Id;
+use OCP\DB\Schema\ColumnType;
 
-/**
- * @method int getTokenId()
- * @method void setTokenId(int $identifier)
- * @method int getClientId()
- * @method void setClientId(int $identifier)
- * @method string getEncryptedToken()
- * @method void setEncryptedToken(string $token)
- * @method string getHashedCode()
- * @method void setHashedCode(string $token)
- * @method int getCodeCreatedAt()
- * @method void setCodeCreatedAt(int $createdAt)
- * @method int getTokenCount()
- * @method void setTokenCount(int $tokenCount)
- */
-class AccessToken extends Entity {
-	/** @var int */
-	protected $tokenId;
-	/** @var int */
-	protected $clientId;
-	/** @var string */
-	protected $hashedCode;
-	/** @var string */
-	protected $encryptedToken;
-	/** @var int */
-	protected $codeCreatedAt;
-	/** @var int */
-	protected $tokenCount;
+#[Entity(name: 'oauth2_access_tokens')]
+class AccessToken {
+	#[Id, Column(name: 'id', type: ColumnType::Integer)]
+	public int $id;
 
-	public function __construct() {
-		$this->addType('id', Types::INTEGER);
-		$this->addType('tokenId', Types::INTEGER);
-		$this->addType('clientId', Types::INTEGER);
-		$this->addType('hashedCode', 'string');
-		$this->addType('encryptedToken', 'string');
-		$this->addType('codeCreatedAt', Types::INTEGER);
-		$this->addType('tokenCount', Types::INTEGER);
-	}
+	#[Column(name: 'token_id', type: ColumnType::Integer)]
+	public int $tokenId;
+
+	#[Column(name: 'client_id', type: ColumnType::Integer)]
+	public int $clientId;
+
+	#[Column(name: 'hashed_code', type: ColumnType::String, length: 128)]
+	public string $hashedCode;
+
+	#[Column(name: 'encrypted_token', type: ColumnType::String, length: 786)]
+	public string $encryptedToken;
+
+	#[Column(name: 'code_created_at', type: ColumnType::Bigint, default: 0)]
+	public int $codeCreatedAt = 0;
+
+	#[Column(name: 'token_count', type: ColumnType::Bigint, default: 0)]
+	public int $tokenCount = 0;
 }

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -14,8 +14,11 @@ use OCP\AppFramework\ORM\Attribute\Entity;
 use OCP\AppFramework\ORM\Attribute\Id;
 use OCP\DB\Schema\ColumnType;
 
+/**
+ * @psalm-suppress MissingConstructor ORM based hydration
+ */
 #[Entity(name: 'oauth2_access_tokens')]
-class AccessToken {
+final class AccessToken {
 	#[Id, Column(name: 'id', type: ColumnType::Integer)]
 	public int $id;
 

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -11,57 +11,41 @@ namespace OCA\OAuth2\Db;
 
 use OCA\OAuth2\Controller\OauthApiController;
 use OCA\OAuth2\Exceptions\AccessTokenNotFoundException;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\IMapperException;
 use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\ORM\Repository;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 /**
- * @template-extends QBMapper<AccessToken>
+ * @template-extends Repository<AccessToken>
  */
-class AccessTokenMapper extends QBMapper {
-
-	public function __construct(
-		IDBConnection $db,
-		private ITimeFactory $timeFactory,
-	) {
-		parent::__construct($db, 'oauth2_access_tokens');
-	}
+class AccessTokenMapper extends Repository {
+	const string entityClass = AccessToken::class;
 
 	/**
-	 * @param string $code
-	 * @return AccessToken
 	 * @throws AccessTokenNotFoundException
 	 */
 	public function getByCode(string $code): AccessToken {
-		$qb = $this->db->getQueryBuilder();
-		$qb
-			->select('*')
-			->from($this->tableName)
-			->where($qb->expr()->eq('hashed_code', $qb->createNamedParameter(hash('sha512', $code))));
-
 		try {
-			$token = $this->findEntity($qb);
-		} catch (IMapperException $e) {
+			return $this->findOneBy([
+				'hashedCode' => hash('sha512', $code),
+			]);
+		} catch (DoesNotExistException $e) {
 			throw new AccessTokenNotFoundException('Could not find access token', 0, $e);
 		}
-
-		return $token;
 	}
 
 	/**
-	 * delete all access token from a given client
-	 *
-	 * @param int $id
+	 * Delete all access token from a given client
 	 */
-	public function deleteByClientId(int $id) {
-		$qb = $this->db->getQueryBuilder();
-		$qb
-			->delete($this->tableName)
-			->where($qb->expr()->eq('client_id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$qb->executeStatement();
+	public function deleteByClientId(int $id): void {
+		$this->deleteBy([
+			'clientId' => $id,
+		]);
 	}
 
 	/**
@@ -69,16 +53,15 @@ class AccessTokenMapper extends QBMapper {
 	 * -> those that are old enough
 	 * and which never delivered any oauth token (still in authorization state)
 	 *
-	 * @return void
 	 * @throws Exception
 	 */
-	public function cleanupExpiredAuthorizationCode(): void {
-		$now = $this->timeFactory->now()->getTimestamp();
+	public function cleanupExpiredAuthorizationCode(ITimeFactory $timeFactory): void {
+		$now = $timeFactory->now()->getTimestamp();
 		$maxTokenCreationTs = $now - OauthApiController::AUTHORIZATION_CODE_EXPIRES_AFTER;
 
-		$qb = $this->db->getQueryBuilder();
+		$qb = $this->getDatabaseConnection()->getQueryBuilder();
 		$qb
-			->delete($this->tableName)
+			->delete($this->getTableName())
 			->where($qb->expr()->eq('token_count', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->lt('code_created_at', $qb->createNamedParameter($maxTokenCreationTs, IQueryBuilder::PARAM_INT)));
 		$qb->executeStatement();
@@ -87,17 +70,13 @@ class AccessTokenMapper extends QBMapper {
 	/**
 	 * Rotate an access token only if it still matches the caller's previously-read state.
 	 *
-	 * @param int $id
-	 * @param string $oldCode
-	 * @param string $newCode
-	 * @param string $encryptedToken
 	 * @param bool $expectAuthorizationCodeState Require the token to still be unused
 	 * @return int Number of updated rows
 	 */
 	public function rotateToken(int $id, string $oldCode, string $newCode, string $encryptedToken, bool $expectAuthorizationCodeState): int {
-		$qb = $this->db->getQueryBuilder();
+		$qb = $this->getDatabaseConnection()->getQueryBuilder();
 		$qb
-			->update($this->tableName)
+			->update($this->getTableName())
 			->set('hashed_code', $qb->createNamedParameter(hash('sha512', $newCode)))
 			->set('encrypted_token', $qb->createNamedParameter($encryptedToken))
 			->set('token_count', $qb->createFunction('token_count + 1'))

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -22,6 +22,7 @@ use OCP\IDBConnection;
 
 /**
  * @template-extends Repository<AccessToken>
+ * @psalm-suppress ClassMustBeFinal For unit tests
  */
 class AccessTokenMapper extends Repository {
 	const string entityClass = AccessToken::class;

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -57,7 +57,7 @@ class AccessTokenMapper extends Repository {
 		$now = $timeFactory->now()->getTimestamp();
 		$maxTokenCreationTs = $now - OauthApiController::AUTHORIZATION_CODE_EXPIRES_AFTER;
 
-		$qb = $this->getDatabaseConnection()->getQueryBuilder();
+		$qb = $this->connection->getQueryBuilder();
 		$qb
 			->delete($this->getTableName())
 			->where($qb->expr()->eq('token_count', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
@@ -72,7 +72,7 @@ class AccessTokenMapper extends Repository {
 	 * @return int Number of updated rows
 	 */
 	public function rotateToken(int $id, string $oldCode, string $newCode, string $encryptedToken, bool $expectAuthorizationCodeState): int {
-		$qb = $this->getDatabaseConnection()->getQueryBuilder();
+		$qb = $this->connection->getQueryBuilder();
 		$qb
 			->update($this->getTableName())
 			->set('hashed_code', $qb->createNamedParameter(hash('sha512', $newCode)))

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -12,20 +12,17 @@ namespace OCA\OAuth2\Db;
 use OCA\OAuth2\Controller\OauthApiController;
 use OCA\OAuth2\Exceptions\AccessTokenNotFoundException;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\IMapperException;
-use OCP\AppFramework\Db\QBMapper;
 use OCP\AppFramework\ORM\Repository;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IDBConnection;
 
 /**
  * @template-extends Repository<AccessToken>
  * @psalm-suppress ClassMustBeFinal For unit tests
  */
 class AccessTokenMapper extends Repository {
-	const string entityClass = AccessToken::class;
+	public const string entityClass = AccessToken::class;
 
 	/**
 	 * @throws AccessTokenNotFoundException
@@ -35,8 +32,8 @@ class AccessTokenMapper extends Repository {
 			return $this->findOneBy([
 				'hashedCode' => hash('sha512', $code),
 			]);
-		} catch (DoesNotExistException $e) {
-			throw new AccessTokenNotFoundException('Could not find access token', 0, $e);
+		} catch (DoesNotExistException $doesNotExistException) {
+			throw new AccessTokenNotFoundException('Could not find access token', 0, $doesNotExistException);
 		}
 	}
 

--- a/apps/oauth2/lib/Db/Client.php
+++ b/apps/oauth2/lib/Db/Client.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\OAuth2\Db;
 
-
 use OCP\AppFramework\ORM\Attribute\Column;
 use OCP\AppFramework\ORM\Attribute\Entity;
 use OCP\AppFramework\ORM\Attribute\Id;

--- a/apps/oauth2/lib/Db/Client.php
+++ b/apps/oauth2/lib/Db/Client.php
@@ -15,8 +15,11 @@ use OCP\AppFramework\ORM\Attribute\Entity;
 use OCP\AppFramework\ORM\Attribute\Id;
 use OCP\DB\Schema\ColumnType;
 
+/**
+ * @psalm-suppress MissingConstructor ORM based hydration
+ */
 #[Entity(name: 'oauth2_clients')]
-class Client {
+final class Client {
 	#[Id, Column(name: 'id', type: ColumnType::Integer)]
 	public int $id;
 

--- a/apps/oauth2/lib/Db/Client.php
+++ b/apps/oauth2/lib/Db/Client.php
@@ -9,34 +9,26 @@ declare(strict_types=1);
 
 namespace OCA\OAuth2\Db;
 
-use OCP\AppFramework\Db\Entity;
-use OCP\DB\Types;
 
-/**
- * @method string getClientIdentifier()
- * @method void setClientIdentifier(string $identifier)
- * @method string getSecret()
- * @method void setSecret(string $secret)
- * @method string getRedirectUri()
- * @method void setRedirectUri(string $redirectUri)
- * @method string getName()
- * @method void setName(string $name)
- */
-class Client extends Entity {
-	/** @var string */
-	protected $name;
-	/** @var string */
-	protected $redirectUri;
-	/** @var string */
-	protected $clientIdentifier;
-	/** @var string */
-	protected $secret;
+use OCP\AppFramework\ORM\Attribute\Column;
+use OCP\AppFramework\ORM\Attribute\Entity;
+use OCP\AppFramework\ORM\Attribute\Id;
+use OCP\DB\Schema\ColumnType;
 
-	public function __construct() {
-		$this->addType('id', Types::INTEGER);
-		$this->addType('name', 'string');
-		$this->addType('redirectUri', 'string');
-		$this->addType('clientIdentifier', 'string');
-		$this->addType('secret', 'string');
-	}
+#[Entity(name: 'oauth2_clients')]
+class Client {
+	#[Id, Column(name: 'id', type: ColumnType::Integer)]
+	public int $id;
+
+	#[Column(name: 'name', type: ColumnType::String, length: 64)]
+	public string $name;
+
+	#[Column(name: 'redirect_uri', type: ColumnType::String, length: 2000)]
+	public string $redirectUri;
+
+	#[Column(name: 'client_identifier', type: ColumnType::String, length: 64)]
+	public string $clientIdentifier;
+
+	#[Column(name: 'secret', type: ColumnType::String, length: 512)]
+	public string $secret;
 }

--- a/apps/oauth2/lib/Db/ClientMapper.php
+++ b/apps/oauth2/lib/Db/ClientMapper.php
@@ -19,6 +19,7 @@ use OCP\IDBConnection;
 
 /**
  * @template-extends Repository<Client>
+ * @psalm-suppress ClassMustBeFinal For unit tests
  */
 class ClientMapper extends Repository {
 	public const string entityClass = Client::class;

--- a/apps/oauth2/lib/Db/ClientMapper.php
+++ b/apps/oauth2/lib/Db/ClientMapper.php
@@ -10,22 +10,18 @@ declare(strict_types=1);
 namespace OCA\OAuth2\Db;
 
 use OCA\OAuth2\Exceptions\ClientNotFoundException;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\IMapperException;
 use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\ORM\Repository;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 /**
- * @template-extends QBMapper<Client>
+ * @template-extends Repository<Client>
  */
-class ClientMapper extends QBMapper {
-
-	/**
-	 * @param IDBConnection $db
-	 */
-	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'oauth2_clients');
-	}
+class ClientMapper extends Repository {
+	public const string entityClass = Client::class;
 
 	/**
 	 * @param string $clientIdentifier
@@ -33,18 +29,13 @@ class ClientMapper extends QBMapper {
 	 * @throws ClientNotFoundException
 	 */
 	public function getByIdentifier(string $clientIdentifier): Client {
-		$qb = $this->db->getQueryBuilder();
-		$qb
-			->select('*')
-			->from($this->tableName)
-			->where($qb->expr()->eq('client_identifier', $qb->createNamedParameter($clientIdentifier)));
-
 		try {
-			$client = $this->findEntity($qb);
-		} catch (IMapperException $e) {
-			throw new ClientNotFoundException('could not find client ' . $clientIdentifier, 0, $e);
+			return $this->findOneBy([
+				'clientIdentifier' => $clientIdentifier,
+			]);
+		} catch (DoesNotExistException $e) {
+			throw new ClientNotFoundException('Could not find client ' . $clientIdentifier, previous: $e);
 		}
-		return $client;
 	}
 
 	/**
@@ -53,29 +44,19 @@ class ClientMapper extends QBMapper {
 	 * @throws ClientNotFoundException
 	 */
 	public function getByUid(int $id): Client {
-		$qb = $this->db->getQueryBuilder();
-		$qb
-			->select('*')
-			->from($this->tableName)
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-
 		try {
-			$client = $this->findEntity($qb);
-		} catch (IMapperException $e) {
-			throw new ClientNotFoundException('could not find client with id ' . $id, 0, $e);
+			return $this->findOneBy([
+				'id' => $id,
+			]);
+		} catch (DoesNotExistException $e) {
+			throw new ClientNotFoundException('could not find client with id ' . $id, previous: $e);
 		}
-		return $client;
 	}
 
 	/**
-	 * @return Client[]
+	 * @return \Generator<Client>
 	 */
-	public function getClients(): array {
-		$qb = $this->db->getQueryBuilder();
-		$qb
-			->select('*')
-			->from($this->tableName);
-
-		return $this->findEntities($qb);
+	public function getClients(): \Generator {
+		return $this->yieldAll();
 	}
 }

--- a/apps/oauth2/lib/Db/ClientMapper.php
+++ b/apps/oauth2/lib/Db/ClientMapper.php
@@ -11,11 +11,7 @@ namespace OCA\OAuth2\Db;
 
 use OCA\OAuth2\Exceptions\ClientNotFoundException;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\IMapperException;
-use OCP\AppFramework\Db\QBMapper;
 use OCP\AppFramework\ORM\Repository;
-use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IDBConnection;
 
 /**
  * @template-extends Repository<Client>
@@ -25,8 +21,6 @@ class ClientMapper extends Repository {
 	public const string entityClass = Client::class;
 
 	/**
-	 * @param string $clientIdentifier
-	 * @return Client
 	 * @throws ClientNotFoundException
 	 */
 	public function getByIdentifier(string $clientIdentifier): Client {
@@ -34,14 +28,13 @@ class ClientMapper extends Repository {
 			return $this->findOneBy([
 				'clientIdentifier' => $clientIdentifier,
 			]);
-		} catch (DoesNotExistException $e) {
-			throw new ClientNotFoundException('Could not find client ' . $clientIdentifier, previous: $e);
+		} catch (DoesNotExistException $doesNotExistException) {
+			throw new ClientNotFoundException('Could not find client ' . $clientIdentifier, $doesNotExistException->getCode(), previous: $doesNotExistException);
 		}
 	}
 
 	/**
 	 * @param int $id internal id of the client
-	 * @return Client
 	 * @throws ClientNotFoundException
 	 */
 	public function getByUid(int $id): Client {
@@ -49,8 +42,8 @@ class ClientMapper extends Repository {
 			return $this->findOneBy([
 				'id' => $id,
 			]);
-		} catch (DoesNotExistException $e) {
-			throw new ClientNotFoundException('could not find client with id ' . $id, previous: $e);
+		} catch (DoesNotExistException $doesNotExistException) {
+			throw new ClientNotFoundException('could not find client with id ' . $id, $doesNotExistException->getCode(), previous: $doesNotExistException);
 		}
 	}
 

--- a/apps/oauth2/lib/Exceptions/AccessTokenNotFoundException.php
+++ b/apps/oauth2/lib/Exceptions/AccessTokenNotFoundException.php
@@ -9,5 +9,5 @@ declare(strict_types=1);
 
 namespace OCA\OAuth2\Exceptions;
 
-class AccessTokenNotFoundException extends \Exception {
+final class AccessTokenNotFoundException extends \Exception {
 }

--- a/apps/oauth2/lib/Exceptions/ClientNotFoundException.php
+++ b/apps/oauth2/lib/Exceptions/ClientNotFoundException.php
@@ -9,5 +9,5 @@ declare(strict_types=1);
 
 namespace OCA\OAuth2\Exceptions;
 
-class ClientNotFoundException extends \Exception {
+final class ClientNotFoundException extends \Exception {
 }

--- a/apps/oauth2/lib/Migration/SetTokenExpiration.php
+++ b/apps/oauth2/lib/Migration/SetTokenExpiration.php
@@ -10,14 +10,13 @@ declare(strict_types=1);
 namespace OCA\OAuth2\Migration;
 
 use OC\Authentication\Token\IProvider as TokenProvider;
-use OCA\OAuth2\Db\AccessToken;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
-class SetTokenExpiration implements IRepairStep {
+final class SetTokenExpiration implements IRepairStep {
 
 	public function __construct(
 		private IDBConnection $connection,
@@ -32,17 +31,17 @@ class SetTokenExpiration implements IRepairStep {
 	}
 
 	#[\Override]
-	public function run(IOutput $output) {
+	public function run(IOutput $output): void {
 		$qb = $this->connection->getQueryBuilder();
-		$qb->select('*')
+		$qb->select('token_id')
 			->from('oauth2_access_tokens');
 
 		$cursor = $qb->executeQuery();
 
-		while ($row = $cursor->fetchAssociative()) {
-			$token = AccessToken::fromRow($row);
+		while (($row = $cursor->fetchAssociative()) !== false) {
+			$tokenId = (int)$row['token_id'];
 			try {
-				$appToken = $this->tokenProvider->getTokenById($token->getTokenId());
+				$appToken = $this->tokenProvider->getTokenById($tokenId);
 				$appToken->setExpires($this->time->getTime() + 3600);
 				$this->tokenProvider->updateToken($appToken);
 			} catch (InvalidTokenException $e) {

--- a/apps/oauth2/lib/Migration/SetTokenExpiration.php
+++ b/apps/oauth2/lib/Migration/SetTokenExpiration.php
@@ -16,7 +16,7 @@ use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
-final class SetTokenExpiration implements IRepairStep {
+final readonly class SetTokenExpiration implements IRepairStep {
 
 	public function __construct(
 		private IDBConnection $connection,
@@ -44,10 +44,11 @@ final class SetTokenExpiration implements IRepairStep {
 				$appToken = $this->tokenProvider->getTokenById($tokenId);
 				$appToken->setExpires($this->time->getTime() + 3600);
 				$this->tokenProvider->updateToken($appToken);
-			} catch (InvalidTokenException $e) {
+			} catch (InvalidTokenException) {
 				//Skip this token
 			}
 		}
+
 		$cursor->closeCursor();
 	}
 }

--- a/apps/oauth2/lib/Migration/Version010401Date20181207190718.php
+++ b/apps/oauth2/lib/Migration/Version010401Date20181207190718.php
@@ -14,17 +14,9 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version010401Date20181207190718 extends SimpleMigrationStep {
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 * @return null|ISchemaWrapper
-	 */
+final class Version010401Date20181207190718 extends SimpleMigrationStep {
 	#[\Override]
-	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
-		/** @var ISchemaWrapper $schema */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		$schema = $schemaClosure();
 
 		if (!$schema->hasTable('oauth2_clients')) {

--- a/apps/oauth2/lib/Migration/Version010401Date20181207190718.php
+++ b/apps/oauth2/lib/Migration/Version010401Date20181207190718.php
@@ -71,6 +71,7 @@ final class Version010401Date20181207190718 extends SimpleMigrationStep {
 			$table->addUniqueIndex(['hashed_code'], 'oauth2_access_hash_idx');
 			$table->addIndex(['client_id'], 'oauth2_access_client_id_idx');
 		}
+
 		return $schema;
 	}
 }

--- a/apps/oauth2/lib/Migration/Version010402Date20190107124745.php
+++ b/apps/oauth2/lib/Migration/Version010402Date20190107124745.php
@@ -17,9 +17,7 @@ use OCP\Migration\SimpleMigrationStep;
 final class Version010402Date20190107124745 extends SimpleMigrationStep {
 
 	/**
-	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 */
 	#[\Override]

--- a/apps/oauth2/lib/Migration/Version010402Date20190107124745.php
+++ b/apps/oauth2/lib/Migration/Version010402Date20190107124745.php
@@ -14,7 +14,7 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version010402Date20190107124745 extends SimpleMigrationStep {
+final class Version010402Date20190107124745 extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output

--- a/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
+++ b/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
@@ -19,8 +19,8 @@ use OCP\Security\ICrypto;
 final class Version011601Date20230522143227 extends SimpleMigrationStep {
 
 	public function __construct(
-		private IDBConnection $connection,
-		private ICrypto $crypto,
+		private readonly IDBConnection $connection,
+		private readonly ICrypto $crypto,
 	) {
 	}
 
@@ -61,6 +61,7 @@ final class Version011601Date20230522143227 extends SimpleMigrationStep {
 			$qbUpdate->setParameter('updateId', $id, IQueryBuilder::PARAM_INT);
 			$qbUpdate->executeStatement();
 		}
+
 		$req->closeCursor();
 	}
 }

--- a/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
+++ b/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
@@ -10,14 +10,13 @@ declare(strict_types=1);
 namespace OCA\OAuth2\Migration;
 
 use Closure;
-use OCP\DB\ISchemaWrapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Security\ICrypto;
 
-class Version011601Date20230522143227 extends SimpleMigrationStep {
+final class Version011601Date20230522143227 extends SimpleMigrationStep {
 
 	public function __construct(
 		private IDBConnection $connection,
@@ -27,7 +26,6 @@ class Version011601Date20230522143227 extends SimpleMigrationStep {
 
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
 		if ($schema->hasTable('oauth2_clients')) {
@@ -43,7 +41,7 @@ class Version011601Date20230522143227 extends SimpleMigrationStep {
 	}
 
 	#[\Override]
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
 		$qbUpdate = $this->connection->getQueryBuilder();
 		$qbUpdate->update('oauth2_clients')
 			->set('secret', $qbUpdate->createParameter('updateSecret'))
@@ -56,8 +54,8 @@ class Version011601Date20230522143227 extends SimpleMigrationStep {
 			->from('oauth2_clients');
 		$req = $qbSelect->executeQuery();
 		while ($row = $req->fetchAssociative()) {
-			$id = $row['id'];
-			$secret = $row['secret'];
+			$id = (int)$row['id'];
+			$secret = (string)$row['secret'];
 			$encryptedSecret = $this->crypto->encrypt($secret);
 			$qbUpdate->setParameter('updateSecret', $encryptedSecret, IQueryBuilder::PARAM_STR);
 			$qbUpdate->setParameter('updateId', $id, IQueryBuilder::PARAM_INT);

--- a/apps/oauth2/lib/Migration/Version011602Date20230613160650.php
+++ b/apps/oauth2/lib/Migration/Version011602Date20230613160650.php
@@ -15,10 +15,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 final class Version011602Date20230613160650 extends SimpleMigrationStep {
 
-	public function __construct(
-	) {
-	}
-
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
 		$schema = $schemaClosure();

--- a/apps/oauth2/lib/Migration/Version011602Date20230613160650.php
+++ b/apps/oauth2/lib/Migration/Version011602Date20230613160650.php
@@ -10,11 +10,10 @@ declare(strict_types=1);
 namespace OCA\OAuth2\Migration;
 
 use Closure;
-use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version011602Date20230613160650 extends SimpleMigrationStep {
+final class Version011602Date20230613160650 extends SimpleMigrationStep {
 
 	public function __construct(
 	) {
@@ -22,7 +21,6 @@ class Version011602Date20230613160650 extends SimpleMigrationStep {
 
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
 		if ($schema->hasTable('oauth2_clients')) {

--- a/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
+++ b/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
@@ -20,7 +20,7 @@ use OCP\Migration\SimpleMigrationStep;
 final class Version011603Date20230620111039 extends SimpleMigrationStep {
 
 	public function __construct(
-		private IDBConnection $connection,
+		private readonly IDBConnection $connection,
 	) {
 	}
 
@@ -39,6 +39,7 @@ final class Version011603Date20230620111039 extends SimpleMigrationStep {
 				]);
 				$dbChanged = true;
 			}
+
 			if (!$table->hasColumn('token_count')) {
 				$table->addColumn('token_count', Types::BIGINT, [
 					'notnull' => true,
@@ -47,10 +48,12 @@ final class Version011603Date20230620111039 extends SimpleMigrationStep {
 				]);
 				$dbChanged = true;
 			}
+
 			if (!$table->hasIndex('oauth2_tk_c_created_idx')) {
 				$table->addIndex(['token_count', 'code_created_at'], 'oauth2_tk_c_created_idx');
 				$dbChanged = true;
 			}
+
 			if ($dbChanged) {
 				return $schema;
 			}

--- a/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
+++ b/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
@@ -17,7 +17,7 @@ use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version011603Date20230620111039 extends SimpleMigrationStep {
+final class Version011603Date20230620111039 extends SimpleMigrationStep {
 
 	public function __construct(
 		private IDBConnection $connection,
@@ -26,7 +26,6 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
 		if ($schema->hasTable('oauth2_access_tokens')) {

--- a/apps/oauth2/lib/Migration/Version011901Date20240829164356.php
+++ b/apps/oauth2/lib/Migration/Version011901Date20240829164356.php
@@ -16,7 +16,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Security\ICrypto;
 
-class Version011901Date20240829164356 extends SimpleMigrationStep {
+final class Version011901Date20240829164356 extends SimpleMigrationStep {
 
 	public function __construct(
 		private IDBConnection $connection,
@@ -38,8 +38,8 @@ class Version011901Date20240829164356 extends SimpleMigrationStep {
 			->from('oauth2_clients');
 		$req = $qbSelect->executeQuery();
 		while ($row = $req->fetchAssociative()) {
-			$id = $row['id'];
-			$storedEncryptedSecret = $row['secret'];
+			$id = (int)$row['id'];
+			$storedEncryptedSecret = (string)$row['secret'];
 			$secret = $this->crypto->decrypt($storedEncryptedSecret);
 			$hashedSecret = bin2hex($this->crypto->calculateHMAC($secret));
 			$qbUpdate->setParameter('updateSecret', $hashedSecret, IQueryBuilder::PARAM_STR);

--- a/apps/oauth2/lib/Migration/Version011901Date20240829164356.php
+++ b/apps/oauth2/lib/Migration/Version011901Date20240829164356.php
@@ -19,8 +19,8 @@ use OCP\Security\ICrypto;
 final class Version011901Date20240829164356 extends SimpleMigrationStep {
 
 	public function __construct(
-		private IDBConnection $connection,
-		private ICrypto $crypto,
+		private readonly IDBConnection $connection,
+		private readonly ICrypto $crypto,
 	) {
 	}
 
@@ -46,6 +46,7 @@ final class Version011901Date20240829164356 extends SimpleMigrationStep {
 			$qbUpdate->setParameter('updateId', $id, IQueryBuilder::PARAM_INT);
 			$qbUpdate->executeStatement();
 		}
+
 		$req->closeCursor();
 	}
 }

--- a/apps/oauth2/lib/Service/ClientService.php
+++ b/apps/oauth2/lib/Service/ClientService.php
@@ -49,19 +49,19 @@ class ClientService {
 	 */
 	public function addClient(string $name, string $redirectUri): array {
 		$client = new Client();
-		$client->setName($name);
-		$client->setRedirectUri($redirectUri);
+		$client->name = $name;
+		$client->redirectUri = $redirectUri;
 		$secret = $this->secureRandom->generate(64, self::validChars);
 		$hashedSecret = bin2hex($this->crypto->calculateHMAC($secret));
-		$client->setSecret($hashedSecret);
-		$client->setClientIdentifier($this->secureRandom->generate(64, self::validChars));
+		$client->secret = $hashedSecret;
+		$client->clientIdentifier = $this->secureRandom->generate(64, self::validChars);
 		$client = $this->clientMapper->insert($client);
 
 		return [
-			'id' => $client->getId(),
-			'name' => $client->getName(),
-			'redirectUri' => $client->getRedirectUri(),
-			'clientId' => $client->getClientIdentifier(),
+			'id' => $client->id,
+			'name' => $client->name,
+			'redirectUri' => $client->redirectUri,
+			'clientId' => $client->clientIdentifier,
 			'clientSecret' => $secret,
 		];
 	}
@@ -74,7 +74,7 @@ class ClientService {
 			// OAuth2 client does not silently cancel a pending wipe.
 			$tokens = $this->tokenProvider->getTokenByUser($user->getUID());
 			foreach ($tokens as $token) {
-				if ($token->getName() !== $client->getName()) {
+				if ($token->getName() !== $client->name) {
 					continue;
 				}
 				try {

--- a/apps/oauth2/lib/Service/ClientService.php
+++ b/apps/oauth2/lib/Service/ClientService.php
@@ -22,17 +22,17 @@ use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
-final class ClientService {
+final readonly class ClientService {
 	public const string validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 	public function __construct(
-		private readonly ISecureRandom $secureRandom,
-		private readonly ICrypto $crypto,
-		private readonly ClientMapper $clientMapper,
-		private readonly IUserManager $userManager,
-		private readonly IAuthTokenProvider $tokenProvider,
-		private readonly LoggerInterface $logger,
-		private readonly AccessTokenMapper $accessTokenMapper,
+		private ISecureRandom $secureRandom,
+		private ICrypto $crypto,
+		private ClientMapper $clientMapper,
+		private IUserManager $userManager,
+		private IAuthTokenProvider $tokenProvider,
+		private LoggerInterface $logger,
+		private AccessTokenMapper $accessTokenMapper,
 	) {
 	}
 
@@ -79,6 +79,7 @@ final class ClientService {
 				if ($token->getName() !== $client->name) {
 					continue;
 				}
+
 				try {
 					$this->tokenProvider->getTokenById($token->getId());
 				} catch (WipeTokenException) {
@@ -90,6 +91,7 @@ final class ClientService {
 				} catch (InvalidTokenException) {
 					// Token already invalid; let invalidateTokenById handle it.
 				}
+
 				$this->tokenProvider->invalidateTokenById($user->getUID(), $token->getId());
 			}
 		});

--- a/apps/oauth2/lib/Service/ClientService.php
+++ b/apps/oauth2/lib/Service/ClientService.php
@@ -22,8 +22,8 @@ use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
-class ClientService {
-	public const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+final class ClientService {
+	public const string validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 	public function __construct(
 		private readonly ISecureRandom $secureRandom,
@@ -51,9 +51,11 @@ class ClientService {
 		$client = new Client();
 		$client->name = $name;
 		$client->redirectUri = $redirectUri;
+		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$secret = $this->secureRandom->generate(64, self::validChars);
 		$hashedSecret = bin2hex($this->crypto->calculateHMAC($secret));
 		$client->secret = $hashedSecret;
+		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$client->clientIdentifier = $this->secureRandom->generate(64, self::validChars);
 		$client = $this->clientMapper->insert($client);
 

--- a/apps/oauth2/lib/Settings/Admin.php
+++ b/apps/oauth2/lib/Settings/Admin.php
@@ -16,7 +16,7 @@ use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
 use OCP\Util;
 
-class Admin implements ISettings {
+final class Admin implements ISettings {
 
 	public function __construct(
 		private IInitialState $initialState,

--- a/apps/oauth2/lib/Settings/Admin.php
+++ b/apps/oauth2/lib/Settings/Admin.php
@@ -16,7 +16,7 @@ use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
 use OCP\Util;
 
-final class Admin implements ISettings {
+final readonly class Admin implements ISettings {
 
 	public function __construct(
 		private IInitialState $initialState,
@@ -39,6 +39,7 @@ final class Admin implements ISettings {
 				'clientSecret' => '',
 			];
 		}
+
 		$this->initialState->provideInitialState('clients', $result);
 		$this->initialState->provideInitialState('oauth2-doc-link', $this->urlGenerator->linkToDocs('admin-oauth2'));
 

--- a/apps/oauth2/lib/Settings/Admin.php
+++ b/apps/oauth2/lib/Settings/Admin.php
@@ -15,7 +15,6 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
 use OCP\Util;
-use Psr\Log\LoggerInterface;
 
 class Admin implements ISettings {
 
@@ -23,7 +22,6 @@ class Admin implements ISettings {
 		private IInitialState $initialState,
 		private ClientMapper $clientMapper,
 		private IURLGenerator $urlGenerator,
-		private LoggerInterface $logger,
 	) {
 	}
 
@@ -33,17 +31,13 @@ class Admin implements ISettings {
 		$result = [];
 
 		foreach ($clients as $client) {
-			try {
-				$result[] = [
-					'id' => $client->getId(),
-					'name' => $client->getName(),
-					'redirectUri' => $client->getRedirectUri(),
-					'clientId' => $client->getClientIdentifier(),
-					'clientSecret' => '',
-				];
-			} catch (\Exception $e) {
-				$this->logger->error('[Settings] OAuth client secret decryption error', ['exception' => $e]);
-			}
+			$result[] = [
+				'id' => $client->id,
+				'name' => $client->name,
+				'redirectUri' => $client->redirectUri,
+				'clientId' => $client->clientIdentifier,
+				'clientSecret' => '',
+			];
 		}
 		$this->initialState->provideInitialState('clients', $result);
 		$this->initialState->provideInitialState('oauth2-doc-link', $this->urlGenerator->linkToDocs('admin-oauth2'));

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
-class LoginRedirectorControllerTest extends TestCase {
+final class LoginRedirectorControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private IURLGenerator&MockObject $urlGenerator;
 	private ClientMapper&MockObject $clientMapper;
@@ -64,7 +64,8 @@ class LoginRedirectorControllerTest extends TestCase {
 
 	public function testAuthorize(): void {
 		$client = new Client();
-		$client->setClientIdentifier('MyClientIdentifier');
+		$client->name = 'MyClientName';
+		$client->clientIdentifier = 'MyClientIdentifier';
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')
@@ -97,8 +98,8 @@ class LoginRedirectorControllerTest extends TestCase {
 
 	public function testAuthorizeSkipPicker(): void {
 		$client = new Client();
-		$client->setName('MyClientName');
-		$client->setClientIdentifier('MyClientIdentifier');
+		$client->name = 'MyClientName';
+		$client->clientIdentifier = 'MyClientIdentifier';
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')
@@ -114,7 +115,7 @@ class LoginRedirectorControllerTest extends TestCase {
 						/* Expected */
 						break;
 					default:
-						throw new LogicException();
+						throw new \LogicException();
 				}
 			});
 		$this->appConfig
@@ -150,8 +151,8 @@ class LoginRedirectorControllerTest extends TestCase {
 
 	public function testAuthorizeWrongResponseType(): void {
 		$client = new Client();
-		$client->setClientIdentifier('MyClientIdentifier');
-		$client->setRedirectUri('http://foo.bar');
+		$client->clientIdentifier = 'MyClientIdentifier';
+		$client->redirectUri = 'http://foo.bar';
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')
@@ -167,8 +168,9 @@ class LoginRedirectorControllerTest extends TestCase {
 
 	public function testAuthorizeWithLegacyOcClient(): void {
 		$client = new Client();
-		$client->setClientIdentifier('MyClientIdentifier');
-		$client->setRedirectUri('http://localhost:*');
+		$client->name = 'MyClientName';
+		$client->clientIdentifier = 'MyClientIdentifier';
+		$client->redirectUri = 'http://localhost:*';
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')
@@ -201,7 +203,8 @@ class LoginRedirectorControllerTest extends TestCase {
 
 	public function testAuthorizeNotForwardingUntrustedURIs(): void {
 		$client = new Client();
-		$client->setClientIdentifier('MyClientIdentifier');
+		$client->name = 'MyClientName';
+		$client->clientIdentifier = 'MyClientIdentifier';
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -37,6 +37,7 @@ final class LoginRedirectorControllerTest extends TestCase {
 
 	private LoginRedirectorController $loginRedirectorController;
 
+	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 

--- a/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
+++ b/apps/oauth2/tests/Controller/LoginRedirectorControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -27,12 +29,19 @@ use Test\TestCase;
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 final class LoginRedirectorControllerTest extends TestCase {
 	private IRequest&MockObject $request;
+
 	private IURLGenerator&MockObject $urlGenerator;
+
 	private ClientMapper&MockObject $clientMapper;
+
 	private ISession&MockObject $session;
+
 	private IL10N&MockObject $l;
+
 	private ISecureRandom&MockObject $random;
+
 	private IAppConfig&MockObject $appConfig;
+
 	private IConfig&MockObject $config;
 
 	private LoginRedirectorController $loginRedirectorController;

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -7,8 +7,6 @@
 
 namespace OCA\OAuth2\Tests\Controller;
 
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OC\Authentication\Token\PublicKeyToken;
 use OCA\OAuth2\Controller\OauthApiController;
@@ -21,6 +19,8 @@ use OCA\OAuth2\Exceptions\ClientNotFoundException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Token\IToken;
 use OCP\GlobalScale\IConfig as GlobalScaleConfig;
 use OCP\GlobalScale\IGlobalScaleService;
@@ -44,7 +44,7 @@ abstract class RequestMock implements IRequest {
 }
 
 final class OauthApiControllerTest extends TestCase {
-	private IRequest&MockObject $request;
+	private RequestMock&MockObject $request;
 	private ICrypto&MockObject $crypto;
 	private AccessTokenMapper&MockObject $accessTokenMapper;
 	private ClientMapper&MockObject $clientMapper;
@@ -61,6 +61,7 @@ final class OauthApiControllerTest extends TestCase {
 	private ContainerInterface&MockObject $container;
 	private OauthApiController $oauthApiController;
 
+	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -238,7 +239,7 @@ final class OauthApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->oauthApiController->getToken('refresh_token', null, 'validrefresh', null, null));
 	}
 
-	public static function invalidClientProvider() {
+	public static function invalidClientProvider(): array {
 		return [
 			['invalidClientId', 'invalidClientSecret'],
 			['clientId', 'invalidClientSecret'],
@@ -368,7 +369,7 @@ final class OauthApiControllerTest extends TestCase {
 			->with($accessToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function ($len) {
+			->willReturnCallback(function (int $len) {
 				return 'random' . $len;
 			});
 
@@ -478,7 +479,7 @@ final class OauthApiControllerTest extends TestCase {
 			->with($accessToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function ($len) {
+			->willReturnCallback(function (int $len) {
 				return 'random' . $len;
 			});
 
@@ -591,7 +592,7 @@ final class OauthApiControllerTest extends TestCase {
 			->with($accessToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function ($len) {
+			->willReturnCallback(function (int $len) {
 				return 'random' . $len;
 			});
 
@@ -702,7 +703,7 @@ final class OauthApiControllerTest extends TestCase {
 			->willReturn($appToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function ($len) {
+			->willReturnCallback(function (int $len) {
 				return 'random' . $len;
 			});
 
@@ -792,7 +793,7 @@ final class OauthApiControllerTest extends TestCase {
 			->willReturn($appToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function ($len) {
+			->willReturnCallback(function (int $len) {
 				return 'random' . $len;
 			});
 		$this->time->method('getTime')->willReturn(1000);

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -45,20 +47,35 @@ abstract class RequestMock implements IRequest {
 
 final class OauthApiControllerTest extends TestCase {
 	private RequestMock&MockObject $request;
+
 	private ICrypto&MockObject $crypto;
+
 	private AccessTokenMapper&MockObject $accessTokenMapper;
+
 	private ClientMapper&MockObject $clientMapper;
+
 	private TokenProvider&MockObject $tokenProvider;
+
 	private ISecureRandom&MockObject $secureRandom;
+
 	private ITimeFactory&MockObject $time;
+
 	private IThrottler&MockObject $throttler;
+
 	private LoggerInterface&MockObject $logger;
+
 	private ITimeFactory&MockObject $timeFactory;
+
 	private IDBConnection&MockObject $db;
+
 	private GlobalScaleConfig&MockObject $globalScaleConfig;
+
 	private IUserManager&MockObject $userManager;
+
 	private IURLGenerator&MockObject $urlGenerator;
+
 	private ContainerInterface&MockObject $container;
+
 	private OauthApiController $oauthApiController;
 
 	#[\Override]
@@ -268,14 +285,10 @@ final class OauthApiControllerTest extends TestCase {
 
 		$this->crypto
 			->method('calculateHMAC')
-			->with($this->callback(function (string $text) {
-				return $text === 'clientSecret' || $text === 'invalidClientSecret';
-			}))
-			->willReturnCallback(function (string $text) {
-				return $text === 'clientSecret'
+			->with($this->callback(fn (string $text): bool => $text === 'clientSecret' || $text === 'invalidClientSecret'))
+			->willReturnCallback(fn (string $text): string => $text === 'clientSecret'
 					? 'hashedClientSecret'
-					: 'hashedInvalidClientSecret';
-			});
+					: 'hashedInvalidClientSecret');
 
 		$client = new Client();
 		$client->clientIdentifier = 'clientId';
@@ -369,9 +382,7 @@ final class OauthApiControllerTest extends TestCase {
 			->with($accessToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function (int $len) {
-				return 'random' . $len;
-			});
+			->willReturnCallback(fn (int $len): string => 'random' . $len);
 
 		$this->tokenProvider->expects($this->once())
 			->method('rotate')
@@ -399,9 +410,7 @@ final class OauthApiControllerTest extends TestCase {
 		$this->tokenProvider->expects($this->once())
 			->method('updateToken')
 			->with(
-				$this->callback(function (PublicKeyToken $token) {
-					return $token->getExpires() === 4600;
-				})
+				$this->callback(fn (PublicKeyToken $token): bool => $token->getExpires() === 4600)
 			);
 
 		$this->crypto->method('encrypt')
@@ -479,9 +488,7 @@ final class OauthApiControllerTest extends TestCase {
 			->with($accessToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function (int $len) {
-				return 'random' . $len;
-			});
+			->willReturnCallback(fn (int $len): string => 'random' . $len);
 
 		$this->tokenProvider->expects($this->once())
 			->method('rotate')
@@ -509,9 +516,7 @@ final class OauthApiControllerTest extends TestCase {
 		$this->tokenProvider->expects($this->once())
 			->method('updateToken')
 			->with(
-				$this->callback(function (PublicKeyToken $token) {
-					return $token->getExpires() === 4600;
-				})
+				$this->callback(fn (PublicKeyToken $token): bool => $token->getExpires() === 4600)
 			);
 
 		$this->crypto->method('encrypt')
@@ -592,9 +597,7 @@ final class OauthApiControllerTest extends TestCase {
 			->with($accessToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function (int $len) {
-				return 'random' . $len;
-			});
+			->willReturnCallback(fn (int $len): string => 'random' . $len);
 
 		$this->tokenProvider->expects($this->once())
 			->method('rotate')
@@ -622,9 +625,7 @@ final class OauthApiControllerTest extends TestCase {
 		$this->tokenProvider->expects($this->once())
 			->method('updateToken')
 			->with(
-				$this->callback(function (PublicKeyToken $token) {
-					return $token->getExpires() === 4600;
-				})
+				$this->callback(fn (PublicKeyToken $token): bool => $token->getExpires() === 4600)
 			);
 
 		$this->crypto->method('encrypt')
@@ -703,9 +704,7 @@ final class OauthApiControllerTest extends TestCase {
 			->willReturn($appToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function (int $len) {
-				return 'random' . $len;
-			});
+			->willReturnCallback(fn (int $len): string => 'random' . $len);
 
 		$this->tokenProvider->expects($this->never())
 			->method('rotate');
@@ -793,9 +792,7 @@ final class OauthApiControllerTest extends TestCase {
 			->willReturn($appToken);
 
 		$this->secureRandom->method('generate')
-			->willReturnCallback(function (int $len) {
-				return 'random' . $len;
-			});
+			->willReturnCallback(fn (int $len): string => 'random' . $len);
 		$this->time->method('getTime')->willReturn(1000);
 		$this->accessTokenMapper->method('rotateToken')->willReturn(1);
 		$this->request->method('getRemoteAddress')->willReturn('1.2.3.4');
@@ -869,7 +866,7 @@ final class OauthApiControllerTest extends TestCase {
 		$this->globalScaleConfig->method('isGlobalScaleEnabled')->willReturn(true);
 		$this->globalScaleConfig->method('isPrimary')->willReturn(true);
 
-		$user = $this->createMock(IUser::class);
+		$user = $this->createStub(IUser::class);
 		$this->userManager->method('get')->with('userId')->willReturn($user);
 
 		$this->container->method('get')
@@ -888,7 +885,7 @@ final class OauthApiControllerTest extends TestCase {
 		$this->globalScaleConfig->method('isGlobalScaleEnabled')->willReturn(true);
 		$this->globalScaleConfig->method('isPrimary')->willReturn(true);
 
-		$user = $this->createMock(IUser::class);
+		$user = $this->createStub(IUser::class);
 		$this->userManager->method('get')->with('userId')->willReturn($user);
 
 		$this->urlGenerator->method('linkToRoute')
@@ -928,7 +925,7 @@ final class OauthApiControllerTest extends TestCase {
 		$this->globalScaleConfig->method('isGlobalScaleEnabled')->willReturn(true);
 		$this->globalScaleConfig->method('isPrimary')->willReturn(true);
 
-		$user = $this->createMock(IUser::class);
+		$user = $this->createStub(IUser::class);
 		$this->userManager->method('get')->with('userId')->willReturn($user);
 
 		$globalScaleService = $this->createMock(IGlobalScaleService::class);

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -124,6 +124,7 @@ final class OauthApiControllerTest extends TestCase {
 		], Http::STATUS_BAD_REQUEST);
 		$expected->throttle(['invalid_grant' => 'foo']);
 
+		/** @psalm-suppress InvalidArgument Test that we don't trust user input */
 		$this->assertEquals($expected, $this->oauthApiController->getToken('foo', null, null, null, null));
 	}
 

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -43,7 +43,7 @@ abstract class RequestMock implements IRequest {
 	public array $server = [];
 }
 
-class OauthApiControllerTest extends TestCase {
+final class OauthApiControllerTest extends TestCase {
 	private IRequest&MockObject $request;
 	private ICrypto&MockObject $crypto;
 	private AccessTokenMapper&MockObject $accessTokenMapper;
@@ -132,8 +132,8 @@ class OauthApiControllerTest extends TestCase {
 		$expected->throttle(['invalid_request' => 'authorization_code_expired', 'expired_since' => $expiredSince]);
 
 		$accessToken = new AccessToken();
-		$accessToken->setClientId(42);
-		$accessToken->setCodeCreatedAt($codeCreatedAt);
+		$accessToken->clientId = 42;
+		$accessToken->codeCreatedAt = $codeCreatedAt;
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
@@ -158,9 +158,9 @@ class OauthApiControllerTest extends TestCase {
 		$expected->throttle(['invalid_request' => 'authorization_code_received_for_active_token']);
 
 		$accessToken = new AccessToken();
-		$accessToken->setClientId(42);
-		$accessToken->setCodeCreatedAt($codeCreatedAt);
-		$accessToken->setTokenCount(1);
+		$accessToken->clientId = 42;
+		$accessToken->codeCreatedAt = $codeCreatedAt;
+		$accessToken->tokenCount = 1;
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
@@ -185,8 +185,8 @@ class OauthApiControllerTest extends TestCase {
 		$expected->throttle(['invalid_request' => 'client not found', 'client_id' => 42]);
 
 		$accessToken = new AccessToken();
-		$accessToken->setClientId(42);
-		$accessToken->setCodeCreatedAt($codeCreatedAt);
+		$accessToken->clientId = 42;
+		$accessToken->codeCreatedAt = $codeCreatedAt;
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
@@ -225,7 +225,7 @@ class OauthApiControllerTest extends TestCase {
 		$expected->throttle(['invalid_request' => 'client not found', 'client_id' => 42]);
 
 		$accessToken = new AccessToken();
-		$accessToken->setClientId(42);
+		$accessToken->clientId = 42;
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
@@ -259,7 +259,7 @@ class OauthApiControllerTest extends TestCase {
 		$expected->throttle(['invalid_client' => 'client ID or secret does not match']);
 
 		$accessToken = new AccessToken();
-		$accessToken->setClientId(42);
+		$accessToken->clientId = 42;
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
@@ -277,8 +277,8 @@ class OauthApiControllerTest extends TestCase {
 			});
 
 		$client = new Client();
-		$client->setClientIdentifier('clientId');
-		$client->setSecret(bin2hex('hashedClientSecret'));
+		$client->clientIdentifier = 'clientId';
+		$client->secret = bin2hex('hashedClientSecret');
 		$this->clientMapper->method('getByUid')
 			->with(42)
 			->willReturn($client);
@@ -293,17 +293,17 @@ class OauthApiControllerTest extends TestCase {
 		$expected->throttle(['invalid_request' => 'token is invalid']);
 
 		$accessToken = new AccessToken();
-		$accessToken->setClientId(42);
-		$accessToken->setTokenId(1337);
-		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->clientId = 42;
+		$accessToken->tokenId = 1337;
+		$accessToken->encryptedToken = 'encryptedToken';
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
 			->willReturn($accessToken);
 
 		$client = new Client();
-		$client->setClientIdentifier('clientId');
-		$client->setSecret(bin2hex('hashedClientSecret'));
+		$client->clientIdentifier = 'clientId';
+		$client->secret = bin2hex('hashedClientSecret');
 		$this->clientMapper->method('getByUid')
 			->with(42)
 			->willReturn($client);
@@ -331,18 +331,18 @@ class OauthApiControllerTest extends TestCase {
 
 	public function testRefreshTokenValidAppToken(): void {
 		$accessToken = new AccessToken();
-		$accessToken->setId(21);
-		$accessToken->setClientId(42);
-		$accessToken->setTokenId(1337);
-		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->id = 21;
+		$accessToken->clientId = 42;
+		$accessToken->tokenId = 1337;
+		$accessToken->encryptedToken = 'encryptedToken';
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
 			->willReturn($accessToken);
 
 		$client = new Client();
-		$client->setClientIdentifier('clientId');
-		$client->setSecret(bin2hex('hashedClientSecret'));
+		$client->clientIdentifier = 'clientId';
+		$client->secret = bin2hex('hashedClientSecret');
 		$this->clientMapper->method('getByUid')
 			->with(42)
 			->willReturn($client);
@@ -441,18 +441,18 @@ class OauthApiControllerTest extends TestCase {
 
 	public function testRefreshTokenValidAppTokenBasicAuth(): void {
 		$accessToken = new AccessToken();
-		$accessToken->setId(21);
-		$accessToken->setClientId(42);
-		$accessToken->setTokenId(1337);
-		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->id = 21;
+		$accessToken->clientId = 42;
+		$accessToken->tokenId = 1337;
+		$accessToken->encryptedToken = 'encryptedToken';
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
 			->willReturn($accessToken);
 
 		$client = new Client();
-		$client->setClientIdentifier('clientId');
-		$client->setSecret(bin2hex('hashedClientSecret'));
+		$client->clientIdentifier = 'clientId';
+		$client->secret = bin2hex('hashedClientSecret');
 		$this->clientMapper->method('getByUid')
 			->with(42)
 			->willReturn($client);
@@ -554,18 +554,18 @@ class OauthApiControllerTest extends TestCase {
 
 	public function testRefreshTokenExpiredAppToken(): void {
 		$accessToken = new AccessToken();
-		$accessToken->setId(21);
-		$accessToken->setClientId(42);
-		$accessToken->setTokenId(1337);
-		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->id = 21;
+		$accessToken->clientId = 42;
+		$accessToken->tokenId = 1337;
+		$accessToken->encryptedToken = 'encryptedToken';
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
 			->willReturn($accessToken);
 
 		$client = new Client();
-		$client->setClientIdentifier('clientId');
-		$client->setSecret(bin2hex('hashedClientSecret'));
+		$client->clientIdentifier = 'clientId';
+		$client->secret = bin2hex('hashedClientSecret');
 		$this->clientMapper->method('getByUid')
 			->with(42)
 			->willReturn($client);
@@ -669,18 +669,18 @@ class OauthApiControllerTest extends TestCase {
 		$expected->throttle(['invalid_request' => 'refresh_token_already_redeemed']);
 
 		$accessToken = new AccessToken();
-		$accessToken->setId(21);
-		$accessToken->setClientId(42);
-		$accessToken->setTokenId(1337);
-		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->id = 21;
+		$accessToken->clientId = 42;
+		$accessToken->tokenId = 1337;
+		$accessToken->encryptedToken = 'encryptedToken';
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
 			->willReturn($accessToken);
 
 		$client = new Client();
-		$client->setClientIdentifier('clientId');
-		$client->setSecret(bin2hex('hashedClientSecret'));
+		$client->clientIdentifier = 'clientId';
+		$client->secret = bin2hex('hashedClientSecret');
 		$this->clientMapper->method('getByUid')
 			->with(42)
 			->willReturn($client);
@@ -753,18 +753,18 @@ class OauthApiControllerTest extends TestCase {
 	 */
 	private function arrangeSuccessfulTokenExchange(): PublicKeyToken {
 		$accessToken = new AccessToken();
-		$accessToken->setId(21);
-		$accessToken->setClientId(42);
-		$accessToken->setTokenId(1337);
-		$accessToken->setEncryptedToken('encryptedToken');
+		$accessToken->id = 21;
+		$accessToken->clientId = 42;
+		$accessToken->tokenId = 1337;
+		$accessToken->encryptedToken = 'encryptedToken';
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validrefresh')
 			->willReturn($accessToken);
 
 		$client = new Client();
-		$client->setClientIdentifier('clientId');
-		$client->setSecret(bin2hex('hashedClientSecret'));
+		$client->clientIdentifier = 'clientId';
+		$client->secret = bin2hex('hashedClientSecret');
 		$this->clientMapper->method('getByUid')
 			->with(42)
 			->willReturn($client);

--- a/apps/oauth2/tests/Controller/SettingsControllerTest.php
+++ b/apps/oauth2/tests/Controller/SettingsControllerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
 #[Group(name: 'DB')]
-class SettingsControllerTest extends TestCase {
+final class SettingsControllerTest extends TestCase {
 	public function testInvalidRedirectUri(): void {
 		$settingsController = Server::get(SettingsController::class);
 		$result = $settingsController->addClient('test', 'invalidurl');

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -17,6 +17,7 @@ use Test\TestCase;
 final class AccessTokenMapperTest extends TestCase {
 	private AccessTokenMapper $accessTokenMapper;
 
+	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->accessTokenMapper = Server::get(AccessTokenMapper::class);

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -30,6 +32,7 @@ final class AccessTokenMapperTest extends TestCase {
 		$token->tokenId = time();
 		$token->encryptedToken = 'MyEncryptedToken';
 		$token->hashedCode = hash('sha512', 'MyAwesomeToken');
+
 		$this->accessTokenMapper->insert($token);
 
 		$result = $this->accessTokenMapper->getByCode('MyAwesomeToken');
@@ -46,6 +49,7 @@ final class AccessTokenMapperTest extends TestCase {
 		$token->tokenId = time();
 		$token->encryptedToken = 'MyEncryptedToken';
 		$token->hashedCode = hash('sha512', 'MyAwesomeToken');
+
 		$this->accessTokenMapper->insert($token);
 		$this->accessTokenMapper->deleteByClientId(1234);
 		$this->accessTokenMapper->getByCode('MyAwesomeToken');

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -10,30 +10,26 @@ namespace OCA\OAuth2\Tests\Db;
 use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Exceptions\AccessTokenNotFoundException;
-use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
-class AccessTokenMapperTest extends TestCase {
-	/** @var AccessTokenMapper */
-	private $accessTokenMapper;
+final class AccessTokenMapperTest extends TestCase {
+	private AccessTokenMapper $accessTokenMapper;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->accessTokenMapper = new AccessTokenMapper(Server::get(IDBConnection::class), Server::get(ITimeFactory::class));
+		$this->accessTokenMapper = Server::get(AccessTokenMapper::class);
 	}
 
 	public function testGetByCode(): void {
 		$this->accessTokenMapper->deleteByClientId(1234);
 		$token = new AccessToken();
-		$token->setClientId(1234);
-		$token->setTokenId(time());
-		$token->setEncryptedToken('MyEncryptedToken');
-		$token->setHashedCode(hash('sha512', 'MyAwesomeToken'));
+		$token->clientId = 1234;
+		$token->tokenId = time();
+		$token->encryptedToken = 'MyEncryptedToken';
+		$token->hashedCode = hash('sha512', 'MyAwesomeToken');
 		$this->accessTokenMapper->insert($token);
-		$token->resetUpdatedFields();
 
 		$result = $this->accessTokenMapper->getByCode('MyAwesomeToken');
 		$this->assertEquals($token, $result);
@@ -45,12 +41,11 @@ class AccessTokenMapperTest extends TestCase {
 
 		$this->accessTokenMapper->deleteByClientId(1234);
 		$token = new AccessToken();
-		$token->setClientId(1234);
-		$token->setTokenId(time());
-		$token->setEncryptedToken('MyEncryptedToken');
-		$token->setHashedCode(hash('sha512', 'MyAwesomeToken'));
+		$token->clientId = 1234;
+		$token->tokenId = time();
+		$token->encryptedToken = 'MyEncryptedToken';
+		$token->hashedCode = hash('sha512', 'MyAwesomeToken');
 		$this->accessTokenMapper->insert($token);
-		$token->resetUpdatedFields();
 		$this->accessTokenMapper->deleteByClientId(1234);
 		$this->accessTokenMapper->getByCode('MyAwesomeToken');
 	}

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -15,13 +15,13 @@ use OCP\Server;
 use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
-class ClientMapperTest extends TestCase {
+final class ClientMapperTest extends TestCase {
 	/** @var ClientMapper */
 	private $clientMapper;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->clientMapper = new ClientMapper(Server::get(IDBConnection::class));
+		$this->clientMapper = Server::get(ClientMapper::class);
 	}
 
 	protected function tearDown(): void {
@@ -33,12 +33,11 @@ class ClientMapperTest extends TestCase {
 
 	public function testGetByIdentifier(): void {
 		$client = new Client();
-		$client->setClientIdentifier('MyAwesomeClientIdentifier');
-		$client->setName('Client Name');
-		$client->setRedirectUri('https://example.com/');
-		$client->setSecret('TotallyNotSecret');
+		$client->clientIdentifier = 'MyAwesomeClientIdentifier';
+		$client->name = 'Client Name';
+		$client->redirectUri = 'https://example.com/';
+		$client->secret = 'TotallyNotSecret';
 		$this->clientMapper->insert($client);
-		$client->resetUpdatedFields();
 		$this->assertEquals($client, $this->clientMapper->getByIdentifier('MyAwesomeClientIdentifier'));
 	}
 
@@ -50,13 +49,12 @@ class ClientMapperTest extends TestCase {
 
 	public function testGetByUid(): void {
 		$client = new Client();
-		$client->setClientIdentifier('MyNewClient');
-		$client->setName('Client Name');
-		$client->setRedirectUri('https://example.com/');
-		$client->setSecret('TotallyNotSecret');
+		$client->clientIdentifier = 'MyNewClient';
+		$client->name = 'Client Name';
+		$client->redirectUri = 'https://example.com/';
+		$client->secret = 'TotallyNotSecret';
 		$this->clientMapper->insert($client);
-		$client->resetUpdatedFields();
-		$this->assertEquals($client, $this->clientMapper->getByUid($client->getId()));
+		$this->assertEquals($client, $this->clientMapper->getByUid($client->id));
 	}
 
 	public function testGetByUidNotExisting(): void {
@@ -66,15 +64,15 @@ class ClientMapperTest extends TestCase {
 	}
 
 	public function testGetClients(): void {
-		$this->assertSame('array', gettype($this->clientMapper->getClients()));
+		$this->assertInstanceOf(\Generator::class, $this->clientMapper->getClients());
 	}
 
 	public function testInsertLongEncryptedSecret(): void {
 		$client = new Client();
-		$client->setClientIdentifier('MyNewClient');
-		$client->setName('Client Name');
-		$client->setRedirectUri('https://example.com/');
-		$client->setSecret('b81dc8e2dc178817bf28ca7b37265aa96559ca02e6dcdeb74b42221d096ed5ef63681e836ae0ba1077b5fb5e6c2fa7748c78463f66fe0110c8dcb8dd7eb0305b16d0cd993e2ae275879994a2abf88c68|e466d9befa6b0102341458e45ecd551a|013af9e277374483123437f180a3b0371a411ad4f34c451547909769181a7d7cc191f0f5c2de78376d124dd7751b8c9660aabdd913f5e071fc6b819ba2e3d919|3');
+		$client->clientIdentifier = 'MyNewClient';
+		$client->name = 'Client Name';
+		$client->redirectUri = 'https://example.com/';
+		$client->secret = 'b81dc8e2dc178817bf28ca7b37265aa96559ca02e6dcdeb74b42221d096ed5ef63681e836ae0ba1077b5fb5e6c2fa7748c78463f66fe0110c8dcb8dd7eb0305b16d0cd993e2ae275879994a2abf88c68|e466d9befa6b0102341458e45ecd551a|013af9e277374483123437f180a3b0371a411ad4f34c451547909769181a7d7cc191f0f5c2de78376d124dd7751b8c9660aabdd913f5e071fc6b819ba2e3d919|3';
 		$this->clientMapper->insert($client);
 		$this->assertTrue(true);
 	}

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -38,6 +40,7 @@ final class ClientMapperTest extends TestCase {
 		$client->name = 'Client Name';
 		$client->redirectUri = 'https://example.com/';
 		$client->secret = 'TotallyNotSecret';
+
 		$this->clientMapper->insert($client);
 		$this->assertEquals($client, $this->clientMapper->getByIdentifier('MyAwesomeClientIdentifier'));
 	}
@@ -54,6 +57,7 @@ final class ClientMapperTest extends TestCase {
 		$client->name = 'Client Name';
 		$client->redirectUri = 'https://example.com/';
 		$client->secret = 'TotallyNotSecret';
+
 		$this->clientMapper->insert($client);
 		$this->assertEquals($client, $this->clientMapper->getByUid($client->id));
 	}
@@ -74,6 +78,7 @@ final class ClientMapperTest extends TestCase {
 		$client->name = 'Client Name';
 		$client->redirectUri = 'https://example.com/';
 		$client->secret = 'b81dc8e2dc178817bf28ca7b37265aa96559ca02e6dcdeb74b42221d096ed5ef63681e836ae0ba1077b5fb5e6c2fa7748c78463f66fe0110c8dcb8dd7eb0305b16d0cd993e2ae275879994a2abf88c68|e466d9befa6b0102341458e45ecd551a|013af9e277374483123437f180a3b0371a411ad4f34c451547909769181a7d7cc191f0f5c2de78376d124dd7751b8c9660aabdd913f5e071fc6b819ba2e3d919|3';
+
 		$this->clientMapper->insert($client);
 		$this->assertTrue(true);
 	}

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -16,14 +16,15 @@ use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 final class ClientMapperTest extends TestCase {
-	/** @var ClientMapper */
-	private $clientMapper;
+	private ClientMapper $clientMapper;
 
+	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->clientMapper = Server::get(ClientMapper::class);
 	}
 
+	#[\Override]
 	protected function tearDown(): void {
 		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('oauth2_clients')->executeStatement();

--- a/apps/oauth2/tests/Service/ClientServiceTest.php
+++ b/apps/oauth2/tests/Service/ClientServiceTest.php
@@ -24,7 +24,7 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
-class ClientServiceTest extends TestCase {
+final class ClientServiceTest extends TestCase {
 	private ClientMapper&MockObject $clientMapper;
 	private ISecureRandom&MockObject $secureRandom;
 	private AccessTokenMapper&MockObject $accessTokenMapper;
@@ -70,21 +70,21 @@ class ClientServiceTest extends TestCase {
 			->willReturn('MyHashedSecret');
 
 		$client = new Client();
-		$client->setName('My Client Name');
-		$client->setRedirectUri('https://example.com/');
-		$client->setSecret(bin2hex('MyHashedSecret'));
-		$client->setClientIdentifier('MyClientIdentifier');
+		$client->name = 'My Client Name';
+		$client->redirectUri = 'https://example.com/';
+		$client->secret = bin2hex('MyHashedSecret');
+		$client->clientIdentifier = 'MyClientIdentifier';
 
 		$this->clientMapper
 			->expects($this->once())
 			->method('insert')
 			->with($this->callback(function (Client $c) {
-				return $c->getName() === 'My Client Name'
-					&& $c->getRedirectUri() === 'https://example.com/'
-					&& $c->getSecret() === bin2hex('MyHashedSecret')
-					&& $c->getClientIdentifier() === 'MyClientIdentifier';
+				return $c->name === 'My Client Name'
+					&& $c->redirectUri === 'https://example.com/'
+					&& $c->secret === bin2hex('MyHashedSecret')
+					&& $c->clientIdentifier === 'MyClientIdentifier';
 			}))->willReturnCallback(function (Client $c) {
-				$c->setId(42);
+				$c->id = 42;
 				return $c;
 			});
 
@@ -125,11 +125,11 @@ class ClientServiceTest extends TestCase {
 			->method('invalidateTokenById');
 
 		$client = new Client();
-		$client->setId(123);
-		$client->setName('My Client Name');
-		$client->setRedirectUri('https://example.com/');
-		$client->setSecret(bin2hex('MyHashedSecret'));
-		$client->setClientIdentifier('MyClientIdentifier');
+		$client->id = 123;
+		$client->name = 'My Client Name';
+		$client->redirectUri = 'https://example.com/';
+		$client->secret = bin2hex('MyHashedSecret');
+		$client->clientIdentifier = 'MyClientIdentifier';
 
 		$this->clientMapper
 			->method('getByUid')
@@ -164,11 +164,11 @@ class ClientServiceTest extends TestCase {
 		$user->updateLastLoginTimestamp();
 
 		$client = new Client();
-		$client->setId(456);
-		$client->setName('My Client Name');
-		$client->setRedirectUri('https://example.com/');
-		$client->setSecret(bin2hex('MyHashedSecret'));
-		$client->setClientIdentifier('MyClientIdentifier');
+		$client->id = 456;
+		$client->name = 'My Client Name';
+		$client->redirectUri = 'https://example.com/';
+		$client->secret = bin2hex('MyHashedSecret');
+		$client->clientIdentifier = 'MyClientIdentifier';
 
 		// Token marked for wipe with a matching client name: must NOT be invalidated.
 		$wipeToken = $this->createMock(IToken::class);

--- a/apps/oauth2/tests/Service/ClientServiceTest.php
+++ b/apps/oauth2/tests/Service/ClientServiceTest.php
@@ -34,6 +34,7 @@ final class ClientServiceTest extends TestCase {
 	private ICrypto&MockObject $crypto;
 	private LoggerInterface&MockObject $logger;
 
+	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -111,6 +112,7 @@ final class ClientServiceTest extends TestCase {
 		};
 		$userManager->callForAllUsers($function);
 		$user1 = $userManager->createUser('test101', 'test101');
+		$this->assertInstanceOf(IUser::class, $user1);
 		$user1->updateLastLoginTimestamp();
 		$tokenProviderMock = $this->getMockBuilder(IAuthTokenProvider::class)->getMock();
 
@@ -161,6 +163,7 @@ final class ClientServiceTest extends TestCase {
 	public function testDeleteClientPreservesWipePendingToken(): void {
 		$userManager = Server::get(IUserManager::class);
 		$user = $userManager->createUser('test_wipe_preserve', 'test_wipe_preserve');
+		$this->assertInstanceOf(IUser::class, $user);
 		$user->updateLastLoginTimestamp();
 
 		$client = new Client();

--- a/apps/oauth2/tests/Service/ClientServiceTest.php
+++ b/apps/oauth2/tests/Service/ClientServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -26,12 +28,19 @@ use Test\TestCase;
 #[\PHPUnit\Framework\Attributes\Group(name: 'DB')]
 final class ClientServiceTest extends TestCase {
 	private ClientMapper&MockObject $clientMapper;
+
 	private ISecureRandom&MockObject $secureRandom;
+
 	private AccessTokenMapper&MockObject $accessTokenMapper;
+
 	private IAuthTokenProvider&MockObject $authTokenProvider;
+
 	private IUserManager&MockObject $userManager;
+
 	private ClientService $clientService;
+
 	private ICrypto&MockObject $crypto;
+
 	private LoggerInterface&MockObject $logger;
 
 	#[\Override]
@@ -79,15 +88,13 @@ final class ClientServiceTest extends TestCase {
 		$this->clientMapper
 			->expects($this->once())
 			->method('insert')
-			->with($this->callback(function (Client $c) {
-				return $c->name === 'My Client Name'
+			->with($this->callback(fn (Client $c): bool => $c->name === 'My Client Name'
 					&& $c->redirectUri === 'https://example.com/'
 					&& $c->secret === bin2hex('MyHashedSecret')
-					&& $c->clientIdentifier === 'MyClientIdentifier';
-			}))->willReturnCallback(function (Client $c) {
-				$c->id = 42;
-				return $c;
-			});
+					&& $c->clientIdentifier === 'MyClientIdentifier'))->willReturnCallback(function (Client $c): Client {
+						$c->id = 42;
+						return $c;
+					});
 
 		$result = $this->clientService->addClient('My Client Name', 'https://example.com/');
 
@@ -107,7 +114,7 @@ final class ClientServiceTest extends TestCase {
 		$count = 0;
 		$function = function (IUser $user) use (&$count): void {
 			if ($user->getLastLogin() > 0) {
-				$count++;
+				++$count;
 			}
 		};
 		$userManager->callForAllUsers($function);
@@ -157,6 +164,7 @@ final class ClientServiceTest extends TestCase {
 		);
 
 		$this->clientService->deleteClient(123);
+
 		$user1->delete();
 	}
 
@@ -190,11 +198,9 @@ final class ClientServiceTest extends TestCase {
 
 		$this->authTokenProvider
 			->method('getTokenByUser')
-			->willReturnCallback(function (string $uid) use ($wipeToken, $regularToken, $otherToken) {
-				return $uid === 'test_wipe_preserve'
+			->willReturnCallback(fn (string $uid): array => $uid === 'test_wipe_preserve'
 					? [$wipeToken, $regularToken, $otherToken]
-					: [];
-			});
+					: []);
 		// Wipe state is signalled via WipeTokenException from getTokenById.
 		$this->authTokenProvider
 			->method('getTokenById')
@@ -202,6 +208,7 @@ final class ClientServiceTest extends TestCase {
 				if ($id === 11) {
 					throw new WipeTokenException($wipeToken);
 				}
+
 				return $regularToken;
 			});
 		$this->authTokenProvider
@@ -224,10 +231,8 @@ final class ClientServiceTest extends TestCase {
 
 		$this->logger->expects($this->atLeastOnce())
 			->method('info')
-			->with($this->stringContains('Preserving token'), $this->callback(function (array $context) {
-				return ($context['tokenId'] ?? null) === 11
-					&& ($context['uid'] ?? null) === 'test_wipe_preserve';
-			}));
+			->with($this->stringContains('Preserving token'), $this->callback(fn (array $context): bool => ($context['tokenId'] ?? null) === 11
+					&& ($context['uid'] ?? null) === 'test_wipe_preserve'));
 
 		$clientService = new ClientService(
 			$this->secureRandom,

--- a/apps/oauth2/tests/Settings/AdminTest.php
+++ b/apps/oauth2/tests/Settings/AdminTest.php
@@ -13,20 +13,14 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
-class AdminTest extends TestCase {
+final class AdminTest extends TestCase {
+	private Admin $admin;
+	private IInitialState&MockObject $initialState;
+	private ClientMapper&MockObject $clientMapper;
 
-	/** @var Admin|MockObject */
-	private $admin;
-
-	/** @var IInitialState|MockObject */
-	private $initialState;
-
-	/** @var ClientMapper|MockObject */
-	private $clientMapper;
-
+	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -37,7 +31,6 @@ class AdminTest extends TestCase {
 			$this->initialState,
 			$this->clientMapper,
 			$this->createMock(IURLGenerator::class),
-			$this->createMock(LoggerInterface::class)
 		);
 	}
 

--- a/apps/oauth2/tests/Settings/AdminTest.php
+++ b/apps/oauth2/tests/Settings/AdminTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -17,7 +19,9 @@ use Test\TestCase;
 
 final class AdminTest extends TestCase {
 	private Admin $admin;
+
 	private IInitialState&MockObject $initialState;
+
 	private ClientMapper&MockObject $clientMapper;
 
 	#[\Override]

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2226,26 +2226,6 @@
       <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/oauth2/lib/Controller/LoginRedirectorController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/oauth2/lib/Controller/OauthApiController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-    <NoInterfaceProperties>
-      <code><![CDATA[$this->request->server]]></code>
-    </NoInterfaceProperties>
-  </file>
-  <file src="apps/oauth2/lib/Service/ClientService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/provisioning_api/lib/Controller/AUserDataOCSController.php">
     <DeprecatedClass>
       <code><![CDATA[\OC_Util::setupFS($user->getUID())]]></code>

--- a/build/rector-strict.php
+++ b/build/rector-strict.php
@@ -49,6 +49,7 @@ return (require __DIR__ . '/rector-shared.php')
 		$nextcloudDir . '/apps/files/tests/Sharing',
 		$nextcloudDir . '/lib/public/AppFramework/ORM',
 		$nextcloudDir . '/lib/private/AppFramework/ORM',
+		$nextcloudDir . '/apps/oauth2',
 	])
 	->withAutoloadPaths([
 		// ensure rector properly autoload the public interfaces

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -104,7 +104,7 @@ class ClientFlowLoginController extends Controller {
 		$client = null;
 		if ($clientIdentifier !== '') {
 			$client = $this->clientMapper->getByIdentifier($clientIdentifier);
-			$clientName = $client->getName();
+			$clientName = $client->name;
 		}
 
 		// No valid clientIdentifier given and no valid API Request (APIRequest header not set)
@@ -134,7 +134,7 @@ class ClientFlowLoginController extends Controller {
 
 		$csp = new ContentSecurityPolicy();
 		if ($client) {
-			$csp->addAllowedFormActionDomain($client->getRedirectUri());
+			$csp->addAllowedFormActionDomain($client->redirectUri);
 		} else {
 			$csp->addAllowedFormActionDomain('nc://*');
 		}
@@ -191,12 +191,12 @@ class ClientFlowLoginController extends Controller {
 		$client = null;
 		if ($clientIdentifier !== '') {
 			$client = $this->clientMapper->getByIdentifier($clientIdentifier);
-			$clientName = $client->getName();
+			$clientName = $client->name;
 		}
 
 		$csp = new ContentSecurityPolicy();
 		if ($client) {
-			$csp->addAllowedFormActionDomain($client->getRedirectUri());
+			$csp->addAllowedFormActionDomain($client->redirectUri);
 		} else {
 			$csp->addAllowedFormActionDomain('nc://*');
 		}
@@ -274,7 +274,7 @@ class ClientFlowLoginController extends Controller {
 		$client = false;
 		if ($clientIdentifier !== '') {
 			$client = $this->clientMapper->getByIdentifier($clientIdentifier);
-			$clientName = $client->getName();
+			$clientName = $client->name;
 		}
 
 		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
@@ -292,16 +292,16 @@ class ClientFlowLoginController extends Controller {
 		if ($client) {
 			$code = $this->random->generate(128, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 			$accessToken = new AccessToken();
-			$accessToken->setClientId($client->getId());
-			$accessToken->setEncryptedToken($this->crypto->encrypt($token, $code));
-			$accessToken->setHashedCode(hash('sha512', $code));
-			$accessToken->setTokenId($generatedToken->getId());
-			$accessToken->setCodeCreatedAt($this->timeFactory->now()->getTimestamp());
+			$accessToken->clientId = $client->id;
+			$accessToken->encryptedToken = $this->crypto->encrypt($token, $code);
+			$accessToken->hashedCode = hash('sha512', $code);
+			$accessToken->tokenId = $generatedToken->getId();
+			$accessToken->codeCreatedAt = $this->timeFactory->now()->getTimestamp();
 			$this->accessTokenMapper->insert($accessToken);
 
 			$enableOcClients = $this->config->getSystemValueBool('oauth2.enable_oc_clients', false);
 
-			$redirectUri = $client->getRedirectUri();
+			$redirectUri = $client->redirectUri;
 			if ($enableOcClients && $redirectUri === 'http://localhost:*') {
 				// Sanity check untrusted redirect URI provided by the client first
 				if (!preg_match('/^http:\/\/localhost:[0-9]+$/', $providedRedirectUri)) {

--- a/lib/private/Repair/Owncloud/MigrateOauthTables.php
+++ b/lib/private/Repair/Owncloud/MigrateOauthTables.php
@@ -221,8 +221,8 @@ class MigrateOauthTables implements IRepairStep {
 			$now = $this->timeFactory->now()->getTimestamp();
 			$index = 0;
 			while ($row = $result->fetchAssociative()) {
-				$clientId = $row['client_id'];
-				$refreshToken = $row['token'];
+				$clientId = (int)$row['client_id'];
+				$refreshToken = (string)$row['token'];
 
 				// Insert expired token so that it can be rotated on the next refresh
 				$accessToken = $this->random->generate(72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
@@ -239,12 +239,12 @@ class MigrateOauthTables implements IRepairStep {
 				$this->tokenProvider->updateToken($authToken);
 
 				$accessTokenEntity = new AccessToken();
-				$accessTokenEntity->setTokenId($authToken->getId());
-				$accessTokenEntity->setClientId($clientId);
-				$accessTokenEntity->setHashedCode(hash('sha512', $refreshToken));
-				$accessTokenEntity->setEncryptedToken($this->crypto->encrypt($accessToken, $refreshToken));
-				$accessTokenEntity->setCodeCreatedAt($now);
-				$accessTokenEntity->setTokenCount(1);
+				$accessTokenEntity->tokenId = $authToken->getId();
+				$accessTokenEntity->clientId = $clientId;
+				$accessTokenEntity->hashedCode = hash('sha512', $refreshToken);
+				$accessTokenEntity->encryptedToken = $this->crypto->encrypt($accessToken, $refreshToken);
+				$accessTokenEntity->codeCreatedAt = $now;
+				$accessTokenEntity->tokenCount = 1;
 				$this->accessTokenMapper->insert($accessTokenEntity);
 
 				$index++;

--- a/psalm-strict.xml
+++ b/psalm-strict.xml
@@ -55,6 +55,7 @@
 		<directory name="apps/files/tests/Sharing"/>
 		<directory name="lib/private/AppFramework/ORM"/>
 		<directory name="lib/public/AppFramework/ORM"/>
+		<directory name="apps/oauth2"/>
 		<ignoreFiles>
 			<!-- Circles internals are used -->
 			<file name="core/Sharing/Recipient/TeamShareRecipientType.php"/>

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -202,8 +202,8 @@ class ClientFlowLoginControllerTest extends TestCase {
 				['OCS-APIREQUEST', 'false'],
 			]);
 		$client = new Client();
-		$client->setName('My external service');
-		$client->setRedirectUri('https://example.com/redirect.php');
+		$client->name = 'My external service';
+		$client->redirectUri = 'https://example.com/redirect.php';
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')
@@ -491,8 +491,9 @@ class ClientFlowLoginControllerTest extends TestCase {
 			)
 			->willReturn($token);
 		$client = new Client();
-		$client->setName('My OAuth client');
-		$client->setRedirectUri($redirectUri);
+		$client->id = 42;
+		$client->name = 'My OAuth client';
+		$client->redirectUri = $redirectUri;
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')


### PR DESCRIPTION
## Summary

Best to review commit by commit

- Port to oauth2 tables to new Entity system
- Use psalm:strict on oauth2 app
- Use rector:strict on oauth2 app

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
