### PR TITLE
fix(core): make the app store link in the app menu configurable

### DIFF
--- a/core/AppInfo/ConfigLexicon.php
+++ b/core/AppInfo/ConfigLexicon.php
@@ -40,6 +40,8 @@ class ConfigLexicon implements ILexicon {
 
 	public const ON_DEMAND_PREVIEW_MIGRATION = 'on_demand_preview_migration';
 
+	public const APPSTORE_LINK_SHOWN = 'appstore_link_shown';
+
 	#[\Override]
 	public function getStrictness(): Strictness {
 		return Strictness::IGNORE;
@@ -101,6 +103,16 @@ class ConfigLexicon implements ILexicon {
 				type: ValueType::BOOL,
 				defaultRaw: true,
 				definition: 'Whether on demand preview migration is enabled.'
+			),
+			new Entry(
+				key: self::APPSTORE_LINK_SHOWN,
+				type: ValueType::BOOL,
+				defaultRaw: fn (Preset $p): bool => match ($p) {
+					Preset::NONE, Preset::PRIVATE, Preset::FAMILY, Preset::CLUB => true,
+					default => false,
+				},
+				definition: 'Show the app store link in the app menu to accounts without admin rights',
+				note: 'When this key is not set, the link is also hidden while a valid subscription is available or while "appstoreenabled" is disabled. Setting this key explicitly takes precedence over both.',
 			),
 			new Entry(
 				key: self::DAV_REPAIR_REMOVED_BROKEN_PROPERTIES,

--- a/core/src/components/AppMenu.vue
+++ b/core/src/components/AppMenu.vue
@@ -152,6 +152,8 @@ export default defineComponent({
 			appList,
 			navigationActions,
 			settingsList,
+			// Fail closed: a missing state must not leak the link.
+			appStoreLinkShown: loadState<boolean>('core', 'appStoreLinkShown', false),
 			isAdmin: getCurrentUser()?.isAdmin ?? false,
 			// Roving tabindex: only this tile has tabindex=0; arrow keys move it.
 			focusedIndex: 0,
@@ -252,12 +254,16 @@ export default defineComponent({
 
 		// Stable-ordered list that focusedIndex indexes into. The trailing
 		// utility tile is "More apps" (local app management) for admins and
-		// "App store" (apps.nextcloud.com) for everyone else.
+		// "App store" (apps.nextcloud.com) for everyone else when
+		// appstore_link_shown allows it.
 		gridItems(): INavigationEntry[] {
-			const tail = this.isAdmin
-				? { ...this.moreAppsEntry, active: this.currentApp?.id === APP_MANAGEMENT_ID }
-				: this.appStoreEntry
-			return [...this.appList, tail]
+			const tail: INavigationEntry[] = []
+			if (this.isAdmin) {
+				tail.push({ ...this.moreAppsEntry, active: this.currentApp?.id === APP_MANAGEMENT_ID })
+			} else if (this.appStoreLinkShown) {
+				tail.push(this.appStoreEntry)
+			}
+			return [...this.appList, ...tail]
 		},
 	},
 

--- a/core/src/tests/components/AppMenu.spec.ts
+++ b/core/src/tests/components/AppMenu.spec.ts
@@ -70,15 +70,10 @@ function fakeApps(): INavigationEntry[] {
 // ships getAll('settings') keyed by entry id.
 function mockActiveSettingsEntry(overrides: Partial<INavigationEntry>): void {
 	const entry = makeApp({ type: 'settings', active: true, ...overrides })
-	initialState.loadState.mockImplementation((_a: string, key: string, fallback: unknown) => {
-		if (key === 'apps') {
-			return [makeApp({ id: 'files', name: 'Files', active: false })]
-		}
-		if (key === 'settingsNavEntries') {
-			return { [entry.id]: entry }
-		}
-		return fallback
-	})
+	initialState.loadState.mockImplementation(stateFor({
+		apps: [makeApp({ id: 'files', name: 'Files', active: false })],
+		settingsNavEntries: { [entry.id]: entry },
+	}))
 }
 
 // Navigation actions (INavigationManager::TYPE_ACTION). Without an `href` the
@@ -98,17 +93,16 @@ function fakeActions(count: number): INavigationEntry[] {
 	return ids.slice(0, count).map((id) => makeAction(id))
 }
 
+// AppMenu hides the app store tile when the state is absent, so a default
+// instance has to supply it.
+function stateFor(states: Record<string, unknown>) {
+	const all: Record<string, unknown> = { appStoreLinkShown: true, ...states }
+	return (_app: string, key: string, fallback: unknown) => key in all ? all[key] : fallback
+}
+
 // loadState implementation serving both apps and navigation actions.
 function stateWith(apps: INavigationEntry[], actions: INavigationEntry[]) {
-	return (_app: string, key: string, fallback: unknown) => {
-		if (key === 'apps') {
-			return apps
-		}
-		if (key === 'navigationActions') {
-			return actions
-		}
-		return fallback
-	}
+	return stateFor({ apps, navigationActions: actions })
 }
 
 function eightApps(activeIndex: number = -1): INavigationEntry[] {
@@ -132,7 +126,7 @@ beforeEach(async () => {
 	for (const k of Object.keys(eventBus.__handlers)) {
 		delete eventBus.__handlers[k]
 	}
-	initialState.loadState.mockImplementation((_app: string, key: string, fallback: unknown) => key === 'apps' ? fakeApps() : fallback)
+	initialState.loadState.mockImplementation(stateFor({ apps: fakeApps() }))
 	auth.getCurrentUser.mockReturnValue({ isAdmin: false })
 	AppMenu = (await import('../../components/AppMenu.vue')).default
 })
@@ -143,6 +137,11 @@ afterEach(() => {
 		document.body.removeChild(document.body.firstChild)
 	}
 })
+
+function gridLabels(): string[] {
+	return Array.from(document.querySelectorAll('.app-menu__grid [role="menuitem"]'))
+		.map((el) => el.querySelector('.app-item__label')?.textContent?.trim() ?? '')
+}
 
 // Click the waffle trigger and poll until the teleported menuitems are in the
 // DOM. NcPopover teleports to <body> so wrapper.find() can't see them; vi.waitFor
@@ -166,10 +165,24 @@ describe('core: AppMenu', () => {
 		const wrapper = mount(AppMenu, { attachTo: document.body })
 		await openPopover(wrapper)
 
-		const items = document.querySelectorAll('.app-menu__grid [role="menuitem"]')
-		expect(items).toHaveLength(4)
-		const labels = Array.from(items).map((el) => el.querySelector('.app-item__label')?.textContent?.trim() ?? '')
-		expect(labels).toEqual(['Files', 'Mail', 'Calendar', 'App store'])
+		expect(gridLabels()).toEqual(['Files', 'Mail', 'Calendar', 'App store'])
+	})
+
+	it('omits the "App store" tile when the instance does not offer it', async () => {
+		initialState.loadState.mockImplementation(stateFor({ apps: fakeApps(), appStoreLinkShown: false }))
+		const wrapper = mount(AppMenu, { attachTo: document.body })
+		await openPopover(wrapper)
+
+		expect(gridLabels()).toEqual(['Files', 'Mail', 'Calendar'])
+	})
+
+	it('keeps the "More apps" tile for admins when the app store link is hidden', async () => {
+		initialState.loadState.mockImplementation(stateFor({ apps: fakeApps(), appStoreLinkShown: false }))
+		auth.getCurrentUser.mockReturnValue({ isAdmin: true })
+		const wrapper = mount(AppMenu, { attachTo: document.body })
+		await openPopover(wrapper)
+
+		expect(gridLabels()).toEqual(['Files', 'Mail', 'Calendar', 'More apps'])
 	})
 
 	it('renders the "More apps" tile when the current user is an admin', async () => {
@@ -196,7 +209,7 @@ describe('core: AppMenu', () => {
 	})
 
 	it('ArrowRight moves the roving stop from index 0 to index 1 and focuses it', async () => {
-		initialState.loadState.mockImplementation((_a: string, key: string, fallback: unknown) => key === 'apps' ? eightApps() : fallback)
+		initialState.loadState.mockImplementation(stateFor({ apps: eightApps() }))
 		const wrapper = mount(AppMenu, { attachTo: document.body })
 		await openPopover(wrapper)
 
@@ -274,15 +287,10 @@ describe('core: AppMenu', () => {
 	})
 
 	it('prefers the active app over a settings entry when both are marked active', () => {
-		initialState.loadState.mockImplementation((_a: string, key: string, fallback: unknown) => {
-			if (key === 'apps') {
-				return [makeApp({ id: 'files', name: 'Files', active: true })]
-			}
-			if (key === 'settingsNavEntries') {
-				return { settings_administration: makeApp({ id: 'settings_administration', name: 'Administration settings', type: 'settings', active: true }) }
-			}
-			return fallback
-		})
+		initialState.loadState.mockImplementation(stateFor({
+			apps: [makeApp({ id: 'files', name: 'Files', active: true })],
+			settingsNavEntries: { settings_administration: makeApp({ id: 'settings_administration', name: 'Administration settings', type: 'settings', active: true }) },
+		}))
 		const wrapper = mount(AppMenu, { attachTo: document.body })
 		expect(wrapper.find('.app-menu__current-app-name').text()).toBe('Files')
 	})
@@ -292,15 +300,10 @@ describe('core: AppMenu', () => {
 		// "current section" even though it carries type=settings. NavigationManager
 		// today never marks it active, but a future regression shouldn't leak a
 		// "Log out" label into the header.
-		initialState.loadState.mockImplementation((_a: string, key: string, fallback: unknown) => {
-			if (key === 'apps') {
-				return [makeApp({ id: 'files', name: 'Files', active: false })]
-			}
-			if (key === 'settingsNavEntries') {
-				return { logout: makeApp({ id: 'logout', name: 'Log out', type: 'settings', href: '/logout', active: true }) }
-			}
-			return fallback
-		})
+		initialState.loadState.mockImplementation(stateFor({
+			apps: [makeApp({ id: 'files', name: 'Files', active: false })],
+			settingsNavEntries: { logout: makeApp({ id: 'logout', name: 'Log out', type: 'settings', href: '/logout', active: true }) },
+		}))
 		const wrapper = mount(AppMenu, { attachTo: document.body })
 		expect(wrapper.find('.app-menu__current-app').exists()).toBe(false)
 	})

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1256,6 +1256,7 @@ return array(
     'OC\\AppScriptSort' => $baseDir . '/lib/private/AppScriptSort.php',
     'OC\\App\\AppManager' => $baseDir . '/lib/private/App/AppManager.php',
     'OC\\App\\AppStore\\AppNotFoundException' => $baseDir . '/lib/private/App/AppStore/AppNotFoundException.php',
+    'OC\\App\\AppStore\\AppStoreLinkVisibility' => $baseDir . '/lib/private/App/AppStore/AppStoreLinkVisibility.php',
     'OC\\App\\AppStore\\Bundles\\Bundle' => $baseDir . '/lib/private/App/AppStore/Bundles/Bundle.php',
     'OC\\App\\AppStore\\Bundles\\BundleFetcher' => $baseDir . '/lib/private/App/AppStore/Bundles/BundleFetcher.php',
     'OC\\App\\AppStore\\Bundles\\EducationBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/EducationBundle.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1297,6 +1297,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\AppScriptSort' => __DIR__ . '/../../..' . '/lib/private/AppScriptSort.php',
         'OC\\App\\AppManager' => __DIR__ . '/../../..' . '/lib/private/App/AppManager.php',
         'OC\\App\\AppStore\\AppNotFoundException' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/AppNotFoundException.php',
+        'OC\\App\\AppStore\\AppStoreLinkVisibility' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/AppStoreLinkVisibility.php',
         'OC\\App\\AppStore\\Bundles\\Bundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/Bundle.php',
         'OC\\App\\AppStore\\Bundles\\BundleFetcher' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/BundleFetcher.php',
         'OC\\App\\AppStore\\Bundles\\EducationBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/EducationBundle.php',

--- a/lib/private/App/AppStore/AppStoreLinkVisibility.php
+++ b/lib/private/App/AppStore/AppStoreLinkVisibility.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\App\AppStore;
+
+use OC\Core\AppInfo\ConfigLexicon;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\Support\Subscription\IRegistry;
+
+/**
+ * Decides whether the app store link is offered to accounts without admin rights.
+ */
+class AppStoreLinkVisibility {
+	public function __construct(
+		private readonly IConfig $config,
+		private readonly IAppConfig $appConfig,
+		private readonly IRegistry $registry,
+	) {
+	}
+
+	/**
+	 * An explicitly set value wins. Without one, a disabled app store or an
+	 * available subscription hides the link.
+	 */
+	public function isShownToUsers(): bool {
+		if (!$this->appConfig->hasKey('core', ConfigLexicon::APPSTORE_LINK_SHOWN)) {
+			if (!$this->config->getSystemValueBool('appstoreenabled', true)) {
+				return false;
+			}
+
+			if ($this->registry->delegateHasValidSubscription()) {
+				return false;
+			}
+		}
+
+		return $this->appConfig->getValueBool('core', ConfigLexicon::APPSTORE_LINK_SHOWN);
+	}
+}

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\App\AppStore\AppStoreLinkVisibility;
 use OC\AppFramework\Http\Request;
 use OC\Authentication\Token\IProvider;
 use OC\Core\AppInfo\Application;
@@ -83,6 +84,7 @@ class TemplateLayout {
 				$this->initialState->provideInitialState('core', 'active-app', $this->navigationManager->getActiveEntry());
 				$this->initialState->provideInitialState('core', 'apps', array_values($this->navigationManager->getAll()));
 				$this->initialState->provideInitialState('core', 'navigationActions', array_values($this->navigationManager->getAll(INavigationManager::TYPE_ACTION)));
+				$this->initialState->provideInitialState('core', 'appStoreLinkShown', Server::get(AppStoreLinkVisibility::class)->isShownToUsers());
 
 				$this->initialState->provideInitialState('unified-search', 'min-search-length', $this->appConfig->getValueInt(Application::APP_ID, ConfigLexicon::UNIFIED_SEARCH_MIN_SEARCH_LENGTH));
 				if ($this->config->getSystemValueBool('unified_search.enabled', false) || !$this->config->getSystemValueBool('enable_non-accessible_features', true)) {

--- a/tests/lib/App/AppStore/AppStoreLinkVisibilityTest.php
+++ b/tests/lib/App/AppStore/AppStoreLinkVisibilityTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\App\AppStore;
+
+use OC\App\AppStore\AppStoreLinkVisibility;
+use OC\Core\AppInfo\ConfigLexicon;
+use OCP\Config\Lexicon\Entry;
+use OCP\Config\Lexicon\Preset;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\Support\Subscription\IRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class AppStoreLinkVisibilityTest extends TestCase {
+	private IConfig&MockObject $config;
+	private IAppConfig&MockObject $appConfig;
+	private IRegistry&MockObject $registry;
+	private AppStoreLinkVisibility $visibility;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->registry = $this->createMock(IRegistry::class);
+
+		$this->visibility = new AppStoreLinkVisibility(
+			$this->config,
+			$this->appConfig,
+			$this->registry,
+		);
+	}
+
+	/**
+	 * @param bool $stored whether an admin set the config key
+	 * @param bool $value the stored value, or the lexicon default when $stored is false
+	 */
+	private function arrange(bool $stored, bool $value, bool $appStoreEnabled, bool $subscription): void {
+		$this->appConfig->method('hasKey')
+			->with('core', ConfigLexicon::APPSTORE_LINK_SHOWN)
+			->willReturn($stored);
+		$this->appConfig->method('getValueBool')
+			->with('core', ConfigLexicon::APPSTORE_LINK_SHOWN)
+			->willReturn($value);
+		$this->config->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn($appStoreEnabled);
+		$this->registry->method('delegateHasValidSubscription')
+			->willReturn($subscription);
+	}
+
+	public static function dataBool(): array {
+		return [
+			'shown' => [true],
+			'hidden' => [false],
+		];
+	}
+
+	#[DataProvider('dataBool')]
+	public function testStoredValueWinsOverSubscriptionAndDisabledAppStore(bool $stored): void {
+		$this->arrange(stored: true, value: $stored, appStoreEnabled: false, subscription: true);
+
+		self::assertSame($stored, $this->visibility->isShownToUsers());
+	}
+
+	public function testHiddenWhenAppStoreIsDisabled(): void {
+		$this->arrange(stored: false, value: true, appStoreEnabled: false, subscription: false);
+
+		self::assertFalse($this->visibility->isShownToUsers());
+	}
+
+	public function testHiddenWhenSubscriptionIsAvailable(): void {
+		$this->arrange(stored: false, value: true, appStoreEnabled: true, subscription: true);
+
+		self::assertFalse($this->visibility->isShownToUsers());
+	}
+
+	#[DataProvider('dataBool')]
+	public function testUnstoredKeyReturnsTheLexiconDefault(bool $default): void {
+		$this->arrange(stored: false, value: $default, appStoreEnabled: true, subscription: false);
+
+		self::assertSame($default, $this->visibility->isShownToUsers());
+	}
+
+	public static function dataLexiconPreset(): array {
+		return [
+			// Existing instances run without a preset and must keep the link.
+			[Preset::NONE, '1'],
+			[Preset::FAMILY, '1'],
+			[Preset::UNIVERSITY, '0'],
+		];
+	}
+
+	/**
+	 * The lexicon default {@see AppStoreLinkVisibility} falls back to is preset
+	 * dependent. A fresh entry is built per case because {@see Entry::getDefault()}
+	 * memoizes the first default it is asked for.
+	 */
+	#[DataProvider('dataLexiconPreset')]
+	public function testLexiconPresetDefault(Preset $preset, string $expected): void {
+		self::assertSame($expected, $this->lexiconEntry()->getDefault($preset));
+	}
+
+	private function lexiconEntry(): Entry {
+		foreach ((new ConfigLexicon())->getAppConfigs() as $entry) {
+			if ($entry->getKey() === ConfigLexicon::APPSTORE_LINK_SHOWN) {
+				return $entry;
+			}
+		}
+
+		self::fail('No lexicon entry for ' . ConfigLexicon::APPSTORE_LINK_SHOWN);
+	}
+}

--- a/tests/playwright/e2e/core/admin-settings-appstore-link.spec.ts
+++ b/tests/playwright/e2e/core/admin-settings-appstore-link.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { runOcc } from '@nextcloud/e2e-test-server'
+import { expect } from '@playwright/test'
+import { test as userTest } from '../../support/fixtures/random-user-session.ts'
+import { NavigationHeaderPage } from '../../support/sections/NavigationHeaderPage.ts'
+
+/**
+ * Set the app config key that decides whether the app store tile is offered.
+ *
+ * @param shown - Whether the tile should be offered
+ */
+async function setAppStoreLinkShown(shown: boolean): Promise<void> {
+	await runOcc(['config:app:set', 'core', 'appstore_link_shown', '--value', String(shown), '--type', 'boolean'])
+}
+
+// The `admin-settings-` prefix puts this in the serial project: it changes
+// instance-wide config. Both states are set explicitly because the test server
+// runs with `appstoreenabled` disabled, which hides the tile when the key is unset.
+userTest.describe('core: app store link visibility', () => {
+	userTest.afterAll(async () => {
+		await runOcc(['config:app:delete', 'core', 'appstore_link_shown'])
+	})
+
+	userTest('offers the "App store" tile only while an admin allows it', async ({ page }) => {
+		const navigationHeader = new NavigationHeaderPage(page)
+		const appStoreTile = () => navigationHeader.navigationEntries().filter({ hasText: 'App store' })
+
+		await setAppStoreLinkShown(true)
+		await page.goto('/')
+		await navigationHeader.openMenu()
+		await expect(appStoreTile()).toBeVisible()
+
+		await setAppStoreLinkShown(false)
+		await page.goto('/')
+		await navigationHeader.openMenu()
+		await expect(navigationHeader.navigationEntries()).not.toHaveCount(0)
+		await expect(appStoreTile()).toHaveCount(0)
+	})
+})


### PR DESCRIPTION
* Resolves: #60495

## Summary

Non-admins get an "App store" tile linking to apps.nextcloud.com with no way to turn it off.
This introduces a new config key `appstore_link_shown`, with preset defaults:

| Preset | Link |
| --- | --- |
| none, private, family, club | shown |
| shared, school, university, small, medium, large | hidden |

An explicitly set value always wins. Otherwise the link is hidden when `appstoreenabled` is off or a subscription is available, else the preset default applies. No preset means the link stays, so upgrades don't change.

This does also broaden `appstoreenabled`. It used to only gate installing from the store, now it hides the link too.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI (tests, reviewed)
