### PR TITLE
fix(external-share): move ExternalShareScanJob creation deeper

### DIFF
--- a/apps/files_sharing/lib/Controller/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controller/ExternalSharesController.php
@@ -8,12 +8,10 @@
 
 namespace OCA\Files_Sharing\Controller;
 
-use OCA\Files_Sharing\BackgroundJob\ExternalShareScanJob;
 use OCA\Files_Sharing\External\Manager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\BackgroundJob\IJobList;
 use OCP\IRequest;
 
 /**
@@ -26,7 +24,6 @@ class ExternalSharesController extends Controller {
 		string $appName,
 		IRequest $request,
 		private readonly Manager $externalManager,
-		private IJobList $jobList,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -47,7 +44,6 @@ class ExternalSharesController extends Controller {
 		$externalShare = $this->externalManager->getShare($id);
 		if ($externalShare !== false) {
 			$this->externalManager->acceptShare($externalShare);
-			$this->jobList->add(ExternalShareScanJob::class, [$externalShare->getUser(), $externalShare->getMountpoint()]);
 		}
 		return new JSONResponse();
 	}

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -10,8 +10,10 @@ namespace OCA\Files_Sharing\External;
 
 use OC\Files\Filesystem;
 use OCA\FederatedFileSharing\Events\FederatedShareAddedEvent;
+use OCA\Files_Sharing\BackgroundJob\ExternalShareScanJob;
 use OCA\Files_Sharing\Helper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\BackgroundJob\IJobList;
 use OCP\DB\Exception;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
@@ -58,6 +60,7 @@ class Manager {
 		private ICertificateManager $certificateManager,
 		private ExternalShareMapper $externalShareMapper,
 		private IConfig $config,
+		private readonly IJobList $jobList,
 	) {
 		$this->user = $userSession->getUser();
 	}
@@ -249,6 +252,7 @@ class Manager {
 				$externalShare->setMountpoint($mountPoint);
 				$this->externalShareMapper->update($externalShare);
 				$userShareAccepted = true;
+				$this->jobList->add(ExternalShareScanJob::class, [$externalShare->getUser(), $externalShare->getMountpoint()]);
 			}
 		} else {
 			try {

--- a/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
@@ -12,7 +12,6 @@ use OCA\Files_Sharing\Controller\ExternalSharesController;
 use OCA\Files_Sharing\External\ExternalShare;
 use OCA\Files_Sharing\External\Manager;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\BackgroundJob\IJobList;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -24,13 +23,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 class ExternalShareControllerTest extends \Test\TestCase {
 	private IRequest&MockObject $request;
 	private Manager&MockObject $externalManager;
-	private IJobList&MockObject $jobList;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->request = $this->createMock(IRequest::class);
 		$this->externalManager = $this->createMock(Manager::class);
-		$this->jobList = $this->createMock(IJobList::class);
 	}
 
 	public function getExternalShareController(): ExternalSharesController {
@@ -38,7 +35,6 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			'files_sharing',
 			$this->request,
 			$this->externalManager,
-			$this->jobList,
 		);
 	}
 
@@ -62,9 +58,6 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('acceptShare')
 			->with($share);
-		$this->jobList
-			->expects($this->once())
-			->method('add');
 
 		$this->assertEquals(new JSONResponse(), $this->getExternalShareController()->create('4'));
 	}

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -18,6 +18,7 @@ use OCA\Files_Sharing\External\ExternalShareMapper;
 use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\External\MountProvider;
 use OCA\Files_Sharing\Tests\TestCase;
+use OCP\BackgroundJob\IJobList;
 use OCP\Contacts\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
@@ -77,6 +78,7 @@ class ManagerTest extends TestCase {
 	private IOCMDiscoveryService&MockObject $ocmDiscoveryService;
 	private ExternalShareMapper $externalShareMapper;
 	private IConfig $config;
+	private IJobList&MockObject $jobList;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -93,6 +95,7 @@ class ManagerTest extends TestCase {
 		$this->cloudFederationProviderManager = $this->createMock(ICloudFederationProviderManager::class);
 		$this->cloudFederationFactory = $this->createMock(ICloudFederationFactory::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->jobList = $this->createMock(IJobList::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -182,6 +185,7 @@ class ManagerTest extends TestCase {
 					$this->certificateManager,
 					$this->externalShareMapper,
 					$this->config,
+					$this->jobList,
 				]
 			)->onlyMethods(['tryOCMEndPoint'])->getMock();
 	}

--- a/apps/files_sharing/tests/External/ManagerUpdateAccessTokenTest.php
+++ b/apps/files_sharing/tests/External/ManagerUpdateAccessTokenTest.php
@@ -13,6 +13,7 @@ use OCA\Files_Sharing\External\ExternalShare;
 use OCA\Files_Sharing\External\ExternalShareMapper;
 use OCA\Files_Sharing\External\Manager;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\BackgroundJob\IJobList;
 use OCP\DB\Exception;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
@@ -64,6 +65,7 @@ class ManagerUpdateAccessTokenTest extends TestCase {
 			$this->createMock(ICertificateManager::class),
 			$this->externalShareMapper,
 			$this->createMock(IConfig::class),
+			$this->createMock(IJobList::class),
 		);
 	}
 


### PR DESCRIPTION
This move the creation of the background job `ExternalShareScanJob` - implemented with #61908 - deeper/closer to the Share Acceptance action.
The reason for this change is that some path to reach the share acceptance (ie. auto-accept on trusted server) would not trigger the background job, therefor not scan the freshly created mountpoint.

