### PR TITLE
[stable33] fix(preview): First cleanup from filecache and then from preview table

### DIFF
--- a/core/Command/Preview/Cleanup.php
+++ b/core/Command/Preview/Cleanup.php
@@ -30,18 +30,20 @@ class Cleanup extends Base {
 		parent::__construct();
 	}
 
+	#[\Override]
 	protected function configure(): void {
 		$this
 			->setName('preview:cleanup')
 			->setDescription('Removes existing preview files');
 	}
 
+	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		if ($this->deletePreviewFromPreviewTable($output) !== 0) {
+		if ($this->deletePreviewFromFileCacheTable($output) !== 0) {
 			return 1;
 		}
 
-		return $this->deletePreviewFromFileCacheTable($output);
+		return $this->deletePreviewFromPreviewTable($output);
 	}
 
 	/**
@@ -75,9 +77,8 @@ class Cleanup extends Base {
 			$previewFolder = $appDataFolder->get('preview');
 
 		} catch (NotFoundException $e) {
-			$this->logger->error("Previews can't be removed: appdata folder can't be found", ['exception' => $e]);
-			$output->writeln("Previews can't be removed: preview folder isn't deletable");
-			return 1;
+			$this->logger->info("Legacy previews can't be removed: appdata folder can't be found", ['exception' => $e]);
+			return 0;
 		}
 
 		if (!$previewFolder->isDeletable()) {
@@ -97,16 +98,6 @@ class Cleanup extends Base {
 		} catch (NotPermittedException $e) {
 			$output->writeln("Previews weren't deleted: you don't have the permission to delete preview folder");
 			$this->logger->error("Previews weren't deleted: you don't have the permission to delete preview folder", ['exception' => $e]);
-			return 1;
-		}
-
-		try {
-			$appDataFolder->newFolder('preview');
-			$this->logger->debug('Preview folder recreated');
-			$output->writeln('Preview folder recreated', OutputInterface::VERBOSITY_VERBOSE);
-		} catch (NotPermittedException $e) {
-			$output->writeln("Preview folder was deleted, but you don't have the permission to create preview folder");
-			$this->logger->error("Preview folder was deleted, but you don't have the permission to create preview folder", ['exception' => $e]);
 			return 1;
 		}
 

--- a/lib/private/Preview/PreviewMigrationService.php
+++ b/lib/private/Preview/PreviewMigrationService.php
@@ -94,8 +94,9 @@ class PreviewMigrationService {
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)))
 			->setMaxResults(1);
 
-		$result = $qb->executeQuery();
-		$result = $result->fetchAssociative();
+		$cursor = $qb->executeQuery();
+		$result = $cursor->fetchAssociative();
+		$cursor->closeCursor();
 
 		if ($result !== false) {
 			$oldFileIdsToDelete = [];

--- a/tests/Core/Command/Preview/CleanupTest.php
+++ b/tests/Core/Command/Preview/CleanupTest.php
@@ -4,7 +4,8 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace Core\Command\Preview;
+
+namespace Tests\Core\Command\Preview;
 
 use OC\Core\Command\Preview\Cleanup;
 use OC\Preview\PreviewService;
@@ -26,6 +27,7 @@ class CleanupTest extends TestCase {
 	private PreviewService&MockObject $previewService;
 	private Cleanup $repair;
 
+	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->rootFolder = $this->createMock(IRootFolder::class);
@@ -54,7 +56,6 @@ class CleanupTest extends TestCase {
 
 		$appDataFolder = $this->createMock(Folder::class);
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->once())->method('newFolder')->with('preview');
 
 		$this->rootFolder->expects($this->once())
 			->method('getAppDataDirectoryName')
@@ -65,13 +66,12 @@ class CleanupTest extends TestCase {
 			->with('appdata_some_id')
 			->willReturn($appDataFolder);
 
-		$this->output->expects($this->exactly(3))->method('writeln')
+		$this->output->expects($this->exactly(2))->method('writeln')
 			->with(self::callback(function (string $message): bool {
 				static $i = 0;
 				return match (++$i) {
 					1 => $message === 'Preview folder deleted',
-					2 => $message === 'Preview folder recreated',
-					3 => $message === 'Previews removed'
+					2 => $message === 'Previews removed'
 				};
 			}));
 
@@ -79,8 +79,6 @@ class CleanupTest extends TestCase {
 	}
 
 	public function testCleanupWhenNotDeletable(): void {
-		$this->previewService->expects($this->once())->method('deleteAll');
-
 		$previewFolder = $this->createMock(Folder::class);
 		$previewFolder->expects($this->once())
 			->method('isDeletable')
@@ -91,7 +89,6 @@ class CleanupTest extends TestCase {
 
 		$appDataFolder = $this->createMock(Folder::class);
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->never())->method('newFolder')->with('preview');
 
 		$this->rootFolder->expects($this->once())
 			->method('getAppDataDirectoryName')
@@ -110,8 +107,6 @@ class CleanupTest extends TestCase {
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestCleanupWithDeleteException')]
 	public function testCleanupWithDeleteException(string $exceptionClass, string $errorMessage): void {
-		$this->previewService->expects($this->once())->method('deleteAll');
-
 		$previewFolder = $this->createMock(Folder::class);
 		$previewFolder->expects($this->once())
 			->method('isDeletable')
@@ -123,7 +118,6 @@ class CleanupTest extends TestCase {
 
 		$appDataFolder = $this->createMock(Folder::class);
 		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->never())->method('newFolder')->with('preview');
 
 		$this->rootFolder->expects($this->once())
 			->method('getAppDataDirectoryName')
@@ -147,52 +141,15 @@ class CleanupTest extends TestCase {
 		];
 	}
 
-	public function testCleanupWithCreateException(): void {
-		$this->previewService->expects($this->once())->method('deleteAll');
-
-		$previewFolder = $this->createMock(Folder::class);
-		$previewFolder->expects($this->once())
-			->method('isDeletable')
-			->willReturn(true);
-
-		$previewFolder->expects($this->once())
-			->method('delete');
-
-		$appDataFolder = $this->createMock(Folder::class);
-		$appDataFolder->expects($this->once())->method('get')->with('preview')->willReturn($previewFolder);
-		$appDataFolder->expects($this->once())->method('newFolder')->with('preview')->willThrowException(new NotPermittedException());
-
-		$this->rootFolder->expects($this->once())
-			->method('getAppDataDirectoryName')
-			->willReturn('appdata_some_id');
-
-		$this->rootFolder->expects($this->once())
-			->method('get')
-			->with('appdata_some_id')
-			->willReturn($appDataFolder);
-
-		$this->output->expects($this->exactly(2))->method('writeln')
-			->with(self::callback(function (string $message): bool {
-				static $i = 0;
-				return match (++$i) {
-					1 => $message === 'Preview folder deleted',
-					2 => $message === "Preview folder was deleted, but you don't have the permission to create preview folder",
-				};
-			}));
-
-		$this->logger->expects($this->once())->method('error')->with("Preview folder was deleted, but you don't have the permission to create preview folder");
-
-		$this->assertEquals(1, $this->repair->run($this->input, $this->output));
-	}
-
 	public function testCleanupWithPreviewServiceException(): void {
+		$this->rootFolder->method('getAppDataDirectoryName')
+			->willThrowException(new NotFoundException());
+
 		$this->previewService->expects($this->once())->method('deleteAll')
 			->willThrowException(new NotPermittedException('abc'));
 
+		$this->logger->expects($this->once())->method('info')->with("Legacy previews can't be removed: appdata folder can't be found");
 		$this->logger->expects($this->once())->method('error')->with("Previews can't be removed: exception occurred: abc");
-
-		$this->rootFolder->expects($this->never())
-			->method('get');
 
 		$this->assertEquals(1, $this->repair->run($this->input, $this->output));
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Manual backport of #61011

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
