### PR TITLE
fix: Make Vue's ldapGroupMemberAssocAttr label map LcValue-compatible

### DIFF
--- a/apps/user_ldap/src/components/SettingsTabs/AdvancedTab.vue
+++ b/apps/user_ldap/src/components/SettingsTabs/AdvancedTab.vue
@@ -279,11 +279,11 @@ const ldapConfigProxy = computed(() => ldapConfigsStore.getConfigProxy(props.con
 const instanceName = (getCapabilities() as { theming: { name: string } }).theming.name
 
 const groupMemberAssociation = {
-	uniqueMember: 'uniqueMember',
-	memberUid: 'memberUid',
+	uniquemember: 'uniqueMember',
+	memberuid: 'memberUid',
 	member: 'member (AD)',
-	gidNumber: 'gidNumber',
-	zimbraMailForwardingAddress: 'zimbraMailForwardingAddress',
+	gidnumber: 'gidNumber',
+	zimbramailforwardingaddress: 'zimbraMailForwardingAddress',
 }
 </script>
 


### PR DESCRIPTION
## Summary
The user_ldap plugin features the field ldapGroupMemberAssocAttr and its values are converted into lowercase when set. In the UI, the field loads the labels using the groupMemberAssociation constant, which used to be case-sensitive.
It failed for all entries other than 'member' because these fields had upper letters in it; resulting in the settings panel to display the GUI field as empty.
This is fixed here. (Tested on v33.0.2)

It could be partially related to #60342, but just viewing the field before this PR did not change the ldap settings in my tests.