### PR TITLE
fix(db): reject invalid and duplicate migration identifiers

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -198,17 +198,32 @@ class MigrationService {
 	}
 
 	protected function sortMigrations(string $a, string $b): int {
-		preg_match('/(\d+)Date(\d+)/', basename($a), $matchA);
-		preg_match('/(\d+)Date(\d+)/', basename($b), $matchB);
-		if (!empty($matchA) && !empty($matchB)) {
-			$versionA = (int)$matchA[1];
-			$versionB = (int)$matchB[1];
-			if ($versionA !== $versionB) {
-				return ($versionA < $versionB) ? -1 : 1;
-			}
-			return strnatcmp($matchA[2], $matchB[2]);
+		[$versionA, $dateA] = $this->parseMigrationVersion($a);
+		[$versionB, $dateB] = $this->parseMigrationVersion($b);
+
+		if ($versionA !== $versionB) {
+			return $versionA <=> $versionB;
 		}
-		return strnatcmp(basename($a), basename($b));
+
+		return strcmp($dateA, $dateB);
+	}
+
+	/**
+	 * @return array{int, string}
+	 */
+	private function parseMigrationVersion(string $value): array {
+		$name = basename($value);
+
+		if (preg_match('/^Version(\d{1,16})Date(\d{14})\.php$/', $name, $matches) !== 1
+			&& preg_match('/^(\d{1,16})Date(\d{14})$/', $name, $matches) !== 1
+		) {
+			throw new \InvalidArgumentException(
+				'Invalid migration version "' . $value . '" for app "' . $this->getApp()
+				. '". Expected "<version>Date<YYYYMMDDHHMMSS>".'
+			);
+		}
+
+		return [(int)$matches[1], $matches[2]];
 	}
 
 	/**
@@ -232,6 +247,7 @@ class MigrationService {
 		usort($files, $this->sortMigrations(...));
 
 		$migrations = [];
+		$migrationFiles = [];
 
 		foreach ($files as $file) {
 			$className = basename($file, '.php');
@@ -241,6 +257,14 @@ class MigrationService {
 					"Cannot load a migrations with the name '$version' because it is a reserved number"
 				);
 			}
+			if (isset($migrationFiles[$version])) {
+				throw new \InvalidArgumentException(
+					"Cannot load migration '$version' for app '{$this->appName}' because it is defined by both "
+					. "'{$migrationFiles[$version]}' and '$file'"
+				);
+			}
+
+			$migrationFiles[$version] = $file;
 			$migrations[$version] = sprintf('%s\\%s', $this->migrationsNamespace, $className);
 		}
 

--- a/tests/lib/DB/MigrationServiceTest.php
+++ b/tests/lib/DB/MigrationServiceTest.php
@@ -21,6 +21,7 @@ use OC\DB\MigrationService;
 use OC\DB\SchemaWrapper;
 use OCP\App\AppPathNotFoundException;
 use OCP\IDBConnection;
+use OCP\ITempManager;
 use OCP\Migration\IMigrationStep;
 use OCP\Server;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -67,6 +68,30 @@ class MigrationServiceTest extends \Test\TestCase {
 		$this->assertEquals(\OC::$SERVERROOT . '/core/Migrations', $migrationService->getMigrationsDirectory());
 		$this->assertEquals('OC\Core\Migrations', $migrationService->getMigrationsNamespace());
 		$this->assertEquals('test_oc_migrations', $migrationService->getMigrationsTableName());
+	}
+
+	public static function dataInvalidMigrationFileName(): array {
+		return [
+			'missing version' => ['VersionDate20200819121721.php'],
+			'non-numeric version' => ['VersionFooDate20200819121721.php'],
+			'invalid separator' => ['Version10000Data20200819121721.php'],
+			'short timestamp' => ['Version10000Date2020081912172.php'],
+			'non-numeric timestamp' => ['Version10000Date2020081912172A.php'],
+			'unexpected suffix' => ['Version10000Date20200819121721Extra.php'],
+		];
+	}
+
+	#[DataProvider('dataInvalidMigrationFileName')]
+	public function testGetAvailableVersionsRejectsInvalidIdentifier(string $fileName): void {
+		$directory = Server::get(ITempManager::class)->getTemporaryFolder();
+		self::assertNotFalse(\touch($directory . '/' . $fileName));
+
+		$migrationService = $this->createMigrationServiceForDirectory($directory);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage($fileName);
+
+		$migrationService->getAvailableVersions();
 	}
 
 	public function testExecuteUnknownStep(): void {

--- a/tests/lib/DB/MigrationServiceTest.php
+++ b/tests/lib/DB/MigrationServiceTest.php
@@ -277,22 +277,8 @@ class MigrationServiceTest extends \Test\TestCase {
 	public function testGetMigratedVersionsSortsByVersionThenDate(): void {
 		/** @var Connection $db */
 		$db = Server::get(IDBConnection::class);
-		$appId = 'migration_sort_' . bin2hex(random_bytes(8));
-
-		$migrationService = new class('testing', $db, $appId) extends MigrationService {
-			public function __construct(
-				string $appName,
-				Connection $connection,
-				private string $migrationApp,
-			) {
-				parent::__construct($appName, $connection);
-			}
-
-			#[\Override]
-			public function getApp(): string {
-				return $this->migrationApp;
-			}
-		};
+		$appId = 'migration_sort_' . \bin2hex(\random_bytes(8));
+		$migrationService = $this->createMigrationServiceForApp($db, $appId);
 
 		// Ensure the migrations table exists before inserting the fixtures.
 		self::assertSame([], $migrationService->getMigratedVersions());
@@ -319,13 +305,35 @@ class MigrationServiceTest extends \Test\TestCase {
 				'20000Date20240718031959',
 			], $migrationService->getMigratedVersions());
 		} finally {
-			$qb = $db->getQueryBuilder();
-			$qb->delete('migrations')
-				->where($qb->expr()->eq(
-					'app',
-					$qb->createNamedParameter($appId),
-				))
-				->executeStatement();
+			$this->deleteMigrationVersions($db, $appId);
+		}
+	}
+
+	#[Group('DB')]
+	public function testGetMigratedVersionsRejectsInvalidIdentifier(): void {
+		/** @var Connection $db */
+		$db = Server::get(IDBConnection::class);
+		$appId = 'migration_invalid_' . \bin2hex(\random_bytes(8));
+		$migrationService = $this->createMigrationServiceForApp($db, $appId);
+
+		// Ensure the migrations table exists before inserting the fixture.
+		self::assertSame([], $migrationService->getMigratedVersions());
+
+		$invalidVersion = '10000Data20200819121721';
+
+		try {
+			$db->insertIfNotExist('*PREFIX*migrations', [
+				'app' => $appId,
+				'version' => $invalidVersion,
+			]);
+
+			$migrationService->getMigratedVersions();
+			self::fail('Expected an invalid stored migration identifier to be rejected');
+		} catch (\InvalidArgumentException $e) {
+			self::assertStringContainsString($invalidVersion, $e->getMessage());
+			self::assertStringContainsString($appId, $e->getMessage());
+		} finally {
+			$this->deleteMigrationVersions($db, $appId);
 		}
 	}
 
@@ -1073,5 +1081,47 @@ class MigrationServiceTest extends \Test\TestCase {
 			->willReturn(false);
 
 		$this->migrationService->ensureOracleConstraints($sourceSchema, $schema);
+	}
+
+	private function createMigrationServiceForDirectory(string $directory): MigrationService {
+		$migrationService = new MigrationService('testing', $this->db);
+
+		$property = new \ReflectionProperty(
+			MigrationService::class,
+			'migrationsPath',
+		);
+		$property->setValue($migrationService, $directory);
+
+		return $migrationService;
+	}
+
+	private function createMigrationServiceForApp(
+		Connection $db,
+		string $appId,
+	): MigrationService {
+		return new class('testing', $db, $appId) extends MigrationService {
+			public function __construct(
+				string $appName,
+				Connection $connection,
+				private string $migrationApp,
+			) {
+				parent::__construct($appName, $connection);
+			}
+
+			#[\Override]
+			public function getApp(): string {
+				return $this->migrationApp;
+			}
+		};
+	}
+
+	private function deleteMigrationVersions(Connection $db, string $appId): void {
+		$qb = $db->getQueryBuilder();
+		$qb->delete('migrations')
+			->where($qb->expr()->eq(
+				'app',
+				$qb->createNamedParameter($appId),
+			))
+			->executeStatement();
 	}
 }

--- a/tests/lib/DB/MigrationServiceTest.php
+++ b/tests/lib/DB/MigrationServiceTest.php
@@ -94,6 +94,36 @@ class MigrationServiceTest extends \Test\TestCase {
 		$migrationService->getAvailableVersions();
 	}
 
+	public function testGetAvailableVersionsRejectsDuplicateIdentifiers(): void {
+		$directory = Server::get(ITempManager::class)->getTemporaryFolder();
+		$firstDirectory = $directory . '/first';
+		$secondDirectory = $directory . '/second';
+
+		self::assertTrue(\mkdir($firstDirectory));
+		self::assertTrue(\mkdir($secondDirectory));
+
+		$fileName = 'Version10000Date20200819121721.php';
+		$firstFile = $firstDirectory . '/' . $fileName;
+		$secondFile = $secondDirectory . '/' . $fileName;
+
+		self::assertNotFalse(\touch($firstFile));
+		self::assertNotFalse(\touch($secondFile));
+
+		$migrationService = $this->createMigrationServiceForDirectory($directory);
+
+		try {
+			$migrationService->getAvailableVersions();
+			self::fail('Expected duplicate migration identifiers to be rejected');
+		} catch (\InvalidArgumentException $e) {
+			self::assertStringContainsString(
+				'10000Date20200819121721',
+				$e->getMessage(),
+			);
+			self::assertStringContainsString($firstFile, $e->getMessage());
+			self::assertStringContainsString($secondFile, $e->getMessage());
+		}
+	}
+
 	public function testExecuteUnknownStep(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Version 20170130180000 is unknown.');

--- a/tests/lib/DB/MigrationServiceTest.php
+++ b/tests/lib/DB/MigrationServiceTest.php
@@ -380,6 +380,24 @@ class MigrationServiceTest extends \Test\TestCase {
 		], $calls);
 	}
 
+	public function testMigrateRejectsInvalidTargetIdentifier(): void {
+		$migrationService = $this->getMockBuilder(MigrationService::class)
+			->onlyMethods(['getMigratedVersions', 'findMigrations', 'executeStep'])
+			->setConstructorArgs(['testing', $this->db])
+			->getMock();
+
+		$migrationService->method('getMigratedVersions')->willReturn([]);
+		$migrationService->method('findMigrations')->willReturn([
+			'10000Date20200819121721' => 'A',
+		]);
+		$migrationService->expects(self::never())->method('executeStep');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('invalid-target');
+
+		$migrationService->migrate('invalid-target');
+	}
+
 	#[DataProvider('dataEnsureNamingConstraintsTableName')]
 	public function testEnsureNamingConstraintsTableName(string $name, int $prefixLength, bool $tableExists, bool $throws): void {
 		if ($throws) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This hardens migrations by preventing invalid or duplicate migration identifiers from producing an incorrect or ambiguous migration order.

Specifically:

- Migration ordering depends on the documented `<version>Date<YYYYMMDDHHMMSS>` identifier format.
- The parser accepts partial or malformed identifiers and otherwise falls back to natural string sorting.
- Recursive migration discovery can silently overwrite one file (migration) when multiple files use the same identifier across subdirectories.

Changes:

- Validate migration names against the supported version and timestamp format.
- Reject overlapping identifiers discovered in multiple migration files instead of silently overwriting one of them.
- Add test coverage for malformed filenames, stored identifiers, explicit targets, and duplicates.

## TODO

- [ ] Backport?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
