### PR TITLE
feat: introduce unstable Resource API [skip ci]

### DIFF
--- a/lib/private/Actor/ActorResolver.php
+++ b/lib/private/Actor/ActorResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Actor;
+
+use NCU\Actor\Actors\AnonymousActor;
+use NCU\Actor\Actors\UserActor;
+use NCU\Actor\IActor;
+use NCU\Actor\IActorResolver;
+use OCP\IUserSession;
+
+final readonly class ActorResolver implements IActorResolver {
+	public function __construct(
+		private IUserSession $userSession,
+	) {
+	}
+
+	public function fromSession(): IActor {
+		$user = $this->userSession->getUser();
+
+		return $user !== null ? new UserActor($user->getUID()) : new AnonymousActor();
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1161,6 +1161,8 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias(\NCU\Sharing\ISharingManager::class, SharingManager::class);
 		$this->registerAlias(\NCU\Sharing\ISharingBackend::class, SharingBackend::class);
 
+		$this->registerAlias(\NCU\Actor\IActorResolver::class, \OC\Actor\ActorResolver::class);
+
 		$this->registerService(IGlobalScaleService::class, function (ContainerInterface $c): IGlobalScaleService {
 			/** @var Coordinator $coordinator */
 			$coordinator = $c->get(Coordinator::class);

--- a/lib/unstable/Actor/Actors/AnonymousActor.php
+++ b/lib/unstable/Actor/Actors/AnonymousActor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor\Actors;
+
+use NCU\Actor\IActor;
+use OCP\AppFramework\Attribute\Consumable;
+
+/**
+ * An unauthenticated caller, where no identity can be derived: a public share
+ * visitor, an unauthenticated request.
+ *
+ * Satisfies no sub-interface of {@see \NCU\Actor\IActor}: it carries neither
+ * an identifier nor any authority.
+ *
+ * @experimental 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+final class AnonymousActor implements IActor {
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	#[\Override]
+	public function getTypeIdentifier(): string {
+		return 'anonymous';
+	}
+}

--- a/lib/unstable/Actor/Actors/FederatedUserActor.php
+++ b/lib/unstable/Actor/Actors/FederatedUserActor.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor\Actors;
+
+use NCU\Actor\IIdentifiableActor;
+use OCP\AppFramework\Attribute\Consumable;
+
+/**
+ * A user account on another server.
+ *
+ * Identifiable but not an {@see \NCU\Actor\ILocalAccountActor}: another server
+ * is the authority behind the identifier, so it must not be resolved against
+ * local accounts, groups or quotas.
+ *
+ * @experimental 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+final class FederatedUserActor implements IIdentifiableActor {
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	public function __construct(
+		protected string $id,
+	) {
+	}
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	#[\Override]
+	public function getId(): string {
+		return $this->id;
+	}
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	#[\Override]
+	public function getTypeIdentifier(): string {
+		return 'federated_user';
+	}
+}

--- a/lib/unstable/Actor/Actors/SystemActor.php
+++ b/lib/unstable/Actor/Actors/SystemActor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor\Actors;
+
+use NCU\Actor\ISystemActor;
+use OCP\AppFramework\Attribute\Consumable;
+
+/**
+ * The instance itself: cron jobs, `occ` commands without a user option.
+ *
+ * Carries no identifier, and so is not an
+ * {@see \NCU\Actor\IIdentifiableActor} or an
+ * {@see \NCU\Actor\ILocalAccountActor}.
+ *
+ * @experimental 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+final class SystemActor implements ISystemActor {
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	#[\Override]
+	public function getTypeIdentifier(): string {
+		return 'system';
+	}
+}

--- a/lib/unstable/Actor/Actors/UserActor.php
+++ b/lib/unstable/Actor/Actors/UserActor.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor\Actors;
+
+use NCU\Actor\ILocalAccountActor;
+use OCP\AppFramework\Attribute\Consumable;
+
+/**
+ * A user account on this instance. Its identifier is a uid.
+ *
+ * @experimental 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+final class UserActor implements ILocalAccountActor {
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	public function __construct(
+		protected string $id,
+	) {
+	}
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	#[\Override]
+	public function getId(): string {
+		return $this->id;
+	}
+
+	/**
+	 * @experimental 35.0.0
+	 */
+	#[\Override]
+	public function getTypeIdentifier(): string {
+		return 'user';
+	}
+}

--- a/lib/unstable/Actor/IActor.php
+++ b/lib/unstable/Actor/IActor.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor;
+
+use OCP\AppFramework\Attribute\Implementable;
+
+/**
+ * Transports who is asking, at the point an API or function call is made, so
+ * the callee can adjust its answer and behavior.
+ *
+ * Consumers SHOULD narrow on the sub-interfaces {@see IIdentifiableActor},
+ * {@see ILocalAccountActor}, {@see ISystemActor}, each answering one question
+ * about the actor, and not on a concrete implementation. An implementation
+ * may therefore be added without existing call sites changing, provided it
+ * declares the sub-interfaces it satisfies. Only in cases where a specific
+ * actor is wanted, apps MAY exclude all other implementations by referring to
+ * a specific actor class.
+ *
+ * New implementations MUST NOT introduce actor types which are deducible in
+ * type and location by a combination of the existing interfaces, or which
+ * represent a property resolvable from {@see IIdentifiableActor::getId()},
+ * such as administrator status or an app-specific role.
+ *
+ * @experimental 35.0.0
+ */
+#[Implementable(since: '35.0.0')]
+interface IActor {
+	/**
+	 * Stable identifier for this kind of actor, for persisting a reference to
+	 * an actor or configuration keyed by actor kind.
+	 *
+	 * Declared per implementation, never derived from the class name and never
+	 * a fully qualified class name. Core uses bare words (`user`, `system`); an
+	 * app prefixes with its app id (`myapp_bot`).
+	 *
+	 * Persist together with {@see IIdentifiableActor::getId()}: an identifier is
+	 * unique within its kind, not across kinds.
+	 *
+	 * @experimental 35.0.0
+	 */
+	public function getTypeIdentifier(): string;
+}

--- a/lib/unstable/Actor/IActorResolver.php
+++ b/lib/unstable/Actor/IActorResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor;
+
+use OCP\AppFramework\Attribute\Consumable;
+
+/**
+ * Resolves the actor for the current request.
+ *
+ * @experimental 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+interface IActorResolver {
+	/**
+	 * The actor for the current session, or an
+	 * {@see \NCU\Actor\Actors\AnonymousActor} if nobody is logged in.
+	 *
+	 * @experimental 35.0.0
+	 */
+	public function fromSession(): IActor;
+}

--- a/lib/unstable/Actor/IIdentifiableActor.php
+++ b/lib/unstable/Actor/IIdentifiableActor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor;
+
+use OCP\AppFramework\Attribute\Implementable;
+
+/**
+ * For actors carrying an identifier, e.g. a user id or an email address.
+ *
+ * Narrow to this wherever an identifier is needed; actors without one like the
+ * system, or an unauthenticated caller, do not satisfy it.
+ *
+ * The identifier is unique within the actor kind, not across kinds. Resolve it
+ * only against the authority the actor's other interfaces imply, and persist it
+ * together with {@see IActor::getTypeIdentifier()}.
+ *
+ * @experimental 35.0.0
+ */
+#[Implementable(since: '35.0.0')]
+interface IIdentifiableActor extends IActor {
+	/**
+	 * @experimental 35.0.0
+	 */
+	public function getId(): string;
+}

--- a/lib/unstable/Actor/ILocalAccountActor.php
+++ b/lib/unstable/Actor/ILocalAccountActor.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor;
+
+use OCP\AppFramework\Attribute\Implementable;
+
+/**
+ * For actors whose identifier is a local account, as resolved by
+ * `IUserManager::get()`.
+ *
+ * Narrow to this before resolving an actor against group membership,
+ * administrator status, quota or any other account property.
+ *
+ * Originating on this instance is not sufficient: a bot or a guest participant
+ * may be local and still have no account. Nor is the identifier's shape a
+ * reliable test — user ids may contain `@`, so a local id can be
+ * indistinguishable by value from a federated one.
+ *
+ * @experimental 35.0.0
+ */
+#[Implementable(since: '35.0.0')]
+interface ILocalAccountActor extends IIdentifiableActor {
+}

--- a/lib/unstable/Actor/ISystemActor.php
+++ b/lib/unstable/Actor/ISystemActor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Actor;
+
+use OCP\AppFramework\Attribute\Implementable;
+
+/**
+ * For actors whose authority comes from the instance's configuration rather
+ * than from an account: cron jobs, `occ` commands without a user option,
+ * system-wide bots.
+ *
+ * Narrow to this for a check meaning "trusted internal caller, per-user checks
+ * do not apply".
+ *
+ * May be combined with {@see IIdentifiableActor} by implementations that carry
+ * an identifier without having an account.
+ *
+ * @experimental 35.0.0
+ */
+#[Implementable(since: '35.0.0')]
+interface ISystemActor extends IActor {
+}

--- a/lib/unstable/Resource/FileResource.php
+++ b/lib/unstable/Resource/FileResource.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Resource;
+
+/**
+ * Represents a file as provided by the files app.
+ *
+ * @experimental 35.0.0
+ */
+final class FileResource implements IResource {
+}

--- a/lib/unstable/Resource/IResource.php
+++ b/lib/unstable/Resource/IResource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace NCU\Resource;
+
+use OCP\AppFramework\Attribute\Implementable;
+
+/**
+ * Names a kind of resource an API or function call can be about: a Talk room,
+ * a Tables row, a file version. Resource types are open - every app defines
+ * its own.
+ *
+ * @experimental 35.0.0
+ */
+#[Implementable(since: '35.0.0')]
+interface IResource {
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The idea behind this is to be able to build a shared vocabulary of resource types supported, to be able to reference them across the board: e.g. a function in my app expects a `class-of<IResource`>` and an ID as input.
 
**A resource type is its class.** `IResource` is therefore a marker; implementations are never instantiated.

```php
namespace NCU\Resource;

interface IResource {
}

// example materializations
final class FileResource implements IResource {}
final class TableResource implements IResource {}
final class RoomResource implements IResource {}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
