### PR TITLE
Db info fixes

### DIFF
--- a/core/Command/Db/DbInfo.php
+++ b/core/Command/Db/DbInfo.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\Core\Command\Db;
 
+use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
@@ -76,11 +77,21 @@ class DbInfo extends Command {
 	}
 
 	private function getMySQLInfo(): array {
-		$result = $this->connection->executeQuery(
-			'SELECT VERSION() AS version, @@innodb_buffer_pool_size AS buffer_pool,
+		try {
+			return $this->getMySQLInfoUsingQuery(
+				'SELECT VERSION() AS version, @@innodb_buffer_pool_size AS buffer_pool,
 					@@max_connections AS max_conn, @@character_set_database AS charset,
 					@@transaction_isolation AS tx_isolation'
-		);
+			);
+		} catch (DriverException $e) {
+			return $this->getMySQLInfoUsingQuery('SELECT VERSION() AS version, @@innodb_buffer_pool_size AS buffer_pool,
+					@@max_connections AS max_conn, @@character_set_database AS charset,
+					@@tx_isolation AS tx_isolation');
+		}
+	}
+
+	private function getMySQLInfoUsingQuery(string $query): array {
+		$result = $this->connection->executeQuery($query);
 		$info = $result->fetchAssociative();
 
 		$bufferPoolGB = round(($info['buffer_pool'] / 1024 / 1024 / 1024), 2);

--- a/core/Command/Db/DbLocks.php
+++ b/core/Command/Db/DbLocks.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\Core\Command\Db;
 
+use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use OC\DB\Connection;
@@ -74,7 +75,16 @@ class DbLocks extends Command {
 			return Command::SUCCESS;
 		}
 
-		$rows = $this->connection->executeQuery($sql)->fetchAllAssociative();
+		try {
+			$rows = $this->connection->executeQuery($sql)->fetchAllAssociative();
+		} catch (DriverException $e) {
+			if ($e->getCode() === 1227) {
+				$output->writeln('<comment>The configured database user doesn\'t have permissions to query active locks, PROCESS privilege required.</comment>');
+			} else {
+				$output->writeln('<comment>Failed to query active locks: ' . $e->getMessage() . '.</comment>');
+			}
+			return Command::FAILURE;
+		}
 
 		if (empty($rows)) {
 			$output->writeln('<info>No active locks or blocking transactions detected.</info>');

--- a/core/Command/Db/DbSize.php
+++ b/core/Command/Db/DbSize.php
@@ -45,7 +45,7 @@ class DbSize extends Command {
 					   ROUND((data_length + index_length) / 1024 / 1024, 2) AS total_mb,
 					   ROUND(data_length / 1024 / 1024, 2) AS data_mb,
 					   ROUND(index_length / 1024 / 1024, 2) AS index_mb,
-					   table_rows AS rows,
+					   table_rows AS `rows`,
 					   IF(table_rows > 0, ROUND((data_length + index_length) / table_rows, 0), 0) AS avg_row_bytes
 				FROM information_schema.tables
 				WHERE table_schema = DATABASE()


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

A set of fixes for the `db:*` informational commands:

- Fallback to the older `tx_isolation` command for older mariadb/mysql for `db:info`
- Quote `rows` for mariadb/mysql for `db:size`
- Show a proper error if we don't have enough permissions for `db:locks`

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
