### PR TITLE
feat(taskprocessing): add edit image task

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1038,6 +1038,7 @@ return array(
     'OCP\\TaskProcessing\\TaskTypes\\ContextAgentInteraction' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php',
     'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',
     'OCP\\TaskProcessing\\TaskTypes\\GenerateEmoji' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php',
+    'OCP\\TaskProcessing\\TaskTypes\\ImageToImage' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ImageToImage.php',
     'OCP\\TaskProcessing\\TaskTypes\\ImageToTextOpticalCharacterRecognition' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ImageToTextOpticalCharacterRecognition.php',
     'OCP\\TaskProcessing\\TaskTypes\\MultimodalChatWithTools' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/MultimodalChatWithTools.php',
     'OCP\\TaskProcessing\\TaskTypes\\MultimodalContextAgentInteraction' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/MultimodalContextAgentInteraction.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1079,6 +1079,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\TaskTypes\\ContextAgentInteraction' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php',
         'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',
         'OCP\\TaskProcessing\\TaskTypes\\GenerateEmoji' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php',
+        'OCP\\TaskProcessing\\TaskTypes\\ImageToImage' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ImageToImage.php',
         'OCP\\TaskProcessing\\TaskTypes\\ImageToTextOpticalCharacterRecognition' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ImageToTextOpticalCharacterRecognition.php',
         'OCP\\TaskProcessing\\TaskTypes\\MultimodalChatWithTools' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/MultimodalChatWithTools.php',
         'OCP\\TaskProcessing\\TaskTypes\\MultimodalContextAgentInteraction' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/MultimodalContextAgentInteraction.php',

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -81,6 +81,7 @@ use OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction;
 use OCP\TaskProcessing\TaskTypes\ContextAgentInteraction;
 use OCP\TaskProcessing\TaskTypes\ContextWrite;
 use OCP\TaskProcessing\TaskTypes\GenerateEmoji;
+use OCP\TaskProcessing\TaskTypes\ImageToImage;
 use OCP\TaskProcessing\TaskTypes\ImageToTextOpticalCharacterRecognition;
 use OCP\TaskProcessing\TaskTypes\MultimodalChatWithTools;
 use OCP\TaskProcessing\TaskTypes\MultimodalContextAgentInteraction;
@@ -713,6 +714,7 @@ class Manager implements IManager {
 			MultimodalContextAgentInteraction::ID => Server::get(MultimodalContextAgentInteraction::class),
 			AnalyzeImages::ID => Server::get(AnalyzeImages::class),
 			ImageToTextOpticalCharacterRecognition::ID => Server::get(ImageToTextOpticalCharacterRecognition::class),
+			ImageToImage::ID => Server::get(ImageToImage::class),
 		];
 
 		foreach ($context->getTaskProcessingTaskTypes() as $providerServiceRegistration) {

--- a/lib/public/TaskProcessing/TaskTypes/ImageToImage.php
+++ b/lib/public/TaskProcessing/TaskTypes/ImageToImage.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\TaskProcessing\TaskTypes;
+
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\ShapeDescriptor;
+
+/**
+ * This is the task processing task type for editing images
+ * @since 36.0.0
+ */
+class ImageToImage implements ITaskType {
+	/**
+	 * @since 36.0.0
+	 */
+	public const string ID = 'core:image2image';
+
+	private IL10N $l;
+
+	/**
+	 * @param IFactory $l10nFactory
+	 * @since 36.0.0
+	 */
+	public function __construct(
+		IFactory $l10nFactory,
+	) {
+		$this->l = $l10nFactory->get('lib');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 36.0.0
+	 */
+	#[\Override]
+	public function getName(): string {
+		return $this->l->t('Edit image');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 36.0.0
+	 */
+	#[\Override]
+	public function getDescription(): string {
+		return $this->l->t('Edit an image based on a text description of the changes');
+	}
+
+	/**
+	 * @return string
+	 * @since 36.0.0
+	 */
+	#[\Override]
+	public function getId(): string {
+		return self::ID;
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 36.0.0
+	 */
+	#[\Override]
+	public function getInputShape(): array {
+		return [
+			'input' => new ShapeDescriptor(
+				$this->l->t('Input images'),
+				$this->l->t('The images to edit'),
+				EShapeType::ListOfImages
+			),
+			'prompt' => new ShapeDescriptor(
+				$this->l->t('Prompt'),
+				$this->l->t('Describe the changes you want to make to the image'),
+				EShapeType::Text
+			),
+		];
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 36.0.0
+	 */
+	#[\Override]
+	public function getOutputShape(): array {
+		return [
+			'output' => new ShapeDescriptor(
+				$this->l->t('Output image'),
+				$this->l->t('The edited image'),
+				EShapeType::Image
+			),
+		];
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Task type for editing images used by text2image_flux and https://github.com/nextcloud/integration_openai/pull/423

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
