### PR TITLE
fix(auth): correctly size keys for encrypted token passwords

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -471,7 +471,7 @@ class PublicKeyTokenProvider implements IProvider {
 
 		if ($storeCryptedPassword && $passwordLength > IUserManager::MAX_PASSWORD_LENGTH) {
 			throw new \RuntimeException(sprintf(
-				'Storing an encrypted password longer than %d bytes in an authentication token is not supported.',				
+				'Storing an encrypted password longer than %d bytes in an authentication token is not supported.',
 				IUserManager::MAX_PASSWORD_LENGTH,
 			));
 		}

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -30,8 +30,15 @@ use Psr\Log\LoggerInterface;
 
 class PublicKeyTokenProvider implements IProvider {
 	public const TOKEN_MIN_LENGTH = 22;
+
 	/** Token cache TTL in seconds */
 	private const int TOKEN_CACHE_TTL = 10;
+
+	/**
+	 * Maximum plaintext size for a 2048-bit RSA key using OAEP with SHA-1:
+	 * 256 - (2 * 20) - 2 = 214 bytes.
+	 */
+	private const int RSA_2048_OAEP_MAX_PLAINTEXT_LENGTH = 214;
 
 	use TTransactional;
 
@@ -439,12 +446,13 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	/**
-	 * @throws \RuntimeException when OpenSSL reports a problem
+	 * @throws \RuntimeException when the password cannot be stored or OpenSSL reports a problem
 	 */
-	private function newToken(string $token,
+	private function newToken(
+		string $token,
 		string $uid,
 		string $loginName,
-		$password,
+		?string $password,
 		string $name,
 		int $type,
 		int $remember,
@@ -454,9 +462,25 @@ class PublicKeyTokenProvider implements IProvider {
 		$dbToken->setUid($uid);
 		$dbToken->setLoginName($loginName);
 
+		$storeCryptedPassword = $password !== null
+			&& $this->config->getSystemValueBool('auth.storeCryptedPassword', true);
+		$passwordLength = $storeCryptedPassword ? strlen($password) : 0;
+
+		if ($storeCryptedPassword && $passwordLength > IUserManager::MAX_PASSWORD_LENGTH) {
+			throw new \RuntimeException(sprintf(
+				'Storing an encrypted password longer than %d bytes in an authentication token is not supported.',				
+				IUserManager::MAX_PASSWORD_LENGTH,
+			));
+		}
+
+		$requiredKeySize = $storeCryptedPassword
+			&& $passwordLength > self::RSA_2048_OAEP_MAX_PLAINTEXT_LENGTH
+			? 4096
+			: 2048;
+
 		$config = array_merge([
 			'digest_alg' => 'sha512',
-			'private_key_bits' => $password !== null && strlen($password) > 250 ? 4096 : 2048,
+			'private_key_bits' => $requiredKeySize,
 		], $this->config->getSystemValue('openssl', []));
 
 		// Generate new key
@@ -478,10 +502,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$dbToken->setPublicKey($publicKey);
 		$dbToken->setPrivateKey($this->encrypt($privateKey, $token));
 
-		if (!is_null($password) && $this->config->getSystemValueBool('auth.storeCryptedPassword', true)) {
-			if (strlen($password) > IUserManager::MAX_PASSWORD_LENGTH) {
-				throw new \RuntimeException('Trying to save a password with more than 469 characters is not supported. If you want to use big passwords, disable the auth.storeCryptedPassword option in config.php');
-			}
+		if ($storeCryptedPassword) {
 			$dbToken->setPassword($this->encryptPassword($password, $publicKey));
 			$dbToken->setPasswordHash($this->hashPassword($password));
 		}

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -420,10 +420,13 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	private function encryptPassword(string $password, string $publicKey): string {
-		openssl_public_encrypt($password, $encryptedPassword, $publicKey, OPENSSL_PKCS1_OAEP_PADDING);
-		$encryptedPassword = base64_encode($encryptedPassword);
+		if (!openssl_public_encrypt($password, $encryptedPassword, $publicKey, OPENSSL_PKCS1_OAEP_PADDING)) {
+			// Never store missing or invalid ciphertext when password encryption fails.
+			$this->logOpensslError();
+			throw new \RuntimeException('OpenSSL reported a problem');
+		}
 
-		return $encryptedPassword;
+		return base64_encode($encryptedPassword);
 	}
 
 	private function decryptPassword(string $encryptedPassword, string $privateKey): string {

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -22,6 +22,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Security\ICrypto;
 use OCP\Security\IHasher;
 use OCP\Server;
@@ -128,23 +129,33 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->tokenProvider->getPassword($actual, $token);
 	}
 
-	public function testGenerateTokenLongPassword(): void {
-		$token = 'tokentokentokentokentoken';
-		$uid = 'user';
-		$user = 'User';
-		$password = '';
-		for ($i = 0; $i < 500; $i++) {
-			$password .= 'e';
-		}
+	public function testGenerateTokenRejectsPasswordAboveStorageLimit(): void {
+		$password = str_repeat('e', IUserManager::MAX_PASSWORD_LENGTH + 1);
 		$name = 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12';
-		$type = IToken::PERMANENT_TOKEN;
+
 		$this->config->method('getSystemValueBool')
 			->willReturnMap([
 				['auth.storeCryptedPassword', true, true],
 			]);
-		$this->expectException(\RuntimeException::class);
 
-		$actual = $this->tokenProvider->generateToken($token, $uid, $user, $password, $name, $type, IToken::DO_NOT_REMEMBER);
+		$this->mapper->expects($this->never())
+			->method('insert');
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage(sprintf(
+			'Storing an encrypted password longer than %d bytes in an authentication token is not supported.',
+			IUserManager::MAX_PASSWORD_LENGTH,
+		));
+
+		$this->tokenProvider->generateToken(
+			'tokentokentokentokentoken',
+			'user',
+			'User',
+			$password,
+			$name,
+			IToken::PERMANENT_TOKEN,
+			IToken::DO_NOT_REMEMBER,
+		);
 	}
 
 	public function testGenerateTokenInvalidName(): void {

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -158,6 +158,68 @@ class PublicKeyTokenProviderTest extends TestCase {
 		);
 	}
 
+	private function getPublicKeyBits(PublicKeyToken $token): int {
+		$publicKey = openssl_pkey_get_public($token->getPublicKey());
+		$this->assertNotFalse($publicKey);
+
+		$details = openssl_pkey_get_details($publicKey);
+		$this->assertIsArray($details);
+
+		return $details['bits'];
+	}
+
+	public function testGenerateTokenUses2048BitKeyAtOaepLimit(): void {
+		// 214 = PublicKeyTokenProvider::RSA_2048_OAEP_MAX_PLAINTEXT_LENGTH
+		$password = str_repeat('a', 214);
+
+		$this->config->method('getSystemValueBool')
+			->willReturnMap([
+				['auth.storeCryptedPassword', true, true],
+			]);
+
+		$actual = $this->tokenProvider->generateToken(
+			'tokentokentokentokentoken',
+			'user',
+			'User',
+			$password,
+			'Test token',
+			IToken::PERMANENT_TOKEN,
+			IToken::DO_NOT_REMEMBER,
+		);
+
+		$this->assertSame(2048, $this->getPublicKeyBits($actual));
+		$this->assertSame(
+			$password,
+			$this->tokenProvider->getPassword($actual, 'tokentokentokentokentoken'),
+		);
+	}
+
+	public function testGenerateTokenUses4096BitKeyAboveOaepLimit(): void {
+		// 215 = PublicKeyTokenProvider::RSA_2048_OAEP_MAX_PLAINTEXT_LENGTH + 1
+		$password = str_repeat('a', 215);
+
+		$this->config->method('getSystemValueBool')
+			->willReturnMap([
+				['auth.storeCryptedPassword', true, true],
+			]);
+
+		$actual = $this->tokenProvider->generateToken(
+			'tokentokentokentokentoken',
+			'user',
+			'User',
+			$password,
+			'Test token',
+			IToken::PERMANENT_TOKEN,
+			IToken::DO_NOT_REMEMBER,
+		);
+
+		$this->assertSame(4096, $this->getPublicKeyBits($actual));
+		$this->assertSame(
+			$password,
+			$this->tokenProvider->getPassword($actual, 'tokentokentokentokentoken'),
+		);
+	}
+	
 	public function testGenerateTokenInvalidName(): void {
 		$token = 'tokentokentokentokentoken';
 		$uid = 'user';

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -385,6 +385,48 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->assertSame($newpass, $this->tokenProvider->getPassword($actual, 'tokentokentokentokentoken'));
 	}
 
+	public function testSetPasswordFailsWhenExistingKeyIsTooSmall(): void {
+		$tokenId = 'tokentokentokentokentoken';
+
+		$this->config->method('getSystemValueBool')
+			->willReturnMap([
+				['auth.storeCryptedPassword', true, true],
+			]);
+
+		$token = $this->tokenProvider->generateToken(
+			$tokenId,
+			'user',
+			'User',
+			'short-password',
+			'Test token',
+			IToken::PERMANENT_TOKEN,
+			IToken::DO_NOT_REMEMBER,
+		);
+
+		$this->assertSame(2048, $this->getPublicKeyBits($token));
+
+		$this->mapper->method('getTokenByUser')
+			->with('user')
+			->willReturn([$token]);
+
+		$this->logger->expects($this->once())
+			->method('critical')
+			->with($this->stringStartsWith('Something is wrong with your openssl setup:'));
+
+		$this->mapper->expects($this->never())
+			->method('update');
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('OpenSSL reported a problem');
+
+		$this->tokenProvider->setPassword(
+			$token,
+			$tokenId,
+			// 215 = PublicKeyTokenProvider::RSA_2048_OAEP_MAX_PLAINTEXT_LENGTH + 1
+			str_repeat('a', 215),
+		);
+	}
+
 	public function testSetPasswordInvalidToken(): void {
 		$this->expectException(InvalidTokenException::class);
 

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -242,7 +242,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 			$this->tokenProvider->getPassword($actual, 'tokentokentokentokentoken'),
 		);
 	}
-	
+
 	public function testGenerateTokenInvalidName(): void {
 		$token = 'tokentokentokentokentoken';
 		$uid = 'user';

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -158,6 +158,29 @@ class PublicKeyTokenProviderTest extends TestCase {
 		);
 	}
 
+	public function testGenerateTokenDoesNotStoreLongPasswordWhenStorageIsDisabled(): void {
+		$password = str_repeat('a', IUserManager::MAX_PASSWORD_LENGTH + 1);
+
+		$this->config->method('getSystemValueBool')
+			->willReturnMap([
+				['auth.storeCryptedPassword', true, false],
+			]);
+
+		$actual = $this->tokenProvider->generateToken(
+			'tokentokentokentokentoken',
+			'user',
+			'User',
+			$password,
+			'Test token',
+			IToken::PERMANENT_TOKEN,
+			IToken::DO_NOT_REMEMBER,
+		);
+
+		$this->assertSame(2048, $this->getPublicKeyBits($actual));
+		$this->assertNull($actual->getPassword());
+		$this->assertNull($actual->getPasswordHash());
+	}
+
 	private function getPublicKeyBits(PublicKeyToken $token): int {
 		$publicKey = openssl_pkey_get_public($token->getPublicKey());
 		$this->assertNotFalse($publicKey);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Correct the RSA key-size selection used to encrypt passwords associated with authentication tokens.

A 2048-bit RSA key using OAEP with SHA-1 can encrypt up to 214 bytes, but the existing code only selected a 4096-bit key for passwords longer than 250 bytes. Passwords between 215 and 250 bytes could therefore be assigned a key that was too small, causing password encryption to fail. Because that failure was not checked, the code subsequently attempted to Base64-encode an unset ciphertext value.

This change:

- uses the 214-byte RSA-OAEP plaintext limit when selecting between 2048-bit and 4096-bit keys;
- only generates a 4096-bit key when encrypted password storage (`auth.storeCryptedPassword`) is enabled;
- validates the encrypted-password storage limit before generating a key;
- clarifies that the storage limit is measured in bytes;
- checks the result of `openssl_public_encrypt()` before encoding or storing its output.

Checking the encryption result also provides a controlled failure when an existing token with a 2048-bit key cannot accommodate a subsequently changed, longer password. The short-to-long password transition was already a problem, as reported in #45090, but its encryption failure was not handled explicitly. Regenerating existing token key pairs to accommodate a new, longer password (and defining the associated user experience) remain outside the scope of this PR.

## Tests

Added unit coverage for:

- rejecting passwords above the encrypted-password storage limit;
- allowing long passwords when encrypted password storage is disabled;
- using a 2048-bit key at the 214-byte OAEP boundary;
- using a 4096-bit key above the OAEP boundary;
- explicitly failing a short-to-long password transition when the existing token key is too small.

## TODO

- [ ] Backport

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
