### PR TITLE
fix(navigation): Allow apps to hide registered navigation entries

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4080,6 +4080,11 @@
       <code><![CDATA[DEFAULT_TTL]]></code>
     </AmbiguousConstantInheritance>
   </file>
+  <file src="ocs/v1.php">
+    <InternalMethod>
+      <code><![CDATA[setup]]></code>
+    </InternalMethod>
+  </file>
   <file src="public.php">
     <DeprecatedMethod>
       <code><![CDATA[getAppValue]]></code>

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -57,7 +57,7 @@ class NavigationManager implements INavigationManager {
 	protected ?string $activeEntry = null;
 	/** @var array<string, NavigationEntryOutput> */
 	protected array $entries = [];
-	/** @var list<callable(): NavigationEntry> */
+	/** @var list<callable(): ?NavigationEntry> */
 	protected array $closureEntries = [];
 	/** User defined app order (cached for the `add` function) */
 	protected ?array $customAppOrder = null;
@@ -357,7 +357,12 @@ class NavigationManager implements INavigationManager {
 			// as apps might add new navigation entries via closures at any time
 			while ($c = array_pop($this->closureEntries)) {
 				try {
-					$this->add($c());
+					$entry = $c();
+					if ($entry === null) {
+						$this->logger->debug('Closure of navigation entry returned null, skipping');
+						continue;
+					}
+					$this->add($entry);
 				} catch (\Throwable $e) {
 					$this->logger->error('Failed to add navigation entry from closure', ['exception' => $e]);
 				}

--- a/lib/public/INavigationManager.php
+++ b/lib/public/INavigationManager.php
@@ -80,9 +80,9 @@ interface INavigationManager {
 	/**
 	 * Creates a new navigation entry
 	 *
-	 * @param NavigationEntry|callable():NavigationEntry $entry If a menu entry (type = 'link') is added, you shall also set app to the app that
-	 *                                                          added the entry. The use of a closure is preferred, because it will avoid loading
-	 *                                                          the routing of your app, unless required.
+	 * @param NavigationEntry|callable():?NavigationEntry $entry If a menu entry (type = 'link') is added, you shall also set app to the app that
+	 *                                                           added the entry. The use of a closure is preferred, because it will avoid loading
+	 *                                                           the routing of your app, unless required.
 	 * @return void
 	 * @since 6.0.0
 	 */

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -79,6 +79,10 @@ require_once __DIR__ . '/../lib/OC.php';
 			$appManager->loadApps(['core']);
 		}
 
+		// All apps are now loaded to handle the request
+		Server::get(\OC\NavigationManager::class)->setup();
+		Server::get(\OCP\EventDispatcher\IEventDispatcher::class)->dispatchTyped(new \OCP\App\Events\AppsLoadedEvent());
+
 		Server::get(Router::class)->match('/ocsapp' . $request->getRawPathInfo());
 	} catch (MaxDelayReached $ex) {
 		ApiHelper::respond(Http::STATUS_TOO_MANY_REQUESTS, $ex->getMessage());

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -173,6 +173,36 @@ class NavigationManagerTest extends TestCase {
 		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists after clear()');
 	}
 
+	/**
+	 * Entry points that never call setup() (e.g. the OCS dispatch in ocs/v1.php)
+	 * must not silently lose closure-registered entries such as an app's nav
+	 * link: getAll() should only resolve what it can, not resolve nothing.
+	 */
+	public function testGetAllDoesNotResolveClosureBeforeSetup(): void {
+		$numberOfCalls = 0;
+		$this->navigationManager->add(function () use (&$numberOfCalls) {
+			$numberOfCalls++;
+
+			return [
+				'id' => 'entry id',
+				'name' => 'link text',
+				'order' => 1,
+				'href' => 'url',
+			];
+		});
+
+		$navigationEntries = $this->navigationManager->getAll('all');
+
+		$this->assertEquals(0, $numberOfCalls, 'Expected that the closure is not called by getAll() before setup()');
+		$this->assertEmpty($navigationEntries, 'Expected no navigation entry exists before setup()');
+
+		$this->navigationManager->setup();
+		$navigationEntries = $this->navigationManager->getAll('all');
+
+		$this->assertEquals(1, $numberOfCalls, 'Expected that the closure is called by getAll() once setup() has run');
+		$this->assertArrayHasKey('entry id', $navigationEntries);
+	}
+
 	public function testAddClosureAfterSetup(): void {
 		$this->navigationManager->setup();
 		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists');


### PR DESCRIPTION
- Since https://github.com/nextcloud/server/pull/63134 Talk's Psalm CI is red:
```
Error: lib/AppInfo/Application.php:423:27: InvalidArgument: Argument 1 of OCP\INavigationManager::add expects
array{app?: string, classes?: string, color?: string, href: string, icon?: string, id: string, name: string, order: int, type?: 'action'|'link'|'settings'}|callable():array{app?: string, classes?: string, color?: string, href: string, icon?: string, id: string, name: string, order: int, type?: 'action'|'link'|'settings'}
, but impure-Closure():
array{href: non-empty-string, icon: string, id: 'spreed', name: non-empty-string, order: -5, type: 'hidden'|'link'}
provided
```
- This "workaround" was used since Feb 2019
- If we don't want this as general behaviour as it requires to still generate a valid entry, we should find another way to allow this (e.g. returning null from the closure or something like that)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
