### PR TITLE
Fix quota handling for unlimited object storage

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -229,7 +229,7 @@ class Quota extends Wrapper {
 		}
 
 		if ($size !== null) {
-			if ($size < $free) {
+			if ($free < 0 || $size < $free) {
 				return parent::writeStream($path, $stream, $size);
 			} else {
 				throw new NotEnoughSpaceException();


### PR DESCRIPTION
## Problem

When the wrapped storage reports `SPACE_UNLIMITED`, the quota wrapper can receive a negative free-space value. A zero-byte temporary upload target may then be rejected as insufficient space.

This results in a WebDAV upload failure reported as HTTP 413 / `EntityTooLarge`.

## Change

Treat negative free-space values as unlimited space before comparing the requested write size.

## Validation

- `php -l lib/private/Files/Storage/Wrapper/Quota.php`

## Environment

- Nextcloud 34
- Primary object storage: S3-compatible Ceph/RGW
- Upload path: WebDAV chunked upload
