### PR TITLE
fix(files): pass the strict flag to in_array()

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -550,7 +550,7 @@ class Folder extends Node implements IFolder {
 					return $folder;
 				}
 			} catch (NotFoundException) {
-				$folder = in_array(dirname($path), ['.','/']) ? $this : $this->get(dirname($path));
+				$folder = in_array(dirname($path), ['.','/'], true) ? $this : $this->get(dirname($path));
 				if (!($folder instanceof Folder)) {
 					throw new NotPermittedException("Unable to create folder $path. Parent is not a directory.");
 				}


### PR DESCRIPTION
## Summary

Fixes the `static-code-analysis` failure every pull request currently hits:

https://github.com/nextcloud/server/actions/runs/34507108876/job/102971934630?pr=63998

The call came in with #53048 after the strict `in_array()` psalm rule landed, and master didn't flag it because `static-code-analysis` is skipped on master pushes. `dirname()` always returns a string, so passing `true` doesn't change behaviour.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
