### PR TITLE
fix(files_sharing): bump @nextcloud/sharing to 1.0.0-beta.4

### DIFF
--- a/apps/files_sharing/src/components/UnifiedShareEntry.spec.ts
+++ b/apps/files_sharing/src/components/UnifiedShareEntry.spec.ts
@@ -146,7 +146,7 @@ describe('deleting the share', () => {
 describe('removing a participant', () => {
 	it('removes the recipient of the row it was triggered on', async () => {
 		const wrapper = mountEntry(share([recipient('bob'), recipient('carol')]))
-		await triggerAction(wrapper, 'Remove participant')
+		await triggerAction(wrapper, 'Remove recipient')
 		expect(removeRecipient).toHaveBeenCalledWith('42', 'UserRecipient', 'bob', null)
 		expect(wrapper.emitted('refresh')).toHaveLength(1)
 	})
@@ -154,7 +154,7 @@ describe('removing a participant', () => {
 	it('does not refresh when the removal fails', async () => {
 		vi.mocked(removeRecipient).mockRejectedValueOnce(new Error('nope'))
 		const wrapper = mountEntry(share([recipient('bob'), recipient('carol')]))
-		await triggerAction(wrapper, 'Remove participant')
+		await triggerAction(wrapper, 'Remove recipient')
 		expect(wrapper.emitted('refresh')).toBeUndefined()
 	})
 })

--- a/apps/files_sharing/src/components/UnifiedShareEntry.vue
+++ b/apps/files_sharing/src/components/UnifiedShareEntry.vue
@@ -82,11 +82,11 @@
 						:user="isNoUserRecipient(recipient) ? undefined : recipient.value"
 						:displayName="recipient.display_name" />
 				</template>
-				<NcActionButton :aria-label="t('files_sharing', 'Remove participant')" @click="removeOne(recipient)">
+				<NcActionButton :aria-label="t('files_sharing', 'Remove recipient')" @click="removeOne(recipient)">
 					<template #icon>
 						<DeleteIcon :size="20" />
 					</template>
-					{{ t('files_sharing', 'Remove participant') }}
+					{{ t('files_sharing', 'Remove recipient') }}
 				</NcActionButton>
 			</SharingEntrySimple>
 		</template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nextcloud/password-confirmation": "^6.1.0",
         "@nextcloud/paths": "^3.1.0",
         "@nextcloud/router": "^3.1.0",
-        "@nextcloud/sharing": "^1.0.0-beta.2",
+        "@nextcloud/sharing": "^1.0.0-beta.4",
         "@nextcloud/vue": "^9.10.0",
         "@vueuse/core": "^14.1.0",
         "@vueuse/integrations": "^14.1.0",
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/@nextcloud/sharing": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-1.0.0-beta.2.tgz",
-      "integrity": "sha512-XMx32IkE0GoPxEY8lp/lnGIj5AGm2sj9vXUGD7TEw1r+qJfJkhKAwAFjQzEzVzMaa7V1J8KgrvcUVWe4w2e6cA==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-1.0.0-beta.4.tgz",
+      "integrity": "sha512-IhfqfgmFSg6LMYfOhhVqeyGAkgp2D80htf3+6hoESoqFFl2672IiurIH3S6oMYCLEcfIw7iXuKZ2MMOAK9i3eQ==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",
@@ -2110,17 +2110,15 @@
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/logger": "^3.0.3",
         "@nextcloud/router": "^3.1.0",
+        "@nextcloud/vue": "^9.11.0",
         "debounce": "^3.0.0",
         "is-svg": "^6.1.0",
         "qrcode.vue": "^3.10.0",
-        "uuid": "^14.0.2"
+        "uuid": "^14.0.2",
+        "vue": "^3.5.0"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      },
-      "peerDependencies": {
-        "@nextcloud/vue": "^9.0.0",
-        "vue": "^3.5.0"
+        "node": "^22.0.0 || ^24.0.0 || >=26"
       }
     },
     "node_modules/@nextcloud/sharing/node_modules/uuid": {
@@ -2196,9 +2194,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.10.0.tgz",
-      "integrity": "sha512-Za9O6ZpRNmjMuKPgiUDg98lY4+sFasemaPY6h7rti4H4An9VglKjL7l/YZh3criJLfhoDL6ACMwZiNcvFV626A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.11.0.tgz",
+      "integrity": "sha512-LRsyU9Mxs0b2xWqbxygps8O7/i1z4QhNQD9/QDni+VqFY3V0N95mAgmKJm6vfoFuxTAMXERp9bjqFn3UV542gw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nextcloud/password-confirmation": "^6.1.0",
     "@nextcloud/paths": "^3.1.0",
     "@nextcloud/router": "^3.1.0",
-    "@nextcloud/sharing": "^1.0.0-beta.2",
+    "@nextcloud/sharing": "^1.0.0-beta.4",
     "@nextcloud/vue": "^9.10.0",
     "@vueuse/core": "^14.1.0",
     "@vueuse/integrations": "^14.1.0",

--- a/tests/playwright/e2e/files_sharing/unified-share-edit.spec.ts
+++ b/tests/playwright/e2e/files_sharing/unified-share-edit.spec.ts
@@ -120,7 +120,7 @@ test.describe('files_sharing: editing a share with the unified dialog', () => {
 
 		await expect(menu.getByRole('menuitem', { name: 'Can view (default)' })).toBeVisible()
 		await expect(menu.getByRole('menuitem', { name: 'Custom permissions' })).toBeVisible()
-		await expect(menu.getByRole('menuitem', { name: 'Remove participant' })).toBeVisible()
+		await expect(menu.getByRole('menuitem', { name: 'Remove recipient' })).toBeVisible()
 	})
 
 	test('caps the recipient toggles at the permissions the share grants', async ({ page, recipient, filesListPage, unifiedShareList, sharingDialog }) => {

--- a/tests/playwright/e2e/files_sharing/unified-sidebar.spec.ts
+++ b/tests/playwright/e2e/files_sharing/unified-sidebar.spec.ts
@@ -160,7 +160,7 @@ test.describe('files_sharing: unified share list in the sidebar', () => {
 
 		const removed = page.waitForResponse((response) => response.request().method() === 'DELETE'
 			&& response.url().includes('/recipient'))
-		await unifiedShareList.triggerAction(recipient.userId, 'Remove participant')
+		await unifiedShareList.triggerAction(recipient.userId, 'Remove recipient')
 		await removed
 
 		// One recipient left, so the group collapses into a plain row.


### PR DESCRIPTION
* Resolves: # <!-- relates to nextcloud-libraries/nextcloud-sharing#279, #281, #282 -->

## Summary

Picks up `@nextcloud/sharing` 1.0.0-beta.4, which fixes three things reported against the dialog: the sharee is called "recipient" throughout instead of a mix of people, participants and recipients; the scrollbar sits at the dialog edge rather than floating over the form; and the recipient menu closes when it opens the permissions modal instead of overlapping it.

The sidebar has its own "Remove participant" action, so it follows the same wording, along with the tests that assert those labels.

The translated strings in `apps/files_sharing/l10n/` still carry the old wording; those come from Transifex and update on the next sync.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
