### PR TITLE
fix: update last share update time when changing user status

### DIFF
--- a/lib/private/Sharing/SharingManager.php
+++ b/lib/private/Sharing/SharingManager.php
@@ -231,14 +231,17 @@ final readonly class SharingManager implements ISharingManager, IEventListener {
 			throw new ShareInvalidException('Cannot set user status for the owner of the share.', $this->l10n->t('Cannot set user status for the owner of the share.'));
 		}
 
-		// We don't update the share last updated value, because the user status is not part of the share itself.
+		// We update the share last updated value, even though the user status is not part of the share itself,
+		// so we can use the last updated value to coordinate syncing between unified and legacy shares.
+		$time = $this->getTime();
+		$this->backend->setLastUpdated([$share->id], $time);
 
 		$this->backend->updateShareUserStatus($share->id, $currentUser->getUID(), $userStatus);
 
 		$share = new Share(
 			$share->id,
 			$share->owner,
-			$share->lastUpdated,
+			$time,
 			$share->state,
 			$userStatus,
 			$share->sources,

--- a/tests/lib/Sharing/AbstractSharingManagerTests.php
+++ b/tests/lib/Sharing/AbstractSharingManagerTests.php
@@ -853,7 +853,9 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		foreach (ShareUserStatus::cases() as $case) {
 			$userStatus = ShareUserStatus::from($case->value);
 
+			$before = $this->manager->getTime();
 			$formatted = $this->updateShareUserStatus($accessContext2, $share2, $userStatus);
+			$after = $this->manager->getTime();
 			$this->assertDateBetween($before, $after, $this->parseTime($formatted['last_updated']));
 			$this->assertEquals($userStatus->value, $formatted['user_status']);
 		}
@@ -3733,12 +3735,12 @@ abstract class AbstractSharingManagerTests extends TestCase {
 		$share2 = $this->manager->updateShareState($accessContext, $share2, ShareState::Active);
 
 		$this->dbConnection->commit();
-		$after2 = $this->manager->getTime();
 
 		$accessContext2 = new ShareAccessContext($this->user2);
 		$this->dbConnection->beginTransaction();
 		$this->manager->updateShareUserStatus($accessContext2, $this->manager->getShare($accessContext2, $share2->id), ShareUserStatus::Accepted);
 		$this->dbConnection->commit();
+		$after2 = $this->manager->getTime();
 
 		$formatted = $this->getShares($accessContext, null, null, null, null, null, null);
 		$this->assertCount(2, $formatted);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

We're planning on using the share modified date to coordinate syncing legacy shares, so we also need to update it when a user changes their suer status.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
