### PR TITLE
fix(contactsmenu): restore avatars for non-user contacts

### DIFF
--- a/core/src/components/ContactsMenu/ContactMenuEntry.vue
+++ b/core/src/components/ContactsMenu/ContactMenuEntry.vue
@@ -10,7 +10,8 @@
 			:user="contact.isUser ? contact.uid : undefined"
 			:is-no-user="!contact.isUser"
 			:disable-menu="true"
-			:display-name="contact.avatarLabel"
+			:display-name="contact.fullName"
+			:url="contact.isUser ? undefined : contact.avatar"
 			:preloaded-user-status="preloadedUserStatus" />
 		<a
 			class="contact__body"

--- a/core/src/tests/components/ContactsMenu/ContactMenuEntry.spec.js
+++ b/core/src/tests/components/ContactsMenu/ContactMenuEntry.spec.js
@@ -5,9 +5,51 @@
 
 import { shallowMount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import ContactMenuEntry from '../../../components/ContactsMenu/ContactMenuEntry.vue'
 
 describe('Contact', function() {
+	it('passes the avatar url to non-user contacts', () => {
+		const view = shallowMount(ContactMenuEntry, {
+			propsData: {
+				contact: {
+					id: '11111111-2222-3333-4444-555555555555',
+					uid: '11111111-2222-3333-4444-555555555555',
+					fullName: 'Jane Doe',
+					avatar: 'https://localhost/remote.php/dav/addressbooks/users/admin/contacts/jane.vcf?photo',
+					isUser: false,
+					emailAddresses: [],
+					actions: [],
+				},
+			},
+		})
+
+		const avatar = view.findComponent(NcAvatar)
+		expect(avatar.props('user')).toBeUndefined()
+		expect(avatar.props('url')).toBe('https://localhost/remote.php/dav/addressbooks/users/admin/contacts/jane.vcf?photo')
+		expect(avatar.props('displayName')).toBe('Jane Doe')
+	})
+
+	it('lets user contacts resolve the avatar via their user id', () => {
+		const view = shallowMount(ContactMenuEntry, {
+			propsData: {
+				contact: {
+					id: 'jane',
+					uid: 'jane',
+					fullName: 'Jane Doe',
+					avatar: 'https://localhost/remote.php/dav/addressbooks/system/system/system/jane.vcf?photo',
+					isUser: true,
+					emailAddresses: [],
+					actions: [],
+				},
+			},
+		})
+
+		const avatar = view.findComponent(NcAvatar)
+		expect(avatar.props('user')).toBe('jane')
+		expect(avatar.props('url')).toBeUndefined()
+	})
+
 	it('links to the top action', () => {
 		const view = shallowMount(ContactMenuEntry, {
 			propsData: {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

The contacts menu never passed the avatar URL to NcAvatar for non-user contacts and bound the display name to a non-existent `avatarLabel` field, so plain address-book contacts rendered the "?" fallback. User contacts kept working because they resolve their avatar via the `user` prop instead.

Pass `contact.avatar` as the avatar URL for non-user contacts and use `contact.fullName` for the initials fallback, matching the behaviour before the binding was dropped.

Regression of 58d34f0f60b.

## How to test

1. Have a contact with a photo
2. Open the contacts menu

master: you will see `?` as avatar
here: you will see the actual photo

Note: **System address book contacts** will work on either branch! The bug only shows for "real" contacts.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
