### PR TITLE
chore: Undeprecated ISecureRandom

### DIFF
--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -88,7 +88,6 @@ final class LoginRedirectorController extends Controller {
 
 		if (in_array($client->name, $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/
-			/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 			$stateToken = $this->random->generate(
 				64,
 				ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -213,9 +213,7 @@ final class OauthApiController extends Controller {
 		}
 
 		// Rotate the apptoken (so the old one becomes invalid basically)
-		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$newToken = $this->secureRandom->generate(72, ISecureRandom::CHAR_ALPHANUMERIC);
-		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$newCode = $this->secureRandom->generate(128, ISecureRandom::CHAR_ALPHANUMERIC);
 		$newEncryptedToken = $this->crypto->encrypt($newToken, $newCode);
 		$redeemedThrottleReason = $grant_type === 'authorization_code'

--- a/apps/oauth2/lib/Service/ClientService.php
+++ b/apps/oauth2/lib/Service/ClientService.php
@@ -51,11 +51,9 @@ final readonly class ClientService {
 		$client = new Client();
 		$client->name = $name;
 		$client->redirectUri = $redirectUri;
-		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$secret = $this->secureRandom->generate(64, self::validChars);
 		$hashedSecret = bin2hex($this->crypto->calculateHMAC($secret));
 		$client->secret = $hashedSecret;
-		/** @psalm-suppress DeprecatedMethod No Randomizer-based replacement is mockable in tests yet. */
 		$client->clientIdentifier = $this->secureRandom->generate(64, self::validChars);
 		$client = $this->clientMapper->insert($client);
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -28,11 +28,6 @@
       <code><![CDATA[getFederationIdFromSharedSecret]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/cloud_federation_api/lib/Controller/TokenController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/comments/lib/Activity/Listener.php">
     <DeprecatedConstant>
       <code><![CDATA[CommentsEvent::EVENT_ADD]]></code>
@@ -190,7 +185,6 @@
   </file>
   <file src="apps/dav/lib/CalDAV/CalDavBackend.php">
     <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
@@ -274,11 +268,6 @@
     <UndefinedMagicPropertyFetch>
       <code><![CDATA[$this->baseEvent->DTSTART]]></code>
     </UndefinedMagicPropertyFetch>
-  </file>
-  <file src="apps/dav/lib/CalDAV/Federation/FederationSharingService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/ICSExportPlugin/ICSExportPlugin.php">
     <DeprecatedMethod>
@@ -454,9 +443,6 @@
     </RedundantCondition>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
     <UndefinedMagicPropertyFetch>
       <code><![CDATA[$component->DTSTART]]></code>
       <code><![CDATA[$component->UID]]></code>
@@ -878,11 +864,6 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/dav/lib/Controller/DirectController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/dav/lib/Controller/InvitationResponseController.php">
     <UndefinedMagicPropertyFetch>
       <code><![CDATA[$vObject->{'VEVENT'}]]></code>
@@ -1016,11 +997,6 @@
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/dav/lib/Paginate/PaginateCache.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/dav/lib/Search/ACalendarSearchProvider.php">
     <UndefinedMagicPropertyFetch>
       <code><![CDATA[$component->{'RECURRENCE-ID'}]]></code>
@@ -1079,9 +1055,6 @@
     </UndefinedMagicPropertyFetch>
   </file>
   <file src="apps/dav/lib/Service/ExampleEventService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
     <UndefinedMagicPropertyAssignment>
       <code><![CDATA[$vEvent->DTEND]]></code>
       <code><![CDATA[$vEvent->DTSTART]]></code>
@@ -1262,9 +1235,6 @@
     </TypeDoesNotContainType>
   </file>
   <file src="apps/encryption/lib/Crypto/EncryptAll.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[copy]]></code>
       <code><![CDATA[file_exists]]></code>
@@ -1351,7 +1321,6 @@
   </file>
   <file src="apps/federatedfilesharing/lib/FederatedShareProvider.php">
     <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
@@ -1386,16 +1355,6 @@
       <code><![CDATA[sendNotification]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/federatedfilesharing/lib/TokenHandler.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/federation/lib/Controller/OCSAuthAPIController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/federation/lib/DbHandler.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$result]]></code>
@@ -1403,11 +1362,6 @@
     <MoreSpecificReturnType>
       <code><![CDATA[list<array{id: int, url: string, url_hash: string, shared_secret: ?string, status: int, sync_token: ?string}>]]></code>
     </MoreSpecificReturnType>
-  </file>
-  <file src="apps/federation/lib/TrustedServers.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/files/lib/Activity/Provider.php">
     <FalsableReturnStatement>
@@ -1474,11 +1428,6 @@
     <UndefinedInterfaceMethod>
       <code><![CDATA[getTemplates]]></code>
     </UndefinedInterfaceMethod>
-  </file>
-  <file src="apps/files/lib/Controller/OpenLocalEditorController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/files/lib/Controller/ViewController.php">
     <DeprecatedMethod>
@@ -1620,11 +1569,6 @@
       <code><![CDATA[registerBackends]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/files_external/lib/Service/EncryptionService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/files_external/lib/Service/StoragesService.php">
     <DeprecatedMethod>
       <code><![CDATA[Util::emitHook(
@@ -1704,7 +1648,6 @@
       <code><![CDATA[emitAccessShareHook]]></code>
       <code><![CDATA[emitAccessShareHook]]></code>
       <code><![CDATA[emitAccessShareHook]]></code>
-      <code><![CDATA[generate]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/files_sharing/lib/External/Manager.php">
@@ -2260,12 +2203,6 @@
     </DeprecatedConstant>
     <DeprecatedMethod>
       <code><![CDATA[deleteUserValue]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getUserValue]]></code>
@@ -2288,11 +2225,6 @@
     <DeprecatedConstant>
       <code><![CDATA[IAccountManager::PROPERTY_TWITTER]]></code>
     </DeprecatedConstant>
-  </file>
-  <file src="apps/settings/lib/Controller/AuthSettingsController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/settings/lib/Controller/MailSettingsController.php">
     <DeprecatedMethod>
@@ -2333,7 +2265,6 @@
   </file>
   <file src="apps/settings/lib/Mailer/NewUserMailHelper.php">
     <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
       <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
@@ -2437,21 +2368,10 @@
       <code><![CDATA[getAppValue]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="apps/settings/lib/SetupChecks/RandomnessSecure.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/sharebymail/lib/Settings/SettingsManager.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/sharebymail/lib/ShareByMailProvider.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
     </DeprecatedMethod>
   </file>
   <file src="apps/testing/lib/AlternativeHomeUserBackend.php">
@@ -2641,16 +2561,6 @@
       <code><![CDATA[$svg]]></code>
     </NullableReturnStatement>
   </file>
-  <file src="apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/updatenotification/lib/Controller/AdminController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/user_ldap/lib/Access.php">
     <DeprecatedMethod>
       <code><![CDATA[emit]]></code>
@@ -2836,11 +2746,6 @@
       <code><![CDATA[is_array($value) ? json_encode($value) : $value]]></code>
     </FalsableReturnStatement>
   </file>
-  <file src="apps/webhook_listeners/lib/Service/TokenService.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/workflowengine/lib/AppInfo/Application.php">
     <RedundantCondition>
       <code><![CDATA[$event instanceof Event]]></code>
@@ -3005,19 +2910,11 @@
       <code><![CDATA[listen]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="core/Command/User/Add.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="core/Command/User/AuthTokens/Add.php">
     <DeprecatedClass>
       <code><![CDATA[IToken::DO_NOT_REMEMBER]]></code>
       <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
     </DeprecatedClass>
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="core/Command/User/AuthTokens/ListCommand.php">
     <DeprecatedClass>
@@ -3054,23 +2951,8 @@
       <code><![CDATA[IToken::DO_NOT_REMEMBER]]></code>
       <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
     </DeprecatedClass>
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="core/Controller/ClientFlowLoginController.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="core/Controller/ClientFlowLoginV2Controller.php">
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
     <TypeDoesNotContainType>
       <code><![CDATA[!is_string($stateToken)]]></code>
     </TypeDoesNotContainType>
@@ -3219,11 +3101,6 @@
       <code><![CDATA[IToken::DO_NOT_REMEMBER]]></code>
       <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
     </DeprecatedClass>
-    <DeprecatedMethod>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-      <code><![CDATA[generate]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="core/Sharing/Recipient/TeamShareRecipientType.php">
     <ImplementedParamTypeMismatch>
@@ -4217,7 +4094,6 @@
   <file src="tests/lib/TestCase.php">
     <DeprecatedMethod>
       <code><![CDATA[$container]]></code>
-      <code><![CDATA[generate]]></code>
     </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[lockFile]]></code>

--- a/lib/public/Security/ISecureRandom.php
+++ b/lib/public/Security/ISecureRandom.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace OCP\Security;
 
-use Random\Randomizer;
-
 /**
  * Class SecureRandom provides a wrapper around the random_int function to generate
  * secure random strings. For PHP 7 the native CSPRNG is used, older versions do
@@ -64,7 +62,6 @@ interface ISecureRandom {
 	 *                           specified all valid base64 characters are used.
 	 * @return string
 	 * @since 8.0.0
-	 * @deprecated 35.0.0 Use {@see Randomizer::getBytesFromString()} available in PHP 8.3+ instead.
 	 */
 	public function generate(int $length,
 		string $characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'): string;


### PR DESCRIPTION


* Resolves: # <!-- related github issue -->

## Summary

- This makes it easy to mock randomness in unit tests as ISecureRandom is a service.
- The default list of character would then need to be copied everywhere
- This is used all other the place

See also comment from @nickvergessen https://github.com/nextcloud/server/pull/61538#issuecomment-4798856177


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
