### PR TITLE
test(files_external): call parent::setUp() in BackendServiceTest

### DIFF
--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -23,6 +23,7 @@ class BackendServiceTest extends \Test\TestCase {
 	protected LoggerInterface&MockObject $logger;
 
 	protected function setUp(): void {
+		parent::setUp();
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 	}


### PR DESCRIPTION
`BackendServiceTest` skipped `parent::setUp()` but still ran `TestCase::tearDown()`, which re-registers `IDBConnection` as `TestCase::$realDatabase`. That property is only set in the parent `setUp()`, so when this test is the first non-DB test in a run it stays null and every later test gets a null database connection.

CI doesn't hit this because the full files_external suite runs other tests first. Running `apps/files_external/tests/Service` on its own reproduces it: 112 of 138 tests error with `IDBConnection, null given` without this change, and all pass with it, on MariaDB 11.8 and PostgreSQL 16.
