### PR TITLE
Improve corrupt share permission situation

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -15,6 +15,7 @@ use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\User\DisplayNameCache;
+use OCP\Constants;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchBinaryOperator;
@@ -152,6 +153,14 @@ class Cache extends CacheJail {
 				$entry['permissions'] &= $this->share->getPermissions();
 			} else {
 				$entry['permissions'] = $this->storage->getPermissions($entry['path']);
+			}
+
+			if (!SharedStorage::hasValidSourcePermissions($this->sourceRootInfo)) {
+				// SharedStorage disables a share whose source lost the share permission:
+				// every write is refused while reading still works. Report the same here,
+				// otherwise the file list advertises write permissions that every
+				// operation then denies with a 403.
+				$entry['permissions'] &= Constants::PERMISSION_READ;
 			}
 
 			if ($this->share->getNodeId() === $entry['fileid']) {

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -238,10 +238,21 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 		return $this->superShare->getId();
 	}
 
+	/**
+	 * A share only works as long as its source still carries the share permission.
+	 * Both this storage and its cache have to agree on that, so keep the check in
+	 * one place.
+	 *
+	 * @param ICacheEntry|false|null $sourceRootInfo
+	 */
+	public static function hasValidSourcePermissions($sourceRootInfo): bool {
+		return $sourceRootInfo instanceof ICacheEntry
+			&& ($sourceRootInfo->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE;
+	}
+
 	private function isValid(): bool {
 		$sourceRootInfo = $this->getSourceRootInfo();
-		if ($sourceRootInfo instanceof ICacheEntry
-			&& ($sourceRootInfo->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE) {
+		if (self::hasValidSourcePermissions($sourceRootInfo)) {
 			return true;
 		}
 

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -63,6 +63,8 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 
 	private $initialized = false;
 
+	private bool $invalidSourceLogged = false;
+
 	/**
 	 * @var ICacheEntry
 	 */
@@ -237,7 +239,46 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	}
 
 	private function isValid(): bool {
-		return $this->getSourceRootInfo() && ($this->getSourceRootInfo()->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE;
+		$sourceRootInfo = $this->getSourceRootInfo();
+		if ($sourceRootInfo instanceof ICacheEntry
+			&& ($sourceRootInfo->getPermissions() & Constants::PERMISSION_SHARE) === Constants::PERMISSION_SHARE) {
+			return true;
+		}
+
+		$this->logInvalidSource($sourceRootInfo);
+
+		return false;
+	}
+
+	/**
+	 * An invalid share is disabled entirely: every permission check returns 0 while
+	 * reading keeps working, which is easy to mistake for arbitrary breakage such as
+	 * failing uploads or renames that revert. Leave a trace naming the share and the
+	 * source that has to be repaired.
+	 *
+	 * @param ICacheEntry|false|null $sourceRootInfo
+	 */
+	private function logInvalidSource($sourceRootInfo): void {
+		if ($this->invalidSourceLogged) {
+			return;
+		}
+		$this->invalidSourceLogged = true;
+
+		if (!($sourceRootInfo instanceof ICacheEntry) || $sourceRootInfo->getId() < 0) {
+			// The source could not be resolved at all, in which case `init()` has
+			// already swapped in a `FailedStorage` and `FailedCache` and the root info
+			// is only a read-only placeholder. That is a different problem from a
+			// source whose cached permissions are wrong, so don't report it as one.
+			return;
+		}
+
+		$this->logger->warning('Share {shareId} is disabled because its source is missing the share permission. Repair the cached permissions of {shareOwner} with "occ files:scan", or check whether the source is masked by a read-only mount or access control rule.', [
+			'app' => 'files_sharing',
+			'shareId' => $this->superShare->getId(),
+			'shareOwner' => $this->superShare->getShareOwner(),
+			'sourceFileId' => $sourceRootInfo->getId(),
+			'sourcePermissions' => $sourceRootInfo->getPermissions(),
+		]);
 	}
 
 	#[\Override]

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -443,6 +443,47 @@ class SharedStorageTest extends TestCase {
 		$this->shareManager->deleteShare($share);
 	}
 
+	public function testInvalidSourcePermissionsAreReportedAsReadOnly(): void {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$share = $this->share(
+			IShare::TYPE_USER,
+			$this->folder,
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			Constants::PERMISSION_ALL
+		);
+
+		// Drop the share permission of the source in the file cache, the way a scan
+		// through a permission mask used to persist masked permissions. This disables
+		// the share in `SharedStorage::isValid()`.
+		$sourceInfo = $this->view->getFileInfo($this->folder);
+		$sourceCache = $sourceInfo->getStorage()->getCache();
+		$sourceCache->update($sourceInfo->getId(), [
+			'permissions' => Constants::PERMISSION_ALL & ~Constants::PERMISSION_SHARE,
+		]);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+
+		// the storage refuses every write, so the cache must not advertise more than read
+		$folderInfo = $user2View->getFileInfo($this->folder);
+		$this->assertNotFalse($folderInfo);
+		$this->assertSame(0, $folderInfo->getPermissions() & ~Constants::PERMISSION_READ);
+
+		$fileInfo = $user2View->getFileInfo($this->folder . $this->filename);
+		$this->assertNotFalse($fileInfo);
+		$this->assertSame(0, $fileInfo->getPermissions() & ~Constants::PERMISSION_READ);
+
+		// and what it does advertise still holds
+		$this->assertSame('file in subfolder', $user2View->file_get_contents($this->folder . $this->filename));
+		$this->assertFalse($user2View->fopen($this->folder . '/blocked.txt', 'w'));
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$sourceCache->update($sourceInfo->getId(), ['permissions' => Constants::PERMISSION_ALL]);
+		$this->shareManager->deleteShare($share);
+	}
+
 	public function testInitWithNonExistingUser(): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareOwner')->willReturn('unexist');

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -466,14 +466,20 @@ class SharedStorageTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
-		// the storage refuses every write, so the cache must not advertise more than read
+		// the storage refuses every write, so the cache must not advertise more.
+		// The mount point keeps its delete permission: `View::getFileInfo()` adds that
+		// for every movable mount, so the recipient can always remove the share from
+		// their own view.
 		$folderInfo = $user2View->getFileInfo($this->folder);
 		$this->assertNotFalse($folderInfo);
-		$this->assertSame(0, $folderInfo->getPermissions() & ~Constants::PERMISSION_READ);
+		$this->assertTrue($folderInfo->isReadable());
+		$this->assertFalse($folderInfo->isCreatable());
+		$this->assertFalse($folderInfo->isUpdateable());
+		$this->assertFalse($folderInfo->isShareable());
 
 		$fileInfo = $user2View->getFileInfo($this->folder . $this->filename);
 		$this->assertNotFalse($fileInfo);
-		$this->assertSame(0, $fileInfo->getPermissions() & ~Constants::PERMISSION_READ);
+		$this->assertSame(Constants::PERMISSION_READ, $fileInfo->getPermissions());
 
 		// and what it does advertise still holds
 		$this->assertSame('file in subfolder', $user2View->file_get_contents($this->folder . $this->filename));


### PR DESCRIPTION
## Summary
Patch 1: fix(files_sharing): log when a share is disabled by invalid source permissions

SharedStorage::isValid() silently disabled a whole share when its source lost the share permission bit in the file cache. Now it logs one warning per storage instance naming the share id, owner, source file id and the source's cached permissions, with a pointer to occ files:scan. Unresolvable sources (fileid -1, the FailedCache placeholder) are excluded so orphaned shares don't spam the log; that's a different failure, already handled by FailedStorage.

Patch 2: fix(files_sharing): don't advertise permissions an invalid share denies

The shared cache reported filecache.permissions & share.permissions without consulting isValid(), so a folder looked writable while every write got a 403. The bit test moved into SharedStorage::hasValidSourcePermissions(), and Cache::formatCacheEntry() now masks reported permissions down to READ when the source is invalid; matching what the storage actually grants, since reads keep working via fopen() in read mode. Includes a regression test.

Together they turn the reported symptom set, the missing share icon, "Resharing is not allowed", 403 uploads, renames reverting, into a visible, diagnosable read-only share plus a log line naming the row to repair.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
