### PR TITLE
perf: make request to /contactsmenu/teams only when contacts menu is opened

### DIFF
--- a/core/src/views/ContactsMenu.vue
+++ b/core/src/views/ContactsMenu.vue
@@ -11,7 +11,7 @@ import { getBuilder } from '@nextcloud/browser-storage'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import debounce from 'debounce'
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
@@ -45,22 +45,10 @@ const teams = ref<ITeam[]>([])
 const selectedTeam = ref<string>('$_all_$')
 const selectedTeamName = computed(() => teams.value.find((t) => t.teamId === selectedTeam.value)?.displayName)
 
-onMounted(async () => {
-	const team = storage.getItem('core:contacts:team')
-	if (team) {
-		selectedTeam.value = JSON.parse(team)
-	}
-
-	if (userTeams.length === 0) {
-		try {
-			const { data } = await axios.get<ITeam[]>(generateUrl('/contactsmenu/teams'))
-			userTeams.push(...data)
-		} catch (error) {
-			logger.error('could not load user teams', { error })
-		}
-	}
-	teams.value = [...userTeams]
-})
+const team = storage.getItem('core:contacts:team')
+if (team) {
+	selectedTeam.value = JSON.parse(team)
+}
 
 watch(selectedTeam, () => {
 	storage.setItem('core:contacts:team', JSON.stringify(selectedTeam.value))
@@ -71,7 +59,22 @@ watch(selectedTeam, () => {
  * Load contacts when opening the menu
  */
 async function onOpened() {
-	await getContacts('')
+	await Promise.all([getContacts(''), getTeams()])
+}
+
+/**
+ * Load teams for current user from the server
+ */
+async function getTeams() {
+	if (userTeams.length === 0) {
+		try {
+			const { data } = await axios.get<ITeam[]>(generateUrl('/contactsmenu/teams'))
+			userTeams.push(...data)
+		} catch (error) {
+			logger.error('could not load user teams', { error })
+		}
+	}
+	teams.value = [...userTeams]
 }
 
 /**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

- a `GET contactsmenu/teams` request was being made on every page load
- this happened because the endpoint was being called inside `onMounted`, and since the contacts menu is on the header of the page, every page load triggered it
- moved the `GET contactsmenu/teams` request inside the `onOpened` function, so it's only triggered when the contacts menu is actually opened
- with this fix, the request is only made when clicking on the contacts menu for the first time, subsequent openings of the menu do not trigger it again, only if the page is reloaded

for context, contacts menu:
<img width="393" height="409" alt="image" src="https://github.com/user-attachments/assets/7e681fcf-c3d6-45fa-9b67-e36db1c46bbe" />

changes look good from my tests, functionality keeps working as expected

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
