### PR TITLE
Handle missing cached share mounts

### DIFF
--- a/apps/files_sharing/lib/Repair/CleanupShareTarget.php
+++ b/apps/files_sharing/lib/Repair/CleanupShareTarget.php
@@ -118,16 +118,18 @@ class CleanupShareTarget implements IRepairStepExpensive {
 					$oldMountPoint = "/{$recipient->getUID()}/files$oldTarget/";
 					$newMountPoint = "/{$recipient->getUID()}/files$newTarget/";
 
-					/** @var ICachedMountInfo $mount */
-					$mount = $userMounts[$oldMountPoint];
-					$userMounts[$newMountPoint] = $mount;
-					unset($userMounts[$oldMountPoint]);
+					/** @var ICachedMountInfo|null $mount */
+					$mount = $userMounts[$oldMountPoint] ?? null;
+					if ($mount !== null) {
+						$userMounts[$newMountPoint] = $mount;
+						unset($userMounts[$oldMountPoint]);
 
-					$this->userMountCache->removeMount($oldMountPoint);
-					$this->userMountCache->addMount($recipient, $newMountPoint, new CacheEntry([
-						'fileid' => $mount->getRootId(),
-						'storage' => $mount->getStorageId(),
-					]), $mount->getMountProvider(), $mount->getMountId());
+						$this->userMountCache->removeMount($oldMountPoint);
+						$this->userMountCache->addMount($recipient, $newMountPoint, new CacheEntry([
+							'fileid' => $mount->getRootId(),
+							'storage' => $mount->getStorageId(),
+						]), $mount->getMountProvider(), $mount->getMountId());
+					}
 				}
 			} catch (\Exception $e) {
 				$msg = 'error cleaning up share target: ' . $e->getMessage();

--- a/apps/files_sharing/tests/Repair/CleanupShareTargetTest.php
+++ b/apps/files_sharing/tests/Repair/CleanupShareTargetTest.php
@@ -10,6 +10,7 @@ namespace OCA\Files_Sharing\Tests\Repair;
 use OC\Migration\NullOutput;
 use OCA\Files_Sharing\Repair\CleanupShareTarget;
 use OCA\Files_Sharing\Tests\TestCase;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\NotFoundException;
 use OCP\Server;
 use OCP\Share\IShare;
@@ -59,6 +60,17 @@ class CleanupShareTargetTest extends TestCase {
 
 	public function testBasicRepair() {
 		$share = $this->createUserShare(self::TEST_FILES_SHARING_API_USER1, self::TEST_FOLDER_NAME . ' (2) (2) (2) (2)');
+
+		$this->cleanupShareTarget->run(new NullOutput());
+
+		$share = $this->shareManager->getShareById($share->getFullId());
+		$this->assertEquals(self::TEST_FOLDER_NAME, $share->getTarget());
+	}
+
+	public function testRepairWithoutCachedMount() {
+		$share = $this->createUserShare(self::TEST_FILES_SHARING_API_USER1, self::TEST_FOLDER_NAME . ' (2) (2) (2) (2)');
+		$mountPoint = '/' . self::TEST_FILES_SHARING_API_USER2 . '/files' . $share->getTarget() . '/';
+		Server::get(IUserMountCache::class)->removeMount($mountPoint);
 
 		$this->cleanupShareTarget->run(new NullOutput());
 


### PR DESCRIPTION
Fixes #62545

## Summary

`CleanupShareTarget` can encounter a missing recipient mount-cache entry while repairing a share target. The previous code dereferenced the missing entry before updating the target, causing the repair to fail. This change treats the cached mount as optional and only rewrites the cache when the entry exists, allowing the repair to continue safely.

## Validation

- PHP syntax and formatting checks passed locally.
- - The focused database-backed PHPUnit test could not be run in this environment because the required Nextcloud test services were unavailable.
## Checklist

- [x] Code is properly formatted
- [ ] - [x] Commit includes the required sign-off
- [ ] - [ ] Focused regression test will be added to this branch in the next commit