### PR TITLE
perf(files): keep the mimetype table in the local cache

### DIFF
--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -12,6 +12,8 @@ use OC\DB\Exceptions\DbalException;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\DB\Exception as DBException;
 use OCP\Files\IMimeTypeLoader;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\IDBConnection;
 
 /**
@@ -22,20 +24,32 @@ use OCP\IDBConnection;
 class Loader implements IMimeTypeLoader {
 	use TTransactional;
 
+	private const string CACHE_KEY = 'mimetypes';
+	private const int CACHE_TTL = 3600;
+
 	/** @psalm-var array<int, string> */
-	protected array $mimetypes;
+	protected array $mimetypes = [];
 
 	/** @psalm-var array<string, int> */
-	protected array $mimetypeIds;
+	protected array $mimetypeIds = [];
+
+	private ICache $cache;
+
+	/**
+	 * The cached copy of the table may lack rows added by another process,
+	 * so a miss reloads from the database once per instance.
+	 */
+	private bool $reloaded = false;
 
 	/**
 	 * @param IDBConnection $dbConnection
+	 * @param ICacheFactory $cacheFactory
 	 */
 	public function __construct(
 		private IDBConnection $dbConnection,
+		ICacheFactory $cacheFactory,
 	) {
-		$this->mimetypes = [];
-		$this->mimetypeIds = [];
+		$this->cache = $cacheFactory->createLocal('mimetypes');
 	}
 
 	/**
@@ -46,10 +60,10 @@ class Loader implements IMimeTypeLoader {
 		if (!$this->mimetypes) {
 			$this->loadMimetypes();
 		}
-		if (isset($this->mimetypes[$id])) {
-			return $this->mimetypes[$id];
+		if (!isset($this->mimetypes[$id])) {
+			$this->reloadOnMiss();
 		}
-		return null;
+		return $this->mimetypes[$id] ?? null;
 	}
 
 	/**
@@ -59,6 +73,9 @@ class Loader implements IMimeTypeLoader {
 	public function getId(string $mimetype): int {
 		if (!$this->mimetypeIds) {
 			$this->loadMimetypes();
+		}
+		if (!isset($this->mimetypeIds[$mimetype])) {
+			$this->reloadOnMiss();
 		}
 		if (isset($this->mimetypeIds[$mimetype])) {
 			return $this->mimetypeIds[$mimetype];
@@ -74,6 +91,9 @@ class Loader implements IMimeTypeLoader {
 		if (!$this->mimetypeIds) {
 			$this->loadMimetypes();
 		}
+		if (!isset($this->mimetypeIds[$mimetype])) {
+			$this->reloadOnMiss();
+		}
 		return isset($this->mimetypeIds[$mimetype]);
 	}
 
@@ -84,6 +104,8 @@ class Loader implements IMimeTypeLoader {
 	public function reset(): void {
 		$this->mimetypes = [];
 		$this->mimetypeIds = [];
+		$this->reloaded = false;
+		$this->cache->remove(self::CACHE_KEY);
 	}
 
 	/**
@@ -118,30 +140,63 @@ class Loader implements IMimeTypeLoader {
 			if ($id === false) {
 				throw new \Exception("Database threw an unique constraint on inserting a new mimetype, but couldn't return the ID for this very mimetype");
 			}
-
 			$mimetypeId = (int)$id;
 		}
 
 		$this->mimetypes[$mimetypeId] = $mimetype;
 		$this->mimetypeIds[$mimetype] = $mimetypeId;
+		$this->cache->remove(self::CACHE_KEY);
+
 		return $mimetypeId;
 	}
 
 	/**
-	 * Load all mimetypes from DB
+	 * Load all mimetypes from the cache, falling back to the DB
 	 */
 	private function loadMimetypes(): void {
+		$cached = $this->cache->get(self::CACHE_KEY);
+		if (is_array($cached) && $cached !== []) {
+			$this->setMimetypes($cached);
+			return;
+		}
+		$this->loadMimetypesFromDatabase();
+	}
+
+	private function reloadOnMiss(): void {
+		if ($this->reloaded) {
+			return;
+		}
+		$this->reloaded = true;
+		$this->loadMimetypesFromDatabase();
+	}
+
+	private function loadMimetypesFromDatabase(): void {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('id', 'mimetype')
 			->from('mimetypes');
-
 		$result = $qb->executeQuery();
 		$results = $result->fetchAllAssociative();
 		$result->closeCursor();
 
+		$mimetypes = [];
 		foreach ($results as $row) {
-			$this->mimetypes[(int)$row['id']] = $row['mimetype'];
-			$this->mimetypeIds[$row['mimetype']] = (int)$row['id'];
+			$mimetypes[(int)$row['id']] = (string)$row['mimetype'];
+		}
+		$this->setMimetypes($mimetypes);
+		if ($mimetypes !== []) {
+			$this->cache->set(self::CACHE_KEY, $mimetypes, self::CACHE_TTL);
+		}
+	}
+
+	/**
+	 * @param array<int, string> $mimetypes
+	 */
+	private function setMimetypes(array $mimetypes): void {
+		$this->mimetypes = [];
+		$this->mimetypeIds = [];
+		foreach ($mimetypes as $id => $mimetype) {
+			$this->mimetypes[(int)$id] = $mimetype;
+			$this->mimetypeIds[$mimetype] = (int)$id;
 		}
 	}
 

--- a/tests/lib/Files/Type/LoaderTest.php
+++ b/tests/lib/Files/Type/LoaderTest.php
@@ -9,6 +9,9 @@
 namespace Test\Files\Type;
 
 use OC\Files\Type\Loader;
+use OC\Memcache\ArrayCache;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\Server;
 use PHPUnit\Framework\Attributes\Group;
@@ -17,6 +20,7 @@ use Test\TestCase;
 #[Group('DB')]
 class LoaderTest extends TestCase {
 	protected IDBConnection $db;
+	protected ICache $cache;
 	protected Loader $loader;
 
 	#[\Override]
@@ -24,7 +28,8 @@ class LoaderTest extends TestCase {
 		parent::setUp();
 
 		$this->db = Server::get(IDBConnection::class);
-		$this->loader = new Loader($this->db);
+		$this->cache = new ArrayCache();
+		$this->loader = $this->createLoader($this->db);
 	}
 
 	#[\Override]
@@ -38,13 +43,24 @@ class LoaderTest extends TestCase {
 		parent::tearDown();
 	}
 
-	public function testGetMimetype(): void {
+	private function createLoader(IDBConnection $db): Loader {
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createLocal')->willReturn($this->cache);
+		return new Loader($db, $cacheFactory);
+	}
+
+	private function insertMimetype(string $mimetype): int {
 		$qb = $this->db->getQueryBuilder();
 		$qb->insert('mimetypes')
 			->values([
-				'mimetype' => $qb->createPositionalParameter('testing/mymimetype')
+				'mimetype' => $qb->createPositionalParameter($mimetype)
 			]);
 		$qb->executeStatement();
+		return $qb->getLastInsertId();
+	}
+
+	public function testGetMimetype(): void {
+		$this->insertMimetype('testing/mymimetype');
 
 		$this->assertTrue($this->loader->exists('testing/mymimetype'));
 		$mimetypeId = $this->loader->getId('testing/mymimetype');
@@ -83,5 +99,44 @@ class LoaderTest extends TestCase {
 		$mimetypeId2 = $this->loader->getId('testing/mymimetype');
 
 		$this->assertEquals($mimetypeId, $mimetypeId2);
+	}
+
+	public function testMimetypesAreServedFromTheLocalCache(): void {
+		$mimetypeId = $this->insertMimetype('testing/cached');
+		$this->assertEquals('testing/cached', $this->loader->getMimetypeById($mimetypeId));
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->expects($this->never())->method('getQueryBuilder');
+		$loader = $this->createLoader($db);
+
+		$this->assertEquals('testing/cached', $loader->getMimetypeById($mimetypeId));
+		$this->assertEquals($mimetypeId, $loader->getId('testing/cached'));
+		$this->assertTrue($loader->exists('testing/cached'));
+	}
+
+	public function testUnknownIdIsReloadedFromTheDatabase(): void {
+		$this->assertTrue($this->loader->exists('httpd/unix-directory'));
+
+		// added by another process after this instance loaded the table
+		$mimetypeId = $this->insertMimetype('testing/late');
+
+		$this->assertEquals('testing/late', $this->loader->getMimetypeById($mimetypeId));
+		$this->assertEquals($mimetypeId, $this->createLoader($this->db)->getId('testing/late'));
+		// only one reload per instance
+		$this->assertNull($this->loader->getMimetypeById(12345));
+	}
+
+	public function testStoreAndResetInvalidateTheCache(): void {
+		$this->assertTrue($this->loader->exists('httpd/unix-directory'));
+		$this->assertTrue($this->cache->hasKey('mimetypes'));
+
+		$this->loader->getId('testing/new');
+		$this->assertFalse($this->cache->hasKey('mimetypes'));
+
+		$this->assertTrue($this->createLoader($this->db)->exists('testing/new'));
+		$this->assertTrue($this->cache->hasKey('mimetypes'));
+
+		$this->loader->reset();
+		$this->assertFalse($this->cache->hasKey('mimetypes'));
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`OC\Files\Type\Loader` loaded the whole `oc_mimetypes` table from the database in **every PHP process that touched the filesystem**: in a captured workload the `SELECT id, mimetype FROM oc_mimetypes` statement ran 154 times across 169 connections. The table is append-only and tiny, so keep it in the local memcache (one hour TTL) and serve lookups from there.

A cached copy can miss rows another process or host added after it was taken, so an unknown id or mimetype reloads the table from the database once per loader instance before it is reported as missing; `store()` and `reset()` drop the cached copy.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI