### PR TITLE
fix(share-folder): use it on federated share

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -236,11 +236,11 @@ class Manager {
 		$this->setupManager->setupForUser($user);
 		$folder = $this->rootFolder->getUserFolder($user->getUID());
 
-		$shareFolder = Helper::getShareFolder(null, $user->getUID());
-		$shareFolder = $folder->get($shareFolder);
+		$shareFolderPath = Helper::getShareFolder(null, $user->getUID());
+		$shareFolder = $folder->get($shareFolderPath);
 		/** @var Folder $shareFolder */
 		$mountPoint = $shareFolder->getNonExistingName($externalShare->getName());
-		$mountPoint = Filesystem::normalizePath($mountPoint);
+		$mountPoint = Filesystem::normalizePath($shareFolderPath . '/' . $mountPoint);
 		$userShareAccepted = false;
 
 		if ($externalShare->getShareType() === IShare::TYPE_USER) {


### PR DESCRIPTION
`'share_folder'` from `config/config.php` is not used when creating the mountpoint of a federated share because `getNonExistingName()` returns a value relative to the share folder, not the absolute path.

This patch will add the `$shareFolderPath` to the mount point.