### PR TITLE
docs: fix typo orginal -> original

### DIFF
--- a/apps/theming/README.md
+++ b/apps/theming/README.md
@@ -29,8 +29,8 @@ A reference to why it was very difficult to actually find good background pictur
 
 In `img/background/`:
 
-- Default background: [Fluid (Jo Myoung Hee - Nextcloud GmbH, CC-BY-SA-4.0)](https://nextcloud.com/trademarks/) - orginal 4k
-- [Globe (Jenna Kim - Nextcloud GmbH, CC-BY-SA-4.0)](https://nextcloud.com/trademarks/) - orginal 4k
+- Default background: [Fluid (Jo Myoung Hee - Nextcloud GmbH, CC-BY-SA-4.0)](https://nextcloud.com/trademarks/) - original 4k
+- [Globe (Jenna Kim - Nextcloud GmbH, CC-BY-SA-4.0)](https://nextcloud.com/trademarks/) - original 4k
 - [Clouds (Kamil Porembiński, CC BY-SA)](https://www.flickr.com/photos/paszczak000/8715851521/) – original 4k, color modified and sky color changed to Nextcloud blue.
 - [Pedra azul milky way (Eduardo Neves, CC BY-SA)](https://commons.wikimedia.org/wiki/File:Pedra_Azul_Milky_Way.jpg) – original 5k.
 - [Soft floral (Hannah MacLean, CC0)](https://stocksnap.io/photo/soft-floral-XOYWCCW5PA) – original 5.5k.


### PR DESCRIPTION
Corrects the misspelling `orginal` -> `original` in `apps/theming/README.md`.

Documentation only, no behaviour change.