### PR TITLE
docs(auth): clarify recoverable password storage

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -582,7 +582,7 @@ $CONFIG = [
 	 * reversibly encrypted copy of the password is stored in the server-side records
 	 * associated with the user's authentication tokens. This is separate from the
 	 * one-way password hash used for account authentication.
-	 * 
+	 *
 	 * The recoverable password copy is used for features that require the original
 	 * login credentials, such as connecting to external storage, autoconfiguring
 	 * accounts in the Mail app, and periodically checking whether a password remains

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -575,21 +575,40 @@ $CONFIG = [
 	'auth.webauthn.enabled' => true,
 
 	/**
-	 * Whether encrypted passwords should be stored in the database
+	 * Whether recoverable login passwords should be stored in authentication-token
+	 * records.
 	 *
-	 * The passwords are only decrypted using the login token stored uniquely in the
-	 * clients and allow connecting to external storages, autoconfiguring mail accounts in
-	 * the mail app, and periodically checking if the password is still valid.
+	 * When enabled and the login password is available to Nextcloud, a separate,
+	 * reversibly encrypted copy of the password is stored in the server-side records
+	 * associated with the user's authentication tokens. This is separate from the
+	 * one-way password hash used for account authentication.
+	 * 
+	 * The recoverable password copy is used for features that require the original
+	 * login credentials, such as connecting to external storage, autoconfiguring
+	 * accounts in the Mail app, and periodically checking whether a password remains
+	 * valid.
 	 *
-	 * This might be desirable to disable this functionality when using one-time
-	 * passwords or when having a password policy enforcing long passwords (> 300
-	 * characters).
+	 * A recoverable password is encrypted using an RSA key pair associated with its
+	 * authentication-token record. Passwords longer than 214 bytes require a larger
+	 * RSA key, which increases token-generation overhead.
 	 *
-	 * By default, the passwords are stored encrypted in the database.
+	 * Administrators may wish to disable this option when users routinely use very
+	 * long passwords (215 to 469 bytes), when one-time login credentials should not
+	 * be stored, or when deployed authentication flows do not require password
+	 * recovery. Disabling it prevents the recoverable password copy from being stored
+	 * and avoids password-length-related RSA key-size increases. However, operations
+	 * that require Nextcloud to have access to the original login password will no
+	 * longer work.
 	 *
-	 * WARNING: If disabled, password changes on the user backend (e.g., on LDAP) no
-	 * longer log connected clients out automatically. Users can still disconnect
-	 * the clients by deleting the app token from the security settings.
+	 * NOTE: Nextcloud enforces a maximum account password length of 469 bytes whether
+	 * this option is enabled or disabled.
+	 *
+	 * WARNING: If disabled, password changes made directly in an external user
+	 * backend, such as LDAP, no longer automatically invalidate connected clients.
+	 * Users can still disconnect clients by deleting their app tokens from the
+	 * security settings.
+	 *
+	 * Defaults to ``true``.
 	 */
 	'auth.storeCryptedPassword' => true,
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

* Supersedes: #54091
* Depends on (a soft dependency; not a hard dependency): #63804
* Related: nextcloud/documentation#15476
* Historical context: #33110

Clarify the documentation for `auth.storeCryptedPassword`:

- clearly distinguish the recoverable password copy stored with authentication tokens from the one-way password hash used for account authentication;
- replace the approximate password-length threshold of 300 characters with the actual thresholds, measured in bytes;
- document that passwords longer than 214 bytes require a larger RSA key, increasing token-generation overhead;
- explain that disabling the setting avoids password-length-related RSA key-size increases; and
- clarify that Nextcloud's 469-byte account-password maximum remains enforced whether this option is enabled or disabled.

The 214-byte threshold reflects the corrected RSA-OAEP key-size selection in #63804. It is the actual maximum plaintext size for the existing 2048-bit RSA-OAEP configuration, rather than the approximate 300-character guidance. Before #63804, the implementation switched to a larger key only above 250 bytes, leaving passwords from 215 through 250 bytes assigned to a key too small to encrypt them. (In other words, 214 was already the true cryptographic maximum, but it was not the implemented key-selection threshold before #63804).

## TODO

- [ ] Backport to v35
- [ ] Backport to v34-v33?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
