### PR TITLE
feat(Teams): Add quota management to TeamFolder and ITeamFolderProvider

### DIFF
--- a/lib/public/Teams/ITeamFolderProvider.php
+++ b/lib/public/Teams/ITeamFolderProvider.php
@@ -40,6 +40,16 @@ interface ITeamFolderProvider extends ITeamResourceProvider {
 	public function createTeamFolder(Team $team, int $quota = 0): TeamFolder;
 
 	/**
+	 * Update the storage quota of the team folder.
+	 *
+	 * @param string $teamId The team single id.
+	 * @param int $quota Quota in bytes; zero means unlimited.
+	 * @return TeamFolder The updated folder.
+	 * @since 35.0.0
+	 */
+	public function updateTeamFolderQuota(string $teamId, int $quota): TeamFolder;
+
+	/**
 	 * Remove the exclusive relationship but retain the folder and its contents.
 	 *
 	 * @return TeamFolder|null The unlinked folder, if one existed.

--- a/lib/public/Teams/TeamFolder.php
+++ b/lib/public/Teams/TeamFolder.php
@@ -24,6 +24,7 @@ class TeamFolder implements \JsonSerializable {
 	public function __construct(
 		private int $id,
 		private string $mountPoint,
+		private ?int $quota = null,
 	) {
 	}
 
@@ -42,13 +43,24 @@ class TeamFolder implements \JsonSerializable {
 	}
 
 	/**
-	 * @return array{id: int, mountPoint: string}
+	 * The storage quota in bytes, zero for unlimited, or null if the active
+	 * provider does not expose a quota for this folder.
+	 *
+	 * @since 35.0.0
+	 */
+	public function getQuota(): ?int {
+		return $this->quota;
+	}
+
+	/**
+	 * @return array{id: int, quota: int|null, mountPoint: string}
 	 * @since 35.0.0
 	 */
 	#[\Override]
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,
+			'quota' => $this->quota,
 			'mountPoint' => $this->mountPoint,
 		];
 	}

--- a/tests/lib/Teams/TeamFolderTest.php
+++ b/tests/lib/Teams/TeamFolderTest.php
@@ -18,6 +18,14 @@ class TeamFolderTest extends TestCase {
 
 		$this->assertSame(42, $folder->getId());
 		$this->assertSame('Engineering', $folder->getMountPoint());
-		$this->assertSame(['id' => 42, 'mountPoint' => 'Engineering'], $folder->jsonSerialize());
+		$this->assertNull($folder->getQuota());
+		$this->assertSame(['id' => 42, 'quota' => null, 'mountPoint' => 'Engineering'], $folder->jsonSerialize());
+	}
+
+	public function testSerializesFolderQuota(): void {
+		$folder = new TeamFolder(42, 'Engineering', 1024);
+
+		$this->assertSame(1024, $folder->getQuota());
+		$this->assertSame(['id' => 42, 'quota' => 1024, 'mountPoint' => 'Engineering'], $folder->jsonSerialize());
 	}
 }


### PR DESCRIPTION
Closed in favor of #63958

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # Task https://github.com/nextcloud/circles/issues/2781

## Summary

Add storage quota support to the TeamFolder public API. 

## Changes

- Add an optional quota property to `TeamFolder`
- Expose the quota through `getQuota()`
- Include the quota in the serialized TeamFolder response
- Extend `ITeamFolderProvider` with methods to create and update team folder quotas
- Represent quotas in bytes, with `0` meaning unlimited
- Use `null` when the active provider does not expose quota information

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
