### PR TITLE
feat: add option to show background jobs grouped by class

### DIFF
--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -29,21 +29,27 @@ class ListCommand extends Base {
 			->addOption(
 				'class',
 				'c',
-				InputOption::VALUE_OPTIONAL,
+				InputOption::VALUE_REQUIRED,
 				'Job class to search for',
 				null
 			)->addOption(
 				'limit',
 				'l',
-				InputOption::VALUE_OPTIONAL,
+				InputOption::VALUE_REQUIRED,
 				'Number of jobs to retrieve',
 				'500'
 			)->addOption(
 				'offset',
 				'o',
-				InputOption::VALUE_OPTIONAL,
+				InputOption::VALUE_REQUIRED,
 				'Offset for retrieving jobs',
 				'0'
+			)
+			->addOption(
+				'group',
+				null,
+				InputOption::VALUE_NONE,
+				'Group jobs by class'
 			)
 		;
 		parent::configure();
@@ -52,10 +58,17 @@ class ListCommand extends Base {
 	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$limit = (int)$input->getOption('limit');
-		$jobsInfo = $this->formatJobs($this->jobList->getJobsIterator($input->getOption('class'), $limit, (int)$input->getOption('offset')));
-		$this->writeTableInOutputFormat($input, $output, $jobsInfo);
-		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN && count($jobsInfo) >= $limit) {
-			$output->writeln("\n<comment>Output is currently limited to " . $limit . ' jobs. Specify `-l, --limit[=LIMIT]` to override.</comment>');
+		$offset = (int)$input->getOption('offset');
+		$group = $input->getOption('group');
+		if ($group) {
+			$grouped = $this->jobList->countByClass($limit, $offset);
+			$this->writeTableInOutputFormat($input, $output, $grouped);
+		} else {
+			$jobsInfo = $this->formatJobs($this->jobList->getJobsIterator($input->getOption('class'), $limit, $offset));
+			$this->writeTableInOutputFormat($input, $output, $jobsInfo);
+			if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN && count($jobsInfo) >= $limit) {
+				$output->writeln("\n<comment>Output is currently limited to " . $limit . ' jobs. Specify `-l, --limit[=LIMIT]` to override.</comment>');
+			}
 		}
 		return 0;
 	}

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -422,13 +422,19 @@ class JobList implements IJobList {
 	}
 
 	#[Override]
-	public function countByClass(): array {
+	public function countByClass(?int $limit = null, int $offset = 0): array {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('class')
 			->selectAlias($query->func()->count('id'), 'count')
 			->from('jobs')
 			->orderBy('count')
 			->groupBy('class');
+		if ($offset > 0) {
+			$query = $query->setFirstResult($offset);
+		}
+		if ($limit !== null) {
+			$query = $query->setMaxResults($limit);
+		}
 
 		$result = $query->executeQuery();
 

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -173,5 +173,5 @@ interface IJobList {
 	 * @return list<array{class:class-string<IJob>, count:int}>
 	 * @since 30.0.0
 	 */
-	public function countByClass(): array;
+	public function countByClass(?int $limit = null, int $offset = 0): array;
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Useful for getting an overview of what jobs are in the queue

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
