### PR TITLE
fix(jobs-worker): delay next check by one second

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -246,7 +246,7 @@ class JobList implements IJobList {
 			$update = $this->connection->getQueryBuilder();
 			$update->update('jobs')
 				->set('reserved_at', $update->createNamedParameter($this->timeFactory->getTime()))
-				->set('last_checked', $update->createNamedParameter($this->timeFactory->getTime()))
+				->set('last_checked', $update->createNamedParameter($this->timeFactory->getTime() + 1))
 				->where($update->expr()->eq('id', $update->createParameter('jobid')))
 				->andWhere($update->expr()->eq('reserved_at', $update->createParameter('reserved_at')))
 				->andWhere($update->expr()->eq('last_checked', $update->createParameter('last_checked')));

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -80,7 +80,7 @@ abstract class TimedJob extends Job {
 	 */
 	#[\Override]
 	final public function start(IJobList $jobList): void {
-		if (($this->time->getTime() - $this->lastRun) > $this->interval) {
+		if (($this->time->getTime() - $this->lastRun) >= $this->interval) {
 			if ($this->interval >= 12 * 60 * 60 && $this->isTimeSensitive()) {
 				Server::get(LoggerInterface::class)->debug('TimedJob ' . get_class($this) . ' has a configured interval of ' . $this->interval . ' seconds, but is also marked as time sensitive. Please consider marking it as time insensitive to allow more sensitive jobs to run when needed.');
 			}


### PR DESCRIPTION
When running `./occ background-job:worker` we need to add a slightly delay to the next check of a job returned by `IJobList::getNext()`

Currently the same job - with small value in `setInterval()` - is returned multiple time until interval fit,
resulting in a loop of 10-20 identical select+update for a full second:
<img width="933" height="620" alt="image" src="https://github.com/user-attachments/assets/0682d0aa-8d9b-4369-a00a-cba4d89fa674" />

This patch will avoid that loop:
<img width="882" height="139" alt="image" src="https://github.com/user-attachments/assets/bd082583-5ed3-41d5-a40d-cceb7766e64d" />

---

The edit in `TimedJob` is to avoid a job to be initiated (returned as ready from the database) but not started before the next second (and reinitiated)