### PR TITLE
fix(core): preserve UTF-8 system tag names

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -140,7 +140,7 @@ class SystemTagManager implements ISystemTagManager {
 	#[\Override]
 	public function getTag(string $tagName, bool $userVisible, bool $userAssignable): ISystemTag {
 		// Length of name column is 64
-		$truncatedTagName = substr($tagName, 0, 64);
+		$truncatedTagName = mb_strcut($tagName, 0, 64, 'UTF-8');
 		$result = $this->selectTagQuery
 			->setParameter('name', $truncatedTagName)
 			->setParameter('visibility', $userVisible ? 1 : 0)
@@ -185,7 +185,7 @@ class SystemTagManager implements ISystemTagManager {
 		}
 
 		// Length of name column is 64
-		$truncatedTagName = substr($tagName, 0, 64);
+		$truncatedTagName = mb_strcut($tagName, 0, 64, 'UTF-8');
 		$query = $this->connection->getQueryBuilder();
 		$query->insert(self::TAG_TABLE)
 			->values([
@@ -251,7 +251,7 @@ class SystemTagManager implements ISystemTagManager {
 		$newName = Util::sanitizeWordsAndEmojis($newName);
 
 		// Length of name column is 64
-		$truncatedNewName = substr($newName, 0, 64);
+		$truncatedNewName = mb_strcut($newName, 0, 64, 'UTF-8');
 		$afterUpdate = new SystemTag(
 			$tagId,
 			$truncatedNewName,

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -248,7 +248,7 @@ class SystemTagManagerTest extends TestCase {
 
 	public function testCreateOverlongName(): void {
 		$tag = $this->tagManager->createTag('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)', true, true);
-		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das', $tag->getName());
+		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas', $tag->getName());
 		$this->assertSame($tag->getName(), $this->tagManager->getTag($tag->getName(), true, true)->getName());
 	}
 
@@ -263,8 +263,8 @@ class SystemTagManagerTest extends TestCase {
 			null,
 		);
 
-		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das', $this->tagManager->getTag(
-			'Zona circundante do Palácio Nacional da Ajuda (Jardim das',
+		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas', $this->tagManager->getTag(
+			'Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas',
 			true,
 			true,
 		)->getName());

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -248,7 +248,26 @@ class SystemTagManagerTest extends TestCase {
 
 	public function testCreateOverlongName(): void {
 		$tag = $this->tagManager->createTag('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)', true, true);
-		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas', $tag->getName()); // 63 characters but 64 bytes due to "á"
+		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das', $tag->getName());
+		$this->assertSame($tag->getName(), $this->tagManager->getTag($tag->getName(), true, true)->getName());
+	}
+
+	public function testUpdateOverlongName(): void {
+		$tag = $this->tagManager->createTag('initial', true, true);
+
+		$this->tagManager->updateTag(
+			$tag->getId(),
+			'Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)',
+			true,
+			true,
+			null,
+		);
+
+		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das', $this->tagManager->getTag(
+			'Zona circundante do Palácio Nacional da Ajuda (Jardim das',
+			true,
+			true,
+		)->getName());
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('oneTagMultipleFlagsProvider')]


### PR DESCRIPTION
## Summary

Fix system tag name truncation when a name contains multibyte UTF-8
characters and is longer than the database column limit.

The affected code previously used byte-based `substr()`, which could
split a UTF-8 character and produce an invalid string. The affected
paths now use `mb_strcut()` with explicit UTF-8 encoding.

Fixes #63712

## Tests

- PHP 8.3.8
- PHPUnit 11.5.56
- SQLite
- 64 tests, 174 assertions

Command:

    php vendor-bin/phpunit/vendor/bin/phpunit --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --configuration tests/phpunit-autotest.xml --group DB tests/lib/SystemTag/SystemTagManagerTest.php

## AI Disclosure

I used OpenCode with the gpt-5.6-sol model to assist with repository
research and implementation. I reviewed the resulting changes and
test coverage before submitting this pull request.