### PR TITLE
fix(2fa): Add missing BruteForceProtection attribute

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -12,6 +12,7 @@ use OC\AppFramework\Http\Attributes\TwoFactorSetUpDoneRequired;
 use OC\Authentication\TwoFactorAuth\Manager;
 use OC_User;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
@@ -145,6 +146,7 @@ class TwoFactorChallengeController extends Controller {
 	#[FrontpageRoute(verb: 'POST', url: '/login/challenge/{challengeProviderId}')]
 	#[TwoFactorSetUpDoneRequired]
 	#[UserRateLimit(limit: 5, period: 100)]
+	#[BruteForceProtection(action: 'solveChallenge')]
 	public function solveChallenge(string $challengeProviderId, string $challenge, ?string $redirect_url = null): RedirectResponse {
 		$user = $this->userSession->getUser();
 		$provider = $this->twoFactorManager->getProvider($user, $challengeProviderId);
@@ -172,10 +174,12 @@ class TwoFactorChallengeController extends Controller {
 		$uid = $user->getUID();
 		$this->logger->warning("Two-factor challenge failed: $uid (Remote IP: $ip)");
 		$this->session->set('two_factor_auth_error', true);
-		return new RedirectResponse($this->urlGenerator->linkToRoute('core.TwoFactorChallenge.showChallenge', [
+		$response = new RedirectResponse($this->urlGenerator->linkToRoute('core.TwoFactorChallenge.showChallenge', [
 			'challengeProviderId' => $provider->getId(),
 			'redirect_url' => $redirect_url,
 		]));
+		$response->throttle(['user' => $uid, 'provider' => $challengeProviderId]);
+		return $response;
 	}
 
 	#[NoAdminRequired]

--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -254,6 +254,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 
 	public function testSolveInvalidChallenge(): void {
 		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuser');
 		$provider = $this->createMock(IProvider::class);
 
 		$this->userSession->expects($this->once())
@@ -283,11 +284,13 @@ class TwoFactorChallengeControllerTest extends TestCase {
 			->willReturn('myprovider');
 
 		$expected = new RedirectResponse('files/index/url');
+		$expected->throttle(['user' => 'myuser', 'provider' => 'myprovider']);
 		$this->assertEquals($expected, $this->controller->solveChallenge('myprovider', 'token', '/url'));
 	}
 
 	public function testSolveChallengeTwoFactorException(): void {
 		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuser');
 		$provider = $this->createMock(IProvider::class);
 		$exception = new TwoFactorException('2FA failed');
 
@@ -325,6 +328,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 			->willReturn('myprovider');
 
 		$expected = new RedirectResponse('files/index/url');
+		$expected->throttle(['user' => 'myuser', 'provider' => 'myprovider']);
 		$this->assertEquals($expected, $this->controller->solveChallenge('myprovider', 'token', '/url'));
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
