### PR TITLE
fix(federated-sharing): avoid duplicate shares

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -30,6 +30,7 @@ use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
+use OCP\Share\Exceptions\AlreadySharedException;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IShare;
@@ -101,20 +102,25 @@ class FederatedShareProvider implements IShareProvider, IShareProviderSupportsAl
 			throw new \Exception($message_t);
 		}
 
+		$cloudId = $this->cloudIdManager->resolveCloudId($shareWith);
+
 		/*
-		 * Check if file is not already shared with the remote user
+		 * Check if file is not already shared with the remote user.
+		 * Has to be looked up by the normalized cloud ID, because that is what
+		 * gets stored below. Otherwise spellings like "user@server.com/" slip
+		 * past this check and create a duplicate share.
 		 */
-		$alreadyShared = $this->getSharedWith($shareWith, IShare::TYPE_REMOTE, $share->getNode(), 1, 0);
-		$alreadySharedGroup = $this->getSharedWith($shareWith, IShare::TYPE_REMOTE_GROUP, $share->getNode(), 1, 0);
-		if (!empty($alreadyShared) || !empty($alreadySharedGroup)) {
+		// getSharedWith() ignores its $shareType argument and always
+		// queries all supported remote types, so a single lookup covers both.
+		$alreadyShared = $this->getSharedWith($cloudId->getId(), IShare::TYPE_REMOTE, $share->getNode(), 1, 0);
+		if (!empty($alreadyShared)) {
 			$message = 'Sharing %1$s failed, because this item is already shared with %2$s';
 			$message_t = $this->l->t('Sharing %1$s failed, because this item is already shared with the account %2$s', [$share->getNode()->getName(), $shareWith]);
 			$this->logger->debug(sprintf($message, $share->getNode()->getName(), $shareWith), ['app' => 'Federated File Sharing']);
-			throw new \Exception($message_t);
+			throw new AlreadySharedException($message_t, $alreadyShared[0]);
 		}
 
 		// don't allow federated shares if source and target server are the same
-		$cloudId = $this->cloudIdManager->resolveCloudId($shareWith);
 		$currentServer = $this->addressHandler->generateRemoteURL();
 		$currentUser = $sharedBy;
 		if ($this->addressHandler->compareAddresses($cloudId->getUser(), $cloudId->getRemote(), $currentUser, $currentServer)) {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderReshareRemoteTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderReshareRemoteTest.php
@@ -100,7 +100,7 @@ class FederatedShareProviderReshareRemoteTest extends \Test\TestCase {
 		$node->method('getName')->willReturn('Share 1');
 
 		/*
-		 * Mocks getSharedWith ($alreadyShared and $alreadySharedGroup).
+		 * Mocks getSharedWith ($alreadyShared).
 		 * The share we are going to create does not already exist.
 		 */
 		$expr1 = $this->createMock(IExpressionBuilder::class);
@@ -247,18 +247,18 @@ class FederatedShareProviderReshareRemoteTest extends \Test\TestCase {
 		$qb6->method('createNamedParameter')->willReturn('');
 		$qb6->method('executeQuery')->willReturn($result6);
 
-		$queryBuilderMatcher = $this->exactly(7);
+		$queryBuilderMatcher = $this->exactly(6);
 		$this->connection
 			->expects($queryBuilderMatcher)
 			->method('getQueryBuilder')
 			->willReturnCallback(function () use ($queryBuilderMatcher, $qb1, $qb2, $qb3, $qb4, $qb5, $qb6) {
 				return match ($queryBuilderMatcher->numberOfInvocations()) {
-					1, 2 => $qb1,
-					3 => $qb2,
-					4 => $qb3,
-					5 => $qb4,
-					6 => $qb5,
-					7 => $qb6,
+					1 => $qb1,
+					2 => $qb2,
+					3 => $qb3,
+					4 => $qb4,
+					5 => $qb5,
+					6 => $qb6,
 					default => throw new LogicException('Unexpected number of invocations for getQueryBuilder')
 				};
 			});

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -32,6 +32,7 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
+use OCP\Share\Exceptions\AlreadySharedException;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -416,6 +417,66 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		} catch (\Exception $e) {
 			$this->assertEquals('Sharing myFile failed, because this item is already shared with the account user@server.com', $e->getMessage());
 		}
+	}
+
+	public static function dataTestCreateAlreadySharedWithEquivalentCloudId(): array {
+		return [
+			['user@server.com'],
+			['user@server.com/'],
+			['user@server.com/index.php'],
+		];
+	}
+
+	/**
+	 * Sharing a node with a recipient it is already shared with has to be
+	 * rejected with an AlreadySharedException, for every spelling that
+	 * normalizes to the same cloud ID.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestCreateAlreadySharedWithEquivalentCloudId')]
+	public function testCreateAlreadySharedWithEquivalentCloudId(string $shareWith): void {
+		$node = $this->createMock(File::class);
+		$node->method('getId')->willReturn(42);
+		$node->method('getName')->willReturn('myFile');
+
+		$this->addressHandler->expects($this->any())->method('splitUserRemote')
+			->willReturn(['user', 'server.com']);
+		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
+			->willReturn('http://localhost/');
+		$this->tokenHandler->method('generateToken')->willReturn('token');
+		$this->contactsManager->expects($this->any())->method('search')
+			->willReturn([]);
+		$this->notifications->expects($this->once())
+			->method('sendRemoteShare')
+			->willReturn(true);
+
+		$share = $this->shareManager->newShare();
+		$share->setSharedWith('user@server.com')
+			->setSharedBy('sharedBy')
+			->setShareOwner('shareOwner')
+			->setPermissions(19)
+			->setShareType(IShare::TYPE_REMOTE)
+			->setNode($node)
+			->setTarget('');
+		$existingShare = $this->provider->create($share);
+
+		// a recipient of the node re-sharing it with the same account
+		$duplicate = $this->shareManager->newShare();
+		$duplicate->setSharedWith($shareWith)
+			->setSharedBy('otherRecipient')
+			->setShareOwner('shareOwner')
+			->setPermissions(19)
+			->setShareType(IShare::TYPE_REMOTE)
+			->setNode($node)
+			->setTarget('');
+
+		try {
+			$this->provider->create($duplicate);
+			$this->fail('Expected an AlreadySharedException');
+		} catch (AlreadySharedException $e) {
+			$this->assertEquals($existingShare->getId(), $e->getExistingShare()->getId());
+		}
+
+		$this->assertCount(1, $this->provider->getSharesByPath($node));
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'dataTestUpdate')]


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary
Reproduction steps: 
 - admin shares folder 'Test' with local user Bob 
 - admin shares 'Test' with remote user User1 by typing his name in the user selecting it 
 - Bob attempts to share the way but gets an error ( Expected behaviour ✅) 
 - Bob manually types `user1@http://nextcloud2.local/ ` ( Works 🚫 ) 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
