### PR TITLE
Strict comparaison

### DIFF
--- a/apps/appstore/lib/Controller/ApiController.php
+++ b/apps/appstore/lib/Controller/ApiController.php
@@ -129,11 +129,11 @@ class ApiController extends OCSController {
 
 			$appData['groups'] = $groups;
 			// analyze dependencies
-			$ignoreMax = in_array($appData['id'], $ignoreMaxApps);
+			$ignoreMax = in_array($appData['id'], $ignoreMaxApps, true);
 			$missing = $this->dependencyAnalyzer->analyze($appData, $ignoreMax);
 			$appData['missingDependencies'] = $missing;
 			$appData['isCompatible'] = $this->dependencyAnalyzer->isMarkedCompatible($appData);
-			$appData['internal'] = in_array($appData['id'], $this->appManager->getAlwaysEnabledApps());
+			$appData['internal'] = in_array($appData['id'], $this->appManager->getAlwaysEnabledApps(), true);
 
 			return $appData;
 		}, $apps);
@@ -332,7 +332,7 @@ class ApiController extends OCSController {
 		$supportedApps = $this->subscriptionRegistry->delegateGetSupportedApps();
 		$shippedApps = $this->appManager->getAlwaysEnabledApps();
 		foreach ($apps as $app) {
-			if (in_array($app['id'], $shippedApps)) {
+			if (in_array($app['id'], $shippedApps, true)) {
 				// shipped apps are no longer published on the appstore
 				// so skip them to avoid confusion with outdated data
 				continue;
@@ -345,7 +345,7 @@ class ApiController extends OCSController {
 				$this->allApps[$app['id']] = array_merge($app, $this->allApps[$app['id']]);
 			}
 
-			if (in_array($app['id'], $supportedApps)) {
+			if (in_array($app['id'], $supportedApps, true)) {
 				$this->allApps[$app['id']]['level'] = \OC_App::supportedApp;
 			}
 		}
@@ -463,7 +463,7 @@ class ApiController extends OCSController {
 				'license' => $app['releases'][0]['licenses'],
 				'author' => $authors,
 				'shipped' => $this->appManager->isShipped($app['id']),
-				'internal' => in_array($app['id'], $this->appManager->getAlwaysEnabledApps()),
+				'internal' => in_array($app['id'], $this->appManager->getAlwaysEnabledApps(), true),
 				'version' => $currentVersion,
 				'types' => [],
 				'documentation' => [

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -148,6 +148,8 @@ class RequestHandlerController extends Controller {
 		}
 
 		$supportedShareTypes = $this->config->getSupportedShareTypes($resourceType);
+		// $shareType is an untyped parameter taken directly from the OCS request body
+		/** @psalm-suppress UnrecognizedExpression */
 		if (!in_array($shareType, $supportedShareTypes)) {
 			return new JSONResponse(
 				['message' => 'Share type "' . $shareType . '" not implemented'],

--- a/apps/comments/lib/Listener/CommentsEventListener.php
+++ b/apps/comments/lib/Listener/CommentsEventListener.php
@@ -60,7 +60,7 @@ class CommentsEventListener implements IEventListener {
 			CommentsEvent::EVENT_UPDATE,
 			CommentsEvent::EVENT_DELETE,
 		];
-		if (in_array($eventType, $applicableEvents)) {
+		if (in_array($eventType, $applicableEvents, true)) {
 			$this->notificationHandler($event);
 			return;
 		}

--- a/apps/dashboard/lib/Controller/DashboardApiController.php
+++ b/apps/dashboard/lib/Controller/DashboardApiController.php
@@ -64,7 +64,7 @@ class DashboardApiController extends OCSController {
 		return array_filter(
 			$this->dashboardManager->getWidgets(),
 			static function (IWidget $widget) use ($widgetIds) {
-				return in_array($widget->getId(), $widgetIds);
+				return in_array($widget->getId(), $widgetIds, true);
 			},
 		);
 	}

--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -97,7 +97,7 @@ $server = $serverFactory->createServer(
 		$linkCheckPlugin,
 		$filesDropPlugin
 	) {
-		$isAjax = in_array('XMLHttpRequest', explode(',', $_SERVER['HTTP_X_REQUESTED_WITH'] ?? ''));
+		$isAjax = in_array('XMLHttpRequest', explode(',', $_SERVER['HTTP_X_REQUESTED_WITH'] ?? ''), true);
 		/** @var FederatedShareProvider $shareProvider */
 		$federatedShareProvider = Server::get(FederatedShareProvider::class);
 		if ($federatedShareProvider->isOutgoingServer2serverShareEnabled() === false && !$isAjax) {

--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -34,6 +34,7 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory as IL10nFactory;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Server;
+use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
 // load needed apps
@@ -132,7 +133,7 @@ $server = $serverFactory->createServer(
 		Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 
 		$rootFolder = Server::get(IRootFolder::class);
-		$userId = $share->getShareType() === \OCP\Share\IShare::TYPE_REMOTE
+		$userId = $share->getShareType() === IShare::TYPE_REMOTE
 			? $share->getShareOwner()
 			: $share->getSharedBy();
 		$userFolder = $rootFolder->getUserFolder($userId);

--- a/apps/dav/appinfo/v2/publicremote.php
+++ b/apps/dav/appinfo/v2/publicremote.php
@@ -101,7 +101,7 @@ $server = $serverFactory->createServer(true, $baseuri, $requestUri, $authPlugin,
 	// GET must be allowed for e.g. showing images and allowing Zip downloads
 	if ($server->httpRequest->getMethod() !== 'GET') {
 		// If this is *not* a GET request we only allow access to public DAV from AJAX or when Server2Server is allowed
-		$isAjax = in_array('XMLHttpRequest', explode(',', $_SERVER['HTTP_X_REQUESTED_WITH'] ?? ''));
+		$isAjax = in_array('XMLHttpRequest', explode(',', $_SERVER['HTTP_X_REQUESTED_WITH'] ?? ''), true);
 		$federatedShareProvider = Server::get(FederatedShareProvider::class);
 		if ($federatedShareProvider->isOutgoingServer2serverShareEnabled() === false && $isAjax === false) {
 			// this is what is thrown when trying to access a non-existing share

--- a/apps/dav/lib/CalDAV/Activity/Backend.php
+++ b/apps/dav/lib/CalDAV/Activity/Backend.php
@@ -578,7 +578,7 @@ class Backend {
 		$vObject = Reader::read($objectData['calendardata']);
 		$component = $componentType = null;
 		foreach ($vObject->getComponents() as $component) {
-			if (in_array($component->name, ['VEVENT', 'VTODO'])) {
+			if (in_array($component->name, ['VEVENT', 'VTODO'], true)) {
 				$componentType = $component->name;
 				break;
 			}

--- a/apps/dav/lib/CalDAV/CachedSubscriptionProvider.php
+++ b/apps/dav/lib/CalDAV/CachedSubscriptionProvider.php
@@ -23,7 +23,7 @@ class CachedSubscriptionProvider implements ICalendarProvider {
 		$calendarInfos = $this->calDavBackend->getSubscriptionsForUser($principalUri);
 
 		if (count($calendarUris) > 0) {
-			$calendarInfos = array_filter($calendarInfos, fn (array $subscription) => in_array($subscription['uri'], $calendarUris));
+			$calendarInfos = array_filter($calendarInfos, fn (array $subscription) => in_array($subscription['uri'], $calendarUris, true));
 		}
 
 		$calendarInfos = array_values(array_filter($calendarInfos));

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3043,7 +3043,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		foreach ($this->subscriptionPropertyMap as $xmlName => [$dbName, $type]) {
 			if (array_key_exists($xmlName, $properties)) {
 				$values[$dbName] = $properties[$xmlName];
-				if (in_array($dbName, $propertiesBoolean)) {
+				if (in_array($dbName, $propertiesBoolean, true)) {
 					$values[$dbName] = true;
 				}
 			}
@@ -3684,7 +3684,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 			$indexComponents = ['VEVENT', 'VJOURNAL', 'VTODO'];
 			foreach ($vCalendar->getComponents() as $component) {
-				if (!in_array($component->name, $indexComponents)) {
+				if (!in_array($component->name, $indexComponents, true)) {
 					continue;
 				}
 
@@ -3708,7 +3708,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 						$indexedParametersForProperty = self::INDEXED_PARAMETERS[$property->name];
 
 						foreach ($parameters as $key => $value) {
-							if (in_array($key, $indexedParametersForProperty)) {
+							if (in_array($key, $indexedParametersForProperty, true)) {
 								// is this a shitty db?
 								if ($this->db->supports4ByteText()) {
 									$value = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $value);

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2166,7 +2166,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$result = [];
 			while ($row = $stmt->fetchAssociative()) {
 				$path = $uriMapper[$row['calendarid']] . '/' . $row['uri'];
-				if (!in_array($path, $result)) {
+				if (!in_array($path, $result, true)) {
 					$result[] = $path;
 				}
 			}

--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -37,11 +37,11 @@ class CalendarProvider implements ICalendarProvider {
 
 		if (!empty($calendarUris)) {
 			$calendarInfos = array_filter($calendarInfos, function ($calendar) use ($calendarUris) {
-				return in_array($calendar['uri'], $calendarUris);
+				return in_array($calendar['uri'], $calendarUris, true);
 			});
 
 			$federatedCalendarInfos = array_filter($federatedCalendarInfos, function ($federatedCalendar) use ($calendarUris) {
-				return in_array($federatedCalendar['uri'], $calendarUris);
+				return in_array($federatedCalendar['uri'], $calendarUris, true);
 			});
 		}
 

--- a/apps/dav/lib/CalDAV/EventReader.php
+++ b/apps/dav/lib/CalDAV/EventReader.php
@@ -182,7 +182,7 @@ class EventReader {
 		// evaluate if start date is floating
 		// set duration to 24 hours and calculate the end date
 		// according to the rfc any event without a end date or duration is a complete day
-		elseif ($this->baseEventStartDateFloating == true) {
+		elseif ($this->baseEventStartDateFloating === true) {
 			$this->baseEventDuration = 86400;
 			$this->baseEventEndDate = DateTimeImmutable::createFromInterface($this->baseEventStartDate)
 				->setTimestamp($this->baseEventStartDate->getTimestamp() + $this->baseEventDuration);

--- a/apps/dav/lib/CalDAV/EventReader.php
+++ b/apps/dav/lib/CalDAV/EventReader.php
@@ -739,6 +739,9 @@ class EventReader {
 			$nextExceptionDate = $edateDate;
 		}
 		// if the next date is part of exrule or exdate find another date
+		// loose comparison needed: DateTime value equality, not instance identity
+		// (type comes from an untyped Iterator::current(), so psalm can't verify it statically)
+		/** @psalm-suppress UnrecognizedExpression */
 		if ($nextOccurrenceDate !== null && $nextExceptionDate !== null && $nextOccurrenceDate == $nextExceptionDate) {
 			$this->recurrenceCurrentDate = $nextOccurrenceDate;
 			$this->recurrenceAdvance();

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -247,7 +247,7 @@ class EmailProvider extends AbstractProvider {
 				}
 
 				$cuType = $this->getCUTypeOfAttendee($attendee);
-				if (\in_array($cuType, ['RESOURCE', 'ROOM', 'UNKNOWN'])) {
+				if (\in_array($cuType, ['RESOURCE', 'ROOM', 'UNKNOWN'], true)) {
 					// Don't send emails to things
 					continue;
 				}

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -253,8 +253,8 @@ class IMipPlugin extends SabreIMipPlugin {
 			$invitationLinkRecipients = explode(',', preg_replace('/\s+/', '', strtolower($this->config->getValueString('dav', 'invitation_link_recipients', 'yes'))));
 
 			if (strcmp('yes', $invitationLinkRecipients[0]) === 0
-				|| in_array(strtolower($recipient), $invitationLinkRecipients)
-				|| in_array(strtolower($recipientDomain), $invitationLinkRecipients)) {
+				|| in_array(strtolower($recipient), $invitationLinkRecipients, true)
+				|| in_array(strtolower($recipientDomain), $invitationLinkRecipients, true)) {
 				$token = $this->imipService->createInvitationToken($iTipMessage, $vEvent, $lastOccurrence);
 				$this->imipService->addResponseButtons($template, $token);
 				$this->imipService->addMoreOptionsButton($template, $token);

--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -1273,7 +1273,7 @@ class IMipService {
 
 	public function minimizeInterval(\DateInterval $dateInterval): array {
 		// evaluate if time interval is in the past
-		if ($dateInterval->invert == 1) {
+		if ($dateInterval->invert === 1) {
 			return ['interval' => 1, 'scale' => 'past'];
 		}
 		// evaluate interval parts and return smallest time period

--- a/apps/dav/lib/CalDAV/Status/StatusService.php
+++ b/apps/dav/lib/CalDAV/Status/StatusService.php
@@ -163,7 +163,7 @@ class StatusService {
 			}
 
 			$sct = $calendarObject->getSchedulingTransparency();
-			if ($sct !== null && strtolower($sct->getValue()) == ScheduleCalendarTransp::TRANSPARENT) {
+			if ($sct !== null && strtolower($sct->getValue()) === ScheduleCalendarTransp::TRANSPARENT) {
 				// If a calendar is marked as 'transparent', it means we must
 				// ignore it for free-busy purposes.
 				continue;

--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -259,7 +259,7 @@ class AddressBookImpl implements ICreateContactFromString, IAddressBookEnabled, 
 		];
 
 		foreach ($vCard->children() as $property) {
-			if ($property->name === 'PHOTO' && in_array($property->getValueType(), ['BINARY', 'URI'])) {
+			if ($property->name === 'PHOTO' && in_array($property->getValueType(), ['BINARY', 'URI'], true)) {
 				$url = $this->urlGenerator->getAbsoluteURL(
 					$this->urlGenerator->linkTo('', 'remote.php') . '/dav/');
 				$url .= implode('/', [
@@ -270,7 +270,7 @@ class AddressBookImpl implements ICreateContactFromString, IAddressBookEnabled, 
 				]) . '?photo';
 
 				$result['PHOTO'] = 'VALUE=uri:' . $url;
-			} elseif (in_array($property->name, ['URL', 'GEO', 'CLOUD', 'ADR', 'EMAIL', 'IMPP', 'TEL', 'X-SOCIALPROFILE', 'RELATED', 'LANG', 'X-ADDRESSBOOKSERVER-MEMBER'])) {
+			} elseif (in_array($property->name, ['URL', 'GEO', 'CLOUD', 'ADR', 'EMAIL', 'IMPP', 'TEL', 'X-SOCIALPROFILE', 'RELATED', 'LANG', 'X-ADDRESSBOOKSERVER-MEMBER'], true)) {
 				if (!isset($result[$property->name])) {
 					$result[$property->name] = [];
 				}

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -1434,7 +1434,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 				);
 
 			foreach ($vCard->children() as $property) {
-				if (!in_array($property->name, self::INDEXED_PROPERTIES)) {
+				if (!in_array($property->name, self::INDEXED_PROPERTIES, true)) {
 					continue;
 				}
 				$preferred = 0;

--- a/apps/dav/lib/Comments/CommentsPlugin.php
+++ b/apps/dav/lib/Comments/CommentsPlugin.php
@@ -151,7 +151,7 @@ class CommentsPlugin extends ServerPlugin {
 		];
 		$ns = '{' . $this::NS_OWNCLOUD . '}';
 		foreach ($report as $parameter) {
-			if (!in_array($parameter['name'], $acceptableParameters) || empty($parameter['value'])) {
+			if (!in_array($parameter['name'], $acceptableParameters, true) || empty($parameter['value'])) {
 				continue;
 			}
 			$args[str_replace($ns, '', $parameter['name'])] = $parameter['value'];

--- a/apps/dav/lib/Connector/LegacyPublicAuth.php
+++ b/apps/dav/lib/Connector/LegacyPublicAuth.php
@@ -77,7 +77,7 @@ class LegacyPublicAuth extends AbstractBasic {
 					&& $this->session->get(PublicAuth::DAV_AUTHENTICATED) === $share->getId()) {
 					return true;
 				} else {
-					if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
+					if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')), true)) {
 						// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
 						http_response_code(401);
 						header('WWW-Authenticate: DummyBasic realm="' . $this->realm . '"');

--- a/apps/dav/lib/Connector/Sabre/AppleQuirksPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AppleQuirksPlugin.php
@@ -67,7 +67,7 @@ class AppleQuirksPlugin extends ServerPlugin {
 	 * @return bool
 	 */
 	public function report($reportName, $report, $path) {
-		if ($reportName == '{DAV:}principal-property-search' && $this->isMacOSDavAgent) {
+		if ($reportName === '{DAV:}principal-property-search' && $this->isMacOSDavAgent) {
 			/** @var \Sabre\DAVACL\Xml\Request\PrincipalPropertySearchReport $report */
 			$report->applyToPrincipalCollectionSet = true;
 		}

--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -129,7 +129,7 @@ class Auth extends AbstractBasic {
 	private function requiresCSRFCheck(): bool {
 
 		$methodsWithoutCsrf = ['GET', 'HEAD', 'OPTIONS'];
-		if (in_array($this->request->getMethod(), $methodsWithoutCsrf)) {
+		if (in_array($this->request->getMethod(), $methodsWithoutCsrf, true)) {
 			return false;
 		}
 
@@ -204,7 +204,7 @@ class Auth extends AbstractBasic {
 			$startPos = strrpos($data[1], '/') + 1;
 			$user = $this->userSession->getUser()->getUID();
 			$data[1] = substr_replace($data[1], $user, $startPos);
-		} elseif (in_array('XMLHttpRequest', explode(',', $request->getHeader('X-Requested-With') ?? ''))) {
+		} elseif (in_array('XMLHttpRequest', explode(',', $request->getHeader('X-Requested-With') ?? ''), true)) {
 			// For ajax requests use dummy auth name to prevent browser popup in case of invalid creditials
 			$response->addHeader('WWW-Authenticate', 'DummyBasic realm="' . $this->realm . '"');
 			$response->setStatus(Http::STATUS_UNAUTHORIZED);

--- a/apps/dav/lib/Connector/Sabre/CachingTree.php
+++ b/apps/dav/lib/Connector/Sabre/CachingTree.php
@@ -31,7 +31,7 @@ class CachingTree extends Tree {
 		$path = trim($path, '/');
 		foreach ($this->cache as $nodePath => $node) {
 			$nodePath = (string)$nodePath;
-			if ($path === '' || $nodePath == $path || str_starts_with($nodePath, $path . '/')) {
+			if ($path === '' || $nodePath === $path || str_starts_with($nodePath, $path . '/')) {
 				unset($this->cache[$nodePath]);
 			}
 		}

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -331,7 +331,7 @@ class FilesReportPlugin extends ServerPlugin {
 			$result['href'] = $propFind->getPath();
 
 			$resourceType = $this->server->getResourceTypeForNode($node);
-			if (in_array('{DAV:}collection', $resourceType) || in_array('{DAV:}principal', $resourceType)) {
+			if (in_array('{DAV:}collection', $resourceType, true) || in_array('{DAV:}principal', $resourceType, true)) {
 				$result['href'] .= '/';
 			}
 

--- a/apps/dav/lib/Connector/Sabre/PublicAuth.php
+++ b/apps/dav/lib/Connector/Sabre/PublicAuth.php
@@ -194,7 +194,7 @@ class PublicAuth extends AbstractBasic {
 					return true;
 				}
 
-				if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')))) {
+				if (in_array('XMLHttpRequest', explode(',', $this->request->getHeader('X-Requested-With')), true)) {
 					// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
 					http_response_code(401);
 					header('WWW-Authenticate: DummyBasic realm="' . $this->realm . '"');
@@ -245,6 +245,6 @@ class PublicAuth extends AbstractBasic {
 			return false;
 		}
 
-		return in_array($share->getId(), $allowedShareIds);
+		return in_array($share->getId(), $allowedShareIds, true);
 	}
 }

--- a/apps/dav/lib/Controller/InvitationResponseController.php
+++ b/apps/dav/lib/Controller/InvitationResponseController.php
@@ -116,6 +116,8 @@ class InvitationResponseController extends Controller {
 		$partstat = $this->request->getParam('partStat');
 
 		$row = $this->getTokenInformation($token);
+		// $partstat comes from IRequest::getParam(), which is untyped
+		/** @psalm-suppress UnrecognizedExpression */
 		if (!$row || !\in_array($partstat, ['ACCEPTED', 'DECLINED', 'TENTATIVE'])) {
 			return new TemplateResponse($this->appName, 'schedule-response-error', [], 'guest');
 		}

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -198,7 +198,7 @@ class CustomPropertiesBackend implements BackendInterface {
 			];
 
 			foreach ($customPropertiesForShares as $customPropertyForShares) {
-				if (in_array($customPropertyForShares, $allRequestedProps)) {
+				if (in_array($customPropertyForShares, $allRequestedProps, true)) {
 					$requestedProps[] = $customPropertyForShares;
 				}
 			}

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -276,11 +276,11 @@ class CustomPropertiesBackend implements BackendInterface {
 	}
 
 	private function isPropertyAllowed(string $property): bool {
-		if (in_array($property, self::IGNORED_PROPERTIES)) {
+		if (in_array($property, self::IGNORED_PROPERTIES, true)) {
 			return false;
 		}
 		if (str_starts_with($property, '{http://owncloud.org/ns}') || str_starts_with($property, '{http://nextcloud.org/ns}')) {
-			return in_array($property, self::ALLOWED_NC_PROPERTIES);
+			return in_array($property, self::ALLOWED_NC_PROPERTIES, true);
 		}
 		return true;
 	}
@@ -651,7 +651,7 @@ class CustomPropertiesBackend implements BackendInterface {
 					"Property \"$name\" has an invalid value of type " . gettype($value),
 				);
 			} else {
-				if (!in_array($value::class, self::ALLOWED_SERIALIZED_CLASSES)) {
+				if (!in_array($value::class, self::ALLOWED_SERIALIZED_CLASSES, true)) {
 					throw new DavException(
 						"Property \"$name\" has an invalid value of class " . $value::class,
 					);

--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -224,7 +224,7 @@ abstract class Backend {
 					'principal' => $share['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}principal'],
 					'protected' => true,
 				];
-			} elseif (in_array($this->service->getResourceType(), ['calendar','addressbook'])) {
+			} elseif (in_array($this->service->getResourceType(), ['calendar','addressbook'], true)) {
 				// Allow changing the properties of read only calendars,
 				// so users can change the visibility.
 				$acl[] = [

--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -118,7 +118,7 @@ class FileSearchBackend implements ISearchBackend {
 		$metadata = $this->filesMetadataManager->getKnownMetadata();
 		$indexes = $metadata->getIndexes();
 		foreach ($metadata->getKeys() as $key) {
-			$isIndex = in_array($key, $indexes);
+			$isIndex = in_array($key, $indexes, true);
 			$type = match ($metadata->getType($key)) {
 				IMetadataValueWrapper::TYPE_INT => SearchPropertyDefinition::DATATYPE_INTEGER,
 				IMetadataValueWrapper::TYPE_FLOAT => SearchPropertyDefinition::DATATYPE_DECIMAL,

--- a/apps/dav/lib/SetupChecks/WebdavEndpoint.php
+++ b/apps/dav/lib/SetupChecks/WebdavEndpoint.php
@@ -51,7 +51,7 @@ class WebdavEndpoint implements ISetupCheck {
 			$works = null;
 			foreach ($this->runRequest($verb, $url, ['httpErrors' => false]) as $response) {
 				// Check that the response status matches
-				$works = in_array($response->getStatusCode(), $validStatuses);
+				$works = in_array($response->getStatusCode(), $validStatuses, true);
 				// Skip the other requests if one works
 				if ($works === true) {
 					break;

--- a/apps/dav/lib/SystemTag/SystemTagNode.php
+++ b/apps/dav/lib/SystemTag/SystemTagNode.php
@@ -188,7 +188,7 @@ class SystemTagNode implements \Sabre\DAV\ICollection {
 	#[\Override]
 	public function childExists($name) {
 		$objectTypes = $this->tagMapper->getAvailableObjectTypes();
-		return in_array($name, $objectTypes);
+		return in_array($name, $objectTypes, true);
 	}
 
 	#[\Override]

--- a/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
@@ -32,7 +32,7 @@ class SystemTagsInUseCollection extends SimpleCollection {
 		protected string $mediaType = '',
 	) {
 		$this->name = 'systemtags-assigned';
-		if ($this->mediaType != '') {
+		if ($this->mediaType !== '') {
 			$this->name .= '/' . $this->mediaType;
 		}
 	}

--- a/apps/encryption/lib/Command/CleanOrphanedKeys.php
+++ b/apps/encryption/lib/Command/CleanOrphanedKeys.php
@@ -94,7 +94,7 @@ class CleanOrphanedKeys extends Command {
 		foreach ($orphanedKeys as $keyPath) {
 			$output->writeln('Orphaned key found: ' . $keyPath);
 		}
-		if (count($orphanedKeys) == 0) {
+		if (count($orphanedKeys) === 0) {
 			return self::SUCCESS;
 		}
 		$question = new ConfirmationQuestion('Do you want to delete all orphaned keys? (y/n) ', false);
@@ -199,7 +199,7 @@ class CleanOrphanedKeys extends Command {
 				return $k !== trim($path);
 			});
 		}
-		if (count($orphanedKeys) == 0) {
+		if (count($orphanedKeys) === 0) {
 			return;
 		}
 		$output->writeln('Remaining orphaned keys: ');

--- a/apps/encryption/lib/Command/CleanOrphanedKeys.php
+++ b/apps/encryption/lib/Command/CleanOrphanedKeys.php
@@ -185,7 +185,7 @@ class CleanOrphanedKeys extends Command {
 	private function deleteSpecific(InputInterface $input, OutputInterface $output, array $orphanedKeys) {
 		$question = new Question('Please enter path for key to delete: ');
 		$path = $this->questionHelper->ask($input, $output, $question);
-		if (!in_array(trim($path), $orphanedKeys)) {
+		if (!in_array(trim($path), $orphanedKeys, true)) {
 			$output->writeln('Wrong key path');
 		} else {
 			try {

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -182,7 +182,7 @@ class FixEncryptedVersion extends Command {
 				}
 				$encryptedVersion = $fileInfo->getEncryptedVersion();
 				$stat = $this->view->stat($path);
-				if (($encryptedVersion == 0) && isset($stat['hasHeader']) && ($stat['hasHeader'] == true)) {
+				if (($encryptedVersion === 0) && isset($stat['hasHeader']) && ($stat['hasHeader'] === true)) {
 					// The file has encrypted to false but has an encryption header
 					if ($ignoreCorrectEncVersionCall === true) {
 						// Lets rectify the file by correcting encrypted version

--- a/apps/encryption/lib/Command/FixKeyLocation.php
+++ b/apps/encryption/lib/Command/FixKeyLocation.php
@@ -323,7 +323,7 @@ class FixKeyLocation extends Command {
 				throw new \Exception('Invalid base path ' . $basePath);
 			}
 			while ($child = readdir($dh)) {
-				if ($child != '..' && $child != '.') {
+				if ($child !== '..' && $child !== '.') {
 					$childPath = $basePath . '/' . $child;
 
 					// recurse if the child is not a key folder

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -409,17 +409,10 @@ class Crypt {
 	}
 
 	/**
-	 * @param string $keyFileContents
-	 * @param string $passPhrase
-	 * @param string $cipher
-	 * @param int $version
-	 * @param int|string $position
-	 * @param boolean $binaryEncoding
-	 * @return string
 	 * @throws DecryptionFailedException
 	 */
-	public function symmetricDecryptFileContent($keyFileContents, $passPhrase, $cipher = self::DEFAULT_CIPHER, $version = 0, $position = 0, bool $binaryEncoding = false) {
-		if ($keyFileContents == '') {
+	public function symmetricDecryptFileContent(string $keyFileContents, string $passPhrase, string $cipher = self::DEFAULT_CIPHER, int $version = 0, int|string $position = 0, bool $binaryEncoding = false): string {
+		if ($keyFileContents === '') {
 			return '';
 		}
 

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -131,7 +131,7 @@ class Encryption implements IEncryptionModule {
 		}
 
 		/* If useLegacyFileKey is not specified in header, auto-detect, to be safe */
-		$useLegacyFileKey = (($header['useLegacyFileKey'] ?? '') == 'false' ? false : null);
+		$useLegacyFileKey = ((string)($header['useLegacyFileKey'] ?? '') === 'false' ? false : null);
 
 		$this->fileKey = $this->keyManager->getFileKey($this->path, $useLegacyFileKey, $this->session->decryptAllModeActivated());
 

--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -95,7 +95,7 @@ class MountPublicLinkController extends Controller {
 			$allowedShareIds = [];
 		}
 
-		$authenticated = in_array($share->getId(), $allowedShareIds)
+		$authenticated = in_array($share->getId(), $allowedShareIds, true)
 			|| $this->shareManager->checkPassword($share, $password);
 
 		if ($share->isPasswordProtected() && !$authenticated) {

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -127,6 +127,8 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 
 		// Check for must-exchange-token requirement
 		$requirements = $protocol['webdav']['requirements'] ?? $protocol['options']['requirements'] ?? [];
+		// $requirements comes from remote-supplied protocol data of unknown element types
+		/** @psalm-suppress UnrecognizedExpression */
 		$mustExchangeToken = in_array('must-exchange-token', $requirements);
 		$accessToken = '';
 

--- a/apps/files/lib/Listener/SyncLivePhotosListener.php
+++ b/apps/files/lib/Listener/SyncLivePhotosListener.php
@@ -149,7 +149,7 @@ class SyncLivePhotosListener implements IEventListener {
 		$peerTargetName = substr($targetName, 0, -strlen($sourceExtension)) . $peerFileExtension;
 
 		// in case the rename was initiated from this listener, we stop right now
-		if (in_array($peerFile->getId(), $this->pendingRenames)) {
+		if (in_array($peerFile->getId(), $this->pendingRenames, true)) {
 			return;
 		}
 
@@ -245,7 +245,7 @@ class SyncLivePhotosListener implements IEventListener {
 			}
 		} elseif ($sourceNode instanceof File && $targetNode instanceof File) {
 			// in case the copy was initiated from this listener, we stop right now
-			if (in_array($sourceNode->getId(), $this->pendingCopies)) {
+			if (in_array($sourceNode->getId(), $this->pendingCopies, true)) {
 				return;
 			}
 

--- a/apps/files/lib/Service/UserConfig.php
+++ b/apps/files/lib/Service/UserConfig.php
@@ -143,10 +143,12 @@ class UserConfig {
 			throw new \Exception('No user logged in');
 		}
 
-		if (!in_array($key, $this->getAllowedConfigKeys())) {
+		if (!in_array($key, $this->getAllowedConfigKeys(), true)) {
 			throw new \InvalidArgumentException('Unknown config key');
 		}
 
+		// $value is a string, but allowed values may be booleans (e.g. for toggle configs), so comparison must stay loose
+		/** @psalm-suppress UnrecognizedExpression */
 		if (!in_array($value, $this->getAllowedConfigValues($key))) {
 			throw new \InvalidArgumentException('Invalid config value');
 		}

--- a/apps/files/lib/Service/ViewConfig.php
+++ b/apps/files/lib/Service/ViewConfig.php
@@ -102,10 +102,12 @@ class ViewConfig {
 			throw new \Exception('Unknown view');
 		}
 
-		if (!in_array($key, $this->getAllowedConfigKeys())) {
+		if (!in_array($key, $this->getAllowedConfigKeys(), true)) {
 			throw new \InvalidArgumentException('Unknown config key');
 		}
 
+		// $value is a string, but allowed values may be booleans (e.g. for toggle configs), so comparison must stay loose
+		/** @psalm-suppress UnrecognizedExpression */
 		if (!in_array($value, $this->getAllowedConfigValues($key))
 			&& !empty($this->getAllowedConfigValues($key))) {
 			throw new \InvalidArgumentException('Invalid config value');

--- a/apps/files_external/lib/Command/Create.php
+++ b/apps/files_external/lib/Command/Create.php
@@ -120,7 +120,7 @@ class Create extends Base {
 			return Http::STATUS_NOT_FOUND;
 		}
 		$supportedSchemes = array_keys($storageBackend->getAuthSchemes());
-		if (!in_array($authBackend->getScheme(), $supportedSchemes)) {
+		if (!in_array($authBackend->getScheme(), $supportedSchemes, true)) {
 			$output->writeln('<error>Authentication backend "' . $authIdentifier . '" not valid for storage backend "' . $storageIdentifier . '" (see `occ files_external:backends storage ' . $storageIdentifier . '` for possible values)</error>');
 			return self::FAILURE;
 		}

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -114,7 +114,7 @@ class ListCommand extends Base {
 			foreach ($mounts as $mount) {
 				$config = $mount->getBackendOptions();
 				foreach ($config as $key => $value) {
-					if (in_array($key, $hideKeys)) {
+					if (in_array($key, $hideKeys, true)) {
 						$mount->setBackendOption($key, '***REMOVED SENSITIVE VALUE***');
 					}
 				}

--- a/apps/files_external/lib/Lib/ApplicableHelper.php
+++ b/apps/files_external/lib/Lib/ApplicableHelper.php
@@ -51,12 +51,12 @@ class ApplicableHelper {
 		if (count($storage->getApplicableUsers()) + count($storage->getApplicableGroups()) === 0) {
 			return true;
 		}
-		if (in_array($user->getUID(), $storage->getApplicableUsers())) {
+		if (in_array($user->getUID(), $storage->getApplicableUsers(), true)) {
 			return true;
 		}
 		$groupIds = $this->groupManager->getUserGroupIds($user);
 		foreach ($groupIds as $groupId) {
-			if (in_array($groupId, $storage->getApplicableGroups())) {
+			if (in_array($groupId, $storage->getApplicableGroups(), true)) {
 				return true;
 			}
 		}
@@ -84,7 +84,7 @@ class ApplicableHelper {
 		} else {
 			$yielded = [];
 			foreach ($a->getApplicableGroups() as $groupId) {
-				if (!in_array($groupId, $b->getApplicableGroups())) {
+				if (!in_array($groupId, $b->getApplicableGroups(), true)) {
 					$group = $this->groupManager->get($groupId);
 					if ($group) {
 						foreach ($group->getUsers() as $user) {
@@ -99,7 +99,7 @@ class ApplicableHelper {
 				}
 			}
 			foreach ($a->getApplicableUsers() as $userId) {
-				if (!in_array($userId, $b->getApplicableUsers())) {
+				if (!in_array($userId, $b->getApplicableUsers(), true)) {
 					$user = $this->userManager->get($userId);
 					if ($user && !$this->isApplicableForUser($b, $user)) {
 						if (!isset($yielded[$user->getUID()])) {

--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -177,7 +177,7 @@ class SFTPReadStream implements File {
 				return $temp;
 			case NET_SFTP_STATUS:
 				[1 => $status] = unpack('N', substr($response, 0, 4));
-				if ($status == NET_SFTP_STATUS_EOF) {
+				if ($status === NET_SFTP_STATUS_EOF) {
 					$this->eof = true;
 				}
 				return '';

--- a/apps/files_external/lib/Service/StoragesService.php
+++ b/apps/files_external/lib/Service/StoragesService.php
@@ -437,12 +437,12 @@ abstract class StoragesService {
 		$appIdsList = $this->appConfig->getValueArray(FilesApplication::APP_ID, ConfigLexicon::OVERWRITES_HOME_FOLDERS);
 
 		if ($this->dbConfig->hasHomeFolderOverwriteMount()) {
-			if (!in_array(Application::APP_ID, $appIdsList)) {
+			if (!in_array(Application::APP_ID, $appIdsList, true)) {
 				$appIdsList[] = Application::APP_ID;
 				$this->appConfig->setValueArray(FilesApplication::APP_ID, ConfigLexicon::OVERWRITES_HOME_FOLDERS, $appIdsList);
 			}
 		} else {
-			if (in_array(Application::APP_ID, $appIdsList)) {
+			if (in_array(Application::APP_ID, $appIdsList, true)) {
 				$appIdsList = array_values(array_filter($appIdsList, fn ($v) => $v !== Application::APP_ID));
 				$this->appConfig->setValueArray(FilesApplication::APP_ID, ConfigLexicon::OVERWRITES_HOME_FOLDERS, $appIdsList);
 			}

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -34,7 +34,7 @@ class SmbTest extends \Test\Files\Storage\Storage {
 
 		$id = $this->getUniqueID();
 		$this->loadConfig(__DIR__ . '/../config.smb.php');
-		if (substr($this->config['root'], -1, 1) != '/') {
+		if (substr($this->config['root'], -1, 1) !== '/') {
 			$this->config['root'] .= '/';
 		}
 		$this->config['root'] .= $id; //make sure we have an new empty folder to work in

--- a/apps/files_reminders/lib/Dav/PropFindPlugin.php
+++ b/apps/files_reminders/lib/Dav/PropFindPlugin.php
@@ -51,7 +51,7 @@ class PropFindPlugin extends ServerPlugin {
 	}
 
 	public function propFind(PropFind $propFind, INode $node) {
-		if (!in_array(static::REMINDER_DUE_DATE_PROPERTY, $propFind->getRequestedProperties())) {
+		if (!in_array(static::REMINDER_DUE_DATE_PROPERTY, $propFind->getRequestedProperties(), true)) {
 			return;
 		}
 

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -891,7 +891,7 @@ class ShareAPIController extends OCSController {
 		$resharingRight = false;
 		$known = [];
 		foreach ($shares as $share) {
-			if (in_array($share->getId(), $known) || $share->getSharedWith() === $this->userId) {
+			if (in_array($share->getId(), $known, true) || $share->getSharedWith() === $this->userId) {
 				continue;
 			}
 
@@ -1070,7 +1070,7 @@ class ShareAPIController extends OCSController {
 				continue;
 			}
 
-			if (in_array($share->getId(), $known)
+			if (in_array($share->getId(), $known, true)
 				|| ($share->getSharedWith() === $this->userId && $share->getShareType() === IShare::TYPE_USER)) {
 				continue;
 			}

--- a/apps/files_sharing/lib/Listener/BeforeNodeReadListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeNodeReadListener.php
@@ -75,7 +75,7 @@ class BeforeNodeReadListener implements IEventListener {
 		/** @var ISharedStorage $storage */
 		$share = $storage->getShare();
 
-		if (!in_array($share->getShareType(), [IShare::TYPE_EMAIL, IShare::TYPE_LINK])) {
+		if (!in_array($share->getShareType(), [IShare::TYPE_EMAIL, IShare::TYPE_LINK], true)) {
 			return;
 		}
 
@@ -104,7 +104,7 @@ class BeforeNodeReadListener implements IEventListener {
 		/** @var ISharedStorage $storage */
 		$share = $storage->getShare();
 
-		if (!in_array($share->getShareType(), [IShare::TYPE_EMAIL, IShare::TYPE_LINK])) {
+		if (!in_array($share->getShareType(), [IShare::TYPE_EMAIL, IShare::TYPE_LINK], true)) {
 			return;
 		}
 

--- a/apps/files_sharing/lib/Listener/RestrictInteractionListener.php
+++ b/apps/files_sharing/lib/Listener/RestrictInteractionListener.php
@@ -78,7 +78,7 @@ final class RestrictInteractionListener implements IEventListener {
 					if (!$receiver instanceof LinkReceiver
 						&& !$receiver instanceof EmailReceiver
 						&& (($event->action->filesSharingPermissions !== null && ($event->action->filesSharingPermissions & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ)
-							|| ($event->action->unifiedSharingPermissions !== null && !in_array(NodeReadSharePermissionType::class, $event->action->unifiedSharingPermissions)))) {
+							|| ($event->action->unifiedSharingPermissions !== null && !in_array(NodeReadSharePermissionType::class, $event->action->unifiedSharingPermissions, true)))) {
 						throw new InteractionRestrictedException('No read permission on the share.', $this->l10n->t('File share needs at least read permission.'));
 					}
 

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -342,7 +342,7 @@ class MountProvider implements IMountProvider, IAuthoritativeMountProvider, IPar
 				$share->getPermissions() > 0
 				&& $share->getShareOwner() !== $userId
 				&& $share->getSharedBy() !== $userId
-				&& !in_array($share->getFullId(), $excludeShareIds)
+				&& !in_array($share->getFullId(), $excludeShareIds, true)
 			) {
 				yield $share;
 			}

--- a/apps/files_sharing/lib/ShareRecipientUpdater.php
+++ b/apps/files_sharing/lib/ShareRecipientUpdater.php
@@ -101,7 +101,7 @@ class ShareRecipientUpdater {
 	 */
 	public function updateForMovedShare(IUser $user, IShare $share): void {
 		$originalTarget = $share->getOriginalTarget();
-		if ($originalTarget != null) {
+		if ($originalTarget !== null) {
 			$newMountPoint = $this->getMountPointFromTarget($user, $share->getTarget());
 			$oldMountPoint = $this->getMountPointFromTarget($user, $originalTarget);
 			$this->userMountCache->removeMount($oldMountPoint, $user);

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -222,7 +222,8 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 			Home::class,
 			HomeObjectStoreStorage::class,
 			IHomeStorage::class
-		])) {
+		],
+			true)) {
 			return false;
 		}
 		return parent::instanceOfStorage($class);

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -212,7 +212,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 
 	#[\Override]
 	public function instanceOfStorage(string $class): bool {
-		if ($class === '\OC\Files\Storage\Common' || $class == Common::class) {
+		if ($class === '\OC\Files\Storage\Common' || $class === Common::class) {
 			return true;
 		}
 		if (in_array($class, [

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -219,7 +219,7 @@ class SharesReminderJob extends TimedJob {
 	private function prepareReminder(IShare $share): ?array {
 		$sharedWith = $share->getSharedWith();
 		$reminderInfo = [];
-		if ($share->getShareType() == IShare::TYPE_USER) {
+		if ((int)$share->getShareType() === IShare::TYPE_USER) {
 			$user = $this->userManager->get($sharedWith);
 			if ($user === null) {
 				return null;

--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -165,7 +165,7 @@ class RestoreAllFiles extends Base {
 			$output);
 
 		$trashCount = count($userTrashItems);
-		if ($trashCount == 0) {
+		if ($trashCount === 0) {
 			$output->writeln('User has no deleted files in the trashbin matching the given filters');
 			return;
 		}

--- a/apps/files_trashbin/lib/Command/Size.php
+++ b/apps/files_trashbin/lib/Command/Size.php
@@ -89,7 +89,7 @@ class Size extends Base {
 				$userHumanSize = Util::humanFileSize($userSize);
 			}
 
-			if ($input->getOption('output') == self::OUTPUT_FORMAT_PLAIN) {
+			if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
 				$output->writeln($userHumanSize);
 			} else {
 				$userValue = ($userSize < 0) ? 'default' : $userSize;
@@ -107,7 +107,7 @@ class Size extends Base {
 			});
 			$userValues = $this->config->getUserValueForUsers('files_trashbin', 'trashbin_size', $users);
 
-			if ($input->getOption('output') == self::OUTPUT_FORMAT_PLAIN) {
+			if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
 				$output->writeln("Default size: $globalHumanSize");
 				$output->writeln('');
 				if (count($userValues)) {

--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -255,7 +255,7 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 				if (!in_array($e->getReason(), [
 					\OCP\DB\Exception::REASON_CONSTRAINT_VIOLATION,
 					\OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION,
-				])
+				], true)
 				) {
 					throw $e;
 				}

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -205,7 +205,7 @@ class VersionManager implements IVersionManager, IDeletableVersionBackend, INeed
 		} catch (ManuallyLockedException $e) {
 			$owner = (string)$e->getOwner();
 			$appsThatHandleUpdates = ['text', 'richdocuments'];
-			if (!in_array($owner, $appsThatHandleUpdates)) {
+			if (!in_array($owner, $appsThatHandleUpdates, true)) {
 				throw $e;
 			}
 			// The LockWrapper in the files_lock app only compares the lock type and owner

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -86,7 +86,7 @@ final class LoginRedirectorController extends Controller {
 
 		$this->session->set('oauth.state', $state);
 
-		if (in_array($client->name, $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []))) {
+		if (in_array($client->name, $this->appConfig->getValueArray('oauth2', 'skipAuthPickerApplications', []), true)) {
 			/** @see ClientFlowLoginController::showAuthPickerPage **/
 			$stateToken = $this->random->generate(
 				64,

--- a/apps/provisioning_api/lib/Controller/AppConfigController.php
+++ b/apps/provisioning_api/lib/Controller/AppConfigController.php
@@ -200,7 +200,7 @@ class AppConfigController extends OCSController {
 	 * @throws \InvalidArgumentException
 	 */
 	protected function verifyConfigKey(string $app, string $key, string $value) {
-		if (in_array($key, ['installed_version', 'enabled', 'types'])) {
+		if (in_array($key, ['installed_version', 'enabled', 'types'], true)) {
 			throw new \InvalidArgumentException('The given key can not be set');
 		}
 

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -845,7 +845,7 @@ class UsersController extends AUserDataOCSController {
 		}
 
 		// Check if permitted to edit this field
-		if (!in_array($collectionName, $permittedFields)) {
+		if (!in_array($collectionName, $permittedFields, true)) {
 			throw new OCSException('', 103);
 		}
 
@@ -1311,7 +1311,7 @@ class UsersController extends AUserDataOCSController {
 			}
 		}
 		// Check if permitted to edit this field
-		if (!in_array($key, $permittedFields)) {
+		if (!in_array($key, $permittedFields, true)) {
 			throw new OCSException('', 113);
 		}
 		// Process the edit
@@ -1359,7 +1359,7 @@ class UsersController extends AUserDataOCSController {
 				break;
 			case self::USER_FIELD_TIMEZONE:
 				// Older browsers still report deprecated aliases like Europe/Kiev.
-				if (!in_array($value, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC))) {
+				if (!in_array($value, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC), true)) {
 					throw new OCSException($this->l10n->t('Invalid timezone'), 101);
 				}
 				$this->config->setUserValue($targetUser->getUID(), 'core', 'timezone', $value);

--- a/apps/settings/lib/Controller/MailSettingsController.php
+++ b/apps/settings/lib/Controller/MailSettingsController.php
@@ -62,7 +62,7 @@ class MailSettingsController extends Controller {
 		string $mail_sendmailmode,
 		?bool $mail_noverify = null,
 	): DataResponse {
-		$mail_smtpauth = $mail_smtpauth == '1';
+		$mail_smtpauth = $mail_smtpauth === true;
 
 		$configs = [
 			'mail_domain' => $mail_domain,

--- a/apps/settings/lib/SetupChecks/MemcacheConfigured.php
+++ b/apps/settings/lib/SetupChecks/MemcacheConfigured.php
@@ -42,7 +42,7 @@ class MemcacheConfigured implements ISetupCheck {
 		$memcacheLockingClass = $this->config->getSystemValue('memcache.locking', null);
 		$memcacheLocalClass = $this->config->getSystemValue('memcache.local', null);
 		$caches = array_filter([$memcacheDistributedClass,$memcacheLockingClass,$memcacheLocalClass]);
-		if (in_array(Memcached::class, array_map(fn (string $class) => ltrim($class, '\\'), $caches))) {
+		if (in_array(Memcached::class, array_map(fn (string $class) => ltrim($class, '\\'), $caches), true)) {
 			// wrong PHP module is installed
 			if (extension_loaded('memcache') && !extension_loaded('memcached')) {
 				return SetupResult::warning(

--- a/apps/settings/lib/SetupChecks/OverwriteCliUrl.php
+++ b/apps/settings/lib/SetupChecks/OverwriteCliUrl.php
@@ -40,7 +40,7 @@ class OverwriteCliUrl implements ISetupCheck {
 
 		// Check correctness by checking if it is a valid URL
 		if (filter_var($currentOverwriteCliUrl, FILTER_VALIDATE_URL)) {
-			if ($currentOverwriteCliUrl == $suggestedOverwriteCliUrl) {
+			if ($currentOverwriteCliUrl === $suggestedOverwriteCliUrl) {
 				return SetupResult::success(
 					$this->l10n->t(
 						'The "overwrite.cli.url" option in your config.php is correctly set to "%s".',

--- a/apps/settings/lib/SetupChecks/SecurityHeaders.php
+++ b/apps/settings/lib/SetupChecks/SecurityHeaders.php
@@ -57,7 +57,7 @@ class SecurityHeaders implements ISetupCheck {
 			$works = null;
 			foreach ($this->runRequest($verb, $url, ['httpErrors' => false]) as $response) {
 				// Check that the response status matches
-				if (!in_array($response->getStatusCode(), $validStatuses)) {
+				if (!in_array($response->getStatusCode(), $validStatuses, true)) {
 					$works = false;
 					continue;
 				}

--- a/apps/settings/lib/SetupChecks/WellKnownUrls.php
+++ b/apps/settings/lib/SetupChecks/WellKnownUrls.php
@@ -59,7 +59,7 @@ class WellKnownUrls implements ISetupCheck {
 			$works = null;
 			foreach ($this->runRequest($verb, $url, $requestOptions, isRootRequest: true) as $response) {
 				// Check that the response status matches
-				$works = in_array($response->getStatusCode(), $validStatuses);
+				$works = in_array($response->getStatusCode(), $validStatuses, true);
 				// and (if needed) the custom Nextcloud header is set
 				if ($checkCustomHeader) {
 					$works = $works && !empty($response->getHeader('X-NEXTCLOUD-WELL-KNOWN'));

--- a/apps/sharebymail/lib/Activity.php
+++ b/apps/sharebymail/lib/Activity.php
@@ -212,6 +212,8 @@ class Activity implements IProvider {
 				continue;
 			}
 
+			// $contact['EMAIL'] structure varies by address book backend and vCard cardinality
+			/** @psalm-suppress UnrecognizedExpression */
 			if (in_array($email, $contact['EMAIL'])) {
 				return $contact['FN'];
 			}

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -402,7 +402,7 @@ class ThemingController extends Controller {
 	#[NoSameSiteCookieRequired]
 	public function getThemeStylesheet(string $themeId, bool $plain = false, bool $withCustomCss = false) {
 		$themes = $this->themesService->getThemes();
-		if (!in_array($themeId, array_keys($themes))) {
+		if (!in_array($themeId, array_keys($themes), true)) {
 			return new NotFoundResponse();
 		}
 

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -130,7 +130,7 @@ class ThemingController extends Controller {
 				break;
 			case 'disableUserTheming':
 			case 'disable-user-theming':
-				if (!in_array($value, ['yes', 'true', 'no', 'false'])) {
+				if (!in_array($value, ['yes', 'true', 'no', 'false'], true)) {
 					$error = $this->l10n->t('%1$s should be true or false', ['disable-user-theming']);
 				} else {
 					$this->appConfig->setAppValueBool('disable-user-theming', $value === 'yes' || $value === 'true');

--- a/apps/theming/lib/Listener/BeforePreferenceListener.php
+++ b/apps/theming/lib/Listener/BeforePreferenceListener.php
@@ -48,7 +48,7 @@ class BeforePreferenceListener implements IEventListener {
 	}
 
 	private function handleThemingValues(BeforePreferenceSetEvent|BeforePreferenceDeletedEvent $event): void {
-		if (!in_array($event->getConfigKey(), self::ALLOWED_KEYS)) {
+		if (!in_array($event->getConfigKey(), self::ALLOWED_KEYS, true)) {
 			// Not allowed config key
 			return;
 		}

--- a/apps/theming/lib/Service/ThemesService.php
+++ b/apps/theming/lib/Service/ThemesService.php
@@ -91,7 +91,7 @@ class ThemesService {
 		$enabledThemeIds = $this->getEnabledThemes();
 
 		// If already enabled, ignore
-		if (in_array($theme->getId(), $enabledThemeIds)) {
+		if (in_array($theme->getId(), $enabledThemeIds, true)) {
 			return $enabledThemeIds;
 		}
 
@@ -116,7 +116,7 @@ class ThemesService {
 		$themesIds = $this->getEnabledThemes();
 
 		// If enabled, removing it
-		if (in_array($theme->getId(), $themesIds)) {
+		if (in_array($theme->getId(), $themesIds, true)) {
 			$enabledThemes = array_values(array_diff($themesIds, [$theme->getId()]));
 			$this->setEnabledThemes($enabledThemes);
 			return $enabledThemes;
@@ -136,7 +136,7 @@ class ThemesService {
 		if ($user instanceof IUser) {
 			// Using keys as it's faster
 			$themes = $this->getEnabledThemes();
-			return in_array($theme->getId(), $themes);
+			return in_array($theme->getId(), $themes, true);
 		}
 		return false;
 	}

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -464,7 +464,7 @@ class ThemingDefaults extends \OC_Defaults {
 				$this->appConfig->setAppValueInt(ConfigLexicon::CACHE_BUSTER, (int)$value);
 				break;
 			case ConfigLexicon::USER_THEMING_DISABLED:
-				$value = in_array($value, ['1', 'true', 'yes', 'on']);
+				$value = in_array($value, ['1', 'true', 'yes', 'on'], true);
 				$this->appConfig->setAppValueBool(ConfigLexicon::USER_THEMING_DISABLED, $value);
 				break;
 			default:

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1052,7 +1052,7 @@ class Access extends LDAPUtility {
 	 * @throws ServerNotAvailableException
 	 */
 	private function invokeLDAPMethod(string $command, ...$arguments) {
-		if ($command == 'controlPagedResultResponse') {
+		if ($command === 'controlPagedResultResponse') {
 			// php no longer supports call-time pass-by-reference
 			// thus cannot support controlPagedResultResponse as the third argument
 			// is a reference

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -364,7 +364,7 @@ class Access extends LDAPUtility {
 			// memberOf is an "operational" attribute, without a definition in any RFC
 			'memberof'
 		];
-		return in_array($attr, $resemblingAttributes);
+		return in_array($attr, $resemblingAttributes, true);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -171,7 +171,7 @@ class CheckUser extends Command {
 			foreach ($result[0] as $attribute => $valueSet) {
 				$output->writeln('  ' . $attribute . ': ');
 				foreach ($valueSet as $value) {
-					if (in_array($attribute, $avatarAttributes)) {
+					if (in_array($attribute, $avatarAttributes, true)) {
 						$value = '{ImageData}';
 					}
 					$output->writeln('    ' . $value);

--- a/apps/user_ldap/lib/Command/ResetGroup.php
+++ b/apps/user_ldap/lib/Command/ResetGroup.php
@@ -55,7 +55,7 @@ class ResetGroup extends Command {
 				throw new \Exception('Group not found');
 			}
 			$backends = $group->getBackendNames();
-			if (!in_array('LDAP', $backends)) {
+			if (!in_array('LDAP', $backends, true)) {
 				throw new \Exception('The given group is not a recognized LDAP group.');
 			}
 			if ($input->getOption('yes') === false) {

--- a/apps/user_ldap/lib/Command/SetConfig.php
+++ b/apps/user_ldap/lib/Command/SetConfig.php
@@ -51,7 +51,7 @@ class SetConfig extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
-		if (!in_array($configID, $availableConfigs)) {
+		if (!in_array($configID, $availableConfigs, true)) {
 			$output->writeln('Invalid configID');
 			return self::FAILURE;
 		}

--- a/apps/user_ldap/lib/Command/ShowConfig.php
+++ b/apps/user_ldap/lib/Command/ShowConfig.php
@@ -56,7 +56,7 @@ class ShowConfig extends Base {
 		$configID = $input->getArgument('configID');
 		if (!is_null($configID)) {
 			$configIDs[] = $configID;
-			if (!in_array($configIDs[0], $availableConfigs)) {
+			if (!in_array($configIDs[0], $availableConfigs, true)) {
 				$output->writeln('Invalid configID');
 				return self::FAILURE;
 			}

--- a/apps/user_ldap/lib/Command/TestConfig.php
+++ b/apps/user_ldap/lib/Command/TestConfig.php
@@ -48,7 +48,7 @@ class TestConfig extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
-		if (!in_array($configID, $availableConfigs)) {
+		if (!in_array($configID, $availableConfigs, true)) {
 			$output->writeln('Invalid configID');
 			return self::FAILURE;
 		}

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -160,7 +160,7 @@ class Connection extends LDAPUtility {
 		}
 		$helper = Server::get(Helper::class);
 		$this->doNotValidate = !in_array($this->configPrefix,
-			$helper->getServerConfigurationPrefixes());
+			$helper->getServerConfigurationPrefixes(), true);
 		$this->logger = Server::get(LoggerInterface::class);
 		$this->l10n = Util::getL10N('user_ldap');
 	}
@@ -416,7 +416,7 @@ class Connection extends LDAPUtility {
 			} else {
 				$uuidAttributes = Access::UUID_ATTRIBUTES;
 				array_unshift($uuidAttributes, 'auto');
-				if (!in_array($this->configuration->$effectiveSetting, $uuidAttributes)
+				if (!in_array($this->configuration->$effectiveSetting, $uuidAttributes, true)
 					&& !is_null($this->configID)) {
 					$this->configuration->$effectiveSetting = 'auto';
 					$this->configuration->saveConfiguration();

--- a/apps/user_ldap/lib/GroupPluginManager.php
+++ b/apps/user_ldap/lib/GroupPluginManager.php
@@ -55,7 +55,7 @@ class GroupPluginManager {
 	 * @return bool
 	 */
 	public function implementsActions($actions) {
-		return ($actions & $this->respondToActions) == $actions;
+		return ($actions & $this->respondToActions) === $actions;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -79,7 +79,7 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 		$userDN = $this->access->username2dn($uid);
 
 		if (isset($this->cachedGroupMembers[$gid])) {
-			return in_array($userDN, $this->cachedGroupMembers[$gid]);
+			return in_array($userDN, $this->cachedGroupMembers[$gid], true);
 		}
 
 		$cacheKeyMembers = 'inGroup-members:' . $gid;
@@ -157,7 +157,7 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 			return false;
 		}
 
-		$isInGroup = in_array($userDN, $members);
+		$isInGroup = in_array($userDN, $members, true);
 		$this->access->connection->writeToCache($cacheKey, $isInGroup);
 		$this->access->connection->writeToCache($cacheKeyMembers, $members);
 		$this->cachedGroupMembers[$gid] = $members;
@@ -1245,7 +1245,7 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 					$this->access->cacheGroupExists($gid);
 				}
 			}
-			return $dn != null;
+			return $dn !== null && $dn !== false;
 		}
 		throw new Exception('Could not create group in LDAP backend.');
 	}

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -160,7 +160,7 @@ class Sync extends TimedJob {
 
 		if (
 			$cycleData['prefix'] !== 'none'
-			&& in_array($cycleData['prefix'], $prefixes)
+			&& in_array($cycleData['prefix'], $prefixes, true)
 		) {
 			return $cycleData;
 		}

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -150,7 +150,7 @@ class Manager {
 		$attributes = array_reduce($attributes,
 			function ($list, $attribute) {
 				$attribute = strtolower(trim((string)$attribute));
-				if (!empty($attribute) && !in_array($attribute, $list)) {
+				if (!empty($attribute) && !in_array($attribute, $list, true)) {
 					$list[] = $attribute;
 				}
 

--- a/apps/user_ldap/lib/UserPluginManager.php
+++ b/apps/user_ldap/lib/UserPluginManager.php
@@ -61,7 +61,7 @@ class UserPluginManager {
 	 * @return bool
 	 */
 	public function implementsActions($actions) {
-		return ($actions & $this->respondToActions) == $actions;
+		return ($actions & $this->respondToActions) === $actions;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -1161,7 +1161,7 @@ class Wizard extends LDAPUtility {
 					$rr = $entry; //will be expected by nextEntry next round
 					$attributes = $this->ldap->getAttributes($cr, $entry);
 					$dn = $this->ldap->getDN($cr, $entry);
-					if ($attributes === false || $dn === false || in_array($dn, $dnRead)) {
+					if ($attributes === false || $dn === false || in_array($dn, $dnRead, true)) {
 						continue;
 					}
 					$newItems = [];
@@ -1256,6 +1256,8 @@ class Wizard extends LDAPUtility {
 				if ($key === 'count') {
 					continue;
 				}
+				// $val comes from the raw ldap_get_attributes() result with unknown element types
+				/** @psalm-suppress UnrecognizedExpression */
 				if (!in_array($val, $known)) {
 					$known[] = $val;
 				}

--- a/apps/webhook_listeners/lib/Service/PHPMongoQuery.php
+++ b/apps/webhook_listeners/lib/Service/PHPMongoQuery.php
@@ -174,9 +174,13 @@ abstract class PHPMongoQuery {
 	 */
 	private static function _isEqual($v, $operatorValue): bool {
 		if (is_array($v) && is_array($operatorValue)) {
+			// deliberately Mongo-style loose array equality, see method docblock
+			/** @psalm-suppress UnrecognizedExpression */
 			return $v == $operatorValue;
 		}
 		if (is_array($v)) {
+			// deliberately Mongo-style loose membership check, see method docblock
+			/** @psalm-suppress UnrecognizedExpression */
 			return in_array($operatorValue, $v);
 		}
 		if (is_string($operatorValue) && preg_match('/^\/(.*?)\/([a-z]*)$/i', $operatorValue, $matches)) {
@@ -267,6 +271,8 @@ abstract class PHPMongoQuery {
 				if (is_array($v)) {
 					return count(array_intersect($v, $operatorValue)) > 0;
 				}
+				// $v and $operatorValue are Mongo-style query values of unknown type, loose match is intentional
+				/** @psalm-suppress UnrecognizedExpression */
 				return in_array($v, $operatorValue);
 			case '$lt':		return $exists && $v < $operatorValue;
 			case '$lte':	return $exists && $v <= $operatorValue;
@@ -286,6 +292,8 @@ abstract class PHPMongoQuery {
 				if (is_array($v)) {
 					return count(array_intersect($v, $operatorValue)) === 0;
 				}
+				// $v and $operatorValue are Mongo-style query values of unknown type, loose match is intentional
+				/** @psalm-suppress UnrecognizedExpression */
 				return !in_array($v, $operatorValue);
 			case '$exists':	return ($operatorValue && $exists) || (!$operatorValue && !$exists);
 			case '$mod':

--- a/apps/workflowengine/lib/Check/AbstractStringCheck.php
+++ b/apps/workflowengine/lib/Check/AbstractStringCheck.php
@@ -68,7 +68,7 @@ abstract class AbstractStringCheck implements ICheck {
 	 */
 	#[\Override]
 	public function validateCheck($operator, $value): void {
-		if (!in_array($operator, ['is', '!is', 'matches', '!matches'])) {
+		if (!in_array($operator, ['is', '!is', 'matches', '!matches'], true)) {
 			throw new \UnexpectedValueException($this->l->t('The given operator is invalid'), 1);
 		}
 

--- a/apps/workflowengine/lib/Check/AbstractStringCheck.php
+++ b/apps/workflowengine/lib/Check/AbstractStringCheck.php
@@ -72,7 +72,7 @@ abstract class AbstractStringCheck implements ICheck {
 			throw new \UnexpectedValueException($this->l->t('The given operator is invalid'), 1);
 		}
 
-		if (in_array($operator, ['matches', '!matches'])
+		if (in_array($operator, ['matches', '!matches'], true)
 			  && @preg_match($value, '') === false) {
 			throw new \UnexpectedValueException($this->l->t('The given regular expression is invalid'), 2);
 		}

--- a/apps/workflowengine/lib/Check/FileSize.php
+++ b/apps/workflowengine/lib/Check/FileSize.php
@@ -51,7 +51,7 @@ class FileSize implements ICheck {
 	 */
 	#[\Override]
 	public function validateCheck($operator, $value): void {
-		if (!in_array($operator, ['less', '!less', 'greater', '!greater'])) {
+		if (!in_array($operator, ['less', '!less', 'greater', '!greater'], true)) {
 			throw new \UnexpectedValueException($this->l->t('The given operator is invalid'), 1);
 		}
 

--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -48,7 +48,7 @@ class FileSystemTags implements ICheck, IFileCheck {
 	#[\Override]
 	public function executeCheck($operator, $value) {
 		$systemTags = $this->getSystemTags();
-		return ($operator === 'is') === in_array($value, $systemTags);
+		return ($operator === 'is') === in_array($value, $systemTags, true);
 	}
 
 	/**
@@ -58,7 +58,7 @@ class FileSystemTags implements ICheck, IFileCheck {
 	 */
 	#[\Override]
 	public function validateCheck($operator, $value) {
-		if (!in_array($operator, ['is', '!is'])) {
+		if (!in_array($operator, ['is', '!is'], true)) {
 			throw new \UnexpectedValueException($this->l->t('The given operator is invalid'), 1);
 		}
 

--- a/apps/workflowengine/lib/Check/RequestRemoteAddress.php
+++ b/apps/workflowengine/lib/Check/RequestRemoteAddress.php
@@ -60,7 +60,7 @@ class RequestRemoteAddress implements ICheck {
 	 */
 	#[\Override]
 	public function validateCheck($operator, $value) {
-		if (!in_array($operator, ['matchesIPv4', '!matchesIPv4', 'matchesIPv6', '!matchesIPv6'])) {
+		if (!in_array($operator, ['matchesIPv4', '!matchesIPv4', 'matchesIPv6', '!matchesIPv6'], true)) {
 			throw new \UnexpectedValueException($this->l->t('The given operator is invalid'), 1);
 		}
 

--- a/apps/workflowengine/lib/Check/RequestRemoteAddress.php
+++ b/apps/workflowengine/lib/Check/RequestRemoteAddress.php
@@ -69,7 +69,7 @@ class RequestRemoteAddress implements ICheck {
 			throw new \UnexpectedValueException($this->l->t('The given IP range is invalid'), 2);
 		}
 
-		if (in_array($operator, ['matchesIPv4', '!matchesIPv4'])) {
+		if (in_array($operator, ['matchesIPv4', '!matchesIPv4'], true)) {
 			if (!filter_var($decodedValue[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
 				throw new \UnexpectedValueException($this->l->t('The given IP range is not valid for IPv4'), 3);
 			}

--- a/apps/workflowengine/lib/Check/RequestTime.php
+++ b/apps/workflowengine/lib/Check/RequestTime.php
@@ -81,7 +81,7 @@ class RequestTime implements ICheck {
 	 */
 	#[\Override]
 	public function validateCheck($operator, $value) {
-		if (!in_array($operator, ['in', '!in'])) {
+		if (!in_array($operator, ['in', '!in'], true)) {
 			throw new \UnexpectedValueException($this->l->t('The given operator is invalid'), 1);
 		}
 

--- a/apps/workflowengine/lib/Check/RequestURL.php
+++ b/apps/workflowengine/lib/Check/RequestURL.php
@@ -39,7 +39,7 @@ class RequestURL extends AbstractStringCheck {
 		} else {
 			$actualValue = $this->getActualValue();
 		}
-		if (in_array($operator, ['is', '!is'])) {
+		if (in_array($operator, ['is', '!is'], true)) {
 			switch ($value) {
 				case 'webdav':
 					if ($operator === 'is') {

--- a/apps/workflowengine/lib/Check/UserGroupMembership.php
+++ b/apps/workflowengine/lib/Check/UserGroupMembership.php
@@ -45,7 +45,7 @@ class UserGroupMembership implements ICheck {
 
 		if ($user instanceof IUser) {
 			$groupIds = $this->getUserGroups($user);
-			return ($operator === 'is') === in_array($value, $groupIds);
+			return ($operator === 'is') === in_array($value, $groupIds, true);
 		} else {
 			return $operator !== 'is';
 		}
@@ -58,7 +58,7 @@ class UserGroupMembership implements ICheck {
 	 */
 	#[\Override]
 	public function validateCheck($operator, $value) {
-		if (!in_array($operator, ['is', '!is'])) {
+		if (!in_array($operator, ['is', '!is'], true)) {
 			throw new \UnexpectedValueException($this->l->t('The given operator is invalid'), 1);
 		}
 

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -613,7 +613,7 @@ class Manager implements IManager {
 	protected function validateEvents(string $entity, array $events, IOperation $operation): void {
 		/** @psalm-suppress TaintedCallable newInstance is not called */
 		$reflection = new \ReflectionClass($entity);
-		if ($entity !== IEntity::class && !in_array(IEntity::class, $reflection->getInterfaceNames())) {
+		if ($entity !== IEntity::class && !in_array(IEntity::class, $reflection->getInterfaceNames(), true)) {
 			throw new \UnexpectedValueException($this->l->t('Entity %s is invalid', [$entity]));
 		}
 
@@ -655,7 +655,7 @@ class Manager implements IManager {
 
 		/** @psalm-suppress TaintedCallable newInstance is not called */
 		$reflection = new \ReflectionClass($class);
-		if ($class !== IOperation::class && !in_array(IOperation::class, $reflection->getInterfaceNames())) {
+		if ($class !== IOperation::class && !in_array(IOperation::class, $reflection->getInterfaceNames(), true)) {
 			throw new \UnexpectedValueException($this->l->t('Operation %s is invalid', [$class]) . join(', ', $reflection->getInterfaceNames()));
 		}
 
@@ -688,7 +688,7 @@ class Manager implements IManager {
 			}
 
 			$reflection = new \ReflectionClass($check['class']);
-			if ($check['class'] !== ICheck::class && !in_array(ICheck::class, $reflection->getInterfaceNames())) {
+			if ($check['class'] !== ICheck::class && !in_array(ICheck::class, $reflection->getInterfaceNames(), true)) {
 				throw new \UnexpectedValueException($this->l->t('Check %s is invalid', [$class]));
 			}
 
@@ -700,7 +700,7 @@ class Manager implements IManager {
 			}
 
 			if (!empty($instance->supportedEntities())
-				&& !in_array($entity, $instance->supportedEntities())
+				&& !in_array($entity, $instance->supportedEntities(), true)
 			) {
 				throw new \UnexpectedValueException($this->l->t('Check %s is not allowed with this entity', [$class]));
 			}

--- a/apps/workflowengine/lib/Service/RuleMatcher.php
+++ b/apps/workflowengine/lib/Service/RuleMatcher.php
@@ -121,6 +121,8 @@ class RuleMatcher implements IRuleMatcher {
 			$additionalScopes = $this->manager->getAllConfiguredScopesForOperation($class)
 				+ $this->manager->getAllConfiguredScopesForRuntimeOperation($class);
 			foreach ($additionalScopes as $hash => $scopeCandidate) {
+				// $scopes and $scopeCandidate are freshly built ScopeContext instances, strict comparison would compare identity instead of value
+				/** @psalm-suppress UnrecognizedExpression */
 				if ($scopeCandidate->getScope() !== IManager::SCOPE_USER || in_array($scopeCandidate, $scopes)) {
 					continue;
 				}
@@ -151,6 +153,8 @@ class RuleMatcher implements IRuleMatcher {
 				$checks = $this->manager->getChecks($checkIds);
 			}
 
+			// $configuredEvents may come from json_decode() of stored data with unverified element types
+			/** @psalm-suppress UnrecognizedExpression */
 			if ($this->eventName !== null && !in_array($this->eventName, $configuredEvents)) {
 				continue;
 			}

--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -250,7 +250,7 @@ trait BasicStructure {
 	public function isExpectedUrl($possibleUrl, $finalPart) {
 		$baseUrlChopped = substr($this->baseUrl, 0, -4);
 		$endCharacter = strlen($baseUrlChopped) + strlen($finalPart);
-		return (substr($possibleUrl, 0, $endCharacter) == "$baseUrlChopped" . "$finalPart");
+		return (substr($possibleUrl, 0, $endCharacter) === "$baseUrlChopped" . "$finalPart");
 	}
 
 	/**

--- a/build/integration/features/bootstrap/FakeSMTPHelper.php
+++ b/build/integration/features/bootstrap/FakeSMTPHelper.php
@@ -91,7 +91,7 @@ class fakeSMTP {
 				$receivingData = false;
 				$this->reply('250 2.0.0 Ok: queued as ' . $this->generateRandom(10));
 				$splitmail = explode("\n\n", $this->mail['rawEmail'], 2);
-				if (count($splitmail) == 2) {
+				if (count($splitmail) === 2) {
 					$this->mail['emailHeaders'] = $splitmail[0];
 					$this->mail['emailBody'] = $splitmail[1];
 					$headers = preg_replace("/ \s+/", ' ', preg_replace("/\n\s/", ' ', $this->mail['emailHeaders']));

--- a/build/integration/features/bootstrap/FederationContext.php
+++ b/build/integration/features/bootstrap/FederationContext.php
@@ -63,7 +63,7 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	 * @param 'LOCAL'|'REMOTE' $shareeServer
 	 */
 	public function federateSharing(string $sharerUser, string $sharerServer, string $sharerPath, string $shareeUser, string $shareeServer): void {
-		if ($shareeServer == 'REMOTE') {
+		if ($shareeServer === 'REMOTE') {
 			$shareWith = "$shareeUser@" . substr($this->remoteBaseUrl, 0, -4);
 		} else {
 			$shareWith = "$shareeUser@" . substr($this->localBaseUrl, 0, -4);
@@ -80,7 +80,7 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	 * @param 'LOCAL'|'REMOTE' $shareeServer
 	 */
 	public function federateGroupSharing(string $sharerUser, string $sharerServer, string $sharerPath, string $shareeGroup, string $shareeServer): void {
-		if ($shareeServer == 'REMOTE') {
+		if ($shareeServer === 'REMOTE') {
 			$shareWith = "$shareeGroup@" . substr($this->remoteBaseUrl, 0, -4);
 		} else {
 			$shareWith = "$shareeGroup@" . substr($this->localBaseUrl, 0, -4);

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -378,7 +378,7 @@ trait Sharing {
 
 	public function isFieldInResponse($field, $contentExpected) {
 		$data = simplexml_load_string($this->response->getBody())->data[0];
-		if ((string)$field == 'expiration') {
+		if ((string)$field === 'expiration') {
 			if (!empty($contentExpected)) {
 				$contentExpected = date('Y-m-d', strtotime($contentExpected)) . ' 23:59:59';
 			}
@@ -387,7 +387,7 @@ trait Sharing {
 			foreach ($data as $element) {
 				if ($contentExpected == 'A_TOKEN') {
 					$tokenLength = strlen((string)$element->$field);
-					return $tokenLength == 15 || $tokenLength == 32;
+					return $tokenLength === 15 || $tokenLength === 32;
 				} elseif ($contentExpected == 'A_NUMBER') {
 					return is_numeric((string)$element->$field);
 				} elseif ($contentExpected == 'AN_URL') {
@@ -403,7 +403,7 @@ trait Sharing {
 		} else {
 			if ($contentExpected == 'A_TOKEN') {
 				$tokenLength = strlen((string)$data->$field);
-				return $tokenLength == 15 || $tokenLength == 32;
+				return $tokenLength === 15 || $tokenLength === 32;
 			} elseif ($contentExpected == 'A_NUMBER') {
 				return is_numeric((string)$data->$field);
 			} elseif ($contentExpected == 'AN_URL') {

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -1219,7 +1219,7 @@ trait WebDav {
 		array_shift($elementListKeys);
 		$davPrefix = '/' . $this->getDavFilesPath($user);
 		foreach ($elementListKeys as $element) {
-			if (substr($element, 0, strlen($davPrefix)) == $davPrefix) {
+			if (substr($element, 0, strlen($davPrefix)) === $davPrefix) {
 				$element = substr($element, strlen($davPrefix));
 			}
 			$this->userDeletesFile($user, 'element', $element);

--- a/build/psalm/InArrayStrictChecker.php
+++ b/build/psalm/InArrayStrictChecker.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+
+/**
+ * Complains about in_array() calls that do not explicitly set the $strict parameter
+ */
+class InArrayStrictChecker implements AfterExpressionAnalysisInterface {
+	public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool {
+		$stmt = $event->getExpr();
+		if (!$stmt instanceof FuncCall
+			|| !$stmt->name instanceof Name
+			|| strtolower($stmt->name->toString()) !== 'in_array') {
+			return null;
+		}
+
+		$hasStrictArg = false;
+		foreach ($stmt->getArgs() as $index => $arg) {
+			if ($arg->name !== null) {
+				if ($arg->name->toString() === 'strict') {
+					$hasStrictArg = true;
+					break;
+				}
+				continue;
+			}
+			if ($index === 2) {
+				$hasStrictArg = true;
+				break;
+			}
+		}
+
+		if (!$hasStrictArg) {
+			IssueBuffer::maybeAdd(
+				new \Psalm\Issue\UnrecognizedExpression(
+					'in_array() must be called with an explicit $strict parameter',
+					new CodeLocation($event->getStatementsSource()->getSource(), $stmt),
+				),
+				$event->getStatementsSource()->getSuppressedIssues(),
+			);
+		}
+
+		return null;
+	}
+}

--- a/build/psalm/UnstrictComparisonChecker.php
+++ b/build/psalm/UnstrictComparisonChecker.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\Node\VirtualNode;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+use Psalm\Type\Atomic\TNamedObject;
+
+class UnstrictComparisonChecker implements AfterExpressionAnalysisInterface {
+	/**
+	 * Classes that must be compared by value (==) since strict comparison (===)
+	 * would compare instance identity instead, which is almost never what is intended.
+	 */
+	private const VALUE_COMPARISON_CLASSES = [
+		\DateTimeInterface::class,
+		\DateTimeZone::class,
+	];
+
+	public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool {
+		$stmt = $event->getExpr();
+		if ($stmt instanceof VirtualNode) {
+			// Synthesized by Psalm itself (e.g. the implicit == of a switch/case), not written in the source
+			return null;
+		}
+		if (!$stmt instanceof PhpParser\Node\Expr\BinaryOp\Equal
+			&& !$stmt instanceof PhpParser\Node\Expr\BinaryOp\NotEqual) {
+			return null;
+		}
+
+		if (self::isValueComparisonType($event, $stmt->left) && self::isValueComparisonType($event, $stmt->right)) {
+			return null;
+		}
+
+		IssueBuffer::maybeAdd(
+			new \Psalm\Issue\UnrecognizedExpression(
+				'Non-strict comparison operators == and != are not allowed in the Nextcloud codebase, use === and !== instead',
+				new CodeLocation($event->getStatementsSource()->getSource(), $stmt),
+			),
+			$event->getStatementsSource()->getSuppressedIssues(),
+		);
+		return null;
+	}
+
+	private static function isValueComparisonType(AfterExpressionAnalysisEvent $event, PhpParser\Node\Expr $expr): bool {
+		$type = $event->getStatementsSource()->getNodeTypeProvider()->getType($expr);
+		$atomicTypes = $type?->getAtomicTypes() ?? [];
+		if ($atomicTypes === []) {
+			return false;
+		}
+
+		foreach ($atomicTypes as $atomic) {
+			if (!$atomic instanceof TNamedObject) {
+				return false;
+			}
+
+			$isAllowed = false;
+			foreach (self::VALUE_COMPARISON_CLASSES as $allowedClass) {
+				if (is_a($atomic->value, $allowedClass, true)) {
+					$isAllowed = true;
+					break;
+				}
+			}
+			if (!$isAllowed) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/build/rector.php
+++ b/build/rector.php
@@ -7,6 +7,9 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use Nextcloud\Rector\Rector\ReplaceInjectedMethodCallRector;
+use Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector;
+use Rector\CodingStyle\Rector\FuncCall\StrictInArrayRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 
 $nextcloudDir = dirname(__DIR__);
@@ -33,5 +36,10 @@ return (require 'rector-shared.php')
 	])
 	->withTypeCoverageLevel(0)
 	->withRules([
-		SafeDeclareStrictTypesRector::class
+		SafeDeclareStrictTypesRector::class,
+		StrictInArrayRector::class,
+		UseIdenticalOverEqualWithSameTypeRector::class,
+	])
+	->withSkip([
+		ReplaceInjectedMethodCallRector::class,
 	]);

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -134,7 +134,7 @@ class Base extends Command implements CompletionAwareInterface {
 		for ($i = 0; $iterator->valid(); $i++) {
 			$chunk[] = $iterator->current();
 			$iterator->next();
-			if (count($chunk) == $count) {
+			if (count($chunk) === $count) {
 				// Got a full chunk, yield and start a new one
 				yield $chunk;
 				$chunk = [];

--- a/core/Command/Config/System/DeleteConfig.php
+++ b/core/Command/Config/System/DeleteConfig.php
@@ -48,7 +48,7 @@ class DeleteConfig extends Base {
 		$configName = $configNames[0];
 
 		if (count($configNames) > 1) {
-			if ($input->hasParameterOption('--error-if-not-exists') && !in_array($configName, $this->systemConfig->getKeys())) {
+			if ($input->hasParameterOption('--error-if-not-exists') && !in_array($configName, $this->systemConfig->getKeys(), true)) {
 				$output->writeln('<error>System config ' . implode(' => ', $configNames) . ' could not be deleted because it did not exist</error>');
 				return 1;
 			}
@@ -66,7 +66,7 @@ class DeleteConfig extends Base {
 			$output->writeln('<info>System config value ' . implode(' => ', $configNames) . ' deleted</info>');
 			return 0;
 		} else {
-			if ($input->hasParameterOption('--error-if-not-exists') && !in_array($configName, $this->systemConfig->getKeys())) {
+			if ($input->hasParameterOption('--error-if-not-exists') && !in_array($configName, $this->systemConfig->getKeys(), true)) {
 				$output->writeln('<error>System config ' . $configName . ' could not be deleted because it did not exist</error>');
 				return 1;
 			}

--- a/core/Command/Config/System/GetConfig.php
+++ b/core/Command/Config/System/GetConfig.php
@@ -55,11 +55,11 @@ class GetConfig extends Base {
 		$configName = array_shift($configNames);
 		$defaultValue = $input->getOption('default-value');
 
-		if (!in_array($configName, $this->systemConfig->getKeys()) && !$input->hasParameterOption('--default-value')) {
+		if (!in_array($configName, $this->systemConfig->getKeys(), true) && !$input->hasParameterOption('--default-value')) {
 			return 1;
 		}
 
-		if (!in_array($configName, $this->systemConfig->getKeys())) {
+		if (!in_array($configName, $this->systemConfig->getKeys(), true)) {
 			$configValue = $defaultValue;
 		} else {
 			$configValue = $this->systemConfig->getValue($configName);

--- a/core/Command/Db/SchemaEncoder.php
+++ b/core/Command/Db/SchemaEncoder.php
@@ -69,7 +69,7 @@ class SchemaEncoder {
 			} elseif ($platform instanceof AbstractMySqlPlatform) {
 				if ($column->getType() instanceof PhpIntegerMappingType) {
 					$data['length'] = null;
-				} elseif (in_array($data['type'], ['text', 'blob', 'datetime', 'float', 'json'])) {
+				} elseif (in_array($data['type'], ['text', 'blob', 'datetime', 'float', 'json'], true)) {
 					$data['length'] = 0;
 				}
 				unset($data['collation']);

--- a/core/Command/Info/File.php
+++ b/core/Command/Info/File.php
@@ -101,7 +101,7 @@ class File extends Command {
 			$childSize = array_sum(array_map(function (Node $node) {
 				return $node->getSize();
 			}, $children));
-			if ($childSize != $node->getSize()) {
+			if ((float)$childSize !== (float)$node->getSize()) {
 				$output->writeln('    <error>warning: folder has a size of ' . Util::humanFileSize($node->getSize()) . " but it's children sum up to " . Util::humanFileSize($childSize) . '</error>.');
 				if (!$node->getStorage()->instanceOfStorage(ObjectStoreStorage::class)) {
 					$output->writeln('    Run <info>occ files:scan --path ' . $node->getPath() . '</info> to attempt to resolve this.');

--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -90,7 +90,7 @@ class FileUtils {
 	}
 
 	public function formatPermissions(string $type, int $permissions): string {
-		if ($permissions == Constants::PERMISSION_ALL || ($type === 'file' && $permissions == (Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE))) {
+		if ($permissions === Constants::PERMISSION_ALL || ($type === 'file' && $permissions === (Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE))) {
 			return 'full permissions';
 		}
 

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -119,7 +119,7 @@ class Install extends Command {
 	protected function validateInput(InputInterface $input, OutputInterface $output, $supportedDatabases) {
 		$db = strtolower($input->getOption('database'));
 
-		if (!in_array($db, $supportedDatabases)) {
+		if (!in_array($db, $supportedDatabases, true)) {
 			throw new InvalidArgumentException("Database <$db> is not supported. " . implode(', ', $supportedDatabases) . ' are supported.');
 		}
 

--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -57,7 +57,7 @@ class Generate extends Command {
 
 			return array_map('intval', $sizeParts);
 		}, $sizes);
-		if (in_array(null, $sizes)) {
+		if (in_array(null, $sizes, true)) {
 			return 1;
 		}
 

--- a/core/Command/TaskProcessing/ListCommand.php
+++ b/core/Command/TaskProcessing/ListCommand.php
@@ -85,7 +85,7 @@ class ListCommand extends Base {
 		$appId = $input->getOption('appId');
 		$customId = $input->getOption('customId');
 		$status = $input->getOption('status') !== null ? (int)$input->getOption('status') : null;
-		$scheduledAfter = $input->getOption('scheduledAfter') != null ? (int)$input->getOption('scheduledAfter') : null;
+		$scheduledAfter = $input->getOption('scheduledAfter') !== null ? (int)$input->getOption('scheduledAfter') : null;
 		$endedBefore = $input->getOption('endedBefore') !== null ? (int)$input->getOption('endedBefore') : null;
 
 		$tasks = $this->taskProcessingManager->getTasks($userIdFilter, $type, $appId, $customId, $status, $scheduledAfter, $endedBefore);

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -163,7 +163,7 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($output): void {
 				// Read per event, the overwrites are cleared during a major upgrade
 				$incompatibleOverwrites = $this->config->getSystemValue('app_install_overwrite', []);
-				if (!in_array($app, $incompatibleOverwrites)) {
+				if (!in_array($app, $incompatibleOverwrites, true)) {
 					$output->writeln('<comment>Disabled incompatible app: ' . $app . '</comment>');
 				}
 			});

--- a/core/Command/User/Keys/Verify.php
+++ b/core/Command/User/Keys/Verify.php
@@ -80,7 +80,7 @@ class Verify extends Command {
 		$output->writeln('Derived public key:');
 		$output->writeln($publicKeyDerived);
 
-		if ($publicKey != $publicKeyDerived) {
+		if ($publicKey !== $publicKeyDerived) {
 			if (!$input->getOption('update')) {
 				$output->writeln('<error>Stored public key does not match stored private key</error>');
 				return static::FAILURE;

--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -154,26 +154,28 @@ class Setting extends Base {
 					return 1;
 				}
 
-				if ($app === 'settings' && in_array($key, ['email', 'display_name'])) {
+				if ($app === 'settings' && in_array($key, ['email', 'display_name'], true)) {
 					$user = $this->userManager->get($uid);
 					if ($user instanceof IUser) {
 						if ($key === 'email') {
 							$email = $input->getArgument('value');
 							$user->setSystemEMailAddress(mb_strtolower(trim($email)));
-						} elseif ($key === 'display_name') {
-							if (!$user->setDisplayName($input->getArgument('value'))) {
-								if ($user->getDisplayName() === $input->getArgument('value')) {
-									$output->writeln('<error>New and old display name are the same</error>');
-								} elseif ($input->getArgument('value') === '') {
-									$output->writeln('<error>New display name can\'t be empty</error>');
-								} else {
-									$output->writeln('<error>Could not set display name</error>');
-								}
-								return 1;
-							}
+							return 0;
 						}
-						// setEmailAddress and setDisplayName both internally set the value
-						return 0;
+
+						// key === 'display_name'
+						if ($user->setDisplayName($input->getArgument('value'))) {
+							return 0;
+						}
+
+						if ($user->getDisplayName() === $input->getArgument('value')) {
+							$output->writeln('<error>New and old display name are the same</error>');
+						} elseif ($input->getArgument('value') === '') {
+							$output->writeln('<error>New display name can\'t be empty</error>');
+						} else {
+							$output->writeln('<error>Could not set display name</error>');
+						}
+						return 1;
 					}
 				}
 
@@ -185,14 +187,14 @@ class Setting extends Base {
 					return 1;
 				}
 
-				if ($app === 'settings' && in_array($key, ['email', 'display_name'])) {
+				if ($app === 'settings' && in_array($key, ['email', 'display_name'], true)) {
 					$user = $this->userManager->get($uid);
 					if ($user instanceof IUser) {
 						if ($key === 'email') {
 							$user->setEMailAddress('');
 							// setEmailAddress already deletes the value
 							return 0;
-						} elseif ($key === 'display_name') {
+						} else {
 							$output->writeln('<error>Display name can\'t be deleted.</error>');
 							return 1;
 						}

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -50,7 +50,7 @@ class SetupController {
 			return;
 		}
 
-		if (isset($post['install']) && $post['install'] == 'true') {
+		if (isset($post['install']) && $post['install'] === 'true') {
 			// We have to launch the installation process :
 			$e = $this->setupHelper->install($post);
 			$errors = ['errors' => $e];

--- a/core/Controller/TaskProcessingApiController.php
+++ b/core/Controller/TaskProcessingApiController.php
@@ -554,7 +554,7 @@ class TaskProcessingApiController extends OCSController {
 	 */
 	private function getFileContentsInternal(Task $task, int $fileId): StreamResponse|DataResponse {
 		$ids = $this->taskProcessingManager->extractFileIdsFromTask($task);
-		if (!in_array($fileId, $ids)) {
+		if (!in_array($fileId, $ids, true)) {
 			return new DataResponse(['message' => $this->l->t('Not found')], Http::STATUS_NOT_FOUND);
 		}
 		if ($task->getUserId() !== null) {

--- a/core/Controller/UpdateController.php
+++ b/core/Controller/UpdateController.php
@@ -129,7 +129,7 @@ class UpdateController extends OCSController {
 		$this->updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps): void {
 			// Read per event, the overwrites are cleared during a major upgrade
 			$incompatibleOverwrites = $this->config->getSystemValue('app_install_overwrite', []);
-			if (!in_array($app, $incompatibleOverwrites)) {
+			if (!in_array($app, $incompatibleOverwrites, true)) {
 				$incompatibleApps[] = $app;
 			}
 		});

--- a/core/Service/CronService.php
+++ b/core/Service/CronService.php
@@ -282,7 +282,7 @@ class CronService {
 		} else {
 			// Work and success :-)
 			$job = $this->jobList->getNext();
-			if ($job != null) {
+			if ($job !== null) {
 				$this->logger->debug('WebCron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);
 				$job->start($this->jobList);
 				$this->jobList->setLastJob($job);

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -39,7 +39,7 @@ p($theme->getTitle());
 		<?php } ?>
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
-		<meta name="apple-mobile-web-app-title" content="<?php p((!empty($_['application']) && $_['appid'] != 'files')? $_['application']:$theme->getTitle()); ?>">
+		<meta name="apple-mobile-web-app-title" content="<?php p((!empty($_['application']) && $_['appid'] !== 'files')? $_['application']:$theme->getTitle()); ?>">
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="theme-color" content="<?php p($theme->getColorPrimary()); ?>">
 		<link rel="icon" href="<?php print_unescaped(image_path($_['appid'], 'favicon.ico')); /* IE11+ supports png */ ?>">
@@ -84,7 +84,7 @@ p($theme->getTitle());
 
 		<div id="content" class="app-<?php p($_['appid']) ?>">
 			<h1 class="hidden-visually" id="page-heading-level-1">
-				<?php p((!empty($_['application']) && !empty($_['pageTitle']) && $_['application'] != $_['pageTitle'])
+				<?php p((!empty($_['application']) && !empty($_['pageTitle']) && $_['application'] !== $_['pageTitle'])
 					? $_['application'] . ': ' . $_['pageTitle']
 					: (!empty($_['pageTitle']) ? $_['pageTitle'] : $theme->getName())
 				); ?>

--- a/lib/OC.php
+++ b/lib/OC.php
@@ -133,7 +133,7 @@ class OC {
 			new \OC\AllConfig(new \OC\SystemConfig(self::$config))
 		);
 		$scriptName = $fakeRequest->getScriptName();
-		if (substr($scriptName, -1) == '/') {
+		if (substr($scriptName, -1) === '/') {
 			$scriptName .= 'index.php';
 			//make sure suburi follows the same rules as scriptName
 			if (substr(OC::$SUBURI, -9) !== 'index.php') {
@@ -363,7 +363,7 @@ class OC {
 			if ($appManager->isShipped($appInfo['id'])) {
 				$incompatibleShippedApps[] = $appInfo['name'] . ' (' . $appInfo['id'] . ')';
 			}
-			if (!in_array($appInfo['id'], $incompatibleOverwrites)) {
+			if (!in_array($appInfo['id'], $incompatibleOverwrites, true)) {
 				$incompatibleDisabledApps[] = $appInfo;
 			}
 		}
@@ -682,7 +682,7 @@ class OC {
 		// register autoloader
 		self::$loaderStart = microtime(true);
 
-		self::$CLI = (php_sapi_name() == 'cli');
+		self::$CLI = (php_sapi_name() === 'cli');
 
 		// Add default composer PSR-4 autoloader, ensure apcu to be disabled
 		self::$composerAutoloader = require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
@@ -790,7 +790,7 @@ class OC {
 			logger('core')->error('Failed to start profiler: ' . $e->getMessage(), ['app' => 'base']);
 		}
 
-		if (self::$CLI && in_array('--' . \OCP\Console\ReservedOptions::DEBUG_LOG, $_SERVER['argv'])) {
+		if (self::$CLI && in_array('--' . \OCP\Console\ReservedOptions::DEBUG_LOG, $_SERVER['argv'], true)) {
 			\OC\Core\Listener\BeforeMessageLoggedEventListener::setup();
 		}
 
@@ -1260,7 +1260,7 @@ class OC {
 		// This prevents browsers from redirecting to the default page and then
 		// attempting to parse HTML as CSS and similar.
 		$destinationHeader = $request->getHeader('Sec-Fetch-Dest');
-		if (in_array($destinationHeader, ['font', 'script', 'style'])) {
+		if (in_array($destinationHeader, ['font', 'script', 'style'], true)) {
 			http_response_code(404);
 			return;
 		}

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -121,7 +121,7 @@ class AccountManager implements IAccountManager {
 
 		if (
 			$property->getScope() === self::SCOPE_PRIVATE
-			&& in_array($property->getName(), [self::PROPERTY_DISPLAYNAME, self::PROPERTY_EMAIL])
+			&& in_array($property->getName(), [self::PROPERTY_DISPLAYNAME, self::PROPERTY_EMAIL], true)
 		) {
 			if ($throwOnData) {
 				// v2-private is not available for these fields

--- a/lib/private/Accounts/AccountProperty.php
+++ b/lib/private/Accounts/AccountProperty.php
@@ -65,7 +65,7 @@ class AccountProperty implements IAccountProperty {
 			IAccountManager::SCOPE_FEDERATED,
 			IAccountManager::SCOPE_PRIVATE,
 			IAccountManager::SCOPE_PUBLISHED
-		])) {
+		], true)) {
 			throw new InvalidArgumentException('Invalid scope');
 		}
 		$this->scope = $newScope;
@@ -153,7 +153,7 @@ class AccountProperty implements IAccountProperty {
 			IAccountManager::NOT_VERIFIED,
 			IAccountManager::VERIFICATION_IN_PROGRESS,
 			IAccountManager::VERIFIED,
-		])) {
+		], true)) {
 			throw new InvalidArgumentException('Provided verification value is invalid');
 		}
 		$this->locallyVerified = $verified;

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -417,7 +417,7 @@ class AppManager implements IAppManager {
 				return false;
 			}
 
-			return in_array($group->getGID(), $groupIds);
+			return in_array($group->getGID(), $groupIds, true);
 		}
 	}
 
@@ -1007,7 +1007,7 @@ class AppManager implements IAppManager {
 	 */
 	#[\Override]
 	public function isDefaultEnabled(string $appId): bool {
-		return (in_array($appId, $this->getDefaultEnabledApps()));
+		return (in_array($appId, $this->getDefaultEnabledApps(), true));
 	}
 
 	/**

--- a/lib/private/App/AppStore/Bundles/HubBundle.php
+++ b/lib/private/App/AppStore/Bundles/HubBundle.php
@@ -25,7 +25,7 @@ class HubBundle extends Bundle {
 		];
 
 		$architecture = function_exists('php_uname') ? php_uname('m') : null;
-		if (isset($architecture) && PHP_OS_FAMILY === 'Linux' && in_array($architecture, ['x86_64', 'aarch64'])) {
+		if (isset($architecture) && PHP_OS_FAMILY === 'Linux' && in_array($architecture, ['x86_64', 'aarch64'], true)) {
 			$hubApps[] = 'richdocuments';
 			$hubApps[] = 'richdocumentscode' . ($architecture === 'aarch64' ? '_arm64' : '');
 		}

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -165,7 +165,7 @@ class AppFetcher extends Fetcher {
 		// If the admin specified a allow list, filter apps from the appstore
 		if (is_array($allowList) && $this->registry->delegateHasValidSubscription()) {
 			return array_values(array_filter($apps, function (array $app) use ($allowList) {
-				return in_array($app['id'], $allowList);
+				return in_array($app['id'], $allowList, true);
 			}));
 		}
 

--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -179,7 +179,7 @@ class DependencyAnalyzer {
 			return $this->getValue($db);
 		}, $supportedDatabases);
 		$currentDatabase = $this->platform->getDatabase();
-		if (!in_array($currentDatabase, $supportedDatabases)) {
+		if (!in_array($currentDatabase, $supportedDatabases, true)) {
 			$missing[] = $this->getL()->t('The following databases are supported: %s', [implode(', ', $supportedDatabases)]);
 		}
 		return $missing;
@@ -279,6 +279,8 @@ class DependencyAnalyzer {
 			$oss = [$oss];
 		}
 		$currentOS = $this->platform->getOS();
+		// $oss may contain raw, unnormalized entries (e.g. with @attributes) when a single <os> was given without going through getValue()
+		/** @psalm-suppress UnrecognizedExpression */
 		if (!in_array($currentOS, $oss)) {
 			$missing[] = $this->getL()->t('The following platforms are supported: %s', [implode(', ', $oss)]);
 		}

--- a/lib/private/App/PlatformRepository.php
+++ b/lib/private/App/PlatformRepository.php
@@ -29,7 +29,7 @@ class PlatformRepository {
 
 		// Extensions scanning
 		foreach ($loadedExtensions as $name) {
-			if (in_array($name, ['standard', 'Core'])) {
+			if (in_array($name, ['standard', 'Core'], true)) {
 				continue;
 			}
 

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -461,7 +461,7 @@ class AppConfig implements IAppConfig {
 		$value = $this->getTypedValue($app, $key, $default ? 'true' : 'false', $lazy, self::VALUE_BOOL) ?? ($default ? 'true' : 'false');
 		/** @psalm-suppress RedundantCast */
 		$b = strtolower((string)$value);
-		return in_array($b, ['1', 'true', 'yes', 'on']);
+		return in_array($b, ['1', 'true', 'yes', 'on'], true);
 	}
 
 	/**
@@ -1587,7 +1587,7 @@ class AppConfig implements IAppConfig {
 			case self::VALUE_FLOAT:
 				return (float)$value;
 			case self::VALUE_BOOL:
-				return in_array(strtolower($value), ['1', 'true', 'yes', 'on']);
+				return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
 			case self::VALUE_ARRAY:
 				try {
 					return json_decode($value, true, flags: JSON_THROW_ON_ERROR);
@@ -1769,7 +1769,8 @@ class AppConfig implements IAppConfig {
 				'enabled',
 				'installed_version',
 				'types',
-			])) {
+			],
+			true)) {
 			return true; // we don't break stuff for this list of config keys.
 		}
 		$configDetails = $this->getConfigDetailsFromLexicon($app);

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -988,7 +988,7 @@ class AppConfig implements IAppConfig {
 		$this->isLazy($app, $key); // confirm key exists
 
 		// type can only be one type
-		if (!in_array($type, [self::VALUE_MIXED, self::VALUE_STRING, self::VALUE_INT, self::VALUE_FLOAT, self::VALUE_BOOL, self::VALUE_ARRAY])) {
+		if (!in_array($type, [self::VALUE_MIXED, self::VALUE_STRING, self::VALUE_INT, self::VALUE_FLOAT, self::VALUE_BOOL, self::VALUE_ARRAY], true)) {
 			throw new AppConfigIncorrectTypeException('Unknown value type');
 		}
 
@@ -1365,7 +1365,7 @@ class AppConfig implements IAppConfig {
 		}
 		if ($valueType > -1) {
 			$valueType &= ~self::VALUE_SENSITIVE;
-			if (!in_array($valueType, [self::VALUE_MIXED, self::VALUE_STRING, self::VALUE_INT, self::VALUE_FLOAT, self::VALUE_BOOL, self::VALUE_ARRAY])) {
+			if (!in_array($valueType, [self::VALUE_MIXED, self::VALUE_STRING, self::VALUE_INT, self::VALUE_FLOAT, self::VALUE_BOOL, self::VALUE_ARRAY], true)) {
 				throw new InvalidArgumentException('Unknown value type');
 			}
 		}

--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -258,7 +258,7 @@ class TAR extends Archive {
 	#[\Override]
 	public function fileExists(string $path): bool {
 		$files = $this->getFiles();
-		if ((in_array($path, $files)) || (in_array($path . '/', $files))) {
+		if ((in_array($path, $files, true)) || (in_array($path . '/', $files, true))) {
 			return true;
 		} else {
 			$folderPath = rtrim($path, '/') . '/';

--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -175,7 +175,7 @@ class TAR extends Archive {
 				if ($pos = strpos($result, '/')) {
 					$result = substr($result, 0, $pos + 1);
 				}
-				if (!in_array($result, $folderContent)) {
+				if (!in_array($result, $folderContent, true)) {
 					$folderContent[] = $result;
 				}
 			}

--- a/lib/private/Authentication/Login/SetUserTimezoneCommand.php
+++ b/lib/private/Authentication/Login/SetUserTimezoneCommand.php
@@ -39,6 +39,6 @@ class SetUserTimezoneCommand extends ALoginCommand {
 
 	private function isValidTimezone(?string $value): bool {
 		// Older browsers still report deprecated aliases like Europe/Kiev.
-		return $value && in_array($value, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC));
+		return $value && in_array($value, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC), true);
 	}
 }

--- a/lib/private/Collaboration/Collaborators/GroupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/GroupPlugin.php
@@ -80,7 +80,7 @@ class GroupPlugin implements ISearchPlugin {
 
 			// FIXME: use a more efficient approach
 			$gid = $group->getGID();
-			if (!in_array($gid, $groupIds)) {
+			if (!in_array($gid, $groupIds, true)) {
 				continue;
 			}
 			if (strtolower($gid) === $lowerSearch || strtolower($group->getDisplayName()) === $lowerSearch) {
@@ -109,7 +109,7 @@ class GroupPlugin implements ISearchPlugin {
 			// On page one we try if the search result has a direct hit on the
 			// user id and if so, we add that to the exact match list
 			$group = $this->groupManager->get($search);
-			if ($group instanceof IGroup && !$group->hideFromCollaboration() && (!$this->shareWithGroupOnly || in_array($group->getGID(), $userGroups))) {
+			if ($group instanceof IGroup && !$group->hideFromCollaboration() && (!$this->shareWithGroupOnly || in_array($group->getGID(), $userGroups, true))) {
 				$result['exact'][] = [
 					'label' => $group->getDisplayName(),
 					'value' => [

--- a/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php
@@ -24,7 +24,7 @@ class RemoteGroupPlugin implements ISearchPlugin {
 		try {
 			$fileSharingProvider = $cloudFederationProviderManager->getCloudFederationProvider('file');
 			$supportedShareTypes = $fileSharingProvider->getSupportedShareTypes();
-			if (in_array('group', $supportedShareTypes)) {
+			if (in_array('group', $supportedShareTypes, true)) {
 				$this->enabled = true;
 			}
 		} catch (\Exception $e) {

--- a/lib/private/Config/ConfigManager.php
+++ b/lib/private/Config/ConfigManager.php
@@ -242,7 +242,8 @@ class ConfigManager {
 	}
 
 	public function convertToInt(string $value): int {
-		if (!is_numeric($value) || (float)$value <> (int)$value) {
+		// checks the numeric string has no fractional part
+		if (!is_numeric($value) || (float)$value !== (float)(int)$value) {
 			throw new TypeConflictException('Value is not an integer');
 		}
 

--- a/lib/private/Config/ConfigManager.php
+++ b/lib/private/Config/ConfigManager.php
@@ -258,9 +258,9 @@ class ConfigManager {
 	}
 
 	public function convertToBool(string $value, ?Entry $entry = null): bool {
-		if (in_array(strtolower($value), ['true', '1', 'on', 'yes'])) {
+		if (in_array(strtolower($value), ['true', '1', 'on', 'yes'], true)) {
 			$valueBool = true;
-		} elseif (in_array(strtolower($value), ['false', '0', 'off', 'no'])) {
+		} elseif (in_array(strtolower($value), ['false', '0', 'off', 'no'], true)) {
 			$valueBool = false;
 		} else {
 			throw new TypeConflictException('Value cannot be converted to boolean');

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -724,7 +724,7 @@ class UserConfig implements IUserConfig {
 		$value = $this->getTypedValue($userId, $app, $key, $default ? 'true' : 'false', $lazy, ValueType::BOOL) ?? ($default ? 'true' : 'false');
 		/** @psalm-suppress RedundantCast */
 		$b = strtolower((string)$value);
-		return in_array($b, ['1', 'true', 'yes', 'on']);
+		return in_array($b, ['1', 'true', 'yes', 'on'], true);
 	}
 
 	/**
@@ -1931,7 +1931,7 @@ class UserConfig implements IUserConfig {
 			case ValueType::FLOAT:
 				return (float)$value;
 			case ValueType::BOOL:
-				return in_array(strtolower($value), ['1', 'true', 'yes', 'on']);
+				return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
 			case ValueType::ARRAY:
 				try {
 					return json_decode($value, true, flags: JSON_THROW_ON_ERROR);

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -282,7 +282,7 @@ class ContactsStore implements IContactsStore {
 
 		foreach ($contacts as $contact) {
 			if ($shareType === 4 && isset($contact['EMAIL'])) {
-				if (in_array($shareWith, $contact['EMAIL'])) {
+				if (in_array($shareWith, $contact['EMAIL'], true)) {
 					$match = $contact;
 					break;
 				}

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -609,7 +609,7 @@ class Connection extends PrimaryReadReplicaConnection {
 			if (!in_array($e->getReason(), [
 				\OCP\DB\Exception::REASON_CONSTRAINT_VIOLATION,
 				\OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION,
-			])
+			], true)
 			) {
 				throw $e;
 			}

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -274,7 +274,7 @@ class MigrationService {
 	 * @return bool
 	 */
 	private function shallBeExecuted($m, $knownMigrations): bool {
-		if (in_array($m, $knownMigrations)) {
+		if (in_array($m, $knownMigrations, true)) {
 			return false;
 		}
 

--- a/lib/private/DB/QueryBuilder/Partitioned/PartitionSplit.php
+++ b/lib/private/DB/QueryBuilder/Partitioned/PartitionSplit.php
@@ -37,7 +37,7 @@ class PartitionSplit {
 	}
 
 	public function containsTable(string $table): bool {
-		return in_array($table, $this->tables);
+		return in_array($table, $this->tables, true);
 	}
 
 	public function containsAlias(string $alias): bool {

--- a/lib/private/DB/QueryBuilder/Sharded/ShardDefinition.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardDefinition.php
@@ -53,7 +53,7 @@ class ShardDefinition {
 		if ($this->table === $table) {
 			return true;
 		}
-		return in_array($table, $this->companionTables);
+		return in_array($table, $this->companionTables, true);
 	}
 
 	public function getShardForKey(int $key): int {
@@ -75,6 +75,6 @@ class ShardDefinition {
 	}
 
 	public function isKey(string $column): bool {
-		return $column === $this->primaryKey || in_array($column, $this->companionKeys);
+		return $column === $this->primaryKey || in_array($column, $this->companionKeys, true);
 	}
 }

--- a/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
@@ -55,7 +55,7 @@ class ShardQueryRunner {
 	private function getLikelyShards(array $primaryKeys): array {
 		$shards = [];
 		foreach ($primaryKeys as $primaryKey) {
-			if ($primaryKey < $this->shardDefinition->fromFileId && !in_array(ShardDefinition::MIGRATION_SHARD, $shards)) {
+			if ($primaryKey < $this->shardDefinition->fromFileId && !in_array(ShardDefinition::MIGRATION_SHARD, $shards, true)) {
 				$shards[] = ShardDefinition::MIGRATION_SHARD;
 			}
 			$encodedShard = $primaryKey & ShardDefinition::PRIMARY_KEY_SHARD_MASK;

--- a/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
@@ -59,7 +59,7 @@ class ShardQueryRunner {
 				$shards[] = ShardDefinition::MIGRATION_SHARD;
 			}
 			$encodedShard = $primaryKey & ShardDefinition::PRIMARY_KEY_SHARD_MASK;
-			if ($encodedShard < count($this->shardDefinition->shards) && !in_array($encodedShard, $shards)) {
+			if ($encodedShard < count($this->shardDefinition->shards) && !in_array($encodedShard, $shards, true)) {
 				$shards[] = $encodedShard;
 			}
 		}

--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -141,33 +141,33 @@ class DateTimeFormatter implements IDateTimeFormatter {
 		$baseTimestamp->setTime(0, 0, 0);
 		$dateInterval = $timestamp->diff($baseTimestamp);
 
-		if ($dateInterval->y == 0 && $dateInterval->m == 0 && $dateInterval->d == 0) {
+		if ($dateInterval->y === 0 && $dateInterval->m === 0 && $dateInterval->d === 0) {
 			return $l->t('today');
-		} elseif ($dateInterval->y == 0 && $dateInterval->m == 0 && $dateInterval->d == 1) {
+		} elseif ($dateInterval->y === 0 && $dateInterval->m === 0 && $dateInterval->d === 1) {
 			if ($timestamp > $baseTimestamp) {
 				return $l->t('tomorrow');
 			} else {
 				return $l->t('yesterday');
 			}
-		} elseif ($dateInterval->y == 0 && $dateInterval->m == 0) {
+		} elseif ($dateInterval->y === 0 && $dateInterval->m === 0) {
 			if ($timestamp > $baseTimestamp) {
 				return $l->n('in %n day', 'in %n days', $dateInterval->d);
 			} else {
 				return $l->n('%n day ago', '%n days ago', $dateInterval->d);
 			}
-		} elseif ($dateInterval->y == 0 && $dateInterval->m == 1) {
+		} elseif ($dateInterval->y === 0 && $dateInterval->m === 1) {
 			if ($timestamp > $baseTimestamp) {
 				return $l->t('next month');
 			} else {
 				return $l->t('last month');
 			}
-		} elseif ($dateInterval->y == 0) {
+		} elseif ($dateInterval->y === 0) {
 			if ($timestamp > $baseTimestamp) {
 				return $l->n('in %n month', 'in %n months', $dateInterval->m);
 			} else {
 				return $l->n('%n month ago', '%n months ago', $dateInterval->m);
 			}
-		} elseif ($dateInterval->y == 1) {
+		} elseif ($dateInterval->y === 1) {
 			if ($timestamp > $baseTimestamp) {
 				return $l->t('next year');
 			} else {

--- a/lib/private/DateTimeZone.php
+++ b/lib/private/DateTimeZone.php
@@ -87,6 +87,8 @@ class DateTimeZone implements IDateTimeZone {
 				}
 
 				$dtOffset = $dtz->getOffset($dateTime);
+				// $dtOffset is int|false and $offset is untyped/mixed; loose comparison intentional
+				/** @psalm-suppress UnrecognizedExpression */
 				if ($dtOffset == 3600 * $offset) {
 					return $dtz;
 				}

--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -157,7 +157,7 @@ class Manager implements IManager {
 
 	private function findEditorForFile(File $file) {
 		foreach ($this->editors as $editor) {
-			if (in_array($file->getMimeType(), $editor->getMimetypes())) {
+			if (in_array($file->getMimeType(), $editor->getMimetypes(), true)) {
 				return $editor->getId();
 			}
 		}

--- a/lib/private/Encryption/File.php
+++ b/lib/private/Encryption/File.php
@@ -95,7 +95,7 @@ class File implements IFile {
 			$storageService = Server::get(GlobalStoragesService::class);
 			$storages = $storageService->getAllStorages();
 			foreach ($storages as $storage) {
-				if ($storage->getMountPoint() == substr($ownerPath, 0, strlen($storage->getMountPoint()))) {
+				if ($storage->getMountPoint() === substr($ownerPath, 0, strlen($storage->getMountPoint()))) {
 					$mountedFor = $this->util->getUserWithAccessToMountPoint($storage->getApplicableUsers(), $storage->getApplicableGroups());
 					$userIds = array_merge($userIds, $mountedFor);
 				}

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -96,6 +96,8 @@ class Util {
 	public function createHeader(array $headerData, IEncryptionModule $encryptionModule) {
 		$header = self::HEADER_START . ':' . self::HEADER_ENCRYPTION_MODULE_KEY . ':' . $encryptionModule->getId() . ':';
 		foreach ($headerData as $key => $value) {
+			// $headerData comes from the pluggable IEncryptionModule::begin() contract with untyped array keys
+			/** @psalm-suppress UnrecognizedExpression */
 			if (in_array($key, $this->ocHeaderKeys)) {
 				throw new EncryptionHeaderKeyExistsException($key);
 			}
@@ -277,13 +279,13 @@ class Util {
 			}
 
 			//detect system wide folders
-			if (in_array($root[1], $this->excludedPaths)) {
+			if (in_array($root[1], $this->excludedPaths, true)) {
 				return true;
 			}
 
 			// detect user specific folders
 			if ($this->userManager->userExists($root[1])
-				&& in_array($root[2] ?? '', $this->excludedPaths)) {
+				&& in_array($root[2] ?? '', $this->excludedPaths, true)) {
 				return true;
 			}
 		}

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -489,7 +489,7 @@ class Cache implements ICache {
 		$params = [];
 		$extensionParams = [];
 		foreach ($data as $name => $value) {
-			if (in_array($name, $fields)) {
+			if (in_array($name, $fields, true)) {
 				if ($name === 'path') {
 					$params['path_hash'] = md5($value);
 				} elseif ($name === 'mimetype') {
@@ -509,7 +509,7 @@ class Cache implements ICache {
 				}
 				$params[$name] = $value;
 			}
-			if (in_array($name, $extensionFields)) {
+			if (in_array($name, $extensionFields, true)) {
 				$extensionParams[$name] = $value;
 			}
 		}

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -130,7 +130,8 @@ class Cache implements ICache {
 		$query->selectFileCache();
 		$metadataQuery = $query->selectMetadata();
 
-		if (is_string($file) || $file == '') {
+		// a file id of 0 is treated the same as an empty path
+		if (is_string($file) || $file === 0) {
 			// normalize file
 			$file = $this->normalize($file);
 
@@ -603,7 +604,7 @@ class Cache implements ICache {
 				->hintShardKey('storage', $this->getNumericStorageId());
 			$query->executeStatement();
 
-			if ($entry->getMimeType() == FileInfo::MIMETYPE_FOLDER) {
+			if ($entry->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
 				$this->removeChildren($entry);
 			}
 
@@ -655,7 +656,7 @@ class Cache implements ICache {
 			/** @var ICacheEntry[] $childFolders */
 			$childFolders = [];
 			foreach ($children as $child) {
-				if ($child->getMimeType() == FileInfo::MIMETYPE_FOLDER) {
+				if ($child->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
 					$childFolders[] = $child;
 				}
 			}

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -152,20 +152,20 @@ class QuerySearchHelper {
 			$searchQuery->getSelectFields(),
 		);
 
-		$joinExtendedCache = in_array('metadata_etag', $requestedFields)
-			|| in_array('creation_time', $requestedFields)
-			|| in_array('upload_time', $requestedFields)
-			|| in_array('last_activity', $requestedFields);
+		$joinExtendedCache = in_array('metadata_etag', $requestedFields, true)
+			|| in_array('creation_time', $requestedFields, true)
+			|| in_array('upload_time', $requestedFields, true)
+			|| in_array('last_activity', $requestedFields, true);
 
 		$query = $builder->selectFileCache('file', $joinExtendedCache);
 
-		if (in_array('systemtag', $requestedFields)) {
+		if (in_array('systemtag', $requestedFields, true)) {
 			$this->equipQueryForSystemTags($query, $this->requireUser($searchQuery));
 		}
-		if (in_array('tagname', $requestedFields) || in_array('favorite', $requestedFields)) {
+		if (in_array('tagname', $requestedFields, true) || in_array('favorite', $requestedFields, true)) {
 			$this->equipQueryForDavTags($query, $this->requireUser($searchQuery));
 		}
-		if (in_array('owner', $requestedFields) || in_array('share_with', $requestedFields) || in_array('share_type', $requestedFields)) {
+		if (in_array('owner', $requestedFields, true) || in_array('share_with', $requestedFields, true) || in_array('share_type', $requestedFields, true)) {
 			$this->equipQueryForShares($query);
 		}
 

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -278,7 +278,7 @@ class SearchBuilder {
 				throw new \InvalidArgumentException('Invalid type for field ' . $operator->getField());
 			}
 		}
-		if (!in_array($operator->getType(), $comparisons[$operator->getField()])) {
+		if (!in_array($operator->getType(), $comparisons[$operator->getField()], true)) {
 			throw new \InvalidArgumentException('Unsupported comparison for field  ' . $operator->getField() . ': ' . $operator->getType());
 		}
 	}

--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -144,7 +144,7 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 	public function getUserMountsForProviderClasses(IUser $user, array $mountProviderClasses): array {
 		$providers = array_filter(
 			$this->providers,
-			fn (string $providerClass) => in_array($providerClass, $mountProviderClasses),
+			fn (string $providerClass) => in_array($providerClass, $mountProviderClasses, true),
 			ARRAY_FILTER_USE_KEY
 		);
 		return $this->getUserMountsForProviders($user, array_values($providers));

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -85,7 +85,7 @@ class UserMountCache implements IUserMountCache {
 				if ($mountInfo->getMountProvider() === '' && isset($newMounts[$mountInfo->getKey()])) {
 					return true;
 				}
-				return in_array($mountInfo->getMountProvider(), $mountProviderClasses);
+				return in_array($mountInfo->getMountProvider(), $mountProviderClasses, true);
 			});
 		}
 

--- a/lib/private/Files/Conversion/ConversionManager.php
+++ b/lib/private/Files/Conversion/ConversionManager.php
@@ -128,7 +128,7 @@ class ConversionManager implements IConversionManager {
 			$appId = $providerRegistration->getAppId();
 
 			try {
-				if (in_array($appId, $this->preferredApps)) {
+				if (in_array($appId, $this->preferredApps, true)) {
 					$this->preferredProviders[$class] = $this->serverContainer->get($class);
 					continue;
 				}

--- a/lib/private/Files/FilenameValidator.php
+++ b/lib/private/Files/FilenameValidator.php
@@ -224,7 +224,7 @@ class FilenameValidator implements IFilenameValidator {
 
 		// Check for forbidden filenames
 		$forbiddenNames = $this->getForbiddenFilenames();
-		if (in_array($filename, $forbiddenNames)) {
+		if (in_array($filename, $forbiddenNames, true)) {
 			return true;
 		}
 
@@ -254,7 +254,7 @@ class FilenameValidator implements IFilenameValidator {
 		$basename = strlen($name) > 1
 			? substr($name, 0, strpos($name, '.', 1) ?: null)
 			: $name;
-		if (in_array(mb_strtolower($basename), $this->getForbiddenBasenames())) {
+		if (in_array(mb_strtolower($basename), $this->getForbiddenBasenames(), true)) {
 			$name = str_replace($basename, $this->l10n->t('%1$s (renamed)', [$basename]), $name);
 		}
 
@@ -262,7 +262,7 @@ class FilenameValidator implements IFilenameValidator {
 			$name = $this->l10n->t('renamed file');
 		}
 
-		if (in_array(mb_strtolower($name), $this->getForbiddenFilenames())) {
+		if (in_array(mb_strtolower($name), $this->getForbiddenFilenames(), true)) {
 			$name = $this->l10n->t('%1$s (renamed)', [$name]);
 		}
 
@@ -280,7 +280,7 @@ class FilenameValidator implements IFilenameValidator {
 		// (except if the dot is the first character as this is then part of the basename "hidden files")
 		$basename = substr($filename, 0, strpos($filename, '.', 1) ?: null);
 		$forbiddenNames = $this->getForbiddenBasenames();
-		if (in_array($basename, $forbiddenNames)) {
+		if (in_array($basename, $forbiddenNames, true)) {
 			throw new ReservedWordException($this->l10n->t('"%1$s" is a forbidden prefix for file or folder names.', [$filename]));
 		}
 	}

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -249,7 +249,7 @@ class Manager implements IMountManager {
 	 */
 	public function getMountsByMountProvider(string $path, array $mountProviders): array {
 		$this->getSetupManager()->setupForProvider($path, $mountProviders);
-		if (\in_array('', $mountProviders)) {
+		if (\in_array('', $mountProviders, true)) {
 			return $this->mounts;
 		}
 

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -435,7 +435,7 @@ class Root extends Folder implements IRootFolder, Emitter {
 		$mountRoots = array_combine($mountRootIds, $mountRootPaths);
 
 		$mounts = $this->mountManager->getMountsByMountProvider($path, $mountProviders);
-		$mountsContainingFile = array_filter($mounts, fn (IMountPoint $mount) => in_array($mount->getMountPoint(), $mountPoints));
+		$mountsContainingFile = array_filter($mounts, fn (IMountPoint $mount) => in_array($mount->getMountPoint(), $mountPoints, true));
 
 		// if we haven't found a relevant mount that is setup, but we do have relevant mount infos
 		// we try to load them from the mount info.

--- a/lib/private/Files/ObjectStore/PrimaryObjectStoreConfig.php
+++ b/lib/private/Files/ObjectStore/PrimaryObjectStoreConfig.php
@@ -150,7 +150,7 @@ class PrimaryObjectStoreConfig {
 		foreach ($configs as $config) {
 			if (is_array($config)) {
 				$bucket = $config['arguments']['bucket'] ?? '';
-				if (in_array($bucket, $usedBuckets)) {
+				if (in_array($bucket, $usedBuckets, true)) {
 					throw new InvalidObjectStoreConfigurationException('Each object store configuration must use distinct bucket names');
 				}
 				$usedBuckets[] = $bucket;

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -290,7 +290,7 @@ class SetupManager implements ISetupManager {
 			$this->mountProviderCollection->addMountForUser($user, $this->mountManager, function (
 				string $providerClass,
 			) use ($user) {
-				return !in_array($providerClass, $this->setupUserMountProviders[$user->getUID()]);
+				return !in_array($providerClass, $this->setupUserMountProviders[$user->getUID()], true);
 			});
 		});
 		$this->afterUserFullySetup($user, $previouslySetupProviders);
@@ -384,7 +384,7 @@ class SetupManager implements ISetupManager {
 		));
 		$newProviders = array_diff($allProviders, $previouslySetupProviders);
 		$mounts = array_filter($mounts, function (IMountPoint $mount) use ($previouslySetupProviders) {
-			return !in_array($mount->getMountProvider(), $previouslySetupProviders);
+			return !in_array($mount->getMountProvider(), $previouslySetupProviders, true);
 		});
 		$this->registerMounts($user, $mounts, $newProviders);
 
@@ -525,7 +525,7 @@ class SetupManager implements ISetupManager {
 
 		$mountProvider = $cachedMount->getMountProvider();
 		$mountPoint = $cachedMount->getMountPoint();
-		$isMountProviderSetup = in_array($mountProvider, $setupProviders);
+		$isMountProviderSetup = in_array($mountProvider, $setupProviders, true);
 		$isPathSetupAsAuthoritative = $this->isPathSetup($mountPoint);
 		if (!$isMountProviderSetup && !$isPathSetupAsAuthoritative) {
 			if ($mountProvider === '') {
@@ -584,7 +584,7 @@ class SetupManager implements ISetupManager {
 				$mountProvider = $cachedMount->getMountProvider();
 
 				// skip setup for already set up providers
-				if (in_array($mountProvider, $setupProviders)) {
+				if (in_array($mountProvider, $setupProviders, true)) {
 					continue;
 				}
 
@@ -720,7 +720,7 @@ class SetupManager implements ISetupManager {
 			return !is_subclass_of($provider, IHomeMountProvider::class);
 		});
 
-		if (in_array('', $providers)) {
+		if (in_array('', $providers, true)) {
 			$this->setupForUser($user);
 			return;
 		}

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -116,7 +116,7 @@ class Local extends Common {
 				 */
 				$file = $it->current();
 				clearstatcache(true, $file->getRealPath());
-				if (in_array($file->getBasename(), ['.', '..'])) {
+				if (in_array($file->getBasename(), ['.', '..'], true)) {
 					$it->next();
 					continue;
 				} elseif ($file->isFile() || $file->isLink()) {

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -128,7 +128,8 @@ class Quota extends Wrapper {
 		}
 
 		$free = $this->free_space($path);
-		if ($this->shouldApplyQuota($path) && $free == 0) {
+		// treat a failed free_space() the same as no free space
+		if ($this->shouldApplyQuota($path) && ($free === 0 || $free === 0.0 || $free === false)) {
 			return false;
 		}
 
@@ -194,7 +195,8 @@ class Quota extends Wrapper {
 			return $this->getWrapperStorage()->mkdir($path);
 		}
 		$free = $this->free_space($path);
-		if ($this->shouldApplyQuota($path) && $free == 0) {
+		// treat a failed free_space() the same as no free space
+		if ($this->shouldApplyQuota($path) && ($free === 0 || $free === 0.0 || $free === false)) {
 			return false;
 		}
 
@@ -207,7 +209,8 @@ class Quota extends Wrapper {
 			return $this->getWrapperStorage()->touch($path, $mtime);
 		}
 		$free = $this->free_space($path);
-		if ($free == 0) {
+		// treat a failed free_space() the same as no free space
+		if ($free === 0 || $free === 0.0 || $free === false) {
 			return false;
 		}
 
@@ -225,7 +228,8 @@ class Quota extends Wrapper {
 		}
 
 		$free = $this->free_space($path);
-		if ($this->shouldApplyQuota($path) && $free == 0) {
+		// treat a failed free_space() the same as no free space
+		if ($this->shouldApplyQuota($path) && ($free === 0 || $free === 0.0 || $free === false)) {
 			throw new NotEnoughSpaceException();
 		}
 

--- a/lib/private/Files/Stream/SeekableHttpStream.php
+++ b/lib/private/Files/Stream/SeekableHttpStream.php
@@ -21,7 +21,7 @@ class SeekableHttpStream implements File {
 	 * $return void
 	 */
 	private static function registerIfNeeded() {
-		if (!in_array(self::PROTOCOL, stream_get_wrappers())) {
+		if (!in_array(self::PROTOCOL, stream_get_wrappers(), true)) {
 			stream_wrapper_register(
 				self::PROTOCOL,
 				self::class

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1210,7 +1210,7 @@ class View {
 				return false;
 			}
 
-			if (in_array('write', $hooks) || in_array('delete', $hooks) || in_array('read', $hooks)) {
+			if (in_array('write', $hooks, true) || in_array('delete', $hooks, true) || in_array('read', $hooks, true)) {
 				// always a shared lock during pre-hooks so the hook can read the file
 				$this->lockFile($path, ILockingProvider::LOCK_SHARED);
 			}
@@ -1219,7 +1219,7 @@ class View {
 			[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
 			if ($run && $storage) {
 				/** @var Storage $storage */
-				if (in_array('write', $hooks) || in_array('delete', $hooks)) {
+				if (in_array('write', $hooks, true) || in_array('delete', $hooks, true)) {
 					try {
 						$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
 					} catch (LockedException $e) {
@@ -1235,15 +1235,15 @@ class View {
 						$result = $storage->$operation($internalPath);
 					}
 				} catch (\Exception $e) {
-					if (in_array('write', $hooks) || in_array('delete', $hooks)) {
+					if (in_array('write', $hooks, true) || in_array('delete', $hooks, true)) {
 						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-					} elseif (in_array('read', $hooks)) {
+					} elseif (in_array('read', $hooks, true)) {
 						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 					}
 					throw $e;
 				}
 
-				if ($result !== false && in_array('delete', $hooks)) {
+				if ($result !== false && in_array('delete', $hooks, true)) {
 					$this->removeUpdate($storage, $internalPath);
 				}
 				if ($result !== false && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
@@ -1251,11 +1251,11 @@ class View {
 					$sizeDifference = $operation === 'mkdir' ? 0 : $result;
 					$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
 				}
-				if ($result !== false && in_array('touch', $hooks)) {
+				if ($result !== false && in_array('touch', $hooks, true)) {
 					$this->writeUpdate($storage, $internalPath, $extraParam, 0);
 				}
 
-				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {
+				if ((in_array('write', $hooks, true) || in_array('delete', $hooks, true)) && ($operation !== 'fopen' || $result === false)) {
 					$this->changeLock($path, ILockingProvider::LOCK_SHARED);
 				}
 
@@ -1265,9 +1265,9 @@ class View {
 					// make sure our unlocking callback will still be called if connection is aborted
 					ignore_user_abort(true);
 					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path): void {
-						if (in_array('write', $hooks)) {
+						if (in_array('write', $hooks, true)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-						} elseif (in_array('read', $hooks)) {
+						} elseif (in_array('read', $hooks, true)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 						}
 					});
@@ -1280,7 +1280,7 @@ class View {
 				}
 
 				if (!$unlockLater
-					&& (in_array('write', $hooks) || in_array('delete', $hooks) || in_array('read', $hooks))
+					&& (in_array('write', $hooks, true) || in_array('delete', $hooks, true) || in_array('read', $hooks, true))
 				) {
 					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 				}

--- a/lib/private/FilesMetadata/Model/FilesMetadata.php
+++ b/lib/private/FilesMetadata/Model/FilesMetadata.php
@@ -82,7 +82,7 @@ class FilesMetadata implements IFilesMetadata {
 
 	/**
 	 * @inheritDoc
-	 * @return string[] list of keys
+	 * @return list<string> list of keys
 	 * @since 28.0.0
 	 */
 	#[\Override]
@@ -99,7 +99,7 @@ class FilesMetadata implements IFilesMetadata {
 	 */
 	#[\Override]
 	public function hasKey(string $needle): bool {
-		return (in_array($needle, $this->getKeys()));
+		return (in_array($needle, $this->getKeys(), true));
 	}
 
 	/**

--- a/lib/private/GlobalScale/Config.php
+++ b/lib/private/GlobalScale/Config.php
@@ -52,7 +52,7 @@ class Config implements \OCP\GlobalScale\IConfig {
 
 	#[Override]
 	public function isPrimaryAdmin(string $userId): bool {
-		return in_array($userId, $this->config->getSystemValue('gss.master.admin', []))
-			|| in_array($userId, $this->config->getSystemValue('gss.primary.admin', []));
+		return in_array($userId, $this->config->getSystemValue('gss.master.admin', []), true)
+			|| in_array($userId, $this->config->getSystemValue('gss.primary.admin', []), true);
 	}
 }

--- a/lib/private/Group/Backend.php
+++ b/lib/private/Group/Backend.php
@@ -70,7 +70,7 @@ abstract class Backend implements GroupInterface {
 	 */
 	#[\Override]
 	public function inGroup($uid, $gid) {
-		return in_array($gid, $this->getUserGroups($uid));
+		return in_array($gid, $this->getUserGroups($uid), true);
 	}
 
 	/**
@@ -108,7 +108,7 @@ abstract class Backend implements GroupInterface {
 	 */
 	#[\Override]
 	public function groupExists($gid) {
-		return in_array($gid, $this->getGroups($gid, 1));
+		return in_array($gid, $this->getGroups($gid, 1), true);
 	}
 
 	/**

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -356,7 +356,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 */
 	#[\Override]
 	public function isInGroup($userId, $group) {
-		return in_array($group, $this->getUserIdGroupIds($userId));
+		return in_array($group, $this->getUserIdGroupIds($userId), true);
 	}
 
 	#[\Override]

--- a/lib/private/Hooks/EmitterTrait.php
+++ b/lib/private/Hooks/EmitterTrait.php
@@ -50,14 +50,14 @@ trait EmitterTrait {
 		} elseif ($scope) {
 			foreach ($allNames as $name) {
 				$parts = explode('::', $name, 2);
-				if ($parts[0] == $scope) {
+				if ($parts[0] === $scope) {
 					$names[] = $name;
 				}
 			}
 		} elseif ($method) {
 			foreach ($allNames as $name) {
 				$parts = explode('::', $name, 2);
-				if ($parts[1] == $method) {
+				if ($parts[1] === $method) {
 					$names[] = $name;
 				}
 			}

--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -944,7 +944,7 @@ class Image implements IImage {
 		}
 		$widthOrig = imagesx($this->resource);
 		$heightOrig = imagesy($this->resource);
-		if ($widthOrig === $heightOrig && $size == 0) {
+		if ($widthOrig === $heightOrig && $size === 0) {
 			return true;
 		}
 		$ratioOrig = $widthOrig / $heightOrig;

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -505,7 +505,7 @@ class Installer {
 						if (file_exists($app_dir['path'] . "/$filename/appinfo/info.xml")) {
 							if ($this->config->getAppValue($filename, 'installed_version') === '') {
 								$enabled = $this->appManager->isDefaultEnabled($filename);
-								if (($enabled || in_array($filename, $this->appManager->getAlwaysEnabledApps()))
+								if (($enabled || in_array($filename, $this->appManager->getAlwaysEnabledApps(), true))
 									  && $this->config->getAppValue($filename, 'enabled') !== 'no') {
 									if ($softErrors) {
 										try {

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -404,7 +404,7 @@ class Factory implements IFactory {
 		}
 
 		$languages = $this->findAvailableLanguages($app);
-		return in_array($lang, $languages);
+		return in_array($lang, $languages, true);
 	}
 
 	#[\Override]
@@ -598,8 +598,8 @@ class Factory implements IFactory {
 	 * @param string $app App id or empty string for core
 	 * @return string directory
 	 */
-	protected function findL10nDir($app = null) {
-		if (in_array($app, ['core', 'lib'])) {
+	protected function findL10nDir(?string $app = null): string {
+		if (in_array($app, ['core', 'lib'], true)) {
 			if (file_exists($this->serverRoot . '/' . $app . '/l10n/')) {
 				return $this->serverRoot . '/' . $app . '/l10n/';
 			}
@@ -664,7 +664,7 @@ class Factory implements IFactory {
 
 			// put appropriate languages into appropriate arrays, to print them sorted
 			// common languages -> divider -> other languages
-			if (in_array($lang, self::COMMON_LANGUAGE_CODES)) {
+			if (in_array($lang, self::COMMON_LANGUAGE_CODES, true)) {
 				$commonLanguages[array_search($lang, self::COMMON_LANGUAGE_CODES, true)] = $ln;
 			} else {
 				$otherLanguages[] = $ln;

--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -86,11 +86,12 @@ class File extends LogDetails implements IWriter, IFileBased {
 			while ($pos >= 0 && ($limit === null || $entriesCount < $limit)) {
 				fseek($handle, $pos);
 				$ch = fgetc($handle);
-				if ($ch == "\n" || $pos == 0) {
+				// treat a failed ftell() the same as start-of-file
+				if ($ch === "\n" || $pos === 0 || $pos === false) {
 					if ($line !== '') {
 						// Add the first character if at the start of the file,
 						// because it doesn't hit the else in the loop
-						if ($pos == 0) {
+						if ($pos === 0 || $pos === false) {
 							$line = $ch . $line;
 						}
 						$entry = json_decode($line);

--- a/lib/private/Migration/MetadataManager.php
+++ b/lib/private/Migration/MetadataManager.php
@@ -112,6 +112,8 @@ class MetadataManager {
 	private function parseMigrations(array $migrations, array $ignoreMigrations = []): array {
 		$parsed = [];
 		foreach (array_keys($migrations) as $entry) {
+			// $entry may be an int since json_decode() casts numeric-looking migration version keys to integers
+			/** @psalm-suppress UnrecognizedExpression */
 			if (in_array($entry, $ignoreMigrations)) {
 				continue;
 			}

--- a/lib/private/Net/HostnameClassifier.php
+++ b/lib/private/Net/HostnameClassifier.php
@@ -41,7 +41,7 @@ class HostnameClassifier {
 		$hostname = rtrim($hostname, '.');
 		// Disallow local network top-level domains from RFC 6762
 		$topLevelDomain = substr((strrchr($hostname, '.') ?: ''), 1);
-		if (in_array($topLevelDomain, self::LOCAL_TOPLEVEL_DOMAINS)) {
+		if (in_array($topLevelDomain, self::LOCAL_TOPLEVEL_DOMAINS, true)) {
 			return true;
 		}
 

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -141,7 +141,7 @@ class OCMProvider implements IOCMProvider {
 	 */
 	#[\Override]
 	public function getTokenEndPoint(): string {
-		if (in_array('exchange-token', $this->capabilities)) {
+		if (in_array('exchange-token', $this->capabilities, true)) {
 			return $this->tokenEndPoint;
 		}
 		return '';

--- a/lib/private/Preview/HEIC.php
+++ b/lib/private/Preview/HEIC.php
@@ -36,7 +36,7 @@ class HEIC extends ProviderV2 {
 	 */
 	#[\Override]
 	public function isAvailable(FileInfo $file): bool {
-		return in_array('HEIC', \Imagick::queryFormats('HEI*'));
+		return in_array('HEIC', \Imagick::queryFormats('HEI*'), true);
 	}
 
 	/**

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -279,7 +279,7 @@ class PreviewManager implements IPreview {
 			OpenDocument::class,
 		], $imageProviders));
 
-		if (in_array(Image::class, $this->defaultProviders)) {
+		if (in_array(Image::class, $this->defaultProviders, true)) {
 			$this->defaultProviders = array_merge($this->defaultProviders, $imageProviders);
 		}
 		$this->defaultProviders = array_values(array_unique($this->defaultProviders));
@@ -292,7 +292,7 @@ class PreviewManager implements IPreview {
 	 * Register the default providers (if enabled)
 	 */
 	protected function registerCoreProvider(string $class, string $mimeType, array $options = []): void {
-		if (in_array(trim($class, '\\'), $this->getEnabledDefaultProvider())) {
+		if (in_array(trim($class, '\\'), $this->getEnabledDefaultProvider(), true)) {
 			$this->registerProviderClosure($mimeType, function () use ($class, $options): IProviderV2 {
 				/** @var IProviderV2 $class */
 				return new $class($options);
@@ -340,7 +340,7 @@ class PreviewManager implements IPreview {
 
 			foreach ($imagickProviders as $queryFormat => $provider) {
 				$class = $provider['class'];
-				if (!in_array(trim($class, '\\'), $this->getEnabledDefaultProvider())) {
+				if (!in_array(trim($class, '\\'), $this->getEnabledDefaultProvider(), true)) {
 					continue;
 				}
 
@@ -353,7 +353,7 @@ class PreviewManager implements IPreview {
 		$this->registerCoreProvidersOffice();
 
 		// Video requires ffmpeg
-		if (in_array(Movie::class, $this->getEnabledDefaultProvider())) {
+		if (in_array(Movie::class, $this->getEnabledDefaultProvider(), true)) {
 			$movieBinary = $this->config->getSystemValue('preview_ffmpeg_path', null);
 			if (!is_string($movieBinary)) {
 				$movieBinary = $this->binaryFinder->findBinaryPath('ffmpeg');
@@ -380,7 +380,7 @@ class PreviewManager implements IPreview {
 
 		foreach ($officeProviders as $provider) {
 			$class = $provider['class'];
-			if (!in_array(trim($class, '\\'), $this->getEnabledDefaultProvider())) {
+			if (!in_array(trim($class, '\\'), $this->getEnabledDefaultProvider(), true)) {
 				continue;
 			}
 

--- a/lib/private/Repair/NC29/SanitizeAccountPropertiesJob.php
+++ b/lib/private/Repair/NC29/SanitizeAccountPropertiesJob.php
@@ -57,7 +57,7 @@ class SanitizeAccountPropertiesJob extends QueuedJob {
 					$this->accountManager->updateAccount($account);
 					return;
 				} catch (InvalidArgumentException $e) {
-					if (in_array($e->getMessage(), IAccountManager::ALLOWED_PROPERTIES)) {
+					if (in_array($e->getMessage(), IAccountManager::ALLOWED_PROPERTIES, true)) {
 						$numRemoved++;
 						$property = $account->getProperty($e->getMessage());
 						$account->setProperty($property->getName(), '', $property->getScope(), IAccountManager::NOT_VERIFIED);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -794,7 +794,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 
 			if (defined('PHPUNIT_RUN') && PHPUNIT_RUN
-				&& in_array('fakeinput', stream_get_wrappers())
+				&& in_array('fakeinput', stream_get_wrappers(), true)
 			) {
 				$stream = 'fakeinput://data';
 			} else {

--- a/lib/private/Settings/DeclarativeManager.php
+++ b/lib/private/Settings/DeclarativeManager.php
@@ -186,7 +186,7 @@ class DeclarativeManager implements IDeclarativeManager {
 		if (array_key_exists($app, $this->appSchemas)) {
 			foreach ($this->appSchemas[$app] as $schema) {
 				foreach ($schema['fields'] as $field) {
-					if ($field['id'] == $fieldId) {
+					if ($field['id'] === $fieldId) {
 						if (array_key_exists('storage_type', $field)) {
 							return $field['storage_type'];
 						}
@@ -210,7 +210,7 @@ class DeclarativeManager implements IDeclarativeManager {
 		if (array_key_exists($app, $this->appSchemas)) {
 			foreach ($this->appSchemas[$app] as $schema) {
 				foreach ($schema['fields'] as $field) {
-					if ($field['id'] == $fieldId) {
+					if ($field['id'] === $fieldId) {
 						return $schema['section_type'];
 					}
 				}
@@ -407,7 +407,7 @@ class DeclarativeManager implements IDeclarativeManager {
 			$this->logger->warning('Declarative settings: missing section_type', ['app' => $appId, 'form_id' => $formId]);
 			return false;
 		}
-		if (!in_array($schema['section_type'], [DeclarativeSettingsTypes::SECTION_TYPE_ADMIN, DeclarativeSettingsTypes::SECTION_TYPE_PERSONAL])) {
+		if (!in_array($schema['section_type'], [DeclarativeSettingsTypes::SECTION_TYPE_ADMIN, DeclarativeSettingsTypes::SECTION_TYPE_PERSONAL], true)) {
 			$this->logger->warning('Declarative settings: invalid section_type', ['app' => $appId, 'form_id' => $formId, 'section_type' => $schema['section_type']]);
 			return false;
 		}
@@ -419,7 +419,7 @@ class DeclarativeManager implements IDeclarativeManager {
 			$this->logger->warning('Declarative settings: missing storage_type', ['app' => $appId, 'form_id' => $formId]);
 			return false;
 		}
-		if (!in_array($schema['storage_type'], [DeclarativeSettingsTypes::STORAGE_TYPE_EXTERNAL, DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL])) {
+		if (!in_array($schema['storage_type'], [DeclarativeSettingsTypes::STORAGE_TYPE_EXTERNAL, DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL], true)) {
 			$this->logger->warning('Declarative settings: invalid storage_type', ['app' => $appId, 'form_id' => $formId, 'storage_type' => $schema['storage_type']]);
 			return false;
 		}
@@ -450,13 +450,13 @@ class DeclarativeManager implements IDeclarativeManager {
 				DeclarativeSettingsTypes::SELECT, DeclarativeSettingsTypes::CHECKBOX,
 				DeclarativeSettingsTypes::URL, DeclarativeSettingsTypes::EMAIL, DeclarativeSettingsTypes::NUMBER,
 				DeclarativeSettingsTypes::TEL, DeclarativeSettingsTypes::TEXT, DeclarativeSettingsTypes::PASSWORD,
-			])) {
+			], true)) {
 				$this->logger->warning('Declarative settings: invalid field type', [
 					'app' => $appId, 'form_id' => $formId, 'field_id' => $fieldId, 'type' => $field['type'],
 				]);
 				return false;
 			}
-			if (isset($field['sensitive']) && $field['sensitive'] === true && !in_array($field['type'], [DeclarativeSettingsTypes::TEXT, DeclarativeSettingsTypes::PASSWORD])) {
+			if (isset($field['sensitive']) && $field['sensitive'] === true && !in_array($field['type'], [DeclarativeSettingsTypes::TEXT, DeclarativeSettingsTypes::PASSWORD], true)) {
 				$this->logger->warning('Declarative settings: sensitive field type is supported only for TEXT and PASSWORD types ({app}, {form_id}, {field_id})', [
 					'app' => $appId, 'form_id' => $formId, 'field_id' => $fieldId,
 				]);
@@ -475,7 +475,7 @@ class DeclarativeManager implements IDeclarativeManager {
 		if (in_array($field['type'], [
 			DeclarativeSettingsTypes::MULTI_SELECT, DeclarativeSettingsTypes::MULTI_CHECKBOX, DeclarativeSettingsTypes::RADIO,
 			DeclarativeSettingsTypes::SELECT
-		])) {
+		], true)) {
 			if (!isset($field['options'])) {
 				$this->logger->warning('Declarative settings: missing field options', ['app' => $appId, 'form_id' => $formId, 'field_id' => $fieldId]);
 				return false;

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -330,11 +330,11 @@ class Manager implements IManager {
 			if ($this->subAdmin->isSubAdmin($user)) {
 				$authorizedGroupFilter = function (ISettings $settings) use ($authorizedSettingsClasses) {
 					return $settings instanceof ISubAdminSettings
-						|| in_array(get_class($settings), $authorizedSettingsClasses) === true;
+						|| in_array(get_class($settings), $authorizedSettingsClasses, true) === true;
 				};
 			} else {
 				$authorizedGroupFilter = function (ISettings $settings) use ($authorizedSettingsClasses) {
-					return in_array(get_class($settings), $authorizedSettingsClasses) === true;
+					return in_array(get_class($settings), $authorizedSettingsClasses, true) === true;
 				};
 			}
 			$appSettings = $this->getSettings('admin', $section, $authorizedGroupFilter);
@@ -362,7 +362,7 @@ class Manager implements IManager {
 		$authorizedSettingsClasses = $this->mapper->findAllClassesForUser($user);
 		foreach ($this->settings['admin'] as $section) {
 			foreach ($section as $setting) {
-				if (in_array(get_class($setting), $authorizedSettingsClasses) === true) {
+				if (in_array(get_class($setting), $authorizedSettingsClasses, true) === true) {
 					$settings[] = $setting;
 				}
 			}

--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -718,7 +718,7 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 		$permissionPresetCompatiblePermissionTypeClasses = $this->registry->getPermissionPresetCompatiblePermissionTypeClasses()[$permissionPresetClass];
 		$presetPermissions = array_combine($allPermissionClasses, array_map(fn (string $class): SharePermission => new SharePermission(
 			$class,
-			in_array($class, $permissionPresetCompatiblePermissionTypeClasses),
+			in_array($class, $permissionPresetCompatiblePermissionTypeClasses, true),
 		), $allPermissionClasses));
 
 		$share = new Share(

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -1071,7 +1071,7 @@ class Manager implements IManager {
 		}
 
 		$guestsAllowed = $this->appConfig->getValueString('core', 'ai.taskprocessing_guests', 'false');
-		if ($guestsAllowed == 'true' || !class_exists(UserBackend::class) || !($user->getBackend() instanceof UserBackend)) {
+		if ($guestsAllowed === 'true' || !class_exists(UserBackend::class) || !($user->getBackend() instanceof UserBackend)) {
 			return true;
 		}
 		return false;
@@ -1920,7 +1920,7 @@ class Manager implements IManager {
 		}
 		$mounts = $this->userMountCache->getMountsForFileId($fileId);
 		$userIds = array_map(fn ($mount) => $mount->getUser()->getUID(), $mounts);
-		if (!in_array($userId, $userIds)) {
+		if (!in_array($userId, $userIds, true)) {
 			throw new UnauthorizedException('User ' . $userId . ' does not have access to file ' . $fileId);
 		}
 	}

--- a/lib/private/Template/Template.php
+++ b/lib/private/Template/Template.php
@@ -125,7 +125,7 @@ class Template extends Base implements ITemplate {
 			$headers = '';
 			foreach (array_merge(\OC_Util::$headers, $this->headers) as $header) {
 				$headers .= '<' . Util::sanitizeHTML($header['tag']);
-				if (strcasecmp($header['tag'], 'script') === 0 && in_array('src', array_map('strtolower', array_keys($header['attributes'])))) {
+				if (strcasecmp($header['tag'], 'script') === 0 && in_array('src', array_map('strtolower', array_keys($header['attributes'])), true)) {
 					$headers .= ' defer';
 				}
 				foreach ($header['attributes'] as $name => $value) {

--- a/lib/private/Template/functions.php
+++ b/lib/private/Template/functions.php
@@ -316,6 +316,8 @@ function html_select_options($options, $selected, $params = []): string {
 		if ($label_name && is_array($label)) {
 			$label = $label[$label_name];
 		}
+		// $value may be a numeric array key or an arbitrary label value, while $selected is a string list
+		/** @psalm-suppress UnrecognizedExpression */
 		$select = in_array($value, $selected) ? ' selected="selected"' : '';
 		$html .= '<option value="' . Util::sanitizeHTML($value) . '"' . $select . '>' . Util::sanitizeHTML($label) . '</option>' . "\n";
 	}

--- a/lib/private/TextProcessing/Manager.php
+++ b/lib/private/TextProcessing/Manager.php
@@ -131,7 +131,7 @@ class Manager implements IManager {
 	}
 
 	public function canHandleTask(OCPTask $task): bool {
-		return in_array($task->getType(), $this->getAvailableTaskTypes());
+		return in_array($task->getType(), $this->getAvailableTaskTypes(), true);
 	}
 
 	/**

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -145,7 +145,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		}
 
 		$cachedBackend = $this->cache->get(sha1($uid));
-		if (in_array($cachedBackend, $excludeBackends)) {
+		if (in_array((string)$cachedBackend, $excludeBackends, true)) {
 			$cachedBackend = null;
 		}
 
@@ -163,7 +163,7 @@ class Manager extends PublicEmitter implements IUserManager {
 				continue;
 			}
 
-			if (in_array($i, $excludeBackends)) {
+			if (in_array($i, $excludeBackends, true)) {
 				continue;
 			}
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -408,7 +408,7 @@ class Session implements IUserSession, Emitter {
 			$dbToken = $this->getTokenFromPassword($password);
 			$isTokenPassword = $dbToken !== null;
 			if (($dbToken instanceof PublicKeyToken)
-				&& !in_array($dbToken->getType(), [IToken::PERMANENT_TOKEN,IToken::ONETIME_TOKEN])
+				&& !in_array($dbToken->getType(), [IToken::PERMANENT_TOKEN,IToken::ONETIME_TOKEN], true)
 			) {
 				// Refuse session tokens here, only app tokens and onetime tokens are handled
 				return false;

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -381,7 +381,7 @@ class OC_App {
 		$supportedApps = $this->getSupportedApps();
 
 		foreach ($installedApps as $app) {
-			if (!in_array($app, $blacklist)) {
+			if (!in_array($app, $blacklist, true)) {
 				$info = $appManager->getAppInfo($app, false, $langCode);
 				if (!is_array($info)) {
 					Server::get(LoggerInterface::class)->error('Could not read app info file for app "' . $app . '"', ['app' => 'core']);
@@ -415,7 +415,7 @@ class OC_App {
 					$info['removable'] = true;
 				}
 
-				if (in_array($app, $supportedApps)) {
+				if (in_array($app, $supportedApps, true)) {
 					$info['level'] = self::supportedApp;
 				}
 

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -236,7 +236,7 @@ class OC_App {
 				$topFolder = substr($path_info, 1, strpos($path_info, '/', 1) - 1);
 			}
 		}
-		if ($topFolder == 'apps') {
+		if ($topFolder === 'apps') {
 			$length = strlen($topFolder);
 			return substr($script, $length + 1, strpos($script, '/', $length + 1) - $length - 1) ?: '';
 		} else {

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -121,7 +121,7 @@ class OC_User {
 			$class = $config['class'];
 			$arguments = $config['arguments'];
 			if (class_exists($class)) {
-				if (!in_array($i, self::$_setupedBackends)) {
+				if (!in_array($i, self::$_setupedBackends, true)) {
 					// make a reflection object
 					$reflectionObj = new ReflectionClass($class);
 

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -221,7 +221,7 @@ class OC_Util {
 	 */
 	private static function addExternalResource($application, $prepend, $path, $type = 'script'): void {
 		if ($type === 'style') {
-			if (!in_array($path, self::$styles)) {
+			if (!in_array($path, self::$styles, true)) {
 				if ($prepend === true) {
 					array_unshift(self::$styles, $path);
 				} else {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -447,7 +447,7 @@ class OC_Util {
 		}
 
 		// Cache the result of this function
-		Server::get(ISession::class)->set('checkServer_succeeded', count($errors) == 0);
+		Server::get(ISession::class)->set('checkServer_succeeded', count($errors) === 0);
 
 		return $errors;
 	}

--- a/lib/public/AppFramework/AuthPublicShareController.php
+++ b/lib/public/AppFramework/AuthPublicShareController.php
@@ -137,7 +137,7 @@ abstract class AuthPublicShareController extends PublicShareController {
 		}
 
 		// Is user requesting a temporary password?
-		if ($passwordRequest == '') {
+		if ($passwordRequest === '') {
 			if ($this->validateIdentity($identityToken)) {
 				$this->generatePassword();
 				$response = $this->showIdentificationResult(true);

--- a/lib/public/FilesMetadata/Model/IFilesMetadata.php
+++ b/lib/public/FilesMetadata/Model/IFilesMetadata.php
@@ -64,7 +64,7 @@ interface IFilesMetadata extends JsonSerializable {
 	/**
 	 * returns all current metadata keys
 	 *
-	 * @return string[] list of keys
+	 * @return list<string> list of keys
 	 * @since 28.0.0
 	 */
 	public function getKeys(): array;

--- a/lib/public/OCM/Events/OCMEndpointRequestEvent.php
+++ b/lib/public/OCM/Events/OCMEndpointRequestEvent.php
@@ -106,7 +106,8 @@ final class OCMEndpointRequestEvent extends Event {
 			}
 			$typedArgs[] = match($param) {
 				ParamType::STRING => $args[$i],
-				ParamType::INT => (is_numeric($args[$i]) && ((int)$args[$i] == (float)$args[$i])) ? (int)$args[$i] : null,
+				// checks the numeric string has no fractional part
+				ParamType::INT => (is_numeric($args[$i]) && ((float)$args[$i] === (float)(int)$args[$i])) ? (int)$args[$i] : null,
 				ParamType::FLOAT => (is_numeric($args[$i])) ? (float)$args[$i] : null,
 				ParamType::BOOL => in_array(strtolower($args[$i]), ['1', 'true', 'yes', 'on'], true),
 			};

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -623,7 +623,7 @@ class Util {
 		$ini = Server::get(IniGetWrapper::class);
 		$disabled = explode(',', $ini->get('disable_functions') ?: '');
 		$disabled = array_map('trim', $disabled);
-		if (in_array($functionName, $disabled)) {
+		if (in_array($functionName, $disabled, true)) {
 			return false;
 		}
 		return true;

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -7,14 +7,16 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
+use OC\NavigationManager;
 use OC\OCS\ApiHelper;
 use OC\Route\Router;
 use OC\SystemConfig;
 use OC\User\LoginException;
+use OCP\App\Events\AppsLoadedEvent;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\OCSController;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -80,8 +82,8 @@ require_once __DIR__ . '/../lib/OC.php';
 		}
 
 		// All apps are now loaded to handle the request
-		Server::get(\OC\NavigationManager::class)->setup();
-		Server::get(\OCP\EventDispatcher\IEventDispatcher::class)->dispatchTyped(new \OCP\App\Events\AppsLoadedEvent());
+		Server::get(NavigationManager::class)->setup();
+		Server::get(IEventDispatcher::class)->dispatchTyped(new AppsLoadedEvent());
 
 		Server::get(Router::class)->match('/ocsapp' . $request->getRawPathInfo());
 	} catch (MaxDelayReached $ex) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -22,6 +22,8 @@
 		<plugin filename="build/psalm/LogicalOperatorChecker.php" />
 		<pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
 		<plugin filename="build/psalm/StaticVarsChecker.php" />
+		<plugin filename="build/psalm/UnstrictComparisonChecker.php" />
+		<plugin filename="build/psalm/InArrayStrictChecker.php" />
 	</plugins>
 	<projectFiles>
 		<directory name="apps/admin_audit"/>

--- a/tests/lib/AppFramework/Http/RequestStream.php
+++ b/tests/lib/AppFramework/Http/RequestStream.php
@@ -104,7 +104,7 @@ class RequestStream {
 	}
 
 	public function stream_metadata(string $path, int $option, $var): bool {
-		if ($option == STREAM_META_TOUCH) {
+		if ($option === STREAM_META_TOUCH) {
 			$url = parse_url($path);
 			$varname = $url['host'] ?? '';
 			if (!isset($GLOBALS[$varname])) {

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -101,7 +101,7 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('/');
 		$content = [];
 		while (($file = readdir($dh)) !== false) {
-			if ($file != '.' && $file != '..') {
+			if ($file !== '.' && $file !== '..') {
 				$content[] = $file;
 			}
 		}
@@ -439,7 +439,7 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('#foo');
 		$content = [];
 		while ($file = readdir($dh)) {
-			if ($file != '.' && $file != '..') {
+			if ($file !== '.' && $file !== '..') {
 				$content[] = $file;
 			}
 		}

--- a/tests/lib/Repair/RepairDavSharesTest.php
+++ b/tests/lib/Repair/RepairDavSharesTest.php
@@ -165,7 +165,7 @@ class RepairDavSharesTest extends TestCase {
 		$this->groupManager->expects($this->any())
 			->method('groupExists')
 			->willReturnCallback(function (string $gid) use ($existingGroups) {
-				return in_array($gid, $existingGroups);
+				return in_array($gid, $existingGroups, true);
 			});
 
 		$this->repair->run($this->output);

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -574,7 +576,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		}
 
 		$r = new \ReflectionClass($this);
-		$doc = $r->getDocComment();
+		$doc = $r->getDocComment() ?: '';
 
 		if (class_exists(Group::class)) {
 			$attributes = array_map(function (\ReflectionAttribute $attribute): string {
@@ -592,6 +594,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 	protected function IsDatabaseAccessAllowed(): bool {
 		$annotations = $this->getGroupAnnotations();
-		return in_array('DB', $annotations) || in_array('SLOWDB', $annotations);
+		return in_array('DB', $annotations, true) || in_array('SLOWDB', $annotations, true);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This add two psalm plugins that checks for `==`, `!=` and `in_array` without strict  set to true. And fix all the reported issues

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
