### PR TITLE
fix(objectstore): do not warn when ensuring the storage root exists

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -82,7 +82,13 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 	public function mkdir(string $path, bool $force = false, array $metadata = []): bool {
 		$path = $this->normalizePath($path);
 		if (!$force && $this->file_exists($path)) {
-			$this->logger->warning("Tried to create an object store folder that already exists: $path");
+			// The storage root is created on the fly by getMetaData() whenever the
+			// cache has no entry for it, so a caller that only wants to make sure the
+			// root exists would be warned about a folder this storage just created
+			// itself. An existing root is never an error, so say nothing about it.
+			if ($path !== '') {
+				$this->logger->warning("Tried to create an object store folder that already exists: '$path'");
+			}
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #63888

### Summary

On instances with primary object storage, every account creation logs a `warning` whose path renders empty:

```
Tried to create an object store folder that already exists: 
```

`ObjectStoreStorage` creates the storage root on the fly in `getMetaData()`, with `$force = true`, whenever the cache has no entry for it:

https://github.com/nextcloud/server/blob/master/lib/private/Files/ObjectStore/ObjectStoreStorage.php#L237-L239

`SetupManager` then explicitly ensures that same root exists, once per account at first filesystem setup:

https://github.com/nextcloud/server/blob/master/lib/private/Files/SetupManager.php#L335

Since that call cannot pass `$force` — `IStorage::mkdir()` declares a single parameter, and `$force`/`$metadata` exist only on the `ObjectStoreStorage` implementation — it takes the warning branch and reports a folder the storage created itself moments earlier. The path is the storage root, which normalises to `''`, hence the empty message.

### What this changes

Skips the warning when the path is the storage root, since an existing root is never an error, and quotes the path so an empty one is not invisible in the log.

The nested condition is deliberate, rather than extending the surrounding `if` to `!$force && $path !== '' && $this->file_exists($path)`. That would stop the function returning early for the root, letting it fall through to

```php
if ($path === '') {
    //create root on the fly
    $data['etag'] = $this->getETag('');
    $this->getCache()->put('', $data);
    return true;
}
```

which re-mints the root's etag and mtime and flips the return from `false` to `true` — i.e. exactly what `$force = true` does, for a caller that deliberately did not pass it. Re-writing the home root's etag on each setup would risk telling sync clients the whole tree changed. Keeping the early return leaves control flow untouched and changes only what is logged.

### How to test

On an instance with primary object storage:

```
occ user:add --password-from-env someuser
```

Before: one `warning`-level entry per account, with an empty path.
After: none. The warning still fires for any non-root folder that already exists.

Verified reproducible on 34.0.3 with S3 primary storage — the occurrence count in `nextcloud.log` rose by exactly one per `occ user:add`.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tested against an instance reproducing the issue
