### PR TITLE
feat(settings): revoke other sessions on password change

### DIFF
--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -212,15 +212,7 @@ class AuthSettingsController extends Controller {
 			return $this->getServiceNotAvailableResponse();
 		}
 
-		$revoked = [];
-		foreach ($this->tokenProvider->getTokenByUser($this->userId) as $token) {
-			if ($token->getId() === $currentTokenId || $token->getType() === IToken::WIPE_TOKEN) {
-				continue;
-			}
-
-			$this->tokenProvider->invalidateTokenById($this->userId, $token->getId());
-			$revoked[] = $token->getId();
-		}
+		$revoked = $this->tokenProvider->invalidateTokensOfUserExcept($this->userId, $currentTokenId);
 
 		if ($revoked !== []) {
 			// One aggregate entry rather than one per token, so a bulk revoke does not bury the feed.

--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -10,6 +10,7 @@
 
 namespace OCA\Settings\Controller;
 
+use OC\Authentication\Token\IProvider;
 use OC\Group\Manager as GroupManager;
 use OC\User\Session;
 use OCA\Encryption\KeyManager;
@@ -21,12 +22,16 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoSubAdminRequired;
 use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\HintException;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
+use OCP\Session\Exceptions\SessionNotAvailableException;
+use Psr\Log\LoggerInterface;
 
 class ChangePasswordController extends Controller {
 	public function __construct(
@@ -38,6 +43,9 @@ class ChangePasswordController extends Controller {
 		private GroupManager $groupManager,
 		private IAppManager $appManager,
 		private IL10N $l,
+		private IProvider $tokenProvider,
+		private ISession $session,
+		private LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -45,7 +53,7 @@ class ChangePasswordController extends Controller {
 	#[NoSubAdminRequired]
 	#[NoAdminRequired]
 	#[BruteForceProtection(action: 'changePersonalPassword')]
-	public function changePersonalPassword(string $oldpassword = '', ?string $newpassword = null): JSONResponse {
+	public function changePersonalPassword(string $oldpassword = '', ?string $newpassword = null, bool $revokeOtherSessions = false): JSONResponse {
 		$loginName = $this->userSession->getLoginName();
 		/** @var IUser $user */
 		$user = $this->userManager->checkPassword($loginName, $oldpassword);
@@ -85,8 +93,28 @@ class ChangePasswordController extends Controller {
 			'status' => 'success',
 			'data' => [
 				'message' => $this->l->t('Saved'),
+				// Consumed by a separate Vue app, see AUTH_TOKENS_REVOKED_EVENT.
+				'revokedTokenIds' => $revokeOtherSessions ? $this->revokeOtherSessions() : [],
 			],
 		]);
+	}
+
+	/**
+	 * The password is already changed, so a failure here must not fail the request.
+	 * Without a usable session token nothing is revoked, since the alternative is
+	 * signing the user out of the request they are in.
+	 *
+	 * @return list<int> Ids of the revoked tokens
+	 */
+	private function revokeOtherSessions(): array {
+		try {
+			$currentTokenId = $this->tokenProvider->getToken($this->session->getId())->getId();
+		} catch (SessionNotAvailableException|InvalidTokenException $e) {
+			$this->logger->warning('Could not revoke the other sessions after a password change', ['exception' => $e]);
+			return [];
+		}
+
+		return $this->tokenProvider->invalidateTokensOfUserExcept($this->userId, $currentTokenId);
 	}
 
 	#[NoAdminRequired]

--- a/apps/settings/src/components/AuthTokenRevokeAll.spec.ts
+++ b/apps/settings/src/components/AuthTokenRevokeAll.spec.ts
@@ -19,9 +19,11 @@ vi.mock('@nextcloud/initial-state', () => ({
 	loadState: vi.fn((_app: string, key: string) => (key === 'app_tokens' ? [] : true)),
 }))
 
+import { emit } from '@nextcloud/event-bus'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import AuthTokenRevokeAllDialog from './AuthTokenRevokeAllDialog.vue'
 import AuthTokenSection from './AuthTokenSection.vue'
+import { AUTH_TOKENS_REVOKED_EVENT } from '../constants/AuthTokenConstants.ts'
 import { TokenType, useAuthTokenStore } from '../store/authtoken.ts'
 
 function makeToken(overrides: Partial<IToken> = {}): IToken {
@@ -167,6 +169,41 @@ describe('AuthTokenSection revoke-all button', () => {
 
 		expect(wrapper.findComponent(AuthTokenRevokeAllDialog).exists()).toBe(false)
 		expect(store.deleteAllOtherTokens).not.toHaveBeenCalled()
+	})
+})
+
+describe('AuthTokenSection reacting to a password change', () => {
+	// Separate Vue app, separate store: the event bus is the only link.
+	it('drops the tokens a password change revoked, without a reload', async () => {
+		const wrapper = mountSection([
+			makeToken({ id: 1, current: true }),
+			makeToken({ id: 2 }),
+			makeToken({ id: 3 }),
+		])
+		const store = useAuthTokenStore()
+		store.removeTokens = ((ids: number[]) => {
+			store.tokens = store.tokens.filter(({ id }) => !ids.includes(id))
+		}) as typeof store.removeTokens
+
+		emit(AUTH_TOKENS_REVOKED_EVENT, [2, 3])
+		await wrapper.vm.$nextTick()
+
+		expect(store.tokens.map(({ id }) => id)).toEqual([1])
+		expect(wrapper.find('button').exists()).toBe(false)
+	})
+
+	it('stops listening once unmounted', async () => {
+		const wrapper = mountSection([
+			makeToken({ id: 1, current: true }),
+			makeToken({ id: 2 }),
+		])
+		const store = useAuthTokenStore()
+
+		wrapper.destroy()
+		emit(AUTH_TOKENS_REVOKED_EVENT, [2])
+		await Promise.resolve()
+
+		expect(store.removeTokens).not.toHaveBeenCalled()
 	})
 })
 

--- a/apps/settings/src/components/AuthTokenSection.vue
+++ b/apps/settings/src/components/AuthTokenSection.vue
@@ -27,6 +27,7 @@
 </template>
 
 <script lang="ts">
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import { translate as t } from '@nextcloud/l10n'
 import { defineComponent } from 'vue'
@@ -35,6 +36,7 @@ import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
 import AuthTokenList from './AuthTokenList.vue'
 import AuthTokenRevokeAllDialog from './AuthTokenRevokeAllDialog.vue'
 import AuthTokenSetup from './AuthTokenSetup.vue'
+import { AUTH_TOKENS_REVOKED_EVENT } from '../constants/AuthTokenConstants.ts'
 import { useAuthTokenStore } from '../store/authtoken.ts'
 
 export default defineComponent({
@@ -59,8 +61,20 @@ export default defineComponent({
 		}
 	},
 
+	mounted() {
+		subscribe(AUTH_TOKENS_REVOKED_EVENT, this.handleTokensRevoked)
+	},
+
+	beforeDestroy() {
+		unsubscribe(AUTH_TOKENS_REVOKED_EVENT, this.handleTokensRevoked)
+	},
+
 	methods: {
 		t,
+
+		handleTokensRevoked(ids: number[]) {
+			this.authTokenStore.removeTokens(ids)
+		},
 
 		revokeAllOthers() {
 			this.authTokenStore.deleteAllOtherTokens()

--- a/apps/settings/src/components/PasswordSection.vue
+++ b/apps/settings/src/components/PasswordSection.vue
@@ -6,18 +6,22 @@
 <script setup lang="ts">
 import axios from '@nextcloud/axios'
 import { showError, showSuccess } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import { NcFormBox } from '@nextcloud/vue'
 import { ref } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
+import { AUTH_TOKENS_REVOKED_EVENT } from '../constants/AuthTokenConstants.ts'
 
 const passwordform = ref<HTMLFormElement>()
 
 const oldPass = ref('')
 const newPass = ref('')
+const revokeOtherSessions = ref(false)
 
 /**
  * Change the user's password
@@ -26,13 +30,16 @@ async function changePassword() {
 	const { data } = await axios.post(generateUrl('/settings/personal/changepassword'), {
 		oldpassword: oldPass.value,
 		newpassword: newPass.value,
+		revokeOtherSessions: revokeOtherSessions.value,
 	})
 	if (data.status === 'error') {
 		showError(data.data.message)
 	} else {
 		showSuccess(data.data.message)
+		emit(AUTH_TOKENS_REVOKED_EVENT, data.data.revokedTokenIds)
 		oldPass.value = ''
 		newPass.value = ''
+		revokeOtherSessions.value = false
 		passwordform.value?.reset()
 	}
 }
@@ -66,6 +73,17 @@ async function changePassword() {
 					spellcheck="false" />
 			</NcFormBox>
 
+			<NcCheckboxRadioSwitch
+				v-model="revokeOtherSessions"
+				aria-describedby="password-revoke-other-sessions-hint">
+				{{ t('settings', 'Sign out all other devices and apps') }}
+			</NcCheckboxRadioSwitch>
+			<p
+				id="password-revoke-other-sessions-hint"
+				:class="$style.passwordSection__hint">
+				{{ t('settings', 'Sync clients and connected apps lose access and have to sign in again. This device stays signed in.') }}
+			</p>
+
 			<NcButton
 				type="submit"
 				variant="primary"
@@ -82,5 +100,9 @@ async function changePassword() {
 	flex-direction: column;
 	gap: calc(2 * var(--default-grid-baseline));
 	max-width: 300px !important;
+}
+
+.passwordSection__hint {
+	color: var(--color-text-maxcontrast);
 }
 </style>

--- a/apps/settings/src/constants/AuthTokenConstants.ts
+++ b/apps/settings/src/constants/AuthTokenConstants.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Carries the revoked token ids. The password form and the token list are mounted as
+ * separate Vue apps, so the event bus is the only link between them.
+ */
+export const AUTH_TOKENS_REVOKED_EVENT = 'settings:auth-tokens:revoked'

--- a/apps/settings/src/store/authtoken.ts
+++ b/apps/settings/src/store/authtoken.ts
@@ -142,8 +142,7 @@ export const useAuthTokenStore = defineStore('auth-token', {
 
 			try {
 				const { data } = await axios.delete<IRevokeAllResponse>(BASE_URL, { confirmPassword: PwdConfirmationMode.Strict })
-				const revoked = new Set(data.revoked)
-				this.tokens = this.tokens.filter(({ id }) => !revoked.has(id))
+				this.removeTokens(data.revoked)
 				logger.debug('Other app tokens revoked', { count: data.revoked.length })
 				showSuccess(n('settings', 'Revoked %n other session', 'Revoked %n other sessions', data.revoked.length))
 				return data
@@ -152,6 +151,17 @@ export const useAuthTokenStore = defineStore('auth-token', {
 				showError(t('settings', 'Could not revoke the other sessions'))
 			}
 			return null
+		},
+
+		/**
+		 * Drop tokens that something else already revoked, e.g. a password change in
+		 * the separately mounted password form.
+		 *
+		 * @param ids Ids of the tokens the server revoked
+		 */
+		removeTokens(ids: number[]) {
+			const revoked = new Set(ids)
+			this.tokens = this.tokens.filter(({ id }) => !revoked.has(id))
 		},
 
 		/**

--- a/apps/settings/tests/Controller/AuthSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AuthSettingsControllerTest.php
@@ -273,61 +273,26 @@ class AuthSettingsControllerTest extends TestCase {
 	}
 
 	public function testDestroyOthersRevokesEveryTokenButTheCurrent(): void {
-		$currentToken = $this->mockAuthToken(10);
-		$otherToken = $this->mockAuthToken(11);
-		$appPassword = $this->mockAuthToken(12);
-
 		$this->session->method('getId')->willReturn('sessionid');
 		$this->tokenProvider->expects($this->once())
 			->method('getToken')
 			->with('sessionid')
-			->willReturn($currentToken);
-		$this->tokenProvider->expects($this->once())
-			->method('getTokenByUser')
-			->with($this->uid)
-			->willReturn([$currentToken, $otherToken, $appPassword]);
+			->willReturn($this->mockAuthToken(10));
 
-		$revokedIds = [];
-		$this->tokenProvider->expects($this->exactly(2))
-			->method('invalidateTokenById')
-			->willReturnCallback(function (string $uid, int $id) use (&$revokedIds): void {
-				$this->assertSame($this->uid, $uid);
-				$revokedIds[] = $id;
-			});
+		$this->tokenProvider->expects($this->once())
+			->method('invalidateTokensOfUserExcept')
+			->with($this->uid, 10)
+			->willReturn([11, 12]);
 
 		$this->mockActivityManager();
 
-		$response = $this->controller->destroyOthers();
-
-		$this->assertSame([11, 12], $revokedIds, 'the current session token must not be revoked');
-		$this->assertSame(['revoked' => [11, 12]], $response->getData());
-	}
-
-	public function testDestroyOthersKeepsWipePendingTokens(): void {
-		$currentToken = $this->mockAuthToken(10);
-		$otherToken = $this->mockAuthToken(11);
-		$wipingToken = $this->mockAuthToken(12, IToken::WIPE_TOKEN);
-
-		$this->session->method('getId')->willReturn('sessionid');
-		$this->tokenProvider->method('getToken')->willReturn($currentToken);
-		$this->tokenProvider->method('getTokenByUser')->willReturn([$currentToken, $otherToken, $wipingToken]);
-
-		$this->tokenProvider->expects($this->once())
-			->method('invalidateTokenById')
-			->with($this->uid, 11);
-
-		$this->mockActivityManager();
-
-		$this->assertSame(['revoked' => [11]], $this->controller->destroyOthers()->getData());
+		$this->assertSame(['revoked' => [11, 12]], $this->controller->destroyOthers()->getData());
 	}
 
 	public function testDestroyOthersPublishesOneAggregateActivity(): void {
-		$currentToken = $this->mockAuthToken(10);
-
 		$this->session->method('getId')->willReturn('sessionid');
-		$this->tokenProvider->method('getToken')->willReturn($currentToken);
-		$this->tokenProvider->method('getTokenByUser')
-			->willReturn([$currentToken, $this->mockAuthToken(11), $this->mockAuthToken(12)]);
+		$this->tokenProvider->method('getToken')->willReturn($this->mockAuthToken(10));
+		$this->tokenProvider->method('invalidateTokensOfUserExcept')->willReturn([11, 12]);
 
 		$event = $this->createMock(IEvent::class);
 		$event->method('setApp')->willReturnSelf();
@@ -352,13 +317,10 @@ class AuthSettingsControllerTest extends TestCase {
 	}
 
 	public function testDestroyOthersWithNothingToRevokePublishesNoActivity(): void {
-		$currentToken = $this->mockAuthToken(10);
-
 		$this->session->method('getId')->willReturn('sessionid');
-		$this->tokenProvider->method('getToken')->willReturn($currentToken);
-		$this->tokenProvider->method('getTokenByUser')->willReturn([$currentToken]);
+		$this->tokenProvider->method('getToken')->willReturn($this->mockAuthToken(10));
+		$this->tokenProvider->method('invalidateTokensOfUserExcept')->willReturn([]);
 
-		$this->tokenProvider->expects($this->never())->method('invalidateTokenById');
 		$this->activityManager->expects($this->never())->method('publish');
 
 		$this->assertSame(['revoked' => []], $this->controller->destroyOthers()->getData());
@@ -370,7 +332,7 @@ class AuthSettingsControllerTest extends TestCase {
 			->with('app_password')
 			->willReturn(true);
 
-		$this->tokenProvider->expects($this->never())->method('invalidateTokenById');
+		$this->tokenProvider->expects($this->never())->method('invalidateTokensOfUserExcept');
 
 		$response = $this->controller->destroyOthers();
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
@@ -379,7 +341,7 @@ class AuthSettingsControllerTest extends TestCase {
 	public function testDestroyOthersWhileImpersonating(): void {
 		$this->userSession->method('getImpersonatingUserID')->willReturn('admin');
 
-		$this->tokenProvider->expects($this->never())->method('invalidateTokenById');
+		$this->tokenProvider->expects($this->never())->method('invalidateTokensOfUserExcept');
 
 		$response = $this->controller->destroyOthers();
 		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
@@ -389,7 +351,7 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->session->method('getId')
 			->willThrowException(new SessionNotAvailableException());
 
-		$this->tokenProvider->expects($this->never())->method('invalidateTokenById');
+		$this->tokenProvider->expects($this->never())->method('invalidateTokensOfUserExcept');
 
 		$response = $this->controller->destroyOthers();
 		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
@@ -400,7 +362,7 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->tokenProvider->method('getToken')
 			->willThrowException(new InvalidTokenException('Token does not exist'));
 
-		$this->tokenProvider->expects($this->never())->method('invalidateTokenById');
+		$this->tokenProvider->expects($this->never())->method('invalidateTokensOfUserExcept');
 
 		$response = $this->controller->destroyOthers();
 		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -9,6 +9,7 @@
 namespace OC\Core\Controller;
 
 use Exception;
+use OC\Authentication\Token\IProvider;
 use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Core\Events\BeforePasswordResetEvent;
 use OC\Core\Events\PasswordResetEvent;
@@ -74,6 +75,7 @@ class LostController extends Controller {
 		private IVerificationToken $verificationToken,
 		private IEventDispatcher $eventDispatcher,
 		private Limiter $limiter,
+		private IProvider $tokenProvider,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -217,6 +219,14 @@ class LostController extends Controller {
 			\OC_Hook::emit('\OC\Core\LostPassword\Controller\LostController', 'post_passwordReset', ['uid' => $userId, 'password' => $password]);
 
 			$this->twoFactorManager->clearTwoFactorPending($userId);
+
+			// No session to keep on this path, hence the null.
+			try {
+				$this->tokenProvider->invalidateTokensOfUserExcept($userId, null);
+			} catch (Exception $e) {
+				// The password is already reset, so this must not fail the request.
+				$this->logger->warning('Could not revoke the sessions of ' . $userId . ' after a password reset', ['exception' => $e]);
+			}
 
 			$this->config->deleteUserValue($userId, 'core', 'lostpassword');
 			@Server::get(Session::class)->unsetMagicInCookie();

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -100,6 +100,15 @@ interface IProvider {
 	public function invalidateLastUsedBefore(string $uid, int $before): void;
 
 	/**
+	 * Invalidate every token of a user. Tokens pending a remote wipe are kept, because
+	 * invalidating one cancels its wipe.
+	 *
+	 * @param int|null $exceptTokenId Token to keep as well, e.g. the caller's own session
+	 * @return list<int> Ids of the invalidated tokens
+	 */
+	public function invalidateTokensOfUserExcept(string $uid, ?int $exceptTokenId): array;
+
+	/**
 	 * Save the updated token
 	 *
 	 * @param OCPIToken $token

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -210,6 +210,11 @@ class Manager implements IProvider, OCPIProvider {
 		$this->publicKeyTokenProvider->invalidateLastUsedBefore($uid, $before);
 	}
 
+	#[\Override]
+	public function invalidateTokensOfUserExcept(string $uid, ?int $exceptTokenId): array {
+		return $this->publicKeyTokenProvider->invalidateTokensOfUserExcept($uid, $exceptTokenId);
+	}
+
 	/**
 	 * @param OCPIToken $token
 	 * @param string $oldTokenId

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -267,6 +267,14 @@ class PublicKeyTokenProvider implements IProvider {
 		if ($token->getUID() !== $uid) {
 			return;
 		}
+		$this->dropToken($token);
+	}
+
+	/**
+	 * Delete a token the caller already holds, dropping it from the cache and
+	 * notifying listeners.
+	 */
+	private function dropToken(PublicKeyToken $token): void {
 		$this->mapper->invalidate($token->getToken());
 		$this->cacheInvalidHash($token->getToken());
 		$this->eventDispatcher->dispatchTyped(new TokenInvalidatedEvent($token));
@@ -294,6 +302,21 @@ class PublicKeyTokenProvider implements IProvider {
 	#[\Override]
 	public function invalidateLastUsedBefore(string $uid, int $before): void {
 		$this->mapper->invalidateLastUsedBefore($uid, $before);
+	}
+
+	#[\Override]
+	public function invalidateTokensOfUserExcept(string $uid, ?int $exceptTokenId): array {
+		$invalidated = [];
+		foreach ($this->mapper->getTokenByUser($uid) as $token) {
+			if ($token->getId() === $exceptTokenId || $token->getType() === OCPIToken::WIPE_TOKEN) {
+				continue;
+			}
+
+			$this->dropToken($token);
+			$invalidated[] = $token->getId();
+		}
+
+		return $invalidated;
 	}
 
 	#[\Override]

--- a/tests/Core/Controller/ChangePasswordControllerTest.php
+++ b/tests/Core/Controller/ChangePasswordControllerTest.php
@@ -7,16 +7,22 @@
 
 namespace Tests\Core\Controller;
 
+use OC\Authentication\Token\IProvider;
 use OC\User\Session;
 use OCA\Settings\Controller\ChangePasswordController;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Token\IToken;
 use OCP\HintException;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class ChangePasswordControllerTest extends \Test\TestCase {
 	/** @var string */
@@ -35,6 +41,9 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 	private $l;
 	/** @var ChangePasswordController */
 	private $controller;
+	private IProvider&MockObject $tokenProvider;
+	private ISession&MockObject $session;
+	private LoggerInterface&MockObject $logger;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -46,6 +55,9 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->method('t')->willReturnArgument(0);
+		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock(IRequest::class);
@@ -58,7 +70,10 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->groupManager,
 			$this->appManager,
-			$this->l
+			$this->l,
+			$this->tokenProvider,
+			$this->session,
+			$this->logger,
 		);
 	}
 
@@ -185,10 +200,80 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 			'status' => 'success',
 			'data' => [
 				'message' => 'Saved',
+				'revokedTokenIds' => [],
 			],
 		]);
 
 		$actual = $this->controller->changePersonalPassword('old', 'new');
 		$this->assertEquals($expects, $actual);
+	}
+
+	private function arrangeSuccessfulChange(): void {
+		$this->userSession->method('getLoginName')->willReturn($this->loginName);
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('checkPassword')
+			->with($this->loginName, 'old')
+			->willReturn($user);
+		$user->method('setPassword')->with('new')->willReturn(true);
+	}
+
+	private function mockCurrentSessionToken(int $id): void {
+		$token = $this->createMock(IToken::class);
+		$token->method('getId')->willReturn($id);
+		$this->session->method('getId')->willReturn('sessionid');
+		$this->tokenProvider->method('getToken')->with('sessionid')->willReturn($token);
+	}
+
+	public function testChangePersonalPasswordKeepsOtherSessionsByDefault(): void {
+		$this->arrangeSuccessfulChange();
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateTokensOfUserExcept');
+
+		$data = $this->controller->changePersonalPassword('old', 'new')->getData();
+		$this->assertSame('success', $data['status']);
+		$this->assertSame([], $data['data']['revokedTokenIds']);
+	}
+
+	public function testChangePersonalPasswordRevokesOtherSessionsWhenAsked(): void {
+		$this->arrangeSuccessfulChange();
+		$this->mockCurrentSessionToken(10);
+
+		$this->tokenProvider->expects($this->once())
+			->method('invalidateTokensOfUserExcept')
+			->with($this->userId, 10)
+			->willReturn([11, 12]);
+
+		$data = $this->controller->changePersonalPassword('old', 'new', true)->getData();
+		$this->assertSame('success', $data['status']);
+		$this->assertSame([11, 12], $data['data']['revokedTokenIds']);
+	}
+
+	public function testChangePersonalPasswordSkipsTheRevokeWithoutAUsableSessionToken(): void {
+		$this->arrangeSuccessfulChange();
+		$this->session->method('getId')->willReturn('sessionid');
+		$this->tokenProvider->method('getToken')
+			->willThrowException(new InvalidTokenException('gone'));
+
+		// Nothing is revoked rather than signing the user out of their own request.
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateTokensOfUserExcept');
+		$this->logger->expects($this->once())->method('warning');
+
+		$data = $this->controller->changePersonalPassword('old', 'new', true)->getData();
+		$this->assertSame('success', $data['status']);
+	}
+
+	public function testChangePersonalPasswordDoesNotRevokeWhenTheChangeFails(): void {
+		$this->userSession->method('getLoginName')->willReturn($this->loginName);
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('checkPassword')->willReturn($user);
+		$user->method('setPassword')->willReturn(false);
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateTokensOfUserExcept');
+
+		$data = $this->controller->changePersonalPassword('old', 'new', true)->getData();
+		$this->assertSame('error', $data['status']);
 	}
 }

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -7,6 +7,7 @@
 
 namespace Tests\Core\Controller;
 
+use OC\Authentication\Token\IProvider;
 use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Core\Controller\LostController;
 use OC\Core\Events\BeforePasswordResetEvent;
@@ -72,6 +73,7 @@ class LostControllerTest extends TestCase {
 	private $eventDispatcher;
 	/** @var Limiter|MockObject */
 	private $limiter;
+	private IProvider&MockObject $tokenProvider;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -123,6 +125,7 @@ class LostControllerTest extends TestCase {
 		$this->verificationToken = $this->createMock(IVerificationToken::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->limiter = $this->createMock(Limiter::class);
+		$this->tokenProvider = $this->createMock(IProvider::class);
 		$this->lostController = new LostController(
 			'Core',
 			$this->request,
@@ -139,7 +142,8 @@ class LostControllerTest extends TestCase {
 			$this->initialState,
 			$this->verificationToken,
 			$this->eventDispatcher,
-			$this->limiter
+			$this->limiter,
+			$this->tokenProvider,
 		);
 	}
 
@@ -501,6 +505,59 @@ class LostControllerTest extends TestCase {
 		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'ValidTokenUser', 'NewPassword', true);
 		$expectedResponse = ['user' => 'ValidTokenUser', 'status' => 'success'];
 		$this->assertSame($expectedResponse, $response->getData());
+	}
+
+	public function testSetPasswordRevokesEveryExistingSession(): void {
+		$this->config->method('getUserValue')
+			->with('ValidTokenUser', 'core', 'lostpassword', null)
+			->willReturn('encryptedData');
+		$this->existingUser->method('getLastLogin')->willReturn(12344);
+		$this->existingUser->method('setPassword')->willReturn(true);
+		$this->userManager->method('get')
+			->with('ValidTokenUser')
+			->willReturn($this->existingUser);
+
+		$this->tokenProvider->expects($this->once())
+			->method('invalidateTokensOfUserExcept')
+			->with('ValidTokenUser', null);
+
+		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'ValidTokenUser', 'NewPassword', true);
+		$this->assertSame(['user' => 'ValidTokenUser', 'status' => 'success'], $response->getData());
+	}
+
+	public function testSetPasswordStillSucceedsWhenRevokingFails(): void {
+		$this->config->method('getUserValue')
+			->with('ValidTokenUser', 'core', 'lostpassword', null)
+			->willReturn('encryptedData');
+		$this->existingUser->method('getLastLogin')->willReturn(12344);
+		$this->existingUser->method('setPassword')->willReturn(true);
+		$this->userManager->method('get')
+			->with('ValidTokenUser')
+			->willReturn($this->existingUser);
+
+		$this->tokenProvider->method('invalidateTokensOfUserExcept')
+			->willThrowException(new \Exception('database gone'));
+		$this->logger->expects($this->once())->method('warning');
+
+		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'ValidTokenUser', 'NewPassword', true);
+		$this->assertSame(['user' => 'ValidTokenUser', 'status' => 'success'], $response->getData());
+	}
+
+	public function testSetPasswordDoesNotRevokeWhenTheResetFails(): void {
+		$this->config->method('getUserValue')
+			->with('ValidTokenUser', 'core', 'lostpassword', null)
+			->willReturn('encryptedData');
+		$this->existingUser->method('getLastLogin')->willReturn(12344);
+		$this->existingUser->method('setPassword')->willReturn(false);
+		$this->userManager->method('get')
+			->with('ValidTokenUser')
+			->willReturn($this->existingUser);
+
+		$this->tokenProvider->expects($this->never())
+			->method('invalidateTokensOfUserExcept');
+
+		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'ValidTokenUser', 'NewPassword', true);
+		$this->assertSame('error', $response->getData()['status']);
 	}
 
 	public function testSetPasswordExpiredToken(): void {

--- a/tests/lib/Authentication/Token/ManagerTest.php
+++ b/tests/lib/Authentication/Token/ManagerTest.php
@@ -243,6 +243,15 @@ class ManagerTest extends TestCase {
 		$this->manager->invalidateLastUsedBefore('user', 946684800);
 	}
 
+	public function testInvalidateTokensOfUserExcept(): void {
+		$this->publicKeyTokenProvider->expects($this->once())
+			->method('invalidateTokensOfUserExcept')
+			->with('user', 42)
+			->willReturn([1, 2]);
+
+		$this->assertSame([1, 2], $this->manager->invalidateTokensOfUserExcept('user', 42));
+	}
+
 	public function testGetTokenByUser(): void {
 		$t1 = new PublicKeyToken();
 		$t2 = new PublicKeyToken();

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -362,6 +362,50 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->tokenProvider->invalidateLastUsedBefore('user', 946684800);
 	}
 
+	private function tokenFixture(int $id, int $type = IToken::PERMANENT_TOKEN): PublicKeyToken {
+		$token = new PublicKeyToken();
+		$token->setId($id);
+		$token->setUid('user');
+		$token->setType($type);
+		$token->setToken('hash' . $id);
+		return $token;
+	}
+
+	/**
+	 * @param PublicKeyToken[] $tokens
+	 */
+	private function mockTokensOfUser(array $tokens): void {
+		$this->mapper->method('getTokenByUser')->with('user')->willReturn($tokens);
+	}
+
+	public function testInvalidateTokensOfUserExcept(): void {
+		$this->mockTokensOfUser([$this->tokenFixture(1), $this->tokenFixture(2), $this->tokenFixture(3)]);
+
+		// dropToken also clears the cache entry and dispatches TokenInvalidatedEvent.
+		$this->mapper->expects($this->exactly(2))->method('invalidate');
+
+		$this->assertSame([1, 3], $this->tokenProvider->invalidateTokensOfUserExcept('user', 2));
+	}
+
+	public function testInvalidateTokensOfUserExceptKeepsWipePending(): void {
+		$this->mockTokensOfUser([
+			$this->tokenFixture(1),
+			$this->tokenFixture(2, IToken::WIPE_TOKEN),
+		]);
+
+		$this->mapper->expects($this->once())->method('invalidate');
+
+		$this->assertSame([1], $this->tokenProvider->invalidateTokensOfUserExcept('user', null));
+	}
+
+	public function testInvalidateTokensOfUserExceptWithNothingToDo(): void {
+		$this->mockTokensOfUser([$this->tokenFixture(7)]);
+
+		$this->mapper->expects($this->never())->method('invalidate');
+
+		$this->assertSame([], $this->tokenProvider->invalidateTokensOfUserExcept('user', 7));
+	}
+
 	public function testRenewSessionTokenWithoutPassword(): void {
 		$token = 'oldIdtokentokentokentoken';
 		$uid = 'user';

--- a/tests/playwright/e2e/settings/devices-sessions.spec.ts
+++ b/tests/playwright/e2e/settings/devices-sessions.spec.ts
@@ -3,15 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { runOcc } from '@nextcloud/e2e-test-server/docker'
 import { expect } from '@playwright/test'
 import { test } from '../../support/fixtures/personal-settings-page.ts'
-
-// Without --password-from-env the token carries no login password. Fine here: the
-// test only revokes it, it never authenticates with it.
-async function addAppPassword(userId: string, name: string): Promise<void> {
-	await runOcc(['user:auth-tokens:add', userId, '--name', name])
-}
+import { addAppPassword } from '../../support/utils/auth-tokens.ts'
 
 test.describe('Settings: Devices & sessions', () => {
 	test('revokes every other session but keeps the current one', async ({ page, devicesSessionsPage, user }) => {

--- a/tests/playwright/e2e/settings/password-revoke-sessions.spec.ts
+++ b/tests/playwright/e2e/settings/password-revoke-sessions.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect } from '@playwright/test'
+import { test } from '../../support/fixtures/personal-settings-page.ts'
+import { addAppPassword } from '../../support/utils/auth-tokens.ts'
+
+const NEW_PASSWORD = 'a-brand-new-password'
+
+test.describe('Settings: revoking sessions on a password change', () => {
+	test('drops the other sessions live and leaves the current one usable', async ({ page, passwordPage, devicesSessionsPage, user }) => {
+		await addAppPassword(user.userId, 'Playwright device')
+
+		await passwordPage.open()
+		await expect(devicesSessionsPage.tokenRows()).toHaveCount(2)
+
+		await passwordPage.changePassword(NEW_PASSWORD, true)
+
+		// Devices & sessions is a separate Vue app, reached over the event bus.
+		await expect(devicesSessionsPage.tokenRow('Playwright device')).toHaveCount(0)
+		await expect(devicesSessionsPage.tokenRows()).toHaveCount(1)
+
+		// A killed session token would redirect this reload to the login page.
+		await page.reload()
+		await expect(devicesSessionsPage.heading()).toBeVisible()
+		await expect(devicesSessionsPage.tokenRow('This session')).toBeVisible()
+	})
+
+	test('keeps the other sessions when the option is left unticked', async ({ page, passwordPage, devicesSessionsPage, user }) => {
+		await addAppPassword(user.userId, 'Playwright device')
+
+		await passwordPage.open()
+		await passwordPage.changePassword(NEW_PASSWORD)
+
+		// Reload so the assertion reflects the server, not just untouched local state.
+		await page.reload()
+		await expect(devicesSessionsPage.tokenRow('Playwright device')).toBeVisible()
+		await expect(devicesSessionsPage.tokenRows()).toHaveCount(2)
+	})
+})

--- a/tests/playwright/support/fixtures/personal-settings-page.ts
+++ b/tests/playwright/support/fixtures/personal-settings-page.ts
@@ -6,6 +6,7 @@
 import { runOcc } from '@nextcloud/e2e-test-server/docker'
 import { DevicesSessionsSettingsPage } from '../sections/DevicesSessionsSettingsPage.ts'
 import { LanguageLocaleSettingsPage } from '../sections/LanguageLocaleSettingsPage.ts'
+import { PasswordSettingsPage } from '../sections/PasswordSettingsPage.ts'
 import { ProfileContactSettingsPage } from '../sections/ProfileContactSettingsPage.ts'
 import { test as userSessionTest } from './random-user-session.ts'
 
@@ -18,6 +19,7 @@ export const test = userSessionTest.extend<{
 	profileContactPage: ProfileContactSettingsPage
 	languageLocalePage: LanguageLocaleSettingsPage
 	devicesSessionsPage: DevicesSessionsSettingsPage
+	passwordPage: PasswordSettingsPage
 }>({
 	user: async ({ user: baseUser }, use) => {
 		await runOcc(['user:setting', baseUser.userId, 'core', 'lang', 'en'])
@@ -35,5 +37,9 @@ export const test = userSessionTest.extend<{
 
 	devicesSessionsPage: async ({ page, user }, use) => {
 		await use(new DevicesSessionsSettingsPage(page, user))
+	},
+
+	passwordPage: async ({ page, user }, use) => {
+		await use(new PasswordSettingsPage(page, user))
 	},
 })

--- a/tests/playwright/support/sections/PasswordSettingsPage.ts
+++ b/tests/playwright/support/sections/PasswordSettingsPage.ts
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { User } from '@nextcloud/e2e-test-server'
+import type { Locator, Page } from '@playwright/test'
+
+import { expect } from '@playwright/test'
+
+export class PasswordSettingsPage {
+	constructor(
+		private readonly page: Page,
+		private readonly user: User,
+	) {}
+
+	heading(): Locator {
+		return this.page.getByRole('heading', { name: 'Password', exact: true, level: 2 })
+	}
+
+	async open(): Promise<void> {
+		await this.page.goto('settings/user/security')
+		await expect(this.heading()).toBeVisible()
+	}
+
+	/** Password inputs carry no ARIA role, so they are addressed by their label. */
+	private field(label: string): Locator {
+		return this.page.getByLabel(label).and(this.page.locator('input'))
+	}
+
+	private revokeOtherSessionsCheckbox(): Locator {
+		return this.page.getByRole('checkbox', { name: 'Sign out all other devices and apps' })
+	}
+
+	/**
+	 * @param newPassword - Password to set
+	 * @param revokeOtherSessions - Tick the opt-in that signs out every other device
+	 */
+	async changePassword(newPassword: string, revokeOtherSessions = false): Promise<void> {
+		await this.field('Current password').fill(this.user.password)
+		await this.field('New password').fill(newPassword)
+
+		if (revokeOtherSessions) {
+			// NcCheckboxRadioSwitch hides the native input behind its label.
+			await this.revokeOtherSessionsCheckbox().check({ force: true })
+		}
+
+		const changed = this.page.waitForResponse((r) => r.request().method() === 'POST'
+			&& r.url().includes('/settings/personal/changepassword')
+			&& r.ok())
+		await this.page.getByRole('button', { name: 'Change password' }).click()
+		await changed
+	}
+}

--- a/tests/playwright/support/utils/auth-tokens.ts
+++ b/tests/playwright/support/utils/auth-tokens.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { runOcc } from '@nextcloud/e2e-test-server/docker'
+
+/**
+ * Create an app password so there is something to revoke.
+ *
+ * Without --password-from-env the token carries no login password. Fine for tests that
+ * only revoke it and never authenticate with it.
+ *
+ * @param userId - Login to create the token for
+ * @param name - Device name shown in the token list
+ */
+export async function addAppPassword(userId: string, name: string): Promise<void> {
+	await runOcc(['user:auth-tokens:add', userId, '--name', name])
+}


### PR DESCRIPTION
## Summary

Changing your password doesn't touch app passwords, so cleaning up after a compromised account meant revoking each one by hand. 

While we now have a button to destory all tokens (added by https://github.com/nextcloud/server/pull/63543) prompting the user to do this automatically with a check provides additional hardening. This adds an opt-in checkbox to the password form. Resets by mail always revoke.

<img width="331" height="310" alt="image" src="https://github.com/user-attachments/assets/dd391d4a-5d74-4863-8bf2-4a138ef1a390" />

## Notes

- Wipe-pending tokens are kept. Revoking one cancels its wipe.
- Current session survives.
- OAuth2 grants and remember-me cookies go too, same table.
- Admin changes and `occ user:resetpassword` are out of scope.
- Token list updates over the event bus, it's a separate Vue app from the password form.

## Checklist

- Code is properly formatted
- Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation (manuals or wiki) has been updated or is not required
- [x] Backports requested where applicable (ex: critical bugfixes)
- [ ] Labels added where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] Milestone added for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
