### PR TITLE
fix(db): report accurate migration status counts

### DIFF
--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -85,10 +85,11 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 	public function getMigrationsInfos(MigrationService $ms) {
 		$executedMigrations = $ms->getMigratedVersions();
 		$availableMigrations = $ms->getAvailableVersions();
-		$executedUnavailableMigrations = array_diff($executedMigrations, array_keys($availableMigrations));
+		$executedUnavailableMigrations = array_diff($executedMigrations, $availableMigrations);
 
 		$numExecutedUnavailableMigrations = count($executedUnavailableMigrations);
-		$numNewMigrations = count(array_diff(array_keys($availableMigrations), $executedMigrations));
+		$numNewMigrations = count(array_diff($availableMigrations, $executedMigrations));
+	
 		$pending = $ms->describeMigrationStep();
 
 		$infos = [

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -89,7 +89,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 
 		$numExecutedUnavailableMigrations = count($executedUnavailableMigrations);
 		$numNewMigrations = count(array_diff($availableMigrations, $executedMigrations));
-	
+
 		$pending = $ms->describeMigrationStep();
 
 		$infos = [


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

`getAvailableVersions()` returns a list of version strings, so `array_keys()` here produces `0, 1, 2, ...`, not migration identifiers. The code then compares executed version names such as `Version31000Date...` against numeric indexes. 

The "Executed Unavailable Migrations" and "New Migrations" calculations are therefore basically always wrong.

Before:
```console
www-data@7851fbf10178:~/html/core/Command/Db$ NC_debug=true  ../../../occ migrations:status activity
    >> App:                                                activity
    >> Version Table Name:                                 oc_migrations
    >> Migrations Namespace:                               OCA\Activity\Migration
    >> Migrations Directory:                               /var/www/html/apps/activity/lib/Migration
    >> Previous Version:                                   2011Date20201207091915
    >> Current Version:                                    8000Date20260603120000
    >> Next Version:                                       Already at latest migration step
    >> Latest Version:                                     8000Date20260603120000
    >> Executed Migrations:                                12
    >> Executed Unavailable Migrations:                    12
    >> Available Migrations:                               12
    >> New Migrations:                                     12
    >> Pending Migrations:                                 None
www-data@7851fbf10178:~/html/core/Command/Db$ 
```

After:
```console
www-data@7851fbf10178:~/html/core/Command/Db$ NC_debug=true  ../../../occ migrations:status activity
    >> App:                                                activity
    >> Version Table Name:                                 oc_migrations
    >> Migrations Namespace:                               OCA\Activity\Migration
    >> Migrations Directory:                               /var/www/html/apps/activity/lib/Migration
    >> Previous Version:                                   2011Date20201207091915
    >> Current Version:                                    8000Date20260603120000
    >> Next Version:                                       Already at latest migration step
    >> Latest Version:                                     8000Date20260603120000
    >> Executed Migrations:                                12
    >> Executed Unavailable Migrations:                    0
    >> Available Migrations:                               12
    >> New Migrations:                                     0
    >> Pending Migrations:                                 None
```

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
