### PR TITLE
[stable34] fix(metadata): bind chunked file ids in dropMetadataForFiles

### DIFF
--- a/lib/private/FilesMetadata/Service/MetadataRequestService.php
+++ b/lib/private/FilesMetadata/Service/MetadataRequestService.php
@@ -155,7 +155,7 @@ class MetadataRequestService {
 		foreach ($chunks as $chunk) {
 			$qb = $this->dbConnection->getQueryBuilder();
 			$qb->delete(self::TABLE_METADATA)
-				->where($qb->expr()->in('file_id', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)))
+				->where($qb->expr()->in('file_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)))
 				->hintShardKey('storage', $storage);
 			$qb->executeStatement();
 		}


### PR DESCRIPTION
Manual backport of #62331 to `stable34`.

`MetadataRequestService::dropMetadataForFiles()` splits `$fileIds` into chunks of 1000 and iterates over them, but the `IN` clause still binds the full `$fileIds` array instead of the current `$chunk`. Each iteration therefore issues the same full-size `DELETE`, which produces the `More than 1000 expressions in a list are not allowed on Oracle.` entry from `QueryBuilder::prepareForExecute()` and repeats an identical statement once per chunk.

The sibling method `IndexRequestService::dropIndexForFiles()` carried the same copy/paste bug and was already backported to `stable34` in #62771. This applies the equivalent one-line fix to the metadata table.

### Difference from the master patch

master's #62331 switches the chunk size to `IQueryBuilder::MAX_IN_PARAMETERS`, which does not exist on `stable34`. This PR keeps the existing literal `1000` and changes only the bound variable, matching the shape of the already-merged `stable34` backport #62771 (`+1/-1`, same file family).

`getMetadataFromFileIds()` a few lines above also binds an unchunked `$fileIds`, but master's #62331 leaves it untouched as well, so it is out of scope here.

### Why this is filed by hand

`/backport to stable34` was requested on #62331 twice without response — in prose on 2026-08-08 and as the bot command on 2026-09-06. Both requesters have `author_association: NONE`, so the command does not appear to be honoured from non-members. Filing manually rather than leaving `stable34` unpatched; happy to close this if backportbot is triggered by a maintainer instead.

Refs #62331, #62771, #62325
