### PR TITLE
fix(appconfig): make type-conflict error self-explanatory

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -538,8 +538,15 @@ class AppConfig implements IAppConfig {
 			&& $knownType > 0
 			&& !$this->isTyped(self::VALUE_MIXED, $knownType)
 			&& !$this->isTyped($type, $knownType)) {
-			$this->logger->warning('conflict with value type from database', ['app' => $app, 'key' => $key, 'type' => $type, 'knownType' => $knownType]);
-			throw new AppConfigTypeConflictException('conflict with value type from database');
+			$requestedType = $storedType = null;
+			try {
+				$requestedType = $this->convertTypeToString($type);
+				$storedType = $this->convertTypeToString($knownType);
+			} catch (AppConfigIncorrectTypeException) {
+				// can be ignored, this was just needed for a better exception message.
+			}
+			$this->logger->warning('Config value {app}/{key} is stored as {storedType} but was requested as {requestedType}', ['app' => $app, 'key' => $key, 'storedType' => $storedType ?? $knownType, 'requestedType' => $requestedType ?? $type]);
+			throw new AppConfigTypeConflictException('Config value ' . $app . '/' . $key . ' is stored as ' . ($storedType ?? (string)$knownType) . ' but was requested as ' . ($requestedType ?? (string)$type));
 		}
 
 		/**


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

When a stored app config value has a different type than the one an app requests via a typed getter, getTypedValue() threw the opaque message 'conflict with value type from database' with no app, key or type information. Admins had no way to tell which key was affected or why. Example: https://github.com/nextcloud/mail/issues/13537.

Name the config key and both types (using convertTypeToString(), like the setTypedValue() throw already does) in the log line and exception message.

Before:

```
Technical details

    Remote Address: 127.0.0.1
    Request ID: WW1YSUk264BSTx35WFtG
    Type: OCP\Exceptions\AppConfigTypeConflictException
    Code: 0
    Message: conflict with value type from database
    File: /nextcloud/lib/private/AppConfig.php
    Line: 542
```

After:

```
Technical details

    Remote Address: 127.0.0.1
    Request ID: hJHOpVUa9PD4YKLrkV9m
    Type: OCP\Exceptions\AppConfigTypeConflictException
    Code: 0
    Message: Config value mail/importance_classification_default is stored as string but was requested as boolean
    File: /nextcloud/lib/private/AppConfig.php
    Line: 549

```

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
