### PR TITLE
fix(AppMenuItem): Don't bold active label

### DIFF
--- a/core/src/components/AppMenuItem.vue
+++ b/core/src/components/AppMenuItem.vue
@@ -56,7 +56,6 @@ const unreadLabel = computed(() => {
 		:is="app.href ? 'a' : 'button'"
 		class="app-item"
 		:class="{
-			'app-item--active': app.active,
 			'app-item--compact': compact,
 			'app-item--outlined': outlined,
 		}"
@@ -146,10 +145,6 @@ const unreadLabel = computed(() => {
 		max-width: 100%;
 		letter-spacing: -0.3px;
 		padding-inline: var(--default-grid-baseline);
-	}
-
-	&--active &__label {
-		font-weight: bold;
 	}
 
 	// Utility entries ("More apps", "App store") are subdued, they are not apps.


### PR DESCRIPTION
## Summary

Don't bold the label of the active item in the app menu, since this can shift the layout around in ugly ways. For example, before:

<img width="68" height="113" alt="image" src="https://github.com/user-attachments/assets/b7ae7817-1ddd-4147-8021-5823d0c5d2ef" />

After:

<img width="70" height="97" alt="image" src="https://github.com/user-attachments/assets/479fff96-31e6-4366-8adc-1ae27006aa08" />

And the selected app is indicated in the top bar and tab title anyway.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

I wasn't able to actually test the code for unrelated reasons, but I hope this is correct.

cc @pringelmann 