### PR TITLE
feat: Add more debug output when checkTokenCredentials fails

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -749,7 +749,7 @@ class Connection extends LDAPUtility {
 			$errno = $this->ldap->errno($cr);
 
 			$this->logger->warning(
-				'Bind failed: ' . $errno . ': ' . $this->ldap->error($cr),
+				'Bind failed for ' . $this->configuration->ldapAgentName . ': ' . $errno . ': ' . $this->ldap->error($cr),
 				['app' => 'user_ldap']
 			);
 

--- a/lib/private/Authentication/Token/PublicKeyToken.php
+++ b/lib/private/Authentication/Token/PublicKeyToken.php
@@ -128,7 +128,11 @@ class PublicKeyToken extends Entity implements INamedToken, IWipeableToken {
 	 */
 	#[\Override]
 	public function getPassword(): ?string {
-		return parent::getPassword();
+		$password = parent::getPassword();
+		if ($password === '') {
+			return null;
+		}
+		return $password;
 	}
 
 	#[\Override]

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -702,7 +702,7 @@ class Session implements IUserSession, Emitter {
 	 * @param string $token
 	 * @return boolean
 	 */
-	private function checkTokenCredentials(IToken $dbToken, $token) {
+	private function checkTokenCredentials(IToken $dbToken, $token, array &$reason) {
 		// Check whether login credentials are still valid and the user was not disabled
 		// This check is performed each 5 minutes
 		$lastCheck = $dbToken->getLastCheck() ? : 0;
@@ -715,12 +715,19 @@ class Session implements IUserSession, Emitter {
 		try {
 			$pwd = $this->tokenProvider->getPassword($dbToken, $token);
 		} catch (InvalidTokenException $ex) {
+			$reason = [
+				'exception' => $ex,
+			];
+
 			// An invalid token password was used -> log user out
 			return false;
 		} catch (PasswordlessTokenException $ex) {
 			// Token has no password
-
 			if (!is_null($this->activeUser) && !$this->activeUser->isEnabled()) {
+				$reason = [
+					'exception' => $ex,
+					'message' => 'Paswordless token exception with no active or disabled user',
+				];
 				$this->tokenProvider->invalidateToken($token);
 				return false;
 			}
@@ -731,12 +738,18 @@ class Session implements IUserSession, Emitter {
 		// Invalidate token if the user is no longer active
 		if (!is_null($this->activeUser) && !$this->activeUser->isEnabled()) {
 			$this->tokenProvider->invalidateToken($token);
+			$reason = [
+				'message' => 'Invalidate token as the user is no longer active',
+			];
 			return false;
 		}
 
 		// If the token password is no longer valid mark it as such
 		if ($this->manager->checkPassword($dbToken->getLoginName(), $pwd) === false) {
 			$this->tokenProvider->markPasswordInvalid($dbToken, $token);
+			$reason = [
+				'message' => 'The token password is no longer valid',
+			];
 			// User is logged out
 			return false;
 		}
@@ -774,11 +787,12 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		if (!$this->checkTokenCredentials($dbToken, $token)) {
-			$this->logger->warning('Session token credentials are invalid', [
+		$reason = [];
+		if (!$this->checkTokenCredentials($dbToken, $token, $reason)) {
+			$this->logger->warning('Session token credentials are invalid', array_merge($reason, [
 				'app' => 'core',
 				'user' => $user,
-			]);
+			]));
 			return false;
 		}
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -470,7 +470,7 @@ class Session implements IUserSession, Emitter {
 	}
 
 	private function handleLoginFailed(IThrottler $throttler, int $currentDelay, string $remoteAddress, string $user, ?string $password) {
-		$this->logger->warning("Login failed: '" . $user . "' (Remote IP: '" . $remoteAddress . "')", ['app' => 'core']);
+		$this->logger->warning("Login failed: '" . $user . "' (Remote IP: '" . $remoteAddress . "')", ['app' => 'core', 'exception' => new \Exception()]);
 
 		$throttler->registerAttempt('login', $remoteAddress, ['user' => $user]);
 		$this->dispatcher->dispatchTyped(new LoginFailed($user, $password));
@@ -767,11 +767,9 @@ class Session implements IUserSession, Emitter {
 	 *
 	 * Invalidates the token if checks fail
 	 *
-	 * @param string $token
-	 * @param string $user login name
-	 * @return boolean
+	 * @param ?string $user The login name
 	 */
-	private function validateToken($token, $user = null) {
+	private function validateToken(string $token, ?string $user = null): bool {
 		try {
 			$dbToken = $this->tokenProvider->getToken($token);
 		} catch (InvalidTokenException $ex) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -470,7 +470,7 @@ class Session implements IUserSession, Emitter {
 	}
 
 	private function handleLoginFailed(IThrottler $throttler, int $currentDelay, string $remoteAddress, string $user, ?string $password) {
-		$this->logger->warning("Login failed: '" . $user . "' (Remote IP: '" . $remoteAddress . "')", ['app' => 'core', 'exception' => new \Exception()]);
+		$this->logger->debug("Login failed: '" . $user . "' (Remote IP: '" . $remoteAddress . "')", ['app' => 'core', 'exception' => new \Exception()]);
 
 		$throttler->registerAttempt('login', $remoteAddress, ['user' => $user]);
 		$this->dispatcher->dispatchTyped(new LoginFailed($user, $password));
@@ -726,7 +726,7 @@ class Session implements IUserSession, Emitter {
 			if (!is_null($this->activeUser) && !$this->activeUser->isEnabled()) {
 				$reason = [
 					'exception' => $ex,
-					'message' => 'Paswordless token exception with no active or disabled user',
+					'additional_message' => 'Passwordless token exception with no active or disabled user',
 				];
 				$this->tokenProvider->invalidateToken($token);
 				return false;
@@ -739,7 +739,7 @@ class Session implements IUserSession, Emitter {
 		if (!is_null($this->activeUser) && !$this->activeUser->isEnabled()) {
 			$this->tokenProvider->invalidateToken($token);
 			$reason = [
-				'message' => 'Invalidate token as the user is no longer active',
+				'additional_message' => 'Invalidate token as the user is no longer active',
 			];
 			return false;
 		}
@@ -748,7 +748,7 @@ class Session implements IUserSession, Emitter {
 		if ($this->manager->checkPassword($dbToken->getLoginName(), $pwd) === false) {
 			$this->tokenProvider->markPasswordInvalid($dbToken, $token);
 			$reason = [
-				'message' => 'The token password is no longer valid',
+				'additional_message' => 'The token password is no longer valid and is ' . (empty($pwd) ? 'empty' : 'not empty'),
 			];
 			// User is logged out
 			return false;
@@ -787,10 +787,12 @@ class Session implements IUserSession, Emitter {
 
 		$reason = [];
 		if (!$this->checkTokenCredentials($dbToken, $token, $reason)) {
-			$this->logger->warning('Session token credentials are invalid', array_merge($reason, [
+			$this->logger->warning('Session token credentials are invalid', [
 				'app' => 'core',
 				'user' => $user,
-			]));
+				'token name' => $dbToken->getName(),
+				...$reason,
+			]);
 			return false;
 		}
 


### PR DESCRIPTION
## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
