### PR TITLE
feat(sharebymail): add option to put the share initiator in CC

### DIFF
--- a/apps/sharebymail/lib/Settings/Admin.php
+++ b/apps/sharebymail/lib/Settings/Admin.php
@@ -30,6 +30,7 @@ class Admin implements IDelegatedSettings {
 	public function getForm() {
 		$this->initialState->provideInitialState('sendPasswordMail', $this->settingsManager->sendPasswordByMail());
 		$this->initialState->provideInitialState('replyToInitiator', $this->settingsManager->replyToInitiator());
+		$this->initialState->provideInitialState('ccToInitiator', $this->settingsManager->ccToInitiator());
 
 		Util::addStyle('sharebymail', 'admin-settings');
 		Util::addScript('sharebymail', 'admin-settings');
@@ -67,6 +68,7 @@ class Admin implements IDelegatedSettings {
 			'sharebymail' => [
 				'sendpasswordmail',
 				'replyToInitiator',
+				'ccToInitiator',
 			],
 		];
 	}

--- a/apps/sharebymail/lib/Settings/SettingsManager.php
+++ b/apps/sharebymail/lib/Settings/SettingsManager.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\ShareByMail\Settings;
 
-use OCP\IConfig;
+use OCP\IAppConfig;
 
 class SettingsManager {
 
@@ -17,8 +17,10 @@ class SettingsManager {
 
 	private $replyToInitiatorDefault = 'yes';
 
+	private $ccToInitiatorDefault = 'no';
+
 	public function __construct(
-		private IConfig $config,
+		private IAppConfig $appConfig,
 	) {
 	}
 
@@ -28,7 +30,7 @@ class SettingsManager {
 	 * @return bool
 	 */
 	public function sendPasswordByMail(): bool {
-		$sendPasswordByMail = $this->config->getAppValue('sharebymail', 'sendpasswordmail', $this->sendPasswordByMailDefault);
+		$sendPasswordByMail = $this->appConfig->getValueString('sharebymail', 'sendpasswordmail', $this->sendPasswordByMailDefault);
 		return $sendPasswordByMail === 'yes';
 	}
 
@@ -38,7 +40,17 @@ class SettingsManager {
 	 * @return bool
 	 */
 	public function replyToInitiator(): bool {
-		$replyToInitiator = $this->config->getAppValue('sharebymail', 'replyToInitiator', $this->replyToInitiatorDefault);
+		$replyToInitiator = $this->appConfig->getValueString('sharebymail', 'replyToInitiator', $this->replyToInitiatorDefault);
 		return $replyToInitiator === 'yes';
+	}
+
+	/**
+	 * should the initiator be added to the recipients in CC
+	 *
+	 * @return bool
+	 */
+	public function ccToInitiator(): bool {
+		$ccToInitiator = $this->appConfig->getValueString('sharebymail', 'ccToInitiator', $this->ccToInitiatorDefault);
+		return $ccToInitiator === 'yes';
 	}
 }

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -27,6 +27,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
 use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
@@ -404,6 +405,8 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			$emailTemplate->addFooter();
 		}
 
+		$this->addInitiatorToCc($message, $initiatorUser, $initiatorDisplayName);
+
 		$message->useTemplate($emailTemplate);
 		$failedRecipients = $this->mailer->send($message);
 		if (!empty($failedRecipients)) {
@@ -500,6 +503,8 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			$emailTemplate->addFooter();
 		}
 
+		$this->addInitiatorToCc($message, $initiatorUser, $initiatorDisplayName);
+
 		$message->useTemplate($emailTemplate);
 		$failedRecipients = $this->mailer->send($message);
 		if (!empty($failedRecipients)) {
@@ -562,8 +567,29 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		}
 
 		$message->setTo([$recipient]);
+		$this->addInitiatorToCc($message, $initiatorUser, $initiatorDisplayName);
 		$message->useTemplate($emailTemplate);
 		$this->mailer->send($message);
+	}
+
+	/**
+	 * Add the initiator of a share to the recipients of a mail in CC
+	 *
+	 * Does nothing unless the administrator enabled it and the initiator is a
+	 * user with a mail address configured. The address is only looked up when
+	 * the setting is enabled.
+	 *
+	 * The display name is optional, as it is for the "Reply-To" address.
+	 */
+	private function addInitiatorToCc(IMessage $message, ?IUser $initiatorUser, ?string $initiatorDisplayName): void {
+		if ($initiatorUser === null || !$this->settingsManager->ccToInitiator()) {
+			return;
+		}
+
+		$initiatorEmail = $initiatorUser->getEMailAddress();
+		if ($initiatorEmail !== null) {
+			$message->setCc([$initiatorEmail => $initiatorDisplayName]);
+		}
 	}
 
 	/**

--- a/apps/sharebymail/src/components/AdminSettings.vue
+++ b/apps/sharebymail/src/components/AdminSettings.vue
@@ -14,6 +14,10 @@
 		<NcCheckboxRadioSwitch v-model="replyToInitiator" type="switch">
 			{{ t('sharebymail', 'Reply to initiator') }}
 		</NcCheckboxRadioSwitch>
+
+		<NcCheckboxRadioSwitch v-model="ccToInitiator" type="switch">
+			{{ t('sharebymail', 'CC to initiator') }}
+		</NcCheckboxRadioSwitch>
 	</NcSettingsSection>
 </template>
 
@@ -43,6 +47,7 @@ export default {
 		return {
 			sendPasswordMail: loadState('sharebymail', 'sendPasswordMail'),
 			replyToInitiator: loadState('sharebymail', 'replyToInitiator'),
+			ccToInitiator: loadState('sharebymail', 'ccToInitiator'),
 		}
 	},
 
@@ -53,6 +58,10 @@ export default {
 
 		replyToInitiator(newValue) {
 			this.update('replyToInitiator', newValue)
+		},
+
+		ccToInitiator(newValue) {
+			this.update('ccToInitiator', newValue)
 		},
 	},
 

--- a/apps/sharebymail/tests/Settings/SettingsManagerTest.php
+++ b/apps/sharebymail/tests/Settings/SettingsManagerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ShareByMail\Tests\Settings;
+
+use OCA\ShareByMail\Settings\SettingsManager;
+use OCP\IAppConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class SettingsManagerTest extends TestCase {
+	private IAppConfig&MockObject $appConfig;
+	private SettingsManager $settingsManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->settingsManager = new SettingsManager($this->appConfig);
+	}
+
+	public static function settingProvider(): array {
+		return [
+			// setting method, config key, default
+			['sendPasswordByMail', 'sendpasswordmail', 'yes'],
+			['replyToInitiator', 'replyToInitiator', 'yes'],
+			['ccToInitiator', 'ccToInitiator', 'no'],
+		];
+	}
+
+	#[DataProvider('settingProvider')]
+	public function testDefault(string $method, string $key, string $default): void {
+		$this->appConfig->expects($this->once())
+			->method('getValueString')
+			->with('sharebymail', $key, $default)
+			// no value stored, so the default is handed back
+			->willReturn($default);
+
+		$this->assertSame($default === 'yes', $this->settingsManager->$method());
+	}
+
+	#[DataProvider('settingProvider')]
+	public function testEnabled(string $method, string $key, string $default): void {
+		$this->appConfig->expects($this->once())
+			->method('getValueString')
+			->with('sharebymail', $key, $default)
+			->willReturn('yes');
+
+		$this->assertTrue($this->settingsManager->$method());
+	}
+
+	#[DataProvider('settingProvider')]
+	public function testDisabled(string $method, string $key, string $default): void {
+		$this->appConfig->expects($this->once())
+			->method('getValueString')
+			->with('sharebymail', $key, $default)
+			->willReturn('no');
+
+		$this->assertFalse($this->settingsManager->$method());
+	}
+}

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -1897,4 +1897,207 @@ class ShareByMailProviderTest extends TestCase {
 			[$share]
 		);
 	}
+
+	public function testSendMailNotificationWithCcToInitiator(): void {
+		$provider = $this->getInstance();
+		$user = $this->createMock(IUser::class);
+		$this->settingsManager->expects($this->any())->method('replyToInitiator')->willReturn(false);
+		$this->settingsManager->expects($this->any())->method('ccToInitiator')->willReturn(true);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('OwnerUser')
+			->willReturn($user);
+		$user
+			->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Mrs. Owner User');
+		$message = $this->createMock(Message::class);
+		$this->mailer
+			->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+		$template = $this->createMock(IEMailTemplate::class);
+		$this->mailer
+			->expects($this->once())
+			->method('createEMailTemplate')
+			->willReturn($template);
+		$message
+			->expects($this->once())
+			->method('setTo')
+			->with(['john@doe.com']);
+		$this->defaults
+			->expects($this->once())
+			->method('getName')
+			->willReturn('UnitTestCloud');
+		$user
+			->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn('owner@example.com');
+		$message
+			->expects($this->once())
+			->method('setCc')
+			->with(['owner@example.com' => 'Mrs. Owner User']);
+		$message
+			->expects($this->never())
+			->method('setReplyTo');
+		$message
+			->expects($this->once())
+			->method('useTemplate')
+			->with($template);
+
+		$this->mailer
+			->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$this->urlGenerator->expects($this->once())->method('linkToRouteAbsolute')
+			->with('files_sharing.sharecontroller.showShare', ['token' => 'token'])
+			->willReturn('https://example.com/file.txt');
+
+		$node = $this->createMock(File::class);
+		$node->expects($this->any())->method('getName')->willReturn('file.txt');
+
+		$share = $this->createMock(IShare::class);
+		$share->expects($this->any())->method('getSharedBy')->willReturn('OwnerUser');
+		$share->expects($this->any())->method('getSharedWith')->willReturn('john@doe.com');
+		$share->expects($this->any())->method('getNode')->willReturn($node);
+		$share->expects($this->any())->method('getId')->willReturn('42');
+		$share->expects($this->any())->method('getNote')->willReturn('');
+		$share->expects($this->any())->method('getToken')->willReturn('token');
+
+		self::invokePrivate(
+			$provider,
+			'sendMailNotification',
+			[$share]
+		);
+	}
+
+	public function testSendMailNotificationWithCcToInitiatorAndNoUserEmail(): void {
+		$provider = $this->getInstance();
+		$user = $this->createMock(IUser::class);
+		$this->settingsManager->expects($this->any())->method('replyToInitiator')->willReturn(false);
+		$this->settingsManager->expects($this->any())->method('ccToInitiator')->willReturn(true);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('OwnerUser')
+			->willReturn($user);
+		$user
+			->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Mrs. Owner User');
+		$message = $this->createMock(Message::class);
+		$this->mailer
+			->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+		$template = $this->createMock(IEMailTemplate::class);
+		$this->mailer
+			->expects($this->once())
+			->method('createEMailTemplate')
+			->willReturn($template);
+		$this->defaults
+			->expects($this->once())
+			->method('getName')
+			->willReturn('UnitTestCloud');
+		// The initiator has no mail address configured, so there is nothing to CC
+		$user
+			->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn(null);
+		$message
+			->expects($this->never())
+			->method('setCc');
+
+		$this->mailer
+			->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$this->urlGenerator->expects($this->once())->method('linkToRouteAbsolute')
+			->with('files_sharing.sharecontroller.showShare', ['token' => 'token'])
+			->willReturn('https://example.com/file.txt');
+
+		$node = $this->createMock(File::class);
+		$node->expects($this->any())->method('getName')->willReturn('file.txt');
+
+		$share = $this->createMock(IShare::class);
+		$share->expects($this->any())->method('getSharedBy')->willReturn('OwnerUser');
+		$share->expects($this->any())->method('getSharedWith')->willReturn('john@doe.com');
+		$share->expects($this->any())->method('getNode')->willReturn($node);
+		$share->expects($this->any())->method('getId')->willReturn('42');
+		$share->expects($this->any())->method('getNote')->willReturn('');
+		$share->expects($this->any())->method('getToken')->willReturn('token');
+
+		self::invokePrivate(
+			$provider,
+			'sendMailNotification',
+			[$share]
+		);
+	}
+
+	public function testSendMailNotificationWithCcToInitiatorDesactivate(): void {
+		$provider = $this->getInstance();
+		$user = $this->createMock(IUser::class);
+		$this->settingsManager->expects($this->any())->method('replyToInitiator')->willReturn(false);
+		$this->settingsManager->expects($this->any())->method('ccToInitiator')->willReturn(false);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('OwnerUser')
+			->willReturn($user);
+		$user
+			->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Mrs. Owner User');
+		$message = $this->createMock(Message::class);
+		$this->mailer
+			->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+		$template = $this->createMock(IEMailTemplate::class);
+		$this->mailer
+			->expects($this->once())
+			->method('createEMailTemplate')
+			->willReturn($template);
+		$this->defaults
+			->expects($this->once())
+			->method('getName')
+			->willReturn('UnitTestCloud');
+		// Since both replyToInitiator and ccToInitiator are false, we never get
+		// the initiator email address
+		$user
+			->expects($this->never())
+			->method('getEMailAddress');
+		$message
+			->expects($this->never())
+			->method('setCc');
+
+		$this->mailer
+			->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$this->urlGenerator->expects($this->once())->method('linkToRouteAbsolute')
+			->with('files_sharing.sharecontroller.showShare', ['token' => 'token'])
+			->willReturn('https://example.com/file.txt');
+
+		$node = $this->createMock(File::class);
+		$node->expects($this->any())->method('getName')->willReturn('file.txt');
+
+		$share = $this->createMock(IShare::class);
+		$share->expects($this->any())->method('getSharedBy')->willReturn('OwnerUser');
+		$share->expects($this->any())->method('getSharedWith')->willReturn('john@doe.com');
+		$share->expects($this->any())->method('getNode')->willReturn($node);
+		$share->expects($this->any())->method('getId')->willReturn('42');
+		$share->expects($this->any())->method('getNote')->willReturn('');
+		$share->expects($this->any())->method('getToken')->willReturn('token');
+
+		self::invokePrivate(
+			$provider,
+			'sendMailNotification',
+			[$share]
+		);
+	}
 }


### PR DESCRIPTION
## Summary

A mail share is sent from the instance address, with the initiator's name in the `From` display name and, if *Reply to initiator* is on, in `Reply-To`. Either way the initiator keeps no copy of what the recipient actually received, and cannot tell from their own mailbox what was sent or when.

This adds an admin setting that puts the initiator in `CC` of the generated mails, next to the existing *Send password by mail* and *Reply to initiator* switches in **Administration settings → Sharing → Share by mail**.

The setting is **off by default**, so nothing changes for existing instances.

## Implementation

`SettingsManager::ccToInitiator()` reads a new `sharebymail` app config key `ccToInitiator` (`'no'` by default), and `ShareByMailProvider` gains one small helper used by every mail that goes to the recipient:

```php
private function addInitiatorToCc(IMessage $message, ?IUser $initiatorUser, ?string $initiatorDisplayName): void {
	if ($initiatorUser === null || !$this->settingsManager->ccToInitiator()) {
		return;
	}

	$initiatorEmail = $initiatorUser->getEMailAddress();
	if ($initiatorEmail !== null) {
		$message->setCc([$initiatorEmail => $initiatorDisplayName]);
	}
}
```

Notes on the details:

- **All three recipient-facing mails are covered**: `sendEmail()` (share notification), `sendPassword()` (the separate password mail) and `sendNote()` (the note mail). `sendPasswordToOwner()` is deliberately left alone — it is already addressed to the initiator, so a CC there would be a duplicate.
- **The address is only looked up when the setting is enabled.** The setting is checked before `getEMailAddress()` is called, which keeps the existing behaviour asserted by `testSendMailNotificationWithSameUserAndUserEmailAndReplyToDesactivate` ("since replyToInitiator is false, we never get the initiator email address") intact.
- **Guarded on a real initiator**: shares created by something other than a local user, or by a user with no mail address configured, are unaffected.
- **The display name is nullable**, matching how the existing `Reply-To` handling treats it — `$share->getSharedBy()` is the fallback and is not guaranteed to be present.
- The key is added to `Admin::getAuthorizedAppConfig()` so the switch works for delegated sharing admins, not only full admins.
- `CC` is independent of `Reply-To`: the two settings can be toggled separately, and the "Do not reply" footer adjustment stays tied to *Reply to initiator* only.

`SettingsManager` is switched from `IConfig` to `IAppConfig` in the same commit. `IConfig::getAppValue()` has been deprecated since 29.0.0, so the new getter should not use it, and injecting both config APIs into a three-getter class seemed worse than migrating the two existing getters alongside. Happy to split that into a separate commit or PR if you would rather keep this change to the feature alone.


## Screenshots

**Before changes**

<img width="929" height="341" alt="pr63980-1-before" src="https://github.com/user-attachments/assets/9d1315f9-00d1-4b79-87cd-2ff15aa0b682" />

**After changes**

<img width="809" height="350" alt="Screenshot 2026-09-03 at 11 52 26 AM" src="https://github.com/user-attachments/assets/2b020c25-a0a6-4ad3-a245-02d24a715b79" />


<img width="1201" height="526" alt="image" src="https://github.com/user-attachments/assets/299ba27f-275f-4c68-a751-ff021e19f5ce" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
