### PR TITLE
feat(Updater): Ignore incompatible apps if the channel is git

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -360,6 +360,10 @@ class Updater extends BasicEmitter {
 	 * @throws \Exception
 	 */
 	private function checkAppsRequirements(): void {
+		if ($this->serverVersion->getChannel() === 'git') {
+			return;
+		}
+
 		$isCoreUpgrade = $this->isCodeUpgrade();
 		$apps = $this->appManager->getEnabledApps();
 		$version = implode('.', Util::getVersion());


### PR DESCRIPTION
## Summary

Specifically testing upgrades during the branchoff process is painful, because the some shipped apps might not be compatible yet, because their respective version bump PR has not been merged.

On the git channel, it is safe to ignore these problems, because it is only used for development and the difference between master and stableX is basically none during the branchoff.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
