### PR TITLE
fix(settings): clean up regex / app config outliers

### DIFF
--- a/apps/dav/lib/Settings/CalDAVSettings.php
+++ b/apps/dav/lib/Settings/CalDAVSettings.php
@@ -80,7 +80,7 @@ class CalDAVSettings implements IDelegatedSettings {
 	#[\Override]
 	public function getAuthorizedAppConfig(): array {
 		return [
-			'dav' => ['/(' . implode('|', array_keys(self::defaults)) . ')/']
+			'dav' => array_keys(self::defaults),
 		];
 	}
 }

--- a/apps/settings/lib/Settings/Admin/Server.php
+++ b/apps/settings/lib/Settings/Admin/Server.php
@@ -110,10 +110,6 @@ class Server implements IDelegatedSettings {
 
 	#[\Override]
 	public function getAuthorizedAppConfig(): array {
-		return [
-			'core' => [
-				'/mail_general_settings/',
-			],
-		];
+		return [];
 	}
 }

--- a/apps/settings/lib/Settings/Admin/Sharing.php
+++ b/apps/settings/lib/Settings/Admin/Sharing.php
@@ -121,7 +121,7 @@ class Sharing implements IDelegatedSettings {
 	#[\Override]
 	public function getAuthorizedAppConfig(): array {
 		return [
-			'core' => ['/shareapi_.*/'],
+			'core' => ['/^shareapi_.*$/'],
 		];
 	}
 

--- a/apps/sharebymail/lib/Settings/Admin.php
+++ b/apps/sharebymail/lib/Settings/Admin.php
@@ -64,7 +64,10 @@ class Admin implements IDelegatedSettings {
 	#[\Override]
 	public function getAuthorizedAppConfig(): array {
 		return [
-			'sharebymail' => ['s/(sendpasswordmail|replyToInitiator)/'],
+			'sharebymail' => [
+				'sendpasswordmail',
+				'replyToInitiator',
+			],
 		];
 	}
 }

--- a/apps/theming/lib/Settings/Admin.php
+++ b/apps/theming/lib/Settings/Admin.php
@@ -115,7 +115,7 @@ class Admin implements IDelegatedSettings {
 	#[\Override]
 	public function getAuthorizedAppConfig(): array {
 		return [
-			Application::APP_ID => '/.*/',
+			Application::APP_ID => '/^.*$/',
 		];
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Broader follow-up inspired by #63686 that cleans up some other outliers.

- Use explicit configuration keys where regular expressions are unnecessary.
- Remove the obsolete `core/mail_general_settings` authorization entry.
- Anchor the remaining regular expressions so they match the complete key.

## TODO

- [ ] Backport? If so, to the same as #63686 or just to standard non-EOL releases?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
