### PR TITLE
fix: Check that password matches in occ user:auth-tokens:add

### DIFF
--- a/core/Command/User/AuthTokens/Add.php
+++ b/core/Command/User/AuthTokens/Add.php
@@ -12,8 +12,8 @@ namespace OC\Core\Command\User\AuthTokens;
 use OC\Authentication\Events\AppPasswordCreatedEvent;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
+use OC\User\Manager as UserManager;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -25,8 +25,8 @@ use Symfony\Component\Console\Question\Question;
 
 class Add extends Command {
 	public function __construct(
-		protected IUserManager $userManager,
-		protected IProvider $tokenProvider,
+		private UserManager $userManager,
+		private IProvider $tokenProvider,
 		private ISecureRandom $random,
 		private IEventDispatcher $eventDispatcher,
 	) {
@@ -92,11 +92,20 @@ class Add extends Command {
 			$password = $helper->ask($input, $output, $question);
 		}
 
+		$loginName = $input->getOption('login-name') ?? $user->getUID();
+
 		if ($password === null) {
 			$output->writeln('<info>No password provided. The generated app password will therefore have limited capabilities. Any operation that requires the login password will fail.</info>');
+		} else {
+			$loggedInUser = $this->userManager->checkPasswordNoLogging($loginName, $password);
+			if ($loggedInUser === false) {
+				$output->writeln('<error>The given password is invalid for login ' . $loginName . '</error>');
+				return self::FAILURE;
+			} elseif ($loggedInUser->getUID() !== $user->getUID()) {
+				$output->writeln('<error>The user ' . $username . ' does not match the given login ' . $loginName . '</error>');
+				return self::FAILURE;
+			}
 		}
-
-		$loginName = $input->getOption('login-name') ?? $user->getUID();
 
 		$tokenName = $input->getOption('name') ?: 'cli';
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/56412

## Summary

Otherwise you could create tokens containing an invalid password, which was confusing.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
