### PR TITLE
fix(config): Don't print sensitive config when setting them

### DIFF
--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -9,6 +9,7 @@
 namespace OC\Core\Command\Config\System;
 
 use OC\SystemConfig;
+use OCP\IConfig;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -80,8 +81,36 @@ class SetConfig extends Base {
 			$this->systemConfig->setValue($configName, $configValue['value']);
 		}
 
-		$output->writeln('<info>System config value ' . implode(' => ', $configNames) . ' set to ' . $configValue['readable-value'] . '</info>');
+		$readableValue = $this->getReadableValue($configNames, $configValue);
+
+		$output->writeln('<info>System config value ' . implode(' => ', $configNames) . ' set to ' . $readableValue . '</info>');
 		return 0;
+	}
+
+	/**
+	 * Mask sensitive values
+	 * @param string[] $configNames
+	 * @param array{value: mixed, readable-value: string} $configValue
+	 */
+	protected function getReadableValue(array $configNames, array $configValue): string {
+		$filteredValue = $this->systemConfig->getFilteredValue($configNames[0]);
+		foreach (array_slice($configNames, 1) as $key) {
+			if (!is_array($filteredValue) || !array_key_exists($key, $filteredValue)) {
+				// Nothing got filtered along this path
+				return $configValue['readable-value'];
+			}
+			$filteredValue = $filteredValue[$key];
+		}
+
+		if ($filteredValue === $configValue['value']) {
+			return $configValue['readable-value'];
+		}
+
+		if ($filteredValue === IConfig::SENSITIVE_VALUE) {
+			return IConfig::SENSITIVE_VALUE;
+		}
+
+		return 'array ' . json_encode($filteredValue);
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
