### PR TITLE
feat(comments): render Smart Picker links as rich reference widgets

### DIFF
--- a/apps/comments/src/components/CommentEntry.vue
+++ b/apps/comments/src/components/CommentEntry.vue
@@ -100,10 +100,12 @@
 			<NcRichText
 				v-else
 				class="comment__message"
-				:class="{ 'comment__message--expanded': expanded }"
+				:class="{ 'comment__message--expanded': expanded, 'comment__message--has-reference': hasReference }"
 				:text="richContent.message"
 				:arguments="richContent.mentions"
 				useMarkdown
+				:referenceLimit="1"
+				referenceInteractiveOptIn
 				@click="onExpand" />
 		</div>
 	</component>
@@ -242,6 +244,16 @@ export default {
 			return { mentions, message }
 		},
 
+		/**
+		 * Whether the message contains a link, so the reference widget it may
+		 * render never gets clipped by the message's scroll clamp
+		 *
+		 * @return {boolean}
+		 */
+		hasReference() {
+			return /https?:\/\/\S+/i.test(this.richContent.message)
+		},
+
 		isEmptyMessage() {
 			return !this.localMessage || this.localMessage.trim() === ''
 		},
@@ -303,7 +315,10 @@ export default {
 			this.onEditComment(this.localMessage.trim())
 		},
 
-		onExpand() {
+		onExpand(event) {
+			if (event?.target?.closest?.('.rich-text--reference-widget')) {
+				return
+			}
 			this.expanded = true
 		},
 	},
@@ -382,13 +397,18 @@ $comment-padding: 10px;
 		scrollbar-gutter: stable;
 		scrollbar-width: thin;
 		margin-top: -6px;
-		&--expanded {
+		&--expanded,
+		&--has-reference {
 			max-height: none;
 			overflow: visible;
 		}
 		:deep(img) {
 			max-width: 100%;
 			height: auto;
+		}
+		:deep(.rich-text--reference-widget) {
+			max-width: 100%;
+			margin-top: 8px;
 		}
 	}
 }


### PR DESCRIPTION
EDI: honestly, this solution is really a lot worse than the other solution in https://github.com/nextcloud/server/pull/63493 - let's go for that one pls?


Enable NcRichText's reference-widget rendering in CommentEntry so Smart Picker insertions (Files, and other reference providers) render as an inline preview card instead of a bare link. Widget clicks no longer trigger the comment's expand/collapse behavior, and widgets are allowed to use the full comment width instead of being clipped by the message's scroll clamp.

Assisted-by: GitHubCopilot:claude-sonnet-4.5

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #63491

## Summary
render the smart picker.

Alternative approach in https://github.com/nextcloud/server/pull/63493

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes - see the ticket https://github.com/nextcloud/server/issues/63491
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
