### PR TITLE
perf(files): avoid materializing directory listings in scanner

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -443,96 +443,146 @@ class Scanner extends BasicEmitter implements IScanner {
 	}
 
 	/**
+	 * Process the current directory before recursively scanning child directories.
+	 *
+	 * Keeping this work in a separate method releases the current directory's local
+	 * state before scanChildren() descends into the child queue.
+	 *
 	 * @param bool|IScanner::SCAN_RECURSIVE_INCOMPLETE $recursive
 	 */
-	private function handleChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float &$size, bool &$etagChanged): array {
-		// we put this in its own function so it cleans up the memory before we start recursing
+	private function handleChildren(
+		string $path,
+		$recursive,
+		int $reuse,
+		int $folderId,
+		bool $lock,
+		int|float &$size,
+		bool &$etagChanged,
+	): array {
 		$existingChildren = $this->getExistingChildren($folderId);
-		$newChildren = iterator_to_array($this->storage->getDirectoryContent($path));
 
-		if (count($existingChildren) === 0 && count($newChildren) === 0) {
-			// no need to do a transaction
-			return [];
-		}
-
-		if ($this->useTransactions) {
-			$this->connection->beginTransaction();
-		}
-
+		$processingStarted = false;
 		$exceptionOccurred = false;
 		$childQueue = [];
 		$newChildNames = [];
-		foreach ($newChildren as $fileMeta) {
-			$permissions = $fileMeta['scan_permissions'] ?? $fileMeta['permissions'];
-			if ($permissions === 0) {
-				continue;
-			}
-			$originalFile = $fileMeta['name'];
-			$file = trim(Filesystem::normalizePath($originalFile), '/');
-			if (trim($originalFile, '/') !== $file) {
-				// encoding mismatch, might require compatibility wrapper
-				Server::get(LoggerInterface::class)->debug('Scanner: Skipping non-normalized file name "' . $originalFile . '" in path "' . $path . '".', ['app' => 'core']);
-				$this->emit('\OC\Files\Cache\Scanner', 'normalizedNameMismatch', [$path ? $path . '/' . $originalFile : $originalFile]);
-				// skip this entry
-				continue;
-			}
 
-			$newChildNames[] = $file;
-			$child = $path ? $path . '/' . $file : $file;
-			try {
-				$existingData = $existingChildren[$file] ?? false;
-				$data = $this->scanFile($child, $reuse, $folderId, $existingData, $lock, $fileMeta);
-				if ($data) {
-					if ($data['mimetype'] === 'httpd/unix-directory' && $recursive === self::SCAN_RECURSIVE) {
-						$childQueue[$child] = [$data['fileid'], $data['size']];
-					} elseif ($data['mimetype'] === 'httpd/unix-directory' && $recursive === self::SCAN_RECURSIVE_INCOMPLETE && $data['size'] === -1) {
-						// only recurse into folders which aren't fully scanned
-						$childQueue[$child] = [$data['fileid'], $data['size']];
-					} elseif ($data['size'] === -1) {
-						$size = -1;
-					} elseif ($size !== -1) {
-						$size += $data['size'];
+		try {
+			foreach ($this->storage->getDirectoryContent($path) as $fileMeta) {
+				// Avoid opening a transaction for an empty directory with no cached children.
+				if (!$processingStarted) {
+					if ($this->useTransactions) {
+						$this->connection->beginTransaction();
 					}
-
-					if (isset($data['etag_changed']) && $data['etag_changed']) {
-						$etagChanged = true;
-					}
+					$processingStarted = true;
 				}
-			} catch (Exception $ex) {
-				// might happen if inserting duplicate while a scanning
-				// process is running in parallel
-				// log and ignore
+
+				$permissions = $fileMeta['scan_permissions'] ?? $fileMeta['permissions'];
+				if ($permissions === 0) {
+					continue;
+				}
+
+				$originalFile = $fileMeta['name'];
+				$file = trim(Filesystem::normalizePath($originalFile), '/');
+
+				if (trim($originalFile, '/') !== $file) {
+					// Non-normalized names cannot be addressed consistently through the cache; may require compatibility wrapper.
+					Server::get(LoggerInterface::class)->debug(
+						'Scanner: Skipping non-normalized file name "' . $originalFile . '" in path "' . $path . '".',
+						['app' => 'core']
+					);
+					$this->emit(
+						'\OC\Files\Cache\Scanner',
+						'normalizedNameMismatch',
+						[$path ? $path . '/' . $originalFile : $originalFile]
+					);
+					continue;
+				}
+
+				$newChildNames[] = $file;
+				$child = $path ? $path . '/' . $file : $file;
+
+				try {
+					$existingData = $existingChildren[$file] ?? false;
+					$data = $this->scanFile($child, $reuse, $folderId, $existingData, $lock, $fileMeta);
+
+					if ($data) {
+						if (
+							$data['mimetype'] === 'httpd/unix-directory'
+							&& $recursive === self::SCAN_RECURSIVE
+						) {
+							$childQueue[$child] = [$data['fileid'], $data['size']];
+						} elseif (
+							$data['mimetype'] === 'httpd/unix-directory'
+							&& $recursive === self::SCAN_RECURSIVE_INCOMPLETE
+							&& $data['size'] === -1
+						) {
+							// In incomplete scans, recurse only into folders that still need scanning.
+							$childQueue[$child] = [$data['fileid'], $data['size']];
+						} elseif ($data['size'] === -1) {
+							$size = -1;
+						} elseif ($size !== -1) {
+							$size += $data['size'];
+						}
+
+						if (isset($data['etag_changed']) && $data['etag_changed']) {
+							$etagChanged = true;
+						}
+					}
+				} catch (Exception $ex) {
+					// A concurrent scanner may have inserted this entry already.
+					if ($this->useTransactions) {
+						$this->connection->rollback();
+						$this->connection->beginTransaction();
+					}
+					Server::get(LoggerInterface::class)->debug(
+						'Exception while scanning file "' . $child . '"',
+						['app' => 'core', 'exception' => $ex]
+					);
+					$exceptionOccurred = true;
+				} catch (LockedException $e) {
+					if ($this->useTransactions) {
+						$this->connection->rollback();
+					}
+					throw $e;
+				}
+			}
+
+			if (!$processingStarted && $existingChildren === []) {
+				return [];
+			}
+
+			$removedChildren = \array_diff(array_keys($existingChildren), $newChildNames);
+
+			// Removed cached children still require a transaction when the listing is empty.
+			if ($removedChildren !== [] && !$processingStarted) {
 				if ($this->useTransactions) {
-					$this->connection->rollback();
 					$this->connection->beginTransaction();
 				}
-				Server::get(LoggerInterface::class)->debug('Exception while scanning file "' . $child . '"', [
-					'app' => 'core',
-					'exception' => $ex,
-				]);
-				$exceptionOccurred = true;
-			} catch (LockedException $e) {
-				if ($this->useTransactions) {
-					$this->connection->rollback();
-				}
-				throw $e;
+				$processingStarted = true;
 			}
+
+			foreach ($removedChildren as $childName) {
+				$child = $path ? $path . '/' . $childName : $childName;
+				$this->removeFromCache((string)$child);
+			}
+
+			if ($processingStarted && $this->useTransactions) {
+				$this->connection->commit();
+			}
+		} catch (\Throwable $e) {
+			// Lazy directory listings can fail after the transaction has started.
+			if ($this->useTransactions && $this->connection->inTransaction()) {
+				$this->connection->rollBack();
+			}
+
+			throw $e;
 		}
-		$removedChildren = \array_diff(array_keys($existingChildren), $newChildNames);
-		foreach ($removedChildren as $childName) {
-			$child = $path ? $path . '/' . $childName : $childName;
-			$this->removeFromCache((string)$child);
-		}
-		if ($this->useTransactions) {
-			$this->connection->commit();
-		}
+
 		if ($exceptionOccurred) {
-			// It might happen that the parallel scan process has already
-			// inserted mimetypes but those weren't available yet inside the transaction
-			// To make sure to have the updated mime types in such cases,
-			// we reload them here
+			// Reload MIME types that may have been inserted by a concurrent scan.
 			Server::get(IMimeTypeLoader::class)->reset();
 		}
+
 		return $childQueue;
 	}
 

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -21,7 +21,7 @@ use Test\TestCase;
 
 final class LazyDirectoryStorage extends Temporary {
 	public bool $firstChildProcessed = false;
-	public bool $resumeBeforeFirstChildProcessed = false;
+	public bool $resumedBeforeFirstChildProcessed = false;
 	public bool $throwAfterFirstEntry = false;
 
 	#[\Override]

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -19,9 +19,37 @@ use OCP\IDBConnection;
 use OCP\Server;
 use Test\TestCase;
 
+final class LazyDirectoryStorage extends Temporary {
+	public bool $firstChildProcessed = false;
+	public bool $resumeBeforeFirstChildProcessed = false;
+	public bool $throwAfterFirstEntry = false;
+
+	#[\Override]
+	public function getDirectoryContent(string $directory): \Traversable {
+		$first = true;
+
+		foreach (parent::getDirectoryContent($directory) as $entry) {
+			yield $entry;
+
+			if (!$first) {
+				continue;
+			}
+
+			$first = false;
+
+			if (!$this->firstChildProcessed) {
+				$this->resumedBeforeFirstChildProcessed = true;
+			}
+
+			if ($this->throwAfterFirstEntry) {
+				throw new \RuntimeException('Directory listing failed after the first entry');
+			}
+		}
+	}
+}
+
 /**
  * Class ScannerTest
- *
  *
  * @package Test\Files\Cache
  */
@@ -123,6 +151,55 @@ class ScannerTest extends TestCase {
 		$this->assertEquals($cachedDataFolder['fileid'], $cachedDataImage['parent']);
 		$this->assertEquals($cachedDataFolder['size'], $cachedDataImage['size'] + $cachedDataText['size'] + $cachedDataText2['size']);
 		$this->assertEquals($cachedDataFolder2['size'], $cachedDataText2['size']);
+	}
+
+	public function testDirectoryContentIsConsumedLazily(): void {
+		$storage = new LazyDirectoryStorage();
+		$storage->file_put_contents('file.txt', 'content');
+
+		$scanner = new Scanner($storage);
+		$scanner->listen(
+			'\OC\Files\Cache\Scanner',
+			'scanFile',
+			function (string $path) use ($storage): void {
+				if ($path === 'file.txt') {
+					$storage->firstChildProcessed = true;
+				}
+			},
+		);
+
+		$scanner->scan('');
+
+		$this->assertTrue($storage->firstChildProcessed);
+		$this->assertFalse($storage->resumedBeforeFirstChildProcessed);
+		$this->assertTrue($storage->getCache()->inCache('file.txt'));
+	}
+
+	public function testDirectoryContentFailureRollsBackTransaction(): void {
+		$storage = new LazyDirectoryStorage();
+		$storage->file_put_contents('file.txt', 'content');
+		$storage->throwAfterFirstEntry = true;
+
+		$scanner = new Scanner($storage);
+		$connection = Server::get(IDBConnection::class);
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('Directory listing failed after the first entry');
+
+		try {
+			$scanner->scan('');
+		} finally {
+			$this->assertFalse($connection->inTransaction());
+		}
+	}
+
+	public function testEmptyDirectoryScanDoesNotLeaveTransactionOpen(): void {
+		$storage = new LazyDirectoryStorage([]);
+		$scanner = new Scanner($storage);
+
+		$scanner->scan('');
+
+		$this->assertFalse(Server::get(IDBConnection::class)->inTransaction());
 	}
 
 	public function testShallow(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* ~~Resolves: # <!-- related github issue -->~~

## Summary

Process storage directory listings lazily during file scans instead of first materializing them with `iterator_to_array()`.

Transactions are deferred until directory processing or child removal begins, preserving the empty-directory fast path. Exceptions raised while consuming a lazy listing roll back any active transaction.

And added/updated scanner coverage for lazy directory iteration and transaction cleanup.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
