### PR TITLE
fix(comments): recreate comment editor on Activity tab remount

### DIFF
--- a/apps/comments/src/comments-activity-tab.ts
+++ b/apps/comments/src/comments-activity-tab.ts
@@ -38,6 +38,7 @@ export function registerCommentsPlugins() {
 		unmount: () => {
 			// destroy previous instance if available
 			app?.unmount()
+			app = undefined
 		},
 	})
 


### PR DESCRIPTION
* Resolves:  #63487

## Summary

Fixes #63487 

The comment field at the top of the Activity/Comments sidebar tab disappeared after switching away and back, and only came back after a full page reload.

## Root cause
`apps/comments/src/comments-activity-tab.ts` mounts the comment editor into the Activity sidebar's `registerSidebarAction`. The Vue `app` instance is stored in a closure variable and intended to be reused across mount/unmount cycles (switching tabs). `unmount()` calls `app.unmount()`, destroying the instance, but never clears the variable. On the next `mount()`, the (still truthy) `app` check prevents a new instance from being created, and `.mount(el)` is called on an already-destroyed Vue app — which is a no-op. Reloading the page resets module state, which is why that "fixed" it.

Confirmed this only affects the Activity-integrated path: with the Activity app disabled, the plain "Comments" tab (a separate `defineCustomElement`-based mount in `FilesSidebarTab.vue`) is unaffected.

## Fix
Reset `app = undefined` after `app?.unmount()` so the next `mount()` call recreates the Vue app instance instead of reusing a dead one.

## Test plan
- [x] Enable Activity app, open sidebar → Activity tab, confirm comment field is visible
- [x] Switch to Versions (or another file), switch back to Activity tab, confirm comment field is still there without reloading
- [x] Repeat a few times to make sure it doesn't regress after multiple tab switches

Assisted-by: Claude:claude-sonnet-5

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes - didn't bother, it's just that it now doesn't disappear...
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
