### PR TITLE
[stable32] fix: add a11y name in password share button

### DIFF
--- a/core/templates/publicshareauth.php
+++ b/core/templates/publicshareauth.php
@@ -35,7 +35,10 @@
 				<input type="hidden" name="sharingToken" value="<?php p($_['share']->getToken()) ?>" id="sharingToken">
 				<input type="hidden" name="sharingType" value="<?php p($_['share']->getShareType()) ?>" id="sharingType">
 				<input type="submit" id="password-submit"
-					class="svg icon-confirm input-button-inline" value="" disabled="disabled" />
+					class="svg icon-confirm input-button-inline" value=""
+					aria-label="<?php p($l->t('Submit')); ?>"
+					title="<?php p($l->t('Submit')); ?>"
+					disabled="disabled" />
 			</p>
 		</fieldset>
 	</form>
@@ -50,7 +53,10 @@
 			<div class="warning-info" id="email-prompt"><?php p($l->t('Please type in your email address to request a temporary password')); ?></div>
 			 <p>
 				<input type="email" id="email" name="identityToken" placeholder="<?php p($l->t('Email address')); ?>" />
-				<input type="submit" id="password-request" name="passwordRequest" class="svg icon-confirm input-button-inline" value="" disabled="disabled"/>
+				<input type="submit" id="password-request" name="passwordRequest" class="svg icon-confirm input-button-inline" value=""
+					aria-label="<?php p($l->t('Request password')); ?>"
+					title="<?php p($l->t('Request password')); ?>"
+					disabled="disabled"/>
 				<input type="hidden" id="requesttoken" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
 				<input type="hidden" name="sharingToken" value="<?php p($_['share']->getToken()) ?>" id="sharingToken">
 				<input type="hidden" name="sharingType" value="<?php p($_['share']->getShareType()) ?>" id="sharingType">


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/59331

## Summary
Add a11y name to public share password button

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
