### PR TITLE
fix: Check rememberme cookie previous session id matches uid

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -903,6 +903,26 @@ class Session implements IUserSession, Emitter {
 			]);
 			return false;
 		}
+
+		try {
+			$oldToken = $this->tokenProvider->getToken($oldSessionId);
+		} catch (InvalidTokenException $ex) {
+			$this->logger->error('Could not find the session token to renew', [
+				'app' => 'core',
+				'user' => $uid,
+				'exception' => $ex,
+			]);
+			return false;
+		}
+
+		if ($oldToken->getUID() !== $user->getUID()) {
+			$this->logger->warning('Tried to renew a session token belonging to a different user', [
+				'app' => 'core',
+				'user' => $uid,
+			]);
+			return false;
+		}
+
 		// replace successfully used token with a new one
 		$this->config->deleteUserValue($uid, 'login_token', $currentToken);
 		$newToken = $this->random->generate(32);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -794,8 +794,14 @@ class SessionTest extends \Test\TestCase {
 			->with($oldSessionId, $sessionId)
 			->willReturn($tokenObject);
 
-		$this->tokenProvider->expects($this->never())
-			->method('getToken');
+		$oldTokenObject = $this->createMock(IToken::class);
+		$oldTokenObject->expects($this->once())
+			->method('getUID')
+			->willReturn('foo');
+
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->willReturn($oldTokenObject);
 
 		$user->expects($this->any())
 			->method('getUID')
@@ -872,7 +878,16 @@ class SessionTest extends \Test\TestCase {
 			->with($oldSessionId, $sessionId)
 			->willThrowException(new InvalidTokenException());
 
-		$user->expects($this->never())
+		$oldTokenObject = $this->createMock(IToken::class);
+		$oldTokenObject->expects($this->once())
+			->method('getUID')
+			->willReturn('foo');
+
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->willReturn($oldTokenObject);
+
+		$user->expects($this->once())
 			->method('getUID')
 			->willReturn('foo');
 		$userSession->expects($this->never())


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
