### PR TITLE
fix(files): skip directory symlinks that loop back onto the scanned path

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -540,6 +540,73 @@ class Local extends Common {
 	}
 
 	/**
+	 * Skips directory symlinks that resolve to the listed directory or one of
+	 * its ancestors: following such a link sends the scanner back into the tree
+	 * it is already walking, until the path length limit. Only the listing is
+	 * filtered; resolving a path still follows the link.
+	 */
+	#[\Override]
+	public function getDirectoryContent(string $directory): \Traversable {
+		$ancestors = null;
+		foreach (parent::getDirectoryContent($directory) as $metadata) {
+			if ($metadata['mimetype'] === FileInfo::MIMETYPE_FOLDER) {
+				try {
+					$childSource = $this->getSourcePath(rtrim($directory, '/') . '/' . $metadata['name']);
+				} catch (ForbiddenException) {
+					// Retargeted outside the datadir since listed; drop it like getMetaData() would.
+					continue;
+				}
+				if (is_link($childSource)) {
+					$childReal = realpath($childSource);
+					if ($childReal !== false) {
+						// Built lazily, only once a symlinked directory shows up.
+						$ancestors ??= $this->getAncestorRealPaths($directory);
+						if (isset($ancestors[rtrim($childReal, '/')])) {
+							Server::get(LoggerInterface::class)->warning(
+								"Skipping looping directory symlink '$childSource' -> '$childReal'",
+								['app' => 'core']
+							);
+							continue;
+						}
+					}
+				}
+			}
+			yield $metadata;
+		}
+	}
+
+	/**
+	 * Resolved paths of $directory and each of its ancestors up to the storage
+	 * root, as a set. A directory symlink resolving to any of them closes a loop.
+	 */
+	private function getAncestorRealPaths(string $directory): array {
+		$root = rtrim($this->realDataDir, '/');
+		$paths = [];
+		try {
+			$current = $this->getSourcePath(rtrim($directory, '/'));
+		} catch (ForbiddenException) {
+			// No resolvable ancestor chain: filter nothing.
+			return $paths;
+		}
+		while (true) {
+			$real = realpath($current);
+			if ($real !== false) {
+				$real = rtrim($real, '/');
+				$paths[$real] = true;
+				if ($real === $root) {
+					break;
+				}
+			}
+			$parent = dirname($current);
+			if ($parent === $current || strlen($parent) < strlen($root)) {
+				break;
+			}
+			$current = $parent;
+		}
+		return $paths;
+	}
+
+	/**
 	 * Get the source path (on disk) of a given path
 	 *
 	 * @throws ForbiddenException

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -452,4 +452,40 @@ class ScannerTest extends TestCase {
 		$newFolderEntry2 = $this->cache->get('folder/sub');
 		$this->assertNotEquals($newFolderEntry2->getEtag(), $oldFolderEntry2->getEtag());
 	}
+	public function testScanSkipsSelfReferencingSymlink(): void {
+		$root = rtrim($this->storage->getSourcePath(''), '/');
+		mkdir($root . '/dir');
+		file_put_contents($root . '/dir/real.txt', 'data');
+		symlink($root . '/dir', $root . '/dir/self');
+
+		$this->scanner->scan('');
+
+		$this->assertTrue($this->cache->inCache('dir'));
+		$this->assertTrue($this->cache->inCache('dir/real.txt'));
+		// the loop itself is skipped, at every level
+		$this->assertFalse($this->cache->inCache('dir/self'));
+		$this->assertFalse($this->cache->inCache('dir/self/real.txt'));
+		$this->assertFalse($this->cache->inCache('dir/self/self'));
+	}
+
+	public function testScanSkipsIndirectSymlinkCycle(): void {
+		$root = rtrim($this->storage->getSourcePath(''), '/');
+		mkdir($root . '/x');
+		mkdir($root . '/y');
+		symlink($root . '/y', $root . '/x/toy');
+		symlink($root . '/x', $root . '/y/tox');
+
+		$this->scanner->scan('');
+
+		$this->assertTrue($this->cache->inCache('x'));
+		$this->assertTrue($this->cache->inCache('y'));
+		// a link to a sibling is legitimate and stays visible...
+		$this->assertTrue($this->cache->inCache('x/toy'));
+		$this->assertTrue($this->cache->inCache('y/tox'));
+		// ...but the walk stops where the cycle closes: entering x/toy lands
+		// in y, whose link back to x would re-enter the path being walked
+		$this->assertFalse($this->cache->inCache('x/toy/tox'));
+		$this->assertFalse($this->cache->inCache('y/tox/toy'));
+	}
+
 }

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -280,4 +280,100 @@ class LocalTest extends Storage {
 		$this->assertSame('abc', stream_get_contents($handle));
 		fclose($handle);
 	}
+	private function collectNames(\Traversable $content): array {
+		$names = [];
+		foreach ($content as $metadata) {
+			$names[] = $metadata['name'];
+		}
+		sort($names);
+		return $names;
+	}
+
+	public function testGetDirectoryContentSkipsSelfReferencingSymlink(): void {
+		mkdir($this->tmpDir . 'dir');
+		mkdir($this->tmpDir . 'dir/real');
+		symlink($this->tmpDir . 'dir', $this->tmpDir . 'dir/self');
+
+		$storage = new Local(['datadir' => $this->tmpDir]);
+
+		$this->assertEquals(['real'], $this->collectNames($storage->getDirectoryContent('dir')));
+	}
+
+	public function testGetDirectoryContentSkipsParentSymlink(): void {
+		mkdir($this->tmpDir . 'a');
+		mkdir($this->tmpDir . 'a/b');
+		mkdir($this->tmpDir . 'a/b/real');
+		symlink($this->tmpDir . 'a', $this->tmpDir . 'a/b/up');
+
+		$storage = new Local(['datadir' => $this->tmpDir]);
+
+		$this->assertEquals(['real'], $this->collectNames($storage->getDirectoryContent('a/b')));
+	}
+
+	/**
+	 * a -> b while b -> a: neither target is an ancestor of its own parent, so a
+	 * parent-only check walks the pair forever.
+	 */
+	public function testGetDirectoryContentSkipsIndirectCycle(): void {
+		mkdir($this->tmpDir . 'x');
+		mkdir($this->tmpDir . 'y');
+		symlink($this->tmpDir . 'y', $this->tmpDir . 'x/toy');
+		symlink($this->tmpDir . 'x', $this->tmpDir . 'y/tox');
+
+		$storage = new Local(['datadir' => $this->tmpDir]);
+
+		// Entering x/toy lands in y; y's link back to x closes the cycle.
+		$this->assertEquals([], $this->collectNames($storage->getDirectoryContent('x/toy')));
+	}
+
+	/**
+	 * The loops we care about sit under ancestors that are themselves symlinks,
+	 * so the logical path and the resolved path are on different branches.
+	 * Comparing a logical path against a resolved one misses exactly this.
+	 */
+	public function testGetDirectoryContentSkipsLoopReachedThroughASymlinkedAncestor(): void {
+		mkdir($this->tmpDir . 'real');
+		mkdir($this->tmpDir . 'real/leaf');
+		symlink($this->tmpDir . 'real', $this->tmpDir . 'alias');
+		symlink($this->tmpDir . 'real', $this->tmpDir . 'real/leaf/back');
+
+		$storage = new Local(['datadir' => $this->tmpDir]);
+
+		// Reached as alias/leaf, whose resolved parent is real/leaf: 'back'
+		// resolves to 'real', an ancestor, even though the logical path says alias/.
+		$this->assertEquals([], $this->collectNames($storage->getDirectoryContent('alias/leaf')));
+	}
+
+	public function testGetDirectoryContentKeepsNonLoopingSymlinks(): void {
+		mkdir($this->tmpDir . 'a');
+		mkdir($this->tmpDir . 'other');
+		mkdir($this->tmpDir . 'other/deep');
+		file_put_contents($this->tmpDir . 'other/f.txt', 'x');
+		symlink($this->tmpDir . 'other', $this->tmpDir . 'a/sibling');
+		symlink($this->tmpDir . 'other/deep', $this->tmpDir . 'a/deeper');
+		symlink($this->tmpDir . 'other/f.txt', $this->tmpDir . 'a/afile');
+
+		$storage = new Local(['datadir' => $this->tmpDir]);
+
+		$this->assertEquals(
+			['afile', 'deeper', 'sibling'],
+			$this->collectNames($storage->getDirectoryContent('a'))
+		);
+	}
+
+	/**
+	 * Enumeration is filtered, resolution is not: a file behind a directory
+	 * symlink stays reachable. Guards the behaviour asserted by
+	 * testDisallowSymlinksInsideDatadir.
+	 */
+	public function testLoopingSymlinkStillResolvesForFileAccess(): void {
+		mkdir($this->tmpDir . 'dir');
+		symlink($this->tmpDir . 'dir', $this->tmpDir . 'dir/self');
+
+		$storage = new Local(['datadir' => $this->tmpDir]);
+		$storage->file_put_contents('dir/self/foo', 'bar');
+
+		$this->assertEquals('bar', $storage->file_get_contents('dir/foo'));
+	}
+
 }


### PR DESCRIPTION
- resolves #41563

## SUMMARY
    
On a local storage, symlinks to a directories are followed even
if the directory is a parent directory or the directory itself.

Under these conditions, the Nextcloud metadata scanner
continues traversing the tree until it reaches the limit.
Re-entering the same tree in loop.

Basically it will fill the oc_filecache SQL table with a new entry
until the path reach the limit of oc_filecache.path column varchar(4000)
    
## Impact

We had a server crash because Nextcloud filled the database disk
by creating 30M row in this table and producing a 185 GB database.
This is a DoS to become that can be triggered just by creating a symlink.

## History

The bug is known since at least 2017 see #6395 (SMB), #20197, #23022
A previous fix #21723 was closed unmerged.

## Proposed Fix

Local::getDirectoryContent() will skip a symlink whose target is
the directory being listed or a parent directory.
We are comparing both path after resolution so that we also catches
cycles ( a -> b, b->a ).