### PR TITLE
Fix one core migration: Only add taskprocessing columns if they don't exist

### DIFF
--- a/core/Migrations/Version30000Date20240717111406.php
+++ b/core/Migrations/Version30000Date20240717111406.php
@@ -34,24 +34,29 @@ class Version30000Date20240717111406 extends SimpleMigrationStep {
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
+		$schemaChanged = false;
 
 		if ($schema->hasTable('taskprocessing_tasks')) {
 			$table = $schema->getTable('taskprocessing_tasks');
 
-			$table->addColumn('webhook_uri', Types::STRING, [
-				'notnull' => false,
-				'default' => null,
-				'length' => 4000,
-			]);
-			$table->addColumn('webhook_method', Types::STRING, [
-				'notnull' => false,
-				'default' => null,
-				'length' => 64,
-			]);
-
-			return $schema;
+			if (!$table->hasColumn('webhook_uri')) {
+				$table->addColumn('webhook_uri', Types::STRING, [
+					'notnull' => false,
+					'default' => null,
+					'length' => 4000,
+				]);
+				$schemaChanged = true;
+			}
+			if (!$table->hasColumn('webhook_method')) {
+				$table->addColumn('webhook_method', Types::STRING, [
+					'notnull' => false,
+					'default' => null,
+					'length' => 64,
+				]);
+				$schemaChanged = true;
+			}
 		}
 
-		return null;
+		return $schemaChanged ? $schema : null;
 	}
 }


### PR DESCRIPTION
Make OC\Core\Migrations\Version30000Date20240717111406 safer when adding columns in taskprocessing_tasks.

This migration step could not be executed more than once because it always tried to add 2 columns, whether they exist or not.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
