### PR TITLE
fix(files): do not display hidden files count on public shares

### DIFF
--- a/apps/files/src/utils/fileUtils.spec.ts
+++ b/apps/files/src/utils/fileUtils.spec.ts
@@ -1,0 +1,45 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { FileType } from '@nextcloud/files'
+import type { Node } from '@nextcloud/files'
+import { describe, expect, it, vi } from 'vitest'
+import { getSummaryFor } from './fileUtils.ts'
+
+// Mock translation function used in getSummaryFor
+vi.mock('@nextcloud/l10n', () => ({
+	n: vi.fn((app, single, plural, count) => {
+		if (count === 1) return single.replace('%n', count)
+		return plural.replace('%n', count)
+	}),
+}))
+
+describe('fileUtils', () => {
+	describe('getSummaryFor', () => {
+		it('returns correct summary for files and folders', () => {
+			const nodes = [
+				{ type: FileType.File } as Node,
+				{ type: FileType.Folder } as Node,
+			]
+			expect(getSummaryFor(nodes, 1)).toBe('1 file · 1 folder · 1 hidden')
+		})
+
+		it('does not display hidden string when hideHiddenString is true', () => {
+			const nodes = [
+				{ type: FileType.File } as Node,
+				{ type: FileType.Folder } as Node,
+			]
+			expect(getSummaryFor(nodes, 1, true)).toBe('1 file · 1 folder')
+		})
+
+		it('returns correct summary when there are no hidden files', () => {
+			const nodes = [
+				{ type: FileType.File } as Node,
+				{ type: FileType.File } as Node,
+			]
+			expect(getSummaryFor(nodes, 0)).toBe('2 files')
+		})
+	})
+})

--- a/apps/files/src/utils/fileUtils.ts
+++ b/apps/files/src/utils/fileUtils.ts
@@ -26,8 +26,9 @@ export function extractFilePaths(path: string): [string, string] {
  *
  * @param nodes - The nodes to summarize
  * @param hidden - The number of hidden nodes
+ * @param hideHiddenString - Whether to omit the hidden files text from the summary
  */
-export function getSummaryFor(nodes: Node[], hidden = 0): string {
+export function getSummaryFor(nodes: Node[], hidden = 0, hideHiddenString = false): string {
 	const fileCount = nodes.filter((node) => node.type === FileType.File).length
 	const folderCount = nodes.filter((node) => node.type === FileType.Folder).length
 
@@ -40,7 +41,7 @@ export function getSummaryFor(nodes: Node[], hidden = 0): string {
 		const folderSummary = n('files', '%n folder', '%n folders', folderCount)
 		summary.push(folderSummary)
 	}
-	if (hidden > 0) {
+	if (hidden > 0 && !hideHiddenString) {
 		// TRANSLATORS: This is the number of hidden files or folders
 		const hiddenSummary = n('files', '%n hidden', '%n hidden', hidden)
 		summary.push(hiddenSummary)

--- a/apps/files/src/views/FilesList.vue
+++ b/apps/files/src/views/FilesList.vue
@@ -446,7 +446,7 @@ export default defineComponent({
 		 */
 		summary() {
 			const hidden = this.dirContents.length - this.dirContentsFiltered.length
-			return getSummaryFor(this.dirContentsFiltered, hidden)
+			return getSummaryFor(this.dirContentsFiltered, hidden, this.isPublic)
 		},
 
 		debouncedFetchContent() {


### PR DESCRIPTION
* Resolves: #39027

## Summary

This pull request removes the display of the hidden files count in the summary on public share pages.

While dot files are already hidden in the public grid/list view, the footer summary was still displaying "X hidden". Since public users do not have access to toggle the visibility of hidden files via a gear icon, showing this helper text is unnecessary and leaks metadata about the presence of hidden files. 

This change modifies `getSummaryFor` in `fileUtils.ts` to accept a `hideHiddenString` argument, and leverages the existing `isPublic` prop in `FilesList.vue` to skip appending the hidden files string when rendering a public share.

## Screenshots (Before / After)

### Public Share Link (The Fix)
| Before | After |
|--------|-------|
| <img width="1919" height="1079" alt="before-public-link" src="https://github.com/user-attachments/assets/a78081f5-b877-4c85-9462-906b978339af" /> | <img width="1919" height="1006" alt="after-public-link" src="https://github.com/user-attachments/assets/4b828fce-f15a-4012-b8d3-f93355f62622" />  |




### Internal Logged-in View (Regression Check)
| Before | After |
|--------|-------|
| <img width="1919" height="1002" alt="before" src="https://github.com/user-attachments/assets/5f5db171-20f4-45a1-adc2-90251fb76561" /> | <img width="1919" height="1006" alt="after" src="https://github.com/user-attachments/assets/08f331fa-90a2-4366-8d3b-5d42bafe66af" /> |





## TODO

- [x] Pass `isPublic` flag to `getSummaryFor`
- [x] Unit test `getSummaryFor` with new arguments

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

> **Disclosure:** This pull request was assisted by Antigravity (Gemini 3.1 Pro).
