### PR TITLE
fix(dav): make password protected shares usable over /public.php/dav/files

### DIFF
--- a/apps/dav/lib/Connector/Sabre/PublicAuth.php
+++ b/apps/dav/lib/Connector/Sabre/PublicAuth.php
@@ -144,7 +144,12 @@ class PublicAuth extends AbstractBasic {
 		// If the share is protected but user is not authenticated
 		if ($share->isPasswordProtected()) {
 			$this->throttler->registerAttempt(self::BRUTEFORCE_ACTION, $this->request->getRemoteAddress());
-			throw new NotAuthenticated();
+			if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
+				// do not challenge over ajax, it would trigger the browser password prompt
+				throw new NotAuthenticated();
+			}
+			// only a returned failure reaches Auth\Plugin::challenge()
+			return [false, 'No password supplied for password protected share'];
 		}
 
 		return [true, $this->principalPrefix . $token];

--- a/apps/dav/lib/Connector/Sabre/PublicAuth.php
+++ b/apps/dav/lib/Connector/Sabre/PublicAuth.php
@@ -63,10 +63,6 @@ class PublicAuth extends AbstractBasic {
 		try {
 			$this->throttler->sleepDelayOrThrowOnMax($this->request->getRemoteAddress(), self::BRUTEFORCE_ACTION);
 
-			if (count($_COOKIE) > 0 && !$this->request->passesStrictCookieCheck() && $this->getShare()->isPasswordProtected()) {
-				throw new PreconditionFailed('Strict cookie check failed');
-			}
-
 			$auth = new HTTP\Auth\Basic(
 				$this->realm,
 				$request,
@@ -74,6 +70,12 @@ class PublicAuth extends AbstractBasic {
 			);
 
 			$userpass = $auth->getCredentials();
+
+			// the check targets ambient session replay, supplied credentials are not ambient
+			if ($userpass === null && count($_COOKIE) > 0 && !$this->request->passesStrictCookieCheck() && $this->getShare()->isPasswordProtected()) {
+				throw new PreconditionFailed('Strict cookie check failed');
+			}
+
 			// If authentication provided, checking its validity
 			if ($userpass && !$this->validateUserPass($userpass[0], $userpass[1])) {
 				return [false, 'Username or password was incorrect'];

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -144,6 +144,28 @@ class PublicAuthTest extends \Test\TestCase {
 	public function testCheckTokenPasswordNotAuthenticated(): void {
 		$this->request->method('getPathInfo')
 			->willReturn('/dav/files/GX9HSGQrGE');
+		$this->request->method('getHeader')->with('X-Requested-With')->willReturn('');
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getPassword')->willReturn('password');
+		$share->method('isPasswordProtected')->willReturn(true);
+		$share->method('getShareType')->willReturn(42);
+
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->with('GX9HSGQrGE')
+			->willReturn($share);
+
+		$this->session->method('exists')->with('public_link_authenticated')->willReturn(false);
+
+		$result = self::invokePrivate($this->auth, 'checkToken');
+		$this->assertSame([false, 'No password supplied for password protected share'], $result);
+	}
+
+	public function testCheckTokenPasswordNotAuthenticatedAjax(): void {
+		$this->request->method('getPathInfo')
+			->willReturn('/dav/files/GX9HSGQrGE');
+		$this->request->method('getHeader')->with('X-Requested-With')->willReturn('XMLHttpRequest');
 
 		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
@@ -164,6 +186,7 @@ class PublicAuthTest extends \Test\TestCase {
 	public function testCheckTokenPasswordAuthenticatedWrongShare(): void {
 		$this->request->method('getPathInfo')
 			->willReturn('/dav/files/GX9HSGQrGE');
+		$this->request->method('getHeader')->with('X-Requested-With')->willReturn('');
 
 		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
@@ -178,8 +201,8 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(false);
 		$this->session->method('get')->with('public_link_authenticated')->willReturn('43');
 
-		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
-		self::invokePrivate($this->auth, 'checkToken');
+		$result = self::invokePrivate($this->auth, 'checkToken');
+		$this->assertSame([false, 'No password supplied for password protected share'], $result);
 	}
 
 	public function testNoShare(): void {

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -205,6 +205,69 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->assertSame([false, 'No password supplied for password protected share'], $result);
 	}
 
+	public function testCheckWithoutCredentialsRunsStrictCookieCheck(): void {
+		$this->request->method('getPathInfo')
+			->willReturn('/dav/files/GX9HSGQrGE');
+		$this->request->method('passesStrictCookieCheck')->willReturn(false);
+
+		$share = $this->createMock(IShare::class);
+		$share->method('isPasswordProtected')->willReturn(true);
+
+		$this->shareManager->method('getShareByToken')
+			->with('GX9HSGQrGE')
+			->willReturn($share);
+
+		$this->urlGenerator->method('linkToRoute')->willReturn('/s/GX9HSGQrGE');
+
+		$cookies = $_COOKIE;
+		$_COOKIE = ['nc_session_id' => 'irrelevant'];
+
+		try {
+			$this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
+			$this->auth->check(
+				new \Sabre\HTTP\Request('PROPFIND', '/public.php/dav/files/GX9HSGQrGE'),
+				new \Sabre\HTTP\Response(),
+			);
+		} finally {
+			$_COOKIE = $cookies;
+		}
+	}
+
+	public function testCheckWithCredentialsSkipsStrictCookieCheck(): void {
+		$this->request->method('getPathInfo')
+			->willReturn('/dav/files/GX9HSGQrGE');
+		$this->request->method('passesStrictCookieCheck')->willReturn(false);
+
+		$share = $this->createMock(IShare::class);
+		$share->method('isPasswordProtected')->willReturn(true);
+		$share->method('getShareType')->willReturn(IShare::TYPE_LINK);
+		$share->method('getId')->willReturn('42');
+
+		$this->shareManager->method('getShareByToken')
+			->with('GX9HSGQrGE')
+			->willReturn($share);
+		$this->shareManager->method('checkPassword')
+			->with($share, 'password')
+			->willReturn(true);
+
+		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
+		$this->session->method('get')->with('public_link_authenticated')->willReturn(['42']);
+
+		$request = new \Sabre\HTTP\Request('PROPFIND', '/public.php/dav/files/GX9HSGQrGE');
+		$request->addHeader('Authorization', 'Basic ' . base64_encode('GX9HSGQrGE:password'));
+
+		$cookies = $_COOKIE;
+		$_COOKIE = ['nc_session_id' => 'irrelevant'];
+
+		try {
+			$result = $this->auth->check($request, new \Sabre\HTTP\Response());
+		} finally {
+			$_COOKIE = $cookies;
+		}
+
+		$this->assertSame([true, 'principals/GX9HSGQrGE'], $result);
+	}
+
 	public function testNoShare(): void {
 		$this->request->method('getPathInfo')
 			->willReturn('/dav/files/GX9HSGQrGE');


### PR DESCRIPTION
* Resolves: #63418
* Resolves: #59391

## Summary

Two independent defects on `/public.php/dav/files/<token>` for password protected shares, one commit each.

`checkToken()` throws `NotAuthenticated`, which leaves `Auth\Plugin::beforeMethod()` before `challenge()`, so the 401 goes out without `WWW-Authenticate` and clients that wait for the challenge never authenticate. It returns the failure now. Ajax callers keep the throw.

`check()` runs the strict cookie check on every request that carries a cookie and answers a redirect to `/s/<token>`. Clients that cannot hold `__Host-` prefixed cookies follow it, pick up the session cookie there and loop. The check targets ambient session replay, so it now runs only when the request brings no Basic credentials.

Reproduced on 32.0.14 with curl and the Windows WebDAV redirector, details in #63418.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
Assisted-by: ClaudeCode:claude-opus-5
