### PR TITLE
feat(db): improve migration status reporting

### DIFF
--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -124,6 +124,10 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 
 		$numExecutedUnavailableMigrations = count($executedUnavailableMigrations);
 		$numNewMigrations = count(array_diff(array_keys($availableMigrations), $executedMigrations));
+		$currentMigration = $executedMigrations === []
+			? null
+			: end($executedMigrations);
+
 		$pending = $ms->describeMigrationStep();
 
 		$infos = [
@@ -131,10 +135,21 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 			'History Table' => $ms->getMigrationsTableName(),
 			'Migration Namespace' => $ms->getMigrationsNamespace(),
 			'Migration Directory' => $ms->getMigrationsDirectory(),
-			'Previous Available' => $this->getFormattedVersionAlias($ms, 'prev'),
-			'Last Recorded as Executed' => $this->getFormattedVersionAlias($ms, 'current'),
-			'Next Available' => $this->getFormattedVersionAlias($ms, 'next'),
-			'Latest Available' => $this->getFormattedVersionAlias($ms, 'latest'),
+			'Previous Available' => $this->getFormattedRelativeVersion(
+				$availableMigrations,
+				$currentMigration,
+				-1,
+			),
+			'Last Recorded as Executed' => $currentMigration
+				?? 'None (no migrations recorded as executed)',
+			'Next Available' => $this->getFormattedRelativeVersion(
+				$availableMigrations,
+				$currentMigration,
+				1,
+			),
+			'Latest Available' => $availableMigrations === []
+				? 'None (no migration files found)'
+				: end($availableMigrations),
 			'Recorded as Executed' => count($executedMigrations),
 			'Missing from Installed Code' => $numExecutedUnavailableMigrations,
 			'Available in Installed Code' => count($availableMigrations),
@@ -146,23 +161,40 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 	}
 
 	/**
-	 * @param MigrationService $migrationService
-	 * @param string $alias
-	 * @return mixed|null|string
+	 * @param list<string> $availableMigrations
 	 */
-	private function getFormattedVersionAlias(MigrationService $migrationService, $alias) {
-		$migration = $migrationService->getMigration($alias);
-		//No version found
-		if ($migration === null) {
-			if ($alias === 'next') {
-				return 'Already at latest migration step';
+	private function getFormattedRelativeVersion(
+		array $availableMigrations,
+		?string $currentMigration,
+		int $offset,
+	): string {
+		if ($currentMigration === null) {
+			if ($offset < 0) {
+				return 'None (no migrations recorded as executed)';
 			}
 
-			if ($alias === 'prev') {
-				return 'Already at first migration step';
-			}
+			return $availableMigrations === []
+				? 'None (no migration files found)'
+				: $availableMigrations[0];
 		}
 
-		return $migration;
+		$currentIndex = array_search(
+			$currentMigration,
+			$availableMigrations,
+			true,
+		);
+
+		if ($currentIndex === false) {
+			return 'Unknown (last executed migration is missing from code)';
+		}
+
+		$relativeIndex = $currentIndex + $offset;
+		if (!isset($availableMigrations[$relativeIndex])) {
+			return $offset < 0
+				? 'None (at first available migration)'
+				: 'None (at latest available migration)';
+		}
+
+		return $availableMigrations[$relativeIndex];
 	}
 }

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -41,6 +41,25 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 
 		$infos = $this->getMigrationsInfos($ms);
+		$title = sprintf('Database migration status for "%s"', $infos['App']);
+		$output->writeln($title);
+		$output->writeln(str_repeat('=', strlen($title)));
+		$output->writeln('');
+
+		if ($infos['Missing from Installed Code'] > 0) {
+			$output->writeln(
+				'<error>Status: Warning — migration history references migrations missing from installed code</error>',
+			);
+		} elseif ($infos['Unapplied'] > 0) {
+			$output->writeln(sprintf(
+				'<comment>Status: %d unapplied migration%s</comment>',
+				$infos['Unapplied'],
+				$infos['Unapplied'] === 1 ? '' : 's',
+			));
+		} else {
+			$output->writeln('<info>Status: Up to date</info>');
+		}
+		$output->writeln('');
 
 		$sections = [
 			'Migration configuration' => [

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -88,7 +88,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 
 			$values = [];
 			foreach ($keys as $key) {
-				values[$key] = $infos[$key];
+				$values[$key] = $infos[$key];
 			}
 			$this->writeKeyValueRows($output, $values);
 

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -86,9 +86,11 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 			$output->writeln($section);
 			$output->writeln(str_repeat('-', strlen($section)));
 
+			$values = [];
 			foreach ($keys as $key) {
-				$output->writeln("$key: " . str_repeat(' ', 34 - strlen($key)) . $infos[$key]);
+				values[$key] = $infos[$key];
 			}
+			$this->writeKeyValueRows($output, $values);
 
 			$output->writeln('');
 		}
@@ -100,15 +102,43 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 		if ($unappliedMigrations === []) {
 			$output->writeln('None');
 		} else {
+			$first = true;
 			foreach ($unappliedMigrations as $version => $migration) {
+				if (!$first) {
+					$output->writeln('');
+				}
+
 				$output->writeln($version);
-				$output->writeln('  Name: ' . $migration['Name']);
-				$output->writeln('  Description: ' . $migration['Description']);
-				$output->writeln('');
+				$this->writeKeyValueRows($output, $migration, 2);
+				$first = false;
 			}
 		}
 	
 		return 0;
+	}
+
+	/**
+	 * @param array<string, scalar|null> $values
+	 */
+	private function writeKeyValueRows(
+		OutputInterface $output,
+		array $values,
+		int $indent = 0,
+	): void {
+		$labelWidth = max(array_map(
+			static fn (string $label): int => strlen($label) + 1,
+			array_keys($values),
+		));
+		$prefix = str_repeat(' ', $indent);
+
+		foreach ($values as $label => $value) {
+			$output->writeln(sprintf(
+				'%s%-' . $labelWidth . 's  %s',
+				$prefix,
+				$label . ':',
+				$value,
+			));
+		}
 	}
 
 	/**

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -31,8 +31,33 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 	protected function configure() {
 		$this
 			->setName('migrations:status')
-			->setDescription('View the status of a set of migrations.')
-			->addArgument('app', InputArgument::REQUIRED, 'Name of the app this migration command shall work on');
+			->setDescription('Show the database migration status for an app')
+			->addArgument(
+				'app',
+				InputArgument::REQUIRED,
+				'App ID to inspect, or "core" for server migrations',
+			)
+			->setHelp(<<<'HELP'
+The <info>%command.name%</info> command shows the database migration status
+for core or an installed app.
+
+It reports:
+  - migration versions recorded as executed
+  - migration files available in the installed code
+  - migrations that have not yet been applied
+  - executed migrations that are missing from the installed code
+
+This command is read-only. It does not execute migrations or modify migration
+history.
+
+If executed migrations are missing from the installed code, verify that the
+installed app and server code match the intended version. Do not remove records
+from the migration history table manually.
+
+Example:
+
+  <info>php occ migrations:status core</info>
+HELP);
 	}
 
 	#[\Override]

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -93,18 +93,18 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 
 		$infos = [
 			'App' => $ms->getApp(),
-			'Version Table Name' => $ms->getMigrationsTableName(),
-			'Migrations Namespace' => $ms->getMigrationsNamespace(),
-			'Migrations Directory' => $ms->getMigrationsDirectory(),
-			'Previous Version' => $this->getFormattedVersionAlias($ms, 'prev'),
-			'Current Version' => $this->getFormattedVersionAlias($ms, 'current'),
-			'Next Version' => $this->getFormattedVersionAlias($ms, 'next'),
-			'Latest Version' => $this->getFormattedVersionAlias($ms, 'latest'),
-			'Executed Migrations' => count($executedMigrations),
-			'Executed Unavailable Migrations' => $numExecutedUnavailableMigrations,
-			'Available Migrations' => count($availableMigrations),
-			'New Migrations' => $numNewMigrations,
-			'Pending Migrations' => count($pending) ? $pending : 'None'
+			'History Table' => $ms->getMigrationsTableName(),
+			'Migration Namespace' => $ms->getMigrationsNamespace(),
+			'Migration Directory' => $ms->getMigrationsDirectory(),
+			'Previous Available' => $this->getFormattedVersionAlias($ms, 'prev'),
+			'Last Recorded as Executed' => $this->getFormattedVersionAlias($ms, 'current'),
+			'Next Available' => $this->getFormattedVersionAlias($ms, 'next'),
+			'Latest Available' => $this->getFormattedVersionAlias($ms, 'latest'),
+			'Recorded as Executed' => count($executedMigrations),
+			'Missing from Installed Code' => $numExecutedUnavailableMigrations,
+			'Available in Installed Code' => count($availableMigrations),
+			'Unapplied' => $numNewMigrations,
+			'Unapplied Migration Descriptions' => count($pending) ? $pending : 'None'
 		];
 
 		return $infos;

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -47,9 +47,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 		$output->writeln('');
 
 		if ($infos['Missing from Installed Code'] > 0) {
-			$output->writeln(
-				'<error>Status: Warning — migration history references migrations missing from installed code</error>',
-			);
+			$output->writeln('<error>Status: Warning — migration history requires attention</error>');
 		} elseif ($infos['Unapplied'] > 0) {
 			$output->writeln(sprintf(
 				'<comment>Status: %d unapplied migration%s</comment>',
@@ -92,6 +90,31 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 			}
 			$this->writeKeyValueRows($output, $values);
 
+			$output->writeln('');
+		}
+
+		$missingMigrationVersions = $infos['Missing Migration Versions'];
+		if ($missingMigrationVersions !== []) {
+			$output->writeln('<error>Warnings</error>');
+			$output->writeln('--------');
+			$output->writeln(sprintf(
+				'%d migration%s recorded as executed %s not present in the installed code:',
+				count($missingMigrationVersions),
+				count($missingMigrationVersions) === 1 ? '' : 's',
+				count($missingMigrationVersions) === 1 ? 'is' : 'are',
+			));
+
+			foreach ($missingMigrationVersions as $version) {
+				$output->writeln('  - ' . $version);
+			}
+
+			$output->writeln('');
+			$output->writeln(
+				'If this is unexpected, verify that the installed app and server code match the intended version.',
+			);
+			$output->writeln(
+				'Do not remove records from the migration history table manually.',
+			);
 			$output->writeln('');
 		}
 
@@ -213,6 +236,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 				: end($availableMigrations),
 			'Recorded as Executed' => count($executedMigrations),
 			'Missing from Installed Code' => $numExecutedUnavailableMigrations,
+			'Missing Migration Versions' => array_values($executedUnavailableMigrations),
 			'Available in Installed Code' => count($availableMigrations),
 			'Unapplied' => $numNewMigrations,
 			'Unapplied Migrations' => $unappliedMigrations,

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -41,16 +41,51 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 
 		$infos = $this->getMigrationsInfos($ms);
-		foreach ($infos as $key => $value) {
-			if (is_array($value)) {
-				$output->writeln("    <comment>>></comment> $key:");
-				foreach ($value as $subKey => $subValue) {
-					$output->writeln("        <comment>>></comment> $subKey: " . str_repeat(' ', 46 - strlen($subKey)) . $subValue);
-				}
-			} else {
-				$output->writeln("    <comment>>></comment> $key: " . str_repeat(' ', 50 - strlen($key)) . $value);
+
+		$sections = [
+			'Migration configuration' => [
+				'App',
+				'History Table',
+				'Migration Namespace',
+				'Migration Directory',
+			],
+			'Version status' => [
+				'Previous Available',
+				'Last Recorded as Executed',
+				'Next Available',
+				'Latest Available',
+			],
+			'Migration counts' => [
+				'Recorded as Executed',
+				'Missing from Installed Code',
+				'Available in Installed Code',
+				'Unapplied',
+			],
+		];
+
+		foreach ($sections as $section => $keys) {
+			$output->writeln($section);
+			$output->writeln(str_repeat('-', strlen($section)));
+
+			foreach ($keys as $key) {
+				$output->writeln("$key: " . str_repeat(' ', 34 - strlen($key)) . $infos[$key]);
 			}
+
+			$output->writeln('');
 		}
+
+		$output->writeln('Unapplied migrations');
+		$output->writeln('--------------------');
+
+		$pending = $infos['Unapplied Migration Descriptions'];
+		if (is_array($pending)) {
+			foreach ($pending as $name => $description) {
+				$output->writeln("$name: $description");
+			}
+		} else {
+			$output->writeln($pending);
+		}
+	
 		return 0;
 	}
 

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -96,13 +96,16 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 		$output->writeln('Unapplied migrations');
 		$output->writeln('--------------------');
 
-		$pending = $infos['Unapplied Migration Descriptions'];
-		if (is_array($pending)) {
-			foreach ($pending as $name => $description) {
-				$output->writeln("$name: $description");
-			}
+		$unappliedMigrations = $infos['Unapplied Migrations'];
+		if ($unappliedMigrations === []) {
+			$output->writeln('None');
 		} else {
-			$output->writeln($pending);
+			foreach ($unappliedMigrations as $version => $migration) {
+				$output->writeln($version);
+				$output->writeln('  Name: ' . $migration['Name']);
+				$output->writeln('  Description: ' . $migration['Description']);
+				$output->writeln('');
+			}
 		}
 	
 		return 0;
@@ -139,15 +142,24 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 	public function getMigrationsInfos(MigrationService $ms) {
 		$executedMigrations = $ms->getMigratedVersions();
 		$availableMigrations = $ms->getAvailableVersions();
-		$executedUnavailableMigrations = array_diff($executedMigrations, array_keys($availableMigrations));
+		$executedUnavailableMigrations = array_diff($executedMigrations, $availableMigrations);
+		$unappliedMigrationVersions = array_diff($availableMigrations, $executedMigrations);
 
 		$numExecutedUnavailableMigrations = count($executedUnavailableMigrations);
-		$numNewMigrations = count(array_diff(array_keys($availableMigrations), $executedMigrations));
+		$numNewMigrations = count($unappliedMigrationVersions);
 		$currentMigration = $executedMigrations === []
 			? null
 			: end($executedMigrations);
 
 		$pending = $ms->describeMigrationStep();
+		$unappliedMigrations = [];
+		foreach ($unappliedMigrationVersions as $version) {
+			$migration = $ms->createInstance($version);
+			$unappliedMigrations[$version] = [
+				'Name' => $migration->name() ?: 'Not provided',
+				'Description' => $migration->description() ?: 'Not provided',
+			];
+		}
 
 		$infos = [
 			'App' => $ms->getApp(),
@@ -173,7 +185,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 			'Missing from Installed Code' => $numExecutedUnavailableMigrations,
 			'Available in Installed Code' => count($availableMigrations),
 			'Unapplied' => $numNewMigrations,
-			'Unapplied Migration Descriptions' => count($pending) ? $pending : 'None'
+			'Unapplied Migrations' => $unappliedMigrations,
 		];
 
 		return $infos;

--- a/tests/Core/Command/Db/Migrations/StatusCommandTest.php
+++ b/tests/Core/Command/Db/Migrations/StatusCommandTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Tests\Core\Command\Db\Migrations;
+
+use OC\Core\Command\Db\Migrations\StatusCommand;
+use OC\DB\Connection;
+use OC\DB\MigrationService;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class StatusCommandTest extends TestCase {
+	private const VERSION_1 = '10000Date20160101000000';
+	private const VERSION_2 = '20000Date20200101000000';
+	private const VERSION_3 = '30000Date20240101000000';
+	private const MISSING_VERSION = '25000Date20220101000000';
+
+	private StatusCommand $command;
+	private MigrationService&MockObject $migrationService;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->command = new StatusCommand(
+			$this->createMock(Connection::class),
+			$this->createMock(IAppManager::class),
+		);
+
+		$this->migrationService = $this->createMock(MigrationService::class);
+		$this->migrationService->method('getApp')->willReturn('test');
+		$this->migrationService->method('getMigrationsTableName')->willReturn('oc_migrations');
+		$this->migrationService->method('getMigrationsNamespace')->willReturn('OCA\Test\Migration');
+		$this->migrationService->method('getMigrationsDirectory')->willReturn('/tmp/test/lib/Migration');
+		$this->migrationService->method('describeMigrationStep')->willReturn([]);
+	}
+
+	/**
+	 * @param list<string> $executedMigrations
+	 * @param list<string> $availableMigrations
+	 * @param array<string, string> $expectedStatuses
+	 */
+	#[DataProvider('versionStatusProvider')]
+	public function testVersionStatuses(
+		array $executedMigrations,
+		array $availableMigrations,
+		array $expectedStatuses,
+	): void {
+		$this->migrationService
+			->method('getMigratedVersions')
+			->willReturn($executedMigrations);
+		$this->migrationService
+			->method('getAvailableVersions')
+			->willReturn($availableMigrations);
+
+		$infos = $this->command->getMigrationsInfos($this->migrationService);
+
+		foreach ($expectedStatuses as $label => $expectedStatus) {
+			$this->assertSame($expectedStatus, $infos[$label], $label);
+		}
+	}
+
+	public static function versionStatusProvider(): array {
+		$availableMigrations = [
+			self::VERSION_1,
+			self::VERSION_2,
+			self::VERSION_3,
+		];
+
+		return [
+			'no migrations recorded as executed' => [
+				[],
+				$availableMigrations,
+				[
+					'Previous Available' => 'None (no migrations recorded as executed)',
+					'Last Recorded as Executed' => 'None (no migrations recorded as executed)',
+					'Next Available' => self::VERSION_1,
+					'Latest Available' => self::VERSION_3,
+				],
+			],
+			'at first available migration' => [
+				[self::VERSION_1],
+				$availableMigrations,
+				[
+					'Previous Available' => 'None (at first available migration)',
+					'Last Recorded as Executed' => self::VERSION_1,
+					'Next Available' => self::VERSION_2,
+					'Latest Available' => self::VERSION_3,
+				],
+			],
+			'at intermediate migration' => [
+				[self::VERSION_1, self::VERSION_2],
+				$availableMigrations,
+				[
+					'Previous Available' => self::VERSION_1,
+					'Last Recorded as Executed' => self::VERSION_2,
+					'Next Available' => self::VERSION_3,
+					'Latest Available' => self::VERSION_3,
+				],
+			],
+			'at latest available migration' => [
+				$availableMigrations,
+				$availableMigrations,
+				[
+					'Previous Available' => self::VERSION_2,
+					'Last Recorded as Executed' => self::VERSION_3,
+					'Next Available' => 'None (at latest available migration)',
+					'Latest Available' => self::VERSION_3,
+				],
+			],
+			'last executed migration is missing from code' => [
+				[self::VERSION_1, self::MISSING_VERSION],
+				$availableMigrations,
+				[
+					'Previous Available' => 'Unknown (last executed migration is missing from code)',
+					'Last Recorded as Executed' => self::MISSING_VERSION,
+					'Next Available' => 'Unknown (last executed migration is missing from code)',
+					'Latest Available' => self::VERSION_3,
+				],
+			],
+			'no migration files found' => [
+				[],
+				[],
+				[
+					'Previous Available' => 'None (no migrations recorded as executed)',
+					'Last Recorded as Executed' => 'None (no migrations recorded as executed)',
+					'Next Available' => 'None (no migration files found)',
+					'Latest Available' => 'None (no migration files found)',
+				],
+			],
+		];
+	}
+}

--- a/tests/Core/Command/Db/Migrations/StatusCommandTest.php
+++ b/tests/Core/Command/Db/Migrations/StatusCommandTest.php
@@ -16,6 +16,7 @@ use OCP\App\IAppManager;
 use OCP\Migration\IMigrationStep;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Test\TestCase;
 
 class StatusCommandTest extends TestCase {
@@ -190,5 +191,24 @@ class StatusCommandTest extends TestCase {
 				'Description' => 'Not provided',
 			],
 		], $infos['Unapplied Migrations']);
+	}
+
+	public function testWriteKeyValueRowsAlignsLabelsDynamically(): void {
+		$output = new BufferedOutput();
+
+		self::invokePrivate($this->command, 'writeKeyValueRows', [
+			$output,
+			[
+				'Short' => 'first',
+				'Longer Label' => 'second',
+			],
+			2,
+		]);
+
+		$this->assertSame(
+			"  Short:         first\n"
+			. "  Longer Label:  second\n",
+			$output->fetch(),
+		);
 	}
 }

--- a/tests/Core/Command/Db/Migrations/StatusCommandTest.php
+++ b/tests/Core/Command/Db/Migrations/StatusCommandTest.php
@@ -13,6 +13,7 @@ use OC\Core\Command\Db\Migrations\StatusCommand;
 use OC\DB\Connection;
 use OC\DB\MigrationService;
 use OCP\App\IAppManager;
+use OCP\Migration\IMigrationStep;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -21,6 +22,7 @@ class StatusCommandTest extends TestCase {
 	private const VERSION_1 = '10000Date20160101000000';
 	private const VERSION_2 = '20000Date20200101000000';
 	private const VERSION_3 = '30000Date20240101000000';
+	private const VERSION_4 = '40000Date20260101000000';
 	private const MISSING_VERSION = '25000Date20220101000000';
 
 	private StatusCommand $command;
@@ -137,5 +139,56 @@ class StatusCommandTest extends TestCase {
 				],
 			],
 		];
+	}
+
+	public function testListsEveryUnappliedMigrationByVersion(): void {
+		$migration1 = $this->createMock(IMigrationStep::class);
+		$migration1->method('name')->willReturn('Update database schema');
+		$migration1->method('description')->willReturn('Adds the first schema change.');
+
+		$migration2 = $this->createMock(IMigrationStep::class);
+		$migration2->method('name')->willReturn('Update database schema');
+		$migration2->method('description')->willReturn('Adds the second schema change.');
+
+		$unnamedMigration = $this->createMock(IMigrationStep::class);
+		$unnamedMigration->method('name')->willReturn('');
+		$unnamedMigration->method('description')->willReturn('');
+
+		$this->migrationService
+			->method('getMigratedVersions')
+			->willReturn([self::VERSION_1]);
+		$this->migrationService
+			->method('getAvailableVersions')
+			->willReturn([
+				self::VERSION_1,
+				self::VERSION_2,
+				self::VERSION_3,
+				self::VERSION_4,
+			]);
+		$this->migrationService
+			->method('createInstance')
+			->willReturnMap([
+				[self::VERSION_2, $migration1],
+				[self::VERSION_3, $migration2],
+				[self::VERSION_4, $unnamedMigration],
+			]);
+
+		$infos = $this->command->getMigrationsInfos($this->migrationService);
+
+		$this->assertSame(3, $infos['Unapplied']);
+		$this->assertSame([
+			self::VERSION_2 => [
+				'Name' => 'Update database schema',
+				'Description' => 'Adds the first schema change.',
+			],
+			self::VERSION_3 => [
+				'Name' => 'Update database schema',
+				'Description' => 'Adds the second schema change.',
+			],
+			self::VERSION_4 => [
+				'Name' => 'Not provided',
+				'Description' => 'Not provided',
+			],
+		], $infos['Unapplied Migrations']);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Improve the `migrations:status` command so that its output is accurate, easier to interpret, and more useful for diagnosing migration-state inconsistencies.

The command now presents a structured status report with an overall summary, clearer terminology, explicit version states, detailed unapplied migrations, and actionable warnings when migration history references versions missing from the installed code.

## Changes

- Replace ambiguous status labels such as “New Migrations” with more precise terminology.
- Group output into configuration, version status, migration count, warning, and unapplied migration sections.
- Add an overall status indicating whether migrations are:
  - up to date
  - unapplied
  - in need of attention
- Distinguish valid boundary states from indeterminate states:
  - `None` when no previous or next migration exists
  - `Unknown` when the last executed migration is missing from the installed code
- List every unapplied migration by version, including its name and description when provided.
- Report the specific executed migration versions missing from the installed code.
- Add guidance to verify the installed app/server version rather than editing migration history manually.
- Dynamically align labels for more readable terminal output.
- Add focused tests covering version states, unapplied migration details, and output alignment.

## Motivation

The previous output used ambiguous terms and could report that an installation was at the first or latest migration when the current recorded migration was simply unavailable in the installed code. In addition, unnamed migrations were omitted from the pending migration details.

## Examples

```console
Database migration status for "core"
====================================

Status: 2 unapplied migrations

Migration configuration
-----------------------
App:                  core
History Table:        oc_migrations
Migration Namespace:  OC\Core\Migrations
Migration Directory:  /var/www/nextcloud/core/Migrations

Version status
--------------
Previous Available:          32000Date20250501090000
Last Recorded as Executed:   33000Date20251210120000
Next Available:              34000Date20260318095645
Latest Available:            34000Date20260402143000

Migration counts
----------------
Recorded as Executed:          33
Missing from Installed Code:    0
Available in Installed Code:   35
Unapplied:                      2

Unapplied migrations
--------------------
34000Date20260318095645
  Name:         Migrate background job arguments
  Description:  Converts background job arguments to the new storage format.

34000Date20260402143000
  Name:         Not provided
  Description:  Not provided
```

```console
www-data@7851fbf10178:~/html/core/Command/Db$ NC_debug=true  ../../../occ migrations:status activity
Database migration status for "activity"
========================================

Status: Up to date

Migration configuration
-----------------------
App:                  activity
History Table:        oc_migrations
Migration Namespace:  OCA\Activity\Migration
Migration Directory:  /var/www/html/apps/activity/lib/Migration

Version status
--------------
Previous Available:         2011Date20201207091915
Last Recorded as Executed:  8000Date20260603120000
Next Available:             None (at latest available migration)
Latest Available:           8000Date20260603120000

Migration counts
----------------
Recorded as Executed:         12
Missing from Installed Code:  0
Available in Installed Code:  12
Unapplied:                    0

Unapplied migrations
--------------------
None
```

```console
www-data@7851fbf10178:~/html/core/Command/Db$ NC_debug=true  ../../../occ migrations:status --help  
Description:
  Show the database migration status for an app

Usage:
  migrations:status <app>

Arguments:
  app                   App ID to inspect, or "core" for server migrations

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --no-warnings     Skip global warnings, show command output only
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The migrations:status command shows the database migration status
  for core or an installed app.
  
  It reports:
    - migration versions recorded as executed
    - migration files available in the installed code
    - migrations that have not yet been applied
    - executed migrations that are missing from the installed code
  
  This command is read-only. It does not execute migrations or modify migration
  history.
  
  If executed migrations are missing from the installed code, verify that the
  installed app and server code match the intended version. Do not remove records
  from the migration history table manually.
  
  Example:
  
    php occ migrations:status core
www-data@7851fbf10178:~/html/core/Command/Db$ 
```

## Testing

Added tests covering:

- no migrations recorded as executed
- the first available migration
- an intermediate migration
- the latest available migration
- a last executed migration missing from the installed code
- no available migration files
- duplicate and missing migration names and descriptions
- listing every unapplied migration by version
- dynamic terminal-output alignment

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
