### PR TITLE
fix(dav): scope contact photo export to local address books

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -80,11 +80,15 @@ class ImageExportPlugin extends ServerPlugin {
 		$addressbookpath = explode('/', $path);
 		array_pop($addressbookpath);
 		$addressbookpath = implode('/', $addressbookpath);
-		/** @var AddressBook $addressbook */
 		$addressbook = $this->server->tree->getNodeForPath($addressbookpath);
 
 		$response->setHeader('Cache-Control', 'private, max-age=3600, must-revalidate');
 		$response->setHeader('Etag', $node->getETag());
+
+		if (!$addressbook instanceof AddressBook) {
+			$response->setStatus(Http::STATUS_NO_CONTENT);
+			return false;
+		}
 
 		try {
 			$file = $this->cache->get($addressbook->getResourceId(), $node->getName(), $size, $node);

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -11,6 +11,7 @@ namespace OCA\DAV\Tests\unit\CardDAV;
 
 use OCA\DAV\CardDAV\AddressBook;
 use OCA\DAV\CardDAV\ImageExportPlugin;
+use OCA\DAV\CardDAV\Integration\ExternalAddressBook;
 use OCA\DAV\CardDAV\PhotoCache;
 use OCP\AppFramework\Http;
 use OCP\Files\NotFoundException;
@@ -168,6 +169,39 @@ class ImageExportPluginTest extends TestCase {
 				->method('setStatus')
 				->with(Http::STATUS_NO_CONTENT);
 		}
+
+		$result = $this->plugin->httpGet($this->request, $this->response);
+		$this->assertFalse($result);
+	}
+
+	public function testAppGeneratedAddressBook(): void {
+		$this->request->method('getQueryParameters')
+			->willReturn(['photo' => null]);
+		$this->request->method('getPath')
+			->willReturn('user/book/card');
+
+		$card = $this->createMock(Card::class);
+		$card->method('getETag')
+			->willReturn('"myEtag"');
+		$book = $this->createMock(ExternalAddressBook::class);
+
+		$this->tree->method('getNodeForPath')
+			->willReturnCallback(function ($path) use ($card, $book) {
+				if ($path === 'user/book/card') {
+					return $card;
+				} elseif ($path === 'user/book') {
+					return $book;
+				}
+				$this->fail();
+			});
+
+		$this->cache->expects($this->never())
+			->method('get');
+		$this->response->expects($this->once())
+			->method('setStatus')
+			->with(Http::STATUS_NO_CONTENT);
+		$this->response->expects($this->never())
+			->method('setBody');
 
 		$result = $this->plugin->httpGet($this->request, $this->response);
 		$this->assertFalse($result);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- Share a file by email with an external email address
- Open contacts
- Go to recently contacted
- Click contact with email
- See failing request




## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
