### PR TITLE
fix: system address book card restriction

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -11,10 +11,11 @@ namespace OCA\DAV\CardDAV;
 
 use OCA\Federation\TrustedServers;
 use OCP\Accounts\IAccountManager;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 use Sabre\CardDAV\Backend\BackendInterface;
 use Sabre\CardDAV\Backend\SyncSupport;
@@ -35,7 +36,7 @@ class SystemAddressbook extends AddressBook {
 		BackendInterface $carddavBackend,
 		array $addressBookInfo,
 		IL10N $l10n,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IUserSession $userSession,
 		private ?IRequest $request = null,
 		private ?TrustedServers $trustedServers = null,
@@ -53,12 +54,14 @@ class SystemAddressbook extends AddressBook {
 	 * 'Allow username autocompletion in share dialog' + 'Allow username autocompletion to users within the same groups' -> show only users in intersecting groups
 	 * 'Allow username autocompletion in share dialog' + 'Allow username autocompletion to users based on phone number integration' -> show only the same user
 	 * 'Allow username autocompletion in share dialog' + 'Allow username autocompletion to users within the same groups' + 'Allow username autocompletion to users based on phone number integration' -> show only users in intersecting groups
+	 * 'Restrict users to only share with users in their groups' -> show only users in intersecting groups, unless already narrowed further above
 	 */
 	#[\Override]
 	public function getChildren() {
-		$shareEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
-		$shareEnumerationGroup = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
-		$shareEnumerationPhone = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';
+		$shareEnumeration = $this->appConfig->getValueBool('core', 'shareapi_allow_share_dialog_user_enumeration', true);
+		$shareEnumerationGroup = $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_group');
+		$shareEnumerationPhone = $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_phone');
+		$restrictToOwnGroups = $this->appConfig->getValueBool('core', 'shareapi_only_share_with_group_members');
 		$user = $this->userSession->getUser();
 		if (!$user) {
 			// Should never happen because we don't allow anonymous access
@@ -77,18 +80,17 @@ class SystemAddressbook extends AddressBook {
 				// Group manager is not available, so we can't determine which data is safe
 				return [];
 			}
-			$groups = $this->groupManager->getUserGroups($user);
-			$names = [];
-			foreach ($groups as $group) {
-				$users = $group->getUsers();
-				foreach ($users as $groupUser) {
-					if ($groupUser->getBackendClassName() === 'Guests') {
-						continue;
-					}
-					$names[] = SyncService::getCardUri($groupUser);
-				}
+			return parent::getMultipleChildren($this->getCardsForUsersGroups($user));
+		}
+		if ($restrictToOwnGroups) {
+			if ($this->groupManager === null) {
+				// Group manager is not available, so we can't determine which data is safe
+				return [];
 			}
-			return parent::getMultipleChildren(array_unique($names));
+			if (!$this->exemptFromOwnGroupsRestriction($user)) {
+				return parent::getMultipleChildren($this->getCardsForUsersGroups($user));
+			}
+			// Member of an excluded group -> restriction does not apply, fall through to show everyone
 		}
 
 		$children = parent::getChildren();
@@ -105,9 +107,10 @@ class SystemAddressbook extends AddressBook {
 	 */
 	#[\Override]
 	public function getMultipleChildren($paths): array {
-		$shareEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
-		$shareEnumerationGroup = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
-		$shareEnumerationPhone = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';
+		$shareEnumeration = $this->appConfig->getValueBool('core', 'shareapi_allow_share_dialog_user_enumeration', true);
+		$shareEnumerationGroup = $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_group');
+		$shareEnumerationPhone = $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_phone');
+		$restrictToOwnGroups = $this->appConfig->getValueBool('core', 'shareapi_only_share_with_group_members');
 		$user = $this->userSession->getUser();
 		if (($user !== null && $user->getBackendClassName() === 'Guests') || !$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
 			// No user or cards with no access
@@ -126,18 +129,18 @@ class SystemAddressbook extends AddressBook {
 				// Group manager or user is not available, so we can't determine which data is safe
 				return [];
 			}
-			$groups = $this->groupManager->getUserGroups($user);
-			$allowedNames = [];
-			foreach ($groups as $group) {
-				$users = $group->getUsers();
-				foreach ($users as $groupUser) {
-					if ($groupUser->getBackendClassName() === 'Guests') {
-						continue;
-					}
-					$allowedNames[] = SyncService::getCardUri($groupUser);
-				}
+			return parent::getMultipleChildren(array_intersect($paths, $this->getCardsForUsersGroups($user)));
+		}
+		if ($restrictToOwnGroups) {
+			if ($this->groupManager === null || $user === null) {
+				// Group manager or user is not available, so we can't determine which data is safe
+				return [];
 			}
-			return parent::getMultipleChildren(array_intersect($paths, $allowedNames));
+			if (!$this->exemptFromOwnGroupsRestriction($user)) {
+				$allowedNames = $this->getCardsForUsersGroups($user);
+				return parent::getMultipleChildren(array_intersect($paths, $allowedNames));
+			}
+			// Member of an excluded group -> restriction does not apply, fall through to show everyone
 		}
 		if (!$this->isFederation()) {
 			return parent::getMultipleChildren($paths);
@@ -170,9 +173,10 @@ class SystemAddressbook extends AddressBook {
 	#[\Override]
 	public function getChild($name): Card {
 		$user = $this->userSession->getUser();
-		$shareEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
-		$shareEnumerationGroup = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
-		$shareEnumerationPhone = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';
+		$shareEnumeration = $this->appConfig->getValueBool('core', 'shareapi_allow_share_dialog_user_enumeration', true);
+		$shareEnumerationGroup = $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_group');
+		$shareEnumerationPhone = $this->appConfig->getValueBool('core', 'shareapi_restrict_user_enumeration_to_phone');
+		$restrictToOwnGroups = $this->appConfig->getValueBool('core', 'shareapi_only_share_with_group_members');
 		if (($user !== null && $user->getBackendClassName() === 'Guests') || !$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
 			$ownName = $user !== null ? SyncService::getCardUri($user) : null;
 			if ($ownName === $name) {
@@ -185,19 +189,23 @@ class SystemAddressbook extends AddressBook {
 				// Group manager is not available, so we can't determine which data is safe
 				throw new Forbidden();
 			}
-			$groups = $this->groupManager->getUserGroups($user);
-			foreach ($groups as $group) {
-				foreach ($group->getUsers() as $groupUser) {
-					if ($groupUser->getBackendClassName() === 'Guests') {
-						continue;
-					}
-					$otherName = SyncService::getCardUri($groupUser);
-					if ($otherName === $name) {
-						return parent::getChild($name);
-					}
-				}
+			if (in_array($name, $this->getCardsForUsersGroups($user), true)) {
+				return parent::getChild($name);
 			}
 			throw new Forbidden();
+		}
+		if ($restrictToOwnGroups) {
+			if ($user === null || $this->groupManager === null) {
+				// Group manager is not available, so we can't determine which data is safe
+				throw new Forbidden();
+			}
+			if (!$this->exemptFromOwnGroupsRestriction($user)) {
+				if (in_array($name, $this->getCardsForUsersGroups($user), true)) {
+					return parent::getChild($name);
+				}
+				throw new Forbidden();
+			}
+			// Member of an excluded group -> restriction does not apply, fall through to show everyone
 		}
 		if (!$this->isFederation()) {
 			return parent::getChild($name);
@@ -288,6 +296,37 @@ class SystemAddressbook extends AddressBook {
 		}
 
 		return true;
+	}
+
+	/**
+	 * A user who belongs to at least one excluded group is not subject to the
+	 * 'shareapi_only_share_with_group_members' restriction at all, i.e. they can see everyone.
+	 */
+	private function exemptFromOwnGroupsRestriction(IUser $user): bool {
+		$excludedGroupIds = json_decode(
+			$this->appConfig->getValueString('core', 'shareapi_only_share_with_group_members_exclude_group_list', '[]'),
+			true
+		);
+		if (!is_array($excludedGroupIds) || $excludedGroupIds === []) {
+			return false;
+		}
+		return array_intersect($this->groupManager->getUserGroupIds($user), $excludedGroupIds) !== [];
+	}
+
+	/**
+	 * @return string[] card URIs of non-guest users sharing at least one group with $user
+	 */
+	private function getCardsForUsersGroups(IUser $user): array {
+		$names = [];
+		foreach ($this->groupManager->getUserGroups($user) as $group) {
+			foreach ($group->getUsers() as $groupUser) {
+				if ($groupUser->getBackendClassName() === 'Guests') {
+					continue;
+				}
+				$names[] = SyncService::getCardUri($groupUser);
+			}
+		}
+		return array_values(array_unique($names));
 	}
 
 	/**

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -17,7 +17,6 @@ use OCA\DAV\CardDAV\Integration\IAddressBookProvider;
 use OCA\DAV\ConfigLexicon;
 use OCA\Federation\TrustedServers;
 use OCP\IAppConfig;
-use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -35,7 +34,6 @@ use function array_map;
 
 class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 	protected IL10N $l10n;
-	protected IConfig $config;
 	protected IAppConfig $appConfig;
 
 	public function __construct(
@@ -48,7 +46,6 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 		parent::__construct($carddavBackend, $principalUri);
 
 		$this->l10n = Util::getL10N('dav');
-		$this->config = Server::get(IConfig::class);
 		$this->appConfig = Server::get(IAppConfig::class);
 	}
 
@@ -92,7 +89,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 						$this->carddavBackend,
 						$addressBook,
 						$this->l10n,
-						$this->config,
+						$this->appConfig,
 						Server::get(IUserSession::class),
 						$request,
 						$trustedServers,

--- a/apps/dav/tests/unit/CardDAV/SystemAddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/SystemAddressBookTest.php
@@ -14,7 +14,7 @@ use OCA\DAV\CardDAV\SyncService;
 use OCA\DAV\CardDAV\SystemAddressbook;
 use OCA\Federation\TrustedServers;
 use OCP\Accounts\IAccountManager;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -33,7 +33,7 @@ class SystemAddressBookTest extends TestCase {
 	private BackendInterface&MockObject $cardDavBackend;
 	private array $addressBookInfo;
 	private IL10N&MockObject $l10n;
-	private IConfig&MockObject $config;
+	private IAppConfig&MockObject $appConfig;
 	private IUserSession&MockObject $userSession;
 	private IRequest&MockObject $request;
 	private array $server;
@@ -51,7 +51,7 @@ class SystemAddressBookTest extends TestCase {
 			'principaluri' => 'principals/system/system',
 		];
 		$this->l10n = $this->createMock(IL10N::class);
-		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->request = $this->createMock(Request::class);
 		$this->server = [
@@ -66,7 +66,7 @@ class SystemAddressBookTest extends TestCase {
 			$this->cardDavBackend,
 			$this->addressBookInfo,
 			$this->l10n,
-			$this->config,
+			$this->appConfig,
 			$this->userSession,
 			$this->request,
 			$this->trustedServers,
@@ -75,12 +75,13 @@ class SystemAddressBookTest extends TestCase {
 	}
 
 	public function testGetChildrenAsGuest(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user');
@@ -115,12 +116,13 @@ VCF;
 	}
 
 	public function testGetFilteredChildForFederation(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$this->trustedServers->expects(self::once())
 			->method('getServers')
@@ -164,12 +166,13 @@ VCF;
 	}
 
 	public function testGetChildNotFound(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$this->trustedServers->expects(self::once())
 			->method('getServers')
@@ -184,12 +187,13 @@ VCF;
 	}
 
 	public function testGetChildWithoutEnumeration(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, false],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$this->expectException(Forbidden::class);
 
@@ -197,12 +201,13 @@ VCF;
 	}
 
 	public function testGetChildAsGuest(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->method('getBackendClassName')->willReturn('Guests');
@@ -215,12 +220,13 @@ VCF;
 	}
 
 	public function testGetChildWithGroupEnumerationRestriction(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', true],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->method('getBackendClassName')->willReturn('LDAP');
@@ -257,13 +263,142 @@ VCF;
 		$this->addressBook->getChild("{$otherUser->getBackendClassName()}:{$otherUser->getUID()}.vcf");
 	}
 
-	public function testGetChildWithPhoneNumberEnumerationRestriction(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+	public function testGetChildWithOwnGroupsOnlyRestriction(): void {
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'yes'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', true],
+			]);
+		$this->appConfig->expects(self::once())
+			->method('getValueString')
+			->willReturnMap([
+				['core', 'shareapi_only_share_with_group_members_exclude_group_list', '[]', '[]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn($user);
+		$otherUser = $this->createMock(IUser::class);
+		$otherUser->method('getUID')->willReturn('other');
+		$otherUser->method('getBackendClassName')->willReturn('LDAP');
+		$group = $this->createMock(IGroup::class);
+		$group->expects(self::once())
+			->method('getUsers')
+			->willReturn([$otherUser]);
+		$this->groupManager->expects(self::once())
+			->method('getUserGroups')
+			->with($user)
+			->willReturn([$group]);
+		$cardData = <<<VCF
+BEGIN:VCARD
+VERSION:3.0
+PRODID:-//Sabre//Sabre VObject 4.4.2//EN
+UID:admin
+FN;X-NC-SCOPE=v2-federated:other
+END:VCARD
+VCF;
+		$this->cardDavBackend->expects(self::once())
+			->method('getCard')
+			->with($this->addressBookInfo['id'], "{$otherUser->getBackendClassName()}:{$otherUser->getUID()}.vcf")
+			->willReturn([
+				'id' => 123,
+				'carddata' => $cardData,
+			]);
+
+		$this->addressBook->getChild("{$otherUser->getBackendClassName()}:{$otherUser->getUID()}.vcf");
+	}
+
+	public function testGetChildForbiddenWithOwnGroupsOnlyRestriction(): void {
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
+			->willReturnMap([
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', true],
+			]);
+		$this->appConfig->expects(self::once())
+			->method('getValueString')
+			->willReturnMap([
+				['core', 'shareapi_only_share_with_group_members_exclude_group_list', '[]', '[]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn($user);
+		$this->groupManager->expects(self::once())
+			->method('getUserGroups')
+			->with($user)
+			->willReturn([]);
+		$this->expectException(Forbidden::class);
+
+		$this->addressBook->getChild('LDAP:other.vcf');
+	}
+
+	/**
+	 * A user who belongs to an excluded group is entirely exempt from the
+	 * 'shareapi_only_share_with_group_members' restriction, so they can reach
+	 * any card, not just ones sharing a (non-excluded) group with them.
+	 */
+	public function testGetChildBypassesOwnGroupsOnlyForExcludedGroupMember(): void {
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
+			->willReturnMap([
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', true],
+			]);
+		$this->appConfig->expects(self::once())
+			->method('getValueString')
+			->willReturnMap([
+				['core', 'shareapi_only_share_with_group_members_exclude_group_list', '[]', '["excluded"]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn($user);
+		$this->groupManager->expects(self::once())
+			->method('getUserGroupIds')
+			->with($user)
+			->willReturn(['excluded']);
+		$this->groupManager->expects(self::never())
+			->method('getUserGroups');
+		// No matching shared secret -> isFederation() is false, so the plain (non-federation) path runs
+		$this->trustedServers->method('getServers')->willReturn([]);
+		$cardData = <<<VCF
+BEGIN:VCARD
+VERSION:3.0
+PRODID:-//Sabre//Sabre VObject 4.4.2//EN
+UID:admin
+FN;X-NC-SCOPE=v2-federated:other
+END:VCARD
+VCF;
+		$this->cardDavBackend->expects(self::once())
+			->method('getCard')
+			->with($this->addressBookInfo['id'], 'LDAP:other.vcf')
+			->willReturn([
+				'id' => 123,
+				'carddata' => $cardData,
+			]);
+
+		$this->addressBook->getChild('LDAP:other.vcf');
+	}
+
+	public function testGetChildWithPhoneNumberEnumerationRestriction(): void {
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
+			->willReturnMap([
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', true],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->method('getBackendClassName')->willReturn('LDAP');
@@ -276,12 +411,13 @@ VCF;
 	}
 
 	public function testGetOwnChildWithPhoneNumberEnumerationRestriction(): void {
-		$this->config->expects(self::exactly(3))
-			->method('getAppValue')
+		$this->appConfig->expects(self::exactly(4))
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'yes'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', true],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->method('getBackendClassName')->willReturn('LDAP');
@@ -309,12 +445,13 @@ VCF;
 	}
 
 	public function testGetMultipleChildrenWithGroupEnumerationRestriction(): void {
-		$this->config
-			->method('getAppValue')
+		$this->appConfig
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', true],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user');
@@ -364,13 +501,153 @@ VCF;
 		self::assertCount(2, $cards);
 	}
 
-	public function testGetMultipleChildrenAsGuest(): void {
-		$this->config
-			->method('getAppValue')
+	public function testGetMultipleChildrenWithOwnGroupsOnlyRestriction(): void {
+		$this->appConfig
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', true],
+			]);
+		$this->appConfig
+			->method('getValueString')
+			->willReturnMap([
+				['core', 'shareapi_only_share_with_group_members_exclude_group_list', '[]', '[]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user');
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$other1 = $this->createMock(IUser::class);
+		$other1->method('getUID')->willReturn('other1');
+		$other1->method('getBackendClassName')->willReturn('LDAP');
+		$other2 = $this->createMock(IUser::class);
+		$other2->method('getUID')->willReturn('other2');
+		$other2->method('getBackendClassName')->willReturn('LDAP');
+		$this->userSession
+			->method('getUser')
+			->willReturn($user);
+		$group1 = $this->createMock(IGroup::class);
+		$group1
+			->method('getUsers')
+			->willReturn([$user, $other1]);
+		$this->groupManager
+			->method('getUserGroups')
+			->with($user)
+			->willReturn([$group1]);
+		$this->cardDavBackend->expects(self::once())
+			->method('getMultipleCards')
+			->with($this->addressBookInfo['id'], [
+				SyncService::getCardUri($user),
+				SyncService::getCardUri($other1),
+			])
+			->willReturn([
+				[],
+				[],
+			]);
+
+		$cards = $this->addressBook->getMultipleChildren([
+			SyncService::getCardUri($user),
+			SyncService::getCardUri($other1),
+			SyncService::getCardUri($other2), // No overlapping group with this one
+		]);
+
+		self::assertCount(2, $cards);
+	}
+
+	public function testGetMultipleChildrenBypassesOwnGroupsOnlyForExcludedGroupMember(): void {
+		$this->appConfig
+			->method('getValueBool')
+			->willReturnMap([
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', true],
+			]);
+		$this->appConfig
+			->method('getValueString')
+			->willReturnMap([
+				['core', 'shareapi_only_share_with_group_members_exclude_group_list', '[]', '["excluded"]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user');
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$this->userSession
+			->method('getUser')
+			->willReturn($user);
+		$this->groupManager
+			->method('getUserGroupIds')
+			->with($user)
+			->willReturn(['excluded']);
+		$this->groupManager->expects(self::never())
+			->method('getUserGroups');
+		// No matching shared secret -> isFederation() is false, so the plain (non-federation) path runs
+		$this->trustedServers->method('getServers')->willReturn([]);
+		$this->cardDavBackend->expects(self::once())
+			->method('getMultipleCards')
+			->with($this->addressBookInfo['id'], ['Database:other.vcf'])
+			->willReturn([[]]);
+
+		$cards = $this->addressBook->getMultipleChildren(['Database:other.vcf']);
+
+		self::assertCount(1, $cards);
+	}
+
+	public function testGetChildrenWithOwnGroupsOnlyRestriction(): void {
+		$this->appConfig
+			->method('getValueBool')
+			->willReturnMap([
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', true],
+			]);
+		$this->appConfig
+			->method('getValueString')
+			->willReturnMap([
+				['core', 'shareapi_only_share_with_group_members_exclude_group_list', '[]', '[]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user');
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$other1 = $this->createMock(IUser::class);
+		$other1->method('getUID')->willReturn('other1');
+		$other1->method('getBackendClassName')->willReturn('LDAP');
+		$this->userSession
+			->method('getUser')
+			->willReturn($user);
+		$group1 = $this->createMock(IGroup::class);
+		$group1
+			->method('getUsers')
+			->willReturn([$user, $other1]);
+		$this->groupManager
+			->method('getUserGroups')
+			->with($user)
+			->willReturn([$group1]);
+		$this->cardDavBackend->expects(self::once())
+			->method('getMultipleCards')
+			->with($this->addressBookInfo['id'], [
+				SyncService::getCardUri($user),
+				SyncService::getCardUri($other1),
+			])
+			->willReturn([
+				[],
+				[],
+			]);
+
+		$cards = $this->addressBook->getChildren();
+
+		self::assertCount(2, $cards);
+	}
+
+	public function testGetMultipleChildrenAsGuest(): void {
+		$this->appConfig
+			->method('getValueBool')
+			->willReturnMap([
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user');
@@ -385,12 +662,13 @@ VCF;
 	}
 
 	public function testGetMultipleChildren(): void {
-		$this->config
-			->method('getAppValue')
+		$this->appConfig
+			->method('getValueBool')
 			->willReturnMap([
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
-				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
-				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', true, true],
+				['core', 'shareapi_restrict_user_enumeration_to_group', false],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', false],
+				['core', 'shareapi_only_share_with_group_members', false],
 			]);
 		$this->trustedServers
 			->method('getServers')

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -604,19 +604,6 @@
       <code><![CDATA[$vCard->UID]]></code>
     </UndefinedMagicPropertyFetch>
   </file>
-  <file src="apps/dav/lib/CardDAV/SystemAddressbook.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/dav/lib/CardDAV/UserAddressBooks.php">
     <InvalidArgument>
       <code><![CDATA[$this->principalUri]]></code>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

* Resolves: # Client Ticket
* Related: https://github.com/nextcloud/server/pull/60307

- added logic to the system address book to only enumerate users from a users group

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
