### PR TITLE
fix(federation): use share owner

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -132,11 +132,10 @@ $server = $serverFactory->createServer(
 		Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 
 		$rootFolder = Server::get(IRootFolder::class);
-		$sharedBy = $share->getSharedBy();
-		if ($share->getShareType() === \OCP\Share\IShare::TYPE_REMOTE) {
-			$sharedBy = $share->getShareOwner();
-		}
-		$userFolder = $rootFolder->getUserFolder($sharedBy);
+		$userId = $share->getShareType() === \OCP\Share\IShare::TYPE_REMOTE
+			? $share->getShareOwner()
+			: $share->getSharedBy();
+		$userFolder = $rootFolder->getUserFolder($userId);
 		$node = $userFolder->getFirstNodeById($fileId);
 		if (!$node) {
 			throw new \Sabre\DAV\Exception\NotFound();

--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -132,7 +132,11 @@ $server = $serverFactory->createServer(
 		Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 
 		$rootFolder = Server::get(IRootFolder::class);
-		$userFolder = $rootFolder->getUserFolder($share->getSharedBy());
+		$sharedBy = $share->getSharedBy();
+		if ($share->getShareType() === \OCP\Share\IShare::TYPE_REMOTE) {
+			$sharedBy = $share->getShareOwner();
+		}
+		$userFolder = $rootFolder->getUserFolder($sharedBy);
 		$node = $userFolder->getFirstNodeById($fileId);
 		if (!$node) {
 			throw new \Sabre\DAV\Exception\NotFound();


### PR DESCRIPTION
In case of federated/remote share (type=6):

- in case of single federated share, the share owner and sharedby are the same,
- In case of reshare of a federated share, the share owner is the correct value and sharedby is a remote account, making getUserFolder to fail,
- In case of a reshare of a local share, sharedby should still work and the share owner is the original share owner,
- In case of a federated reshare of a local reshare, shareowner is the original share owner and sharedby is a remote account -> fail.

This patch enforce the use of shareowner for every remote instance reaching details about a federated share