### PR TITLE
fix: protect share accept endpoint with CSRF token

### DIFF
--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -69,9 +69,14 @@ return [
 			'verb' => 'DELETE',
 		],
 		[
-			'name' => 'Accept#accept',
+			'name' => 'Accept#showAccept',
 			'url' => '/accept/{shareId}',
 			'verb' => 'GET',
+		],
+		[
+			'name' => 'Accept#accept',
+			'url' => '/accept/{shareId}',
+			'verb' => 'POST',
 		],
 	],
 	'ocs' => [

--- a/apps/files_sharing/css/accept-share.css
+++ b/apps/files_sharing/css/accept-share.css
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+.accept-share {
+	text-align: center;
+}
+
+.accept-share h2,
+.accept-share p {
+	text-align: center;
+}
+
+.accept-share .buttons {
+	display: flex;
+	justify-content: center;
+	margin-top: 1em;
+}
+
+.accept-share input[type="submit"] {
+	margin: 0;
+}

--- a/apps/files_sharing/lib/Controller/AcceptController.php
+++ b/apps/files_sharing/lib/Controller/AcceptController.php
@@ -17,11 +17,17 @@ use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\NotFoundException;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as ShareManager;
+use OCP\Share\IShare;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class AcceptController extends Controller {
@@ -31,12 +37,47 @@ class AcceptController extends Controller {
 		private ShareManager $shareManager,
 		private IUserSession $userSession,
 		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
+		private IGroupManager $groupManager,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 	}
 
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
+	public function showAccept(string $shareId): Response {
+		try {
+			$share = $this->shareManager->getShareById($shareId);
+		} catch (ShareNotFound $e) {
+			return new NotFoundResponse();
+		}
+
+		$user = $this->userSession->getUser();
+		if ($user === null || !$this->isRecipient($share, $user)) {
+			return new NotFoundResponse();
+		}
+
+		try {
+			$filename = $share->getNode()->getName();
+		} catch (NotFoundException) {
+			return new NotFoundResponse();
+		}
+
+		$sharer = $this->userManager->get($share->getSharedBy());
+		$sharerDisplayName = $sharer !== null ? $sharer->getDisplayName() : $share->getSharedBy();
+
+		return new TemplateResponse(
+			Application::APP_ID,
+			'accept-share',
+			[
+				'filename' => $filename,
+				'sharerDisplayName' => $sharerDisplayName,
+			],
+			TemplateResponse::RENDER_AS_GUEST,
+		);
+	}
+
+	#[NoAdminRequired]
 	public function accept(string $shareId): Response {
 		try {
 			$share = $this->shareManager->getShareById($shareId);
@@ -58,5 +99,18 @@ class AcceptController extends Controller {
 		$url = $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $share->getNode()->getId()]);
 
 		return new RedirectResponse($url);
+	}
+
+	private function isRecipient(IShare $share, IUser $user): bool {
+		if ($share->getShareType() === IShare::TYPE_USER) {
+			return $share->getSharedWith() === $user->getUID();
+		}
+
+		if ($share->getShareType() === IShare::TYPE_GROUP) {
+			$group = $this->groupManager->get($share->getSharedWith());
+			return $group !== null && $group->inGroup($user);
+		}
+
+		return false;
 	}
 }

--- a/apps/files_sharing/templates/accept-share.php
+++ b/apps/files_sharing/templates/accept-share.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+\OCP\Util::addStyle('files_sharing', 'accept-share');
+?>
+
+<div class="guest-box accept-share">
+	<form action="" method="post">
+		<h2><?php p($l->t('%1$s shared %2$s with you', [$_['sharerDisplayName'], $_['filename']])); ?></h2>
+		<p><?php p($l->t('Do you want to accept this share?')); ?></p>
+		<div class="buttons">
+			<input type="submit" class="primary" value="<?php p($l->t('Accept')); ?>">
+		</div>
+		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']); ?>">
+	</form>
+</div>

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -7,6 +7,7 @@
  */
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use OCA\Files_Sharing\MountProvider;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
@@ -97,12 +98,64 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^opening last share accept confirmation page$/
+	 */
+	public function openingLastShareAcceptConfirmationPage(): void {
+		$share_id = $this->lastShareData->data[0]->id;
+		$url = "/index.php/apps/files_sharing/accept/ocinternal:$share_id";
+		$baseUrl = substr($this->baseUrl, 0, -5);
+		$client = new Client();
+		try {
+			$this->response = $client->get(
+				$baseUrl . $url,
+				[
+					'cookies' => $this->cookieJar,
+				]
+			);
+		} catch (ClientException $ex) {
+			$this->response = $ex->getResponse();
+		}
+	}
+
+	/**
+	 * @When /^accepting last share via the accept endpoint with requesttoken$/
+	 */
+	public function acceptingLastShareViaAcceptEndpointWithRequesttoken(): void {
+		$share_id = $this->lastShareData->data[0]->id;
+		$url = "/index.php/apps/files_sharing/accept/ocinternal:$share_id";
+		$baseUrl = substr($this->baseUrl, 0, -5);
+		$client = new Client();
+		try {
+			$this->response = $client->post(
+				$baseUrl . $url,
+				[
+					'cookies' => $this->cookieJar,
+					'form_params' => [
+						'requesttoken' => $this->requestToken,
+					],
+					'headers' => [
+						'Origin' => $baseUrl,
+					],
+				]
+			);
+		} catch (ClientException $ex) {
+			$this->response = $ex->getResponse();
+		}
+	}
+
+	/**
 	 * @When /^accepting last share via the accept endpoint$/
 	 */
 	public function acceptingLastShareViaAcceptEndpoint(): void {
-		$share_id = $this->lastShareData->data[0]->id;
-		$url = "/index.php/apps/files_sharing/accept/ocinternal:$share_id";
-		$this->sendingToDirectUrl('GET', $url);
+		$this->loggingInUsingWebAs($this->currentUser);
+		$this->openingLastShareAcceptConfirmationPage();
+
+		if ($this->response->getStatusCode() !== 200) {
+			return;
+		}
+
+		$this->theCsrfTokenIsExtractedFromThePreviousResponse();
+		$this->acceptingLastShareViaAcceptEndpointWithRequesttoken();
 	}
 
 	/**

--- a/build/integration/sharing_features/sharing-accept.feature
+++ b/build/integration/sharing_features/sharing-accept.feature
@@ -28,7 +28,11 @@ Feature: sharing-accept
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And As an "user1"
-    When accepting last share via the accept endpoint
+    And Logging in using web as "user1"
+    When opening last share accept confirmation page
+    Then the HTTP status code should be "200"
+    When the CSRF token is extracted from the previous response
+    And accepting last share via the accept endpoint with requesttoken
     Then the HTTP status code should be "200"
 
   Scenario: Accepting a share as a different user

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1562,7 +1562,7 @@ class DefaultShareProvider implements
 				$this->sendUserShareMail(
 					$l,
 					$share->getNode()->getName(),
-					$this->urlGenerator->linkToRouteAbsolute('files_sharing.Accept.accept', ['shareId' => $share->getFullId()]),
+					$this->urlGenerator->linkToRouteAbsolute('files_sharing.Accept.showAccept', ['shareId' => $share->getFullId()]),
 					$share->getSharedBy(),
 					$emailAddress,
 					$share->getExpirationDate(),


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud-gmbh/h1/issues/252

## Summary
The share accept link in notification emails previously accepted the share on a single GET request, which bypass CSRF protection. This change introduces a confirmation page and moves the actual acceptance to a POST request with a CSRF token.
- GET `/apps/files_sharing/accept/{shareId}` — shows a confirmation page with sharer name and file name
- POST `/apps/files_sharing/accept/{shareId}` — accepts the share and redirects to the shared file (CSRF-protected)
- Share notification emails now link to the confirmation page (showAccept) instead of accepting directly

## Screenshot of Accept page
<img width="1337" height="586" alt="image" src="https://github.com/user-attachments/assets/3faf1478-fd4f-4215-bc92-327b273f1a81" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
