### PR TITLE
[stable28] chore(ci): Use a newer image for s3 ci jobs

### DIFF
--- a/.github/workflows/s3-external.yml
+++ b/.github/workflows/s3-external.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123
-        image: bitnami/minio:2021.10.6
+        image: bitnami/minio@sha256:50cec18ac4184af4671a78aedd5554942c8ae105d51a465fa82037949046da01 # v2025.4.22
         ports:
           - "9000:9000"
 

--- a/.github/workflows/s3-external.yml
+++ b/.github/workflows/s3-external.yml
@@ -28,8 +28,8 @@ jobs:
     services:
       minio:
         env:
-          MINIO_ACCESS_KEY: minio
-          MINIO_SECRET_KEY: minio123
+          MINIO_ROOT_USER: minio
+          MINIO_ROOT_PASSWORD: minio123
         image: bitnami/minio@sha256:50cec18ac4184af4671a78aedd5554942c8ae105d51a465fa82037949046da01 # v2025.4.22
         ports:
           - "9000:9000"

--- a/.github/workflows/s3-primary-integration.yml
+++ b/.github/workflows/s3-primary-integration.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123
-        image: bitnami/minio:2021.12.29
+        image: bitnami/minio@sha256:50cec18ac4184af4671a78aedd5554942c8ae105d51a465fa82037949046da01 # v2025.4.22
         ports:
           - "9000:9000"
 

--- a/.github/workflows/s3-primary-integration.yml
+++ b/.github/workflows/s3-primary-integration.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   s3-primary-integration-tests-minio:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: ${{ github.repository_owner != 'nextcloud-gmbh' }}
 

--- a/.github/workflows/s3-primary-integration.yml
+++ b/.github/workflows/s3-primary-integration.yml
@@ -38,8 +38,8 @@ jobs:
           - "6379:6379"
       minio:
         env:
-          MINIO_ACCESS_KEY: minio
-          MINIO_SECRET_KEY: minio123
+          MINIO_ROOT_USER: minio
+          MINIO_ROOT_PASSWORD: minio123
         image: bitnami/minio@sha256:50cec18ac4184af4671a78aedd5554942c8ae105d51a465fa82037949046da01 # v2025.4.22
         ports:
           - "9000:9000"

--- a/.github/workflows/s3-primary.yml
+++ b/.github/workflows/s3-primary.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   s3-primary-tests-minio:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: ${{ github.repository_owner != 'nextcloud-gmbh' }}
 

--- a/.github/workflows/s3-primary.yml
+++ b/.github/workflows/s3-primary.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123
-        image: bitnami/minio:2021.12.29
+        image: bitnami/minio@sha256:50cec18ac4184af4671a78aedd5554942c8ae105d51a465fa82037949046da01 # v2025.4.22
         ports:
           - "9000:9000"
 

--- a/.github/workflows/s3-primary.yml
+++ b/.github/workflows/s3-primary.yml
@@ -34,8 +34,8 @@ jobs:
     services:
       minio:
         env:
-          MINIO_ACCESS_KEY: minio
-          MINIO_SECRET_KEY: minio123
+          MINIO_ROOT_USER: minio
+          MINIO_ROOT_PASSWORD: minio123
         image: bitnami/minio@sha256:50cec18ac4184af4671a78aedd5554942c8ae105d51a465fa82037949046da01 # v2025.4.22
         ports:
           - "9000:9000"


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

ubuntu-20.04 does not exists anymore so they time out.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
