### PR TITLE
Clean up application autoloading registration

### DIFF
--- a/apps/sharing/tests/CapabilitiesTest.php
+++ b/apps/sharing/tests/CapabilitiesTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-declare(strict_types=1);
+namespace OCA\Sharing\Tests;
 
 use NCU\Sharing\ISharingRegistry;
 use OCA\Sharing\AppInfo\Application;

--- a/apps/sharing/tests/Command/CommandTest.php
+++ b/apps/sharing/tests/Command/CommandTest.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-declare(strict_types=1);
+namespace OCA\Sharing\Tests\Command;
 
+use Exception;
 use NCU\Sharing\ISharingManager;
 use NCU\Sharing\ISharingRegistry;
 use NCU\Sharing\Permission\SharePermission;
@@ -37,7 +40,9 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Server;
+use Override;
 use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
 use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\Output;

--- a/apps/sharing/tests/Controller/ApiV1ControllerTest.php
+++ b/apps/sharing/tests/Controller/ApiV1ControllerTest.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-declare(strict_types=1);
+namespace OCA\Sharing\Tests\Controller;
 
+use Closure;
 use NCU\Sharing\ISharingManager;
 use NCU\Sharing\Permission\SharePermission;
 use NCU\Sharing\Property\ShareProperty;
@@ -25,6 +28,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Server;
+use Override;
 use PHPUnit\Framework\Attributes\Group;
 use Test\Sharing\AbstractSharingManagerTests;
 

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -83,6 +83,8 @@ class AppManager implements IAppManager {
 
 	/** @var array<string, true> */
 	private array $loadedApps = [];
+	/** @var array<string, true> */
+	private array $registeredApps = [];
 
 	/** @var string[] */
 	private $namespaceCache = [];
@@ -267,22 +269,12 @@ class AppManager implements IAppManager {
 
 		// Load the enabled apps here
 		$apps = $this->getEnabledApps();
-
-		// Add each apps' folder as allowed class path
-		foreach ($apps as $app) {
+		$appsToRegister = array_filter(
+			$apps,
 			// If the app is already loaded then autoloading it makes no sense
-			if (!$this->isAppLoaded($app) && ($types === [] || $this->isType($app, $types))) {
-				try {
-					$path = $this->getAppPath($app);
-					\OC_App::registerAutoloading($app, $path);
-				} catch (AppPathNotFoundException $e) {
-					$this->logger->info('Error during app loading: ' . $e->getMessage(), [
-						'exception' => $e,
-						'app' => $app,
-					]);
-				}
-			}
-		}
+			fn (string $app) => (!$this->isAppLoaded($app) && ($types === [] || $this->isType($app, $types))),
+		);
+		$this->registerAppsAutoloading($appsToRegister);
 
 		// prevent app loading from printing output
 		ob_start();
@@ -487,7 +479,7 @@ class AppManager implements IAppManager {
 		$eventLogger->start("bootstrap:load_app:$app", "Load app: $app");
 
 		// in case someone calls loadApp() directly
-		\OC_App::registerAutoloading($app, $appPath);
+		$this->registerAppsAutoloading([$app]);
 
 		if (is_file($appPath . '/appinfo/app.php')) {
 			$this->logger->error('/appinfo/app.php is not supported anymore, use \OCP\AppFramework\Bootstrap\IBootstrap on the application class instead.', [
@@ -576,6 +568,52 @@ class AppManager implements IAppManager {
 		$eventLogger->end("bootstrap:load_app:$app:info");
 
 		$eventLogger->end("bootstrap:load_app:$app");
+	}
+
+	/**
+	 * @internal
+	 */
+	public function registerAppsAutoloading(array $apps): void {
+		foreach ($apps as $app) {
+			if (!isset($this->registeredApps[$app])) {
+				try {
+					$path = $this->getAppPath($app);
+					$this->registerAutoloading($app, $path);
+				} catch (AppPathNotFoundException $e) {
+					$this->logger->info('Error during app loading: ' . $e->getMessage(), [
+						'exception' => $e,
+						'app' => $app,
+					]);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @internal
+	 */
+	public function registerAutoloading(string $app, string $path, bool $force = false): void {
+		if (!$force && isset($this->registeredApps[$app])) {
+			return;
+		}
+
+		$this->registeredApps[$app] = true;
+
+		// Register on PSR-4 composer autoloader
+		$appNamespace = $this->getAppNamespace($app);
+		\OC::$server->registerNamespace($app, $appNamespace);
+
+		if (file_exists($path . '/composer/autoload.php')) {
+			require_once $path . '/composer/autoload.php';
+		} elseif (is_dir($path . '/lib')) {
+			// autoloader crashes on non-existing dir
+			\OC::$composerAutoloader->addPsr4($appNamespace . '\\', $path . '/lib/', true);
+		}
+
+		// Register Test namespace only when testing
+		if (defined('PHPUNIT_RUN') || defined('CLI_TEST_RUN')) {
+			\OC::$composerAutoloader->addPsr4($appNamespace . '\\Tests\\', $path . '/tests/', true);
+		}
 	}
 
 	/**
@@ -1107,7 +1145,7 @@ class AppManager implements IAppManager {
 		$ignoreMax = in_array($appId, $ignoreMaxApps, true);
 		$this->checkAppDependencies($appId, $ignoreMax);
 
-		\OC_App::registerAutoloading($appId, $appPath, true);
+		$this->registerAutoloading($appId, $appPath, true);
 		$this->executeRepairSteps($appId, $appInfo['repair-steps']['pre-migration']);
 
 		$ms = new MigrationService($appId, Server::get(\OC\DB\Connection::class));

--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace OC\AppFramework\Bootstrap;
 
+use OC\App\AppManager;
 use OC\Support\CrashReport\Registry;
-use OC_App;
-use OCP\App\AppPathNotFoundException;
-use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\QueryException;
@@ -40,7 +38,7 @@ class Coordinator {
 		private IManager $dashboardManager,
 		private IEventDispatcher $eventDispatcher,
 		private IEventLogger $eventLogger,
-		private IAppManager $appManager,
+		private AppManager $appManager,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -66,21 +64,12 @@ class Coordinator {
 		if ($this->registrationContext === null) {
 			$this->registrationContext = new RegistrationContext($this->logger);
 		}
+		$this->eventLogger->start('bootstrap:register_app:autoloader', 'Setup autoloader for apps');
+		$this->appManager->registerAppsAutoloading($appIds);
+		$this->eventLogger->end('bootstrap:register_app:autoloader');
 		$apps = [];
 		foreach ($appIds as $appId) {
 			$this->eventLogger->start("bootstrap:register_app:$appId", "Register $appId");
-			$this->eventLogger->start("bootstrap:register_app:$appId:autoloader", "Setup autoloader for $appId");
-			/*
-			 * First, we have to enable the app's autoloader
-			 */
-			try {
-				$path = $this->appManager->getAppPath($appId);
-				OC_App::registerAutoloading($appId, $path);
-			} catch (AppPathNotFoundException) {
-				// Ignore
-				continue;
-			}
-			$this->eventLogger->end("bootstrap:register_app:$appId:autoloader");
 
 			/*
 			 * Next we check if there is an application class, and it implements

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -126,7 +126,6 @@ class Application {
 							}
 						}
 						// load from register_command.php
-						\OC_App::registerAutoloading($app, $appPath);
 						$file = $appPath . '/appinfo/register_command.php';
 						if (file_exists($file)) {
 							try {

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -534,7 +534,7 @@ class Installer {
 	}
 
 	private function installAppLastSteps(string $appPath, array $info, ?IOutput $output = null, string $enabled = 'no'): string {
-		\OC_App::registerAutoloading($info['id'], $appPath);
+		$this->appManager->registerAutoloading($info['id'], $appPath, true);
 
 		$previousVersion = $this->config->getAppValue($info['id'], 'installed_version', '');
 		$ms = new MigrationService($info['id'], Server::get(Connection::class));

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 use OC\App\AppManager;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Installer;
@@ -110,27 +111,7 @@ class OC_App {
 	 * @internal
 	 */
 	public static function registerAutoloading(string $app, string $path, bool $force = false): void {
-		$key = $app . '-' . $path;
-		if (!$force && isset(self::$alreadyRegistered[$key])) {
-			return;
-		}
-
-		self::$alreadyRegistered[$key] = true;
-
-		// Register on PSR-4 composer autoloader
-		$appNamespace = Server::get(IAppManager::class)->getAppNamespace($app);
-		\OC::$server->registerNamespace($app, $appNamespace);
-
-		if (file_exists($path . '/composer/autoload.php')) {
-			require_once $path . '/composer/autoload.php';
-		} else {
-			\OC::$composerAutoloader->addPsr4($appNamespace . '\\', $path . '/lib/', true);
-		}
-
-		// Register Test namespace only when testing
-		if (defined('PHPUNIT_RUN') || defined('CLI_TEST_RUN')) {
-			\OC::$composerAutoloader->addPsr4($appNamespace . '\\Tests\\', $path . '/tests/', true);
-		}
+		Server::get(AppManager::class)->registerAutoloading($app, $path, $force);
 	}
 
 	/**

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -108,13 +108,6 @@ class OC_App {
 	}
 
 	/**
-	 * @internal
-	 */
-	public static function registerAutoloading(string $app, string $path, bool $force = false): void {
-		Server::get(AppManager::class)->registerAutoloading($app, $path, $force);
-	}
-
-	/**
 	 * Check if an app is of a specific type
 	 *
 	 * @deprecated 27.0.0 use IAppManager::isType

--- a/tests/Core/Command/Config/System/CastHelperTest.php
+++ b/tests/Core/Command/Config/System/CastHelperTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Core\Command\Config\System;
+namespace Tests\Core\Command\Config\System;
 
 use OC\Core\Command\Config\System\CastHelper;
 use Test\TestCase;

--- a/tests/Core/Command/Group/AddTest.php
+++ b/tests/Core/Command/Group/AddTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\Group;
+namespace Tests\Core\Command\Group;
 
 use OC\Core\Command\Group\Add;
 use OCP\IGroup;

--- a/tests/Core/Command/Group/AddUserTest.php
+++ b/tests/Core/Command/Group/AddUserTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\Group;
+namespace Tests\Core\Command\Group;
 
 use OC\Core\Command\Group\AddUser;
 use OCP\IGroup;

--- a/tests/Core/Command/Group/DeleteTest.php
+++ b/tests/Core/Command/Group/DeleteTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\Group;
+namespace Tests\Core\Command\Group;
 
 use OC\Core\Command\Group\Delete;
 use OCP\IGroup;

--- a/tests/Core/Command/Group/InfoTest.php
+++ b/tests/Core/Command/Group/InfoTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\Group;
+namespace Tests\Core\Command\Group;
 
 use OC\Core\Command\Group\Info;
 use OCP\IGroup;

--- a/tests/Core/Command/Group/ListCommandTest.php
+++ b/tests/Core/Command/Group/ListCommandTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\Group;
+namespace Tests\Core\Command\Group;
 
 use OC\Core\Command\Group\ListCommand;
 use OCP\IGroup;

--- a/tests/Core/Command/Group/RemoveUserTest.php
+++ b/tests/Core/Command/Group/RemoveUserTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\Group;
+namespace Tests\Core\Command\Group;
 
 use OC\Core\Command\Group\RemoveUser;
 use OCP\IGroup;

--- a/tests/Core/Command/Preview/CleanupTest.php
+++ b/tests/Core/Command/Preview/CleanupTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Core\Command\Preview;
+namespace Tests\Core\Command\Preview;
 
 use OC\Core\Command\Preview\Cleanup;
 use OC\Preview\PreviewService;

--- a/tests/Core/Command/SystemTag/AddTest.php
+++ b/tests/Core/Command/SystemTag/AddTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\SystemTag;
+namespace Tests\Core\Command\SystemTag;
 
 use OC\Core\Command\SystemTag\Add;
 use OCP\SystemTag\ISystemTag;

--- a/tests/Core/Command/SystemTag/DeleteTest.php
+++ b/tests/Core/Command/SystemTag/DeleteTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\SystemTag;
+namespace Tests\Core\Command\SystemTag;
 
 use OC\Core\Command\SystemTag\Delete;
 use OCP\SystemTag\ISystemTagManager;

--- a/tests/Core/Command/SystemTag/EditTest.php
+++ b/tests/Core/Command/SystemTag/EditTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\SystemTag;
+namespace Tests\Core\Command\SystemTag;
 
 use OC\Core\Command\SystemTag\Edit;
 use OCP\SystemTag\ISystemTag;

--- a/tests/Core/Command/SystemTag/ListCommandTest.php
+++ b/tests/Core/Command/SystemTag/ListCommandTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\SystemTag;
+namespace Tests\Core\Command\SystemTag;
 
 use OC\Core\Command\SystemTag\ListCommand;
 use OCP\SystemTag\ISystemTag;

--- a/tests/Core/Command/TwoFactorAuth/CleanupTest.php
+++ b/tests/Core/Command/TwoFactorAuth/CleanupTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Core\Command\TwoFactorAuth;
+namespace Tests\Core\Command\TwoFactorAuth;
 
 use OC\Core\Command\TwoFactorAuth\Cleanup;
 use OCP\Authentication\TwoFactorAuth\IRegistry;

--- a/tests/Core/Command/TwoFactorAuth/DisableTest.php
+++ b/tests/Core/Command/TwoFactorAuth/DisableTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\TwoFactorAuth;
+namespace Tests\Core\Command\TwoFactorAuth;
 
 use OC\Authentication\TwoFactorAuth\ProviderManager;
 use OC\Core\Command\TwoFactorAuth\Disable;

--- a/tests/Core/Command/TwoFactorAuth/EnableTest.php
+++ b/tests/Core/Command/TwoFactorAuth/EnableTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Command\TwoFactorAuth;
+namespace Tests\Core\Command\TwoFactorAuth;
 
 use OC\Authentication\TwoFactorAuth\ProviderManager;
 use OC\Core\Command\TwoFactorAuth\Enable;

--- a/tests/Core/Command/TwoFactorAuth/StateTest.php
+++ b/tests/Core/Command/TwoFactorAuth/StateTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Core\Command\TwoFactorAuth;
+namespace Tests\Core\Command\TwoFactorAuth;
 
 use OC\Core\Command\TwoFactorAuth\State;
 use OCP\Authentication\TwoFactorAuth\IRegistry;

--- a/tests/Core/Command/User/AddTest.php
+++ b/tests/Core/Command/User/AddTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Command\User;
+namespace Tests\Core\Command\User;
 
 use OC\Core\Command\User\Add;
 use OCA\Settings\Mailer\NewUserMailHelper;

--- a/tests/Core/Command/User/ProfileTest.php
+++ b/tests/Core/Command/User/ProfileTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Core\Command\User;
+namespace Tests\Core\Command\User;
 
 use OC\Core\Command\User\Profile;
 use OCP\Accounts\IAccount;

--- a/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Controller;
+namespace Tests\Core\Controller;
 
 use OC\Core\Controller\ClientFlowLoginV2Controller;
 use OC\Core\Data\LoginFlowV2Credentials;

--- a/tests/Core/Controller/ContactsMenuControllerTest.php
+++ b/tests/Core/Controller/ContactsMenuControllerTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Controller;
+namespace Tests\Core\Controller;
 
 use OC\Contacts\ContactsMenu\Manager;
 use OC\Core\Controller\ContactsMenuController;

--- a/tests/Core/Controller/GuestAvatarControllerTest.php
+++ b/tests/Core/Controller/GuestAvatarControllerTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Core\Controller;
+namespace Tests\Core\Controller;
 
 use OC\Core\Controller\GuestAvatarController;
 use OCP\AppFramework\Http\FileDisplayResponse;

--- a/tests/Core/Controller/OCSControllerTest.php
+++ b/tests/Core/Controller/OCSControllerTest.php
@@ -6,9 +6,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OC\Core\Controller;
+namespace Tests\Core\Controller;
 
 use OC\CapabilitiesManager;
+use OC\Core\Controller\OCSController;
 use OC\Security\IdentityProof\Key;
 use OC\Security\IdentityProof\Manager;
 use OCP\AppFramework\Http\DataResponse;

--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Test\Core\Controller;
+namespace Tests\Core\Controller;
 
 use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Authentication\TwoFactorAuth\ProviderSet;

--- a/tests/Core/Controller/UserControllerTest.php
+++ b/tests/Core/Controller/UserControllerTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\Core\Controller;
+namespace Tests\Core\Controller;
 
 use OC\Core\Controller\UserController;
 use OCP\AppFramework\Http\JSONResponse;

--- a/tests/Core/Middleware/TwoFactorMiddlewareTest.php
+++ b/tests/Core/Middleware/TwoFactorMiddlewareTest.php
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Test\Core\Middleware;
+namespace Tests\Core\Middleware;
 
 use OC\AppFramework\Http\Attributes\TwoFactorSetUpDoneRequired;
 use OC\AppFramework\Http\Request;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,7 +21,7 @@ if ($configDir) {
 require_once __DIR__ . '/../lib/base.php';
 require_once __DIR__ . '/autoload.php';
 
-\OC::$composerAutoloader->addPsr4('Tests\\', OC::$SERVERROOT . '/tests/', true);
+\OC::$composerAutoloader->addPsr4('Tests\\Core\\', OC::$SERVERROOT . '/tests/Core/', true);
 
 $dontLoadApps = getenv('TEST_DONT_LOAD_APPS');
 if (!$dontLoadApps) {

--- a/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
+++ b/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace lib\AppFramework\Bootstrap;
 
+use OC\App\AppManager;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Support\CrashReport\Registry;
 use OCA\Settings\AppInfo\Application;
-use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -27,7 +27,7 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class CoordinatorTest extends TestCase {
-	private IAppManager&MockObject $appManager;
+	private AppManager&MockObject $appManager;
 	private ContainerInterface&MockObject $serverContainer;
 	private Registry&MockObject $crashReporterRegistry;
 	private IManager&MockObject $dashboardManager;
@@ -40,7 +40,7 @@ class CoordinatorTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appManager = $this->createMock(IAppManager::class);
+		$this->appManager = $this->createMock(AppManager::class);
 		$this->serverContainer = $this->createMock(ContainerInterface::class);
 		$this->crashReporterRegistry = $this->createMock(Registry::class);
 		$this->dashboardManager = $this->createMock(IManager::class);

--- a/tests/lib/Authentication/TwoFactorAuth/EnforcementStateTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/EnforcementStateTest.php
@@ -12,7 +12,7 @@
  * Time: 13:01
  */
 
-namespace Tests\Authentication\TwoFactorAuth;
+namespace Test\Authentication\TwoFactorAuth;
 
 use OC\Authentication\TwoFactorAuth\EnforcementState;
 use Test\TestCase;

--- a/tests/lib/Authentication/TwoFactorAuth/MandatoryTwoFactorTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/MandatoryTwoFactorTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Authentication\TwoFactorAuth;
+namespace Test\Authentication\TwoFactorAuth;
 
 use OC\Authentication\TwoFactorAuth\EnforcementState;
 use OC\Authentication\TwoFactorAuth\MandatoryTwoFactor;

--- a/tests/lib/Config/LexiconTest.php
+++ b/tests/lib/Config/LexiconTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Tests\lib\Config;
+namespace Test\Config;
 
 use OC\AppConfig;
 use OC\AppFramework\Bootstrap\Coordinator;

--- a/tests/lib/Config/TestConfigLexicon_I.php
+++ b/tests/lib/Config/TestConfigLexicon_I.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Tests\lib\Config;
+namespace Test\Config;
 
 use OCP\Config\IUserConfig;
 use OCP\Config\Lexicon\Entry;

--- a/tests/lib/Config/TestLexicon_E.php
+++ b/tests/lib/Config/TestLexicon_E.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Tests\lib\Config;
+namespace Test\Config;
 
 use OCP\Config\IUserConfig;
 use OCP\Config\Lexicon\Entry;

--- a/tests/lib/Config/TestLexicon_N.php
+++ b/tests/lib/Config/TestLexicon_N.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Tests\lib\Config;
+namespace Test\Config;
 
 use OCP\Config\IUserConfig;
 use OCP\Config\Lexicon\Entry;

--- a/tests/lib/Config/TestLexicon_UserIndexed.php
+++ b/tests/lib/Config/TestLexicon_UserIndexed.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Tests\lib\Config;
+namespace Test\Config;
 
 use OCP\Config\IUserConfig;
 use OCP\Config\Lexicon\Entry;

--- a/tests/lib/Config/TestLexicon_UserIndexedRemove.php
+++ b/tests/lib/Config/TestLexicon_UserIndexedRemove.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Tests\lib\Config;
+namespace Test\Config;
 
 use OCP\Config\Lexicon\Entry;
 use OCP\Config\Lexicon\ILexicon;

--- a/tests/lib/Config/TestLexicon_W.php
+++ b/tests/lib/Config/TestLexicon_W.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Tests\lib\Config;
+namespace Test\Config;
 
 use OCP\Config\IUserConfig;
 use OCP\Config\Lexicon\Entry;

--- a/tests/lib/Config/UserConfigMigrationFallbackTest.php
+++ b/tests/lib/Config/UserConfigMigrationFallbackTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Test\lib\Config;
+namespace Test\Config;
 
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
 use OC\Config\ConfigManager;

--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace Test\lib\Config;
+namespace Test\Config;
 
 use OC\Config\ConfigManager;
 use OC\Config\PresetManager;

--- a/tests/lib/Contacts/ContactsMenu/ActionFactoryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ActionFactoryTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Contacts\ContactsMenu;
+namespace Test\Contacts\ContactsMenu;
 
 use OC\Contacts\ContactsMenu\ActionFactory;
 use OCP\Contacts\ContactsMenu\IAction;

--- a/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Contacts\ContactsMenu;
+namespace Test\Contacts\ContactsMenu;
 
 use OC\App\AppManager;
 use OC\Contacts\ContactsMenu\ActionProviderStore;

--- a/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Contacts\ContactsMenu\Actions;
+namespace Test\Contacts\ContactsMenu\Actions;
 
 use OC\Contacts\ContactsMenu\Actions\LinkAction;
 use Test\TestCase;

--- a/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Contacts\ContactsMenu;
+namespace Test\Contacts\ContactsMenu;
 
 use OC\Contacts\ContactsMenu\ContactsStore;
 use OC\KnownUser\KnownUserService;

--- a/tests/lib/Contacts/ContactsMenu/EntryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/EntryTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Contacts\ContactsMenu;
+namespace Test\Contacts\ContactsMenu;
 
 use OC\Contacts\ContactsMenu\Actions\LinkAction;
 use OC\Contacts\ContactsMenu\Entry;

--- a/tests/lib/Contacts/ContactsMenu/ManagerTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ManagerTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Contacts\ContactsMenu;
+namespace Test\Contacts\ContactsMenu;
 
 use OC\Contacts\ContactsMenu\ActionProviderStore;
 use OC\Contacts\ContactsMenu\ContactsStore;

--- a/tests/lib/Contacts/ContactsMenu/Providers/EMailproviderTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Providers/EMailproviderTest.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Contacts\ContactsMenu\Providers;
+namespace Test\Contacts\ContactsMenu\Providers;
 
 use OC\Contacts\ContactsMenu\Providers\EMailProvider;
 use OCP\Contacts\ContactsMenu\IActionFactory;

--- a/tests/lib/Http/WellKnown/GenericResponseTest.php
+++ b/tests/lib/Http/WellKnown/GenericResponseTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace Tests\Http\WellKnown;
+namespace Test\Http\WellKnown;
 
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Http\WellKnown\GenericResponse;

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -7,7 +7,7 @@
 
 namespace Test;
 
-use OCP\App\IAppManager;
+use OC\App\AppManager;
 use OCP\AppFramework\App;
 use OCP\OpenMetrics\IMetricFamily;
 use OCP\Server;
@@ -19,12 +19,12 @@ use OCP\Server;
  */
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class InfoXmlTest extends TestCase {
-	private IAppManager $appManager;
+	private AppManager $appManager;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
-		$this->appManager = Server::get(IAppManager::class);
+		$this->appManager = Server::get(AppManager::class);
 	}
 
 	public static function dataApps(): array {
@@ -58,7 +58,7 @@ class InfoXmlTest extends TestCase {
 	public function testClasses($app): void {
 		$appInfo = $this->appManager->getAppInfo($app);
 		$appPath = $this->appManager->getAppPath($app);
-		\OC_App::registerAutoloading($app, $appPath);
+		$this->appManager->registerAutoloading($app, $appPath);
 
 		//Add the appcontainer
 		$applicationClassName = $this->appManager->getAppNamespace($app) . '\\AppInfo\\Application';


### PR DESCRIPTION
## Summary

Cleanup and reorganize application autoloading registration to ease future improvements.
Also fixes namespace inconsistencies in tests.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
