### PR TITLE
fix(dav): Do not claim no plugin available when checksum algorithm is not supported

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ChecksumUpdatePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ChecksumUpdatePlugin.php
@@ -8,7 +8,11 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OCA\DAV\Connector\Sabre\Exception\Forbidden as DAVForbiddenException;
 use OCP\AppFramework\Http;
+use OCP\Files\ForbiddenException;
+use Sabre\DAV\Exception;
+use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
@@ -34,25 +38,54 @@ class ChecksumUpdatePlugin extends ServerPlugin {
 		return ['nextcloud-checksum-update'];
 	}
 
+	/**
+	 * @throws BadRequest if the requested hash algorithm is not supported
+	 * @throws DAVForbiddenException if the user may not read and update the node
+	 * @throws Exception if the checksum could not be calculated
+	 */
 	public function httpPatch(RequestInterface $request, ResponseInterface $response) {
 		$path = $request->getPath();
 
 		$node = $this->server->tree->getNodeForPath($path);
-		if ($node instanceof File) {
-			$type = strtolower(
-				(string)$request->getHeader('X-Recalculate-Hash')
-			);
+		if (!$node instanceof File) {
+			return;
+		}
 
+		$type = strtolower(
+			(string)$request->getHeader('X-Recalculate-Hash')
+		);
+
+		// Without the header this is not a checksum update, leave the request to other plugins
+		if ($type === '') {
+			return;
+		}
+
+		if (!in_array($type, hash_algos(), true)) {
+			throw new BadRequest('Unsupported hash algorithm "' . $type . '"');
+		}
+
+		// Recalculating reads the whole file content and persists the result,
+		// so it requires both read and write access to the node.
+		$info = $node->getFileInfo();
+		if (!$info->isReadable() || !$info->isUpdateable()) {
+			throw new DAVForbiddenException('You are not allowed to recalculate the checksum of this file', false);
+		}
+
+		try {
 			$hash = $node->hash($type);
-			if ($hash) {
-				$checksum = strtoupper($type) . ':' . $hash;
-				$node->setChecksum($checksum);
-				$response->addHeader('OC-Checksum', $checksum);
-				$response->setHeader('Content-Length', '0');
-				$response->setStatus(Http::STATUS_NO_CONTENT);
-
-				return false;
+			if ($hash === false) {
+				throw new Exception('Could not calculate the ' . $type . ' checksum of "' . $path . '"');
 			}
+
+			$checksum = strtoupper($type) . ':' . $hash;
+			$node->setChecksum($checksum);
+
+			$response->addHeader('OC-Checksum', $checksum);
+			$response->setHeader('Content-Length', '0');
+			$response->setStatus(Http::STATUS_NO_CONTENT);
+			return false;
+		} catch (ForbiddenException $e) {
+			throw new DAVForbiddenException($e->getMessage(), $e->getRetry(), $e);
 		}
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/ChecksumUpdatePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ChecksumUpdatePluginTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\ChecksumUpdatePlugin;
+use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden as DAVForbiddenException;
+use OCA\DAV\Connector\Sabre\File;
+use OCP\AppFramework\Http;
+use OCP\Files\FileInfo;
+use OCP\Files\ForbiddenException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Exception;
+use Sabre\DAV\Exception\BadRequest;
+use Sabre\DAV\Server;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Test\TestCase;
+
+class ChecksumUpdatePluginTest extends TestCase {
+	private Tree&MockObject $tree;
+	private RequestInterface&MockObject $request;
+	private ResponseInterface&MockObject $response;
+	private ChecksumUpdatePlugin $plugin;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->tree = $this->createMock(Tree::class);
+		$this->request = $this->createMock(RequestInterface::class);
+		$this->response = $this->createMock(ResponseInterface::class);
+
+		$server = $this->createMock(Server::class);
+		$server->tree = $this->tree;
+
+		$this->plugin = new ChecksumUpdatePlugin();
+		$this->plugin->initialize($server);
+
+		$this->request->method('getPath')->willReturn('files/admin/foobar.txt');
+	}
+
+	private function createNode(bool $readable = true, bool $updateable = true): File&MockObject {
+		$info = $this->createMock(FileInfo::class);
+		$info->method('isReadable')->willReturn($readable);
+		$info->method('isUpdateable')->willReturn($updateable);
+
+		$node = $this->createMock(File::class);
+		$node->method('getFileInfo')->willReturn($info);
+
+		return $node;
+	}
+
+	public function testRecalculatesTheChecksum(): void {
+		$node = $this->createNode();
+		$node->expects($this->once())
+			->method('hash')
+			->with('md5')
+			->willReturn('d41d8cd98f00b204e9800998ecf8427e');
+		$node->expects($this->once())
+			->method('setChecksum')
+			->with('MD5:d41d8cd98f00b204e9800998ecf8427e');
+
+		$this->tree->method('getNodeForPath')->willReturn($node);
+		$this->request->method('getHeader')->with('X-Recalculate-Hash')->willReturn('md5');
+
+		$this->response->expects($this->once())
+			->method('addHeader')
+			->with('OC-Checksum', 'MD5:d41d8cd98f00b204e9800998ecf8427e');
+		$this->response->expects($this->once())
+			->method('setStatus')
+			->with(Http::STATUS_NO_CONTENT);
+
+		$this->assertFalse($this->plugin->httpPatch($this->request, $this->response));
+	}
+
+	public static function dataMissingPermissions(): array {
+		return [
+			'not readable' => [false, true],
+			'not updateable' => [true, false],
+			'neither' => [false, false],
+		];
+	}
+
+	#[DataProvider('dataMissingPermissions')]
+	public function testDeniesWithoutPermissions(bool $readable, bool $updateable): void {
+		$node = $this->createNode($readable, $updateable);
+		$node->expects($this->never())->method('hash');
+		$node->expects($this->never())->method('setChecksum');
+
+		$this->tree->method('getNodeForPath')->willReturn($node);
+		$this->request->method('getHeader')->with('X-Recalculate-Hash')->willReturn('md5');
+
+		$this->expectException(DAVForbiddenException::class);
+		$this->plugin->httpPatch($this->request, $this->response);
+	}
+
+	public function testMapsStorageForbiddenExceptionToDav(): void {
+		$node = $this->createNode();
+		$node->method('hash')->willThrowException(new ForbiddenException('Access denied', false));
+		$node->expects($this->never())->method('setChecksum');
+
+		$this->tree->method('getNodeForPath')->willReturn($node);
+		$this->request->method('getHeader')->with('X-Recalculate-Hash')->willReturn('md5');
+
+		$this->expectException(DAVForbiddenException::class);
+		$this->plugin->httpPatch($this->request, $this->response);
+	}
+
+	public function testFailedHashDoesNotFallThrough(): void {
+		$node = $this->createNode();
+		$node->method('hash')->willReturn(false);
+		$node->expects($this->never())->method('setChecksum');
+
+		$this->tree->method('getNodeForPath')->willReturn($node);
+		$this->request->method('getHeader')->with('X-Recalculate-Hash')->willReturn('md5');
+
+		$this->expectException(Exception::class);
+		$this->plugin->httpPatch($this->request, $this->response);
+	}
+
+	public function testRejectsUnknownHashAlgorithm(): void {
+		$node = $this->createNode();
+		$node->expects($this->never())->method('hash');
+
+		$this->tree->method('getNodeForPath')->willReturn($node);
+		$this->request->method('getHeader')->with('X-Recalculate-Hash')->willReturn('notahash');
+
+		$this->expectException(BadRequest::class);
+		$this->plugin->httpPatch($this->request, $this->response);
+	}
+
+	public function testIgnoresRequestWithoutHeader(): void {
+		$node = $this->createNode();
+		$node->expects($this->never())->method('hash');
+
+		$this->tree->method('getNodeForPath')->willReturn($node);
+		$this->request->method('getHeader')->with('X-Recalculate-Hash')->willReturn(null);
+
+		$this->assertNull($this->plugin->httpPatch($this->request, $this->response));
+	}
+
+	public function testIgnoresNonFileNode(): void {
+		$this->tree->method('getNodeForPath')->willReturn($this->createMock(Directory::class));
+		$this->request->method('getHeader')->willReturn('md5');
+
+		$this->assertNull($this->plugin->httpPatch($this->request, $this->response));
+	}
+}


### PR DESCRIPTION
## Summary

Currently the server returns `There was no plugin in the system that was willing to handle this PATCH method` when the hash algorithm is not supported by the server.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
