### PR TITLE
fix: show custom permissions when share is removed from edit bundle

### DIFF
--- a/apps/files_sharing/src/components/SharingEntryQuickShareSelect.vue
+++ b/apps/files_sharing/src/components/SharingEntryQuickShareSelect.vue
@@ -39,10 +39,7 @@ import IconPencil from 'vue-material-design-icons/PencilOutline.vue'
 import IconFileUpload from 'vue-material-design-icons/TrayArrowUp.vue'
 import DropdownIcon from 'vue-material-design-icons/TriangleSmallDown.vue'
 import IconTune from 'vue-material-design-icons/Tune.vue'
-import {
-	ATOMIC_PERMISSIONS,
-	getBundledPermissions,
-} from '../lib/SharePermissionsToolBox.js'
+import { getBundledPermissions } from '../lib/SharePermissionsToolBox.js'
 import ShareDetails from '../mixins/ShareDetails.js'
 import SharesMixin from '../mixins/SharesMixin.js'
 
@@ -98,14 +95,13 @@ export default {
 		},
 
 		preSelectedOption() {
-			// We remove the share permission for the comparison as it is not relevant for bundled permissions.
-			const permissionsWithoutShare = this.share.permissions & ~ATOMIC_PERMISSIONS.SHARE
-			const basePermissions = getBundledPermissions(true)
-			if (permissionsWithoutShare === basePermissions.READ_ONLY) {
+			const permissions = this.share.permissions
+			const basePermissions = this.bundledPermissions
+			if (permissions === basePermissions.READ_ONLY) {
 				return this.canViewText
-			} else if (permissionsWithoutShare === basePermissions.ALL || permissionsWithoutShare === basePermissions.ALL_FILE) {
+			} else if (permissions === basePermissions.ALL || permissions === basePermissions.ALL_FILE) {
 				return this.canEditText
-			} else if (permissionsWithoutShare === basePermissions.FILE_DROP) {
+			} else if (permissions === basePermissions.FILE_DROP) {
 				return this.fileDropText
 			}
 

--- a/apps/files_sharing/src/mixins/SharesMixin.js
+++ b/apps/files_sharing/src/mixins/SharesMixin.js
@@ -10,10 +10,7 @@ import { ShareType } from '@nextcloud/sharing'
 import debounce from 'debounce'
 import PQueue from 'p-queue'
 import { fetchNode } from '../../../files/src/services/WebdavClient.ts'
-import {
-	ATOMIC_PERMISSIONS,
-	getBundledPermissions,
-} from '../lib/SharePermissionsToolBox.js'
+import { getBundledPermissions } from '../lib/SharePermissionsToolBox.js'
 import Share from '../models/Share.ts'
 import Config from '../services/ConfigService.ts'
 import logger from '../services/logger.ts'
@@ -138,15 +135,14 @@ export default {
 			return this.config.isDefaultInternalExpireDateEnforced
 		},
 		hasCustomPermissions() {
-			const basePermissions = getBundledPermissions(true)
+			const basePermissions = getBundledPermissions(this.config.excludeReshareFromEdit)
 			const bundledPermissions = [
 				basePermissions.ALL,
 				basePermissions.ALL_FILE,
 				basePermissions.READ_ONLY,
 				basePermissions.FILE_DROP,
 			]
-			const permissionsWithoutShare = this.share.permissions & ~ATOMIC_PERMISSIONS.SHARE
-			return !bundledPermissions.includes(permissionsWithoutShare)
+			return !bundledPermissions.includes(this.share.permissions)
 		},
 		maxExpirationDateEnforced() {
 			if (this.isExpiryDateEnforced) {

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -1051,12 +1051,14 @@ export default {
 		handleDefaultPermissions() {
 			if (this.isNewShare) {
 				const defaultPermissions = this.config.defaultPermissions
-				const permissionsWithoutShare = defaultPermissions & ~ATOMIC_PERMISSIONS.SHARE
-				const basePermissions = getBundledPermissions(true)
-				if (permissionsWithoutShare === basePermissions.READ_ONLY
-					|| permissionsWithoutShare === basePermissions.ALL
-					|| permissionsWithoutShare === basePermissions.ALL_FILE) {
-					this.sharingPermission = permissionsWithoutShare.toString()
+				const basePermissions = this.bundledPermissions
+				if (defaultPermissions === basePermissions.READ_ONLY) {
+					this.sharingPermission = basePermissions.READ_ONLY.toString()
+				} else if (defaultPermissions === basePermissions.ALL
+					|| defaultPermissions === basePermissions.ALL_FILE) {
+					this.sharingPermission = this.allPermissions
+				} else if (defaultPermissions === basePermissions.FILE_DROP) {
+					this.sharingPermission = basePermissions.FILE_DROP.toString()
 				} else {
 					this.sharingPermission = 'custom'
 					this.share.permissions = defaultPermissions


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud-gmbh/server/issues/1031

## Summary
- Fix permission bundle matching so it compares the full permissions bitmask against the configured edit bundle.
- After refresh, shares with edit rights but without resharing now show `Custom permissions` instead of `Can edit`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
