### PR TITLE
feat: Make it configurable to disable federated sync addressbook

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -46,19 +46,26 @@ class SyncService extends ASyncService {
 	 * @psalm-return list{0: ?string, 1: boolean}
 	 * @throws \Exception
 	 */
-	public function syncRemoteAddressBook(string $url, string $userName, string $addressBookUrl, string $sharedSecret, ?string $syncToken, string $targetBookHash, string $targetPrincipal, array $targetProperties): array {
+	public function syncRemoteAddressBook(string $url, string $userName, string $addressBookUrl, string $sharedSecret, ?string $syncToken, string $targetBookHash, string $targetPrincipal, array $targetProperties, bool $syncAddressBookData = true): array {
 		// 1. create addressbook
-		$book = $this->ensureSystemAddressBookExists($targetPrincipal, $targetBookHash, $targetProperties);
-		$addressBookId = $book['id'];
+		$addressBookId = null;
+		if ($syncAddressBookData) {
+			$book = $this->ensureSystemAddressBookExists($targetPrincipal, $targetBookHash, $targetProperties);
+			$addressBookId = $book['id'];
+		}
 
 		// 2. query changes
+		// This keeps validating the shared secret and advancing the sync token
+		// against the remote even when applying the changes locally is disabled.
 		try {
 			$absoluteUri = $this->prepareUri($url, $addressBookUrl);
 			$response = $this->requestSyncReport($absoluteUri, $userName, $sharedSecret, $syncToken);
 		} catch (ClientExceptionInterface $ex) {
 			if ($ex->getCode() === Http::STATUS_UNAUTHORIZED) {
 				// remote server revoked access to the address book, remove it
-				$this->backend->deleteAddressBook($addressBookId);
+				if ($addressBookId !== null) {
+					$this->backend->deleteAddressBook($addressBookId);
+				}
 				$this->logger->error('Authorization failed, remove address book: ' . $url, ['app' => 'dav']);
 				throw $ex;
 			}
@@ -68,21 +75,23 @@ class SyncService extends ASyncService {
 
 		// 3. apply changes
 		// TODO: use multi-get for download
-		foreach ($response['response'] as $resource => $status) {
-			$cardUri = basename($resource);
-			if (isset($status[200])) {
-				$absoluteUrl = $this->prepareUri($url, $resource);
-				$vCard = $this->download($absoluteUrl, $userName, $sharedSecret);
-				$this->atomic(function () use ($addressBookId, $cardUri, $vCard): void {
-					$existingCard = $this->backend->getCard($addressBookId, $cardUri);
-					if ($existingCard === false) {
-						$this->backend->createCard($addressBookId, $cardUri, $vCard);
-					} else {
-						$this->backend->updateCard($addressBookId, $cardUri, $vCard);
-					}
-				}, $this->dbConnection);
-			} else {
-				$this->backend->deleteCard($addressBookId, $cardUri);
+		if ($syncAddressBookData) {
+			foreach ($response['response'] as $resource => $status) {
+				$cardUri = basename($resource);
+				if (isset($status[200])) {
+					$absoluteUrl = $this->prepareUri($url, $resource);
+					$vCard = $this->download($absoluteUrl, $userName, $sharedSecret);
+					$this->atomic(function () use ($addressBookId, $cardUri, $vCard): void {
+						$existingCard = $this->backend->getCard($addressBookId, $cardUri);
+						if ($existingCard === false) {
+							$this->backend->createCard($addressBookId, $cardUri, $vCard);
+						} else {
+							$this->backend->updateCard($addressBookId, $cardUri, $vCard);
+						}
+					}, $this->dbConnection);
+				} else {
+					$this->backend->deleteCard($addressBookId, $cardUri);
+				}
 			}
 		}
 

--- a/apps/federation/lib/SyncFederationAddressBooks.php
+++ b/apps/federation/lib/SyncFederationAddressBooks.php
@@ -9,6 +9,7 @@ namespace OCA\Federation;
 
 use OCA\DAV\CardDAV\SyncService;
 use OCP\AppFramework\Http;
+use OCP\IConfig;
 use OCP\OCS\IDiscoveryService;
 use Psr\Log\LoggerInterface;
 
@@ -18,6 +19,7 @@ class SyncFederationAddressBooks {
 		private SyncService $syncService,
 		private IDiscoveryService $ocsDiscoveryService,
 		private LoggerInterface $logger,
+		private IConfig $config,
 	) {
 	}
 
@@ -25,6 +27,10 @@ class SyncFederationAddressBooks {
 	 * @param \Closure $callback
 	 */
 	public function syncThemAll(\Closure $callback, bool $full = false) {
+		// When disabled, the sync-report request against the remote still runs
+		// each cycle (validating the shared secret and advancing the sync token),
+		// but the returned cards are not applied to the local address book.
+		$syncAddressBookData = $this->config->getSystemValueBool('federation_sync_addressbook_data', true);
 		$trustedServers = $this->dbHandler->getAllServer();
 		foreach ($trustedServers as $trustedServer) {
 			$url = $trustedServer['url'];
@@ -47,11 +53,19 @@ class SyncFederationAddressBooks {
 			];
 
 			try {
+				// A full resync marks all existing cards as pending and then deletes
+				// whichever ones are not confirmed by the remote. That only makes
+				// sense if card data is actually being applied, otherwise it would
+				// just wipe out the local address book.
+				$full = $full && $syncAddressBookData;
 				$syncToken = $full ? null : $oldSyncToken;
 
-				$book = $this->syncService->ensureSystemAddressBookExists($targetPrincipal, $targetBookId, $targetBookProperties);
-				if ($full) {
-					$this->syncService->markCardsAsPending($book['id']);
+				$book = null;
+				if ($syncAddressBookData) {
+					$book = $this->syncService->ensureSystemAddressBookExists($targetPrincipal, $targetBookId, $targetBookProperties);
+					if ($full) {
+						$this->syncService->markCardsAsPending($book['id']);
+					}
 				}
 
 				do {
@@ -63,7 +77,8 @@ class SyncFederationAddressBooks {
 						$syncToken,
 						$targetBookId,
 						$targetPrincipal,
-						$targetBookProperties
+						$targetBookProperties,
+						$syncAddressBookData
 					);
 				} while ($truncated);
 


### PR DESCRIPTION
## Issue
As an administrator, I want to have a list of trusted servers so that users
can collaborate on documents. I also want to create federated teams to make
sharing easier.
However, I do not want the system address book to sync automatically, as this
would result in me unnecessarily sharing personal data with all users across
different environments, from a privacy and security standpoint.

As a user, I want to be able to collaborate with a few users in another
environment via Federated Teams and Collaborative Document Editing.
However, I have no relationship with the majority of users in that other
environment. It is also undesirable to be able to see all individuals in my
system address book from that other environment.

From a security perspective, I want to encourage collaboration but not share
the personal data of all my users with other environments.

See related issue; https://github.com/nextcloud/server/issues/63437

## Proposal
Make it configurable to sync a system address book between trusted servers.
I want to be able to configure trusted servers to create federated teams and
support collaborative document editing.
In other words, add a configuration option to exchange sync tokens, but make
it configurable to exchange the system address book.

## Acceptance Criteria

- [ ] Trusted servers continue to serve as the foundation for federated teams and
      collaborative document editing, regardless of the address book sync setting.
- [ ] The `shared_secret` pairing and the CardDAV `sync_token` exchange with
      a trusted server continue to occur during every sync cycle, even if the
      address book itself is not being synced (necessary to continue validating the trust relationship and
      connectivity).
- [ ] There is a configuration option that allows an administrator to disable synchronization of the
      system address book (contact information/vCards) from a trusted server on a
      per-environment basis, without breaking the federation itself.
- [ ] When address book sync is disabled, no vCards are downloaded or saved locally,
      and the local system address book is not cleared
      by a potential full resync.
- [ ] Default behavior remains unchanged (address book sync is enabled by default),
      so that existing environments are not broken during an upgrade.

## Implementation (current status in `nextcloud-server`)

New config option in `config.php`:

```php
‘federation_sync_addressbook_data’ => false,
```

Default `true` → current behavior, so backwards compatible.

**`apps/dav/lib/CardDAV/SyncService.php`**
`syncRemoteAddressBook()` has been given a new parameter
`bool $syncAddressBookData = true`:

| Step | `true` (default) | `false` |
|---|---|---|
| 1. Create/look up local system address book | yes | skipped |
| 2. Send sync report request to remote (authenticate with `shared_secret`, returns new `sync_token`) | yes | **runs continuously** |
| 3. Download vCards + create/update/delete locally | yes | skipped |

**`apps/federation/lib/SyncFederationAddressBooks.php`**
- `IConfig` added to the constructor; reads
  `federation_sync_addressbook_data` on each run.
- `ensureSystemAddressBookExists()`, `markCardsAsPending()`, and
  `deletePendingCards()` are only called if address book sync is enabled.
- A `full` resync is forced to `false` if address book sync is disabled
  (otherwise, the local address book would be cleared without syncing back).
- Status logging (`setServerStatus`, error handling for 401/other
  exceptions) remains unchanged—so the trust relationship remains visibly healthy
  regardless of the address book setting.

