### PR TITLE
fix(cardDav): Only update user card on actual mapped propreties changes

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -152,7 +152,12 @@ class SyncService extends ASyncService {
 					if (is_null($vCard)) {
 						$this->backend->deleteCard($addressBookId, $cardId);
 					} else {
-						$this->backend->updateCard($addressBookId, $cardId, $vCard->serialize());
+						$cardData = $vCard->serialize();
+						// Writing an identical card would still bump the address book
+						// sync token and make every client re-download the card
+						if ($card['carddata'] !== $cardData) {
+							$this->backend->updateCard($addressBookId, $cardId, $cardData);
+						}
 					}
 				}
 			}, $this->dbConnection);

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -457,6 +457,45 @@ END:VCARD';
 		$ss->deleteUser($user);
 	}
 
+	public function testUpdateUserSkipsUnchangedCard(): void {
+		$vCard = new VCard();
+		$vCard->VERSION = '3.0';
+		$vCard->UID = 'test-user';
+		$vCard->FN = 'test-user';
+
+		/** @var CardDavBackend&MockObject $backend */
+		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$backend->expects($this->never())->method('createCard');
+		$backend->expects($this->never())->method('updateCard');
+		$backend->expects($this->never())->method('deleteCard');
+
+		$backend->method('getCard')->willReturn(['carddata' => $vCard->serialize()]);
+		$backend->method('getAddressBooksByUri')
+			->with('principals/system/system', 'system')
+			->willReturn(['id' => -1]);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('unittest');
+		$user->method('getUID')->willReturn('test-user');
+		$user->method('isEnabled')->willReturn(true);
+
+		$converter = $this->createMock(Converter::class);
+		$converter->method('createCardFromUser')->willReturn($vCard);
+
+		$ss = new SyncService(
+			$this->createMock(IClientService::class),
+			$this->createMock(IConfig::class),
+			$backend,
+			$this->createMock(IUserManager::class),
+			$this->createMock(IDBConnection::class),
+			$logger,
+			$converter,
+		);
+		$ss->updateUser($user);
+	}
+
 	public function testSyncInstance(): void {
 		/** @var CardDavBackend | MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Reproduction 
1. Edit a user untracked property such as quota or pronouns 
2. Look at oc_addressbookchanges 

### Expected 
No unnecessary row is added  

### Actual 
An unnecessary row is added  



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
