### PR TITLE
fix(core): accept deprecated IANA timezone aliases

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -1358,7 +1358,8 @@ class UsersController extends AUserDataOCSController {
 				$this->config->setUserValue($targetUser->getUID(), 'core', 'locale', $value);
 				break;
 			case self::USER_FIELD_TIMEZONE:
-				if (!in_array($value, \DateTimeZone::listIdentifiers())) {
+				// Older browsers still report deprecated aliases like Europe/Kiev.
+				if (!in_array($value, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC))) {
 					throw new OCSException($this->l10n->t('Invalid timezone'), 101);
 				}
 				$this->config->setUserValue($targetUser->getUID(), 'core', 'timezone', $value);

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -2591,6 +2591,92 @@ class UsersControllerTest extends TestCase {
 		$this->assertEquals([], $this->api->editUser('UserToEdit', 'language', 'ru')->getData());
 	}
 
+	public static function dataEditUserSelfEditChangeTimezone(): array {
+		return [
+			'primary identifier' => ['Europe/Kyiv'],
+			'backward compatible alias' => ['Europe/Kiev'],
+			'legacy region alias' => ['US/Eastern'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataEditUserSelfEditChangeTimezone')]
+	public function testEditUserSelfEditChangeTimezone(string $timezone): void {
+		$loggedInUser = $this->createMock(IUser::class);
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UserToEdit');
+		$targetUser = $this->createMock(IUser::class);
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('UserToEdit', 'core', 'timezone', $timezone);
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($loggedInUser);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->willReturn($targetUser);
+		$this->groupManager
+			->expects($this->atLeastOnce())
+			->method('isAdmin')
+			->with('UserToEdit')
+			->willReturn(false);
+		$targetUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UserToEdit');
+
+		$backend = $this->createMock(UserInterface::class);
+		$targetUser
+			->expects($this->any())
+			->method('getBackend')
+			->willReturn($backend);
+
+		$this->assertEquals([], $this->api->editUser('UserToEdit', 'timezone', $timezone)->getData());
+	}
+
+	public function testEditUserSelfEditChangeTimezoneInvalid(): void {
+		$this->expectException(OCSException::class);
+
+		$loggedInUser = $this->createMock(IUser::class);
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UserToEdit');
+		$targetUser = $this->createMock(IUser::class);
+		$this->config->expects($this->never())
+			->method('setUserValue');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($loggedInUser);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->willReturn($targetUser);
+		$this->groupManager
+			->expects($this->atLeastOnce())
+			->method('isAdmin')
+			->with('UserToEdit')
+			->willReturn(false);
+		$targetUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UserToEdit');
+
+		$backend = $this->createMock(UserInterface::class);
+		$targetUser
+			->expects($this->any())
+			->method('getBackend')
+			->willReturn($backend);
+
+		$this->api->editUser('UserToEdit', 'timezone', 'Mars/Olympus_Mons');
+	}
+
 	public function testEditUserSubadminUserAccessible(): void {
 		$this->appConfig
 			->expects($this->once())

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -2591,16 +2591,32 @@ class UsersControllerTest extends TestCase {
 		$this->assertEquals([], $this->api->editUser('UserToEdit', 'language', 'ru')->getData());
 	}
 
+	/**
+	 * Debian and Ubuntu ship the tz database's backward links in a separate
+	 * tzdata-legacy package, so pick an alias this platform actually knows
+	 * instead of hardcoding one.
+	 */
+	private static function findBackwardCompatibleTimezone(): ?string {
+		$aliases = array_diff(
+			\DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC),
+			\DateTimeZone::listIdentifiers(),
+		);
+		return $aliases === [] ? null : reset($aliases);
+	}
+
 	public static function dataEditUserSelfEditChangeTimezone(): array {
 		return [
-			'primary identifier' => ['Europe/Kyiv'],
-			'backward compatible alias' => ['Europe/Kiev'],
-			'legacy region alias' => ['US/Eastern'],
+			'primary identifier' => ['Europe/Vienna'],
+			'backward compatible alias' => [self::findBackwardCompatibleTimezone()],
 		];
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEditUserSelfEditChangeTimezone')]
-	public function testEditUserSelfEditChangeTimezone(string $timezone): void {
+	public function testEditUserSelfEditChangeTimezone(?string $timezone): void {
+		if ($timezone === null) {
+			$this->markTestSkipped('No backward compatible timezone aliases in this platform\'s tz database');
+		}
+
 		$loggedInUser = $this->createMock(IUser::class);
 		$loggedInUser
 			->expects($this->any())

--- a/lib/private/Authentication/Login/SetUserTimezoneCommand.php
+++ b/lib/private/Authentication/Login/SetUserTimezoneCommand.php
@@ -38,6 +38,7 @@ class SetUserTimezoneCommand extends ALoginCommand {
 	}
 
 	private function isValidTimezone(?string $value): bool {
-		return $value && in_array($value, \DateTimeZone::listIdentifiers());
+		// Older browsers still report deprecated aliases like Europe/Kiev.
+		return $value && in_array($value, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC));
 	}
 }

--- a/tests/lib/Authentication/Login/ALoginTestCommand.php
+++ b/tests/lib/Authentication/Login/ALoginTestCommand.php
@@ -91,14 +91,14 @@ abstract class ALoginTestCommand extends TestCase {
 		return $data;
 	}
 
-	protected function getLoggedInLoginDataWithTimezone(): LoginData {
+	protected function getLoggedInLoginDataWithTimezone(?string $timezone = null): LoginData {
 		$data = new LoginData(
 			$this->request,
 			$this->username,
 			$this->password,
 			true,
 			null,
-			$this->timezone,
+			$timezone ?? $this->timezone,
 			$this->timeZoneOffset
 		);
 		$data->setUser($this->user);

--- a/tests/lib/Authentication/Login/SetUserTimezoneCommandTest.php
+++ b/tests/lib/Authentication/Login/SetUserTimezoneCommandTest.php
@@ -45,8 +45,17 @@ class SetUserTimezoneCommandTest extends ALoginTestCommand {
 		$this->assertTrue($result->isSuccess());
 	}
 
-	public function testProcess(): void {
-		$data = $this->getLoggedInLoginDataWithTimezone();
+	public static function dataAcceptedTimezone(): array {
+		return [
+			'primary identifier' => ['Europe/Vienna'],
+			'backward compatible alias' => ['Europe/Kiev'],
+			'legacy region alias' => ['US/Eastern'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAcceptedTimezone')]
+	public function testProcess(string $timezone): void {
+		$data = $this->getLoggedInLoginDataWithTimezone($timezone);
 		$this->user->expects($this->once())
 			->method('getUID')
 			->willReturn($this->username);
@@ -65,7 +74,7 @@ class SetUserTimezoneCommandTest extends ALoginTestCommand {
 				$this->username,
 				'core',
 				'timezone',
-				$this->timezone
+				$timezone
 			);
 		$this->session->expects($this->once())
 			->method('set')
@@ -73,6 +82,18 @@ class SetUserTimezoneCommandTest extends ALoginTestCommand {
 				'timezone',
 				$this->timeZoneOffset
 			);
+
+		$result = $this->cmd->process($data);
+
+		$this->assertTrue($result->isSuccess());
+	}
+
+	public function testProcessUnknownTimezone(): void {
+		$data = $this->getLoggedInLoginDataWithTimezone('Mars/Olympus_Mons');
+		$this->config->expects($this->never())
+			->method('setUserValue');
+		$this->session->expects($this->never())
+			->method('set');
 
 		$result = $this->cmd->process($data);
 

--- a/tests/lib/Authentication/Login/SetUserTimezoneCommandTest.php
+++ b/tests/lib/Authentication/Login/SetUserTimezoneCommandTest.php
@@ -45,16 +45,32 @@ class SetUserTimezoneCommandTest extends ALoginTestCommand {
 		$this->assertTrue($result->isSuccess());
 	}
 
+	/**
+	 * Debian and Ubuntu ship the tz database's backward links in a separate
+	 * tzdata-legacy package, so pick an alias this platform actually knows
+	 * instead of hardcoding one.
+	 */
+	private static function findBackwardCompatibleTimezone(): ?string {
+		$aliases = array_diff(
+			\DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC),
+			\DateTimeZone::listIdentifiers(),
+		);
+		return $aliases === [] ? null : reset($aliases);
+	}
+
 	public static function dataAcceptedTimezone(): array {
 		return [
 			'primary identifier' => ['Europe/Vienna'],
-			'backward compatible alias' => ['Europe/Kiev'],
-			'legacy region alias' => ['US/Eastern'],
+			'backward compatible alias' => [self::findBackwardCompatibleTimezone()],
 		];
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataAcceptedTimezone')]
-	public function testProcess(string $timezone): void {
+	public function testProcess(?string $timezone): void {
+		if ($timezone === null) {
+			$this->markTestSkipped('No backward compatible timezone aliases in this platform\'s tz database');
+		}
+
 		$data = $this->getLoggedInLoginDataWithTimezone($timezone);
 		$this->user->expects($this->once())
 			->method('getUID')


### PR DESCRIPTION
## Summary

Fixes a bug where legacy timezone identifiers sent by browsers get silently rejected. 

PHP's `listIdentifiers()` defaults to `ALL`, which skips the tz database's backward links. So many older but valid names get refused, `Europe/Kiev`  among them, even though PHP itself resolves them without complaint. Many browsers still send the old names.

Two places got this wrong: 
- The provisioning API throws a 400
- `SetUserTimezoneCommand` quietly drops the value at login

Both use [ALL_WITH_BC](https://www.php.net/manual/en/class.datetimezone.php#datetimezone.constants.all-with-bc) now. Read requests already accepted these names, so this fixes write request cases.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (tests)
