### PR TITLE
feat(comments): render Smart Picker links as a reference preview card

### DIFF
--- a/apps/comments/src/components/CommentEntry.vue
+++ b/apps/comments/src/components/CommentEntry.vue
@@ -105,6 +105,13 @@
 				:arguments="richContent.mentions"
 				useMarkdown
 				@click="onExpand" />
+
+			<!-- Reference preview card, rendered outside the clamped message box -->
+			<NcReferenceList
+				v-if="!editor && !editing"
+				class="comment__reference-list"
+				:text="richContent.message"
+				interactiveOptIn />
 		</div>
 	</component>
 </template>
@@ -132,6 +139,7 @@ import { useDeletedCommentLimbo } from '../store/deletedCommentLimbo.ts'
 // Dynamic loading
 const NcRichContenteditable = defineAsyncComponent(() => import('@nextcloud/vue/components/NcRichContenteditable'))
 const NcRichText = defineAsyncComponent(() => import('@nextcloud/vue/components/NcRichText'))
+const NcReferenceList = defineAsyncComponent(() => import('@nextcloud/vue/components/NcRichText').then((module) => module.NcReferenceList))
 
 export default {
 	name: 'CommentEntry',
@@ -148,6 +156,7 @@ export default {
 		NcButton,
 		NcDateTime,
 		NcLoadingIcon,
+		NcReferenceList,
 		NcRichContenteditable,
 		NcRichText,
 	},
@@ -390,6 +399,11 @@ $comment-padding: 10px;
 			max-width: 100%;
 			height: auto;
 		}
+	}
+
+	&__reference-list {
+		margin-top: var(--default-grid-baseline);
+		max-width: 100%;
 	}
 }
 


### PR DESCRIPTION
Render a reference preview for Smart Picker insertions (Files, and other reference providers) as a card below the comment text, using NcReferenceList, instead of leaving them as a bare link. The card sits outside the message's clamped/scrolling box so it doesn't compete with the text for space or get clipped.

Assisted-by: GitHubCopilot:claude-sonnet-4.5

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #63491 

Screenshots:


| shot 1 | shot 2 | shot 3 |
|-------|-------|--------|
| <img width="414" height="568" alt="Image" src="https://github.com/user-attachments/assets/cbe7bdd7-87cb-483e-8f8b-2d0b8d07509e" /> | <img width="448" height="910" alt="Screenshot 2026-08-24 at 19 06 35" src="https://github.com/user-attachments/assets/b3e2be6c-f490-44f4-a289-d8398b683d06" /> | <img width="414" height="568" alt="Screenshot 2026-08-22 at 20 58 13" src="https://github.com/user-attachments/assets/bd0258c7-f77b-472e-acb3-ec9371769b64" /> |


## Summary
alternative approach compared to #63492 

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes (in issue, both basically look the same)
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
