### PR TITLE
fix(appconfig-userpreference): Fix doc types for returned arrays

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -300,7 +300,13 @@ class AppConfig implements IAppConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 * @param int|null $typedAs enforce type for the returned values ({@see self::VALUE_STRING} and others)
 	 *
-	 * @return array<string, string|int|float|bool|array> [appId => configValue]
+	 * @return (
+	 *      $typedAs is IAppConfig::VALUE_INT ? array<string, int> : (
+	 *      $typedAs is IAppConfig::VALUE_FLOAT ? array<string, float> : (
+	 *      $typedAs is IAppConfig::VALUE_BOOL ? array<string, bool> : (
+	 *      $typedAs is IAppConfig::VALUE_ARRAY ? array<string, array> : (
+	 *      $typedAs is int ? array<string, string> :
+	 *      array<string, string|int|float|bool|array>))))) [appId => configValue]
 	 * @since 29.0.0
 	 */
 	#[\Override]
@@ -1590,11 +1596,11 @@ class AppConfig implements IAppConfig {
 				return in_array(strtolower($value), ['1', 'true', 'yes', 'on']);
 			case self::VALUE_ARRAY:
 				try {
-					return json_decode($value, true, flags: JSON_THROW_ON_ERROR);
-				} catch (JsonException $e) {
-					// ignoreable
+					$decoded = json_decode($value, true, flags: JSON_THROW_ON_ERROR);
+				} catch (JsonException) {
+					$decoded = null;
 				}
-				break;
+				return is_array($decoded) ? $decoded : [];
 		}
 		return $value;
 	}

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -333,7 +333,13 @@ class UserConfig implements IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 * @param ValueType|null $typedAs enforce type for the returned values
 	 *
-	 * @return array<string, string|int|float|bool|array> [appId => value]
+	 * @return (
+	 *      $typedAs is ValueType::INT ? array<string, int> : (
+	 *      $typedAs is ValueType::FLOAT ? array<string, float> : (
+	 *      $typedAs is ValueType::BOOL ? array<string, bool> : (
+	 *      $typedAs is ValueType::ARRAY ? array<string, array> : (
+	 *      $typedAs is ValueType ? array<string, string> :
+	 *      array<string, string|int|float|bool|array>))))) [appId => value]
 	 * @since 31.0.0
 	 */
 	#[\Override]
@@ -354,11 +360,10 @@ class UserConfig implements IUserConfig {
 				$entry = $cache[$app][$key];
 				try {
 					$value = $this->getDecryptedSensitiveValue($userId, $app, $key, $entry);
-					$value = $this->convertTypedValue($value, $typedAs ?? $entry->getType());
 				} catch (IncorrectTypeException|UnknownKeyException) {
 					$value = $entry->getRawValue();
 				}
-				$values[$app] = $value;
+				$values[$app] = $this->convertTypedValue($value, $typedAs ?? $entry->getType());
 			}
 		}
 
@@ -373,7 +378,13 @@ class UserConfig implements IUserConfig {
 	 * @param ValueType|null $typedAs enforce type for the returned values
 	 * @param array|null $userIds limit to a list of user ids
 	 *
-	 * @return array<string, string|int|float|bool|array> [userId => value]
+	 * @return (
+	 *      $typedAs is ValueType::INT ? array<string, int> : (
+	 *      $typedAs is ValueType::FLOAT ? array<string, float> : (
+	 *      $typedAs is ValueType::BOOL ? array<string, bool> : (
+	 *      $typedAs is ValueType::ARRAY ? array<string, array> : (
+	 *      $typedAs is ValueType ? array<string, string> :
+	 *      array<string, string|int|float|bool|array>))))) [userId => value]
 	 * @since 31.0.0
 	 */
 	#[\Override]
@@ -397,12 +408,7 @@ class UserConfig implements IUserConfig {
 		$executeAndStoreValue = function (IQueryBuilder $qb) use (&$values, $typedAs): IResult {
 			$result = $qb->executeQuery();
 			while ($row = $result->fetchAssociative()) {
-				$value = $row['configvalue'];
-				try {
-					$value = $this->convertTypedValue($value, $typedAs ?? ValueType::from((int)$row['type']));
-				} catch (IncorrectTypeException) {
-				}
-				$values[$row['userid']] = $value;
+				$values[$row['userid']] = $this->convertTypedValue($row['configvalue'], $typedAs ?? ValueType::from((int)$row['type']));
 			}
 			return $result;
 		};
@@ -1934,11 +1940,11 @@ class UserConfig implements IUserConfig {
 				return in_array(strtolower($value), ['1', 'true', 'yes', 'on']);
 			case ValueType::ARRAY:
 				try {
-					return json_decode($value, true, flags: JSON_THROW_ON_ERROR);
+					$decoded = json_decode($value, true, flags: JSON_THROW_ON_ERROR);
 				} catch (JsonException) {
-					// ignoreable
+					$decoded = null;
 				}
-				break;
+				return is_array($decoded) ? $decoded : [];
 		}
 		return $value;
 	}

--- a/lib/public/Config/IUserConfig.php
+++ b/lib/public/Config/IUserConfig.php
@@ -202,7 +202,13 @@ interface IUserConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 * @param ValueType|null $typedAs enforce type for the returned values
 	 *
-	 * @return array<string, string|int|float|bool|array> [appId => value]
+	 * @return (
+	 *      $typedAs is ValueType::INT ? array<string, int> : (
+	 *      $typedAs is ValueType::FLOAT ? array<string, float> : (
+	 *      $typedAs is ValueType::BOOL ? array<string, bool> : (
+	 *      $typedAs is ValueType::ARRAY ? array<string, array> : (
+	 *      $typedAs is ValueType ? array<string, string> :
+	 *      array<string, string|int|float|bool|array>))))) [appId => value]
 	 * @throws \InvalidArgumentException if $userId or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0
@@ -220,7 +226,13 @@ interface IUserConfig {
 	 * @param ValueType|null $typedAs enforce type for the returned values
 	 * @param array|null $userIds limit the search to a list of user ids
 	 *
-	 * @return array<string, string|int|float|bool|array> [userId => value]
+	 * @return (
+	 *      $typedAs is ValueType::INT ? array<string, int> : (
+	 *      $typedAs is ValueType::FLOAT ? array<string, float> : (
+	 *      $typedAs is ValueType::BOOL ? array<string, bool> : (
+	 *      $typedAs is ValueType::ARRAY ? array<string, array> : (
+	 *      $typedAs is ValueType ? array<string, string> :
+	 *      array<string, string|int|float|bool|array>))))) [userId => value]
 	 * @throws \InvalidArgumentException if $app or $key is invalid (too long, or empty string)
 	 *
 	 * @since 32.0.0

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -155,7 +155,13 @@ interface IAppConfig {
 	 * @param bool $lazy search within lazy loaded config
 	 * @param int|null $typedAs enforce type for the returned values {@see self::VALUE_STRING} and others
 	 *
-	 * @return array<string, string|int|float|bool|array> [appId => configValue]
+	 * @return (
+	 *      $typedAs is self::VALUE_INT ? array<string, int> : (
+	 *      $typedAs is self::VALUE_FLOAT ? array<string, float> : (
+	 *      $typedAs is self::VALUE_BOOL ? array<string, bool> : (
+	 *      $typedAs is self::VALUE_ARRAY ? array<string, array> : (
+	 *      $typedAs is int ? array<string, string> :
+	 *      array<string, string|int|float|bool|array>))))) [appId => configValue]
 	 * @since 29.0.0
 	 */
 	public function searchValues(string $key, bool $lazy = false, ?int $typedAs = null): array;

--- a/tests/lib/AppConfigIntegrationTest.php
+++ b/tests/lib/AppConfigIntegrationTest.php
@@ -421,6 +421,49 @@ class AppConfigIntegrationTest extends TestCase {
 		$this->assertEqualsCanonicalizing(['testapp' => 'yes', '123456' => 'yes', 'anotherapp' => 'no'], $config->searchValues('enabled'));
 	}
 
+	public static function providerSearchValuesTypedAs(): array {
+		return [
+			[
+				'enabled', IAppConfig::VALUE_STRING,
+				['testapp' => 'yes', '123456' => 'yes', 'anotherapp' => 'no']
+			],
+			[
+				'enabled', IAppConfig::VALUE_MIXED,
+				['testapp' => 'yes', '123456' => 'yes', 'anotherapp' => 'no']
+			],
+			[
+				'enabled', IAppConfig::VALUE_BOOL,
+				['testapp' => true, '123456' => true, 'anotherapp' => false]
+			],
+			[
+				'enabled', IAppConfig::VALUE_INT,
+				['testapp' => 0, '123456' => 0, 'anotherapp' => 0]
+			],
+			[
+				'enabled', IAppConfig::VALUE_ARRAY,
+				['testapp' => [], '123456' => [], 'anotherapp' => []]
+			],
+			[
+				'array', IAppConfig::VALUE_ARRAY,
+				['typed' => ['test' => 1]]
+			],
+			[
+				'int', IAppConfig::VALUE_INT,
+				['typed' => 42]
+			],
+			[
+				'float', IAppConfig::VALUE_FLOAT,
+				['typed' => 3.14]
+			],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSearchValuesTypedAs')]
+	public function testSearchValuesTypedAs(string $key, int $typedAs, array $result): void {
+		$config = $this->generateAppConfig();
+		$this->assertEqualsCanonicalizing($result, $config->searchValues($key, false, $typedAs));
+	}
+
 	public function testGetValueString(): void {
 		$config = $this->generateAppConfig();
 		$this->assertSame('value', $config->getValueString('typed', 'string', ''));

--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -690,6 +690,32 @@ class UserConfigTest extends TestCase {
 					'app2' => 0,
 					'app3' => 0,
 				]
+			],
+			[
+				'user1', 'key1', false, ValueType::BOOL,
+				[
+					'app1' => false,
+					'app3' => false,
+				]
+			],
+			[
+				'user1', 'key1', false, ValueType::ARRAY,
+				[
+					'app1' => [],
+					'app3' => [],
+				]
+			],
+			[
+				'user1', 'fast_array', false, ValueType::ARRAY,
+				[
+					'app1' => ['year' => 2024],
+				]
+			],
+			[
+				'user1', 'fast_array_sensitive', false, ValueType::ARRAY,
+				[
+					'app1' => ['password' => 'pwd'],
+				]
 			]
 		];
 	}
@@ -737,6 +763,34 @@ class UserConfigTest extends TestCase {
 					'user1' => 11,
 					'user2' => 12,
 					'user5' => 12,
+				]
+			],
+			[
+				'app3', 'key10', null, null,
+				[
+					'user1' => true,
+					'user2' => false,
+					'user4' => true,
+				]
+			],
+			[
+				'app2', 'key2', ValueType::BOOL, ['user1', 'user3'],
+				[
+					'user1' => false,
+					'user3' => false,
+				]
+			],
+			[
+				'app2', 'key2', ValueType::ARRAY, ['user1', 'user3'],
+				[
+					'user1' => [],
+					'user3' => [],
+				]
+			],
+			[
+				'app1', 'fast_array', ValueType::ARRAY, null,
+				[
+					'user1' => ['year' => 2024],
 				]
 			],
 		];


### PR DESCRIPTION
Assisted-by: ClaudeCode:claude-opus-5

- Drive by while trying to debug https://github.com/nextcloud/notifications/issues/3338 for https://github.com/nextcloud/notifications/pull/3339
- But Psalm still does not turn red until `<DocblockTypeContradiction errorLevel="error"/>` is added as an IssueHandler sadly. I think it's still worth adding.
- Maybe it would be even better to have \*String, \*Bool, … methods for all of them, so default psalm notices the mistakes?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
