### PR TITLE
fix: truncating caldav subscription data before saving on DB

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -161,13 +161,13 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @var array
 	 */
 	public array $subscriptionPropertyMap = [
-		'{DAV:}displayname' => ['displayname', 'string'],
-		'{http://apple.com/ns/ical/}refreshrate' => ['refreshrate', 'string'],
-		'{http://apple.com/ns/ical/}calendar-order' => ['calendarorder', 'int'],
-		'{http://apple.com/ns/ical/}calendar-color' => ['calendarcolor', 'string'],
-		'{http://calendarserver.org/ns/}subscribed-strip-todos' => ['striptodos', 'bool'],
-		'{http://calendarserver.org/ns/}subscribed-strip-alarms' => ['stripalarms', 'string'],
-		'{http://calendarserver.org/ns/}subscribed-strip-attachments' => ['stripattachments', 'string'],
+		'{DAV:}displayname' => ['displayname', 'string', 100],
+		'{http://apple.com/ns/ical/}refreshrate' => ['refreshrate', 'string', 10],
+		'{http://apple.com/ns/ical/}calendar-order' => ['calendarorder', 'int', 0],
+		'{http://apple.com/ns/ical/}calendar-color' => ['calendarcolor', 'string', 255],
+		'{http://calendarserver.org/ns/}subscribed-strip-todos' => ['striptodos', 'bool', 0],
+		'{http://calendarserver.org/ns/}subscribed-strip-alarms' => ['stripalarms', 'bool', 0],
+		'{http://calendarserver.org/ns/}subscribed-strip-attachments' => ['stripattachments', 'bool', 0],
 	];
 
 	/**
@@ -3040,9 +3040,14 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		$propertiesBoolean = ['striptodos', 'stripalarms', 'stripattachments'];
 
-		foreach ($this->subscriptionPropertyMap as $xmlName => [$dbName, $type]) {
+		foreach ($this->subscriptionPropertyMap as $xmlName => [$dbName, $type, $length]) {
 			if (array_key_exists($xmlName, $properties)) {
-				$values[$dbName] = $properties[$xmlName];
+				if ($type == 'string') {
+					$values[$dbName] = mb_substr($properties[$xmlName], 0, $length);
+				} else {
+					$values[$dbName] = $properties[$xmlName];
+				}
+
 				if (in_array($dbName, $propertiesBoolean)) {
 					$values[$dbName] = true;
 				}
@@ -3099,7 +3104,14 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 					$newValues['source'] = $propertyValue->getHref();
 				} else {
 					$fieldName = $this->subscriptionPropertyMap[$propertyName][0];
-					$newValues[$fieldName] = $propertyValue;
+					$fieldType = $this->subscriptionPropertyMap[$propertyName][1];
+
+					if ($fieldType === 'string') {
+						$fieldLength = $this->subscriptionPropertyMap[$propertyName][2];
+						$newValues[$fieldName] = mb_substr($propertyValue, 0, $fieldLength);
+					} else {
+						$newValues[$fieldName] = $propertyValue;
+					}
 				}
 			}
 

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -729,6 +729,30 @@ EOD;
 		$this->assertCount(0, $subscriptions);
 	}
 
+	public function testSubscriptionsHugeProps(): void {
+		$first_longname = 'This is a very long name, longer than 100 characters, used on purpose with the intention to test truncation';
+		$second_longname = 'Another very long name, longer than 100 characters, used to test truncation while updating the subscription';
+
+		$id = $this->backend->createSubscription(self::UNIT_TEST_USER, 'Subscription', [
+			'{DAV:}displayname' => $first_longname,
+			'{http://calendarserver.org/ns/}source' => new Href('test-source'),
+			'{http://apple.com/ns/ical/}calendar-color' => '#1C4587',
+			'{http://calendarserver.org/ns/}subscribed-strip-todos' => ''
+		]);
+
+		$subscriptions = $this->backend->getSubscriptionsForUser(self::UNIT_TEST_USER);
+		$this->assertEquals(mb_substr($first_longname, 0, 100), $subscriptions[0]['{DAV:}displayname']);
+
+		$patch = new PropPatch([
+			'{DAV:}displayname' => $second_longname,
+		]);
+		$this->backend->updateSubscription($id, $patch);
+		$patch->commit();
+
+		$subscriptions = $this->backend->getSubscriptionsForUser(self::UNIT_TEST_USER);
+		$this->assertEquals(mb_substr($second_longname, 0, 100), $subscriptions[0]['{DAV:}displayname']);
+	}
+
 	public static function providesSchedulingData(): array {
 		$data = <<<EOS
 BEGIN:VCALENDAR


### PR DESCRIPTION
* Resolves: #54859

## Summary

In `$subscriptionPropertyMap` I've added, for "string" properties, the maximum length, to know how to properly truncate incoming values.

Note: I've found that in `$subscriptionPropertyMap` array both `stripalarms` and `stripattachments` were marked as "string", [since the introduction](https://github.com/nextcloud/server/commit/288f07a5a4c0e106672c5e1afee13fd85108f8a9) of those datatypes. But [in database schema](https://github.com/nextcloud/server/blob/master/apps/dav/lib/Migration/Version1004Date20170825134824.php) those are always been "smallint" (boolean) values.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
