### PR TITLE
fix(calendar): Bring back getBackends

### DIFF
--- a/lib/private/Calendar/Resource/Manager.php
+++ b/lib/private/Calendar/Resource/Manager.php
@@ -50,6 +50,7 @@ class Manager implements IManager {
 		}
 	}
 
+	#[\Override]
 	public function getBackends():array {
 		$this->fetchBootstrapBackends();
 
@@ -78,5 +79,10 @@ class Manager implements IManager {
 	#[\Override]
 	public function update(): void {
 		$this->updater->updateResources();
+	}
+
+	#[\Override]
+	public function isEnabled(): bool {
+		return $this->getBackends() !== [];
 	}
 }

--- a/lib/private/Calendar/Room/Manager.php
+++ b/lib/private/Calendar/Room/Manager.php
@@ -50,6 +50,7 @@ class Manager implements IManager {
 		}
 	}
 
+	#[\Override]
 	public function getBackends():array {
 		$this->fetchBootstrapBackends();
 
@@ -84,5 +85,10 @@ class Manager implements IManager {
 	#[\Override]
 	public function update(): void {
 		$this->updater->updateRooms();
+	}
+
+	#[\Override]
+	public function isEnabled(): bool {
+		return $this->getBackends() !== [];
 	}
 }

--- a/lib/public/Calendar/Resource/IManager.php
+++ b/lib/public/Calendar/Resource/IManager.php
@@ -19,4 +19,16 @@ interface IManager {
 	 * @since 30.0.0
 	 */
 	public function update(): void;
+
+	/**
+	 * @return IBackend[]
+	 * @since 14.0.0
+	 * @deprecated 24.0.0 Use isEnabled instead
+	 */
+	public function getBackends():array;
+
+	/**
+	 * @since 35.0.0
+	 */
+	public function isEnabled(): bool;
 }

--- a/lib/public/Calendar/Room/IManager.php
+++ b/lib/public/Calendar/Room/IManager.php
@@ -19,4 +19,16 @@ interface IManager {
 	 * @since 30.0.0
 	 */
 	public function update(): void;
+
+	/**
+	 * @return IBackend[]
+	 * @since 14.0.0
+	 * @deprecated 24.0.0 Use isEnabled instead
+	 */
+	public function getBackends():array;
+
+	/**
+	 * @since 35.0.0
+	 */
+	public function isEnabled(): bool;
 }


### PR DESCRIPTION
Still deprecated but add a new non-deprecated and simpler api

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
