### PR TITLE
feat(updater): clear app_install_overwrite on major upgrades

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -70,7 +70,6 @@ class Upgrade extends Command {
 
 			$self = $this;
 			$updater = Server::get(Updater::class);
-			$incompatibleOverwrites = $this->config->getSystemValue('app_install_overwrite', []);
 
 			/** @var IEventDispatcher $dispatcher */
 			$dispatcher = Server::get(IEventDispatcher::class);
@@ -161,7 +160,9 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($output): void {
 				$output->writeln('<info>Updated database</info>');
 			});
-			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($output, &$incompatibleOverwrites): void {
+			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($output): void {
+				// Read per event, the overwrites are cleared during a major upgrade
+				$incompatibleOverwrites = $this->config->getSystemValue('app_install_overwrite', []);
 				if (!in_array($app, $incompatibleOverwrites)) {
 					$output->writeln('<comment>Disabled incompatible app: ' . $app . '</comment>');
 				}

--- a/core/Controller/UpdateController.php
+++ b/core/Controller/UpdateController.php
@@ -86,7 +86,6 @@ class UpdateController extends OCSController {
 		\OC_User::setIncognitoMode(true);
 
 		$incompatibleApps = [];
-		$incompatibleOverwrites = $this->config->getSystemValue('app_install_overwrite', []);
 
 		$this->dispatcher->addListener(
 			MigratorExecuteSqlEvent::class,
@@ -127,7 +126,9 @@ class UpdateController extends OCSController {
 		$this->updater->listen('\OC\Updater', 'appUpgrade', function ($app, $version) use ($eventSource): void {
 			$eventSource->send('success', $this->l->t('Updated "%1$s" to %2$s', [$app, $version]));
 		});
-		$this->updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps, &$incompatibleOverwrites): void {
+		$this->updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps): void {
+			// Read per event, the overwrites are cleared during a major upgrade
+			$incompatibleOverwrites = $this->config->getSystemValue('app_install_overwrite', []);
 			if (!in_array($app, $incompatibleOverwrites)) {
 				$incompatibleApps[] = $app;
 			}

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -189,6 +189,16 @@ class Updater extends BasicEmitter {
 	}
 
 	/**
+	 * Whether the upgrade crosses a major version boundary
+	 */
+	private function isMajorUpgrade(string $installedVersion, string $currentVersion): bool {
+		$installedMajor = (int)explode('.', $installedVersion)[0];
+		$currentMajor = (int)explode('.', $currentVersion)[0];
+
+		return $currentMajor > $installedMajor;
+	}
+
+	/**
 	 * runs the update actions in maintenance mode, does not upgrade the source files
 	 * except the main .htaccess file
 	 *
@@ -202,6 +212,11 @@ class Updater extends BasicEmitter {
 		$allowedPreviousVersions = $this->getAllowedPreviousVersions();
 		if (!$this->isUpgradePossible($installedVersion, $currentVersion, $allowedPreviousVersions)) {
 			throw new \Exception('Updates between multiple major versions and downgrades are unsupported.');
+		}
+
+		// A force-enable applies to the major version it was granted on
+		if ($this->isMajorUpgrade($installedVersion, $currentVersion)) {
+			$this->config->deleteSystemValue('app_install_overwrite');
 		}
 
 		// Update .htaccess files

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -110,6 +110,25 @@ class UpdaterTest extends TestCase {
 		$this->assertSame($result, $this->updater->isUpgradePossible($oldVersion, $newVersion, $allowedVersions));
 	}
 
+	/**
+	 * @return array
+	 */
+	public static function majorUpgradeTestData(): array {
+		return [
+			// Same major version
+			['33.0.0.10', '33.1.2.3', false],
+			// Major upgrade
+			['33.0.5.1', '34.0.0.10', true],
+			// Downgrade, only reachable with debug enabled
+			['34.0.0.10', '33.0.5.1', false],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('majorUpgradeTestData')]
+	public function testIsMajorUpgrade(string $installedVersion, string $currentVersion, bool $result): void {
+		$this->assertSame($result, self::invokePrivate($this->updater, 'isMajorUpgrade', [$installedVersion, $currentVersion]));
+	}
+
 	public function testUpgradeAppStoreAppsRestoresMissingAutoDisabledAppBeforeEnabling(): void {
 		$this->installer->expects($this->once())
 			->method('isUpdateAvailable')


### PR DESCRIPTION
* Resolves: #43026

## Summary

`app_install_overwrite` records that an admin force-enabled an app despite its `max-version`. That statement is bound to the major version it was made on — it says the app was tried on 33, not that it will work on 34. Today the list survives the upgrade, so on the next major every entry silently re-enables an app that was never checked against the new release. Nothing ever removes an entry, so the list only grows; instances that have been upgraded a few times carry dozens of them.

This clears the value when the upgrade crosses a major boundary. Apps that are genuinely incompatible then stay disabled, and the admin re-grants the overwrite per app, deliberately, on the version it now applies to.

From the support forum: admins regularly do not know what the setting does, collect entries in it over years, and find out what it was for when an upgrade takes the instance down.

### What changes

- `Updater::doUpgrade()` deletes `app_install_overwrite` right after the "upgrade possible" check, before anything else runs. Not a major upgrade, not touched.
- New private helper `Updater::isMajorUpgrade()`, tested in `tests/lib/UpdaterTest.php`.
- `core/Command/Upgrade.php` and `core/Controller/UpdateController.php` read the overwrites inside the `incompatibleAppDisabled` listener instead of copying them into a variable before the upgrade starts. Without this the deletion would take effect but the stale copy would keep suppressing "Disabled incompatible app: …" — the admin would get apps disabled and no word about which ones. The two changes only make sense together.
- The third reader, `lib/OC.php`, renders the "update needed" page before the upgrade starts and reads the value per request. It is unaffected and left alone.

### Behaviour

| | before | after |
|---|---|---|
| minor / patch upgrade | overwrites kept | overwrites kept |
| major upgrade, app has a compatible version | re-enabled | re-enabled (the version fits, no overwrite needed) |
| major upgrade, app still incompatible | silently re-enabled, no message | stays disabled, reported as incompatible |

### Prior art

Two setup projects already do this outside the server, because the server does not.

Nextcloud AIO deletes the value when the image crosses one major, [in its container entrypoint](https://github.com/nextcloud/all-in-one/blob/6b788eec5e61733cf03ed380a3572e43ae3f11ce/Containers/nextcloud/entrypoint.sh#L281-L283). It has been there since the initial import, so there is no PR to point at.

The Nextcloud VM scripts do the same, added in [nextcloud/vm#1835](https://github.com/nextcloud/vm/pull/1835) after [nextcloud/vm#1834](https://github.com/nextcloud/vm/issues/1834) and moved to its current place in [nextcloud/vm#1848](https://github.com/nextcloud/vm/pull/1848). Same major comparison:

```sh
# Prevent apps from breaking the update due to incompatibility
# Fixes errors like https://github.com/nextcloud/vm/issues/1834
# Needs to be executed before backing up the config directory
if [ "${CURRENTVERSION%%.*}" -lt "${NCVERSION%%.*}" ]
then
    print_text_in_color "$ICyan" "Deleting 'app_install_overwrite array' to prevent app breakage..."
    nextcloud_occ config:system:delete app_install_overwrite
fi
```

Both sit in front of the same `occ upgrade` and work around the same gap, and neither helps anyone who installs another way. If this lands, both can drop their own handling.

### Note for admins

Admins who rely on force-enabled apps have to re-force them after a major upgrade. That is the intended cost, and it is the same action they took the first time.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
Assisted-by: ClaudeCode:claude-opus-5