### PR TITLE
fix(Sharing): Fix migration using wrong table names

### DIFF
--- a/apps/sharing/appinfo/info.xml
+++ b/apps/sharing/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Sharing</name>
 	<summary>TODO</summary>
 	<description>TODO</description>
-	<version>2.0.0-dev.0</version>
+	<version>2.0.0-dev.1</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author>Kate Döen</author>
 	<namespace>Sharing</namespace>

--- a/apps/sharing/lib/Migration/Version1000Date20260731171922.php
+++ b/apps/sharing/lib/Migration/Version1000Date20260731171922.php
@@ -50,14 +50,16 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		if (!$schema->hasTable('sharing_classmap')) {
-			$table = $schema->createTable('sharing_classmap');
-			$table->addColumn('class_id', Types::INTEGER, [
+			$mappingTable = $schema->createTable('sharing_classmap');
+			$mappingTable->addColumn('class_id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 			]);
-			$table->addColumn('class_name', Types::STRING, ['length' => 64]);
-			$table->setPrimaryKey(['class_id']);
-			$table->addUniqueIndex(['class_name']);
+			$mappingTable->addColumn('class_name', Types::STRING, ['length' => 64]);
+			$mappingTable->setPrimaryKey(['class_id']);
+			$mappingTable->addUniqueIndex(['class_name']);
+		} else {
+			$mappingTable = $schema->getTable('sharing_classmap');
 		}
 
 		$sourcesTable = $schema->getTable('sharing_share_sources');
@@ -66,7 +68,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$sourcesTable->addColumn('source_class_id', Types::INTEGER);
 			$sourcesTable->dropPrimaryKey();
 			$sourcesTable->setPrimaryKey(['share_id', 'source_class_id', 'source_value']);
-			$sourcesTable->addForeignKeyConstraint('sharing_classmap', ['source_class_id'], ['class_id']);
+			$sourcesTable->addForeignKeyConstraint($mappingTable->getName(), ['source_class_id'], ['class_id']);
 		}
 
 		$recipientsTable = $schema->getTable('sharing_share_recipients');
@@ -75,7 +77,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$recipientsTable->addColumn('recipient_class_id', Types::INTEGER);
 			$recipientsTable->dropPrimaryKey();
 			$recipientsTable->setPrimaryKey(['share_id', 'recipient_class_id', 'recipient_value']);
-			$recipientsTable->addForeignKeyConstraint('sharing_classmap', ['recipient_class_id'], ['class_id']);
+			$recipientsTable->addForeignKeyConstraint($mappingTable->getName(), ['recipient_class_id'], ['class_id']);
 		}
 
 		$propertiesTable = $schema->getTable('sharing_share_properties');
@@ -84,7 +86,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$propertiesTable->addColumn('property_class_id', Types::INTEGER);
 			$propertiesTable->dropPrimaryKey();
 			$propertiesTable->setPrimaryKey(['share_id', 'property_class_id']);
-			$propertiesTable->addForeignKeyConstraint('sharing_classmap', ['property_class_id'], ['class_id']);
+			$propertiesTable->addForeignKeyConstraint($mappingTable->getName(), ['property_class_id'], ['class_id']);
 		}
 
 		$permissionsTable = $schema->getTable('sharing_share_permissions');
@@ -93,7 +95,7 @@ final class Version1000Date20260731171922 extends SimpleMigrationStep {
 			$permissionsTable->addColumn('permission_class_id', Types::INTEGER);
 			$permissionsTable->dropPrimaryKey();
 			$permissionsTable->setPrimaryKey(['share_id', 'permission_class_id']);
-			$permissionsTable->addForeignKeyConstraint('sharing_classmap', ['permission_class_id'], ['class_id']);
+			$permissionsTable->addForeignKeyConstraint($mappingTable->getName(), ['permission_class_id'], ['class_id']);
 		}
 
 		return $schema;


### PR DESCRIPTION
Replaces https://github.com/nextcloud/server/pull/63108.

The first migration was using `Table::getName()` which worked just fine, because it already contains the prefix. In the second migration the plain table name was used, so the prefix was missing.

On stable35 the app version wasn't bumped to trigger the migration. I'm just doing it here on master for good measure and in the backport it needs to be bumped as well.

This is the script I used to trigger the bug:
```
git reset --hard 03c110c7722370903693803dadf2c8ed89bca95d~
git submodule update
./occ maintenance:install --admin-pass admin

git reset --hard 93fbb1ee57e37e228cb56597a03e2423b36cf269
git submodule update
./occ upgrade
```
It simulates an instance that was installed right before the faulty migration was added and then upgrades to the commit in this PR (for triggering it was origin/stable35).