### PR TITLE
Feat/detail panel filepath view in condition

### DIFF
--- a/apps/files/src/actions/viewInFolderAction.spec.ts
+++ b/apps/files/src/actions/viewInFolderAction.spec.ts
@@ -19,6 +19,27 @@ const viewFiles = {
 	name: 'Files',
 } as IView
 
+const viewSearch = {
+	id: 'search',
+	name: 'Search',
+} as IView
+
+const rootFolder = new Folder({
+	id: 10,
+	source: 'https://cloud.domain.com/remote.php/dav/files/admin/',
+	owner: 'admin',
+	permissions: Permission.ALL,
+	root: '/files/admin',
+})
+
+const nestedFolder = new Folder({
+	id: 11,
+	source: 'https://cloud.domain.com/remote.php/dav/files/admin/Foo/Bar/',
+	owner: 'admin',
+	permissions: Permission.ALL,
+	root: '/files/admin',
+})
+
 describe('View in folder action conditions tests', () => {
 	test('Default values', () => {
 		expect(action.id).toBe('view-in-folder')
@@ -41,10 +62,10 @@ describe('View in folder action conditions tests', () => {
 })
 
 describe('View in folder action enabled tests', () => {
-	test('Enabled for trashbin', () => {
+	test('Enabled when search result is shown outside its parent folder', () => {
 		const file = new File({
 			id: 1,
-			source: 'https://cloud.domain.com/remote.php/dav/files/admin/foobar.txt',
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/Foo/Bar/foobar.txt',
 			owner: 'admin',
 			mime: 'text/plain',
 			permissions: Permission.ALL,
@@ -54,16 +75,16 @@ describe('View in folder action enabled tests', () => {
 		expect(action.enabled).toBeDefined()
 		expect(action.enabled!({
 			nodes: [file],
-			view,
-			folder: {} as Folder,
+			view: viewSearch,
+			folder: rootFolder,
 			contents: [],
 		})).toBe(true)
 	})
 
-	test('Disabled for files', () => {
+	test('Disabled when file is already shown in its parent folder', () => {
 		const file = new File({
 			id: 1,
-			source: 'https://cloud.domain.com/remote.php/dav/files/admin/foobar.txt',
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/Foo/Bar/foobar.txt',
 			owner: 'admin',
 			mime: 'text/plain',
 			permissions: Permission.ALL,
@@ -74,7 +95,7 @@ describe('View in folder action enabled tests', () => {
 		expect(action.enabled!({
 			nodes: [file],
 			view: viewFiles,
-			folder: {} as Folder,
+			folder: nestedFolder,
 			contents: [],
 		})).toBe(false)
 	})
@@ -93,7 +114,7 @@ describe('View in folder action enabled tests', () => {
 		expect(action.enabled!({
 			nodes: [file],
 			view,
-			folder: {} as Folder,
+			folder: nestedFolder,
 			contents: [],
 		})).toBe(false)
 	})
@@ -111,7 +132,7 @@ describe('View in folder action enabled tests', () => {
 		expect(action.enabled!({
 			nodes: [file],
 			view,
-			folder: {} as Folder,
+			folder: nestedFolder,
 			contents: [],
 		})).toBe(false)
 	})
@@ -136,7 +157,7 @@ describe('View in folder action enabled tests', () => {
 		expect(action.enabled!({
 			nodes: [file1, file2],
 			view,
-			folder: {} as Folder,
+			folder: nestedFolder,
 			contents: [],
 		})).toBe(false)
 	})
@@ -154,16 +175,17 @@ describe('View in folder action enabled tests', () => {
 		expect(action.enabled!({
 			nodes: [folder],
 			view,
-			folder: {} as Folder,
+			folder: rootFolder,
 			contents: [],
 		})).toBe(false)
 	})
 
 	test('Disabled for files outside the user root folder', () => {
-		const file = new Folder({
+		const file = new File({
 			id: 1,
 			source: 'https://cloud.domain.com/remote.php/dav/trashbin/admin/trash/image.jpg.d1731053878',
 			owner: 'admin',
+			mime: 'image/jpeg',
 			permissions: Permission.READ,
 			root: '/trashbin/admin',
 		})
@@ -172,7 +194,7 @@ describe('View in folder action enabled tests', () => {
 		expect(action.enabled!({
 			nodes: [file],
 			view,
-			folder: {} as Folder,
+			folder: rootFolder,
 			contents: [],
 		})).toBe(false)
 	})

--- a/apps/files/src/actions/viewInFolderAction.ts
+++ b/apps/files/src/actions/viewInFolderAction.ts
@@ -17,14 +17,9 @@ export const action: IFileAction = {
 	},
 	iconSvgInline: () => FolderEyeSvg,
 
-	enabled({ nodes, view }) {
+	enabled({ nodes, folder }) {
 		// Not enabled for public shares
 		if (isPublicShare()) {
-			return false
-		}
-
-		// Only works outside of the main files view
-		if (view.id === 'files') {
 			return false
 		}
 
@@ -40,6 +35,11 @@ export const action: IFileAction = {
 
 		// Can only view files that are in the user root folder
 		if (!node.root?.startsWith('/files')) {
+			return false
+		}
+
+		// Only show if not in same folder
+		if (folder.path === node.dirname) {
 			return false
 		}
 

--- a/apps/files/src/components/FilesSidebar/FilesSidebarSubname.spec.ts
+++ b/apps/files/src/components/FilesSidebar/FilesSidebarSubname.spec.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { IFolder } from '@nextcloud/files'
+
 import { File, Permission } from '@nextcloud/files'
 import { enableAutoDestroy, shallowMount } from '@vue/test-utils'
 import { afterEach, describe, expect, test } from 'vitest'
@@ -11,6 +13,30 @@ import FilesSidebarSubname from './FilesSidebarSubname.vue'
 enableAutoDestroy(afterEach)
 
 describe('FilesSidebarSubname', () => {
+	const folder = { path: '/Current' } as IFolder
+
+	test('renders path in a separate section from metadata', () => {
+		const file = new File({
+			id: 1,
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/report.pdf',
+			owner: 'admin',
+			mime: 'application/pdf',
+			permissions: Permission.READ,
+			root: '/files/admin',
+			size: 1024,
+		})
+
+		const wrapper = shallowMount(FilesSidebarSubname, {
+			propsData: { folder, node: file },
+		})
+		const sections = wrapper.element.children
+
+		expect(sections).toHaveLength(2)
+		expect(sections[0].textContent).toContain('Location')
+		expect(sections[0].textContent).toContain('/report.pdf')
+		expect(sections[1].textContent).toContain('1 KB')
+	})
+
 	test('renders full path for nested file', () => {
 		const file = new File({
 			id: 1,
@@ -23,7 +49,7 @@ describe('FilesSidebarSubname', () => {
 		})
 
 		const wrapper = shallowMount(FilesSidebarSubname, {
-			propsData: { node: file },
+			propsData: { folder, node: file },
 		})
 
 		expect(wrapper.text()).toContain('/Documents/Projects/report.pdf')
@@ -41,7 +67,7 @@ describe('FilesSidebarSubname', () => {
 		})
 
 		const wrapper = shallowMount(FilesSidebarSubname, {
-			propsData: { node: file },
+			propsData: { folder, node: file },
 		})
 
 		expect(wrapper.text()).toContain('/report.pdf')
@@ -66,7 +92,7 @@ describe('FilesSidebarSubname', () => {
 		})
 
 		const wrapper = shallowMount(FilesSidebarSubname, {
-			propsData: { node: firstFile },
+			propsData: { folder, node: firstFile },
 		})
 		expect(wrapper.text()).toContain('/First.txt')
 
@@ -74,5 +100,25 @@ describe('FilesSidebarSubname', () => {
 
 		expect(wrapper.text()).not.toContain('/First.txt')
 		expect(wrapper.text()).toContain('/Documents/Second.txt')
+	})
+
+	test('does not render location for a file in the current folder', () => {
+		const file = new File({
+			id: 1,
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/Documents/report.pdf',
+			owner: 'admin',
+			mime: 'application/pdf',
+			permissions: Permission.READ,
+			root: '/files/admin',
+			size: 1024,
+		})
+
+		const wrapper = shallowMount(FilesSidebarSubname, {
+			propsData: { folder: { path: '/Documents' } as IFolder, node: file },
+		})
+
+		expect(wrapper.text()).not.toContain('Location')
+		expect(wrapper.text()).not.toContain('/Documents/report.pdf')
+		expect(wrapper.text()).toContain('1 KB')
 	})
 })

--- a/apps/files/src/components/FilesSidebar/FilesSidebarSubname.spec.ts
+++ b/apps/files/src/components/FilesSidebar/FilesSidebarSubname.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { File, Permission } from '@nextcloud/files'
+import { enableAutoDestroy, shallowMount } from '@vue/test-utils'
+import { afterEach, describe, expect, test } from 'vitest'
+import FilesSidebarSubname from './FilesSidebarSubname.vue'
+
+enableAutoDestroy(afterEach)
+
+describe('FilesSidebarSubname', () => {
+	test('renders full path for nested file', () => {
+		const file = new File({
+			id: 1,
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/Documents/Projects/report.pdf',
+			owner: 'admin',
+			mime: 'application/pdf',
+			permissions: Permission.READ,
+			root: '/files/admin',
+			size: 1024,
+		})
+
+		const wrapper = shallowMount(FilesSidebarSubname, {
+			propsData: { node: file },
+		})
+
+		expect(wrapper.text()).toContain('/Documents/Projects/report.pdf')
+	})
+
+	test('renders full path for root-level file', () => {
+		const file = new File({
+			id: 2,
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/report.pdf',
+			owner: 'admin',
+			mime: 'application/pdf',
+			permissions: Permission.READ,
+			root: '/files/admin',
+			size: 1024,
+		})
+
+		const wrapper = shallowMount(FilesSidebarSubname, {
+			propsData: { node: file },
+		})
+
+		expect(wrapper.text()).toContain('/report.pdf')
+	})
+
+	test('updates path when selected node changes', async () => {
+		const firstFile = new File({
+			id: 1,
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/First.txt',
+			owner: 'admin',
+			mime: 'text/plain',
+			permissions: Permission.READ,
+			root: '/files/admin',
+		})
+		const secondFile = new File({
+			id: 2,
+			source: 'https://cloud.domain.com/remote.php/dav/files/admin/Documents/Second.txt',
+			owner: 'admin',
+			mime: 'text/plain',
+			permissions: Permission.READ,
+			root: '/files/admin',
+		})
+
+		const wrapper = shallowMount(FilesSidebarSubname, {
+			propsData: { node: firstFile },
+		})
+		expect(wrapper.text()).toContain('/First.txt')
+
+		await wrapper.setProps({ node: secondFile })
+
+		expect(wrapper.text()).not.toContain('/First.txt')
+		expect(wrapper.text()).toContain('/Documents/Second.txt')
+	})
+})

--- a/apps/files/src/components/FilesSidebar/FilesSidebarSubname.vue
+++ b/apps/files/src/components/FilesSidebar/FilesSidebarSubname.vue
@@ -22,6 +22,10 @@ const size = computed(() => formatFileSize(props.node.size ?? 0))
 
 <template>
 	<div :class="$style.filesSidebarSubname">
+		<div class="filesSidebarSubname__path">
+			{{ node.path }}
+		</div>
+
 		<NcIconSvgWrapper
 			v-if="isFavourited"
 			inline

--- a/apps/files/src/components/FilesSidebar/FilesSidebarSubname.vue
+++ b/apps/files/src/components/FilesSidebar/FilesSidebarSubname.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts">
-import type { INode } from '@nextcloud/files'
+import type { IFolder, INode } from '@nextcloud/files'
 
 import { mdiStar } from '@mdi/js'
 import { formatFileSize } from '@nextcloud/files'
@@ -14,15 +14,19 @@ import NcDateTime from '@nextcloud/vue/components/NcDateTime'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcUserBubble from '@nextcloud/vue/components/NcUserBubble'
 
-const props = defineProps<{ node: INode }>()
+const props = defineProps<{
+	folder: IFolder
+	node: INode
+}>()
 
 const isFavourited = computed(() => props.node.attributes.favorite === 1)
+const showLocation = computed(() => props.folder.path !== props.node.dirname)
 const size = computed(() => formatFileSize(props.node.size ?? 0))
 </script>
 
 <template>
 	<div :class="$style.filesSidebarSubname">
-		<div :class="$style.filesSidebarSubname__path">
+		<div v-if="showLocation" :class="$style.filesSidebarSubname__path">
 			<span :class="$style.filesSidebarSubname__label">{{ t('files', 'Location') }}:</span>
 			{{ node.path }}
 		</div>

--- a/apps/files/src/components/FilesSidebar/FilesSidebarSubname.vue
+++ b/apps/files/src/components/FilesSidebar/FilesSidebarSubname.vue
@@ -22,36 +22,56 @@ const size = computed(() => formatFileSize(props.node.size ?? 0))
 
 <template>
 	<div :class="$style.filesSidebarSubname">
-		<div class="filesSidebarSubname__path">
+		<div :class="$style.filesSidebarSubname__path">
+			<span :class="$style.filesSidebarSubname__label">{{ t('files', 'Location') }}:</span>
 			{{ node.path }}
 		</div>
 
-		<NcIconSvgWrapper
-			v-if="isFavourited"
-			inline
-			:path="mdiStar"
-			:name="t('files', 'Favorite')" />
+		<div :class="$style.filesSidebarSubname__metadata">
+			<NcIconSvgWrapper
+				v-if="isFavourited"
+				inline
+				:path="mdiStar"
+				:name="t('files', 'Favorite')" />
 
-		<span>{{ size }}</span>
+			<span>{{ size }}</span>
 
-		<span v-if="node.mtime">
-			<span :class="$style.filesSidebarSubname__separator">•</span>
-			<NcDateTime :timestamp="node.mtime" />
-		</span>
+			<span v-if="node.mtime">
+				<span :class="$style.filesSidebarSubname__separator">•</span>
+				<NcDateTime :timestamp="node.mtime" />
+			</span>
 
-		<template v-if="node.owner">
-			<span :class="$style.filesSidebarSubname__separator">•</span>
-			<NcUserBubble
-				:class="$style.filesSidebarSubname__userBubble"
-				:title="t('files', 'Owner')"
-				:user="node.owner"
-				:display-name="node.attributes['owner-display-name']" />
-		</template>
+			<template v-if="node.owner">
+				<span :class="$style.filesSidebarSubname__separator">•</span>
+				<NcUserBubble
+					:class="$style.filesSidebarSubname__userBubble"
+					:title="t('files', 'Owner')"
+					:user="node.owner"
+					:display-name="node.attributes['owner-display-name']" />
+			</template>
+		</div>
 	</div>
 </template>
 
 <style module>
 .filesSidebarSubname {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.filesSidebarSubname__path {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+}
+
+.filesSidebarSubname__label {
+	color: var(--color-text-maxcontrast);
+	font-weight: bold;
+}
+
+.filesSidebarSubname__metadata {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;

--- a/apps/files/src/views/FilesSidebar.vue
+++ b/apps/files/src/views/FilesSidebar.vue
@@ -83,8 +83,10 @@ function onToggle(open: boolean) {
 		@closed="onClosed"
 		@opened="onOpened"
 		@update:open="onToggle">
-		<template v-if="sidebar.currentNode" #subname>
-			<FilesSidebarSubname :node="sidebar.currentNode" />
+		<template v-if="sidebar.currentNode && sidebar.currentContext" #subname>
+			<FilesSidebarSubname
+				:folder="sidebar.currentContext.folder"
+				:node="sidebar.currentNode" />
 		</template>
 
 		<!-- Actions menu -->


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #60291 

## Summary
- the context menu has an option 'View In Folder' menu item available in the Files app
- Added a file path below the name in files detail page

## TODO:
- [x] Need to add before and after changes for the frontend.

## Before:
- File Details:
<img width="1824" height="921" alt="image" src="https://github.com/user-attachments/assets/b4d62c6d-a083-4ca0-88b5-935c38f0cd11" />

- File View In Folder context item:
<img width="1829" height="930" alt="image" src="https://github.com/user-attachments/assets/382797b1-90ff-43fd-9aa6-47f2875202ce" />


## After:
- File Details
<img width="1484" height="865" alt="image" src="https://github.com/user-attachments/assets/e3352f05-e5de-41bc-b1f0-5a2534df80dd" />
- File View In Folder context item
<img width="1812" height="864" alt="image" src="https://github.com/user-attachments/assets/6d3992a9-71cf-4705-a2b8-b97b7fbc259b" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
The tests written were made using the help of GPT-5.6 Sol 