### PR TITLE
fix: filter system tag object IDs by user visibility

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -329,7 +329,22 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 
 		if ($node instanceof SystemTagObjectType) {
 			$propFind->handle(self::OBJECTIDS_PROPERTYNAME, function () use ($node): SystemTagsObjectList {
-				return new SystemTagsObjectList(array_fill_keys($node->getObjectsIds(), $node->getName()));
+				$user = $this->userSession->getUser();
+				if ($user === null) {
+					return new SystemTagsObjectList([]);
+				}
+
+				$allIds = $node->getObjectsIds();
+				$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+				$filteredIds = [];
+				foreach ($allIds as $id) {
+					if ($userFolder->getFirstNodeById((int)$id) !== null) {
+						$filteredIds[] = $id;
+					}
+				}
+				return new SystemTagsObjectList(
+					array_fill_keys($filteredIds, $node->getName())
+				);
 			});
 		}
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #<!-- related github issue -->

## Summary
Improved system tag object ID handling by filtering results based on the current user's file visibility, ensuring only accessible files are included in the returned object IDs.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
