### PR TITLE
fix(preview): Be a bit more verbose when failing to migrate previews

### DIFF
--- a/core/BackgroundJobs/PreviewMigrationJob.php
+++ b/core/BackgroundJobs/PreviewMigrationJob.php
@@ -45,6 +45,7 @@ class PreviewMigrationJob extends TimedJob {
 
 		$storage = $this->rootFolder->getMountPoint()->getStorage();
 		if ($storage === null) {
+			$this->logger->warning('Preview migration skipped: the root mount point has no storage.');
 			$this->appConfig->setValueBool('core', 'previewMovedDone', true);
 			return;
 		}
@@ -52,7 +53,12 @@ class PreviewMigrationJob extends TimedJob {
 		$cache = $storage->getCache();
 		$previewRootId = $cache->getId(rtrim($this->previewRootPath, '/'));
 		if ($previewRootId === -1) {
-			// No previews have ever been generated on this instance.
+			// No previews were ever generated, or the storage config no longer
+			// matches the one the filecache data was recorded under.
+			$this->logger->warning('Preview migration skipped: no preview root found at "{path}" on storage "{storageId}".', [
+				'path' => $this->previewRootPath,
+				'storageId' => $storage->getId(),
+			]);
 			$this->appConfig->setValueBool('core', 'previewMovedDone', true);
 			return;
 		}

--- a/lib/private/Preview/PreviewMigrationService.php
+++ b/lib/private/Preview/PreviewMigrationService.php
@@ -135,17 +135,25 @@ class PreviewMigrationService {
 			}
 		} else {
 			// No matching fileId, delete the orphaned preview files themselves.
+			$transactionStarted = false;
 			try {
 				$folder = $this->appData->getFolder($internalPath);
 				$this->connection->beginTransaction();
+				$transactionStarted = true;
 				foreach ($folder->getDirectoryListing() as $file) {
 					$file->delete();
 				}
 				$this->connection->commit();
 			} catch (NotFoundException) {
 				// Folder already gone, nothing to clean up.
-			} catch (Exception) {
-				$this->connection->rollback();
+			} catch (\Throwable $e) {
+				// Also catches non-DB failures from $file->delete(), e.g. an unreachable objectstore.
+				if ($transactionStarted) {
+					$this->connection->rollback();
+				}
+				$this->logger->error('Unable to delete orphaned preview at ' . $internalPath, [
+					'exception' => $e,
+				]);
 			}
 		}
 


### PR DESCRIPTION

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
