### PR TITLE
[stable32] fix: Ensure we don't get share by empty name

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1451,10 +1451,11 @@ class Manager implements IManager {
 	 * @throws ShareNotFound
 	 */
 	public function getShareByToken($token) {
-		// tokens cannot be valid local user names
-		if ($this->userManager->userExists($token)) {
+		// tokens cannot be valid local usernames or empty
+		if ($token === '' || $this->userManager->userExists($token)) {
 			throw new ShareNotFound();
 		}
+
 		$share = null;
 		try {
 			if ($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes') {


### PR DESCRIPTION
manual backport of https://github.com/nextcloud/server/pull/63827