### PR TITLE
fix(files_external): guard optional S3 key in storage id computation

### DIFF
--- a/apps/files_external/tests/Storage/Amazons3IdTest.php
+++ b/apps/files_external/tests/Storage/Amazons3IdTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_External\Tests\Storage;
+
+use OCA\Files_External\Lib\Storage\AmazonS3;
+use Test\TestCase;
+
+/**
+ * Regression test for the storage id computation in AmazonS3::__construct().
+ *
+ * Constructs the storage directly (no live S3 backend) to exercise only the id
+ * derivation, which runs unconditionally in the constructor.
+ */
+#[\PHPUnit\Framework\Attributes\Group('S3')]
+class Amazons3IdTest extends TestCase {
+	/**
+	 * Mounts authenticating via the AWS SDK default credential chain (env, EC2
+	 * instance profile, ECS task role) carry no static `key` param. The id must
+	 * still be derivable without emitting an "Undefined array key" warning
+	 * (PHPUnit fails the test on any emitted warning).
+	 */
+	public function testConstructWithoutKey(): void {
+		$storage = new AmazonS3(['bucket' => 'test-bucket']);
+		$this->assertNotEmpty($storage->getId());
+	}
+}

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -64,6 +64,7 @@ trait S3ConnectionTrait {
 		$this->retriesMaxAttempts = $params['retriesMaxAttempts'] ?? 5;
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.' . $params['region'] . '.amazonaws.com' : $params['hostname'];
+		$params['key'] = $params['key'] ?? '';
 		$params['s3-accelerate'] = $params['hostname'] === 's3-accelerate.amazonaws.com' || $params['hostname'] === 's3-accelerate.dualstack.amazonaws.com';
 		if (!isset($params['port']) || $params['port'] === '') {
 			$params['port'] = (isset($params['use_ssl']) && $params['use_ssl'] === false) ? 80 : 443;


### PR DESCRIPTION
* Resolves: #63564
* Resolves #46400
* Resolves #56279

## Summary

S3 external mounts that authenticate via the AWS SDK default credential chain (env vars, EC2 instance profile, ECS task role) carry no static `key` param. `AmazonS3::__construct()` read `$this->params['key']` unconditionally when deriving the storage id, emitting an "Undefined array key" warning on every storage construction for such mounts.

Guard the access with `?? ''`. This aligns the id computation with `paramCredentialProvider()`, which already treats `key` as optional and falls through to the SDK default provider chain when it is absent. The value only feeds an md5() hash, so keyless mounts keep a stable id.

I think this is a backport candidate.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
  - N/A — no front-end changes.
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
