### PR TITLE
fix(ci): run performance tests against fetched PR changes

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,7 +30,9 @@ jobs:
 
     steps:
 
-      - name: Checkout server before PR
+      # Check out the PR base branch first so the initial measurements provide
+      # a baseline for comparison with the PR changes measured below.
+      - name: Check out PR base branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -70,11 +72,19 @@ jobs:
           output: before.json
           profiler-branch: master
 
-      - name: Apply PR # zizmor: ignore[template-injection]
+      - name: Check out PR changes and apply upgrade
+        # Switch from the base branch used for the baseline measurements to the
+        # fetched PR commit so the after measurements run against the PR changes.
+        #
+        # Use FETCH_HEAD explicitly so the local branch points to the fetched PR
+        # commit rather than the currently checked-out base commit.
+        env:
+          PR_HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git remote add pr '${{ github.event.pull_request.head.repo.clone_url }}'
-          git fetch pr '${{ github.event.pull_request.head.ref }}'
-          git checkout -b 'pr/${{ github.event.pull_request.head.ref }}'
+          git remote add pr-source "$PR_HEAD_REPO_URL"
+          git fetch pr-source "$PR_HEAD_REF"
+          git checkout -B "pr/$PR_HEAD_REF" FETCH_HEAD
           git submodule update
 
           ./occ upgrade
@@ -104,6 +114,8 @@ jobs:
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         if: failure() && steps.compare.outcome == 'failure'
+        env:
+          COMPARE_OUTPUT: ${{ steps.compare.outputs.compare }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -111,7 +123,7 @@ jobs:
             comment += `<details><summary>Show Output</summary>
 
             \`\`\`
-            ${{ steps.compare.outputs.compare }}
+            ${process.env.COMPARE_OUTPUT}
             \`\`\`
 
             </details>`;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Fix the performance-testing workflow so after measurements run against the actual fetched PR changes.

The workflow now:

- Explicitly checks out the fetched PR commit via `FETCH_HEAD`.
- Avoids direct interpolation of PR-controlled values. (Historical context: PR #45710)

The interpolation changes provide additional defense-in-depth when handling pull request-controlled values and allow us to remove a no-longer-needed `zizmor: ignore[...]`.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
