### PR TITLE
fix: Revert to registering autoloading app by app while booting them

### DIFF
--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -11,6 +11,7 @@ namespace OC\AppFramework\Bootstrap;
 
 use OC\App\AppManager;
 use OC\Support\CrashReport\Registry;
+use OCP\App\AppPathNotFoundException;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\QueryException;
@@ -64,12 +65,21 @@ class Coordinator {
 		if ($this->registrationContext === null) {
 			$this->registrationContext = new RegistrationContext($this->logger);
 		}
-		$this->eventLogger->start('bootstrap:register_app:autoloader', 'Setup autoloader for apps');
-		$this->appManager->registerAppsAutoloading($appIds);
-		$this->eventLogger->end('bootstrap:register_app:autoloader');
 		$apps = [];
 		foreach ($appIds as $appId) {
 			$this->eventLogger->start("bootstrap:register_app:$appId", "Register $appId");
+			$this->eventLogger->start("bootstrap:register_app:$appId:autoloader", "Setup autoloader for app $appId");
+			try {
+				$path = $this->appManager->getAppPath($appId);
+				$this->appManager->registerAutoloading($appId, $path);
+			} catch (AppPathNotFoundException $e) {
+				$this->logger->info('Error during app loading: ' . $e->getMessage(), [
+					'exception' => $e,
+					'app' => $appId,
+				]);
+				continue;
+			}
+			$this->eventLogger->end("bootstrap:register_app:$appId:autoloader");
 
 			/*
 			 * Next we check if there is an application class, and it implements


### PR DESCRIPTION
## Summary

Partial revert of https://github.com/nextcloud/server/pull/63388

It appears that this change had a bad perf impact. My theory is that
 some app autoloaders are slow and with the previous change they were
 used for a larger part of the boot process. Autoloader performance
 should be investigated (and there is ongoing work) but for now let’s
 revert to the faster version.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
