### PR TITLE
fix: fail uploads when uri does not match session/share token

### DIFF
--- a/apps/dav/lib/Upload/RootCollection.php
+++ b/apps/dav/lib/Upload/RootCollection.php
@@ -13,6 +13,8 @@ namespace OCA\DAV\Upload;
 use OCP\Files\IRootFolder;
 use OCP\IUserSession;
 use OCP\Share\IManager;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\INode;
 use Sabre\DAVACL\AbstractPrincipalCollection;
 use Sabre\DAVACL\PrincipalBackend;
 
@@ -34,7 +36,14 @@ class RootCollection extends AbstractPrincipalCollection {
 	 * @inheritdoc
 	 */
 	#[\Override]
-	public function getChildForPrincipal(array $principalInfo): UploadHome {
+	public function getChildForPrincipal(array $principalInfo): INode|UploadHome {
+		[$prefix, $name] = \Sabre\Uri\split($principalInfo['uri']);
+		$user = $this->userSession->getUser();
+		if ($prefix !== 'principals/shares' && $user?->getUID() !== $name) {
+			// if the request is not using a share token and the URL does not match the user, error out
+			throw new Forbidden('Not allowed');
+		}
+
 		return new UploadHome(
 			$principalInfo,
 			$this->cleanupService,

--- a/apps/dav/tests/unit/Upload/RootCollectionTest.php
+++ b/apps/dav/tests/unit/Upload/RootCollectionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\Upload;
+
+use OCA\DAV\Upload\CleanupService;
+use OCA\DAV\Upload\RootCollection;
+use OCA\DAV\Upload\UploadHome;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Share\IManager as IShareManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAVACL\PrincipalBackend\BackendInterface;
+use Test\TestCase;
+
+class RootCollectionTest extends TestCase {
+	private BackendInterface&MockObject $principalBackend;
+	private CleanupService&MockObject $cleanupService;
+	private IRootFolder&MockObject $rootFolder;
+	private IUserSession&MockObject $userSession;
+	private IShareManager&MockObject $shareManager;
+	private RootCollection $collection;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->principalBackend = $this->createMock(BackendInterface::class);
+		$this->cleanupService = $this->createMock(CleanupService::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->shareManager = $this->createMock(IShareManager::class);
+
+		$this->collection = new RootCollection(
+			$this->principalBackend,
+			'principals/users',
+			$this->cleanupService,
+			$this->rootFolder,
+			$this->userSession,
+			$this->shareManager,
+		);
+	}
+
+	private function mockUser(string $uid): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+
+	public function testGetChildForPrincipalReturnsUploadHomeForOwnPrincipal(): void {
+		$this->userSession->method('getUser')->willReturn($this->mockUser('alice'));
+
+		$node = $this->collection->getChildForPrincipal(['uri' => 'principals/users/alice']);
+
+		$this->assertInstanceOf(UploadHome::class, $node);
+	}
+
+	public function testGetChildForPrincipalReturnsUploadHomeForShareToken(): void {
+		$this->userSession->method('getUser')->willReturn($this->mockUser('alice'));
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareOwner')->willReturn('bob');
+		$this->shareManager->method('getShareByToken')
+			->with('sometoken')
+			->willReturn($share);
+
+		$node = $this->collection->getChildForPrincipal(['uri' => 'principals/shares/sometoken']);
+
+		$this->assertInstanceOf(UploadHome::class, $node);
+	}
+
+	public function testGetChildForPrincipalThrowsWhenPrincipalDoesNotMatchUser(): void {
+		$this->userSession->method('getUser')->willReturn($this->mockUser('alice'));
+
+		$this->expectException(Forbidden::class);
+
+		$this->collection->getChildForPrincipal(['uri' => 'principals/users/bob']);
+	}
+
+	public function testGetChildForPrincipalThrowsWhenNotLoggedIn(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->expectException(Forbidden::class);
+
+		$this->collection->getChildForPrincipal(['uri' => 'principals/users/alice']);
+	}
+}

--- a/build/integration/dav_features/webdav-related.feature
+++ b/build/integration/dav_features/webdav-related.feature
@@ -424,6 +424,14 @@ Feature: webdav-related
 		And Downloading file "/myChunkedFile.txt"
 		Then Downloaded content should be "AAAAABBBBBCCCCC"
 
+	Scenario: Cannot create a chunked upload in another user's uploads folder
+		Given using new dav path
+		And user "user0" exists
+		And user "user1" exists
+		And As an "user1"
+		When user "user1" creates a new chunking upload with id "chunking-42" in the uploads folder for "user0"
+		Then the HTTP status code should be "403"
+
 	Scenario: A disabled user cannot use webdav
 		Given user "userToBeDisabled" exists
 		And As an "admin"

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -879,6 +879,18 @@ trait WebDav {
 	}
 
 	/**
+	 * @When user :user creates a new chunking upload with id :id in the uploads folder for :uidOrToken
+	 */
+	public function userCreatesANewChunkingUploadWithIdInFolderOf($user, $id, $uidOrToken): void {
+		$destination = '/uploads/' . $uidOrToken . '/' . $id;
+		try {
+			$this->response = $this->makeDavRequest($user, 'MKCOL', $destination, [], null, 'uploads');
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
 	 * @Given user :user uploads new chunk file :num with :data to id :id
 	 */
 	public function userUploadsNewChunkFileOfWithToId($user, $num, $data, $id) {


### PR DESCRIPTION

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This is a cosmetic change that can cause false security reports: the current implementation of the upload root collection returns `UploadHome` in every case, based on the current session, either the one of the logged in user, or for the share. The former allows uploading files in what looks like the upload folder of another user, but is in reality the one of the logged in user. Those requests will now fail with a 403 instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
