### PR TITLE
fix(sharing): gate link password enforcement on always ask for password

### DIFF
--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -275,6 +275,8 @@ class ApiTest extends TestCase {
 	public function testEnforceLinkPassword(): void {
 		$password = md5(time());
 		$config = Server::get(IConfig::class);
+		$appConfig = Server::get(IAppConfig::class);
+		$appConfig->setValueBool('core', ConfigLexicon::SHARE_LINK_PASSWORD_DEFAULT, true);
 		$config->setAppValue('core', 'shareapi_enforce_links_password', 'yes');
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
@@ -320,6 +322,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		$config->setAppValue('core', 'shareapi_enforce_links_password', 'no');
+		$appConfig->setValueBool('core', ConfigLexicon::SHARE_LINK_PASSWORD_DEFAULT, false);
 		$this->addToAssertionCount(1);
 	}
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -151,12 +151,29 @@ class CapabilitiesTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_excluded_groups', '', ''],
 		];
 		$typedMap = [
+			['core', 'shareapi_enable_link_password_by_default', true],
 			['core', 'shareapi_enforce_links_password', true],
 		];
 		$result = $this->getResults($map, $typedMap);
 		$this->assertArrayHasKey('password', $result['public']);
 		$this->assertArrayHasKey('enforced', $result['public']['password']);
 		$this->assertTrue($result['public']['password']['enforced']);
+	}
+
+	public function testLinkPasswordEnforcedWithoutDefaultPrompt(): void {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_enforce_links_password_excluded_groups', '', ''],
+		];
+		$typedMap = [
+			['core', 'shareapi_enable_link_password_by_default', false],
+			['core', 'shareapi_enforce_links_password', true],
+		];
+		$result = $this->getResults($map, $typedMap);
+		$this->assertArrayHasKey('password', $result['public']);
+		$this->assertArrayHasKey('enforced', $result['public']['password']);
+		$this->assertFalse($result['public']['password']['enforced']);
 	}
 
 	public function testLinkNoPassword(): void {

--- a/apps/settings/lib/Settings/Admin/Sharing.php
+++ b/apps/settings/lib/Settings/Admin/Sharing.php
@@ -60,7 +60,7 @@ class Sharing implements IDelegatedSettings {
 			'restrictUserEnumerationFullMatchDisplayname' => $this->shareManager->matchDisplayName(),
 			'restrictUserEnumerationFullMatchEmail' => $this->shareManager->matchEmail(),
 			'restrictUserEnumerationFullMatchIgnoreSecondDN' => $this->shareManager->ignoreSecondDisplayName(),
-			'enforceLinksPassword' => $this->shareManager->shareApiLinkEnforcePassword(false),
+			'enforceLinksPassword' => $this->appConfig->getValueBool('core', ConfigLexicon::SHARE_LINK_PASSWORD_ENFORCED),
 			'enforceLinksPasswordExcludedGroups' => json_decode($excludedPasswordGroups) ?? [],
 			'enforceLinksPasswordExcludedGroupsEnabled' => $this->config->getSystemValueBool('sharing.allow_disabled_password_enforcement_groups', false),
 			'onlyShareWithGroupMembers' => $this->shareManager->shareWithGroupMembersOnly(),

--- a/apps/settings/src/components/AdminSettingsSharingForm.vue
+++ b/apps/settings/src/components/AdminSettingsSharingForm.vue
@@ -59,15 +59,20 @@
 				<NcCheckboxRadioSwitch v-model="settings.enableLinkPasswordByDefault">
 					{{ t('settings', 'Always ask for a password') }}
 				</NcCheckboxRadioSwitch>
-				<NcCheckboxRadioSwitch v-model="settings.enforceLinksPassword" :disabled="!settings.enableLinkPasswordByDefault">
+				<NcCheckboxRadioSwitch
+					v-show="settings.enableLinkPasswordByDefault"
+					v-model="settings.enforceLinksPassword">
 					{{ t('settings', 'Enforce password protection') }}
 				</NcCheckboxRadioSwitch>
-				<label v-if="settings.enforceLinksPasswordExcludedGroupsEnabled" class="sharing__labeled-entry sharing__input">
+				<label
+					v-if="settings.enforceLinksPasswordExcludedGroupsEnabled"
+					v-show="settings.enableLinkPasswordByDefault"
+					class="sharing__labeled-entry sharing__input">
 					<span>{{ t('settings', 'Exclude groups from password requirements') }}</span>
 					<NcSettingsSelectGroup
 						v-model="settings.enforceLinksPasswordExcludedGroups"
 						style="width: 100%"
-						:disabled="!settings.enforceLinksPassword || !settings.enableLinkPasswordByDefault" />
+						:disabled="!settings.enforceLinksPassword" />
 				</label>
 				<label class="sharing__labeled-entry sharing__input">
 					<span>{{ t('settings', 'Exclude groups from creating link shares') }}</span>

--- a/apps/settings/tests/Settings/Admin/SharingTest.php
+++ b/apps/settings/tests/Settings/Admin/SharingTest.php
@@ -62,6 +62,7 @@ class SharingTest extends TestCase {
 			->willReturnMap([
 				['core', 'shareapi_allow_federation_on_public_shares', true],
 				['core', 'shareapi_enable_link_password_by_default', true],
+				['core', 'shareapi_enforce_links_password', false],
 				['core', 'shareapi_default_expire_date', false],
 				['core', 'shareapi_enforce_expire_date', false],
 			]);
@@ -163,6 +164,16 @@ class SharingTest extends TestCase {
 	}
 
 	public function testGetFormWithExcludedGroups(): void {
+		$this->appConfig
+			->method('getValueBool')
+			->willReturnMap([
+				['core', 'shareapi_allow_federation_on_public_shares', true],
+				['core', 'shareapi_enable_link_password_by_default', true],
+				['core', 'shareapi_enforce_links_password', false],
+				['core', 'shareapi_default_expire_date', false],
+				['core', 'shareapi_enforce_expire_date', false],
+			]);
+
 		$this->config
 			->method('getAppValue')
 			->willReturnMap([

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1641,6 +1641,11 @@ class Manager implements IManager {
 
 	#[Override]
 	public function shareApiLinkEnforcePassword(bool $checkGroupMembership = true): bool {
+		// Password enforcement requires the default password prompt to be enabled.
+		if (!$this->appConfig->getValueBool('core', ConfigLexicon::SHARE_LINK_PASSWORD_DEFAULT)) {
+			return false;
+		}
+
 		$excludedGroups = $this->config->getAppValue('core', 'shareapi_enforce_links_password_excluded_groups', '');
 		if ($excludedGroups !== '' && $checkGroupMembership) {
 			$excludedGroups = json_decode($excludedGroups);

--- a/tests/Core/Sharing/Property/PasswordSharePropertyTypeTest.php
+++ b/tests/Core/Sharing/Property/PasswordSharePropertyTypeTest.php
@@ -88,10 +88,12 @@ final class PasswordSharePropertyTypeTest extends TestCase {
 		);
 
 		$appConfig = Server::get(IAppConfig::class);
+		$appConfig->deleteKey(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_DEFAULT);
 		$appConfig->deleteKey(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_ENFORCED);
 
 		$this->assertNull($this->propertyType->getDefaultValue($share));
 
+		$appConfig->setValueBool(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_DEFAULT, true);
 		$appConfig->setValueBool(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_ENFORCED, true);
 
 		$value = $this->propertyType->getDefaultValue($share);
@@ -100,6 +102,7 @@ final class PasswordSharePropertyTypeTest extends TestCase {
 		$this->assertGreaterThan(1, strlen((string)$value));
 		$this->assertTrue($this->propertyType->validateValue(Server::get(IFactory::class), $share, $value));
 
+		$appConfig->deleteKey(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_DEFAULT);
 		$appConfig->deleteKey(Application::APP_ID, ConfigLexicon::SHARE_LINK_PASSWORD_ENFORCED);
 	}
 

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -849,16 +849,36 @@ class ManagerTest extends \Test\TestCase {
 		]);
 
 		$this->appConfig->method('getValueBool')->willReturnMap([
+			['core', 'shareapi_enable_link_password_by_default', true],
 			['core', 'shareapi_enforce_links_password', true],
 		]);
 
 		self::invokePrivate($this->manager, 'verifyPassword', [null]);
 	}
 
+	public function testVerifyPasswordEnforcedWithoutDefaultPrompt(): void {
+		$this->config->method('getAppValue')->willReturnMap([
+			['core', 'shareapi_enforce_links_password_excluded_groups', '', ''],
+		]);
+
+		$this->appConfig->method('getValueBool')->willReturnMap([
+			['core', 'shareapi_enable_link_password_by_default', false],
+			['core', 'shareapi_enforce_links_password', true],
+		]);
+
+		$result = self::invokePrivate($this->manager, 'verifyPassword', [null]);
+		$this->assertNull($result);
+	}
+
 	public function testVerifyPasswordNotEnforcedGroup(): void {
 		$this->config->method('getAppValue')->willReturnMap([
 			['core', 'shareapi_enforce_links_password_excluded_groups', '', '["admin"]'],
 			['core', 'shareapi_enforce_links_password', 'no', 'yes'],
+		]);
+
+		$this->appConfig->method('getValueBool')->willReturnMap([
+			['core', 'shareapi_enable_link_password_by_default', true],
+			['core', 'shareapi_enforce_links_password', true],
 		]);
 
 		// Create admin user
@@ -874,6 +894,11 @@ class ManagerTest extends \Test\TestCase {
 		$this->config->method('getAppValue')->willReturnMap([
 			['core', 'shareapi_enforce_links_password_excluded_groups', '', '["admin", "special"]'],
 			['core', 'shareapi_enforce_links_password', 'no', 'yes'],
+		]);
+
+		$this->appConfig->method('getValueBool')->willReturnMap([
+			['core', 'shareapi_enable_link_password_by_default', true],
+			['core', 'shareapi_enforce_links_password', true],
 		]);
 
 		// Create admin user


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/49819

## Summary
- Gate password enforcement on "Always ask for a password".
- When "Always ask for a password" is off, "Enforce password protection" no longer applies in the backend, capabilities or share UI
- Admin sharing form still stores "Enforce password protection" separately, but only shows it when "Always ask for a password" is enabled

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
