### PR TITLE
fix: Make SchemaWrapper compatible with old version of ISchemaWrapper

### DIFF
--- a/lib/private/DB/SchemaWrapper.php
+++ b/lib/private/DB/SchemaWrapper.php
@@ -73,7 +73,7 @@ class SchemaWrapper implements ISchemaWrapper {
 	}
 
 	#[\Override]
-	public function getTable(string $tableName): ITable {
+	public function getTable($tableName): ITable {
 		try {
 			return new Table($this->schema->getTable($this->connection->getPrefix() . $tableName));
 		} catch (DBALSchemaException $e) {
@@ -85,12 +85,12 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * Does this schema have a table with the given name?
 	 */
 	#[\Override]
-	public function hasTable(string $tableName): bool {
+	public function hasTable($tableName): bool {
 		return $this->schema->hasTable($this->connection->getPrefix() . $tableName);
 	}
 
 	#[\Override]
-	public function createTable(string $tableName): ITable {
+	public function createTable($tableName): ITable {
 		unset($this->tablesToDelete[$tableName]);
 		try {
 			return new Table($this->schema->createTable($this->connection->getPrefix() . $tableName));
@@ -100,7 +100,7 @@ class SchemaWrapper implements ISchemaWrapper {
 	}
 
 	#[\Override]
-	public function dropTable(string $tableName): self {
+	public function dropTable($tableName): self {
 		$this->tablesToDelete[$tableName] = true;
 		$this->schema->dropTable($this->connection->getPrefix() . $tableName);
 		return $this;


### PR DESCRIPTION
## Summary

Remove type hinting from parameters.

This should prevent the following:

```
Declaration of OC\\DB\\SchemaWrapper::getTable(string $tableName): OCP\\DB\\Schema\\ITable must be compatible with OCP\\DB\\ISchemaWrapper::getTable($tableName) at /var/www/html/lib/private/DB/SchemaWrapper.php#76
```

This is likely caused by some PHP caching

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
