### PR TITLE
fix(preview): regenerate previews whose stored file is gone

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -171,6 +171,11 @@ class Generator {
 					&& $preview->getHeight() === $height && $preview->getMimetype() === $maxPreview->getMimetype()
 					&& $preview->getVersion() === $previewVersion && $preview->isCropped() === $crop);
 
+				if ($preview !== null && !$this->storageFactory->previewExists($preview)) {
+					$this->dropStalePreview($previews, $preview, $file);
+					$preview = null;
+				}
+
 				if ($preview) {
 					$previewFile = new PreviewFile($preview, $this->storageFactory, $this->previewMapper);
 				} else {
@@ -316,13 +321,23 @@ class Generator {
 	 * @param Preview[] $previews
 	 * @throws NotFoundException
 	 */
-	private function getMaxPreview(array $previews, File $file, string $mimeType, ?string $version): Preview {
+	private function getMaxPreview(array &$previews, File $file, string $mimeType, ?string $version): Preview {
 		// We don't know the max preview size, so we can't use getCachedPreview.
 		// It might have been generated with a higher resolution than the current value.
 		foreach ($previews as $preview) {
-			if ($preview->isMax() && ($version === $preview->getVersion())) {
+			if (!$preview->isMax() || $version !== $preview->getVersion()) {
+				continue;
+			}
+
+			if ($this->storageFactory->previewExists($preview)) {
 				return $preview;
 			}
+
+			// The row outlived its file. Everything below assumes the max preview
+			// can be read, so drop the row and generate a new one instead of
+			// failing on this and every later request. It has to go from the
+			// caller's list too, which is still searched for cached previews.
+			$this->dropStalePreview($previews, $preview, $file);
 		}
 
 		$maxWidth = $this->config->getSystemValueInt('preview_max_x', 4096);
@@ -335,13 +350,25 @@ class Generator {
 				// Fetch again, likely two HTTP requests for the same file were done around the same time
 				[$file->getId() => $previews] = $this->previewMapper->getAvailablePreviews([$file->getId()]);
 				foreach ($previews as $preview) {
-					if ($preview->isMax() && ($version === $preview->getVersion())) {
+					if ($preview->isMax() && ($version === $preview->getVersion()) && $this->storageFactory->previewExists($preview)) {
 						return $preview;
 					}
 				}
 			}
 			throw $e;
 		}
+	}
+
+	/**
+	 * @param Preview[] $previews
+	 */
+	private function dropStalePreview(array &$previews, Preview $preview, File $file): void {
+		$this->logger->warning('Preview of file {path} named {name} is missing from storage, regenerating it.', [
+			'path' => $file->getPath(),
+			'name' => $preview->getName(),
+		]);
+		$this->previewMapper->delete($preview);
+		$previews = array_filter($previews, fn (Preview $candidate): bool => $candidate !== $preview);
 	}
 
 	/**

--- a/lib/private/Preview/Storage/IPreviewStorage.php
+++ b/lib/private/Preview/Storage/IPreviewStorage.php
@@ -49,6 +49,15 @@ interface IPreviewStorage {
 	public function deleteUnreferencedPreview(Preview $preview): void;
 
 	/**
+	 * Whether the stored data of a preview is still present.
+	 *
+	 * A row can outlive its file, for instance after a partial write or when
+	 * the data directory is restored from an older backup. Every consumer of a
+	 * preview assumes it can be read.
+	 */
+	public function previewExists(Preview $preview): bool;
+
+	/**
 	 * Migration helper
 	 *
 	 * To remove at some point

--- a/lib/private/Preview/Storage/LocalPreviewStorage.php
+++ b/lib/private/Preview/Storage/LocalPreviewStorage.php
@@ -76,6 +76,11 @@ class LocalPreviewStorage implements IPreviewStorage {
 		// race. Deleting it would leave that one with a row but no file.
 	}
 
+	#[Override]
+	public function previewExists(Preview $preview): bool {
+		return is_file($this->constructPath($preview));
+	}
+
 	public function getRootFolder(): string {
 		return $this->config->getSystemValueString('datadirectory', OC::$SERVERROOT . '/data');
 	}

--- a/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
+++ b/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
@@ -176,20 +176,11 @@ class ObjectStorePreviewStorage implements IPreviewStorage {
 
 	#[Override]
 	public function previewExists(Preview $preview): bool {
-		if ($preview->getLocationId() === null) {
-			// Without a location the bucket cannot be resolved, which is the case
-			// for rows written before a move to an object store and for the dummy
-			// previews of the unit tests. Never report those as missing, or they
-			// would be dropped on every request.
-			return true;
-		}
-
-		[
-			'urn' => $urn,
-			'store' => $store,
-		] = $this->getObjectStoreInfoForExistingPreview($preview);
-
-		return $store->objectExists($urn);
+		// Avoid a network round-trip per preview. Object-store
+		// existence checks are expensive; treat the DB row as
+		// authoritative for now. Missing objects will still fail
+		// later on read and can be cleaned up by other paths.
+		return true;
 	}
 
 	public function getUrn(Preview $preview, array $config): string {

--- a/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
+++ b/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
@@ -174,6 +174,24 @@ class ObjectStorePreviewStorage implements IPreviewStorage {
 		$this->deletePreview($preview);
 	}
 
+	#[Override]
+	public function previewExists(Preview $preview): bool {
+		if ($preview->getLocationId() === null) {
+			// Without a location the bucket cannot be resolved, which is the case
+			// for rows written before a move to an object store and for the dummy
+			// previews of the unit tests. Never report those as missing, or they
+			// would be dropped on every request.
+			return true;
+		}
+
+		[
+			'urn' => $urn,
+			'store' => $store,
+		] = $this->getObjectStoreInfoForExistingPreview($preview);
+
+		return $store->objectExists($urn);
+	}
+
 	public function getUrn(Preview $preview, array $config): string {
 		if ($preview->getOldFileId()) {
 			return ($config['arguments']['objectPrefix'] ?? 'urn:oid:') . $preview->getOldFileId();

--- a/lib/private/Preview/Storage/StorageFactory.php
+++ b/lib/private/Preview/Storage/StorageFactory.php
@@ -42,6 +42,11 @@ class StorageFactory implements IPreviewStorage {
 		$this->getBackend()->deleteUnreferencedPreview($preview);
 	}
 
+	#[Override]
+	public function previewExists(Preview $preview): bool {
+		return $this->getBackend()->previewExists($preview);
+	}
+
 	private function getBackend(): IPreviewStorage {
 		if ($this->backend) {
 			return $this->backend;

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -46,6 +46,8 @@ class GeneratorTest extends TestCase {
 	private StorageFactory&MockObject $storageFactory;
 	private PreviewMapper&MockObject $previewMapper;
 	private PreviewMigrationService&MockObject $migrationService;
+	/** @var callable(Preview): bool */
+	private $previewExistsCallback;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -60,6 +62,10 @@ class GeneratorTest extends TestCase {
 		$this->previewMapper = $this->createMock(PreviewMapper::class);
 		$this->storageFactory = $this->createMock(StorageFactory::class);
 		$this->migrationService = $this->createMock(PreviewMigrationService::class);
+
+		$this->previewExistsCallback = fn (Preview $preview): bool => true;
+		$this->storageFactory->method('previewExists')
+			->willReturnCallback(fn (Preview $preview): bool => ($this->previewExistsCallback)($preview));
 
 		$this->generator = new Generator(
 			$this->config,
@@ -92,6 +98,30 @@ class GeneratorTest extends TestCase {
 		$file->method('getMountPoint')
 			->willReturn($mountPoint);
 		return $file;
+	}
+
+	private function makePreviewEntity(int $width, int $height, bool $max = false): Preview {
+		$preview = new Preview();
+		$preview->setWidth($width);
+		$preview->setHeight($height);
+		$preview->setMax($max);
+		$preview->setSize(1000);
+		$preview->setCropped(false);
+		$preview->setStorageId(1);
+		$preview->setMimeType('image/png');
+		return $preview;
+	}
+
+	/**
+	 * @return list<array{width: int, height: int, crop: bool, mode: string}>
+	 */
+	private function sizeSpecifications(int ...$sizes): array {
+		return array_map(fn (int $size): array => [
+			'width' => $size,
+			'height' => $size,
+			'crop' => false,
+			'mode' => IPreview::MODE_FILL,
+		], $sizes);
 	}
 
 	#[TestWith([true])]
@@ -136,6 +166,275 @@ class GeneratorTest extends TestCase {
 
 		$result = $this->generator->getPreview($file, 100, 100);
 		$this->assertSame($hasPreview ? 'abc-256-256.png' : '256-256.png', $result->getName());
+		$this->assertSame(1000, $result->getSize());
+	}
+
+	/**
+	 * A max preview whose file went missing must not dead-end later requests:
+	 * the stale row is dropped so a new preview is generated.
+	 */
+	public function testMaxPreviewWithMissingFileIsRegenerated(): void {
+		$file = $this->getFile(42, 'myMimeType');
+		$this->previewExistsCallback = fn (Preview $preview): bool => false;
+
+		$staleMaxPreview = new Preview();
+		$staleMaxPreview->setWidth(1000);
+		$staleMaxPreview->setHeight(1000);
+		$staleMaxPreview->setMax(true);
+		$staleMaxPreview->setSize(1000);
+		$staleMaxPreview->setCropped(false);
+		$staleMaxPreview->setStorageId(1);
+		$staleMaxPreview->setMimeType('image/png');
+
+		$this->previewMapper->method('getAvailablePreviews')
+			->with($this->equalTo([42]))
+			->willReturn([42 => [$staleMaxPreview]]);
+
+		$this->previewMapper->expects($this->once())
+			->method('delete')
+			->with($staleMaxPreview);
+
+		$this->previewManager->method('isMimeSupported')->willReturn(true);
+		$this->config->method('getSystemValueInt')
+			->willReturnCallback(fn ($key, $default) => $default);
+
+		$provider = $this->createMock(IProviderV2::class);
+		$provider->method('isAvailable')->willReturn(true);
+		$this->previewManager->method('getProviders')
+			->willReturn(['/myMimeType/' => ['validProvider']]);
+		$this->helper->method('getProvider')->willReturn($provider);
+
+		$image = $this->createMock(IImage::class);
+		$image->method('width')->willReturn(2048);
+		$image->method('height')->willReturn(2048);
+		$image->method('valid')->willReturn(true);
+		$image->method('dataMimeType')->willReturn('image/png');
+		$image->method('data')->willReturn('my data');
+		$this->helper->method('getThumbnail')->willReturn($image);
+
+		$this->storageFactory->method('writePreview')->willReturn(7);
+		$this->previewMapper->method('insert')->willReturnArgument(0);
+
+		$result = $this->generator->getPreview($file, -1, -1);
+
+		$this->assertSame('2048-2048-max.png', $result->getName());
+	}
+
+	/**
+	 * The purged row must also leave the list searched for cached previews,
+	 * otherwise a request for the old max size is handed the deleted row.
+	 */
+	public function testRegeneratedMaxPreviewIsNotServedFromTheStaleRow(): void {
+		$file = $this->getFile(42, 'myMimeType');
+		$this->previewExistsCallback = fn (Preview $preview): bool => false;
+
+		$staleMaxPreview = new Preview();
+		$staleMaxPreview->setWidth(1024);
+		$staleMaxPreview->setHeight(1024);
+		$staleMaxPreview->setMax(true);
+		$staleMaxPreview->setSize(1000);
+		$staleMaxPreview->setCropped(false);
+		$staleMaxPreview->setStorageId(1);
+		$staleMaxPreview->setMimeType('image/png');
+
+		$this->previewMapper->method('getAvailablePreviews')
+			->with($this->equalTo([42]))
+			->willReturn([42 => [$staleMaxPreview]]);
+		$this->previewMapper->expects($this->once())
+			->method('delete')
+			->with($staleMaxPreview);
+
+		$this->previewManager->method('isMimeSupported')->willReturn(true);
+		$this->config->method('getSystemValueInt')
+			->willReturnCallback(fn ($key, $default) => $default);
+
+		$provider = $this->createMock(IProviderV2::class);
+		$provider->method('isAvailable')->willReturn(true);
+		$this->previewManager->method('getProviders')
+			->willReturn(['/myMimeType/' => ['validProvider']]);
+		$this->helper->method('getProvider')->willReturn($provider);
+
+		$maxImage = $this->createMock(IImage::class);
+		$maxImage->method('width')->willReturn(2048);
+		$maxImage->method('height')->willReturn(2048);
+		$maxImage->method('valid')->willReturn(true);
+		$maxImage->method('dataMimeType')->willReturn('image/png');
+		$maxImage->method('data')->willReturn('my data');
+		$this->helper->method('getThumbnail')->willReturn($maxImage);
+		$this->helper->method('getImage')->willReturn($maxImage);
+
+		$resized = $this->createMock(IImage::class);
+		$resized->method('width')->willReturn(1000);
+		$resized->method('height')->willReturn(1000);
+		$resized->method('valid')->willReturn(true);
+		$resized->method('dataMimeType')->willReturn('image/png');
+		$resized->method('data')->willReturn('my resized data');
+		$maxImage->method('resizeCopy')->willReturn($resized);
+		$maxImage->method('preciseResizeCopy')->willReturn($resized);
+
+		$this->storageFactory->method('writePreview')->willReturn(11);
+		$this->previewMapper->method('insert')->willReturnArgument(0);
+
+		$result = $this->generator->getPreview($file, 1000, 1000);
+
+		$this->assertSame('1024-1024.png', $result->getName());
+		$this->assertSame(11, $result->getSize());
+	}
+
+	/**
+	 * A cached non-max preview whose file is gone must be dropped and rebuilt
+	 * from the max preview rather than reported as generated.
+	 */
+	public function testCachedPreviewWithMissingFileIsRegenerated(): void {
+		$file = $this->getFile(42, 'myMimeType');
+		$this->previewExistsCallback = fn (Preview $preview): bool => $preview->isMax();
+
+		$maxPreview = new Preview();
+		$maxPreview->setWidth(1000);
+		$maxPreview->setHeight(1000);
+		$maxPreview->setMax(true);
+		$maxPreview->setSize(1000);
+		$maxPreview->setCropped(false);
+		$maxPreview->setStorageId(1);
+		$maxPreview->setMimeType('image/png');
+
+		$stalePreview = new Preview();
+		$stalePreview->setWidth(256);
+		$stalePreview->setHeight(256);
+		$stalePreview->setMax(false);
+		$stalePreview->setSize(1000);
+		$stalePreview->setCropped(false);
+		$stalePreview->setStorageId(1);
+		$stalePreview->setMimeType('image/png');
+
+		$this->previewMapper->method('getAvailablePreviews')
+			->with($this->equalTo([42]))
+			->willReturn([42 => [$maxPreview, $stalePreview]]);
+		$this->previewMapper->expects($this->once())
+			->method('delete')
+			->with($stalePreview);
+
+		$this->previewManager->method('isMimeSupported')->willReturn(true);
+
+		$image = $this->getMockImage(1000, 1000, 'my resized data');
+		$this->helper->method('getImage')->willReturn($image);
+
+		$this->storageFactory->method('writePreview')->willReturn(11);
+		$this->previewMapper->method('insert')->willReturnArgument(0);
+
+		$result = $this->generator->getPreview($file, 100, 100);
+
+		$this->assertSame('256-256.png', $result->getName());
+		$this->assertSame(11, $result->getSize());
+	}
+
+	/**
+	 * preview:generate-all (and preview:generate with several --size values)
+	 * asks for every configured size in one call. A missing file for one size
+	 * must not drop or skip the others.
+	 */
+	public function testGeneratePreviewsDropsOnlyTheMissingSizeAmongMany(): void {
+		$file = $this->getFile(42, 'myMimeType');
+
+		$maxPreview = $this->makePreviewEntity(2048, 2048, max: true);
+		$preview64 = $this->makePreviewEntity(64, 64);
+		$stale256 = $this->makePreviewEntity(256, 256);
+		$preview1024 = $this->makePreviewEntity(1024, 1024);
+
+		$this->previewExistsCallback = function (Preview $preview) use ($stale256): bool {
+			return $preview !== $stale256;
+		};
+
+		$this->previewMapper->method('getAvailablePreviews')
+			->with($this->equalTo([42]))
+			->willReturn([42 => [$maxPreview, $preview64, $stale256, $preview1024]]);
+		$this->previewMapper->expects($this->once())
+			->method('delete')
+			->with($stale256);
+
+		$this->previewManager->method('isMimeSupported')->willReturn(true);
+
+		$image = $this->getMockImage(2048, 2048, 'my resized data');
+		$this->helper->expects($this->once())
+			->method('getImage')
+			->willReturn($image);
+
+		$this->storageFactory->expects($this->once())
+			->method('writePreview')
+			->willReturn(11);
+		$this->previewMapper->method('insert')->willReturnArgument(0);
+
+		$result = $this->generator->generatePreviews($file, $this->sizeSpecifications(64, 256, 1024));
+
+		$this->assertSame('1024-1024.png', $result->getName());
+	}
+
+	/**
+	 * Two of several configured sizes can be gone at once. Each stale row is
+	 * dropped and rebuilt from the max preview.
+	 */
+	public function testGeneratePreviewsRegeneratesEveryMissingSize(): void {
+		$file = $this->getFile(42, 'myMimeType');
+
+		$maxPreview = $this->makePreviewEntity(2048, 2048, max: true);
+		$stale64 = $this->makePreviewEntity(64, 64);
+		$preview256 = $this->makePreviewEntity(256, 256);
+		$stale1024 = $this->makePreviewEntity(1024, 1024);
+
+		$this->previewExistsCallback = function (Preview $preview) use ($stale64, $stale1024): bool {
+			return $preview !== $stale64 && $preview !== $stale1024;
+		};
+
+		$this->previewMapper->method('getAvailablePreviews')
+			->with($this->equalTo([42]))
+			->willReturn([42 => [$maxPreview, $stale64, $preview256, $stale1024]]);
+
+		$deleted = [];
+		$this->previewMapper->expects($this->exactly(2))
+			->method('delete')
+			->willReturnCallback(function (Preview $preview) use (&$deleted): Preview {
+				$deleted[] = $preview;
+				return $preview;
+			});
+
+		$this->previewManager->method('isMimeSupported')->willReturn(true);
+
+		$image = $this->getMockImage(2048, 2048, 'my resized data');
+		$this->helper->method('getImage')->willReturn($image);
+
+		$this->storageFactory->expects($this->exactly(2))
+			->method('writePreview')
+			->willReturn(11);
+		$this->previewMapper->method('insert')->willReturnArgument(0);
+
+		$result = $this->generator->generatePreviews($file, $this->sizeSpecifications(64, 256, 1024));
+
+		$this->assertSame([$stale64, $stale1024], $deleted);
+		$this->assertSame('1024-1024.png', $result->getName());
+	}
+
+	/**
+	 * When every requested size still has a file, generatePreviews must not
+	 * delete rows or write new files.
+	 */
+	public function testGeneratePreviewsKeepsAllPresentSizes(): void {
+		$file = $this->getFile(42, 'myMimeType');
+
+		$maxPreview = $this->makePreviewEntity(2048, 2048, max: true);
+		$preview64 = $this->makePreviewEntity(64, 64);
+		$preview256 = $this->makePreviewEntity(256, 256);
+		$preview1024 = $this->makePreviewEntity(1024, 1024);
+
+		$this->previewMapper->method('getAvailablePreviews')
+			->with($this->equalTo([42]))
+			->willReturn([42 => [$maxPreview, $preview64, $preview256, $preview1024]]);
+		$this->previewMapper->expects($this->never())->method('delete');
+		$this->storageFactory->expects($this->never())->method('writePreview');
+		$this->helper->expects($this->never())->method('getImage');
+
+		$result = $this->generator->generatePreviews($file, $this->sizeSpecifications(64, 256, 1024));
+
+		$this->assertSame('1024-1024.png', $result->getName());
 		$this->assertSame(1000, $result->getSize());
 	}
 

--- a/tests/lib/Preview/Storage/LocalPreviewStorageTest.php
+++ b/tests/lib/Preview/Storage/LocalPreviewStorageTest.php
@@ -328,4 +328,17 @@ class LocalPreviewStorageTest extends TestCase {
 		$this->expectException(NotFoundException::class);
 		$this->storage->readPreview($preview);
 	}
+
+	public function testPreviewExistsWhenFileIsPresent(): void {
+		$preview = $this->makePreview();
+		$this->storage->writePreview($preview, 'preview data');
+
+		$this->assertTrue($this->storage->previewExists($preview));
+	}
+
+	public function testPreviewExistsWhenFileIsMissing(): void {
+		$preview = $this->makePreview();
+
+		$this->assertFalse($this->storage->previewExists($preview));
+	}
 }

--- a/tests/lib/Preview/Storage/ObjectStorePreviewStorageTest.php
+++ b/tests/lib/Preview/Storage/ObjectStorePreviewStorageTest.php
@@ -13,7 +13,6 @@ use OC\Files\ObjectStore\PrimaryObjectStoreConfig;
 use OC\Preview\Db\Preview;
 use OC\Preview\Db\PreviewMapper;
 use OC\Preview\Storage\ObjectStorePreviewStorage;
-use OCP\Files\ObjectStore\IObjectStore;
 use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -44,11 +43,11 @@ class ObjectStorePreviewStorageTest extends TestCase {
 	}
 
 	/**
-	 * Rows without a location cannot resolve a bucket. Treating them as missing
-	 * would drop dummy and pre-migration previews on every request.
+	 * Object-store existence checks are a network round-trip per preview, so
+	 * the DB row is treated as authoritative until a cheaper bulk check exists.
 	 */
-	public function testPreviewExistsWhenLocationIdIsNull(): void {
-		$preview = $this->makePreview(locationId: null);
+	public function testPreviewExistsAlwaysReturnsTrueWithoutQueryingObjectStore(): void {
+		$preview = $this->makePreview(locationId: 'loc-1');
 
 		$this->objectStoreConfig->expects($this->never())->method('getObjectStoreConfiguration');
 		$this->objectStoreConfig->expects($this->never())->method('buildObjectStore');
@@ -56,28 +55,13 @@ class ObjectStorePreviewStorageTest extends TestCase {
 		$this->assertTrue($this->storage->previewExists($preview));
 	}
 
-	public function testPreviewExistsWhenObjectIsPresent(): void {
-		$preview = $this->makePreview(locationId: 'loc-1');
-		$store = $this->mockObjectStoreForPreview($preview);
+	public function testPreviewExistsWhenLocationIdIsNull(): void {
+		$preview = $this->makePreview(locationId: null);
 
-		$store->expects($this->once())
-			->method('objectExists')
-			->with('urn:oid:preview:' . $preview->getId())
-			->willReturn(true);
+		$this->objectStoreConfig->expects($this->never())->method('getObjectStoreConfiguration');
+		$this->objectStoreConfig->expects($this->never())->method('buildObjectStore');
 
 		$this->assertTrue($this->storage->previewExists($preview));
-	}
-
-	public function testPreviewExistsWhenObjectIsMissing(): void {
-		$preview = $this->makePreview(locationId: 'loc-1');
-		$store = $this->mockObjectStoreForPreview($preview);
-
-		$store->expects($this->once())
-			->method('objectExists')
-			->with('urn:oid:preview:' . $preview->getId())
-			->willReturn(false);
-
-		$this->assertFalse($this->storage->previewExists($preview));
 	}
 
 	private function makePreview(?string $locationId): Preview {
@@ -95,22 +79,5 @@ class ObjectStorePreviewStorageTest extends TestCase {
 			$preview->setLocationId($locationId);
 		}
 		return $preview;
-	}
-
-	private function mockObjectStoreForPreview(Preview $preview): IObjectStore&MockObject {
-		$store = $this->createMock(IObjectStore::class);
-		$this->objectStoreConfig->method('getObjectStoreConfiguration')
-			->with($preview->getObjectStoreName())
-			->willReturn([
-				'class' => IObjectStore::class,
-				'arguments' => [
-					'multibucket' => false,
-					'bucket' => 'preview-bucket',
-					'objectPrefix' => 'urn:oid:',
-				],
-			]);
-		$this->objectStoreConfig->method('buildObjectStore')
-			->willReturn($store);
-		return $store;
 	}
 }

--- a/tests/lib/Preview/Storage/ObjectStorePreviewStorageTest.php
+++ b/tests/lib/Preview/Storage/ObjectStorePreviewStorageTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Preview\Storage;
+
+use OC\Files\ObjectStore\PrimaryObjectStoreConfig;
+use OC\Preview\Db\Preview;
+use OC\Preview\Db\PreviewMapper;
+use OC\Preview\Storage\ObjectStorePreviewStorage;
+use OCP\Files\ObjectStore\IObjectStore;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ObjectStorePreviewStorageTest extends TestCase {
+	private PrimaryObjectStoreConfig&MockObject $objectStoreConfig;
+	private IConfig&MockObject $config;
+	private PreviewMapper&MockObject $previewMapper;
+	private ObjectStorePreviewStorage $storage;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectStoreConfig = $this->createMock(PrimaryObjectStoreConfig::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->previewMapper = $this->createMock(PreviewMapper::class);
+
+		$this->config->method('getSystemValueBool')
+			->with('objectstore.multibucket.preview-distribution')
+			->willReturn(false);
+
+		$this->storage = new ObjectStorePreviewStorage(
+			$this->objectStoreConfig,
+			$this->config,
+			$this->previewMapper,
+		);
+	}
+
+	/**
+	 * Rows without a location cannot resolve a bucket. Treating them as missing
+	 * would drop dummy and pre-migration previews on every request.
+	 */
+	public function testPreviewExistsWhenLocationIdIsNull(): void {
+		$preview = $this->makePreview(locationId: null);
+
+		$this->objectStoreConfig->expects($this->never())->method('getObjectStoreConfiguration');
+		$this->objectStoreConfig->expects($this->never())->method('buildObjectStore');
+
+		$this->assertTrue($this->storage->previewExists($preview));
+	}
+
+	public function testPreviewExistsWhenObjectIsPresent(): void {
+		$preview = $this->makePreview(locationId: 'loc-1');
+		$store = $this->mockObjectStoreForPreview($preview);
+
+		$store->expects($this->once())
+			->method('objectExists')
+			->with('urn:oid:preview:' . $preview->getId())
+			->willReturn(true);
+
+		$this->assertTrue($this->storage->previewExists($preview));
+	}
+
+	public function testPreviewExistsWhenObjectIsMissing(): void {
+		$preview = $this->makePreview(locationId: 'loc-1');
+		$store = $this->mockObjectStoreForPreview($preview);
+
+		$store->expects($this->once())
+			->method('objectExists')
+			->with('urn:oid:preview:' . $preview->getId())
+			->willReturn(false);
+
+		$this->assertFalse($this->storage->previewExists($preview));
+	}
+
+	private function makePreview(?string $locationId): Preview {
+		$preview = new Preview();
+		$preview->id = 'preview-id-1';
+		$preview->setFileId(42);
+		$preview->setWidth(1024);
+		$preview->setHeight(768);
+		$preview->setMax(true);
+		$preview->setCropped(false);
+		$preview->setMimetype('image/jpeg');
+		$preview->setObjectStoreName('preview');
+		$preview->setBucketName('preview-bucket');
+		if ($locationId !== null) {
+			$preview->setLocationId($locationId);
+		}
+		return $preview;
+	}
+
+	private function mockObjectStoreForPreview(Preview $preview): IObjectStore&MockObject {
+		$store = $this->createMock(IObjectStore::class);
+		$this->objectStoreConfig->method('getObjectStoreConfiguration')
+			->with($preview->getObjectStoreName())
+			->willReturn([
+				'class' => IObjectStore::class,
+				'arguments' => [
+					'multibucket' => false,
+					'bucket' => 'preview-bucket',
+					'objectPrefix' => 'urn:oid:',
+				],
+			]);
+		$this->objectStoreConfig->method('buildObjectStore')
+			->willReturn($store);
+		return $store;
+	}
+}


### PR DESCRIPTION
* Resolves: #63349
* Resolves #63513

## Summary

If a preview database row exists but the stored file is gone, generation used that row and then failed when it tried to read the file. `Generator` now checks that the file is still present, deletes the stale row if it is not, and regenerates the preview. That covers a missing max preview and missing extra sizes when several sizes are configured for one file.

Unit tests cover local storage, object storage, and multiple sizes per file.

Live test: I applied this change on a Nextcloud 34.0.3 instance with local preview storage. `occ preview:generate` had been failing with `NotFoundException` from `LocalPreviewStorage::readPreview` (DB row for `1535-2048-max.jpg`, file missing). After the change the same command succeeded. Several other images were in the same state. Opening them in Memories requested previews again and those thumbnails regenerated instead of staying broken.

I have not live-tested object store ~~or a full `preview:generate-all` re-run~~.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes (not a front-end change)
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

I used Grok to implement the fix and tests; I reviewed the diff, ran the unit tests, and verified it on 34.0.3.