### PR TITLE
fix(files): do not reject ownership transfer when free space is unlimited

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -264,7 +264,9 @@ class OwnershipTransferService {
 		}
 		$size = $sourceFileInfo->getSize(false);
 		$freeSpace = $view->free_space($destinationUid . '/files/');
-		if ($size > $freeSpace && $freeSpace !== FileInfo::SPACE_UNKNOWN) {
+		// SPACE_UNKNOWN and SPACE_UNLIMITED mean there is no finite limit to compare against.
+		// SPACE_NOT_COMPUTED means a quota is set but its headroom is unknown, so it still rejects.
+		if ($freeSpace !== FileInfo::SPACE_UNKNOWN && $freeSpace !== FileInfo::SPACE_UNLIMITED && $size > $freeSpace) {
 			throw new TransferOwnershipException('Target user does not have enough free space available.', 1);
 		}
 


### PR DESCRIPTION
Fixes #64019

The quota check in `analyse()` exempted only `SPACE_UNKNOWN` (`-2`), but `free_space()` also returns `SPACE_UNLIMITED` (`-3`). A quota-less user on object-store primary storage gets `-3`, so `$size > -3` was true for any non-empty source and the transfer aborted with "Target user does not have enough free space available."

Exempt `SPACE_UNLIMITED` as well. `SPACE_NOT_COMPUTED` (`-1`) keeps rejecting: `Quota::free_space()` returns it when a quota is set but the used size could not be read, so there is a finite limit that should still be respected.