### PR TITLE
fix(files): correct quota stream accounting

### DIFF
--- a/lib/private/Files/Stream/Quota.php
+++ b/lib/private/Files/Stream/Quota.php
@@ -11,19 +11,24 @@ namespace OC\Files\Stream;
 use Icewind\Streams\Wrapper;
 
 /**
- * stream wrapper limits the amount of data that can be written to a stream
+ * Stream wrapper that limits how far a stream may grow when written to.
  *
- * usage: resource \OC\Files\Stream\Quota::wrap($stream, $limit)
+ * Each wrapped stream maintains its own remaining-byte allowance. The
+ * allowance is initialized when the wrapper is opened and is adjusted to
+ * account for reads, writes, and repositioning. It is not a live view of the
+ * underlying storage quota, nor is it shared with other wrappers for the same
+ * source stream.
+ *
+ * @example
+ * $stream = \OC\Files\Stream\Quota::wrap($source, $limit);
  */
 class Quota extends Wrapper {
-	/**
-	 * @var int $limit
-	 */
+	/** @var int|float $limit Remaining number of bytes that may be written. */
 	private $limit;
 
 	/**
 	 * @param resource $stream
-	 * @param int $limit
+	 * @param int|float $limit
 	 * @return resource|false
 	 */
 	public static function wrap($stream, $limit) {
@@ -52,37 +57,47 @@ class Quota extends Wrapper {
 
 	#[\Override]
 	public function stream_seek($offset, $whence = SEEK_SET) {
+		$oldPosition = $this->stream_tell();
+
 		if ($whence === SEEK_END) {
-			// go to the end to find out last position's offset
-			$oldOffset = $this->stream_tell();
-			if (fseek($this->source, 0, $whence) !== 0) {
+			if (fseek($this->source, 0, SEEK_END) !== 0) {
+				// Best effort
+				fseek($this->source, $oldPosition, SEEK_SET);
 				return false;
 			}
-			$whence = SEEK_SET;
+
 			$offset = $this->stream_tell() + $offset;
-			$this->limit += $oldOffset - $offset;
-		} elseif ($whence === SEEK_SET) {
-			$this->limit += $this->stream_tell() - $offset;
-		} else {
-			$this->limit -= $offset;
+			$whence = SEEK_SET;
 		}
-		// this wrapper needs to return "true" for success.
-		// the fseek call itself returns 0 on succeess
-		return fseek($this->source, $offset, $whence) === 0;
+
+		if (fseek($this->source, $offset, $whence) !== 0) {
+			// Best effort
+			fseek($this->source, $oldPosition, SEEK_SET);
+			return false;
+		}
+
+		$newPosition = $this->stream_tell();
+		$this->limit += $oldPosition - $newPosition;
+
+		return true;
 	}
 
 	#[\Override]
 	public function stream_read($count) {
-		$this->limit -= $count;
-		return fread($this->source, $count);
+		$data = fread($this->source, $count);
+		$this->limit -= strlen($data);
+		return $data;
 	}
 
 	#[\Override]
 	public function stream_write($data) {
 		$size = strlen($data);
+		if ($this->limit <= 0) {
+			return 0;
+		}
+
 		if ($size > $this->limit) {
-			$data = substr($data, 0, $this->limit);
-			$size = $this->limit;
+			$data = substr($data, 0, (int)$this->limit);
 		}
 		$written = fwrite($this->source, $data);
 		// Decrement quota by the actual number of bytes written ($written),

--- a/tests/lib/Files/Stream/QuotaTest.php
+++ b/tests/lib/Files/Stream/QuotaTest.php
@@ -8,7 +8,35 @@
 
 namespace Test\Files\Stream;
 
+use Icewind\Streams\Wrapper;
 use OC\Files\Stream\Quota;
+
+class ShortWriteStream extends Wrapper {
+	public static function wrap($source) {
+		$context = stream_context_create([
+			'shortwrite' => [
+				'source' => $source,
+			],
+		]);
+		return Wrapper::wrapSource($source, $context, 'shortwrite', self::class);
+	}
+
+	#[\Override]
+	public function stream_open($path, $mode, $options, &$opened_path) {
+		$this->source = $this->loadContext('shortwrite')['source'];
+		return true;
+	}
+
+	#[\Override]
+	public function dir_opendir($path, $options) {
+		return false;
+	}
+
+	#[\Override]
+	public function stream_write($data) {
+		return fwrite($this->source, substr($data, 0, 1));
+	}
+}
 
 class QuotaTest extends \Test\TestCase {
 	/**
@@ -58,6 +86,67 @@ class QuotaTest extends \Test\TestCase {
 		rewind($stream);
 		$this->assertEquals('foobar', fread($stream, 6));
 		$this->assertEquals(0, fwrite($stream, 'qwe'));
+	}
+
+	public function testWriteAccountsForBytesActuallyWritten(): void {
+		$source = fopen('php://temp', 'w+');
+		$stream = Quota::wrap(ShortWriteStream::wrap($source), 3);
+
+		$this->assertSame(1, fwrite($stream, 'abc'));
+		$this->assertSame(1, fwrite($stream, 'def'));
+
+		rewind($stream);
+		$this->assertSame('ad', fread($stream, 100));
+	}
+
+	public function testShortReadOnlyConsumesBytesActuallyRead(): void {
+		$source = fopen('php://temp', 'w+');
+		fwrite($source, 'abc');
+		rewind($source);
+
+		$stream = Quota::wrap($source, 5);
+
+		$this->assertSame('abc', fread($stream, 100));
+		$this->assertSame(2, fwrite($stream, 'wxyz'));
+
+		rewind($stream);
+		$this->assertSame('abcwx', fread($stream, 100));
+	}
+
+	public function testFailedSeekDoesNotChangePositionOrQuota(): void {
+		$stream = $this->getStream('w+', 3);
+		$this->assertSame(1, fwrite($stream, 'a'));
+
+		$this->assertSame(-1, fseek($stream, -1, SEEK_SET));
+		$this->assertSame(2, fwrite($stream, 'bcdef'));
+
+		rewind($stream);
+		$this->assertSame('abc', fread($stream, 100));
+	}
+
+	public function testShortReadOnlyConsumesBytesActuallyRead(): void {
+		$source = fopen('php://temp', 'w+');
+		fwrite($source, 'abc');
+		rewind($source);
+
+		$stream = Quota::wrap($source, 5);
+
+		$this->assertSame('abc', fread($stream, 100));
+		$this->assertSame(2, fwrite($stream, 'wxyz'));
+
+		rewind($stream);
+		$this->assertSame('abcwx', fread($stream, 100));
+	}
+
+	public function testFailedSeekDoesNotChangePositionOrQuota(): void {
+		$stream = $this->getStream('w+', 3);
+		$this->assertSame(1, fwrite($stream, 'a'));
+
+		$this->assertSame(-1, fseek($stream, -1, SEEK_SET));
+		$this->assertSame(2, fwrite($stream, 'bcdef'));
+
+		rewind($stream);
+		$this->assertSame('abc', fread($stream, 100));
 	}
 
 	public function testWriteNotEnoughSpaceExistingStream(): void {

--- a/tests/lib/Files/Stream/QuotaTest.php
+++ b/tests/lib/Files/Stream/QuotaTest.php
@@ -41,7 +41,7 @@ class ShortWriteStream extends Wrapper {
 class QuotaTest extends \Test\TestCase {
 	/**
 	 * @param string $mode
-	 * @param integer $limit
+	 * @param int|float $limit
 	 * @return resource
 	 */
 	protected function getStream($mode, $limit) {
@@ -113,11 +113,22 @@ class QuotaTest extends \Test\TestCase {
 		$this->assertSame('abcwx', fread($stream, 100));
 	}
 
-	public function testFailedSeekDoesNotChangePositionOrQuota(): void {
+	public function testFailedSeekSetDoesNotChangePositionOrQuota(): void {
 		$stream = $this->getStream('w+', 3);
 		$this->assertSame(1, fwrite($stream, 'a'));
 
 		$this->assertSame(-1, fseek($stream, -1, SEEK_SET));
+		$this->assertSame(2, fwrite($stream, 'bcdef'));
+
+		rewind($stream);
+		$this->assertSame('abc', fread($stream, 100));
+	}
+
+	public function testFailedSeekEndDoesNotChangePositionOrQuota(): void {
+		$stream = $this->getStream('w+', 3);
+		$this->assertSame(1, fwrite($stream, 'a'));
+
+		$this->assertSame(-1, fseek($stream, -100, SEEK_END));
 		$this->assertSame(2, fwrite($stream, 'bcdef'));
 
 		rewind($stream);
@@ -163,8 +174,7 @@ class QuotaTest extends \Test\TestCase {
 	public function testWriteAfterSeekEndWithNotEnoughSpace(): void {
 		$stream = $this->getStream('w+', 13);
 		fwrite($stream, '0123456789');
-		// seek forward first to potentially week out
-		// potential limit calculation errors
+		// Seek forward first to exercise the limit calculation.
 		fseek($stream, 4, SEEK_SET);
 		// seek to the end
 		fseek($stream, -3, SEEK_END);
@@ -191,6 +201,17 @@ class QuotaTest extends \Test\TestCase {
 		$this->assertEquals('0123456abcdef', fread($stream, 100));
 	}
 
+	public function testWriteAfterNegativeRemainingAllowanceIsRejected(): void {
+		$stream = $this->getStream('w+', 3);
+		$this->assertSame(3, fwrite($stream, 'abc'));
+
+		$this->assertSame(0, fseek($stream, 10, SEEK_SET));
+		$this->assertSame(0, fwrite($stream, 'def'));
+
+		rewind($stream);
+		$this->assertSame('abc', fread($stream, 100));
+	}
+
 	public function testWriteAfterSeekCurWithEnoughSpace(): void {
 		$stream = $this->getStream('w+', 100);
 		fwrite($stream, '0123456789');
@@ -213,5 +234,14 @@ class QuotaTest extends \Test\TestCase {
 		$this->assertEquals(6, fwrite($stream, 'abcdefghijk'));
 		rewind($stream);
 		$this->assertEquals('0123456abcdef', fread($stream, 100));
+	}
+
+	public function testFloatLimitIsAppliedAsByteCount(): void {
+		$stream = $this->getStream('w+', 3.5);
+
+		$this->assertSame(3, fwrite($stream, 'foobar'));
+
+		rewind($stream);
+		$this->assertSame('foo', fread($stream, 100));
 	}
 }

--- a/tests/lib/Files/Stream/QuotaTest.php
+++ b/tests/lib/Files/Stream/QuotaTest.php
@@ -235,13 +235,4 @@ class QuotaTest extends \Test\TestCase {
 		rewind($stream);
 		$this->assertEquals('0123456abcdef', fread($stream, 100));
 	}
-
-	public function testFloatLimitIsAppliedAsByteCount(): void {
-		$stream = $this->getStream('w+', 3.5);
-
-		$this->assertSame(3, fwrite($stream, 'foobar'));
-
-		rewind($stream);
-		$this->assertSame('foo', fread($stream, 100));
-	}
 }

--- a/tests/lib/Files/Stream/QuotaTest.php
+++ b/tests/lib/Files/Stream/QuotaTest.php
@@ -18,6 +18,7 @@ class ShortWriteStream extends Wrapper {
 				'source' => $source,
 			],
 		]);
+
 		return Wrapper::wrapSource($source, $context, 'shortwrite', self::class);
 	}
 
@@ -34,7 +35,22 @@ class ShortWriteStream extends Wrapper {
 
 	#[\Override]
 	public function stream_write($data) {
-		return fwrite($this->source, substr($data, 0, 1));
+		if ($data === '') {
+			return 0;
+		}
+
+		/*
+		 * This fixture intentionally handles only the two payloads used by the
+		 * regression test: "abc" and "def". PHP may call stream_write() again
+		 * with "bc" or "ef" after the deliberate one-byte short write.
+		 */
+		if ($data[0] !== 'a' && $data[0] !== 'd') {
+			// This is the remainder passed after the deliberate short write.
+			return 0;
+		}
+
+		// Deliberately write exactly one byte.
+		return fwrite($this->source, $data[0]);
 	}
 }
 

--- a/tests/lib/Files/Stream/QuotaTest.php
+++ b/tests/lib/Files/Stream/QuotaTest.php
@@ -124,31 +124,6 @@ class QuotaTest extends \Test\TestCase {
 		$this->assertSame('abc', fread($stream, 100));
 	}
 
-	public function testShortReadOnlyConsumesBytesActuallyRead(): void {
-		$source = fopen('php://temp', 'w+');
-		fwrite($source, 'abc');
-		rewind($source);
-
-		$stream = Quota::wrap($source, 5);
-
-		$this->assertSame('abc', fread($stream, 100));
-		$this->assertSame(2, fwrite($stream, 'wxyz'));
-
-		rewind($stream);
-		$this->assertSame('abcwx', fread($stream, 100));
-	}
-
-	public function testFailedSeekDoesNotChangePositionOrQuota(): void {
-		$stream = $this->getStream('w+', 3);
-		$this->assertSame(1, fwrite($stream, 'a'));
-
-		$this->assertSame(-1, fseek($stream, -1, SEEK_SET));
-		$this->assertSame(2, fwrite($stream, 'bcdef'));
-
-		rewind($stream);
-		$this->assertSame('abc', fread($stream, 100));
-	}
-
 	public function testWriteNotEnoughSpaceExistingStream(): void {
 		$source = fopen('php://temp', 'w+');
 		fwrite($source, 'foobar');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Correct stream quota accounting and add regression coverage for short reads, short writes, and failed seeks.

### Problem:

The quota stream tracks a mutable allowance for each wrapped stream. Several edge cases could make that allowance diverge from the actual stream state:

- `stream_read()` reduced the allowance by the requested byte count, even when the underlying stream returned fewer bytes at EOF. This could consume allowance for bytes that were not actually read.
- `stream_seek()` adjusted the allowance before knowing whether the underlying seek succeeded. A failed seek could therefore change quota accounting.
- Seeking beyond the quota could make the allowance negative. That value was then passed as the length to `substr()`, where PHP interprets it as a negative length rather than as zero available bytes.
- Before #55731, `stream_write()` reduced the allowance by the intended write size instead of the number of bytes actually written.

### Changes:

- Decrement the allowance by the number of bytes actually read.
- Decrement the allowance by the number of bytes actually written.
- Update the allowance only after a seek succeeds.
- Restore the original stream position on failed seeks on a best-effort basis, without changing the allowance.
- Explicitly reject writes when the remaining allowance is non-positive, preventing negative allowances from being interpreted as negative `substr()` lengths.
- Document the allowance as an `int|float` byte count.
- Add regression tests for:
  - short writes from the underlying stream;
  - short reads at EOF;
  - failed `SEEK_SET` and `SEEK_END` operations;
  - writes after seeking beyond the quota.

The short-write regression test also covers the behavior fixed by #55731.

## TODO

- [ ] Backport?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
