### PR TITLE
Take mount name into account when searching by filename.

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -458,6 +458,23 @@ class FileSearchBackend implements ISearchBackend {
 					throw new \InvalidArgumentException('Invalid property value for ' . $property->name, previous: $e);
 				}
 
+				if ($field === 'name') {
+					return new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+						new SearchComparison(
+							$trimmedType,
+							$field,
+							$castedValue,
+							$extra ?? ''
+						),
+						new SearchComparison(
+							$trimmedType,
+							'mount_point_name',
+							$castedValue,
+							$extra ?? ''
+						)
+					]);
+				}
+
 				return new SearchComparison(
 					$trimmedType,
 					$field,

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Tests\unit\Files;
 
+use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\View;
@@ -92,11 +93,18 @@ class FileSearchBackendTest extends TestCase {
 		$this->searchFolder->expects($this->once())
 			->method('search')
 			->with(new SearchQuery(
-				new SearchComparison(
-					ISearchComparison::COMPARE_EQUAL,
-					'name',
-					'foo'
-				),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+					new SearchComparison(
+						ISearchComparison::COMPARE_EQUAL,
+						'name',
+						'foo'
+					),
+					new SearchComparison(
+						ISearchComparison::COMPARE_EQUAL,
+						'mount_point_name',
+						'foo'
+					),
+				]),
 				100,
 				0,
 				[],

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -53,6 +53,10 @@ class FunctionBuilder implements IFunctionBuilder {
 		}
 	}
 
+	public function regexSubstring($input, $pattern): IQueryFunction {
+		return new QueryFunction('REGEXP_SUBSTR(' . $this->helper->quoteColumnName($input) . ', ' . $this->helper->quoteColumnName($pattern) . ')');
+	}
+
 	#[\Override]
 	public function sum($field): IQueryFunction {
 		return new QueryFunction('SUM(' . $this->helper->quoteColumnName($field) . ')');

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
@@ -33,4 +33,8 @@ class PgSqlFunctionBuilder extends FunctionBuilder {
 		$separator = $this->connection->quote($separator);
 		return new QueryFunction('string_agg(' . $castedExpression . ', ' . $separator . ')');
 	}
+
+	public function regexSubstring($input, $pattern): IQueryFunction {
+		return new QueryFunction('substring(' . $this->helper->quoteColumnName($input) . ' from ' . $this->helper->quoteColumnName($pattern) . ')');
+	}
 }

--- a/lib/private/DB/SQLiteSessionInit.php
+++ b/lib/private/DB/SQLiteSessionInit.php
@@ -31,9 +31,9 @@ class SQLiteSessionInit implements EventSubscriber {
 		$connection = $args->getConnection()->getWrappedConnection();
 		$pdo = $connection->getWrappedConnection();
 
-		$regexSubstr = function ($string, $pattern): ?string {
+		$regexSubstr = function ($string, $pattern): string {
 			if (is_null($string) || is_null($pattern)) {
-				return null;
+				return '';
 			} else {
 				$string = (string)$string;
 				$pattern = str_replace('#', '\#', (string)$pattern);
@@ -42,7 +42,7 @@ class SQLiteSessionInit implements EventSubscriber {
 			$matches = [];
 			$result = preg_match("#$pattern#", $string, $matches);
 			if ($result === 0 || $result === false) {
-				return null;
+				return '';
 			} else {
 				return $matches[0];
 			}

--- a/lib/private/DB/SQLiteSessionInit.php
+++ b/lib/private/DB/SQLiteSessionInit.php
@@ -30,10 +30,30 @@ class SQLiteSessionInit implements EventSubscriber {
 		/** @var \Doctrine\DBAL\Driver\PDO\Connection $connection */
 		$connection = $args->getConnection()->getWrappedConnection();
 		$pdo = $connection->getWrappedConnection();
+
+		$regexSubstr = function ($string, $pattern): ?string {
+			if (is_null($string) || is_null($pattern)) {
+				return null;
+			} else {
+				$string = (string)$string;
+				$pattern = str_replace('#', '\#', (string)$pattern);
+			}
+
+			$matches = [];
+			$result = preg_match("#$pattern#", $string, $matches);
+			if ($result === 0 || $result === false) {
+				return null;
+			} else {
+				return $matches[0];
+			}
+		};
+
 		if (PHP_VERSION_ID >= 80500 && method_exists($pdo, 'createFunction')) {
 			$pdo->createFunction('md5', 'md5', 1);
+			$pdo->createFunction('regexp_substr', $regexSubstr, 2);
 		} else {
 			$pdo->sqliteCreateFunction('md5', 'md5', 1);
+			$pdo->sqliteCreateFunction('regexp_substr', $regexSubstr, 2);
 		}
 	}
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -114,6 +114,14 @@ class QuerySearchHelper {
 			));
 	}
 
+	protected function equipQueryForMounts(CacheQueryBuilder $query, IUser $user): void {
+		$query
+			->leftJoin('file', 'mounts', 'm', $query->expr()->andX(
+				$query->expr()->eq('m.root_id', 'file.fileid'),
+				$query->expr()->eq('m.user_id', $query->createNamedParameter($user->getUID()))
+			));
+	}
+
 	protected function equipQueryForShares(CacheQueryBuilder $query): void {
 		$query->join('file', 'share', 's', $query->expr()->eq('file.fileid', 's.file_source'));
 	}
@@ -167,6 +175,9 @@ class QuerySearchHelper {
 		}
 		if (in_array('owner', $requestedFields, true) || in_array('share_with', $requestedFields, true) || in_array('share_type', $requestedFields, true)) {
 			$this->equipQueryForShares($query);
+		}
+		if (in_array('mount_point_name', $requestedFields)) {
+			$this->equipQueryForMounts($query, $this->requireUser($searchQuery));
 		}
 
 		$metadataQuery = $query->selectMetadata();

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -9,6 +9,7 @@ namespace OC\Files\Cache;
 
 use OCP\DB\QueryBuilder\IParameter;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
@@ -67,6 +68,7 @@ class SearchBuilder {
 		'owner' => 'string',
 		'creation_time' => 'integer',
 		'upload_time' => 'integer',
+		'mount_point_name' => 'string',
 	];
 
 	/** @var array<string, int|string> */
@@ -162,7 +164,7 @@ class SearchBuilder {
 		if ($comparison->getExtra()) {
 			[$field, $value, $type, $paramType] = $this->getExtraOperatorField($comparison, $metadataQuery);
 		} else {
-			[$field, $value, $type, $paramType] = $this->getOperatorFieldAndValue($comparison);
+			[$field, $value, $type, $paramType] = $this->getOperatorFieldAndValue($builder, $comparison);
 		}
 
 		if (isset($operatorMap[$type])) {
@@ -175,29 +177,29 @@ class SearchBuilder {
 
 	/**
 	 * @param ISearchComparison $operator
-	 * @return array{string, ParamValue, string, string}
+	 * @return array{string|IQueryFunction, ParamValue, string, string}
 	 */
-	private function getOperatorFieldAndValue(ISearchComparison $operator): array {
+	private function getOperatorFieldAndValue(IQueryBuilder $builder, ISearchComparison $operator): array {
 		$this->validateComparison($operator);
 		$field = $operator->getField();
 		$value = $operator->getValue();
 		$type = $operator->getType();
 		$pathEqHash = $operator->getQueryHint(ISearchComparison::HINT_PATH_EQ_HASH, true);
-		return $this->getOperatorFieldAndValueInner($field, $value, $type, $pathEqHash);
+		return $this->getOperatorFieldAndValueInner($builder, $field, $value, $type, $pathEqHash);
 	}
 
 	/**
 	 * @param ParamValue $value
-	 * @return array{string, ParamValue, string, string}
+	 * @return array{string|IQueryFunction, ParamValue, string, string}
 	 */
-	private function getOperatorFieldAndValueInner(string $field, mixed $value, string $type, bool $pathEqHash): array {
+	private function getOperatorFieldAndValueInner(IQueryBuilder $builder, string $field, mixed $value, string $type, bool $pathEqHash): array {
 		$paramType = self::FIELD_TYPES[$field];
 		if ($type === ISearchComparison::COMPARE_IN) {
 			$resultField = $field;
 			$values = [];
 			foreach ($value as $arrayValue) {
 				/** @var ParamSingleValue $arrayValue */
-				[$arrayField, $arrayValue] = $this->getOperatorFieldAndValueInner($field, $arrayValue, ISearchComparison::COMPARE_EQUAL, $pathEqHash);
+				[$arrayField, $arrayValue] = $this->getOperatorFieldAndValueInner($builder, $field, $arrayValue, ISearchComparison::COMPARE_EQUAL, $pathEqHash);
 				$resultField = $arrayField;
 				$values[] = $arrayValue;
 			}
@@ -237,6 +239,9 @@ class SearchBuilder {
 			$value = md5((string)$value);
 		} elseif ($field === 'owner') {
 			$field = 'uid_owner';
+		} elseif ($field === 'mount_point_name') {
+			$field = $builder->func()->regexSubstring('mount_point', $builder->createNamedParameter('[^/]+/$'));
+			$value = $value . '/';
 		}
 		return [$field, $value, $type, $paramType];
 	}
@@ -258,6 +263,7 @@ class SearchBuilder {
 			'owner' => ['eq'],
 			'creation_time' => ['eq', 'gt', 'lt', 'gte', 'lte'],
 			'upload_time' => ['eq', 'gt', 'lt', 'gte', 'lte'],
+			'mount_point_name' => ['eq', 'like', 'clike', 'in'],
 		];
 
 		if (!isset(self::FIELD_TYPES[$operator->getField()])) {

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -214,7 +214,25 @@ class Folder extends Node implements IFolder {
 	#[\Override]
 	public function search($query) {
 		if (is_string($query)) {
-			$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%' . $query . '%'));
+			$operator = new SearchComparison(
+				ISearchComparison::COMPARE_LIKE,
+				'name',
+				'%' . $query . '%',
+			);
+			$parts = explode('/', $this->path);
+			$uid = null;
+			if (count($parts) > 2) {
+				[, $uid] = $parts;
+				$operator = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+					$operator,
+					new SearchComparison(
+						ISearchComparison::COMPARE_LIKE,
+						'mount_point_name',
+						'%' . $query . '%',
+					)
+				]);
+			}
+			$query = $this->queryFromOperator($operator, $uid);
 		}
 
 		// search is handled by a single query covering all caches that this folder contains

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -64,6 +64,17 @@ interface IFunctionBuilder {
 	public function substring($input, $start, $length = null): IQueryFunction;
 
 	/**
+	 * Takes a substring from the input string using a regex pattern
+	 *
+	 * @param string|ILiteral|IParameter|IQueryFunction $input The input string
+	 * @param string|ILiteral|IParameter|IQueryFunction $pattern The pattern to match and return
+	 *
+	 * @return IQueryFunction
+	 * @since 35.0.0
+	 */
+	public function regexSubstring($input, $pattern): IQueryFunction;
+
+	/**
 	 * Takes the sum of all rows in a column
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $field the column to sum

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -11,6 +11,7 @@ use OC\DB\QueryBuilder\Literal;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\TestCase;
 
 /**
@@ -486,5 +487,33 @@ class FunctionBuilderTest extends TestCase {
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(1, $row);
+	}
+
+	public static function regexSubstringData(): array {
+		return [
+			['foobar', 'foo', 'foo'],
+			['foobar', 'b.+$', 'bar'],
+			['foo#bar', 'ba.+r$', null],
+			['foo#bar', 'o#.', 'o#b'],
+			['a/file/path', '[^/]+$', 'path'],
+		];
+	}
+
+	#[DataProvider('regexSubstringData')]
+	public function testRegexSubstring(string $input, string $pattern, ?string $expected): void {
+		error_reporting(E_ALL);
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->regexSubstring(
+			$query->createNamedParameter($input),
+			$query->createNamedParameter($pattern),
+		));
+		$query->from('appconfig')
+			->setMaxResults(1);
+
+		$result = $query->executeQuery();
+		$row = $result->fetchOne();
+		$result->closeCursor();
+		$this->assertEquals($expected, $row);
 	}
 }

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -39,8 +39,10 @@ use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOrder;
 use OCP\Files\Storage\IStorage;
+use OCP\IUser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use Test\Traits\UserTrait;
 
 /**
  * Class FolderTest
@@ -50,6 +52,14 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class FolderTest extends NodeTestCase {
+	use UserTrait;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->createUser('bar', 'bar');
+	}
+
 	#[\Override]
 	protected function createTestNode(IRootFolder $root, View&MockObject $view, string $path, array $data = [], string $internalPath = '', ?IStorage $storage = null): Folder {
 		$view->expects($this->any())

--- a/tests/lib/Files/Search/SearchIntegrationTest.php
+++ b/tests/lib/Files/Search/SearchIntegrationTest.php
@@ -11,22 +11,45 @@ use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Temporary;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOperator;
+use OCP\Files\Storage\IStorage;
+use OCP\IUser;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 
-#[\PHPUnit\Framework\Attributes\Group('DB')]
+#[Group('DB')]
 class SearchIntegrationTest extends TestCase {
-	private $cache;
-	private $storage;
+	private ICache $cache;
+	private IStorage $storage;
+	private string $mountPoint;
+	private IUserMountCache $mountCache;
+	private IUser $user;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->user = $this->createMock(IUser::class);
+		$this->user->method('getUID')
+			->willReturn('user');
 		$this->storage = new Temporary([]);
 		$this->cache = $this->storage->getCache();
 		$this->storage->getScanner()->scan('');
+		$this->mountCache = Server::get(IUserMountCache::class);
+		$this->mountPoint = '/user/files/search_test/';
+		$this->mountCache->addMount($this->user, $this->mountPoint, $this->cache->get(''), 'dummy');
+	}
+
+	protected function tearDown(): void {
+		$this->mountCache->removeMount($this->mountPoint);
+
+		parent::tearDown();
 	}
 
 	public function testThousandAndOneFilters(): void {
@@ -43,5 +66,28 @@ class SearchIntegrationTest extends TestCase {
 
 		$this->assertCount(1, $results);
 		$this->assertEquals($id, $results[0]->getId());
+	}
+
+	public static function searchMountNameProvider(): array {
+		return [
+			[new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mount_point_name', '%search%'), ''],
+			[new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'mount_point_name', 'search_test'), ''],
+			[new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mount_point_name', '%search_test%'), ''],
+			[new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mount_point_name', '%files%'), null],
+		];
+	}
+
+	#[DataProvider('searchMountNameProvider')]
+	public function testSearchMountName(ISearchOperator $operator, ?string $resultPath): void {
+		$query = new SearchQuery($operator, 10, 0, [], $this->user);
+
+		$results = $this->cache->searchQuery($query);
+
+		if (is_null($resultPath)) {
+			$this->assertCount(0, $results);
+		} else {
+			$this->assertCount(1, $results);
+			$this->assertEquals($this->cache->getId($resultPath), $results[0]->getId());
+		}
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Currently, searching only takes the filename as it exists in the filecache into account. This doesn't (always) work for the root of mounts though.

Renamed shares and the root of groupfolder/external storages aren't matched because their name in the filesystem isn't the same as the name for their cache entry.

This solves that by also taking the name of the mountpoint into account when searching

- Add `regex_substring` to the query builder
- Add `mount_path_name` as a field in the filecache search, which gets transformed to a substring of `mount_path`
- Transform a dav search on filename to searching on both filename and `mount_path_name`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
