### PR TITLE
feat(orm): Add support for BackedEnum in Entity column

### DIFF
--- a/lib/private/AppFramework/ORM/EntityInfo.php
+++ b/lib/private/AppFramework/ORM/EntityInfo.php
@@ -24,6 +24,9 @@ final class EntityInfo {
 	/** @var array<string, ColumnType> */
 	public array $mappingColumnToTypes = [];
 
+	/** @var array<string, class-string<\BackedEnum>> */
+	public array $mappingColumnToEnumType = [];
+
 	/** @var array<string, string> */
 	public array $mappingColumnToProperty = [];
 
@@ -72,6 +75,9 @@ final class EntityInfo {
 					$this->mappingColumnToTypes[$instance->name] = $instance->type;
 					$this->mappingColumnToProperty[$instance->name] = $property->getName();
 					$this->mappingPropertyToColumn[$property->getName()] = $instance->name;
+					if ($instance->enumType !== null) {
+						$this->mappingColumnToEnumType[$instance->name] = $instance->enumType;
+					}
 				} elseif ($instance instanceof Id) {
 					$propertyAttributes->id = $instance;
 					$this->idProperties[] = $property;
@@ -86,6 +92,10 @@ final class EntityInfo {
 
 			if ($propertyAttributes->id instanceof Id && !$propertyAttributes->column instanceof Column) {
 				throw new \RuntimeException($this->entityClass . ' has an Id attribute on ' . $property->getName() . ' but not the corresponding required Column attribute.');
+			}
+
+			if ($propertyAttributes->column instanceof Column && $propertyAttributes->column->enumType !== null) {
+				$this->validateEnumType($property, $propertyAttributes->column);
 			}
 
 			if ($propertyAttributes->oneToOne instanceof OneToOne
@@ -163,6 +173,36 @@ final class EntityInfo {
 
 		if ($targetProperty->getAttributes(JoinColumn::class, \ReflectionAttribute::IS_INSTANCEOF) === []) {
 			throw new \RuntimeException($prefix . $oneToOne->targetEntity . '::' . $mappedBy . ' has no JoinColumn attribute.');
+		}
+	}
+
+	private function validateEnumType(\ReflectionProperty $property, Column $column): void {
+		/** @var class-string $enumType */
+		$enumType = $column->enumType;
+		$prefix = $this->entityClass . '::' . $property->getName() . " declares enumType: {$enumType}, but ";
+
+		if (!enum_exists($enumType)) {
+			throw new \RuntimeException($prefix . 'that class is not an enum.');
+		}
+
+		if (!is_a($enumType, \BackedEnum::class, true)) {
+			throw new \RuntimeException($prefix . 'that enum is not backed. Only backed enums (`enum Foo: string` or `enum Foo: int`) can be mapped to a column.');
+		}
+
+		$propertyType = $property->getType();
+		if ($propertyType instanceof \ReflectionNamedType && ltrim($propertyType->getName(), '\\') !== ltrim($enumType, '\\')) {
+			throw new \RuntimeException($prefix . 'the property is typed as ' . $propertyType->getName() . ' instead.');
+		}
+
+		$backingType = (new \ReflectionEnum($enumType))->getBackingType();
+		$backingTypeName = $backingType instanceof \ReflectionNamedType ? $backingType->getName() : null;
+		$compatibleColumnTypes = match ($backingTypeName) {
+			'int' => [ColumnType::Bigint, ColumnType::Smallint, ColumnType::Integer],
+			'string' => [ColumnType::Binary, ColumnType::Decimal, ColumnType::Text, ColumnType::String],
+			default => [],
+		};
+		if (!in_array($column->type, $compatibleColumnTypes, true)) {
+			throw new \RuntimeException($prefix . "its column type ({$column->type->name}) cannot hold a(n) {$backingTypeName}-backed enum's value.");
 		}
 	}
 }

--- a/lib/private/AppFramework/ORM/EntityManager.php
+++ b/lib/private/AppFramework/ORM/EntityManager.php
@@ -135,7 +135,7 @@ final class EntityManager {
 
 			if ($propertyAttributes->column !== null) {
 				$type = $this->getParameterType($propertyAttributes->column->type, false);
-				$values[$propertyAttributes->column->name] = $insert->createNamedParameter($property->getValue($entity), $type);
+				$values[$propertyAttributes->column->name] = $insert->createNamedParameter($this->toParameterValue($property->getValue($entity)), $type);
 			}
 		}
 
@@ -198,7 +198,7 @@ final class EntityManager {
 
 			if ($propertyAttributes->column !== null) {
 				$type = $this->getParameterType($propertyAttributes->column->type, false);
-				$update->set($propertyAttributes->column->name, $update->createNamedParameter($value, $type));
+				$update->set($propertyAttributes->column->name, $update->createNamedParameter($this->toParameterValue($value), $type));
 			}
 		}
 
@@ -279,6 +279,18 @@ final class EntityManager {
 		};
 	}
 
+	public function toParameterValue(mixed $value): mixed {
+		if ($value instanceof \BackedEnum) {
+			return $value->value;
+		}
+
+		if (is_array($value)) {
+			return array_map($this->toParameterValue(...), $value);
+		}
+
+		return $value;
+	}
+
 	/**
 	 * @internal Only for unit tests.
 	 *
@@ -326,7 +338,11 @@ final class EntityManager {
 		}
 
 		if ($columnAttribute->default !== null) {
-			$options['default'] = $columnAttribute->default;
+			// Column::$default is documented as scalar|\BackedEnum, so unwrapping a \BackedEnum
+			// case here always yields a scalar.
+			/** @var scalar $default */
+			$default = $this->toParameterValue($columnAttribute->default);
+			$options['default'] = $default;
 		}
 
 		// A composite primary key can't rely on a single autoincrement column; see insert().

--- a/lib/public/AppFramework/ORM/Attribute/Column.php
+++ b/lib/public/AppFramework/ORM/Attribute/Column.php
@@ -22,6 +22,24 @@ use OCP\DB\Schema\ColumnType;
  * }
  * ```
  *
+ * A property can be typed as a backed enum instead of a plain scalar by setting `enumType` to
+ * the enum's class-string. The column itself still stores the enum's scalar backing value
+ * (declare `type`/`length` accordingly), but the property is hydrated to and persisted from the
+ * enum case itself:
+ *
+ * ```php
+ * enum Status: string {
+ *     case Draft = 'draft';
+ *     case Published = 'published';
+ * }
+ *
+ * #[Entity(name: 'my_entity')]
+ * final class MyEntity {
+ *     #[Column(name: 'status', type: ColumnType::String, length: 32, enumType: Status::class)]
+ *     public Status $status = Status::Draft;
+ * }
+ * ```
+ *
  * @since 35.0.0
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -37,8 +55,14 @@ final readonly class Column {
 		public ?int $length = null,
 		/** @var bool Whether the column is nullable in the database */
 		public bool $nullable = false,
-		/** @var scalar|null The default value for the column in the database. */
+		/** @var scalar|\BackedEnum|null The default value for the column in the database. */
 		public mixed $default = null,
+		/**
+		 * @var class-string<\BackedEnum>|null The backed enum the property is typed as. The
+		 *                                     column keeps storing the enum's scalar backing
+		 *                                     value; only the PHP property is the enum case.
+		 */
+		public ?string $enumType = null,
 	) {
 	}
 }

--- a/lib/public/AppFramework/ORM/Repository.php
+++ b/lib/public/AppFramework/ORM/Repository.php
@@ -109,6 +109,16 @@ class Repository {
 				ColumnType::Blob => $value,
 			};
 
+			$enumType = $entityInfo->mappingColumnToEnumType[$column] ?? null;
+
+			if ($enumType !== null) {
+				if (!is_string($value) && !is_int($value)) {
+					throw new \LogicException('Can only convert int and string to enum');
+				}
+
+				$value = $enumType::from($value);
+			}
+
 			$entity->$property = $value;
 		}
 
@@ -384,7 +394,7 @@ class Repository {
 	/**
 	 * Finds entities by a set of criteria, keyed by property name.
 	 *
-	 * @param array<string, int|float|string|null|\DateTime|list<int|float|string>> $criteria
+	 * @param array<string, int|float|string|null|\DateTime|\BackedEnum|list<int|float|string|\BackedEnum>> $criteria
 	 * @param array<string, \SortDirection> $orderBy
 	 * @return \Generator<T>
 	 * @since 35.0.0
@@ -404,7 +414,7 @@ class Repository {
 	}
 
 	/**
-	 * @param array<string, int|float|string|null|\DateTime|list<int|float|string>> $criteria
+	 * @param array<string, int|float|string|null|\DateTime|\BackedEnum|list<int|float|string|\BackedEnum>> $criteria
 	 * @return int The number of rows deleted
 	 * @throws Exception
 	 * @since 35.0.0
@@ -417,6 +427,8 @@ class Repository {
 
 		foreach ($criteria as $property => $value) {
 			$column = $entityInfo->mappingPropertyToColumn[$property];
+			/** @psalm-suppress MixedAssignment can be anything */
+			$value = $this->entityManager->toParameterValue($value);
 			$type = $this->entityManager->getParameterType($entityInfo->mappingColumnToTypes[$column], is_array($value));
 			if ($value === null) {
 				$qb->andWhere($qb->expr()->isNull($column));
@@ -439,7 +451,7 @@ class Repository {
 	/**
 	 * Finds a single entity by a set of criteria, keyed by property name.
 	 *
-	 * @param array<string, int|float|string|null|\DateTime|list<int|float|string>> $criteria
+	 * @param array<string, int|float|string|null|\DateTime|\BackedEnum|list<int|float|string|\BackedEnum>> $criteria
 	 * @param array<string, \SortDirection> $orderBy
 	 * @return T
 	 * @throws DoesNotExistException
@@ -454,7 +466,7 @@ class Repository {
 	}
 
 	/**
-	 * @param array<string, int|float|string|null|\DateTime|list<int|float|string>> $criteria
+	 * @param array<string, int|float|string|null|\DateTime|\BackedEnum|list<int|float|string|\BackedEnum>> $criteria
 	 * @param array<string, \SortDirection> $orderBy
 	 * @return array{0: IQueryBuilder, 1: array<string, array{attributes: PropertyAttributes, entityInfo: EntityInfo}>}
 	 */
@@ -464,6 +476,8 @@ class Repository {
 
 		foreach ($criteria as $property => $value) {
 			$column = $entityInfo->mappingPropertyToColumn[$property];
+			/** @psalm-suppress MixedAssignment $value is caller-supplied criteria, unwrapped of any \BackedEnum case. */
+			$value = $this->entityManager->toParameterValue($value);
 			$type = $this->entityManager->getParameterType($entityInfo->mappingColumnToTypes[$column], is_array($value));
 			if ($value === null) {
 				$qb->andWhere($qb->expr()->isNull('e.' . $column));

--- a/tests/lib/AppFramework/ORM/RepositoryTest.php
+++ b/tests/lib/AppFramework/ORM/RepositoryTest.php
@@ -29,6 +29,78 @@ class NoPrimaryKey {
 	public ?int $id = null;
 }
 
+enum OrderStatus: string {
+	case Draft = 'draft';
+	case Placed = 'placed';
+	case Shipped = 'shipped';
+}
+
+enum Priority: int {
+	case Low = 1;
+	case High = 2;
+}
+
+enum NotBacked {
+	case Foo;
+}
+
+#[Entity(name: 'repository_enum_order')]
+final class EnumOrder {
+	#[Id]
+	#[Column(name: 'id', type: ColumnType::Bigint)]
+	public ?int $id = null;
+
+	#[Column(name: 'status', type: ColumnType::String, length: 32, enumType: OrderStatus::class, default: OrderStatus::Draft)]
+	public OrderStatus $status = OrderStatus::Draft;
+
+	#[Column(name: 'priority', type: ColumnType::Integer, enumType: Priority::class)]
+	public Priority $priority;
+
+	#[Column(name: 'previous_status', type: ColumnType::String, length: 32, nullable: true, enumType: OrderStatus::class)]
+	public ?OrderStatus $previousStatus = null;
+}
+
+#[Entity(name: 'repository_enum_unknown_class')]
+final class EnumUnknownClass {
+	#[Id]
+	#[Column(name: 'id', type: ColumnType::Bigint)]
+	public ?int $id = null;
+
+	#[Column(name: 'status', type: ColumnType::String, enumType: 'OCP\AppFramework\ORM\Attribute\ThisClassDoesNotExist')]
+	public string $status;
+}
+
+#[Entity(name: 'repository_enum_not_backed')]
+final class EnumNotBacked {
+	#[Id]
+	#[Column(name: 'id', type: ColumnType::Bigint)]
+	public ?int $id = null;
+
+	#[Column(name: 'status', type: ColumnType::String, enumType: NotBacked::class)]
+	public NotBacked $status;
+}
+
+#[Entity(name: 'repository_enum_type_mismatch')]
+final class EnumTypeMismatch {
+	#[Id]
+	#[Column(name: 'id', type: ColumnType::Bigint)]
+	public ?int $id = null;
+
+	#[Column(name: 'status', type: ColumnType::String, enumType: OrderStatus::class)]
+	public string $status;
+}
+
+#[Entity(name: 'repository_enum_column_mismatch')]
+final class EnumColumnTypeMismatch {
+	#[Id]
+	#[Column(name: 'id', type: ColumnType::Bigint)]
+	public ?int $id = null;
+
+	// Priority is int-backed, but the column is declared as a string.
+	#[Column(name: 'priority', type: ColumnType::String, enumType: Priority::class)]
+	public Priority $priority;
+}
+
 #[Entity(name: 'repository_test_test2')]
 class PrimaryKey {
 	#[Id]
@@ -196,6 +268,7 @@ class RepositoryTest extends TestCase {
 		CascadeChild::class,
 		Merchant::class,
 		Order::class,
+		EnumOrder::class,
 	];
 
 	public static function setUpBeforeClass(): void {
@@ -643,5 +716,120 @@ class RepositoryTest extends TestCase {
 				. 'WHERE e.id = :dcValue1',
 			$this->normalizeSql($qb->getSQL()),
 		);
+	}
+
+	public function testEnumColumnRoundTrip(): void {
+		$repo = $this->getRepository(EnumOrder::class);
+
+		$order = new EnumOrder();
+		$order->status = OrderStatus::Placed;
+		$order->priority = Priority::High;
+		$repo->insert($order);
+		$this->assertNotNull($order->id);
+
+		$saved = $repo->findOneBy(['id' => $order->id]);
+		$this->assertSame(OrderStatus::Placed, $saved->status);
+		$this->assertSame(Priority::High, $saved->priority);
+		$this->assertNull($saved->previousStatus);
+
+		$repo->delete($saved);
+	}
+
+	public function testEnumColumnDefault(): void {
+		$repo = $this->getRepository(EnumOrder::class);
+
+		$order = new EnumOrder();
+		$order->priority = Priority::Low;
+		$this->assertSame(OrderStatus::Draft, $order->status);
+
+		$repo->insert($order);
+		$saved = $repo->findOneBy(['id' => $order->id]);
+		$this->assertSame(OrderStatus::Draft, $saved->status);
+
+		$repo->delete($saved);
+	}
+
+	public function testEnumColumnUpdate(): void {
+		$repo = $this->getRepository(EnumOrder::class);
+
+		$order = new EnumOrder();
+		$order->status = OrderStatus::Draft;
+		$order->priority = Priority::Low;
+		$repo->insert($order);
+
+		$order->previousStatus = $order->status;
+		$order->status = OrderStatus::Shipped;
+		$repo->update($order);
+
+		$saved = $repo->findOneBy(['id' => $order->id]);
+		$this->assertSame(OrderStatus::Shipped, $saved->status);
+		$this->assertSame(OrderStatus::Draft, $saved->previousStatus);
+
+		$repo->delete($saved);
+	}
+
+	public function testFindByEnumCriteria(): void {
+		$repo = $this->getRepository(EnumOrder::class);
+
+		$placed = new EnumOrder();
+		$placed->status = OrderStatus::Placed;
+		$placed->priority = Priority::High;
+		$repo->insert($placed);
+
+		$shipped = new EnumOrder();
+		$shipped->status = OrderStatus::Shipped;
+		$shipped->priority = Priority::Low;
+		$repo->insert($shipped);
+
+		$found = $repo->findOneBy(['status' => OrderStatus::Placed]);
+		$this->assertSame($placed->id, $found->id);
+
+		// IN (...) form with a list of enum cases
+		$both = iterator_to_array($repo->findBy(['status' => [OrderStatus::Placed, OrderStatus::Shipped]]));
+		$this->assertCount(2, $both);
+
+		$repo->delete($placed);
+		$repo->delete($shipped);
+	}
+
+	public function testDeleteByEnumCriteria(): void {
+		$repo = $this->getRepository(EnumOrder::class);
+
+		$order = new EnumOrder();
+		$order->status = OrderStatus::Draft;
+		$order->priority = Priority::Low;
+		$repo->insert($order);
+
+		$repo->deleteBy(['status' => OrderStatus::Draft]);
+
+		$this->assertCount(0, iterator_to_array($repo->findBy(['id' => $order->id])));
+	}
+
+	public function testEnumTypeMustExist(): void {
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('that class is not an enum');
+
+		Server::get(EntityManager::class)->getEntityInfo(EnumUnknownClass::class);
+	}
+
+	public function testEnumTypeMustBeBacked(): void {
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('that enum is not backed');
+
+		Server::get(EntityManager::class)->getEntityInfo(EnumNotBacked::class);
+	}
+
+	public function testEnumTypeMustMatchPropertyType(): void {
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('the property is typed as string instead');
+
+		Server::get(EntityManager::class)->getEntityInfo(EnumTypeMismatch::class);
+	}
+
+	public function testEnumBackingTypeMustMatchColumnType(): void {
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage("cannot hold a(n) int-backed enum's value");
+
+		Server::get(EntityManager::class)->getEntityInfo(EnumColumnTypeMismatch::class);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Convert from and to the value in the database

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (code by myself, unit tests by AI)
