### PR TITLE
fix(AppConfig): Mark EuroOffice jwt_secret as sensitive

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1607,6 +1607,9 @@ class AppConfig implements IAppConfig {
 			'call_summary_bot' => [
 				'/^secret_(.*)$/',
 			],
+			'eurooffice' => [
+				'/^jwt_secret$/',
+			],
 			'external' => [
 				'/^sites$/',
 				'/^jwt_token_privkey_(.*)$/',

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -111,6 +111,9 @@ class SystemConfig {
 		'onlyoffice' => [
 			'jwt_secret' => true,
 		],
+		'eurooffice' => [
+			'jwt_secret' => true,
+		],
 		'PASS' => true,
 	];
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/63302

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
