### PR TITLE
fix(files_external): map display names for groups

### DIFF
--- a/apps/files_external/src/components/ExternalStorageTableRow.vue
+++ b/apps/files_external/src/components/ExternalStorageTableRow.vue
@@ -14,7 +14,7 @@ import { computed, ref } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import AddExternalStorageDialog from './AddExternalStorageDialog/AddExternalStorageDialog.vue'
-import { useUsers } from '../composables/useEntities.ts'
+import { useGroups, useUsers } from '../composables/useEntities.ts'
 import { useStorages } from '../store/storages.ts'
 import { StorageStatus, StorageStatusIcons, StorageStatusMessage } from '../types.ts'
 
@@ -51,6 +51,7 @@ const status = computed(() => {
 })
 
 const users = useUsers(() => props.storage.applicableUsers || [])
+const groups = useGroups(() => props.storage.applicableGroups || [])
 
 /**
  * Handle deletion of the external storage mount point
@@ -113,11 +114,11 @@ async function reloadStatus() {
 		<td v-if="isAdmin">
 			<div :class="$style.storageTableRow__cellApplicable">
 				<NcChip
-					v-for="group of storage.applicableGroups"
-					:key="group"
+					v-for="group of groups"
+					:key="group.id"
 					:iconPath="mdiAccountGroupOutline"
 					noClose
-					:text="group" />
+					:text="group.displayName" />
 				<NcUserBubble
 					v-for="user of users"
 					:key="user.user"

--- a/apps/files_external/src/components/ExternalStorageTableRow.vue
+++ b/apps/files_external/src/components/ExternalStorageTableRow.vue
@@ -170,7 +170,7 @@ async function reloadStatus() {
 	align-items: center;
 
 	max-height: calc(48px + 2 * var(--default-grid-baseline));
-	overflow: scroll;
+	overflow: auto;
 }
 
 .storageTableRow__status_warning {

--- a/apps/files_external/src/composables/useEntities.spec.ts
+++ b/apps/files_external/src/composables/useEntities.spec.ts
@@ -1,0 +1,99 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+
+const axios = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }))
+vi.mock('@nextcloud/axios', () => ({ default: axios }))
+
+const { useGroups, useUsers } = await import('./useEntities.ts')
+
+describe('useUsers', () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+	})
+
+	test('resolves display names for given uids', async () => {
+		axios.post.mockResolvedValue({ data: { users: { alice: 'Alice Doe' } } })
+
+		let users
+		effectScope().run(() => {
+			users = useUsers(() => ['alice'])
+		})
+		await flushPromises()
+
+		expect(axios.post).toHaveBeenCalledWith(expect.stringContaining('/displaynames'), { users: ['alice'] })
+		expect(users!.value).toEqual([{ id: 'user:alice', user: 'alice', displayName: 'Alice Doe' }])
+	})
+})
+
+describe('useGroups', () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+	})
+
+	test('resolves display names for given gids via the applicable endpoint', async () => {
+		axios.get.mockResolvedValue({ data: { groups: { grp1: 'Marketing Team' } } })
+
+		let groups
+		effectScope().run(() => {
+			groups = useGroups(() => ['grp1'])
+		})
+		await flushPromises()
+
+		expect(axios.get).toHaveBeenCalledWith(
+			expect.stringContaining('applicable'),
+			{ params: { pattern: 'grp1', limit: 50 } },
+		)
+		expect(groups!.value[0]).toMatchObject({ id: 'grp1', displayName: 'Marketing Team' })
+	})
+
+	test('falls back to the raw gid when the group is unknown', async () => {
+		axios.get.mockResolvedValue({ data: { groups: {} } })
+
+		let groups
+		effectScope().run(() => {
+			groups = useGroups(() => ['deleted-group'])
+		})
+		await flushPromises()
+
+		expect(groups!.value[0]).toMatchObject({ id: 'deleted-group', displayName: 'deleted-group' })
+	})
+
+	test('does not repeat a request for a gid still waiting its turn when the list shrinks back', async () => {
+		const resolvers: Record<string, (value: { data: { groups: Record<string, string> } }) => void> = {}
+		axios.get.mockImplementation((_url: string, config: { params: { pattern: string } }) => new Promise((resolve) => {
+			resolvers[config.params.pattern] = resolve
+		}))
+
+		// missingGroups is computed as [a, b]; 'a' starts its request immediately,
+		// 'b' is still queued behind it in the loop (not requested yet)
+		const gids = ref(['a', 'b'])
+		let groups
+		effectScope().run(() => {
+			groups = useGroups(gids)
+		})
+		await nextTick()
+		expect(axios.get).toHaveBeenCalledTimes(1)
+
+		// list shrinks back to just 'a' while both 'a' and 'b' are already marked pending
+		gids.value = ['a']
+		await nextTick()
+		expect(axios.get).toHaveBeenCalledTimes(1)
+
+		resolvers.a({ data: { groups: { a: 'A Team' } } })
+		await flushPromises()
+
+		// 'b' still gets its request once its turn in the loop comes up, just not a duplicate one
+		expect(axios.get).toHaveBeenCalledTimes(2)
+
+		resolvers.b({ data: { groups: { b: 'B Team' } } })
+		await flushPromises()
+
+		expect(axios.get).toHaveBeenCalledTimes(2)
+	})
+})

--- a/apps/files_external/src/composables/useEntities.ts
+++ b/apps/files_external/src/composables/useEntities.ts
@@ -11,6 +11,8 @@ import { generateUrl } from '@nextcloud/router'
 import { computed, reactive, toValue, watchEffect } from 'vue'
 
 const displayNames = reactive(new Map<string, string>())
+const groupDisplayNames = reactive(new Map<string, string>())
+const pendingGroups = new Set<string>()
 
 /**
  * Fetch and provide user display names for given UIDs
@@ -40,24 +42,42 @@ export function useUsers(uids: MaybeRefOrGetter<string[]>) {
 }
 
 /**
- * Map group ids to IUserData objects
+ * Fetch and provide group display names for given GIDs, mapped to IUserData objects
  *
  * @param gids - The group ids to create entities for
  */
 export function useGroups(gids: MaybeRefOrGetter<string[]>) {
-	return computed(() => toValue(gids).map(mapGroupToUserData))
+	const groups = computed(() => toValue(gids).map((gid) => mapGroupToUserData(gid, groupDisplayNames.get(gid))))
+
+	watchEffect(async () => {
+		const missingGroups = toValue(gids).filter((gid) => !groupDisplayNames.has(gid) && !pendingGroups.has(gid))
+		missingGroups.forEach((gid) => pendingGroups.add(gid))
+		for (const gid of missingGroups) {
+			try {
+				const { data } = await axios.get(generateUrl('apps/files_external/ajax/applicable'), {
+					params: { pattern: gid, limit: 50 },
+				})
+				groupDisplayNames.set(gid, data.groups[gid] ?? gid)
+			} finally {
+				pendingGroups.delete(gid)
+			}
+		}
+	})
+
+	return groups
 }
 
 /**
  * Map a group id to an IUserData object
  *
  * @param gid - The group id to map
+ * @param displayName - The resolved display name for the group, falls back to the group id
  */
-export function mapGroupToUserData(gid: string) {
+export function mapGroupToUserData(gid: string, displayName?: string) {
 	return {
 		id: gid,
 		isNoUser: true,
-		displayName: gid,
+		displayName: displayName || gid,
 		iconSvg: svgAccountGroupOutline,
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- mirror useUsers logic in useEntities composable
	- track pending request to deduplicate them
- reuse same endpoint as in ApplicableEntitied
- set 'overflow' to auto (height for cihp containers limited to 52px)

1 | 2
-- | --
Before | <img width="266" height="91" alt="image" src="https://github.com/user-attachments/assets/fd5c55a7-3160-4174-8f71-37b4887f4515" />
After | <img width="247" height="93" alt="image" src="https://github.com/user-attachments/assets/3023ff31-20b9-4759-813e-03346cc504a8" />
After + CSS fix | <img width="248" height="88" alt="image" src="https://github.com/user-attachments/assets/6bd94227-a461-4b76-9cc2-a9f77bcb4780" /><img width="256" height="89" alt="image" src="https://github.com/user-attachments/assets/c950e6b6-9433-4105-99e9-e94918dd8434" />



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
