### PR TITLE
feat(ContextChat): add IContentProviderWithSearchTask

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -375,6 +375,7 @@ return array(
     'OCP\\ContextChat\\Events\\ContentProviderRegisterEvent' => $baseDir . '/lib/public/ContextChat/Events/ContentProviderRegisterEvent.php',
     'OCP\\ContextChat\\IContentManager' => $baseDir . '/lib/public/ContextChat/IContentManager.php',
     'OCP\\ContextChat\\IContentProvider' => $baseDir . '/lib/public/ContextChat/IContentProvider.php',
+    'OCP\\ContextChat\\IContentProviderWithSearchTask' => $baseDir . '/lib/public/ContextChat/IContentProviderWithSearchTask.php',
     'OCP\\ContextChat\\Type\\UpdateAccessOp' => $baseDir . '/lib/public/ContextChat/Type/UpdateAccessOp.php',
     'OCP\\DB\\Events\\AddMissingColumnsEvent' => $baseDir . '/lib/public/DB/Events/AddMissingColumnsEvent.php',
     'OCP\\DB\\Events\\AddMissingIndicesEvent' => $baseDir . '/lib/public/DB/Events/AddMissingIndicesEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -416,6 +416,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\ContextChat\\Events\\ContentProviderRegisterEvent' => __DIR__ . '/../../..' . '/lib/public/ContextChat/Events/ContentProviderRegisterEvent.php',
         'OCP\\ContextChat\\IContentManager' => __DIR__ . '/../../..' . '/lib/public/ContextChat/IContentManager.php',
         'OCP\\ContextChat\\IContentProvider' => __DIR__ . '/../../..' . '/lib/public/ContextChat/IContentProvider.php',
+        'OCP\\ContextChat\\IContentProviderWithSearchTask' => __DIR__ . '/../../..' . '/lib/public/ContextChat/IContentProviderWithSearchTask.php',
         'OCP\\ContextChat\\Type\\UpdateAccessOp' => __DIR__ . '/../../..' . '/lib/public/ContextChat/Type/UpdateAccessOp.php',
         'OCP\\DB\\Events\\AddMissingColumnsEvent' => __DIR__ . '/../../..' . '/lib/public/DB/Events/AddMissingColumnsEvent.php',
         'OCP\\DB\\Events\\AddMissingIndicesEvent' => __DIR__ . '/../../..' . '/lib/public/DB/Events/AddMissingIndicesEvent.php',

--- a/lib/public/ContextChat/IContentProviderWithSearchTask.php
+++ b/lib/public/ContextChat/IContentProviderWithSearchTask.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\ContextChat;
+
+/**
+ * This interface defines methods to implement a Context Chat content provider
+ * with a search task and data description.
+ * @since 35.0.0
+ */
+interface IContentProviderWithSearchTask extends IContentProvider {
+	/**
+	 * A short description about the kind of data provided by this provider.
+	 * This part is sent to the main model to make sense of the retrieved documents.
+	 *
+	 * Some examples can be:
+	 * - "Email messages from the user's mailbox with sender, recipients, subject,
+	 *    and date."
+	 * - "Chat messages from group and private conversations, each prefixed with
+	 *    author and timestamp. They are short and may be informal, and often only
+	 *    make sense in sequence.
+	 *
+	 * Return an empty string to keep it empty.
+	 *
+	 * @return string
+	 * @since 35.0.0
+	 */
+	public function getDataDescription(): string;
+
+	/**
+	 * A short (10-25 words) search task to be performed by context chat for the
+	 * content provider.
+	 * This is not shown to the user, only passed to the embedding model if the model
+	 * is set to https://huggingface.co/intfloat/multilingual-e5-large-instruct
+	 *
+	 * Some examples can be:
+	 * - "Given a question, retrieve email messages whose subject or body discusses
+	 *    or answers it, including quoted replies inside threads."
+	 * - "Given a question, retrieve chat messages that mention or answer it,
+	 *    even when written informally or as short fragments."
+	 *
+	 * Return an empty string to use the generic default.
+	 *
+	 * @return string
+	 * @since 35.0.0
+	 */
+	public function getSearchTaskDescription(): string;
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Add IContentProviderWithSearchTask extending IContentProvider to include search task and the data description of the data provided.
They will be used to improve document retrieval and LLM responses respectively.

also ref: https://github.com/nextcloud/context_chat_backend/issues/331

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
