### PR TITLE
fix(admin_audit): handle audit reads for new files

### DIFF
--- a/apps/admin_audit/lib/Actions/Action.php
+++ b/apps/admin_audit/lib/Actions/Action.php
@@ -25,12 +25,14 @@ class Action {
 	 * @param array $elements
 	 * @param bool $obfuscateParameters
 	 */
-	public function log(string $text,
+	public function log(
+		string $text,
 		array $params,
 		array $elements,
-		bool $obfuscateParameters = false): void {
+		bool $obfuscateParameters = false,
+	): void {
 		foreach ($elements as $element) {
-			if (!isset($params[$element])) {
+			if (!array_key_exists($element, $params)) {
 				if ($obfuscateParameters) {
 					$this->logger->critical(
 						'$params["' . $element . '"] was missing.',

--- a/apps/admin_audit/lib/Actions/Action.php
+++ b/apps/admin_audit/lib/Actions/Action.php
@@ -33,37 +33,31 @@ class Action {
 	): void {
 		foreach ($elements as $element) {
 			if (!array_key_exists($element, $params)) {
-				if ($obfuscateParameters) {
-					$this->logger->critical(
-						'$params["' . $element . '"] was missing.',
-						['app' => 'admin_audit']
-					);
-				} else {
-					$this->logger->critical(
-						'$params["' . $element . '"] was missing. Transferred value: {params}',
-						['app' => 'admin_audit', 'params' => $params]
-					);
+				$message = '$params["' . $element . '"] was missing.';
+				$context = ['app' => 'admin_audit'];
+
+				if (!$obfuscateParameters) {
+					$message .= ' Transferred value: {params}';
+					$context['params'] = $params;
 				}
+
+				$this->logger->critical($message, $context);
 				return;
 			}
 		}
 
 		$replaceArray = [];
 		foreach ($elements as $element) {
-			if ($params[$element] instanceof \DateTime) {
-				$params[$element] = $params[$element]->format('Y-m-d H:i:s');
+			$value = $params[$element];
+			if ($value instanceof \DateTimeInterface) {
+				$value = $value->format('Y-m-d H:i:s');
 			}
-			$replaceArray[] = $params[$element];
+			$replaceArray[] = $value;
 		}
 
 		$this->logger->info(
-			vsprintf(
-				$text,
-				$replaceArray
-			),
-			[
-				'app' => 'admin_audit'
-			]
+			vsprintf($text, $replaceArray),
+			['app' => 'admin_audit'],
 		);
 	}
 }

--- a/apps/admin_audit/lib/Actions/Action.php
+++ b/apps/admin_audit/lib/Actions/Action.php
@@ -21,8 +21,8 @@ class Action {
 	 * Log a single action with a log level of info
 	 *
 	 * @param string $text
-	 * @param array $params
-	 * @param array $elements
+	 * @param array<string, scalar|null|\DateTimeInterface> $params
+	 * @param list<string> $elements
 	 * @param bool $obfuscateParameters
 	 */
 	public function log(

--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -80,9 +80,10 @@ class Files extends Action {
 	 */
 	public function create(NodeCreatedEvent $event): void {
 		try {
+			$node = $event->getNode();
 			$params = [
-				'id' => $event->getNode()->getId(),
-				'path' => $event->getNode()->getPath(),
+				'id' => $node->getId(),
+				'path' => $node->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(
@@ -105,11 +106,13 @@ class Files extends Action {
 	 */
 	public function copy(NodeCopiedEvent $event): void {
 		try {
+			$source = $event->getSource();
+			$target = $event->getTarget();
 			$params = [
-				'oldid' => $event->getSource()->getId(),
-				'newid' => $event->getTarget()->getId(),
-				'oldpath' => $event->getSource()->getPath(),
-				'newpath' => $event->getTarget()->getPath(),
+				'oldid' => $source->getId(),
+				'newid' => $target->getId(),
+				'oldpath' => $source->getPath(),
+				'newpath' => $target->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(
@@ -128,8 +131,8 @@ class Files extends Action {
 	 * Logs writing of files
 	 */
 	public function write(NodeWrittenEvent $event): void {
-		$node = $event->getNode();
 		try {
+			$node = $event->getNode();
 			$params = [
 				'id' => $node->getId(),
 				'path' => $node->getPath(),
@@ -156,9 +159,10 @@ class Files extends Action {
 	 */
 	public function delete(BeforeNodeDeletedEvent $event): void {
 		try {
+			$node = $event->getNode();
 			$params = [
-				'id' => $event->getNode()->getId(),
-				'path' => $event->getNode()->getPath(),
+				'id' => $node->getId(),
+				'path' => $node->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(

--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -33,7 +33,7 @@ class Files extends Action {
 		try {
 			$node = $event->getNode();
 			$params = [
-				'id' => $node instanceof NonExistingFile ? null : $node->getId(),
+				'id' => $node instanceof NonExistingFile ? 'not-yet-assigned' : $node->getId(),
 				'path' => $node->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Handle audit logging for file reads that occur before a new file has been assigned a file ID.

`BeforeNodeReadEvent` can provide a `NonExistingFile` without an ID. Although #47071 avoided calling `getId()` for this case, `Action::log()` still treated the resulting parameter as missing because it used `!isset()`. As a result, the intended audit entry was not written.

- Follows up on #47071
- Related to the historical behavior addressed by #5185

Changes:

- Use `not-yet-assigned` as the audit ID for `NonExistingFile` reads.
- Treat explicitly provided `null` values as valid audit parameters.
- Clarify `Action::log()` parameter validation and formatting.
- Support both `DateTime` and `DateTimeImmutable` through `DateTimeInterface`.
- Contraint on`Action::log()` with PHPDoc to values that can be safely normalized and passed to `vsprintf()` without introducing a behavior change (static analysis only).
- Avoid repeated node and source/target accessor calls in file actions as a small clarity and performance cleanup.

This preserves the audit event and makes the unavailable ID explicit in the log output:

```
File with id "not-yet-assigned" accessed: "..."
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
