### PR TITLE
fix(files_external): clean up filecache when deleting an external storage

### DIFF
--- a/apps/files_external/lib/Service/StoragesService.php
+++ b/apps/files_external/lib/Service/StoragesService.php
@@ -424,11 +424,13 @@ abstract class StoragesService {
 		$this->dbConfig->removeMount($id);
 
 		$deletedStorage = $this->getStorageConfigFromDBMount($existingMount);
-		$this->eventDispatcher->dispatchTyped(new StorageDeletedEvent($deletedStorage));
 		$this->triggerHooks($deletedStorage, Filesystem::signal_delete_mount);
 
 		// delete oc_storages entries and oc_filecache
 		Storage::cleanByMountId($id);
+
+		// listeners remove the oc_mounts rows that cleanByMountId() uses to find the storages
+		$this->eventDispatcher->dispatchTyped(new StorageDeletedEvent($deletedStorage));
 
 		$this->updateOverwriteHomeFolders();
 	}

--- a/apps/files_external/tests/Service/StoragesServiceTestCase.php
+++ b/apps/files_external/tests/Service/StoragesServiceTestCase.php
@@ -11,6 +11,7 @@ namespace OCA\Files_External\Tests\Service;
 
 use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
+use OCA\Files_External\Event\StorageDeletedEvent;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Auth\InvalidAuth;
 use OCA\Files_External\Lib\Auth\NullMechanism;
@@ -22,6 +23,8 @@ use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\DBConfigService;
 use OCA\Files_External\Service\StoragesService;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Config\IUserMountCache;
@@ -284,6 +287,26 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		// get numeric id for later check
 		$numericId = $storageCache->getNumericId();
 
+		$path = $this->getUniqueID('file');
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
+		$qb->insert('filecache')
+			->values([
+				'storage' => $qb->createNamedParameter($numericId, IQueryBuilder::PARAM_INT),
+				'path' => $qb->createNamedParameter($path),
+				'path_hash' => $qb->createNamedParameter(md5($path)),
+				'parent' => $qb->createNamedParameter(-1, IQueryBuilder::PARAM_INT),
+				'name' => $qb->createNamedParameter($path),
+			])
+			->executeStatement();
+
+		// listeners of StorageDeletedEvent clear the mount cache, like MountCacheService does
+		$this->eventDispatcher->method('dispatchTyped')
+			->willReturnCallback(function (Event $event) use ($mountCache, $user): void {
+				if ($event instanceof StorageDeletedEvent) {
+					$mountCache->removeMount('dummy', $user);
+				}
+			});
+
 		$this->service->removeStorage($id);
 
 		$caught = false;
@@ -305,6 +328,16 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		$storages = $result->fetchAll();
 		$result->closeCursor();
 		$this->assertCount(0, $storages, 'expected 0 storages, got ' . json_encode($storages));
+
+		// filecache entries of the storage were removed
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
+		$result = $qb->select('fileid')
+			->from('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($numericId, IQueryBuilder::PARAM_INT)))
+			->executeQuery();
+		$fileIds = $result->fetchFirstColumn();
+		$result->closeCursor();
+		$this->assertCount(0, $fileIds, 'expected 0 filecache entries, got ' . json_encode($fileIds));
 	}
 
 	protected function actualDeletedUnexistingStorageTest() {


### PR DESCRIPTION
Related to #7312. This fixes the part where removed external storages leave their filecache rows behind, not the table fragmentation discussed there.

Since 33.0.0 (c80c980e299), `StorageDeletedEvent` is dispatched before `Storage::cleanByMountId()`. `MountCacheService` reacts to it by deleting the storage's `oc_mounts` rows, which are exactly what `cleanByMountId()` uses to find the storages, so the `oc_filecache` and `oc_storages` rows stay. `occ files:cleanup` doesn't pick them up either, because the storage row still exists.

The event now fires **after the cleanup**, so its listeners no longer see the deleted storage's cache and storage rows. In server only `MountCacheService` listens, and it doesn't need them.

Rows that were already orphaned on 33 and 34 are not cleaned up by this change. stable33 and stable34 are affected; stable32 doesn't have the event.