### PR TITLE
fix(files): bound SeekableHttpStream reads by Content-Range

### DIFF
--- a/lib/private/Files/Stream/SeekableHttpStream.php
+++ b/lib/private/Files/Stream/SeekableHttpStream.php
@@ -56,12 +56,13 @@ class SeekableHttpStream implements File {
 
 	/** @var ?resource|closed-resource */
 	private $current;
-	/** @var int $offset offset of the current chunk */
+
+	/** Absolute offset within the remote resource represented by this stream */
 	private int $offset = 0;
-	/** @var int $length length of the current chunk */
-	private int $length = 0;
-	/** @var int $totalSize size of the full stream */
+
+	/** Total size of the remote resource represented by this stream. */
 	private int $totalSize = 0;
+
 	private bool $needReconnect = false;
 
 	private function reconnect(int $start): bool {
@@ -104,7 +105,7 @@ class SeekableHttpStream implements File {
 		$content = trim(explode(':', $contentRange)[1]);
 		$range = trim(explode(' ', $content)[1]);
 		$begin = intval(explode('-', $range)[0]);
-		$length = intval(explode('/', $range)[1]);
+		$totalSize = intval(explode('/', $range)[1]);
 
 		if ($begin !== $start) {
 			$this->current = null;
@@ -112,9 +113,11 @@ class SeekableHttpStream implements File {
 		}
 
 		$this->offset = $begin;
-		$this->length = $length;
 		if ($start === 0) {
-			$this->totalSize = $length;
+			$this->totalSize = $totalSize;
+		} elseif ($this->totalSize !== $totalSize) {
+			$this->current = null;
+			return false;
 		}
 
 		return true;
@@ -152,11 +155,27 @@ class SeekableHttpStream implements File {
 
 	#[\Override]
 	public function stream_read($count) {
-		if (!$this->getCurrent()) {
+		$stream = $this->getCurrent();
+		if (!$stream) {
 			return false;
 		}
-		$ret = fread($this->getCurrent(), $count);
+
+		if ($count <= 0) {
+			return '';
+		}
+
+		$remaining = $this->totalSize - $this->offset;
+		if ($remaining <= 0) {
+			return '';
+		}
+
+		$ret = fread($stream, min($count, $remaining));
+		if ($ret === false) {
+			return false;
+		}
+
 		$this->offset += strlen($ret);
+
 		return $ret;
 	}
 
@@ -178,12 +197,12 @@ class SeekableHttpStream implements File {
 				}
 				break;
 			case SEEK_END:
-				if ($this->length === 0) {
+				if ($this->totalSize === 0) {
 					return false;
-				} elseif ($this->length + $offset === $this->offset) {
+				} elseif ($this->totalSize + $offset === $this->offset) {
 					return true;
 				} else {
-					$this->offset = $this->length + $offset;
+					$this->offset = $this->totalSize + $offset;
 				}
 				break;
 		}
@@ -216,11 +235,11 @@ class SeekableHttpStream implements File {
 
 	#[\Override]
 	public function stream_eof() {
-		if ($this->getCurrent()) {
-			return feof($this->getCurrent());
-		} else {
+		if (!$this->getCurrent()) {
 			return true;
-		}
+ 		}
+
+		return $this->offset >= $this->totalSize;
 	}
 
 	#[\Override]

--- a/lib/private/Files/Stream/SeekableHttpStream.php
+++ b/lib/private/Files/Stream/SeekableHttpStream.php
@@ -35,7 +35,7 @@ class SeekableHttpStream implements File {
 	 * The callback is called with a byte range and must return an HTTP stream
 	 * for that range.
 	 *
-	 * @param callable(string): resource|false $callback
+	 * @psalm-param impure-callable(string): resource|false $callback
 	 *
 	 * @return resource|false
 	 */
@@ -54,7 +54,7 @@ class SeekableHttpStream implements File {
 	/** @var resource */
 	public $context;
 
-	/** @var callable(string): resource|false */
+	/** @var impure-callable(string): resource|false */
 	private $openCallback;
 
 	/** @var ?resource|closed-resource */

--- a/lib/private/Files/Stream/SeekableHttpStream.php
+++ b/lib/private/Files/Stream/SeekableHttpStream.php
@@ -35,7 +35,7 @@ class SeekableHttpStream implements File {
 	 * The callback is called with a byte range and must return an HTTP stream
 	 * for that range.
 	 *
-	 * @psalm-param impure-callable(string): resource|false $callback
+	 * @psalm-param impure-callable(string): (resource|false) $callback
 	 *
 	 * @return resource|false
 	 */
@@ -54,7 +54,7 @@ class SeekableHttpStream implements File {
 	/** @var resource */
 	public $context;
 
-	/** @var impure-callable(string): resource|false */
+	/** @var impure-callable(string): (resource|false) */
 	private $openCallback;
 
 	/** @var ?resource|closed-resource */

--- a/lib/private/Files/Stream/SeekableHttpStream.php
+++ b/lib/private/Files/Stream/SeekableHttpStream.php
@@ -11,17 +11,17 @@ use Icewind\Streams\File;
 use Icewind\Streams\Wrapper;
 
 /**
- * A stream wrapper that uses http range requests to provide a seekable stream for http reading
+ * A stream wrapper that uses HTTP range requests to provide a seekable stream
+ * for HTTP reading.
  */
 class SeekableHttpStream implements File {
 	private const string PROTOCOL = 'httpseek';
 
 	/**
-	 * Registers the stream wrapper using the `httpseek://` url scheme
-	 * $return void
+	 * Registers the stream wrapper using the `httpseek://` URL scheme.
 	 */
-	private static function registerIfNeeded() {
-		if (!in_array(self::PROTOCOL, stream_get_wrappers())) {
+	private static function registerIfNeeded(): void {
+		if (!in_array(self::PROTOCOL, stream_get_wrappers(), true)) {
 			stream_wrapper_register(
 				self::PROTOCOL,
 				self::class
@@ -30,34 +30,37 @@ class SeekableHttpStream implements File {
 	}
 
 	/**
-	 * Open a readonly-seekable http stream
+	 * Opens a read-only, seekable HTTP stream.
 	 *
-	 * The provided callback will be called with byte range and should return an http stream for the requested range
+	 * The callback is called with a byte range and must return an HTTP stream
+	 * for that range.
 	 *
-	 * @param callable $callback
-	 * @return false|resource
+	 * @param callable(string): resource|false $callback
+	 *
+	 * @return resource|false
 	 */
 	public static function open(callable $callback) {
 		$context = stream_context_create([
-			SeekableHttpStream::PROTOCOL => [
+			self::PROTOCOL => [
 				'callback' => $callback
 			],
 		]);
 
-		SeekableHttpStream::registerIfNeeded();
-		return fopen(SeekableHttpStream::PROTOCOL . '://', 'r', false, $context);
+		self::registerIfNeeded();
+
+		return fopen(self::PROTOCOL . '://', 'r', false, $context);
 	}
 
 	/** @var resource */
 	public $context;
 
-	/** @var callable */
+	/** @var callable(string): resource|false */
 	private $openCallback;
 
 	/** @var ?resource|closed-resource */
-	private $current;
+	private $current = null;
 
-	/** Absolute offset within the remote resource represented by this stream */
+	/** Absolute offset within the remote resource represented by this stream. */
 	private int $offset = 0;
 
 	/** Total size of the remote resource represented by this stream. */
@@ -65,19 +68,56 @@ class SeekableHttpStream implements File {
 
 	private bool $needReconnect = false;
 
-	private function reconnect(int $start): bool {
-		$this->needReconnect = false;
-		$range = $start . '-';
-		if ($this->hasOpenStream()) {
-			fclose($this->current);
+	/**
+	 * @param array<int, mixed> $responseHeaders
+	 * @return array{begin: int, end: int, totalSize: int}|null
+	 */
+	private function parseContentRange(array $responseHeaders): ?array {
+		foreach ($responseHeaders as $header) {
+			if (!is_string($header)) {
+				continue;
+			}
+
+			if (preg_match(
+				'/^content-range:\s*bytes\s+(\d+)-(\d+)\/(\d+)\s*$/i',
+				$header,
+				$matches
+			) !== 1) {
+				continue;
+			}
+
+			$begin = (int)$matches[1];
+			$end = (int)$matches[2];
+			$totalSize = (int)$matches[3];
+
+			if ($end < $begin || $totalSize <= $end) {
+				return null;
+			}
+
+			return [
+				'begin' => $begin,
+				'end' => $end,
+				'totalSize' => $totalSize,
+			];
 		}
 
-		$stream = ($this->openCallback)($range);
+		return null;
+	}
 
-		if ($stream === false) {
-			$this->current = null;
+	private function reconnect(int $start): bool {
+		if ($start < 0) {
 			return false;
 		}
+
+		$this->closeCurrent();
+
+		$range = $start . '-';
+		$stream = ($this->openCallback)($range);
+		if ($stream === false) {
+			$this->closeCurrent();
+			return false;
+		}
+
 		$this->current = $stream;
 
 		$responseHead = stream_get_meta_data($this->current)['wrapper_data'];
@@ -90,59 +130,64 @@ class SeekableHttpStream implements File {
 					continue 2;
 				}
 			}
-			throw new \Exception('Failed to get source stream from stream wrapper of ' . get_class($responseHead));
+
+			$this->closeCurrent();
+			throw new \Exception(
+				'Failed to get source stream from stream wrapper of ' . get_class($responseHead)
+			);
 		}
 
-		$rangeHeaders = array_values(array_filter($responseHead, function ($v) {
-			return preg_match('#^content-range:#i', $v) === 1;
-		}));
-		if (!$rangeHeaders) {
-			$this->current = null;
-			return false;
-		}
-		$contentRange = $rangeHeaders[0];
-
-		$content = trim(explode(':', $contentRange)[1]);
-		$range = trim(explode(' ', $content)[1]);
-		$begin = intval(explode('-', $range)[0]);
-		$totalSize = intval(explode('/', $range)[1]);
-
-		if ($begin !== $start) {
-			$this->current = null;
+		if (!is_array($responseHead)) {
+			$this->closeCurrent();
 			return false;
 		}
 
-		$this->offset = $begin;
+		$contentRange = $this->parseContentRange($responseHead);
+
+		if ($contentRange === null || $contentRange['begin'] !== $start) {
+			$this->closeCurrent();
+			return false;
+		}
+
 		if ($start === 0) {
-			$this->totalSize = $totalSize;
-		} elseif ($this->totalSize !== $totalSize) {
-			$this->current = null;
+			$this->totalSize = $contentRange['totalSize'];
+		} elseif ($this->totalSize !== $contentRange['totalSize']) {
+			$this->closeCurrent();
 			return false;
 		}
+
+		$this->offset = $contentRange['begin'];
+		$this->needReconnect = false;
 
 		return true;
 	}
 
 	/**
-	 * @return ?resource
+	 * @return resource|null
 	 */
 	private function getCurrent() {
-		if ($this->needReconnect) {
-			$this->reconnect($this->offset);
-		}
-		if (is_resource($this->current)) {
-			return $this->current;
-		} else {
+		if ($this->needReconnect && !$this->reconnect($this->offset)) {
 			return null;
 		}
+
+		return $this->hasOpenStream() ? $this->current : null;
 	}
 
 	/**
 	 * @return bool
+	 *
 	 * @psalm-assert-if-true resource $this->current
 	 */
 	private function hasOpenStream(): bool {
 		return is_resource($this->current);
+	}
+
+	private function closeCurrent(): void {
+		if ($this->hasOpenStream()) {
+			fclose($this->current);
+		}
+
+		$this->current = null;
 	}
 
 	#[\Override]
@@ -155,11 +200,6 @@ class SeekableHttpStream implements File {
 
 	#[\Override]
 	public function stream_read($count) {
-		$stream = $this->getCurrent();
-		if (!$stream) {
-			return false;
-		}
-
 		if ($count <= 0) {
 			return '';
 		}
@@ -169,6 +209,13 @@ class SeekableHttpStream implements File {
 			return '';
 		}
 
+		$stream = $this->getCurrent();
+		if (!$stream) {
+			return false;
+		}
+
+		// Bound reads by Content-Range; premature underlying EOF is not
+		// explicitly detected if fewer bytes than expected are returned.
 		$ret = fread($stream, min($count, $remaining));
 		if ($ret === false) {
 			return false;
@@ -207,11 +254,9 @@ class SeekableHttpStream implements File {
 				break;
 		}
 
-		if ($this->hasOpenStream()) {
-			fclose($this->current);
-		}
-		$this->current = null;
+		$this->closeCurrent();
 		$this->needReconnect = true;
+
 		return true;
 	}
 
@@ -222,32 +267,35 @@ class SeekableHttpStream implements File {
 
 	#[\Override]
 	public function stream_stat() {
-		if ($this->getCurrent()) {
-			$stat = fstat($this->getCurrent());
-			if ($stat) {
-				$stat['size'] = $this->totalSize;
-			}
-			return $stat;
-		} else {
+		$stream = $this->getCurrent();
+		if (!$stream) {
 			return false;
 		}
+
+		$stat = fstat($stream);
+		if ($stat !== false) {
+			$stat['size'] = $this->totalSize;
+		}
+
+		return $stat;
 	}
 
 	#[\Override]
 	public function stream_eof() {
+		if ($this->offset >= $this->totalSize) {
+			return true;
+		}
+
 		if (!$this->getCurrent()) {
 			return true;
- 		}
+		}
 
-		return $this->offset >= $this->totalSize;
+		return false;
 	}
 
 	#[\Override]
 	public function stream_close() {
-		if ($this->hasOpenStream()) {
-			fclose($this->current);
-		}
-		$this->current = null;
+		$this->closeCurrent();
 	}
 
 	#[\Override]
@@ -272,6 +320,6 @@ class SeekableHttpStream implements File {
 
 	#[\Override]
 	public function stream_flush() {
-		return; //noop because readonly stream
+		// No-op because this is a read-only stream.
 	}
 }

--- a/tests/lib/Files/Stream/SeekableHttpStreamTest.php
+++ b/tests/lib/Files/Stream/SeekableHttpStreamTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Files\Stream;
+
+use OC\Files\Stream\SeekableHttpStream;
+use Test\TestCase;
+
+class SeekableHttpStreamTest extends TestCase {
+	public function testReadDoesNotReadBeyondRemoteResourceSize(): void {
+		$stream = new SeekableHttpStream();
+
+		$current = fopen('php://temp', 'r+');
+		fwrite($current, '0123456789');
+		fseek($current, 8);
+
+		$this->setPrivateProperty($stream, 'current', $current);
+		$this->setPrivateProperty($stream, 'offset', 8);
+		$this->setPrivateProperty($stream, 'totalSize', 10);
+
+		$this->assertSame('89', $stream->stream_read(100));
+		$this->assertSame(10, $stream->stream_tell());
+		$this->assertTrue($stream->stream_eof());
+
+		fclose($current);
+	}
+
+	public function testReadAtLogicalEndReturnsEmptyString(): void {
+		$stream = new SeekableHttpStream();
+
+		$this->setPrivateProperty($stream, 'offset', 10);
+		$this->setPrivateProperty($stream, 'totalSize', 10);
+
+		$this->assertSame('', $stream->stream_read(100));
+		$this->assertTrue($stream->stream_eof());
+	}
+
+	public function testEofAtLogicalEndDoesNotReconnect(): void {
+		$stream = new SeekableHttpStream();
+
+		$this->setPrivateProperty($stream, 'offset', 10);
+		$this->setPrivateProperty($stream, 'totalSize', 10);
+		$this->setPrivateProperty($stream, 'needReconnect', true);
+
+		/*
+		 * If stream_eof() attempted to reconnect before checking the logical
+		 * end, this would try to invoke the unset callback.
+		 */
+		$this->assertTrue($stream->stream_eof());
+	}
+
+	public function testParsesContentRange(): void {
+		$stream = new SeekableHttpStream();
+
+		$result = $this->invokePrivate(
+			$stream,
+			'parseContentRange',
+			[[
+				'HTTP/1.1 206 Partial Content',
+				'Content-Range: bytes 10-19/100',
+			]]
+		);
+
+		$this->assertSame([
+			'begin' => 10,
+			'end' => 19,
+			'totalSize' => 100,
+		], $result);
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidContentRangeProvider')]
+	public function testRejectsInvalidContentRange(string $contentRange): void {
+		$stream = new SeekableHttpStream();
+
+		$result = $this->invokePrivate(
+			$stream,
+			'parseContentRange',
+			[[$contentRange]]
+		);
+
+		$this->assertNull($result);
+	}
+
+	public static function invalidContentRangeProvider(): array {
+		return [
+			'missing header' => ['HTTP/1.1 200 OK'],
+			'missing total size' => ['Content-Range: bytes 0-9/*'],
+			'descending range' => ['Content-Range: bytes 9-0/10'],
+			'total smaller than end' => ['Content-Range: bytes 0-9/9'],
+			'not bytes' => ['Content-Range: items 0-9/10'],
+			'malformed range' => ['Content-Range: bytes 0-9'],
+		];
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	private function setPrivateProperty(
+		SeekableHttpStream $stream,
+		string $property,
+		mixed $value,
+	): void {
+		$reflection = new \ReflectionClass($stream);
+		$reflection->getProperty($property)->setValue($stream, $value);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #58276 <!-- related github issue -->

## Summary

Harden `SeekableHttpStream` range handling by making the resource size declared in `Content-Range` authoritative.

The key read-boundary change is:

```php
$remaining = $this->totalSize - $this->offset;
$ret = fread($stream, min($count, $remaining));
```

Reads are now limited to the remaining bytes in the remote resource, so the wrapper no longer requests data beyond the logical end simply because an HTTP connection remains open.

The second commit hardens `Content-Range` validation through a dedicated helper and makes stream lifecycle and reconnect failure handling more explicit. It also ensures that the total resource size remains consistent across range requests.

Logical EOF is determined from the declared resource size rather than transport connection closure. No additional `feof()` check is introduced, since probing a socket for transport-level EOF could add blocking behavior. A response shorter than its declared `Content-Range` remains governed by the existing PHP stream semantics.

This addresses the timeout reported in #58276 while also improving general range-stream correctness and adding focused explicit test coverage.

## TODO

- [ ] Backport?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
