### PR TITLE
fix(dbal): Regression on PreparedStatement caused by fcc63b9603596c1b

### DIFF
--- a/lib/private/DB/PreparedStatement.php
+++ b/lib/private/DB/PreparedStatement.php
@@ -85,7 +85,7 @@ class PreparedStatement implements IPreparedStatement {
 
 	#[\Override]
 	public function execute($params = null): IResult {
-		return ($this->result = new ResultAdapter($this->statement->execute($params ?? [])));
+		return ($this->result = new ResultAdapter($this->statement->execute($params)));
 	}
 
 	#[\Override]


### PR DESCRIPTION
This small change included in https://github.com/nextcloud/server/pull/58891 broke PreparedStatement::bindValue and PreparedStatement::bindParam. The empty array has different meaning on $params argument of [PDOStatement::execute](https://www.php.net/manual/en/pdostatement.execute.php) than the null value, purging all the parameters previously passed to the statement.

The problem commit is included in v35.0.0beta1 and v35.0.0beta2 but not in any v34 versions.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
