### PR TITLE
fix(core): resolve closure-registered nav entries in OCS requests

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use OC\NavigationManager;
 use OC\OCS\ApiHelper;
 use OC\Route\Router;
 use OC\SystemConfig;
@@ -78,6 +79,10 @@ require_once __DIR__ . '/../lib/OC.php';
 		} else {
 			$appManager->loadApps(['core']);
 		}
+
+		// All apps are now loaded to handle the request, resolve their navigation entries
+		// (index.php does this via OC::handleRequest(), which this OCS dispatch bypasses)
+		Server::get(NavigationManager::class)->setup();
 
 		Server::get(Router::class)->match('/ocsapp' . $request->getRawPathInfo());
 	} catch (MaxDelayReached $ex) {

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -173,6 +173,36 @@ class NavigationManagerTest extends TestCase {
 		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists after clear()');
 	}
 
+	/**
+	 * Entry points that never call setup() (e.g. the OCS dispatch in ocs/v1.php)
+	 * must not silently lose closure-registered entries such as an app's nav
+	 * link: getAll() should only resolve what it can, not resolve nothing.
+	 */
+	public function testGetAllDoesNotResolveClosureBeforeSetup(): void {
+		$numberOfCalls = 0;
+		$this->navigationManager->add(function () use (&$numberOfCalls) {
+			$numberOfCalls++;
+
+			return [
+				'id' => 'entry id',
+				'name' => 'link text',
+				'order' => 1,
+				'href' => 'url',
+			];
+		});
+
+		$navigationEntries = $this->navigationManager->getAll('all');
+
+		$this->assertEquals(0, $numberOfCalls, 'Expected that the closure is not called by getAll() before setup()');
+		$this->assertEmpty($navigationEntries, 'Expected no navigation entry exists before setup()');
+
+		$this->navigationManager->setup();
+		$navigationEntries = $this->navigationManager->getAll('all');
+
+		$this->assertEquals(1, $numberOfCalls, 'Expected that the closure is called by getAll() once setup() has run');
+		$this->assertArrayHasKey('entry id', $navigationEntries);
+	}
+
 	public function testAddClosureAfterSetup(): void {
 		$this->navigationManager->setup();
 		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/spreed/issues/19082

## Summary

In Nextcloud 34 ad older, single method `init()` was responsible for resolving entries. It was split in commit bd7fc29d578 into `setup()` and `resolveAppNavigationEntries()`. setup part was called in index.php, but never in ocs/v1.php, so OCS API requests were missing 'closure-' apps, but it was still rendered in navigation.

B | A
-- | --
<img width="417" height="178" alt="image" src="https://github.com/user-attachments/assets/61fc63d1-c2a2-41f5-aea3-39539d60291b" /> | <img width="405" height="205" alt="image" src="https://github.com/user-attachments/assets/669c09ec-f10f-427a-952a-e0ab1fafca5d" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
