### PR TITLE
fix(AppMenuActions): Shorten "More actions" label

### DIFF
--- a/core/src/components/AppMenuActions.vue
+++ b/core/src/components/AppMenuActions.vue
@@ -28,7 +28,7 @@ const emit = defineEmits<{
 
 /**
  * Number of cells in the actions row, matching the column count of the app
- * grid. Actions that do not fit move into the trailing "More actions" cell.
+ * grid. Actions that do not fit move into the trailing "More" cell.
  */
 const ACTIONS_PER_ROW = 4
 
@@ -42,7 +42,7 @@ const overflowEntry: INavigationEntry = {
 	href: '',
 	icon: '',
 	type: 'action',
-	name: t('core', 'More actions'),
+	name: t('core', 'More'),
 	unread: 0,
 }
 

--- a/core/src/tests/components/AppMenu.spec.ts
+++ b/core/src/tests/components/AppMenu.spec.ts
@@ -592,7 +592,7 @@ describe('core: AppMenu navigation actions', () => {
 		expect(document.activeElement).toBe(rowItems()[0])
 	})
 
-	it('moves the actions that do not fit into a "More actions" submenu', async () => {
+	it('moves the actions that do not fit into a "More" submenu', async () => {
 		initialState.loadState.mockImplementation(stateWith(fakeApps(), fakeActions(6)))
 		const wrapper = mount(AppMenu, { attachTo: document.body })
 		await openPopover(wrapper)
@@ -600,7 +600,7 @@ describe('core: AppMenu navigation actions', () => {
 		const items = rowItems()
 		// Three actions plus the trailing overflow item make up the single row.
 		expect(items).toHaveLength(4)
-		expect(items[3].textContent).toContain('More actions')
+		expect(items[3].textContent).toContain('More')
 		expect(items[3].getAttribute('aria-haspopup')).toBe('menu')
 		expect(items[3].getAttribute('aria-expanded')).toBe('false')
 		expect(document.querySelector('.app-menu-actions__submenu')).toBeNull()


### PR DESCRIPTION
Partly to avoid awkward wrapping

Follow-up to #63134

cc @susnux

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
