### PR TITLE
fix(tags): display selected tag in settings

### DIFF
--- a/apps/systemtags/src/components/SystemTagForm.vue
+++ b/apps/systemtags/src/components/SystemTagForm.vue
@@ -235,6 +235,7 @@ function getTagLevel(userVisible: boolean, userAssignable: boolean): TagLevel {
 				:placeholder="t('systemtags', 'Collaborative tags …')"
 				:fetchTags="false"
 				:options="tags"
+				:limit="null"
 				:multiple="false"
 				labelOutside
 				@update:modelValue="onSelectTag">

--- a/apps/systemtags/src/components/SystemTagForm.vue
+++ b/apps/systemtags/src/components/SystemTagForm.vue
@@ -230,7 +230,7 @@ function getTagLevel(userVisible: boolean, userAssignable: boolean): TagLevel {
 		<div class="system-tag-form__group">
 			<label for="system-tags-input">{{ t('systemtags', 'Search for a tag to edit') }}</label>
 			<NcSelectTags
-				:modelValue="selectedTag"
+				:modelValue="selectedTag?.id ?? null"
 				inputId="system-tags-input"
 				:placeholder="t('systemtags', 'Collaborative tags …')"
 				:fetchTags="false"


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

The "Search for a tag to edit" field should display the selected tag, but it continues to show the placeholder after a tag is selected. It fails to do so because the object is passed instead of just the ID.

`NcSelectTags` uses ID-based model values by default (`passthru` is false). `onSelectTag()` expects the numeric ID and resolves it against `props.tags`. 

This change passes the selected tag's ID instead, or `null` when no tag is selected:

- the selector can resolve and display the selected option correctly;
- the value passed to `NcSelectTags` matches the component's expected model format; and
- the selector's model and `onSelectTag()` handler remain consistent.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
