### PR TITLE
fix(ObjectStorePreviewStorage): Close count stream wrapper

### DIFF
--- a/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
+++ b/lib/private/Preview/Storage/ObjectStorePreviewStorage.php
@@ -56,6 +56,10 @@ class ObjectStorePreviewStorage implements IPreviewStorage {
 			$store->writeObject($urn, $countStream);
 		} catch (\Exception $exception) {
 			throw new NotPermittedException('Unable to save preview to object store', previous: $exception);
+		} finally {
+			if (is_resource($countStream)) {
+				fclose($countStream);
+			}
 		}
 		return $size;
 	}


### PR DESCRIPTION

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/63801
* 
## Summary

So that the size is finalized

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
