### PR TITLE
fix(db): correct and clarify `migrations:migrate` command help

### DIFF
--- a/core/Command/Db/Migrations/MigrateCommand.php
+++ b/core/Command/Db/Migrations/MigrateCommand.php
@@ -28,12 +28,21 @@ class MigrateCommand extends Command implements CompletionAwareInterface {
 	}
 
 	#[\Override]
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('migrations:migrate')
-			->setDescription('Execute a migration to a specified version or the latest available version.')
-			->addArgument('app', InputArgument::REQUIRED, 'Name of the app this migration command shall work on')
-			->addArgument('version', InputArgument::OPTIONAL, 'The version number (YYYYMMDDHHMMSS) or alias (first, prev, next, latest) to migrate to.', 'latest');
+			->setDescription('Run pending database migrations for an app up to a specified migration ID or the latest available migration.')
+			->addArgument(
+				'app',
+				InputArgument::REQUIRED,
+				'The app whose database migrations should be run'
+			)
+			->addArgument(
+				'version',
+				InputArgument::OPTIONAL,
+				'Target migration ID (e.g. 2404Date20220903071748) or latest.',
+				'latest'
+			);
 
 		parent::configure();
 	}
@@ -54,7 +63,7 @@ class MigrateCommand extends Command implements CompletionAwareInterface {
 	 * @return string[]
 	 */
 	#[\Override]
-	public function completeOptionValues($optionName, CompletionContext $context) {
+	public function completeOptionValues($optionName, CompletionContext $context): array {
 		return [];
 	}
 
@@ -64,7 +73,7 @@ class MigrateCommand extends Command implements CompletionAwareInterface {
 	 * @return string[]
 	 */
 	#[\Override]
-	public function completeArgumentValues($argumentName, CompletionContext $context) {
+	public function completeArgumentValues($argumentName, CompletionContext $context): array {
 		if ($argumentName === 'app') {
 			$allApps = $this->appManager->getAllAppsInAppsFolders();
 			return array_diff($allApps, $this->appManager->getEnabledApps());
@@ -76,7 +85,7 @@ class MigrateCommand extends Command implements CompletionAwareInterface {
 			$ms = new MigrationService($appName, $this->connection);
 			$migrations = $ms->getAvailableVersions();
 
-			array_unshift($migrations, 'next', 'latest');
+			array_unshift($migrations, 'latest');
 			return $migrations;
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

While updating the developer documentation, I noticed that this command’s help text was inaccurate.

This updates the `migrations:migrate` command help text to make it clearer and more precise.

Changes:

- Remove unsupported aliases (from help and autocomplete).
- Correct the migration ID format.
- Improve the wording for clarity and precision.
- Add explicit return types to the command configuration and completion methods.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
