### PR TITLE
docs(config): clarify forwarded_for_headers configuration

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2679,16 +2679,26 @@ $CONFIG = [
 	'trusted_proxies' => ['203.0.113.45', '198.51.100.128', '192.168.2.0/24'],
 
 	/**
-	 * Headers trusted as containing the client IP address when used with
-	 * ``trusted_proxies``. For example, use ``HTTP_X_FORWARDED_FOR`` for the
-	 * ``X-Forwarded-For`` header.
+	 * HTTP header keys containing the original client IP address as provided by a
+	 * trusted reverse proxy.
 	 *
-	 * Incorrect configuration allows clients to spoof their IP address, bypassing
-	 * access controls and rendering logs unreliable.
+	 * This setting is used only when the request originates from an address listed in
+	 * ``trusted_proxies``. The de facto standard ``X-Forwarded-For`` header, exposed
+	 * as ``HTTP_X_FORWARDED_FOR``, is Nextcloud's default, so this setting often does
+	 * not need to be configured. See
+	 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For
+	 * for details.
 	 *
-	 * Defaults to ``['HTTP_X_FORWARDED_FOR']``
+	 * Only add headers that are set or sanitized by a trusted proxy. Incorrect
+	 * configuration allows clients to spoof their IP address, bypass access
+	 * controls, and make logs unreliable.
+	 *
+	 * Header values may contain a comma-separated list of IP addresses. The
+	 * rightmost non-proxy address is used.
+	 *
+	 * Defaults to ``['HTTP_X_FORWARDED_FOR']``.
 	 */
-	'forwarded_for_headers' => ['HTTP_X_FORWARDED', 'HTTP_FORWARDED_FOR'],
+	'forwarded_for_headers' => ['HTTP_X_FORWARDED_FOR'],
 
 	/**
 	 * List of trusted IP ranges for admin actions. If non-empty, all admin actions


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

- Correct the `forwarded_for_headers` example to use `HTTP_X_FORWARDED_FOR` and remove the confusing references to `HTTP_X_FORWARDED` and `HTTP_FORWARDED_FOR`
- Note that the default `HTTP_X_FORWARDED_FOR` configuration is suitable for many environments and may not need to be changed
- Document the trusted-proxy security requirements and comma-separated address handling
- Link to the `X-Forwarded-For` header reference

Came up due to some confusion on the forum, since a quick scan of the entry could lead one to believe the examples are valid headers/header keys (they aren't): https://help.nextcloud.com/t/administration-settings-not-showing-via-an-https-connection/248505

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
