### PR TITLE
feat(teams): add ITeamFileResourceProvider for cross-provider file lookups

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1056,6 +1056,7 @@ return array(
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextSummary' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextSummary.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextTopics' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextTopics.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextTranslate' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextTranslate.php',
+    'OCP\\Teams\\ITeamFileResolver' => $baseDir . '/lib/public/Teams/ITeamFileResolver.php',
     'OCP\\Teams\\ITeamFolderProvider' => $baseDir . '/lib/public/Teams/ITeamFolderProvider.php',
     'OCP\\Teams\\ITeamManager' => $baseDir . '/lib/public/Teams/ITeamManager.php',
     'OCP\\Teams\\ITeamResourceProvider' => $baseDir . '/lib/public/Teams/ITeamResourceProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1097,6 +1097,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextSummary' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextSummary.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextTopics' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextTopics.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextTranslate' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextTranslate.php',
+        'OCP\\Teams\\ITeamFileResolver' => __DIR__ . '/../../..' . '/lib/public/Teams/ITeamFileResolver.php',
         'OCP\\Teams\\ITeamFolderProvider' => __DIR__ . '/../../..' . '/lib/public/Teams/ITeamFolderProvider.php',
         'OCP\\Teams\\ITeamManager' => __DIR__ . '/../../..' . '/lib/public/Teams/ITeamManager.php',
         'OCP\\Teams\\ITeamResourceProvider' => __DIR__ . '/../../..' . '/lib/public/Teams/ITeamResourceProvider.php',

--- a/lib/private/Teams/TeamManager.php
+++ b/lib/private/Teams/TeamManager.php
@@ -15,6 +15,7 @@ use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Probes\CircleProbe;
 use OCP\IURLGenerator;
 use OCP\Server;
+use OCP\Teams\ITeamFileResolver;
 use OCP\Teams\ITeamFolderProvider;
 use OCP\Teams\ITeamManager;
 use OCP\Teams\ITeamResourceProvider;
@@ -23,6 +24,11 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
 class TeamManager implements ITeamManager {
+	/**
+	 * Id of the provider whose resource ids are file ids. Owned by circles, and
+	 * hardcoded by every caller of the route.
+	 */
+	private const FILE_ADDRESSED_PROVIDER_ID = 'files';
 
 	/** @var ?ITeamResourceProvider[] */
 	private ?array $providers = null;
@@ -130,8 +136,27 @@ class TeamManager implements ITeamManager {
 			return [];
 		}
 
+		return array_map($this->circleToTeam(...), $this->getTeams($this->collectTeamIds($providerId, $resourceId), $userId));
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function collectTeamIds(string $providerId, string $resourceId): array {
 		$provider = $this->getProvider($providerId);
-		return array_map($this->circleToTeam(...), $this->getTeams($provider->getTeamsForResource($resourceId), $userId));
+		$teamIds = $provider->getTeamsForResource($resourceId);
+
+		if ($providerId === self::FILE_ADDRESSED_PROVIDER_ID) {
+			foreach ($this->getProviders() as $candidate) {
+				if ($candidate === $provider || !$candidate instanceof ITeamFileResolver) {
+					continue;
+				}
+
+				$teamIds = array_merge($teamIds, $candidate->getTeamsForFile((int)$resourceId));
+			}
+		}
+
+		return array_values(array_unique($teamIds));
 	}
 
 	private function getTeamInternal(string $teamId, string $userId, ?CircleProbe $probe = null): ?Circle {

--- a/lib/public/Teams/ITeamFileResolver.php
+++ b/lib/public/Teams/ITeamFileResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Teams;
+
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\AppFramework\Attribute\Implementable;
+
+/**
+ * Resolves the teams related to a file, whatever this provider's own resource
+ * ids look like.
+ *
+ * Asked alongside the addressed provider whenever a lookup comes in by file id,
+ * so one provider can contribute what another cannot see. A team folder is
+ * mounted rather than shared, so a share lookup never finds it.
+ *
+ * @since 35.0.0
+ */
+#[Consumable(since: '35.0.0')]
+#[Implementable(since: '35.0.0')]
+interface ITeamFileResolver extends ITeamResourceProvider {
+	/**
+	 * Return the ids of the teams the given file belongs to.
+	 *
+	 * May include teams the current user cannot see. The caller filters those out.
+	 *
+	 * @return list<string> Empty when the file is unrelated to this provider.
+	 * @since 35.0.0
+	 */
+	public function getTeamsForFile(int $fileId): array;
+}

--- a/tests/lib/Teams/TeamManagerTest.php
+++ b/tests/lib/Teams/TeamManagerTest.php
@@ -12,6 +12,7 @@ namespace Test\Teams;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Teams\TeamManager;
 use OCP\IURLGenerator;
+use OCP\Teams\ITeamFileResolver;
 use OCP\Teams\ITeamFolderProvider;
 use OCP\Teams\ITeamResourceProvider;
 use Test\TestCase;
@@ -41,6 +42,75 @@ class TeamManagerTest extends TestCase {
 		]);
 
 		$this->assertSame($folderProvider, $teamManager->getTeamFolderProvider());
+	}
+
+	public function testCollectTeamIdsDoesNotWidenForOtherProviders(): void {
+		$teamManager = $this->createTeamManager(true);
+		$addressed = $this->createMock(ITeamResourceProvider::class);
+		$addressed->expects($this->once())
+			->method('getTeamsForResource')
+			->with('42')
+			->willReturn(['team-1']);
+
+		$resolver = $this->createMock(ITeamFileResolver::class);
+		$resolver->expects($this->never())->method('getTeamsForFile');
+
+		$this->setProviders($teamManager, ['deck' => $addressed, 'groupfolders' => $resolver]);
+
+		$this->assertSame(['team-1'], $this->collectTeamIds($teamManager, 'deck', '42'));
+	}
+
+	public function testCollectTeamIdsAsksEveryResolverForTheFilesProvider(): void {
+		$teamManager = $this->createTeamManager(true);
+		$addressed = $this->createMock(ITeamResourceProvider::class);
+		$addressed->method('getTeamsForResource')->with('42')->willReturn(['team-1']);
+
+		$resolver = $this->createMock(ITeamFileResolver::class);
+		$resolver->expects($this->once())
+			->method('getTeamsForFile')
+			->with(42)
+			->willReturn(['team-2']);
+
+		$unrelated = $this->createMock(ITeamResourceProvider::class);
+		$unrelated->expects($this->never())->method('getTeamsForResource');
+
+		$this->setProviders($teamManager, [
+			'files' => $addressed,
+			'groupfolders' => $resolver,
+			'talk' => $unrelated,
+		]);
+
+		$this->assertSame(['team-1', 'team-2'], $this->collectTeamIds($teamManager, 'files', '42'));
+	}
+
+	public function testCollectTeamIdsDoesNotAskTheAddressedProviderTwice(): void {
+		$teamManager = $this->createTeamManager(true);
+		$addressed = $this->createMock(ITeamFileResolver::class);
+		$addressed->method('getTeamsForResource')->willReturn(['team-1']);
+		$addressed->expects($this->never())->method('getTeamsForFile');
+
+		$this->setProviders($teamManager, ['files' => $addressed]);
+
+		$this->assertSame(['team-1'], $this->collectTeamIds($teamManager, 'files', '42'));
+	}
+
+	public function testCollectTeamIdsReturnsEachTeamOnce(): void {
+		$teamManager = $this->createTeamManager(true);
+		$addressed = $this->createMock(ITeamResourceProvider::class);
+		$addressed->method('getTeamsForResource')->willReturn(['team-1']);
+
+		$resolver = $this->createMock(ITeamFileResolver::class);
+		$resolver->method('getTeamsForFile')->willReturn(['team-1', 'team-2']);
+
+		$this->setProviders($teamManager, ['files' => $addressed, 'groupfolders' => $resolver]);
+
+		$this->assertSame(['team-1', 'team-2'], $this->collectTeamIds($teamManager, 'files', '42'));
+	}
+
+	private function collectTeamIds(TeamManager $teamManager, string $providerId, string $resourceId): array {
+		$method = new \ReflectionMethod(TeamManager::class, 'collectTeamIds');
+
+		return $method->invoke($teamManager, $providerId, $resourceId);
 	}
 
 	private function createTeamManager(bool $hasTeamSupport = false): TeamManager {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/groupfolders/issues/2845

## Summary

The teams lookup asks a single provider, picked by the providerId in the route. For a file that is always `files`, which circles owns and answers from `oc_share`. A team folder is mounted rather than shared, so there is no share row, the answer comes back empty, and the sidebar card hides itself.

This adds `ITeamFileResolver`, one interface with one method. When the lookup was addressed by file id, `TeamManager` also asks every provider implementing it and merges the result. groupfolders does the answering in nextcloud/groupfolders#5035.

Tested on a team space, a folder shared with a team, files two levels deep, and a file belonging to no team. A Deck board on the same team lands in the same card:

<img width="900" height="971" alt="image" src="https://github.com/user-attachments/assets/90ed831e-0a49-4fb8-9905-ac7527c20e29" />

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (tests)
