### PR TITLE
fix(dav): only derive the write size from a PUT Content-Length

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -208,8 +208,15 @@ class File extends Node implements IFile {
 				}
 			}
 
-			$lengthHeader = $this->request->getHeader('content-length');
-			$expected = $lengthHeader !== '' ? (int)$lengthHeader : null;
+			// Methods other than PUT carry no Content-Length describing the data written
+			// here: the chunked upload assembly is a MOVE or COPY with no body of its own.
+			$expected = null;
+			if ($this->request->getMethod() === 'PUT') {
+				$lengthHeader = $this->request->getHeader('content-length');
+				if ($lengthHeader !== '') {
+					$expected = (int)$lengthHeader;
+				}
+			}
 
 			if ($partStorage->instanceOfStorage(IWriteStreamStorage::class)) {
 				$isEOF = false;
@@ -265,7 +272,6 @@ class File extends Node implements IFile {
 			// compare expected and actual size
 			if ($expected !== null
 				&& $expected !== $count
-				&& $this->request->getMethod() === 'PUT'
 			) {
 				throw new BadRequest(
 					$this->l10n->t(

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -215,6 +215,75 @@ class FileTest extends TestCase {
 		$this->assertEmpty($this->listPartFiles($view, ''), 'No stray part files');
 	}
 
+	public static function expectedSizeProvider(): array {
+		return [
+			'PUT with a length passes it through' => ['PUT', ['CONTENT_LENGTH' => '9'], 9],
+			'PUT of an empty body still expects zero' => ['PUT', ['CONTENT_LENGTH' => '0'], 0],
+			'PUT without the header expects nothing' => ['PUT', [], null],
+			// The chunked upload assembly reaches put() as a MOVE or COPY, where the
+			// Content-Length describes the request rather than the assembled stream.
+			'MOVE ignores a zero length' => ['MOVE', ['CONTENT_LENGTH' => '0'], null],
+			'MOVE ignores a non-zero length' => ['MOVE', ['CONTENT_LENGTH' => '9'], null],
+			'COPY ignores a zero length' => ['COPY', ['CONTENT_LENGTH' => '0'], null],
+			'COPY ignores a non-zero length' => ['COPY', ['CONTENT_LENGTH' => '9'], null],
+		];
+	}
+
+	/**
+	 * The expected size handed to IWriteStreamStorage::writeStream() may only come from
+	 * the Content-Length of a PUT body. Passing it on for other methods makes storages
+	 * that only measure the stream when given no size - ObjectStoreStorage among them -
+	 * write a truncated or empty file.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'expectedSizeProvider')]
+	public function testPutExpectedSizeOnlyComesFromPutContentLength(string $method, array $server, ?int $expectedSize): void {
+		$storage = $this->getMockBuilder(Local::class)
+			->onlyMethods(['writeStream'])
+			->setConstructorArgs([['datadir' => Server::get(ITempManager::class)->getTemporaryFolder()]])
+			->getMock();
+		Filesystem::mount($storage, [], $this->user . '/');
+
+		/** @var View&MockObject $view */
+		$view = $this->getMockBuilder(View::class)
+			->onlyMethods(['getRelativePath', 'resolvePath'])
+			->getMock();
+		$view->expects($this->atLeastOnce())
+			->method('resolvePath')
+			->willReturnCallback(fn ($path) => [$storage, $path]);
+		$view->expects($this->any())
+			->method('getRelativePath')
+			->willReturnArgument(0);
+
+		$receivedSize = false;
+		$storage->expects($this->once())
+			->method('writeStream')
+			->willReturnCallback(function (string $path, $stream, ?int $size = null) use (&$receivedSize): int {
+				$receivedSize = $size;
+				return (int)stream_copy_to_stream($stream, fopen('php://temp', 'r+'));
+			});
+
+		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
+			'permissions' => Constants::PERMISSION_ALL,
+			'type' => FileInfo::TYPE_FOLDER,
+		], null);
+
+		$request = new Request([
+			'server' => $server,
+			'method' => $method,
+		], $this->requestId, $this->config, null);
+
+		$file = new File($view, $info, null, $request);
+
+		try {
+			$file->put($this->getStream('test data'));
+		} catch (\Exception $e) {
+			// Whatever happens after the write - size checks, renaming the part file - is
+			// not what this test is about.
+		}
+
+		$this->assertSame($expectedSize, $receivedSize);
+	}
+
 	/**
 	 * Simulate putting a file to the given path.
 	 *


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/63504
* Related: https://github.com/nextcloud/server/issues/7995

## Summary

`File::put()` takes the expected write size from the request's `Content-Length`, but it is not reached only by `PUT`. The chunked upload assembly step is a `MOVE` (or `COPY`) of `<upload>/.file`: `Directory::moveInto()` and `Directory::copyInto()` only short-circuit `File` and `Directory` sources at storage level, so a `FutureFile` falls through to `Tree::copyNode()` → `Directory::createFile()` → `File::put()`. There the data is the `AssemblyStream` of the uploaded chunks and the request itself carries no body at all, so its `Content-Length` describes nothing relevant.

```php
$lengthHeader = $this->request->getHeader('content-length');
$expected = $lengthHeader !== '' ? (int)$lengthHeader : null;
...
$count = $partStorage->writeStream($internalPartPath, $wrappedData, $expected);
```

Clients that send `Content-Length: 0` on that request — Safari does, Chrome omits the header entirely — make `$expected` `0` instead of `null`. `ObjectStoreStorage::writeStream()` only measures the stream when it is given no size:

```php
public function writeStream(string $path, $stream, ?int $size = null): int {
	if ($size === null) {
		$stats = fstat($stream);
		...
```

so the `fstat()` fallback is skipped, `$stat['size']` becomes `0`, and the file is recorded as empty while the request still answers `201`. The upload looks successful and the file is silently empty.

The size comparison further down in the same method is *already* restricted to `PUT` for exactly this reason:

```php
if ($expected !== null
	&& $expected !== $count
	&& $this->request->getMethod() === 'PUT'
) {
```

This applies the same restriction when deriving the expected size in the first place. Because the guard is on the method rather than on the value, it covers the `COPY` variant as well as `MOVE` — a fix that special-cased a zero length, or only `MOVE`, would not.

Genuine empty `PUT` uploads are unaffected: the method is still `PUT`, so a `Content-Length` of `0` is passed through exactly as before.

## Scope

Object-storage primary storage is affected. `OC\Files\Storage\Local::writeStream()` ignores the `$size` argument entirely and just calls `file_put_contents()`, so local-storage installs should not be.

Methods that reach `File::put()`:

| method | reaches `put()` | data written | `Content-Length` meaningful |
|---|---|---|---|
| `PUT` | yes, `CorePlugin::httpPut` | the request body | yes |
| `MOVE` of `<upload>/.file` | yes | `AssemblyStream` | no |
| `COPY` of `<upload>/.file` | yes | `AssemblyStream` | no |
| `MOVE`/`COPY` of a normal file | no, handled at storage level | — | — |

## Testing

`FileTest::testPutExpectedSizeOnlyComesFromPutContentLength` covers the size handed to `writeStream()` for `PUT` (with a length, with `0`, and with the header absent) and for `MOVE`/`COPY` (with `0` and with a non-zero length).

Against `master` without the change, 4 of the 7 cases fail:

```
...FFFF                                                             7 / 7 (100%)

1) ... with data set "MOVE ignores a zero length" ('MOVE', ['0'], null)
Failed asserting that 0 is identical to null.
2) ... with data set "MOVE ignores a non-zero length" ('MOVE', ['9'], null)
Failed asserting that 9 is identical to null.
3) ... with data set "COPY ignores a zero length" ('COPY', ['0'], null)
Failed asserting that 0 is identical to null.
4) ... with data set "COPY ignores a non-zero length" ('COPY', ['9'], null)
Failed asserting that 9 is identical to null.

FAILURES!
Tests: 7, Assertions: 13, Failures: 4
```

With the change, `Tests: 7, Assertions: 21`, all passing.

Verified end to end as well, on 33.0.7 with nginx + php-fpm and S3 (MinIO) primary storage, using a 102 395 904 byte file in five chunks. Adding `Content-Length: 0` to the assembly request is the only variable that breaks it, for both `MOVE` and `COPY`, sequentially or in parallel.

## Optional hardening, not included here

@vpecinka independently diagnosed this in https://github.com/nextcloud/server/issues/7995#issuecomment-3739042747 and patched the storage layer instead, forcing `$size = null` in `ObjectStoreStorage::writeStream()` when a zero is announced for a stream that `fstat()` shows is larger. That defends against any other caller passing a bogus zero, which this change does not.

It is deliberately left out to keep this PR to the root cause; `writeStream()` putting the announced size straight into the filecache is arguably worth guarding on its own. Happy to add it here or as a separate PR if you would prefer it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting) (`php-cs-fixer` reports no changes for both files)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) — happy to request these, say which branches
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
