### PR TITLE
Deprecate long, non-lazy app config and user config

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -58,6 +58,7 @@ class AppConfig implements IAppConfig {
 	private const int ENCRYPTION_PREFIX_LENGTH = 21; // strlen(self::ENCRYPTION_PREFIX)
 	private const string LOCAL_CACHE_KEY = 'OC\\AppConfig';
 	private const int LOCAL_CACHE_TTL = 3;
+	private const int MAX_NON_LAZY_SIZE = 128; // bytes
 
 	/** @var array<string, array<string, string>> ['app_id' => ['config_key' => 'config_value']] */
 	private array $fastCache = [];   // cache for normal config keys
@@ -854,6 +855,17 @@ class AppConfig implements IAppConfig {
 		$origValue = $value;
 		if ($sensitive || ($this->hasKey($app, $key, $lazy) && $this->isSensitive($app, $key, $lazy))) {
 			$value = self::ENCRYPTION_PREFIX . $this->crypto->encrypt($value);
+		}
+
+		if (!$lazy && strlen($value) > self::MAX_NON_LAZY_SIZE) {
+			$this->logger->error(
+				'[Deprecated] App config {app}:{key} is larger than {maxSize} bytes. It should be declared as lazy.',
+				[
+					'app' => $app,
+					'key' => $key,
+					'maxSize' => self::MAX_NON_LAZY_SIZE,
+				]
+			);
 		}
 
 		if ($this->hasKey($app, $key, $lazy)) {

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -55,6 +55,7 @@ class UserConfig implements IUserConfig {
 	private const int APP_MAX_LENGTH = 32;
 	private const int KEY_MAX_LENGTH = 64;
 	private const int INDEX_MAX_LENGTH = 64;
+	private const int MAX_NON_LAZY_SIZE = 128; // bytes
 
 	/** @var CappedMemoryCache<array<string, array<string, UserConfigEntry>>>  cache for normal config keys */
 	private CappedMemoryCache $fastCache;
@@ -1153,6 +1154,17 @@ class UserConfig implements IUserConfig {
 			return false;
 		}
 		$this->loadConfig($userId, $lazy);
+		if (!$lazy && strlen($value) > self::MAX_NON_LAZY_SIZE) {
+			$this->logger->error(
+				'[Deprecated] User {userId} config "{app}:{key}" is larger than {maxSize} bytes. It should be declared as lazy.',
+				[
+					'app' => $app,
+					'key' => $key,
+					'userId' => $userId,
+					'maxSize' => self::MAX_NON_LAZY_SIZE,
+				]
+			);
+		}
 
 		$inserted = $refreshCache = false;
 		$origValue = $value;


### PR DESCRIPTION
* Resolves: #61729

## Summary

Long configuration value and long preferences should be lazy, loaded only if really required.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
