### PR TITLE
feat(upgrade): localize app names if available on upgrade page

### DIFF
--- a/lib/OC.php
+++ b/lib/OC.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use OC\App\InfoParser;
 use OC\Files\Filesystem;
 use OC\NavigationManager;
 use OC\Profiler\BuiltInProfiler;
@@ -351,6 +352,9 @@ class OC {
 
 		/** @var \OC\App\AppManager $appManager */
 		$appManager = Server::get(\OCP\App\IAppManager::class);
+		$l10nFactory = Server::get(\OCP\L10N\IFactory::class);
+		$infoParser = new InfoParser();
+		$lang = $l10nFactory->findLanguage();
 
 		// get third party apps
 		$ocVersion = $serverVersion->getVersion();
@@ -360,6 +364,7 @@ class OC {
 		$incompatibleShippedApps = [];
 		$incompatibleDisabledApps = [];
 		foreach ($incompatibleApps as $appInfo) {
+			$appInfo = $infoParser->applyL10N($appInfo, $lang);
 			if ($appManager->isShipped($appInfo['id'])) {
 				$incompatibleShippedApps[] = $appInfo['name'] . ' (' . $appInfo['id'] . ')';
 			}
@@ -369,13 +374,14 @@ class OC {
 		}
 
 		if (!empty($incompatibleShippedApps)) {
-			$l = Server::get(\OCP\L10N\IFactory::class)->get('core');
+			$l = $l10nFactory->get('core');
 			$hint = $l->t('Application %1$s is not present or has a non-compatible version with this server. Please check the apps directory.', [implode(', ', $incompatibleShippedApps)]);
 			throw new \OCP\HintException('Application ' . implode(', ', $incompatibleShippedApps) . ' is not present or has a non-compatible version with this server. Please check the apps directory.', $hint);
 		}
 
 		$appConfig = Server::get(IAppConfig::class);
-		$appsToUpgrade = array_map(function ($app) use (&$appConfig) {
+		$appsToUpgrade = array_map(function ($app) use (&$appConfig, $infoParser, $lang) {
+			$app = $infoParser->applyL10N($app, $lang);
 			return [
 				'id' => $app['id'],
 				'name' => $app['name'],


### PR DESCRIPTION
## Summary

This allows to use the localized app names set in `info.xml` instead of showing the raw data of the serialized `info.xml`

| Before | After |
|--------|--------|
| <img width="688" height="358" alt="Capture d’écran du 2026-09-12 17-28-34" src="https://github.com/user-attachments/assets/064a7f97-0348-42e2-9e87-95456bf09782" /> | <img width="688" height="305" alt="Capture d’écran du 2026-09-12 17-29-19" src="https://github.com/user-attachments/assets/354040b9-2206-428d-80d9-0e202f56a244" /> |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
