### PR TITLE
ci(playwright): skip browser installation on CI an reuse action provided chrome

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -121,7 +121,7 @@ jobs:
         npm run build --if-present
 
     - name: Install Playwright browsers
-      run: npx playwright install --with-deps
+      run: npm run playwright:install-ci --if-present
 
     - name: Run Playwright tests
       run: npm run playwright -- --shard='${{ matrix.shardIndex }}/${{ matrix.shardTotal }}'
@@ -228,7 +228,7 @@ jobs:
         npm run build --if-present
 
     - name: Install Playwright browsers
-      run: npx playwright install --with-deps
+      run: npm run playwright:install-ci --if-present
 
     - name: Run Playwright setup tests
       run: npm run playwright:setup

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postlint": "build/demi.sh lint",
     "lint:fix": "concurrently 'npm run lint -- --fix' 'build/demi.sh lint:fix'",
     "playwright": "playwright test --project=default --project=admin-settings",
-    "playwright:install": "playwright install chromium-headless-shell",
+    "playwright:install": "playwright install chromium",
     "playwright:setup": "playwright test --project=setup",
     "sass": "sass --style compressed --load-path core/css core/css/ $(for cssdir in $(find apps -mindepth 2 -maxdepth 2 -name \"css\"); do if ! $(git check-ignore -q $cssdir); then printf \"$cssdir \"; fi; done)",
     "sass:icons": "node build/icons.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,17 @@
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+/// <reference types="@types/node" />
 
 import { defineConfig, devices } from '@playwright/test'
+
+type DeviceDescriptor = typeof devices[string]
+const BROWSWER_CONFIG_CHROME: DeviceDescriptor & { channel: string } = {
+	...devices['Desktop Chrome'],
+	channel: process.env.CI
+		? 'chrome' // on CI use the chrome browser provided by the GitHub Actions runner
+		: 'chromium', // locally use the default playwright chromium browser
+}
 
 export default defineConfig({
 	testDir: './tests/playwright/e2e',
@@ -26,7 +35,7 @@ export default defineConfig({
 			workers: 1,
 			grep: /@setup/,
 			use: {
-				...devices['Desktop Chrome'],
+				...BROWSWER_CONFIG_CHROME,
 			},
 		},
 
@@ -36,7 +45,7 @@ export default defineConfig({
 			workers: 1, // only one admin setting test can run at a time due to shared state
 			testMatch: '**/admin-settings*.spec.ts',
 			use: {
-				...devices['Desktop Chrome'],
+				...BROWSWER_CONFIG_CHROME,
 			},
 		},
 
@@ -45,10 +54,11 @@ export default defineConfig({
 			testMatch: /\/(?!admin-settings)[^/]*\.spec\.ts$/,
 			grepInvert: /@setup/,
 			use: {
-				...devices['Desktop Chrome'],
+				...BROWSWER_CONFIG_CHROME,
 			},
 		},
 	],
+
 	webServer: {
 		command: 'node tests/playwright/start-nextcloud-server.js',
 		env: {


### PR DESCRIPTION
## Summary
The idea is to save us roughly 20 minutes of CI time per pull request.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
