### PR TITLE
build(deps): bump @nextcloud/upload from 1.11.1 to 1.12.0 in /build/frontend-legacy

### DIFF
--- a/build/frontend-legacy/package-lock.json
+++ b/build/frontend-legacy/package-lock.json
@@ -28,7 +28,7 @@
         "@nextcloud/paths": "^3.1.0",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.4.0",
-        "@nextcloud/upload": "^1.11.1",
+        "@nextcloud/upload": "^1.12.0",
         "@nextcloud/vue": "^8.41.0",
         "@simplewebauthn/browser": "^13.3.0",
         "@vue/web-component-wrapper": "^1.3.0",
@@ -4587,26 +4587,26 @@
       }
     },
     "node_modules/@nextcloud/upload": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/upload/-/upload-1.11.1.tgz",
-      "integrity": "sha512-2Wf9W0Hfrd3MsEMTrIvEmpxSyfeUXCA7nzL7XE16exUuCmmSq5vHz6B+4bOQig7kK+xG39P3p9mLlEcLLoECLA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/upload/-/upload-1.12.0.tgz",
+      "integrity": "sha512-KyN3m9IvqLmnXZLRJ8f7NdDuncGRT1KtH7P3bJYDsDPgjG8dd5TCc2vDsw6YfWS95q/QsKKI4ZrjPBZkkRlRAg==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",
-        "@nextcloud/axios": "^2.5.2",
+        "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
         "@nextcloud/dialogs": "^6.4.2",
         "@nextcloud/files": "^3.12.2",
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/logger": "^3.0.3",
-        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/paths": "^3.1.0",
         "@nextcloud/router": "^3.1.0",
-        "@nextcloud/sharing": "^0.3.0",
-        "axios": "^1.13.2",
+        "@nextcloud/sharing": "^0.4.0",
+        "axios": "^1.20.0",
         "axios-retry": "^4.5.0",
         "crypto-browserify": "^3.12.1",
         "p-cancelable": "^4.0.1",
-        "p-queue": "^9.0.1",
+        "p-queue": "^9.3.3",
         "typescript-event-target": "^1.1.2"
       },
       "engines": {
@@ -4686,6 +4686,18 @@
       },
       "optionalDependencies": {
         "@nextcloud/files": "^3.12.0"
+      }
+    },
+    "node_modules/@nextcloud/upload/node_modules/axios": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@nextcloud/vue": {

--- a/build/frontend-legacy/package.json
+++ b/build/frontend-legacy/package.json
@@ -47,7 +47,7 @@
     "@nextcloud/paths": "^3.1.0",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/sharing": "^0.4.0",
-    "@nextcloud/upload": "^1.11.1",
+    "@nextcloud/upload": "^1.12.0",
     "@nextcloud/vue": "^8.41.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@vue/web-component-wrapper": "^1.3.0",


### PR DESCRIPTION
## Summary

Bumps `@nextcloud/upload` from 1.11.1 to 1.12.0 in `build/frontend-legacy`.

Changelog: https://github.com/nextcloud-libraries/nextcloud-upload/blob/main/CHANGELOG.md#v1120
Diff: https://github.com/nextcloud-libraries/nextcloud-upload/compare/v1.11.1...v1.12.0

Notable changes in this release:
- Fixed: chunked upload response missing (nextcloud-libraries/nextcloud-upload#2092), InvalidFilenameDialog binding/CI flakes (nextcloud-libraries/nextcloud-upload#2107)
- Changed: file conflict dialog simplification (nextcloud-libraries/nextcloud-upload#2151), upload icon variant (nextcloud-libraries/nextcloud-upload#2099), upload input tab-focus fix (nextcloud-libraries/nextcloud-upload#2138)

___

AI disclosure

This dependency bump was prepared with Claude Code (AI-assisted), per the [Nextcloud AI contribution policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md). Only `package.json`/`package-lock.json` in `build/frontend-legacy` were touched (targeted `npm install`, no unrelated lockfile churn).
