### PR TITLE
fix: Cache enabled apps for user in appmanager

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -24,6 +24,7 @@ use OCP\App\Events\AppUpdateEvent;
 use OCP\App\IAppManager;
 use OCP\App\ManagerEvent;
 use OCP\BackgroundJob\IJobList;
+use OCP\Cache\CappedMemoryCache;
 use OCP\Collaboration\AutoComplete\IManager as IAutoCompleteManager;
 use OCP\Collaboration\Collaborators\ISearch as ICollaboratorSearch;
 use OCP\Diagnostics\IEventLogger;
@@ -61,6 +62,7 @@ class AppManager implements IAppManager {
 
 	/** @var string[] $appId => $enabled */
 	private array $enabledAppsCache = [];
+	private CappedMemoryCache $enabledAppsForUserCache;
 
 	/** @var array<string, array{path: string, url: string}> $appId => approot information */
 	private array $appsDirCache = [];
@@ -108,6 +110,7 @@ class AppManager implements IAppManager {
 		private ConfigManager $configManager,
 		private DependencyAnalyzer $dependencyAnalyzer,
 	) {
+		$this->enabledAppsForUserCache = new CappedMemoryCache();
 	}
 
 	private function getNavigationManager(): INavigationManager {
@@ -241,11 +244,15 @@ class AppManager implements IAppManager {
 	 */
 	#[\Override]
 	public function getEnabledAppsForUser(IUser $user) {
+		$uid = $user->getUID();
+		if (isset($this->enabledAppsForUserCache[$uid])) {
+			return $this->enabledAppsForUserCache[$uid];
+		}
 		$apps = $this->getEnabledAppsValues();
 		$appsForUser = array_filter($apps, function ($enabled) use ($user) {
 			return $this->checkAppForUser($enabled, $user);
 		});
-		return array_keys($appsForUser);
+		return $this->enabledAppsForUserCache[$uid] = array_keys($appsForUser);
 	}
 
 	#[\Override]
@@ -648,6 +655,7 @@ class AppManager implements IAppManager {
 		}
 
 		$this->enabledAppsCache[$appId] = 'yes';
+		$this->enabledAppsForUserCache = new CappedMemoryCache();
 		$this->getAppConfig()->setValue($appId, 'enabled', 'yes');
 		$this->dispatcher->dispatchTyped(new AppEnableEvent($appId));
 		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE, new ManagerEvent(
@@ -704,6 +712,7 @@ class AppManager implements IAppManager {
 		}, $groups);
 
 		$this->enabledAppsCache[$appId] = json_encode($groupIds);
+		$this->enabledAppsForUserCache = new CappedMemoryCache();
 		$this->getAppConfig()->setValue($appId, 'enabled', json_encode($groupIds));
 		$this->dispatcher->dispatchTyped(new AppEnableEvent($appId, $groupIds));
 		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, new ManagerEvent(
@@ -736,6 +745,7 @@ class AppManager implements IAppManager {
 		}
 
 		unset($this->enabledAppsCache[$appId]);
+		$this->enabledAppsForUserCache = new CappedMemoryCache();
 		$this->getAppConfig()->setValue($appId, 'enabled', 'no');
 
 		// run uninstall steps


### PR DESCRIPTION
## Summary

When some apps are enabled only for some groups this avoids recomputing
 the list several times in the same request in some situations.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
