### PR TITLE
fix(files_external): set usePresignedUrl before first S3 connection

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -75,6 +75,7 @@ trait S3ConnectionTrait {
 		}
 
 		$this->params = $params;
+		$this->usePresignedUrl = $params['use_presigned_url'] ?? false;
 	}
 
 	public function getBucket() {
@@ -112,8 +113,6 @@ trait S3ConnectionTrait {
 				CredentialProvider::defaultProvider(['use_aws_shared_config_files' => false])
 			)
 		);
-
-		$this->usePresignedUrl = $this->params['use_presigned_url'] ?? false;
 
 		$options = [
 			'version' => $this->params['version'] ?? 'latest',


### PR DESCRIPTION
## Summary
- `isUsePresignedUrl()` could return `false` even with `use_presigned_url` configured, because the flag was only ever assigned inside `getConnection()` — a lazy, on-demand S3 client init.
- `preSignedUrl()` checks `isUsePresignedUrl()` *before* calling `getConnection()`, so on any request path that never opens a real S3 connection first (e.g. a WebDAV PROPFIND for `downloadURL` that only reads cached DB metadata), the flag was stuck at its default `false` and the presigned URL silently came back empty.
- Moves the assignment into `parseParams()`, which runs at construction time for both primary S3 storage and S3 external storage, so the flag is correct from the start regardless of connection state.

Fixes #59249

## Test plan
- [ ] Configure `use_presigned_url => true` on a primary S3 objectstore (or an S3 external storage mount)
- [ ] PROPFIND a file for `{http://owncloud.org/ns}downloadURL` without triggering any prior S3 read in the same request
- [ ] Confirm a presigned URL is now returned instead of an empty value